### PR TITLE
formatting of help pages

### DIFF
--- a/help/en/index.html
+++ b/help/en/index.html
@@ -15,6 +15,10 @@
 </head>
 
 <body>
+<!-- This page doesn't have the usual formatting because its  -->
+<!-- only encountered (normally) from the help system. See    -->
+<!-- http://jmri.org/help/en/html/doc/Technical/Help.shtml    -->
+
 <div id="mainContent">
 
 <h1>JMRI Help</h1>
@@ -62,6 +66,7 @@ We're always short of documentation, so if you're interested
 in working with the code or updating some Help files, we'd love to help you <a href="http://jmri.sourceforge.net/help/en/html/doc/Technical/getgitcode.shtml">get started</a>.</p>
 
 </div>
+
 </body>
 </html>
 

--- a/help/en/package/jmri/jmrit/blockboss/SimpleSignalExample.shtml
+++ b/help/en/package/jmri/jmrit/blockboss/SimpleSignalExample.shtml
@@ -20,8 +20,8 @@
 <body>
 <!--#include virtual="/Header" -->
 
-<!--#include virtual="Sidebar" -->
-<div id="mainContent">
+<div class="nomenu" id="mBody">
+ <div id="mainContent">
 
 
 <!-- Page Body -->


### PR DESCRIPTION
Add a comment in the index.html page usually only visible in JavaHelp; formatting of the SSL example page, which had a failed include of the Sidebar.