### PR TITLE
Add developerID attribute for LocoNet SV2 devices

### DIFF
--- a/xml/schema/decoder.xsd
+++ b/xml/schema/decoder.xsd
@@ -394,7 +394,20 @@
           <xs:attribute name="numOuts" type="xs:int" />
           <xs:attribute name="lowVersionID" type="xs:int" />
           <xs:attribute name="highVersionID" type="xs:int" />
-          <xs:attribute name="productID" type="xs:string" />
+          <xs:attribute name="productID" type="xs:string" >
+            <xs:annotation><xs:documentation>For a decoder definition which 
+                describes a device implementing the LocoNet SV2 messaging protocol, 
+                this value is used to match a "discovered" device
+                to an appropriate decoder definition</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="developerID" type="xs:int" default="-1" >
+            <xs:annotation><xs:documentation>For a decoder definition which 
+                describes a device implementing the LocoNet SV2 messaging protocol, 
+                this value is used to match a "discovered" device
+                to an appropriate decoder definition</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
           <xs:attribute name="maxInputVolts" type="xs:string" />
           <xs:attribute name="maxMotorCurrent" type="xs:string" />
           <xs:attribute name="maxTotalCurrent" type="xs:string" />


### PR DESCRIPTION
Allows decoder files for LocoNet SV Format 2 devices to provide the device's SV2 developerID value as part of the <decoder><family><model> element.  The value is an integer, and may be used by JMRI SV2 tools when attempting to find a decoder file which corresponds to a device which has been reported by an SV2 Discovery reply message or an SV2 Identify reply message.