### PR TITLE
Set default python settings explicitly.

### DIFF
--- a/python.properties
+++ b/python.properties
@@ -14,7 +14,7 @@
 # In addition to normal directories, individual python.path entries may refer to
 # zipfiles containing pure Python modules (in either source or compiled form).
 # Extension modules cannot be imported from zipfiles.
-#python.path=
+python.path=
 
 # Scan the classpath for Java packages if false. This allows Java packages to be
 # imported into a Python script without using "import" statements for each Java
@@ -24,13 +24,13 @@
 # The JMRI default is false for ease of use
 python.cachedir.skip=false
 
-# Use the Jython PythonInterpreter.execfile() method to execute Jython files
+# Use the Jython PythonInterpreter.execfile() method to execute Python files
 # instead of using the PythonInterpreter.eval() method if set to true.
-# Note that Jython code embedded in a panel or run from the Script Input window
+# Note that Python code embedded in a panel or run from the Script Input window
 # will always use the eval() method.
 # Setting this to true will allow unusually large script files to be run (more
 # than 100,000 characters in length).
 # The recommended and default setting is false. If setting jython.exec to true,
 # you may need to also ensure that jmri_bindings.py is executed at application
 # start.
-#jython.exec=true
+jython.exec=false


### PR DESCRIPTION
By including the default values as uncommented values, this may avoid some confusion about how to set these values.