### PR TITLE
Change time separator in release builds

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -297,7 +297,7 @@
             <format property="TODAY" pattern="yyyyMMdd" timezone="GMT"/>
             <format property="NOW"   pattern="HHmm"     timezone="GMT"/>
         </tstamp>
-        <property name="release.build_date" value="${TODAY}:${NOW}"/>
+        <property name="release.build_date" value="${TODAY}${NOW}"/>
         <!-- Create the build directory structure used by compile -->
         <quiet>
         <mkdir dir="${target}"/>


### PR DESCRIPTION
Can't use a colon : as a time separator in a release name because it prevents using the release name as a Mac OS X file name.