### PR TITLE
Minor improvements to Version string handling

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -33,8 +33,19 @@
     <!-- this file should NEVER be checked-in to SVN, it is in the svn:ignore properties list -->
     <property file="local.properties"/>
 
+    <!-- set any propertise not overridden by local.properties -->
     <property file="${basedir}/release.properties"/>
 
+    <!-- The Jenkins official release builds force: -->
+    <!--    release.official=true                   -->
+    <!--    release.is_branched=true                -->
+    <!--    nsis.home=/opt/nsis/nsis-2.46/          -->
+    <!-- in their "invoke ant" step                 -->
+    <!-- The Packages build (dev downloads) forces: -->
+    <!--    release.official=true                   -->
+    <!--    nsis.home=/opt/nsis/nsis-2.46/          -->
+    <!-- in its "invoke ant" step                   -->
+    
     <property name="release.build_user" value="${user.name}"/>
 
     <property name="release" value="${release.major}.${release.minor}.${release.build}"/>
@@ -45,7 +56,7 @@
         <arg value="--short"/>
         <arg value="HEAD"/>
     </exec>
-
+    <!-- check output of git rev-parse above and place in release.revision_id -->
     <condition property="release.revision_id"
                 value="${git.revision}"
                 else="unknown">
@@ -55,10 +66,13 @@
         </and>
     </condition>
 
+    <!-- RELEASED set in the environment forces release.official to true -->
+    <!-- Unless release.properties file already set it -->
     <condition property="release.official" value="true" else="false">
       <isset property="RELEASED"/>
     </condition>
 
+    <!-- release.is_branched defaults to false unless release.properties file already set -->
     <property name="release.is_branched" value="false"/>
 
     <!-- should compiler warn of use of deprecated APIs? (on/off) -->
@@ -283,7 +297,7 @@
             <format property="TODAY" pattern="yyyyMMdd" timezone="GMT"/>
             <format property="NOW"   pattern="HHmm"     timezone="GMT"/>
         </tstamp>
-        <property name="release.build_date" value="${TODAY}-${NOW}"/>
+        <property name="release.build_date" value="${TODAY}:${NOW}"/>
         <!-- Create the build directory structure used by compile -->
         <quiet>
         <mkdir dir="${target}"/>
@@ -372,6 +386,10 @@
 
 
     <!-- generated source code that uses keyword substitution -->
+    <!-- Typically configured to take a template Version.properties -->
+    <!-- file from java/templates/jmri and copy it, expanded, to -->
+    <!-- java/classes where the jmri.Version class can reference -->
+    <!-- the values at run time -->
     <target name="update-template-code"
             description="create the substituted template java code"
             depends="init">

--- a/java/src/jmri/Version.java
+++ b/java/src/jmri/Version.java
@@ -55,6 +55,12 @@ public class Version {
     /* Has this build been created from a branch in Subversion? */
     static final public boolean branched = Boolean.parseBoolean(versionBundle.getString("release.is_branched")); // NOI18N;
 
+    /**
+     * The Modifier is the third term in the
+     * 1.2.3 version name.  It's not present in production
+     * versions that set it to zero.
+     * Non-official branched versions get an "ish"
+     */
     public static String getModifier() {
         StringBuilder modifier = new StringBuilder("");
 
@@ -62,7 +68,7 @@ public class Version {
             modifier.append(".").append(test);
         }
 
-        if (branched && !official) {
+        if (! (branched && official) ) {
             modifier.append("ish");
         }
 
@@ -73,8 +79,8 @@ public class Version {
      * Provide the current version string.
      * <P>
      * This string is built using various known build parameters, including the
-     * versionBundle.{major,minor,build} values, the SVN revision ID (if known)
-     * and the branched & versionBundle.official statuses.
+     * versionBundle.{major,minor,build} values, the Git revision ID (if known)
+     * and the branched & official properties
      *
      * @return The current version string
      */
@@ -85,13 +91,17 @@ public class Version {
             if ("unknown".equals(revisionId)) {
                 addOn = buildDate + "-" + buildUser;
             } else {
-                addOn = "r" + revisionId;
+                addOn = "R" + revisionId;
             }
             releaseName = major + "." + minor + getModifier() + "-" + addOn;
-        } else if (revisionId.equals("unknown")) {
-            releaseName = buildDate + "-" + buildUser;
-        } else {
-            releaseName = "r" + revisionId;
+        } else { // not branched, so a local build that gets a user name
+            String addOn;
+            if ("unknown".equals(revisionId)) {
+                addOn = buildDate + "-" + buildUser;
+            } else {
+                addOn = buildDate + (!official ? "-"+buildUser :"") + "-R" + revisionId;
+            }
+            releaseName = major + "." + minor + getModifier() + "-" + addOn;
         }
         return releaseName;
     }

--- a/java/test/jmri/VersionTest.java
+++ b/java/test/jmri/VersionTest.java
@@ -56,4 +56,10 @@ public class VersionTest extends TestCase {
         TestSuite suite = new TestSuite(VersionTest.class);
         return suite;
     }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {"-noloading", VersionTest.class.getName()};
+        junit.swingui.TestRunner.main(testCaseName);
+    }
 }


### PR DESCRIPTION
Added lots of comments to build.xml to try to make it clearer where all the info comes from.

Under SVN, the r1234 revision numbers were monotonic, which gave a nice clue in the version numbers.  Git object hashes aren't.  Added a date to the JMRI version number for unofficial (e.g. in your own development area or Jenkins Packages job) builds. 