### PR TITLE
Fix several bugs in CPE and PE involving rotated items with margins and

### DIFF
--- a/java/src/jmri/jmrit/display/CoordinateEdit.java
+++ b/java/src/jmri/jmrit/display/CoordinateEdit.java
@@ -467,7 +467,9 @@ public class CoordinateEdit extends JmriJFrame {
         okButton.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent e) {
                 int l = ((Number) spinX.getValue()).intValue();
-                pl.getPopupUtility().setBorderSize(l);
+                PositionablePopupUtil util = pl.getPopupUtility();
+                util.setBorderSize(l);
+                pl.getEditor().setAttributes(util, pl);
                 textX.setText("Border= " + l);
                 dispose();
             }
@@ -503,7 +505,9 @@ public class CoordinateEdit extends JmriJFrame {
         okButton.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent e) {
                 int l = ((Number) spinX.getValue()).intValue();
+                PositionablePopupUtil util = pl.getPopupUtility();
                 pl.getPopupUtility().setMargin(l);
+                pl.getEditor().setAttributes(util, pl);
                 textX.setText("Margin= " + l);
                 dispose();
             }
@@ -552,6 +556,7 @@ public class CoordinateEdit extends JmriJFrame {
                 int width = ((Number) spinY.getValue()).intValue();
                 PositionablePopupUtil util = pl.getPopupUtility();
                 util.setFixedSize(width, height);
+                pl.getEditor().setAttributes(util, pl);
                 textX.setText("Height= " + util.getFixedHeight());
                 textY.setText("Width= " + util.getFixedWidth());
                 dispose();

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -118,9 +118,6 @@ import org.slf4j.LoggerFactory;
 abstract public class Editor extends JmriJFrame implements MouseListener, MouseMotionListener,
         ActionListener, KeyListener, java.beans.VetoableChangeListener {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -8861685536112059782L;
     final public static int BKG = 1;
     final public static int TEMP = 2;
@@ -2911,9 +2908,6 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
 
     class TextAttrDialog extends JDialog {
 
-        /**
-         *
-         */
         private static final long serialVersionUID = 6801138901620891961L;
         Positionable _pos;
         jmri.jmrit.display.palette.DecoratorPanel _decorator;
@@ -2942,9 +2936,9 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
                     PositionablePopupUtil util = _decorator.getPositionablePopupUtil();
                     _decorator.getText(_pos);
                     if (_selectionGroup == null) {
-                        setAttributes(util, _pos, _decorator.isOpaque());
+                        setAttributes(util, _pos);
                     } else {
-                        setSelectionsAttributes(util, _pos, _decorator.isOpaque());
+                        setSelectionsAttributes(util, _pos);
                     }
                     dispose();
                 }
@@ -2971,38 +2965,38 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
      * @param p
      * @param isOpaque
      */
-    protected void setAttributes(PositionablePopupUtil newUtil, Positionable p, boolean isOpaque) {
+    protected void setAttributes(PositionablePopupUtil newUtil, Positionable p) {
         p.setPopupUtility(newUtil.clone(p, p.getTextComponent()));
-        p.setOpaque(isOpaque);
+        int mar = newUtil.getMargin();
+        int bor = newUtil.getBorderSize();
+        javax.swing.border.Border outlineBorder;
+        if (bor == 0) {
+            outlineBorder = BorderFactory.createEmptyBorder(0, 0, 0, 0);
+        } else {
+            outlineBorder = new javax.swing.border.LineBorder(newUtil.getBorderColor(), bor);
+        }
+        javax.swing.border.Border borderMargin;
+        if (newUtil.hasBackground()) {
+            borderMargin = new javax.swing.border.LineBorder(p.getBackground(), mar);
+        } else {
+            borderMargin = BorderFactory.createEmptyBorder(mar, mar, mar, mar);
+        }
         if (p instanceof PositionableLabel) {
             PositionableLabel pos = (PositionableLabel) p;
-            if (!pos.isText() || (pos.isText() && pos.isIcon())) {
-                return;
-            } else {
+            if (pos.isText() && !pos.isIcon()) {
                 int deg = pos.getDegrees();
-                if (deg != 0) {
-                    pos.setOpaque(false);
-                    pos.saveOpaque(isOpaque);
-                    pos.rotate(0);
-                    int mar = newUtil.getMargin();
-                    int bor = newUtil.getBorderSize();
-                    javax.swing.border.Border outlineBorder;
-                    if (bor == 0) {
-                        outlineBorder = BorderFactory.createEmptyBorder(0, 0, 0, 0);
-                    } else {
-                        outlineBorder = new javax.swing.border.LineBorder(newUtil.getBorderColor(), bor);
-                    }
-                    javax.swing.border.Border borderMargin;
-                    if (isOpaque) {
-                        borderMargin = new javax.swing.border.LineBorder(pos.getBackground(), mar);
-                    } else {
-                        borderMargin = BorderFactory.createEmptyBorder(mar, mar, mar, mar);
-                    }
-                    pos.setBorder(new javax.swing.border.CompoundBorder(outlineBorder, borderMargin));
-                    pos.setOpaque(isOpaque);
-                    pos.rotate(deg);
+                pos.rotate(0);
+                pos.setBorder(new javax.swing.border.CompoundBorder(outlineBorder, borderMargin));
+                if (deg == 0) {
+                    p.setOpaque(newUtil.hasBackground());
+                } else {
+                    pos.rotate(deg);                    
                 }
             }
+        } else if (p instanceof PositionableJPanel) {
+            p.setOpaque(newUtil.hasBackground());
+            p.getTextComponent().setOpaque(newUtil.hasBackground());
+            p.setBorder(new javax.swing.border.CompoundBorder(outlineBorder, borderMargin));
         }
         p.updateSize();
         p.repaint();
@@ -3014,11 +3008,11 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
         }
     }
 
-    protected void setSelectionsAttributes(PositionablePopupUtil util, Positionable pos, boolean isOpaque) {
+    protected void setSelectionsAttributes(PositionablePopupUtil util, Positionable pos) {
         if (_selectionGroup != null && _selectionGroup.contains(pos)) {
             for (Positionable p : _selectionGroup) {
                 if (p instanceof PositionableLabel) {
-                    setAttributes(util, p, false);
+                    setAttributes(util, p);
                 }
             }
         }

--- a/java/src/jmri/jmrit/display/MemoryComboIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryComboIcon.java
@@ -33,9 +33,6 @@ import org.slf4j.LoggerFactory;
 public class MemoryComboIcon extends PositionableJPanel
         implements java.beans.PropertyChangeListener, ActionListener {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 5312988172386396581L;
     JComboBox<String> _comboBox;
     ComboModel _model;
@@ -68,12 +65,12 @@ public class MemoryComboIcon extends PositionableJPanel
         }
         setPopupUtility(new PositionablePopupUtil(this, _comboBox));
     }
+    
+    public javax.swing.JComponent getTextComponent() {
+        return _comboBox;
+    }
 
     class ComboModel extends DefaultComboBoxModel<String> {
-
-        /**
-         *
-         */
         private static final long serialVersionUID = 2915042785923780735L;
 
         ComboModel() {

--- a/java/src/jmri/jmrit/display/MemoryIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryIcon.java
@@ -33,13 +33,8 @@ import org.slf4j.LoggerFactory;
  */
 public class MemoryIcon extends PositionableLabel implements java.beans.PropertyChangeListener/*, DropTargetListener*/ {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 5188156981152521812L;
     NamedIcon defaultIcon = null;
-    // the associated Memory object
-    //protected Memory memory = null;
     // the map of icons
     java.util.HashMap<String, NamedIcon> map = null;
     private NamedBeanHandle<Memory> namedMemory;
@@ -47,9 +42,7 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
     public MemoryIcon(String s, Editor editor) {
         super(s, editor);
         resetDefaultIcon();
-        //setIcon(defaultIcon);
         _namedIcon = defaultIcon;
-        //updateSize();
         //By default all memory is left justified
         _popupUtil.setJustification(LEFT);
         this.setTransferHandler(new TransferHandler());
@@ -59,7 +52,6 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
         super(s, editor);
         setDisplayLevel(Editor.LABELS);
         defaultIcon = s;
-        //updateSize();
         _popupUtil.setJustification(LEFT);
         log.debug("MemoryIcon ctor= " + MemoryIcon.class.getName());
         this.setTransferHandler(new TransferHandler());
@@ -224,9 +216,6 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
                 String key = iterator.next().toString();
                 //String value = ((NamedIcon)map.get(key)).getName();
                 popup.add(new AbstractAction(key) {
-                    /**
-                     *
-                     */
                     private static final long serialVersionUID = 8228751338976484794L;
 
                     public void actionPerformed(ActionEvent e) {
@@ -257,9 +246,6 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
                     final jmri.jmrit.dispatcher.ActiveTrain at = df.getActiveTrainForRoster(re);
                     if (at != null) {
                         popup.add(new AbstractAction(Bundle.getMessage("MenuTerminateTrain")) {
-                            /**
-                             *
-                             */
                             private static final long serialVersionUID = 7567050494629070812L;
 
                             public void actionPerformed(ActionEvent e) {
@@ -267,9 +253,6 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
                             }
                         });
                         popup.add(new AbstractAction(Bundle.getMessage("MenuAllocateExtra")) {
-                            /**
-                             *
-                             */
                             private static final long serialVersionUID = 1179666702674214743L;
 
                             public void actionPerformed(ActionEvent e) {
@@ -280,9 +263,6 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
                         });
                         if (at.getStatus() == jmri.jmrit.dispatcher.ActiveTrain.DONE) {
                             popup.add(new AbstractAction(Bundle.getMessage("MenuRestartTrain")) {
-                                /**
-                                 *
-                                 */
                                 private static final long serialVersionUID = -6796040644749115017L;
 
                                 public void actionPerformed(ActionEvent e) {
@@ -292,9 +272,6 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
                         }
                     } else {
                         popup.add(new AbstractAction(Bundle.getMessage("MenuNewTrain")) {
-                            /**
-                             *
-                             */
                             private static final long serialVersionUID = -5264943430258540552L;
 
                             public void actionPerformed(ActionEvent e) {
@@ -320,9 +297,6 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
      */
     public boolean setTextEditMenu(JPopupMenu popup) {
         popup.add(new AbstractAction(Bundle.getMessage("EditMemoryValue")) {
-            /**
-             *
-             */
             private static final long serialVersionUID = -2220596646271191216L;
 
             public void actionPerformed(ActionEvent e) {
@@ -398,7 +372,7 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
                             _saveColor = null;
                         }
                     }
-                    _editor.setAttributes(getPopupUtility(), this, false);
+                    _editor.setAttributes(getPopupUtility(), this);
                 } else if (val instanceof javax.swing.ImageIcon) {
                     _icon = true;
                     _text = false;

--- a/java/src/jmri/jmrit/display/MemorySpinnerIcon.java
+++ b/java/src/jmri/jmrit/display/MemorySpinnerIcon.java
@@ -61,9 +61,9 @@ public class MemorySpinnerIcon extends PositionableJPanel implements ChangeListe
         pos.setMemory(namedMemory.getName());
         return super.finishClone(pos);
     }
-    /*    public JComponent getTextComponent() {
-     return ((JSpinner.DefaultEditor)spinner.getEditor()).getTextField();
-     }*/
+    public javax.swing.JComponent getTextComponent() {
+        return ((JSpinner.DefaultEditor)spinner.getEditor()).getTextField();
+    }
 
     public Dimension getSize() {
         if (debug) {

--- a/java/src/jmri/jmrit/display/Positionable.java
+++ b/java/src/jmri/jmrit/display/Positionable.java
@@ -125,8 +125,6 @@ public interface Positionable extends Cloneable {
 
     public int getDegrees();
 
-    public boolean getSaveOpaque();		// for rotated text
-
     public JComponent getTextComponent();
 
     public void remove();

--- a/java/src/jmri/jmrit/display/PositionableJComponent.java
+++ b/java/src/jmri/jmrit/display/PositionableJComponent.java
@@ -175,10 +175,6 @@ public class PositionableJComponent extends JComponent implements Positionable {
         return 0;
     }
 
-    public boolean getSaveOpaque() {
-        return isOpaque();
-    }
-
     public String getNameString() {
         return getName();
     }

--- a/java/src/jmri/jmrit/display/PositionableJPanel.java
+++ b/java/src/jmri/jmrit/display/PositionableJPanel.java
@@ -172,10 +172,6 @@ public class PositionableJPanel extends JPanel implements Positionable, MouseLis
         return 0;
     }
 
-    public boolean getSaveOpaque() {
-        return isOpaque();
-    }
-
     public JComponent getTextComponent() {
         return this;
     }

--- a/java/src/jmri/jmrit/display/PositionableLabel.java
+++ b/java/src/jmri/jmrit/display/PositionableLabel.java
@@ -34,9 +34,6 @@ import org.slf4j.LoggerFactory;
  */
 public class PositionableLabel extends JLabel implements Positionable {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 2620446240151660560L;
 
     public static final ResourceBundle rbean = ResourceBundle.getBundle("jmri.NamedBeanBundle");
@@ -251,7 +248,6 @@ public class PositionableLabel extends JLabel implements Positionable {
             pos.setPopupUtility(getPopupUtility().clone(pos, pos.getTextComponent()));
         }
         pos.setOpaque(isOpaque());
-        pos._saveOpaque = _saveOpaque;
         if (_namedIcon != null) {
             pos._namedIcon = cloneIcon(_namedIcon, pos);
             pos.setIcon(pos._namedIcon);
@@ -651,39 +647,28 @@ public class PositionableLabel extends JLabel implements Positionable {
         }
         return ((NamedIcon) getIcon()).getScale();
     }
-
-    private boolean _saveOpaque;
-
-    public void saveOpaque(boolean set) {
-        _saveOpaque = set;
-    }
-
-    public boolean getSaveOpaque() {
-        return _saveOpaque;
-    }
-
+    
     public void rotate(int deg) {
         _degrees = deg;
         if (_rotateText) {
             if (deg == 0) {				// restore unrotated whatever
                 _rotateText = false;
-                if (_text && _icon) {	// restore horizontal icon and its text
-                    String url = _namedIcon.getURL();
-                    _namedIcon = new NamedIcon(url, url);
+                if(_text) {
                     super.setText(_unRotatedText);
-                    setIcon(new NamedIcon(url, url));
-                } else if (_text) {		// restore original text as a label
-                    setIcon(null);
-                    _namedIcon = null;
-                    super.setText(_unRotatedText);
-                    setOpaque(_saveOpaque);
-                    _popupUtil.setBorder(true);
+                    setOpaque( _popupUtil.hasBackground());
+                    if (_icon) {
+                        String url = _namedIcon.getURL();
+                        _namedIcon = new NamedIcon(url, url);                        
+                    } else {
+                        _namedIcon = null;
+                        _popupUtil.setBorder(true);
+                    }
+                    setIcon(_namedIcon);
                 } else {
                     _namedIcon.rotate(deg, this);
                     setIcon(_namedIcon);
                 }
             } else {
-                setOpaque(_saveOpaque);
                 if (_text & _icon) {	// update text over icon
                     _namedIcon = makeTextOverlaidIcon(_unRotatedText, _namedIcon);
                 } else if (_text) {		// update text only icon image        			
@@ -691,7 +676,7 @@ public class PositionableLabel extends JLabel implements Positionable {
                 }
                 _namedIcon.rotate(deg, this);
                 setIcon(_namedIcon);
-                setOpaque(false);
+                setOpaque(false);   // rotations cannot be opaque
             }
         } else {
             if (deg != 0) {	// first time text or icon is rotated from horizontal
@@ -700,7 +685,6 @@ public class PositionableLabel extends JLabel implements Positionable {
                     super.setText(null);
                     _rotateText = true;
                 } else if (_text) {
-                    _saveOpaque = isOpaque();
                     _namedIcon = makeTextIcon(_unRotatedText);
                     super.setText(null);
                     _rotateText = true;
@@ -814,7 +798,7 @@ public class PositionableLabel extends JLabel implements Positionable {
                 RenderingHints.VALUE_INTERPOLATION_BICUBIC);
 
         if (_popupUtil != null) {
-            if (/*isOpaque() &&*/_popupUtil.getBackground() != null) {
+            if ( _popupUtil.hasBackground()) {
                 g2d.setColor(_popupUtil.getBackground());
                 g2d.fillRect(0, 0, width, height);
             }

--- a/java/src/jmri/jmrit/display/PositionablePopupUtil.java
+++ b/java/src/jmri/jmrit/display/PositionablePopupUtil.java
@@ -2,9 +2,7 @@
 package jmri.jmrit.display;
 
 import java.awt.Color;
-import java.awt.Container;
 import java.awt.Font;
-import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
@@ -32,6 +30,7 @@ import org.slf4j.LoggerFactory;
  * Justification.
  * </p>
  *
+ * moved from PositionableLabel
  * @author Pete Cressman copyright (C) 2010
  * @version $I $
  */
@@ -41,6 +40,7 @@ public class PositionablePopupUtil {
     protected JComponent _textComponent;    // closest ancestor for JLabel and JTextField
     protected int _textType;                // JComponent does not have text, used for casting
     protected Positionable _parent;
+    protected PositionablePopupUtil _self;
     protected PositionablePropertiesUtil _propertiesUtil;
 
     private Color defaultForeground;
@@ -61,6 +61,7 @@ public class PositionablePopupUtil {
             _textType = JCOMPONENT;
         }
         _textComponent = textComp;
+        _self = this;
         debug = log.isDebugEnabled();
         defaultForeground = _textComponent.getForeground();
         defaultBackground = _textComponent.getBackground();
@@ -82,6 +83,7 @@ public class PositionablePopupUtil {
         util.setOrientation(getOrientation());
         util.setBackgroundColor(getBackground());
         util.setForeground(getForeground());
+        util.setHasBackground(hasBackground());     // must do this AFTER setBackgroundColor
         return util;
     }
 
@@ -105,6 +107,7 @@ public class PositionablePopupUtil {
     private Color borderColor = null;
     private Border borderMargin = BorderFactory.createEmptyBorder(0, 0, 0, 0);
     private Border outlineBorder = BorderFactory.createEmptyBorder(0, 0, 0, 0);
+    private boolean _hasBackground;      // Should background be painted or clear
 
     JMenuItem italic = null;
     JMenuItem bold = null;
@@ -181,11 +184,8 @@ public class PositionablePopupUtil {
         margin = m;
         if (_parent.isOpaque()) {
             borderMargin = new LineBorder(getBackground(), m);
-            //_parent.setBorder(new LineBorder(setBackground(), m));
-
         } else {
             borderMargin = BorderFactory.createEmptyBorder(m, m, m, m);
-            //_parent.setBorder(BorderFactory.createEmptyBorder(m, m, m, m));
         }
         if (_showBorder) {
             _parent.setBorder(new CompoundBorder(outlineBorder, borderMargin));
@@ -242,7 +242,7 @@ public class PositionablePopupUtil {
     public void setBorder(boolean set) {
         _showBorder = set;
         if (set) {
-            if (borderColor != null) {
+            if (borderColor != null && _showBorder) {
                 outlineBorder = new LineBorder(borderColor, borderSize);
                 _parent.setBorder(new CompoundBorder(outlineBorder, borderMargin));
             }
@@ -281,23 +281,35 @@ public class PositionablePopupUtil {
 
     public void setBackgroundColor(Color color) {
         if (color == null) {
-            _textComponent.setOpaque(false);
-            _parent.setOpaque(false);
+            _hasBackground = false;
         } else {
-            _textComponent.setOpaque(true);
+            _hasBackground = true;
             _textComponent.setBackground(color);
-            _parent.setOpaque(true);
             _parent.setBackground(color);
         }
-        setMargin(margin);  //This rebuilds margin and sets it colour.
+        if (_hasBackground) {
+            setMargin(margin);  //This rebuilds margin and sets it colour.            
+        }
         _parent.updateSize();
     }
+    
+    public void setHasBackground(boolean set) {
+        _hasBackground = set;
+        if (_textComponent instanceof PositionableJPanel) {
+            _textComponent.setOpaque(_hasBackground);
+        }
+        if (!_hasBackground) {
+            _parent.setOpaque(false);            
+        }
+    }
+
+    public boolean hasBackground() {
+        return _hasBackground;
+    }
+
 
     public Color getBackground() {
-        if (_textComponent.isOpaque()) {
-            return _textComponent.getBackground();            
-        }
-        return null;
+        return _textComponent.getBackground();            
     }
 
     protected JMenu makeFontSizeMenu() {
@@ -347,7 +359,6 @@ public class PositionablePopupUtil {
 
     public void setFontSize(float newSize) {
         _textComponent.setFont(jmri.util.FontUtil.deriveFont(_textComponent.getFont(), newSize));
-        //setSize(getPreferredSize().width, getPreferredSize().height);
         _parent.updateSize();
     }
 
@@ -491,7 +502,8 @@ public class PositionablePopupUtil {
                         break;
                     case BACKGROUND_COLOR:
                         if (desiredColor == null) {
-                            _textComponent.setOpaque(false);
+                            _self.setHasBackground(false);
+/*                            _textComponent.setOpaque(false);
                             _parent.setOpaque(false);
                             //We need to force a redisplay when going to clear as the area
                             //doesn't always go transparent on the first click.
@@ -500,17 +512,21 @@ public class PositionablePopupUtil {
                             int h = _parent.getHeight();
                             Container parent = _parent.getParent();
                             // force redisplay
-                            setMargin(margin);  //This rebuilds margin and clears it colour.
+                            if(_hasBackground) {
+                                setMargin(margin);  //This rebuilds margin and clears it color.                                
+                            }
                             parent.revalidate();
-                            parent.repaint(p.x, p.y, w, h);
+                            parent.repaint(p.x, p.y, w, h);*/
                         } else {
                             setBackgroundColor(desiredColor);
-                        }
+                            _self.setHasBackground(true);
+                       }
                         break;
                     case BORDER_COLOR:
                         setBorderColor(desiredColor);
                         break;
                 }
+                _parent.getEditor().setAttributes(_self, _parent);
             }
 
             ActionListener init(Color c) {

--- a/java/src/jmri/jmrit/display/SensorIcon.java
+++ b/java/src/jmri/jmrit/display/SensorIcon.java
@@ -11,6 +11,7 @@ import java.util.Map.Entry;
 import javax.swing.AbstractAction;
 import javax.swing.ButtonGroup;
 import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JComponent;
 import javax.swing.JMenu;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButtonMenuItem;
@@ -949,6 +950,24 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
         }
 
         @Override
+        public SensorPopupUtil clone(Positionable parent, JComponent textComp) {
+            SensorPopupUtil util = new SensorPopupUtil(parent, textComp);
+            util.setJustification(getJustification());
+            util.setHorizontalAlignment(getJustification());
+            util.setFixedWidth(getFixedWidth());
+            util.setFixedHeight(getFixedHeight());
+            util.setMargin(getMargin());
+            util.setBorderSize(getBorderSize());
+            util.setBorderColor(getBorderColor());
+            util.setFont(util.getFont().deriveFont(getFontStyle()));
+            util.setFontSize(getFontSize());
+            util.setOrientation(getOrientation());
+            util.setBackgroundColor(getBackground());
+            util.setForeground(getForeground());
+            util.setHasBackground(hasBackground());     // must do this AFTER setBackgroundColor
+            return util;
+        }
+        @Override
         public void setTextJustificationMenu(JPopupMenu popup) {
             if (isText()) {
                 super.setTextJustificationMenu(popup);
@@ -1028,7 +1047,8 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
                             break;
                         case BACKGROUND_COLOR:
                             if (color == null) {
-                                setOpaque(false);
+                                _self.setHasBackground(false);
+/*                                setOpaque(false);
                                 //We need to force a redisplay when going to clear as the area
                                 //doesn't always go transparent on the first click.
                                 java.awt.Point p = getLocation();
@@ -1037,9 +1057,10 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
                                 java.awt.Container parent = getParent();
                                 // force redisplay
                                 parent.revalidate();
-                                parent.repaint(p.x, p.y, w, h);
+                                parent.repaint(p.x, p.y, w, h);*/
                             } else {
                                 setBackgroundColor(desiredColor);
+                                _self.setHasBackground(true);
                             }
                             break;
                         case BORDER_COLOR:
@@ -1056,9 +1077,11 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
                             break;
                         case ACTIVE_BACKGROUND_COLOR:
                             setBackgroundActive(desiredColor);
+                            _self.setHasBackground(true);
                             break;
                         case INACTIVE_FONT_COLOR:
                             setTextInActive(desiredColor);
+                            _self.setHasBackground(true);
                             break;
                         case INACTIVE_BACKGROUND_COLOR:
                             setBackgroundInActive(desiredColor);
@@ -1072,7 +1095,8 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
                         default:
                             break;
                     }
-                }
+                    _parent.getEditor().setAttributes(_self, _parent);
+               }
             };
             JRadioButtonMenuItem r = new JRadioButtonMenuItem(name);
             r.addActionListener(a);
@@ -1082,7 +1106,11 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
                     setColorButton(getForeground(), color, r);
                     break;
                 case BACKGROUND_COLOR:
-                    setColorButton(getBackground(), color, r);
+                    if (hasBackground()) {
+                        setColorButton(getBackground(), color, r);                       
+                    } else {
+                        setColorButton(null, color, r);                        
+                    }
                     break;
                 case BORDER_COLOR:
                     setColorButton(getBorderColor(), color, r);

--- a/java/src/jmri/jmrit/display/configurexml/PositionableLabelXml.java
+++ b/java/src/jmri/jmrit/display/configurexml/PositionableLabelXml.java
@@ -74,11 +74,12 @@ public class PositionableLabelXml extends AbstractXmlAdapter {
         element.setAttribute("green", "" + util.getForeground().getGreen());
         element.setAttribute("blue", "" + util.getForeground().getBlue());
 
-        if (p.isOpaque() || p.getSaveOpaque()) {
-            element.setAttribute("redBack", "" + util.getBackground().getRed());
-            element.setAttribute("greenBack", "" + util.getBackground().getGreen());
-            element.setAttribute("blueBack", "" + util.getBackground().getBlue());
-        }
+        element.setAttribute("hasBackground", util.hasBackground() ? "yes" : "no");
+        // store default regardless
+        element.setAttribute("redBack", "" + util.getBackground().getRed());
+        element.setAttribute("greenBack", "" + util.getBackground().getGreen());
+        element.setAttribute("blueBack", "" + util.getBackground().getBlue());
+
         if (util.getMargin() != 0) {
             element.setAttribute("margin", "" + util.getMargin());
         }
@@ -306,6 +307,12 @@ public class PositionableLabelXml extends AbstractXmlAdapter {
         } catch (NullPointerException e) {  // considered normal if the attributes are not present
         }
 
+        a = element.getAttribute("hasBackground");
+        if (a!=null) {
+            util.setHasBackground("yes".equals(a.getValue()));            
+        } else {
+            util.setHasBackground(true);                        
+        }
         try {
             int red = element.getAttribute("redBack").getIntValue();
             int blue = element.getAttribute("blueBack").getIntValue();
@@ -314,9 +321,9 @@ public class PositionableLabelXml extends AbstractXmlAdapter {
         } catch (org.jdom2.DataConversionException e) {
             log.warn("Could not parse background color attributes!");
         } catch (NullPointerException e) {
-            util.setBackgroundColor(null);// if the attributes are not listed, we consider the background as clear.
+            util.setHasBackground(false);// if the attributes are not listed, we consider the background as clear.
         }
-
+        
         int fixedWidth = 0;
         int fixedHeight = 0;
         try {

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -64,6 +64,7 @@ import jmri.jmrit.display.PositionableJComponent;
 import jmri.jmrit.display.PositionableJPanel;
 import jmri.jmrit.display.PositionableLabel;
 import jmri.jmrit.display.PositionablePopupUtil;
+import jmri.jmrit.display.SensorIcon;
 import jmri.jmrit.display.ToolTip;
 import jmri.jmrit.display.controlPanelEditor.shape.ShapeDrawer;
 import jmri.jmrit.display.palette.ItemPalette;
@@ -99,10 +100,6 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class ControlPanelEditor extends Editor implements DropTargetListener, ClipboardOwner {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 2767111074938103944L;
     public boolean _debug;
     protected JMenuBar _menuBar;
@@ -1704,11 +1701,14 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
                 popup.addSeparator();
                 popupSet = false;
             }
-            popupSet = p.setTextEditMenu(popup);
             if (p instanceof PositionableLabel) {
                 PositionableLabel pl = (PositionableLabel) p;
                 if (!pl.isIcon()) {
                     popupSet |= setTextAttributes(pl, popup);
+                } else if (p instanceof SensorIcon) {
+                    popup.add(CoordinateEdit.getTextEditAction((SensorIcon)p, "OverlayText"));
+                } else {
+                    popupSet = p.setTextEditMenu(popup);                
                 }
             } else if (p instanceof PositionableJPanel) {
                 popupSet |= setTextAttributes(p, popup);


### PR DESCRIPTION
Fix several bugs in CPE and PE involving rotated items with margins and
borders (Text, the 4 Memory types and Sensors). Fixed inability to save
items with transparent backgrounds.  Layout Editor inherits most of these fixes from PE