### PR TITLE
Fixes application hanging at startup

### DIFF
--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -1026,6 +1026,8 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
                                     KeyEvent ky = (KeyEvent) e;
                                     if (ky.getKeyCode() == 119) {
                                         startupDebug();
+                                    } else {
+                                        debugmsg = false;
                                     }
                                 } else {
                                     debugmsg = false;


### PR DESCRIPTION
Fixes leaking debugmsg in case the user was pressing a different key than F8 at startup.

If the debugmsg is leaked, then the application hangs forever at startup. This was happening to me about 3 out of 4 startup attempts under linux. The typical case why another key event might be coming in is if the user operates the profiles dialog with the keyboard. All those events will show up here.

Note: I don't think it's a good idea to manipulate the debugmsg in the key handler, since it will be set in startupDebug() anyway. The difference between the key handler and startupDebug's first statement is in microseconds, so I don't quite get the need for the complicated code in the key handler. I would just drastically simplify the key handler and remove the comment at line 1021.