### PR TITLE
Minor typo fix in documentation

### DIFF
--- a/help/en/html/tools/consisttool/ConsistTool.shtml
+++ b/help/en/html/tools/consisttool/ConsistTool.shtml
@@ -136,7 +136,7 @@
                 By default, locomotives in a DAC ignore function commands 
                 sent to the consist address.  You can configure some decoders 
                 so they will respond to function commands issued to the 
-                consist address as well (through CVS 21 and 22).  If 
+                consist address as well (through CVs 21 and 22).  If 
                 supported by the decoder, The appropriate values can also 
                 be configured through DecoderPro using the Consisting Tab 
                 in the comprehensive programmer.


### PR DESCRIPTION
It's just a small typo fix, which normally would roll up with some other commits.  But this one also forms the examples