### PR TITLE
More release process

### DIFF
--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -45,7 +45,7 @@ How best to deal with bringing additional commits into the branch from master - 
 
 ============================================================================
 
-# Existing SVN Build Instructions
+# Current Instructions (Modified from Pre-GitHub Build Instructions)
 
 This is the HOWTO file to make a complete SourceForge downloadable
 distribution.
@@ -64,7 +64,7 @@ If you're attempting to perform this on MS Windows, refer to the MS Windows note
 ================================================================================
 First, we merge in as much tentative content as possible to the SVN trunk.
 
-( ) If it's a new year, update copyright dates (done for 2012):
+( ) If it's a new year, update copyright dates (done for 2015):
 
     * build.xml (3) in the jmri.copyright.years property value
     * site/Copyright.html (3 places)
@@ -73,6 +73,8 @@ First, we merge in as much tentative content as possible to the SVN trunk.
 
 ( ) Bring in all possible sf.net patches, including decoders
 
+( ) Bring in all possible GitHub pull requests
+
 ( ) Check if the decoder definitions have changed since the previous release (almost always true) If so, remake the decoder index.
 
         ant remakedecoderindex
@@ -80,7 +82,7 @@ First, we merge in as much tentative content as possible to the SVN trunk.
         (Check 'session.log' and 'messages.log' located in current directory as,
         in case of errors they might not always be output to the console)
 
-        svn diff as a check.
+        git diff # as a check.
         Commit.
 
 ( ) Update the help/en/Acknowledgements.shtml help page with any recent changes
@@ -113,21 +115,9 @@ First, we merge in as much tentative content as possible to the SVN trunk.
 This group of items it just general code maintenance that we roll into the
 release process.  They can be skipped occasionally.
 
-( ) Check for line ends with the scripts/checkCR.sh script.  Fix those that you find wrong.  (So far, not found a way to do this on Windows...)
-    
-    (To scan, e.g the xml tree, do:
-        find xml -type f -exec ./scripts/checkCR.sh {} \; -print
-    )
-
-    Also, do 
-
-    svn propset svn:eol-style native <file-path-name>
-
-    to fix it for good. (if you hit a 'has binary mime type`, svn propdel svn:mime-type <filename> )
-
 ( ) Check for any files with multiple UTF-8 Byte-Order-Marks.  This shouldn't usually happen but when it does can be a bit tricky to find. Scan from the root of the repository and fix any files found:
 
-        grep -rlI --exclude-dir=.svn $'\xEF\xBB\xBF\xEF\xBB\xBF'
+        grep -rlI --exclude-dir=.git $'\xEF\xBB\xBF\xEF\xBB\xBF'
 
 It might be necessary to use a Hex editor to remove the erroneous extra Byte-Order-Marks - a valid UTF-8 file should only have either one 3-byte BOM (EF BB BF) or no BOM at all.
 
@@ -171,27 +161,6 @@ This will do (more or less) the following actions:
     git push JMRI/JMRI master
     
     git pull
-
-( ) If using the CI system, set up CI builds for that branch
-
-    Sign on to Jenkins
-    Under Test Releases, select "New Item",
-        create the job with the new release name, 
-        using Copy Existing Item with the previous test release
-    Then fix the version number in a couple of places:
-        Description, 
-        and then Source Code Management|Repository URL.
-    Start the first build manually, and make sure it went OK
-
-( ) Move to the releases/ part of the SVN tree on your local machine
-    and update to get the release copy:
-
-    cd ../../branches/jmri/releases
-    svn update 3.11.6
-
-If you don't have this, check out the specific section with 
-    
-    svn co ${SVNREPO}/branches/jmri/releases/3.11.6
     
 ================================================================================
 If you're doing the build using the CI engine, configure it to build the new release:
@@ -208,7 +177,7 @@ If you're doing the build using the CI engine, configure it to build the new rel
 
         Project Name
         Description
-        Git Modules Repository URL
+        Git Modules: Branch
     
 and click "Save"
 
@@ -217,9 +186,13 @@ The build will start shortly.
 ====================================================================================
 For local builds, these are the build instructions; CI builds will already be running)
 
+( ) Get the release in your local work directory
+
+    git checkout release-3.11.6
+
 ( ) edit release.properties to say release.official=true (last line)
 
-( ) setenv SVN_REVISION 23699
+( ) Do the build:
 
     ant -Dnsis.home="" clean packages
 
@@ -241,17 +214,9 @@ puts them at
 
 ================================================================================
 
-If anybody discovers a problem from here on in, they should fix it on a Git branch and have you merge it into the release branch.  CI will automatically rebuild, or you'll have to redo a manual build manually.
+If anybody discovers a problem from here on in, they should fix it on a Git branch and have you pull it into the release branch.  CI will automatically rebuild, or you'll have to redo a manual build manually.
 
-To merge everything to date: 
-
-    svn merge ^/trunk/jmri
-
-If you do this, beware, the first time you'll also merge in the new release.properties file, which you do NOT want to do. You can undo that merge with 'svn revert release.properties'.
-
-To merge a single later revision: 
-
-    svn merge -c <changeset#> ^/trunk/jmri )
+If you do this, beware of merging in the new release.properties file, which you do NOT want to do. (If you do, might be easiest just to edit in the fixes and commit/push it back)
 
 ================================================================================
 Third, we do the release-specific updates.
@@ -364,6 +329,8 @@ GitHub release steps
     
     Click "Publish Release"
     Wait for completion, which might be a while with big uploads
+    
+    (It might be possible to automate this in Ant, see http://stackoverflow.com/questions/24585609/upload-build-artifact-to-github-as-release-in-jenkins and https://github.com/JMRI/JMRI/issues/103 )
     
 ====================================================================================
 Announcement and post-release steps

--- a/scripts/diskimage.sh
+++ b/scripts/diskimage.sh
@@ -48,16 +48,17 @@ rm -f temp.dmg $IMAGEFILE
 
 # create disk image and mount
 
+jmrisize=`du -ms "$INPUT" | awk '{print $1}'`
+imagesize=`expr $jmrisize + 10`
+
 if [ "$SYSTEM" = "MACOSX" ]
 then
-    jmrisize=`du -ms "$INPUT" | awk '{print $1}'`
-    imagesize=`expr $jmrisize + 10`
     
     hdiutil create -size ${imagesize}MB -fs HFS+ -layout SPUD -volname "JMRI ${REL_VER}" "$IMAGEFILE"
     hdiutil attach "$IMAGEFILE" -mountpoint "$tmpdir" -nobrowse
     trap '[ "$EJECTED" = 0 ] && hdiutil eject "$IMAGEFILE"' 0
 else
-    dd if=/dev/zero of="$IMAGEFILE" bs=1M count=100
+    dd if=/dev/zero of="$IMAGEFILE" bs=1m count=${imagesize}
     mkfs.hfsplus -v "JMRI ${REL_VER}" "${IMAGEFILE}"
     sudo mount -t hfsplus -o loop,rw,uid=$UID "$IMAGEFILE" $tmpdir
     trap '[ "$EJECTED" = 0 ] && sudo umount "$tmpdir"' 0


### PR DESCRIPTION
Improve HOWTO-distribution discussion of release process.  Update the script for building Mac OS X .dmg file on Linux so that it pulls a dynamic size for the .dmg file.  There's still no compression compaction on that, so the Linux-built one will be a larger download, but it appears to be working now.