### PR TITLE
Use SSI for Style blocks in web pages; suppress log messages routine to testing; suppress routine messages during ant build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ java/docs
 
 # test artifacts
 junit-results.xml
+junit*.properties
 
 # runtime artifacts
 messages.log*

--- a/build.xml
+++ b/build.xml
@@ -214,6 +214,20 @@
       <pathelement location="${svnantdir}/svnkit.jar"/>
     </path>
 
+    <macrodef name="quiet">
+        <element name="body" implicit="yes"/>
+        <sequential>
+            <script language="javascript">
+                project.getBuildListeners().firstElement().setMessageOutputLevel(0);
+            </script>
+            <body/>
+            <script language="javascript">
+                // TODO: restore last log level
+                project.getBuildListeners().firstElement().setMessageOutputLevel(2);
+            </script>
+        </sequential>
+    </macrodef>
+
     <typedef
         resource="org/tigris/subversion/svnant/svnantlib.xml"
         classpathref="path.svnant"/>
@@ -260,10 +274,12 @@
         </tstamp>
         <property name="release.build_date" value="${TODAY}-${NOW}"/>
         <!-- Create the build directory structure used by compile -->
+        <quiet>
         <mkdir dir="${target}"/>
         <mkdir dir="${target}/resources"/>
         <mkdir dir="${genjavasrcdir}/jmri/jmris/srcp/parser"/>
         <mkdir dir="${genjavasrcdir}/jmri/jmrix/srcp/parser"/>
+        </quiet>
 
         <filterset id="release-information"
                    begintoken="@@"
@@ -361,6 +377,7 @@
     <target name="jjtree"
             description="Run JJTree related actions"
             depends="init">
+        <quiet>
         <!-- Run JJTree -->
         <!-- Create the build directory structure used by compiler -->
         <mkdir dir="${genjavasrcdir}/jmri/jmris/srcp/parser"/>
@@ -373,6 +390,7 @@
             target="${source}/jmri/jmrix/srcp/SRCPClientParser.jjt"
             outputdirectory="${genjavasrcdir}/jmri/jmrix/srcp/parser"
             javacchome="${libdir}"/>
+        </quiet>
     </target>
 
 
@@ -390,6 +408,7 @@
             description="JavaCC related actions"
             depends="jjtree">
         <!-- Run JavaCC -->
+        <quiet>
         <javacc
             target="${genjavasrcdir}/jmri/jmris/srcp/parser/SRCPParser.jj"
             outputdirectory="${genjavasrcdir}/jmri/jmris/srcp/parser"
@@ -398,6 +417,7 @@
             target="${genjavasrcdir}/jmri/jmrix/srcp/parser/SRCPClientParser.jj"
             outputdirectory="${genjavasrcdir}/jmri/jmrix/srcp/parser"
             javacchome="${libdir}"/>
+        </quiet>
     </target>
 
 

--- a/help/en/html/doc/Technical/XCode.shtml
+++ b/help/en/html/doc/Technical/XCode.shtml
@@ -15,13 +15,7 @@
     <!-- delete the following 2 Defines if you want to use the default JMRI logo -->
     <!-- or change them to reflect your alternative logo -->
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/XmlDtdUsage.shtml
+++ b/help/en/html/doc/Technical/XmlDtdUsage.shtml
@@ -15,13 +15,7 @@
     <!-- delete the following 2 Defines if you want to use the default JMRI logo -->
     <!-- or change them to reflect your alternative logo -->
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/XmlEditors.shtml
+++ b/help/en/html/doc/Technical/XmlEditors.shtml
@@ -8,13 +8,7 @@
     <META content="Bob Jacobsen" name=Author>
     <meta name="keywords" content="JMRI technical code xml editors">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/XmlPersistance.shtml
+++ b/help/en/html/doc/Technical/XmlPersistance.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <meta name="keywords" content="JMRI technical code xml persistance">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/XmlSchema.shtml
+++ b/help/en/html/doc/Technical/XmlSchema.shtml
@@ -15,13 +15,7 @@
     <!-- delete the following 2 Defines if you want to use the default JMRI logo -->
     <!-- or change them to reflect your alternative logo -->
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/XmlSchemaExamples.shtml
+++ b/help/en/html/doc/Technical/XmlSchemaExamples.shtml
@@ -15,13 +15,7 @@
     <!-- delete the following 2 Defines if you want to use the default JMRI logo -->
     <!-- or change them to reflect your alternative logo -->
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/XmlUsage.shtml
+++ b/help/en/html/doc/Technical/XmlUsage.shtml
@@ -8,13 +8,7 @@
     <META content="Bob Jacobsen" name=Author>
     <meta name="keywords" content="JMRI technical code xml usage">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/XmlView.shtml
+++ b/help/en/html/doc/Technical/XmlView.shtml
@@ -8,13 +8,7 @@
     <META content="Bob Jacobsen" name=Author>
     <meta name="keywords" content="JMRI technical code xml usage">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/getcvscode.shtml
+++ b/help/en/html/doc/Technical/getcvscode.shtml
@@ -15,13 +15,7 @@
     <!-- delete the following 2 Defines if you want to use the default JMRI logo -->
     <!-- or change them to reflect your alternative logo -->
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/getgitcode.shtml
+++ b/help/en/html/doc/Technical/getgitcode.shtml
@@ -15,13 +15,7 @@
     <!-- delete the following 2 Defines if you want to use the default JMRI logo -->
     <!-- or change them to reflect your alternative logo -->
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/getsvncode.shtml
+++ b/help/en/html/doc/Technical/getsvncode.shtml
@@ -15,13 +15,7 @@
     <!-- delete the following 2 Defines if you want to use the default JMRI logo -->
     <!-- or change them to reflect your alternative logo -->
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/gitdeveloper.shtml
+++ b/help/en/html/doc/Technical/gitdeveloper.shtml
@@ -15,13 +15,7 @@
     <!-- delete the following 2 Defines if you want to use the default JMRI logo -->
     <!-- or change them to reflect your alternative logo -->
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/index.shtml
+++ b/help/en/html/doc/Technical/index.shtml
@@ -15,13 +15,7 @@
     <!-- delete the following 2 Defines if you want to use the default JMRI logo -->
     <!-- or change them to reflect your alternative logo -->
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/html/doc/Technical/plugins.shtml
+++ b/help/en/html/doc/Technical/plugins.shtml
@@ -16,13 +16,7 @@
     <!-- delete the following 2 Defines if you want to use the default JMRI logo -->
     <!-- or change them to reflect your alternative logo -->
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+    <!--#include virtual="/Style" -->
 </head>
 
 <!--#include virtual="/Header" -->

--- a/help/en/package/jmri/jmrit/beantable/AddEditAction.shtml
+++ b/help/en/package/jmri/jmrit/beantable/AddEditAction.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Transit Special Actions">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/AddEditSignalingLogic.shtml
+++ b/help/en/package/jmri/jmrit/beantable/AddEditSignalingLogic.shtml
@@ -10,15 +10,7 @@
 <META NAME="Author" CONTENT="Kevin Dickerson, Egbert Broerse">
 <META NAME="keywords" CONTENT="JMRI help SignalMast Logic Add Edit">
 
-<!-- Style -->
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/default.css"
-	MEDIA="screen">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/print.css"
-	MEDIA="print">
-<LINK REL="icon" HREF="/images/jmri.ico" TYPE="image/png">
-<LINK REL="home" TITLE="Home" HREF="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </HEAD>
 
 <BODY>

--- a/help/en/package/jmri/jmrit/beantable/AudioAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/AudioAddEdit.shtml
@@ -9,13 +9,7 @@
     <META content="Matt Harris" name=Author>
     <META name="keywords" content="JMRI help Audio Add Edit">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/AudioTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/AudioTable.shtml
@@ -9,13 +9,7 @@
     <META content="Matt Harris" name=Author>
     <META name="keywords" content="JMRI help Audio Table">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/BlockAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/BlockAddEdit.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Block Table">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/BlockEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/BlockEdit.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Memory Table">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/BlockTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/BlockTable.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Memory Table">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/ConditionalAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/ConditionalAddEdit.shtml
@@ -7,15 +7,7 @@
 <META CONTENT="Bob Jacobsen" NAME="Author">
 <META NAME="keywords" CONTENT="JMRI help Logix Conditional Add Edit">
 
-<!-- Style -->
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/default.css"
-	MEDIA="screen">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/print.css"
-	MEDIA="print">
-<LINK REL="icon" HREF="/images/jmri.ico" TYPE="image/png">
-<LINK REL="home" TITLE="Home" HREF="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </HEAD>
 
 <BODY>

--- a/help/en/package/jmri/jmrit/beantable/IdTagAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/IdTagAddEdit.shtml
@@ -9,13 +9,7 @@
     <meta content="Matthew Harris" name=Author>
     <meta name="keywords" content="JMRI help Id Tag Add Edit">
 
-<!-- Style -->
-  <meta http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/IdTagTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/IdTagTable.shtml
@@ -9,13 +9,7 @@
     <meta content="Matthew Harris" name=Author>
     <meta name="keywords" content="JMRI help Id Tag Table">
 
-<!-- Style -->
-  <meta http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/LRouteAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/LRouteAddEdit.shtml
@@ -7,15 +7,7 @@
 <META CONTENT="Bob Jacobsen" NAME="Author">
 <META NAME="keywords" CONTENT="JMRI help LRoute Add Edit">
 
-<!-- Style -->
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/default.css"
-	MEDIA="screen">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/print.css"
-	MEDIA="print">
-<LINK REL="icon" HREF="/images/jmri.ico" TYPE="image/png">
-<LINK REL="home" TITLE="Home" HREF="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </HEAD>
 
 <BODY>

--- a/help/en/package/jmri/jmrit/beantable/LRouteTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/LRouteTable.shtml
@@ -7,15 +7,7 @@
 <META CONTENT="Bob Jacobsen" NAME="Author">
 <META NAME="keywords" CONTENT="JMRI help LRoute Table">
 
-<!-- Style -->
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/default.css"
-	MEDIA="screen">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/print.css"
-	MEDIA="print">
-<LINK REL="icon" HREF="/images/jmri.ico" TYPE="image/png">
-<LINK REL="home" TITLE="Home" HREF="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </HEAD>
 
 <BODY>

--- a/help/en/package/jmri/jmrit/beantable/LightAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/LightAddEdit.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Light Add Edit">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/LightTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/LightTable.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Light Table">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/LogixAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/LogixAddEdit.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Logix Add Edit">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/LogixTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/LogixTable.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Logix Table">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/MemoryAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/MemoryAddEdit.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Memory Add Edit">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/MemoryTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/MemoryTable.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Memory Table">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/ReporterAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/ReporterAddEdit.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Reporter Add Edit">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/ReporterTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/ReporterTable.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Reporter Table">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/RouteAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/RouteAddEdit.shtml
@@ -7,15 +7,7 @@
 <META CONTENT="Bob Jacobsen" NAME="Author">
 <META NAME="keywords" CONTENT="JMRI help Route Add Edit">
 
-<!-- Style -->
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/default.css"
-	MEDIA="screen">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/print.css"
-	MEDIA="print">
-<LINK REL="icon" HREF="/images/jmri.ico" TYPE="image/png">
-<LINK REL="home" TITLE="Home" HREF="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </HEAD>
 
 <BODY>

--- a/help/en/package/jmri/jmrit/beantable/RouteTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/RouteTable.shtml
@@ -7,15 +7,7 @@
 <META CONTENT="Bob Jacobsen" NAME="Author">
 <META NAME="keywords" CONTENT="JMRI help Route Table">
 
-<!-- Style -->
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/default.css"
-	MEDIA="screen">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/print.css"
-	MEDIA="print">
-<LINK REL="icon" HREF="/images/jmri.ico" TYPE="image/png">
-<LINK REL="home" TITLE="Home" HREF="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </HEAD>
 
 <BODY>

--- a/help/en/package/jmri/jmrit/beantable/SectionAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SectionAddEdit.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Section Add Edit">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/SectionTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SectionTable.shtml
@@ -9,13 +9,7 @@
     <META content="Dave Duchamp" name=Author>
     <META name="keywords" content="JMRI help Section Table">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/SensorAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SensorAddEdit.shtml
@@ -7,15 +7,7 @@
 <META CONTENT="Bob Jacobsen" NAME="Author">
 <META NAME="keywords" CONTENT="JMRI help Sensor Add Edit">
 
-<!-- Style -->
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/default.css"
-	MEDIA="screen">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/print.css"
-	MEDIA="print">
-<LINK REL="icon" HREF="/images/jmri.ico" TYPE="image/png">
-<LINK REL="home" TITLE="Home" HREF="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </HEAD>
 
 <BODY>

--- a/help/en/package/jmri/jmrit/beantable/SensorTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SensorTable.shtml
@@ -7,15 +7,7 @@
 <META CONTENT="Bob Jacobsen" NAME="Author">
 <META NAME="keywords" CONTENT="JMRI help Sensor Table">
 
-<!-- Style -->
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/default.css"
-	MEDIA="screen">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/print.css"
-	MEDIA="print">
-<LINK REL="icon" HREF="/images/jmri.ico" TYPE="image/png">
-<LINK REL="home" TITLE="Home" HREF="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </HEAD>
 
 <BODY>

--- a/help/en/package/jmri/jmrit/beantable/SignalAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SignalAddEdit.shtml
@@ -11,44 +11,11 @@
 	<meta name="Date.Modified" content="20150920"/>
     <META name="keywords" content="JMRI help Signal Heads Add Edit">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>
-<!-- Header -->
-  <p class="skipLink"><a href="#mainContent" accesskey="2">Skip to main content</a></p>
-
-  <div id="header">
-	<!-- Logo -->
-	<a href="/" title="Return to home page" accesskey="1">
-	    <img src="/images/logo-jmri.gif" width="160" height="135" alt="JMRI Logo"> </a>
-	<!-- /Logo -->
-	<ul id="mainNav"> <!-- Top tool bar -->
-	   <li><a href="/download/index.shtml"  title="Get the latest software">Download</a></li>
-	   <li><a href="/help/en/html/apps/index.shtml"      title="Learn about JMRI applications">Applications</a></li>
-	   <li><a href="/help/en/html/hardware/index.shtml"  title="What hardware does JMRI support">Hardware</a></li>
-	   <li><a href="/help/en/webtoc.shtml"   title="JMRI Help Screens">Help</a></li>
-	   <li><a href="/help/en/manual/index.shtml"   title="DecoderPro Manual">Manual</a></li>
-	   <li><a href="/help/en/html/doc/Technical/index.shtml" title="Developing and extending JMRI">Developers</a></li>
-	   <li><A href="/help/en/Acknowledgements.shtml" title="Who is JMRI">Acknowledgements</a></li>
-	</ul>
-
-	<div id="searchform"> <!--  Search Form -->
-          <form method="get" action="http://www.google.com/search">
-            <label for="q" title="Search JMRI.org">search JMRI: </label>
-            <input type="hidden" name="sitesearch" value="jmri.org">
-            <input type="text" id="q" name="q" accesskey="s" size="30">
-	    <input type="submit" id="submit" value="go">
-          </form>
-    </div> <!--  End #searchform -->
-  </div> <!-- closes #header-->
-<!-- /Header -->
+<!--#include virtual="/Header" -->
 
   <div class="nomenu" id="mBody">
     <div id="mainContent">

--- a/help/en/package/jmri/jmrit/beantable/SignalGroupAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SignalGroupAddEdit.shtml
@@ -6,13 +6,7 @@
 <title>JMRI: Adding Signal Groups</title>
 <meta name="Author" content="Bob Jacobsen, Egbert Broerse">
 <meta name="Date.Modified" content="20150125">
-<!-- Style -->
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-<link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-<link rel="icon" href="/images/jmri.ico" TYPE="image/png">
-<link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/SignalGroupTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SignalGroupTable.shtml
@@ -10,12 +10,7 @@
 <meta name="Date.Modified" content="20150125"/>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
 <meta name="keywords" content="model railroad JMRI decoderpro panelpro signal">
-<!-- Style -->
-<link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-<link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-<link rel="icon" href="/images/jmri.ico" TYPE="image/png">
-<link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/SignalHeadTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SignalHeadTable.shtml
@@ -10,13 +10,7 @@
 	<META name="Date.Modified" content="20140515"/>
     <META name="keywords" content="JMRI help Signal Heads Table">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/SignalMastAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SignalMastAddEdit.shtml
@@ -10,13 +10,7 @@
 <meta name="Date.Modified" content="20150125"/>
     <META name="keywords" content="JMRI help Signal Mast Add">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/SignalMastLogicTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SignalMastLogicTable.shtml
@@ -8,15 +8,7 @@
 <META NAME="Author" CONTENT="Kevin Dickerson, Egbert Broerse">
 <META NAME="keywords" CONTENT="JMRI help Signal Mast Logic Table">
 
-<!-- Style -->
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/default.css"
-	MEDIA="screen">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/print.css"
-	MEDIA="print">
-<LINK REL="icon" HREF="/images/jmri.ico" TYPE="image/png">
-<LINK REL="home" TITLE="Home" HREF="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </HEAD>
 
 <BODY>

--- a/help/en/package/jmri/jmrit/beantable/SignalMastRepeater.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SignalMastRepeater.shtml
@@ -9,13 +9,7 @@
     <META content="Kevin Dickerson" name=Author>
     <META name="keywords" content="JMRI help Signal Mast Repeater">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/SignalMastTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SignalMastTable.shtml
@@ -10,13 +10,7 @@
 <meta name="Date.Modified" content="20140420"/>
     <META name="keywords" content="JMRI help Signal Mast Table">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/TransitAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/TransitAddEdit.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Transit Add Edit">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/TransitTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/TransitTable.shtml
@@ -9,13 +9,7 @@
     <META content="Dave Duchamp" name=Author>
     <META name="keywords" content="JMRI help Transit Table">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/TurnoutAddEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/TurnoutAddEdit.shtml
@@ -8,15 +8,7 @@
 <meta name="Date.Modified" content="20150920"/>
 <META NAME="keywords" CONTENT="JMRI help Turnout Add Edit">
 
-<!-- Style -->
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/default.css"
-	MEDIA="screen">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/print.css"
-	MEDIA="print">
-<LINK REL="icon" HREF="/images/jmri.ico" TYPE="image/png">
-<LINK REL="home" TITLE="Home" HREF="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </HEAD>
 
 <BODY>

--- a/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml
@@ -7,15 +7,7 @@
 <META CONTENT="Bob Jacobsen" NAME="Author">
 <META NAME="keywords" CONTENT="JMRI help Turnout Table">
 
-<!-- Style -->
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/default.css"
-	MEDIA="screen">
-<LINK REL="stylesheet" TYPE="text/css" HREF="/css/print.css"
-	MEDIA="print">
-<LINK REL="icon" HREF="/images/jmri.ico" TYPE="image/png">
-<LINK REL="home" TITLE="Home" HREF="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </HEAD>
 
 <BODY>

--- a/help/en/package/jmri/jmrit/beantable/UserMessagePreferences.shtml
+++ b/help/en/package/jmri/jmrit/beantable/UserMessagePreferences.shtml
@@ -9,13 +9,7 @@
     <META content="Kevin Dickerson" name=Author>
     <META name="keywords" content="User Message Preferences">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/help/en/package/jmri/jmrit/beantable/ViewSpecialActions.shtml
+++ b/help/en/package/jmri/jmrit/beantable/ViewSpecialActions.shtml
@@ -9,13 +9,7 @@
     <META content="Bob Jacobsen" name=Author>
     <META name="keywords" content="JMRI help Transit Special Actions">
 
-<!-- Style -->
-  <META http-equiv=Content-Type content="text/html; charset=iso-8859-1">
-  <link rel="stylesheet" type="text/css" href="/css/default.css" media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css" media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/">
-<!-- /Style -->
+<!--#include virtual="/Style" -->
 </head>
 
 <body>

--- a/java/src/jmri/jmris/json/package-info.java
+++ b/java/src/jmri/jmris/json/package-info.java
@@ -35,4 +35,5 @@
  * </ul></dd>
  * </dl>
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmris.json;

--- a/java/src/jmri/jmrit/MemoryContents.java
+++ b/java/src/jmri/jmrit/MemoryContents.java
@@ -956,7 +956,7 @@ public class MemoryContents {
         currentPage = location / PAGESIZE;
         if (pageArray[currentPage] == null) {
             log.error("Error in getLocation(0x" // NOI18N
-                    + location
+                    + Integer.toHexString(location)
                     + "): accessed uninitialized page " // NOI18N
                     + currentPage);
             return DEFAULT_MEM_VALUE;

--- a/java/src/jmri/jmrix/dcc/package-info.java
+++ b/java/src/jmri/jmrix/dcc/package-info.java
@@ -32,4 +32,5 @@
  *
  * @since 3.9.6
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmrix.dcc;

--- a/java/src/jmri/jmrix/loconet/Intellibox/package-info.java
+++ b/java/src/jmri/jmrix/loconet/Intellibox/package-info.java
@@ -11,4 +11,5 @@
  * Uhlenbrock page</a>.
  */
 //@annotations for the entire package go here
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmrix.loconet.Intellibox;

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/package-info.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/package-info.java
@@ -11,4 +11,5 @@
  * Uhlenbrock page</a>.
  */
 //@annotations for the entire package go here
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmrix.loconet.uhlenbrock;

--- a/java/src/jmri/jmrix/modbus/common/package-info.java
+++ b/java/src/jmri/jmrix/modbus/common/package-info.java
@@ -11,4 +11,5 @@
  * @see jmri.jmrix.modbus.master
  * @since JMRI 3.11.1
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmrix.modbus.common;

--- a/java/src/jmri/jmrix/modbus/master/package-info.java
+++ b/java/src/jmri/jmrix/modbus/master/package-info.java
@@ -10,4 +10,5 @@
  * @see jmri.jmrix.modbus.slave
  * @since JMRI 3.11.1
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmrix.modbus.master;

--- a/java/src/jmri/jmrix/modbus/package-info.java
+++ b/java/src/jmri/jmrix/modbus/package-info.java
@@ -10,4 +10,5 @@
  * @see jmri.jmrix.modbus.master
  * @since JMRI 3.11.1
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmrix.modbus;

--- a/java/src/jmri/jmrix/modbus/slave/package-info.java
+++ b/java/src/jmri/jmrix/modbus/slave/package-info.java
@@ -9,4 +9,5 @@
  * @see jmri.jmrix.modbus.master
  * @since JMRI 3.11.1
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmrix.modbus.slave;

--- a/java/src/jmri/jmrix/openlcb/package-info.java
+++ b/java/src/jmri/jmrix/openlcb/package-info.java
@@ -11,4 +11,5 @@
  * <!-- Put @see and @since tags down here. -->
  * @since 2.1.7
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmrix.openlcb;

--- a/java/src/jmri/jmrix/openlcb/swing/downloader/package-info.java
+++ b/java/src/jmri/jmrix/openlcb/swing/downloader/package-info.java
@@ -23,4 +23,5 @@
  * @see jmri.managers
  * @see jmri.implementation
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmrix.openlcb.swing.downloader;

--- a/java/src/jmri/jmrix/openlcb/swing/package-info.java
+++ b/java/src/jmri/jmrix/openlcb/swing/package-info.java
@@ -11,4 +11,5 @@
  * <!-- Put @see and @since tags down here. -->
  * @since 2.1.7
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmrix.openlcb.swing;

--- a/java/src/jmri/jmrix/openlcb/swing/send/package-info.java
+++ b/java/src/jmri/jmrix/openlcb/swing/send/package-info.java
@@ -14,4 +14,5 @@
  * <!-- Put @see and @since tags down here. -->
  * @since 2.9.6
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmrix.openlcb.swing.send;

--- a/java/src/jmri/jmrix/openlcb/swing/tie/package-info.java
+++ b/java/src/jmri/jmrix/openlcb/swing/tie/package-info.java
@@ -11,4 +11,5 @@
  * <li><a href="http://openlcb.org/">OpenLCB project overview page</a>
  * </ul>
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.jmrix.openlcb.swing.tie;

--- a/java/src/jmri/package-info.java
+++ b/java/src/jmri/package-info.java
@@ -20,4 +20,5 @@
  * @see jmri.managers
  * @see jmri.implementation
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri;

--- a/java/src/jmri/profile/package-info.java
+++ b/java/src/jmri/profile/package-info.java
@@ -8,4 +8,5 @@
  * {@link jmri.profile.ProfilePreferencesPanel}. This allows profiles to be
  * imported into a JMRI instance while that instance is not running.
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.profile;

--- a/java/src/jmri/util/node/package-info.java
+++ b/java/src/jmri/util/node/package-info.java
@@ -3,4 +3,5 @@
  *
  * @since JMRI 3.7.1
  */
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({})
 package jmri.util.node;

--- a/java/test/jmri/BlockManagerTest.java
+++ b/java/test/jmri/BlockManagerTest.java
@@ -132,6 +132,8 @@ public class BlockManagerTest extends TestCase {
             } else {
                 Assert.fail("failed to set speed due to wrong reason: " + ex);
             }
+        } finally {
+            jmri.util.JUnitAppender.assertWarnMessage("attempting to set invalid speed: Faster");
         }
         //Assert.assertEquals("faster block speed", "Faster", InstanceManager.blockManagerInstance().getDefaultSpeed());
         Assert.assertTrue("Expected exception", threw);

--- a/java/test/jmri/jmrit/MemoryContentsTest.java
+++ b/java/test/jmri/jmrit/MemoryContentsTest.java
@@ -100,7 +100,10 @@ public class MemoryContentsTest extends TestCase {
         verifyMemoryData(0x30003, -1, m);
 
         verifyMemoryData(0x3FFFF, -1, m);
+
         verifyMemoryData(0x9FFFF, -1, m);
+        jmri.util.JUnitAppender.assertErrorMessage("Error in getLocation(0x9ffff): accessed uninitialized page 9");
+        
         verifyMemoryData(0xA0000, 0xa0, m);
         verifyMemoryData(0xA0001, 0xa1, m);
         verifyMemoryData(0xA0002, -1, m);

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -701,6 +701,7 @@ public class AbstractThrottleTest extends TestCase {
         Object newValue = null;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.notifyPropertyChangeListener(property, oldValue, newValue);
+        jmri.util.JUnitAppender.assertErrorMessage("notifyPropertyChangeListener without change");
     }
 
     /**
@@ -719,6 +720,7 @@ public class AbstractThrottleTest extends TestCase {
     public void testDispose_0args() {
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.dispose();
+        jmri.util.JUnitAppender.assertWarnMessage("Dispose called without knowing the original throttle listener");
     }
 
     /**
@@ -736,6 +738,7 @@ public class AbstractThrottleTest extends TestCase {
     public void testDispatch_0args() {
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.dispatch();
+        jmri.util.JUnitAppender.assertWarnMessage("dispatch called without knowing the original throttle listener");
     }
 
     /**
@@ -753,6 +756,7 @@ public class AbstractThrottleTest extends TestCase {
     public void testRelease_0args() {
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.release();
+        jmri.util.JUnitAppender.assertWarnMessage("Release called without knowing the original throttle listener");
     }
 
     /**

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -22,6 +22,7 @@ public class AbstractThrottleTest extends TestCase {
 
     @Override
     protected void setUp() throws Exception {
+        apps.tests.Log4JFixture.setUp(); 
         super.setUp();
         InstanceManager.setThrottleManager(new AbstractThrottleManager() {
 
@@ -50,6 +51,7 @@ public class AbstractThrottleTest extends TestCase {
     protected void tearDown() throws Exception {
         InstanceManager.setThrottleManager(null);
         super.tearDown();
+        apps.tests.Log4JFixture.tearDown(); 
     }
 
     /**
@@ -787,6 +789,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f0 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF0(f0);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup1 needs to be implemented if invoked");
     }
 
     /**
@@ -796,6 +799,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f1 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF1(f1);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup1 needs to be implemented if invoked");
     }
 
     /**
@@ -805,6 +809,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f2 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF2(f2);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup1 needs to be implemented if invoked");
     }
 
     /**
@@ -814,6 +819,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f3 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF3(f3);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup1 needs to be implemented if invoked");
     }
 
     /**
@@ -823,6 +829,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f4 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF4(f4);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup1 needs to be implemented if invoked");
     }
 
     /**
@@ -832,6 +839,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f5 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF5(f5);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup2 needs to be implemented if invoked");
     }
 
     /**
@@ -841,6 +849,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f6 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF6(f6);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup2 needs to be implemented if invoked");
     }
 
     /**
@@ -850,6 +859,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f7 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF7(f7);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup2 needs to be implemented if invoked");
     }
 
     /**
@@ -859,6 +869,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f8 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF8(f8);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup2 needs to be implemented if invoked");
     }
 
     /**
@@ -868,6 +879,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f9 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF9(f9);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup3 needs to be implemented if invoked");
     }
 
     /**
@@ -877,6 +889,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f10 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF10(f10);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup3 needs to be implemented if invoked");
     }
 
     /**
@@ -886,6 +899,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f11 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF11(f11);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup3 needs to be implemented if invoked");
     }
 
     /**
@@ -895,6 +909,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f12 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF12(f12);
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup3 needs to be implemented if invoked");
     }
 
     /**
@@ -904,6 +919,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f13 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF13(f13);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F13-F20 since no command station defined");
     }
 
     /**
@@ -913,6 +929,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f14 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF14(f14);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F13-F20 since no command station defined");
     }
 
     /**
@@ -922,6 +939,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f15 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF15(f15);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F13-F20 since no command station defined");
     }
 
     /**
@@ -931,6 +949,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f16 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF16(f16);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F13-F20 since no command station defined");
     }
 
     /**
@@ -940,6 +959,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f17 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF17(f17);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F13-F20 since no command station defined");
     }
 
     /**
@@ -949,6 +969,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f18 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF18(f18);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F13-F20 since no command station defined");
     }
 
     /**
@@ -958,6 +979,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f19 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF19(f19);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F13-F20 since no command station defined");
     }
 
     /**
@@ -967,6 +989,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f20 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF20(f20);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F13-F20 since no command station defined");
     }
 
     /**
@@ -976,6 +999,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f21 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF21(f21);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F21-F28 since no command station defined");
     }
 
     /**
@@ -985,6 +1009,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f22 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF22(f22);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F21-F28 since no command station defined");
     }
 
     /**
@@ -994,6 +1019,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f23 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF23(f23);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F21-F28 since no command station defined");
     }
 
     /**
@@ -1003,6 +1029,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f24 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF24(f24);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F21-F28 since no command station defined");
     }
 
     /**
@@ -1012,6 +1039,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f25 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF25(f25);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F21-F28 since no command station defined");
     }
 
     /**
@@ -1021,6 +1049,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f26 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF26(f26);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F21-F28 since no command station defined");
     }
 
     /**
@@ -1030,6 +1059,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f27 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF27(f27);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F21-F28 since no command station defined");
     }
 
     /**
@@ -1039,6 +1069,7 @@ public class AbstractThrottleTest extends TestCase {
         boolean f28 = false;
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.setF28(f28);
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F21-F28 since no command station defined");
     }
 
     /**
@@ -1047,6 +1078,7 @@ public class AbstractThrottleTest extends TestCase {
     public void testSendFunctionGroup1() {
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.sendFunctionGroup1();
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup1 needs to be implemented if invoked");
     }
 
     /**
@@ -1055,6 +1087,7 @@ public class AbstractThrottleTest extends TestCase {
     public void testSendFunctionGroup2() {
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.sendFunctionGroup2();
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup2 needs to be implemented if invoked");
     }
 
     /**
@@ -1063,6 +1096,7 @@ public class AbstractThrottleTest extends TestCase {
     public void testSendFunctionGroup3() {
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.sendFunctionGroup3();
+        jmri.util.JUnitAppender.assertErrorMessage("sendFunctionGroup3 needs to be implemented if invoked");
     }
 
     /**
@@ -1071,6 +1105,7 @@ public class AbstractThrottleTest extends TestCase {
     public void testSendFunctionGroup4() {
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.sendFunctionGroup4();
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F13-F20 since no command station defined");
     }
 
     /**
@@ -1079,6 +1114,7 @@ public class AbstractThrottleTest extends TestCase {
     public void testSendFunctionGroup5() {
         AbstractThrottle instance = new AbstractThrottleImpl();
         instance.sendFunctionGroup5();
+        jmri.util.JUnitAppender.assertErrorMessage("Can't send F21-F28 since no command station defined");
     }
 
     /**


### PR DESCRIPTION
Goal is to reduce the volume of the Travis build output.  

The JDNS logging completely dominates the middle, but this simplifies/shortens the build text at the beginning and spurious log messages at the end.