### PR TITLE
Add test cases for all implemented RFID protocols and fix some issues…

### DIFF
--- a/java/src/jmri/jmrix/rfid/protocol/coreid/CoreIdRfidProtocol.java
+++ b/java/src/jmri/jmrix/rfid/protocol/coreid/CoreIdRfidProtocol.java
@@ -87,14 +87,15 @@ public class CoreIdRfidProtocol extends RfidProtocol {
 
     @Override
     public boolean isValid(AbstractMRReply msg) {
-        return ((!isConcentrator && msg.getElement(0) == 0x02
+        return (((!isConcentrator && msg.getElement(0) == 0x02
                 && (msg.getElement(SPECIFICMAXSIZE - 1) & 0xFF) == 0x03)
                 || (isConcentrator
                 && msg.getElement(portPosition) >= concentratorFirst
                 && msg.getElement(portPosition) <= concentratorLast
-                && (msg.getElement(SPECIFICMAXSIZE - 1) & 0xFF) == 0x3E)
+                && (msg.getElement(SPECIFICMAXSIZE - 1) & 0xFF) == 0x3E))
                 && (msg.getElement(SPECIFICMAXSIZE - 2) & 0xFF) == 0x0A
-                && (msg.getElement(SPECIFICMAXSIZE - 3) & 0xFF) == 0x0D);
+                && (msg.getElement(SPECIFICMAXSIZE - 3) & 0xFF) == 0x0D
+                && isCheckSumValid(msg));
     }
 
     public boolean isCheckSumValid(AbstractMRReply msg) {

--- a/java/src/jmri/jmrix/rfid/protocol/em18/Em18RfidProtocol.java
+++ b/java/src/jmri/jmrix/rfid/protocol/em18/Em18RfidProtocol.java
@@ -89,12 +89,13 @@ public class Em18RfidProtocol extends RfidProtocol {
 
     @Override
     public boolean isValid(AbstractMRReply msg) {
-        return ((!isConcentrator && msg.getElement(0) != 0x02
+        return (((!isConcentrator && msg.getElement(0) != 0x02
                 && (msg.getElement(SPECIFICMAXSIZE - 1) & 0xFF) != 0x03)
                 || (isConcentrator
                 && msg.getElement(portPosition) >= concentratorFirst
                 && msg.getElement(portPosition) <= concentratorLast
-                && (msg.getElement(SPECIFICMAXSIZE - 1) & 0xFF) != 0x3E));
+                && (msg.getElement(SPECIFICMAXSIZE - 1) & 0xFF) != 0x3E))
+                && isCheckSumValid(msg));
     }
 
     public boolean isCheckSumValid(AbstractMRReply msg) {

--- a/java/src/jmri/jmrix/rfid/protocol/olimex/OlimexRfidProtocol.java
+++ b/java/src/jmri/jmrix/rfid/protocol/olimex/OlimexRfidProtocol.java
@@ -43,7 +43,7 @@ public class OlimexRfidProtocol extends RfidProtocol {
     public String getTag(AbstractMRReply msg) {
         StringBuilder sb = new StringBuilder(10);
 
-        for (int i = 4; i < 14; i++) {
+        for (int i = 3; i < 13; i++) {
             sb.append((char) msg.getElement(i));
         }
 

--- a/java/src/jmri/jmrix/rfid/protocol/seeedstudio/SeeedStudioRfidProtocol.java
+++ b/java/src/jmri/jmrix/rfid/protocol/seeedstudio/SeeedStudioRfidProtocol.java
@@ -88,12 +88,13 @@ public class SeeedStudioRfidProtocol extends RfidProtocol {
 
     @Override
     public boolean isValid(AbstractMRReply msg) {
-        return ((!isConcentrator && msg.getElement(0) == 0x02
+        return (((!isConcentrator && msg.getElement(0) == 0x02
                 && (msg.getElement(SPECIFICMAXSIZE - 1) & 0xFF) == 0x03)
                 || (isConcentrator
                 && msg.getElement(portPosition) >= concentratorFirst
                 && msg.getElement(portPosition) <= concentratorLast
-                && (msg.getElement(SPECIFICMAXSIZE - 1) & 0xFF) == 0x3E));
+                && (msg.getElement(SPECIFICMAXSIZE - 1) & 0xFF) == 0x3E))
+                && isCheckSumValid(msg));
     }
 
     public boolean isCheckSumValid(AbstractMRReply msg) {

--- a/java/test/jmri/jmrix/rfid/PackageTest.java
+++ b/java/test/jmri/jmrix/rfid/PackageTest.java
@@ -38,6 +38,9 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.jmrix.rfid.RfidSystemConnectionMemoTest.suite());
         suite.addTest(jmri.jmrix.rfid.protocol.coreid.CoreIdRfidProtocolTest.suite());
         suite.addTest(jmri.jmrix.rfid.protocol.em18.Em18RfidProtocolTest.suite());
+        suite.addTest(jmri.jmrix.rfid.protocol.olimex.OlimexRfidProtocolTest.suite());
+        suite.addTest(jmri.jmrix.rfid.protocol.parallax.ParallaxRfidProtocolTest.suite());
+        suite.addTest(jmri.jmrix.rfid.protocol.seeedstudio.SeeedStudioRfidProtocolTest.suite());
 
         return suite;
     }

--- a/java/test/jmri/jmrix/rfid/protocol/coreid/CoreIdRfidProtocolTest.java
+++ b/java/test/jmri/jmrix/rfid/protocol/coreid/CoreIdRfidProtocolTest.java
@@ -73,11 +73,11 @@ public class CoreIdRfidProtocolTest extends TestCase {
         // First as stand-alone
         CoreIdRfidProtocol instance = new CoreIdRfidProtocol();
         assertEquals(true, instance.isValid(msgStandalone));
-        assertEquals(true, instance.isValid(msgBadChkSumStandalone));
+        assertEquals(false, instance.isValid(msgBadChkSumStandalone));
         // Now as concentrator
         instance = new CoreIdRfidProtocol('A', 'H', 1);
         assertEquals(true, instance.isValid(msgConcentrator));
-        assertEquals(true, instance.isValid(msgBadChkSumConcentrator));
+        assertEquals(false, instance.isValid(msgBadChkSumConcentrator));
     }
 
     /**

--- a/java/test/jmri/jmrix/rfid/protocol/olimex/OlimexRfidProtocolTest.java
+++ b/java/test/jmri/jmrix/rfid/protocol/olimex/OlimexRfidProtocolTest.java
@@ -1,0 +1,141 @@
+package jmri.jmrix.rfid.protocol.olimex;
+
+import jmri.jmrix.AbstractMRReply;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for the OlimexRfidProtocol class
+ *
+ * @author Matthew Harris
+ */
+public class OlimexRfidProtocolTest extends TestCase {
+
+    AbstractMRReply msgStandalone = new AbstractMRReplyImpl("\r\n-020047C8C3\r\n>");
+    AbstractMRReply msgInvalidStandalone = new AbstractMRReplyImpl("\r\n+020047C8C3\r\n>");
+
+    /**
+     * Test of getMaxSize method, of class OlimexRfidProtocol.
+     */
+    public void testGetMaxSize() {
+        assertEquals(16, OlimexRfidProtocol.getMaxSize());
+    }
+
+    /**
+     * Test of initString method, of class OlimexRfidProtocol.
+     */
+    public void testInitString() {
+        OlimexRfidProtocol instance = new OlimexRfidProtocol();
+        assertEquals("mc00", instance.initString());
+    }
+
+    /**
+     * Test of getTag method, of class OlimexRfidProtocol.
+     */
+    public void testGetTag() {
+        OlimexRfidProtocol instance = new OlimexRfidProtocol();
+        assertEquals("020047C8C3", instance.getTag(msgStandalone));
+    }
+
+    /**
+     * Test of providesChecksum method, of class OlimexRfidProtocol.
+     */
+    public void testProvidesChecksum() {
+        OlimexRfidProtocol instance = new OlimexRfidProtocol();
+        assertEquals(false, instance.providesChecksum());
+    }
+
+    /**
+     * Test of getCheckSum method, of class OlimexRfidProtocol.
+     */
+    public void testGetCheckSum() {
+        OlimexRfidProtocol instance = new OlimexRfidProtocol();
+        assertEquals("", instance.getCheckSum(msgStandalone));
+    }
+
+    /**
+     * Test of isValid method, of class OlimexRfidProtocol.
+     */
+    public void testIsValid() {
+        OlimexRfidProtocol instance = new OlimexRfidProtocol();
+        assertEquals(true, instance.isValid(msgStandalone));
+        assertEquals(false, instance.isValid(msgInvalidStandalone));
+    }
+
+    /**
+     * Test of endOfMessage method, of class OlimexRfidProtocol.
+     */
+    public void testEndOfMessage() {
+        OlimexRfidProtocol instance = new OlimexRfidProtocol();
+        assertEquals(true, instance.endOfMessage(msgStandalone));
+    }
+
+    /**
+     * Test of getReaderPort method, of class CoreIdRfidProtocol.
+     */
+    public void testGetReaderPort() {
+        OlimexRfidProtocol instance = new OlimexRfidProtocol();
+        char expResult = 0x00;
+        assertEquals(expResult, instance.getReaderPort(msgStandalone));
+    }
+
+    /**
+     * Test of toMonitorString method, of class OlimexRfidProtocol.
+     */
+    public void testToMonitorString() {
+        OlimexRfidProtocol instance = new OlimexRfidProtocol();
+        String expResult = "Reply from Olimex reader. Tag read 020047C8C3";
+        assertEquals(expResult, instance.toMonitorString(msgStandalone));
+    }
+
+    class AbstractMRReplyImpl extends AbstractMRReply {
+
+        AbstractMRReplyImpl() {
+            super();
+        }
+
+        AbstractMRReplyImpl(String s) {
+            super(s);
+        }
+
+        @Override
+        protected int skipPrefix(int index) {
+            // doesn't have to do anything
+            return index;
+        }
+    }
+
+    // from here down is testing infrastructure
+    public OlimexRfidProtocolTest(String testName) {
+        super(testName);
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {"-noloading", OlimexRfidProtocolTest.class.getName()};
+        junit.swingui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        TestSuite suite = new TestSuite(OlimexRfidProtocolTest.class);
+        return suite;
+    }
+
+    // The minimal setup for log4J
+    protected void setUp() throws Exception {
+        apps.tests.Log4JFixture.setUp();
+        super.setUp();
+    }
+
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        apps.tests.Log4JFixture.tearDown();
+    }
+
+    static Logger log = LoggerFactory.getLogger(OlimexRfidProtocolTest.class.getName());
+
+}

--- a/java/test/jmri/jmrix/rfid/protocol/parallax/ParallaxRfidProtocolTest.java
+++ b/java/test/jmri/jmrix/rfid/protocol/parallax/ParallaxRfidProtocolTest.java
@@ -1,0 +1,141 @@
+package jmri.jmrix.rfid.protocol.parallax;
+
+import jmri.jmrix.AbstractMRReply;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for the ParallaxRfidProtocol class
+ *
+ * @author Matthew Harris
+ */
+public class ParallaxRfidProtocolTest extends TestCase {
+
+    AbstractMRReply msgStandalone = new AbstractMRReplyImpl("\n7800656EB6\r");
+    AbstractMRReply msgInvalidStandalone = new AbstractMRReplyImpl("\r\n7800656EB6");
+
+    /**
+     * Test of getMaxSize method, of class ParallaxRfidProtocol.
+     */
+    public void testGetMaxSize() {
+        assertEquals(12, ParallaxRfidProtocol.getMaxSize());
+    }
+
+    /**
+     * Test of initString method, of class ParallaxRfidProtocol.
+     */
+    public void testInitString() {
+        ParallaxRfidProtocol instance = new ParallaxRfidProtocol();
+        assertEquals("", instance.initString());
+    }
+
+    /**
+     * Test of getTag method, of class ParallaxRfidProtocol.
+     */
+    public void testGetTag() {
+        ParallaxRfidProtocol instance = new ParallaxRfidProtocol();
+        assertEquals("7800656EB6", instance.getTag(msgStandalone));
+    }
+
+    /**
+     * Test of providesChecksum method, of class ParallaxRfidProtocol.
+     */
+    public void testProvidesChecksum() {
+        ParallaxRfidProtocol instance = new ParallaxRfidProtocol();
+        assertEquals(false, instance.providesChecksum());
+    }
+
+    /**
+     * Test of getCheckSum method, of class ParallaxRfidProtocol.
+     */
+    public void testGetCheckSum() {
+        ParallaxRfidProtocol instance = new ParallaxRfidProtocol();
+        assertEquals("", instance.getCheckSum(msgStandalone));
+    }
+
+    /**
+     * Test of isValid method, of class ParallaxRfidProtocol.
+     */
+    public void testIsValid() {
+        ParallaxRfidProtocol instance = new ParallaxRfidProtocol();
+        assertEquals(true, instance.isValid(msgStandalone));
+        assertEquals(false, instance.isValid(msgInvalidStandalone));
+    }
+
+    /**
+     * Test of endOfMessage method, of class ParallaxRfidProtocol.
+     */
+    public void testEndOfMessage() {
+        ParallaxRfidProtocol instance = new ParallaxRfidProtocol();
+        assertEquals(true, instance.endOfMessage(msgStandalone));
+    }
+
+    /**
+     * Test of getReaderPort method, of class CoreIdRfidProtocol.
+     */
+    public void testGetReaderPort() {
+        ParallaxRfidProtocol instance = new ParallaxRfidProtocol();
+        char expResult = 0x00;
+        assertEquals(expResult, instance.getReaderPort(msgStandalone));
+    }
+
+    /**
+     * Test of toMonitorString method, of class ParallaxRfidProtocol.
+     */
+    public void testToMonitorString() {
+        ParallaxRfidProtocol instance = new ParallaxRfidProtocol();
+        String expResult = "Reply from Parallax reader. Tag read 7800656EB6";
+        assertEquals(expResult, instance.toMonitorString(msgStandalone));
+    }
+
+    class AbstractMRReplyImpl extends AbstractMRReply {
+
+        AbstractMRReplyImpl() {
+            super();
+        }
+
+        AbstractMRReplyImpl(String s) {
+            super(s);
+        }
+
+        @Override
+        protected int skipPrefix(int index) {
+            // doesn't have to do anything
+            return index;
+        }
+    }
+
+    // from here down is testing infrastructure
+    public ParallaxRfidProtocolTest(String testName) {
+        super(testName);
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {"-noloading", ParallaxRfidProtocolTest.class.getName()};
+        junit.swingui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        TestSuite suite = new TestSuite(ParallaxRfidProtocolTest.class);
+        return suite;
+    }
+
+    // The minimal setup for log4J
+    protected void setUp() throws Exception {
+        apps.tests.Log4JFixture.setUp();
+        super.setUp();
+    }
+
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        apps.tests.Log4JFixture.tearDown();
+    }
+
+    static Logger log = LoggerFactory.getLogger(ParallaxRfidProtocolTest.class.getName());
+
+}

--- a/java/test/jmri/jmrix/rfid/protocol/seeedstudio/SeeedStudioRfidProtocolTest.java
+++ b/java/test/jmri/jmrix/rfid/protocol/seeedstudio/SeeedStudioRfidProtocolTest.java
@@ -1,4 +1,4 @@
-package jmri.jmrix.rfid.protocol.em18;
+package jmri.jmrix.rfid.protocol.seeedstudio;
 
 import jmri.jmrix.AbstractMRReply;
 import junit.framework.Test;
@@ -8,77 +8,84 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Tests for the Em18RfidProtocol class
- *
+ * Tests for the SeeedStudioRfidProtocol class
+ * 
+ * SeeedStudio protocol:
+ * 
+ * 1-char - [STX] - 0x02
+ * 10-chars - ASCII representation of 5 Tag ID bytes
+ * 2-chars - ASCII representation of 1 checksum bytes
+ * 1-char - [ETX] - 0x03
+ * 
  * @author Matthew Harris
  */
-public class Em18RfidProtocolTest extends TestCase {
+public class SeeedStudioRfidProtocolTest extends TestCase {
 
-    AbstractMRReply msgStandalone = new AbstractMRReplyImpl("7800656EB6C5");
-    AbstractMRReply msgBadChkSumStandalone = new AbstractMRReplyImpl("7800656EB6C6");
+    AbstractMRReply msgStandalone = new AbstractMRReplyImpl("\u00027800652CC9F8\u0003");
+    AbstractMRReply msgBadChkSumStandalone = new AbstractMRReplyImpl("\u00027800652CC9C6\u0003");
 
     /**
-     * Test of getMaxSize method, of class Em18RfidProtocol.
+     * Test of getMaxSize method, of class SeeedStudioRfidProtocol.
      */
     public void testGetMaxSize() {
-        assertEquals(12, Em18RfidProtocol.getMaxSize());
+        assertEquals(14, SeeedStudioRfidProtocol.getMaxSize());
     }
 
     /**
-     * Test of initString method, of class Em18RfidProtocol.
+     * Test of initString method, of class SeeedStudioRfidProtocol.
      */
     public void testInitString() {
-        Em18RfidProtocol instance = new Em18RfidProtocol();
+        SeeedStudioRfidProtocol instance = new SeeedStudioRfidProtocol();
         assertEquals("", instance.initString());
     }
 
     /**
-     * Test of getTag method, of class Em18RfidProtocol.
+     * Test of getTag method, of class SeeedStudioRfidProtocol.
      */
     public void testGetTag() {
-        Em18RfidProtocol instance = new Em18RfidProtocol();
-        assertEquals("7800656EB6", instance.getTag(msgStandalone));
+        SeeedStudioRfidProtocol instance = new SeeedStudioRfidProtocol();
+        assertEquals("7800652CC9", instance.getTag(msgStandalone));
     }
 
     /**
-     * Test of providesChecksum method, of class Em18RfidProtocol.
+     * Test of providesChecksum method, of class SeeedStudioRfidProtocol.
      */
     public void testProvidesChecksum() {
-        Em18RfidProtocol instance = new Em18RfidProtocol();
+        SeeedStudioRfidProtocol instance = new SeeedStudioRfidProtocol();
         assertEquals(true, instance.providesChecksum());
     }
 
     /**
-     * Test of getCheckSum method, of class Em18RfidProtocol.
+     * Test of getCheckSum method, of class SeeedStudioRfidProtocol.
      */
     public void testGetCheckSum() {
-        Em18RfidProtocol instance = new Em18RfidProtocol();
-        assertEquals("C5", instance.getCheckSum(msgStandalone));
+        SeeedStudioRfidProtocol instance = new SeeedStudioRfidProtocol();
+        assertEquals("F8", instance.getCheckSum(msgStandalone));
     }
 
     /**
-     * Test of isValid method, of class Em18RfidProtocol.
+     * Test of isValid method, of class SeeedStudioRfidProtocol.
      */
     public void testIsValid() {
-        Em18RfidProtocol instance = new Em18RfidProtocol();
+        SeeedStudioRfidProtocol instance = new SeeedStudioRfidProtocol();
         assertEquals(true, instance.isValid(msgStandalone));
         assertEquals(false, instance.isValid(msgBadChkSumStandalone));
     }
 
     /**
-     * Test of isCheckSumValid method, of class Em18RfidProtocol.
+     * Test of isCheckSumValid method, of class SeeedStudioRfidProtocol.
      */
     public void testIsCheckSumValid() {
-        Em18RfidProtocol instance = new Em18RfidProtocol();
+        SeeedStudioRfidProtocol instance = new SeeedStudioRfidProtocol();
         assertEquals(true, instance.isCheckSumValid(msgStandalone));
         assertEquals(false, instance.isCheckSumValid(msgBadChkSumStandalone));
     }
 
     /**
-     * Test of endOfMessage method, of class Em18RfidProtocol.
+     * Test of endOfMessage method, of class SeeedStudioRfidProtocol.
      */
     public void testEndOfMessage() {
-        Em18RfidProtocol instance = new Em18RfidProtocol();
+        SeeedStudioRfidProtocol instance = new SeeedStudioRfidProtocol();
         assertEquals(true, instance.endOfMessage(msgStandalone));
     }
 
@@ -86,17 +93,17 @@ public class Em18RfidProtocolTest extends TestCase {
      * Test of getReaderPort method, of class CoreIdRfidProtocol.
      */
     public void testGetReaderPort() {
-        Em18RfidProtocol instance = new Em18RfidProtocol();
+        SeeedStudioRfidProtocol instance = new SeeedStudioRfidProtocol();
         char expResult = 0x00;
         assertEquals(expResult, instance.getReaderPort(msgStandalone));
     }
 
     /**
-     * Test of toMonitorString method, of class Em18RfidProtocol.
+     * Test of toMonitorString method, of class SeeedStudioRfidProtocol.
      */
     public void testToMonitorString() {
-        Em18RfidProtocol instance = new Em18RfidProtocol();
-        String expResult = "Reply from EM-18 reader. Tag read 7800656EB6 checksum C5 valid? yes";
+        SeeedStudioRfidProtocol instance = new SeeedStudioRfidProtocol();
+        String expResult = "Reply from SeeedStudio reader. Tag read 7800652CC9 checksum F8 valid? yes";
         assertEquals(expResult, instance.toMonitorString(msgStandalone));
     }
 
@@ -118,19 +125,19 @@ public class Em18RfidProtocolTest extends TestCase {
     }
 
     // from here down is testing infrastructure
-    public Em18RfidProtocolTest(String testName) {
+    public SeeedStudioRfidProtocolTest(String testName) {
         super(testName);
     }
 
     // Main entry point
     static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", Em18RfidProtocolTest.class.getName()};
+        String[] testCaseName = {"-noloading", SeeedStudioRfidProtocolTest.class.getName()};
         junit.swingui.TestRunner.main(testCaseName);
     }
 
     // test suite from all defined tests
     public static Test suite() {
-        TestSuite suite = new TestSuite(Em18RfidProtocolTest.class);
+        TestSuite suite = new TestSuite(SeeedStudioRfidProtocolTest.class);
         return suite;
     }
 
@@ -145,6 +152,6 @@ public class Em18RfidProtocolTest extends TestCase {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    static Logger log = LoggerFactory.getLogger(Em18RfidProtocolTest.class.getName());
+    static Logger log = LoggerFactory.getLogger(SeeedStudioRfidProtocolTest.class.getName());
 
 }


### PR DESCRIPTION
… in the protocol implementations found as a result of writing these tests.

Issues fixed include correctly rejecting messages that have an incorrect checksum for CoreID, EM18 and SeeedStudio protocols (Olimex does not provide checksum) and correctly decoding the tag data for Olimex readers.