### PR TITLE
Refactor monitor filtering and fix for LocoNet

### DIFF
--- a/java/src/jmri/jmrix/AbstractMonPane.java
+++ b/java/src/jmri/jmrix/AbstractMonPane.java
@@ -431,21 +431,12 @@ public abstract class AbstractMonPane extends JmriPanel {
         if (freezeButton.isSelected()) {
             return;
         }
-        //note: raw is now formatted like "Tx - BB 01 00 45", so extract the correct bytes from it (BB) for comparison
-        //don't bother to check filter if no raw value passed
-        if (raw != null && raw.length() >= 7) {
-            // if first bytes are in the skip list,  exit without adding to the Swing thread
-            String[] filters = filterField.getText().toUpperCase().split(" ");
-            String checkRaw = raw.substring(5, 7);
-
-            for (String s : filters) {
-                if (s.equals(checkRaw)) {
-                    linesBuffer.setLength(0);
-                    return;
-                }
-            }
+        
+        // if this message is filtered out, end
+        if (isFiltered(raw)) {
+            return;
         }
-
+        
         Runnable r = new Runnable() {
             @Override
             public void run() {
@@ -467,6 +458,30 @@ public abstract class AbstractMonPane extends JmriPanel {
         javax.swing.SwingUtilities.invokeLater(r);
     }
 
+    /**
+     * Default filtering implementation, more of an example
+     * than anything else, not clear it really works
+     * for any system.  Override this in system-specific subclasses to do something 
+     * useful.
+     */
+    protected boolean isFiltered(String raw) {
+        //note: raw is now formatted like "Tx - BB 01 00 45", so extract the correct bytes from it (BB) for comparison
+        //don't bother to check filter if no raw value passed
+        if (raw != null && raw.length() >= 7) {
+            // if first bytes are in the skip list,  exit without adding to the Swing thread
+            String[] filters = filterField.getText().toUpperCase().split(" ");
+            String checkRaw = raw.substring(5, 7);
+
+            for (String s : filters) {
+                if (s.equals(checkRaw)) {
+                    linesBuffer.setLength(0);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    
     String newline = System.getProperty("line.separator"); // NOI18N
 
     public synchronized void clearButtonActionPerformed(java.awt.event.ActionEvent e) {
@@ -549,7 +564,7 @@ public abstract class AbstractMonPane extends JmriPanel {
     // to get a time string
     DateFormat df = new SimpleDateFormat("HH:mm:ss.SSS");
 
-    StringBuffer linesBuffer = new StringBuffer();
+    protected StringBuffer linesBuffer = new StringBuffer();
     static private int MAX_LINES = 500;
 
     private static final Logger log = LoggerFactory.getLogger(AbstractMonFrame.class.getName());

--- a/java/src/jmri/jmrix/loconet/locomon/LocoMonPane.java
+++ b/java/src/jmri/jmrix/loconet/locomon/LocoMonPane.java
@@ -93,6 +93,23 @@ public class LocoMonPane extends jmri.jmrix.AbstractMonPane implements LocoNetLi
 
     jmri.jmrix.loconet.locomon.Llnmon llnmon = new jmri.jmrix.loconet.locomon.Llnmon();
 
+    protected boolean isFiltered(String raw) {
+        //expects raw to be formatted like "BB 01 00 45", so extract the value of the 1st byte
+        if (raw != null && raw.length() >= 7) {
+            // if first bytes are in the skip list,  exit without adding to the Swing thread
+            String[] filters = filterField.getText().toUpperCase().split(" ");
+            String checkRaw = raw.substring(0, 2);
+
+            for (String s : filters) {
+                if (s.equals(checkRaw)) {
+                    linesBuffer.setLength(0);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     /**
      * Nested class to create one of these using old-style defaults
      */

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <!--Written by JMRI version 4.1.3ish-R9cbcaa1 on Sun Nov 01 10:38:40 PST 2015 $Id$-->
-  <decoderIndex version="670">
+  <!--Written by JMRI version 4.1.3ish-R08ef8d5 on Sun Nov 01 10:50:37 PST 2015 $Id$-->
+  <decoderIndex version="672">
     <mfgList nmraListDate="2015-03-06" updated="2015-03-25" lastadd="107,124,126,128,134">
       <manufacturer mfg="NMRA" mfgID="999" />
       <manufacturer mfg="A-Train Electronics" mfgID="137" />
@@ -3607,6 +3607,9 @@
           <size length="20" width="12" height="1.9" units="mm" />
         </model>
         <model model="SH10A (firmware 1.05+)" numOuts="0" numFns="0" productID="SH10A_1.05" comment="SH10A with firmware 1.05 or later" maxInputVolts="30V" connector="SUSI">
+          <size length="20" width="12" height="1.9" units="mm" />
+        </model>
+        <model model="SH10A (firmware 1.06+)" numOuts="0" numFns="0" productID="SH10A_1.06" comment="SH10A with firmware 1.06 or later" maxInputVolts="30V" connector="SUSI">
           <size length="20" width="12" height="1.9" units="mm" />
         </model>
       </family>

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <!--Written by JMRI version 4.1.3ish-R96c9883 on Thu Oct 29 09:24:34 AEDT 2015 $Id$-->
-  <decoderIndex version="666">
+  <!--Written by JMRI version 4.1.3ish-R9cbcaa1 on Sun Nov 01 10:38:40 PST 2015 $Id$-->
+  <decoderIndex version="670">
     <mfgList nmraListDate="2015-03-06" updated="2015-03-25" lastadd="107,124,126,128,134">
       <manufacturer mfg="NMRA" mfgID="999" />
       <manufacturer mfg="A-Train Electronics" mfgID="137" />
@@ -266,6 +266,7 @@
           <output name="2" label="rearlight" />
         </model>
         <functionlabels>
+          <functionlabel num="0" lockable="true">Headlight</functionlabel>
           <functionlabel num="1" lockable="true">Bell</functionlabel>
           <functionlabel num="2" lockable="false">Whistle</functionlabel>
           <functionlabel num="3" lockable="true">Coupler</functionlabel>
@@ -352,6 +353,44 @@
         <functionlabels>
           <functionlabel num="0" lockable="true">L1-L4</functionlabel>
           <functionlabel num="7" lockable="true">L5</functionlabel>
+        </functionlabels>
+      </family>
+      <family name="Paragon 3" mfg="Broadway Limited Imports, LLC" file="BLI_Paragon3_Steam.xml">
+        <model model="Steam" numOuts="3" numFns="30" connector="9pin">
+          <versionCV lowVersionID="32" highVersionID="63" />
+          <output name="1" label="headlight" />
+          <output name="2" label="rearlight" />
+        </model>
+        <functionlabels>
+          <functionlabel num="0" lockable="true">Headlight</functionlabel>
+          <functionlabel num="1" lockable="true">Bell</functionlabel>
+          <functionlabel num="2" lockable="false">Whistle</functionlabel>
+          <functionlabel num="3" lockable="true">Coupler</functionlabel>
+          <functionlabel num="4" lockable="true">Air Pump</functionlabel>
+          <functionlabel num="5" lockable="true">Blow Down/Chuff Up</functionlabel>
+          <functionlabel num="6" lockable="true">Water Fill/Chuff Dn</functionlabel>
+          <functionlabel num="7" lockable="true">Smoke Control</functionlabel>
+          <functionlabel num="8" lockable="true">Mute/Master Volume</functionlabel>
+          <functionlabel num="9" lockable="true">Shutdown and Startup</functionlabel>
+          <functionlabel num="10" lockable="true">Shovel Coal</functionlabel>
+          <functionlabel num="11" lockable="true">Water Injector</functionlabel>
+          <functionlabel num="12" lockable="true">Brake Set/Release/Squeal</functionlabel>
+          <functionlabel num="13" lockable="true">Horn Grade Crossing</functionlabel>
+          <functionlabel num="14" lockable="true">Passenger Sounds</functionlabel>
+          <functionlabel num="15" lockable="true">Freight Sounds</functionlabel>
+          <functionlabel num="16" lockable="true">Maintenance Sounds</functionlabel>
+          <functionlabel num="17" lockable="true">Radio Chatter</functionlabel>
+          <functionlabel num="18" lockable="true">City Sounds</functionlabel>
+          <functionlabel num="19" lockable="true">Farm Sounds</functionlabel>
+          <functionlabel num="20" lockable="true">Industrial Sounds</functionlabel>
+          <functionlabel num="21" lockable="true">Lumber Sounds</functionlabel>
+          <functionlabel num="22" lockable="true">Horn2</functionlabel>
+          <functionlabel num="23" lockable="true">Track Sounds</functionlabel>
+          <functionlabel num="24" lockable="true">Aux Light Control</functionlabel>
+          <functionlabel num="25" lockable="true">Long Whistle</functionlabel>
+          <functionlabel num="26" lockable="true">Play Macro</functionlabel>
+          <functionlabel num="27" lockable="true">Record Macro</functionlabel>
+          <functionlabel num="28" lockable="true">Brake Squeal</functionlabel>
         </functionlabels>
       </family>
       <family name="E-Z Command decoders" mfg="Bachmann Trains" file="Bachmann_EZDCC.xml">
@@ -5384,6 +5423,18 @@
       </family>
       <family name="DCCACC" mfg="MERG" comment="DCCACC is a stationary decoder, but it can be programmed in the usual way" file="MERG_DCCACC.xml">
         <model model="DCCACC" />
+      </family>
+      <family name="BTLocobridge" mfg="MGP" type="stationary" comment="Bluetooth LocoNet interface" file="MGP_BT_LocoBridge.xml">
+        <model model="BTLocobridge" lowVersionID="1" />
+      </family>
+      <family name="Panel" mfg="MGP" type="stationary" comment="Panel, a LocoNet decoder control panels" file="MGP_Panel.xml">
+        <model model="Panel" lowVersionID="1" />
+      </family>
+      <family name="Servo5" mfg="MGP" type="stationary" comment="Servo5, a LocoNet decoder for railway switches" file="MGP_Servo5.xml">
+        <model model="Servo5" lowVersionID="1" />
+      </family>
+      <family name="Signal10" mfg="MGP" type="stationary" comment="Signal10, a LocoNet decoder for railway signals" file="MGP_Signal10.xml">
+        <model model="Signal10" lowVersionID="1" />
       </family>
       <family name="MRC 14/28/128 step decoders" mfg="MRC" file="MRC_128step.xml">
         <model model="AD322" lowVersionID="32" formFactor="N" numOuts="4" numFns="6">
@@ -10655,116 +10706,134 @@
           <!-- headlight-->
         </model>
       </family>
+      <family name="Lighting Decoder" mfg="SoundTraxx (Throttle-Up)" comment="Athearn Genesis Bay-Window Caboose" file="SoundTraxx_Lighting_Athearn_Genesis_Caboose.xml">
+        <model model="Athearn Genesis Bay-Window Caboose" numOuts="2" numFns="14" connector="other" productID="???">
+          <versionCV lowVersionID="1" />
+          <!-- Function Mapping Table / page 17 -->
+          <output name="1" label="  Marker Lamp B  " />
+          <!-- FX0F      -->
+          <output name="2" label="  Marker Lamp A  " />
+          <!-- FX0R      -->
+          <output name="Grade Crossing Logic" label="(Horn)" />
+          <!-- XingLogic -->
+          <output name="FX5" label="  Interior Light  " />
+          <!-- FX5       -->
+          <output name="FX6" label="        n.c.      " />
+          <!-- FX6       -->
+          <output name="Dimming" />
+          <!-- Dimming   -->
+        </model>
+      </family>
       <family name="MC Motor Decoders" mfg="SoundTraxx (Throttle-Up)" file="SoundTraxx_MC.xml">
         <model model="MC1Z102P6" numOuts="2" numFns="14" connector="other" productID="851001">
           <versionCV lowVersionID="80" />
-          <output name="Xing Logic" />
-          <output name="FX5" label=" Rule 17">
-            <label xml:lang="it">Regola 17</label>
+          <output name="3" label="Xing|Logic" />
+          <output name="4" label="FX5|Rule 17">
+            <label xml:lang="it">FX5|Regola 17</label>
           </output>
-          <output name="FX6" label="Mode">
-            <label xml:lang="it">Modo</label>
+          <output name="5" label="FX6|Mode">
+            <label xml:lang="it">FX6|Modo</label>
           </output>
-          <output name="Dimmer" />
-          <output name="Brakes" />
+          <output name="6" label="Dimmer| " />
+          <output name="7" label="Brakes| " />
         </model>
         <model model="MC1Z102SQ" numOuts="2" numFns="14" connector="other" productID="851002">
           <versionCV lowVersionID="80" />
-          <output name="Xing Logic" />
-          <output name="FX5" label=" Rule 17">
-            <label xml:lang="it">Regola 17</label>
+          <output name="3" label="Xing|Logic" />
+          <output name="4" label="FX5|Rule 17">
+            <label xml:lang="it">FX5|Regola 17</label>
           </output>
-          <output name="FX6" label="Mode">
-            <label xml:lang="it">Modo</label>
+          <output name="5" label="FX6|Mode">
+            <label xml:lang="it">FX6|Modo</label>
           </output>
-          <output name="Dimmer" />
-          <output name="Brakes" />
+          <output name="6" label="Dimmer| " />
+          <output name="7" label="Brakes| " />
         </model>
         <model model="MC1H102P8" numOuts="2" numFns="14" connector="other" productID="852001">
           <versionCV lowVersionID="80" />
-          <output name="Xing Logic" />
-          <output name="FX5" label=" Rule 17">
-            <label xml:lang="it">Regola 17</label>
+          <output name="3" label="Xing|Logic" />
+          <output name="4" label="FX5|Rule 17">
+            <label xml:lang="it">FX5|Regola 17</label>
           </output>
-          <output name="FX6" label="Mode">
-            <label xml:lang="it">Modo</label>
+          <output name="5" label="FX6|Mode">
+            <label xml:lang="it">FX6|Modo</label>
           </output>
-          <output name="Dimmer" />
-          <output name="Brakes" />
+          <output name="6" label="Dimmer| " />
+          <output name="7" label="Brakes| " />
         </model>
         <model model="MC2H104AT" numOuts="4" numFns="14" connector="other" productID="852002">
           <versionCV lowVersionID="96" />
-          <output name="Xing Logic" />
-          <output name="3" label="  FX5  " />
-          <output name="4" label="  FX6  " />
-          <output name="Dimmer" />
-          <output name="Brakes" />
+          <output name="3" label="Xing|Logic" />
+          <output name="4" label="  FX5  | " />
+          <output name="5" label="  FX6  | " />
+          <output name="6" label="Dimmer| " />
+          <output name="7" label="Brakes| " />
         </model>
         <model model="MC2H104OP" numOuts="4" numFns="14" connector="other" productID="852003">
           <versionCV lowVersionID="96" />
-          <output name="Xing Logic" />
-          <output name="3" label="  FX5  " />
-          <output name="4" label="  FX6  " />
-          <output name="Dimmer" />
-          <output name="Brakes" />
+          <output name="3" label="Xing|Logic" />
+          <output name="4" label="  FX5  | " />
+          <output name="5" label="  FX6  | " />
+          <output name="6" label="Dimmer| " />
+          <output name="7" label="Brakes| " />
         </model>
         <model model="MC2H104P9" numOuts="4" numFns="14" connector="other" productID="852004">
           <versionCV lowVersionID="96" />
-          <output name="Xing Logic" />
-          <output name="3" label="  FX5  " />
-          <output name="4" label="  FX6  " />
-          <output name="Dimmer" />
-          <output name="Brakes" />
+          <output name="3" label="Xing|Logic" />
+          <output name="4" label="  FX5  | " />
+          <output name="5" label="  FX6  | " />
+          <output name="6" label="Dimmer| " />
+          <output name="7" label="Brakes| " />
         </model>
       </family>
       <family name="MC Intermountain OEM" mfg="SoundTraxx (Throttle-Up)" file="SoundTraxx_MC_IMRC_OEM.xml">
         <model model="ES44AC" numOuts="4" numFns="14" connector="other" productID="ES">
           <versionCV lowVersionID="96" />
-          <output name="3" label="  FX5  " />
-          <output name="4" label="  FX6  " />
-          <output name="Brakes" />
+          <output name="3" label="  FX5  | " />
+          <output name="4" label="  FX6  | " />
+          <output name="5" label="Brakes| " />
         </model>
         <model model="ES44DC" numOuts="4" numFns="14" connector="other" productID="ES">
           <versionCV lowVersionID="96" />
-          <output name="3" label="  FX5  " />
-          <output name="4" label="  FX6  " />
-          <output name="Brakes" />
+          <output name="3" label="  FX5  | " />
+          <output name="4" label="  FX6  | " />
+          <output name="5" label="Brakes| " />
         </model>
         <model model="FT" numOuts="4" numFns="14" connector="other" productID="F">
           <versionCV lowVersionID="96" />
-          <output name="3" label="  FX5  " />
-          <output name="4" label="  FX6  " />
-          <output name="Brakes" />
+          <output name="3" label="  FX5  | " />
+          <output name="4" label="  FX6  | " />
+          <output name="5" label="Brakes| " />
         </model>
         <model model="F3" numOuts="4" numFns="14" connector="other" productID="F">
           <versionCV lowVersionID="96" />
-          <output name="3" label="  FX5  " />
-          <output name="4" label="  FX6  " />
-          <output name="Brakes" />
+          <output name="3" label="  FX5  | " />
+          <output name="4" label="  FX6  | " />
+          <output name="5" label="Brakes| " />
         </model>
         <model model="F7" numOuts="4" numFns="14" connector="other" productID="F">
           <versionCV lowVersionID="96" />
-          <output name="3" label="  FX5  " />
-          <output name="4" label="  FX6  " />
-          <output name="Brakes" />
+          <output name="3" label="  FX5  | " />
+          <output name="4" label="  FX6  | " />
+          <output name="5" label="Brakes| " />
         </model>
         <model model="F9" numOuts="4" numFns="14" connector="other" productID="F">
           <versionCV lowVersionID="96" />
-          <output name="3" label="  FX5  " />
-          <output name="4" label="  FX6  " />
-          <output name="Brakes" />
+          <output name="3" label="  FX5  | " />
+          <output name="4" label="  FX6  | " />
+          <output name="5" label="Brakes| " />
         </model>
         <model model="FP7" numOuts="4" numFns="14" connector="other" productID="F">
           <versionCV lowVersionID="96" />
-          <output name="3" label="  FX5  " />
-          <output name="4" label="  FX6  " />
-          <output name="Brakes" />
+          <output name="3" label="  FX5  | " />
+          <output name="4" label="  FX6  | " />
+          <output name="5" label="Brakes| " />
         </model>
         <model model="SD40-2W" numOuts="4" numFns="14" connector="other" productID="SD40">
           <versionCV lowVersionID="96" />
-          <output name="3" label="  FX5  " />
-          <output name="4" label="  FX6  " />
-          <output name="Brakes" />
+          <output name="3" label="  FX5  | " />
+          <output name="4" label="  FX6  | " />
+          <output name="5" label="Brakes| " />
         </model>
       </family>
       <family name="OEM Bachmann E-Z Command decoders" mfg="SoundTraxx (Throttle-Up)" lowVersionID="1" file="SoundTraxx_OEM_Bachmann_v3.xml">


### PR DESCRIPTION
Make the filtering decision in AbstractMonPane a method that can be overridden, then use the to fix the LocoNet filtering.