### PR TITLE
Allow specification of recommended programming mode(s) for Factory Resets

### DIFF
--- a/java/src/jmri/jmrit/decoderdefn/DecoderFile.java
+++ b/java/src/jmri/jmrit/decoderdefn/DecoderFile.java
@@ -475,12 +475,12 @@ public class DecoderFile extends XmlFile {
             List<Element> resetList = decoderElement.getChild("resets").getChildren("factReset");
             for (int i = 0; i < resetList.size(); i++) {
                 Element e = resetList.get(i);
-                resetModel.setRow(i, e);
+                resetModel.setRow(i, e, decoderElement.getChild("resets"), _model);
             }
             List<Element> iresetList = decoderElement.getChild("resets").getChildren("ifactReset");
             for (int i = 0; i < iresetList.size(); i++) {
                 Element e = iresetList.get(i);
-                resetModel.setIndxRow(i, e);
+                resetModel.setIndxRow(i, e, decoderElement.getChild("resets"), _model);
             }
         }
     }

--- a/java/src/jmri/jmrit/symbolicprog/FactoryResetAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/FactoryResetAction.java
@@ -2,6 +2,7 @@
 package jmri.jmrit.symbolicprog;
 
 import java.awt.event.ActionEvent;
+import java.util.ResourceBundle;
 import javax.swing.AbstractAction;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -41,7 +42,7 @@ public class FactoryResetAction extends AbstractAction {
         String s = (String) JOptionPane.showInputDialog(
                 mParent,
                 "Factory Reset" + (options.length > 1 ? "s" : ""),
-                "Caution: Factory Reset",
+                ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetTitle"),
                 JOptionPane.WARNING_MESSAGE,
                 null,
                 options,

--- a/java/src/jmri/jmrit/symbolicprog/ResetTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/ResetTableModel.java
@@ -5,11 +5,17 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ResourceBundle;
 import java.util.Vector;
 import javax.swing.JButton;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.table.AbstractTableModel;
 import jmri.Programmer;
+import jmri.ProgrammingMode;
+import jmri.managers.DefaultProgrammerManager;
 import jmri.util.jdom.LocaleSelector;
 import org.jdom2.Element;
 import org.slf4j.Logger;
@@ -37,6 +43,7 @@ public class ResetTableModel extends AbstractTableModel implements ActionListene
 
     private Vector<CvValue> rowVector = new Vector<CvValue>(); // vector of Reset items
     private Vector<String> labelVector = new Vector<String>(); // vector of related labels
+    private Vector<List> modeVector = new Vector<List>(); // vector of related modes
 
     private Vector<JButton> _writeButtons = new Vector<JButton>();
 
@@ -59,6 +66,18 @@ public class ResetTableModel extends AbstractTableModel implements ActionListene
         for (CvValue cv : rowVector) {
             cv.setProgrammer(p);
         }
+    }
+
+    public boolean hasOpsModeFlag = false;
+
+    protected void flagIfOpsMode(String mode) {
+        if (mode.startsWith("OPS")) {
+            hasOpsModeFlag = true;
+        }
+    }
+
+    public boolean hasOpsMode() {
+        return hasOpsModeFlag;
     }
 
     public int getRowCount() {
@@ -131,7 +150,8 @@ public class ResetTableModel extends AbstractTableModel implements ActionListene
         _siCv = siCv;
     }
 
-    public void setRow(int row, Element e) {
+    public void setRow(int row, Element e, Element p, String model) {
+        decoderModel = model; // Save for use elsewhere
         String label = LocaleSelector.getAttribute(e, "label"); // Note the name variable is actually the label attribute
         if (log.isDebugEnabled()) {
             log.debug("Starting to setRow \""
@@ -145,15 +165,18 @@ public class ResetTableModel extends AbstractTableModel implements ActionListene
         }
 
         CvValue resetCV = new CvValue(cv, mProgrammer);
+        resetCV.addPropertyChangeListener(this);
         resetCV.setValue(cvVal);
         resetCV.setWriteOnly(true);
         resetCV.setState(VariableValue.STORED);
         rowVector.addElement(resetCV);
         labelVector.addElement(label);
+        modeVector.addElement(getResetModeList(e, p));
         return;
     }
 
-    public void setIndxRow(int row, Element e) {
+    public void setIndxRow(int row, Element e, Element p, String model) {
+        decoderModel = model; // Save for use elsewhere
         if (_piCv != "" && _siCv != "") {
             // get the values for the VariableValue ctor
             String label = LocaleSelector.getAttribute(e, "label"); // Note the name variable is actually the label attribute
@@ -170,6 +193,8 @@ public class ResetTableModel extends AbstractTableModel implements ActionListene
             String iCv = e.getAttribute("CV").getValue();
             int icvVal = Integer.valueOf(e.getAttribute("default").getValue()).intValue();
 
+            
+            
             CvValue resetCV = new CvValue("" + row, cvName, _piCv, piVal, _siCv, siVal, iCv, mProgrammer);
             resetCV.addPropertyChangeListener(this);
 
@@ -180,11 +205,103 @@ public class ResetTableModel extends AbstractTableModel implements ActionListene
             resetCV.setState(VariableValue.STORED);
             rowVector.addElement(resetCV);
             labelVector.addElement(label);
+            modeVector.addElement(getResetModeList(e, p));
         }
         return;
     }
 
+    protected List<String> getResetModeList(Element e, Element p) {
+        List<Element> elementList = new ArrayList<Element>();
+        List<String> modeList = new ArrayList<String>();
+        List<Element> elementModes;
+        String mode;
+        boolean resetsModeFound = false;
+
+        elementList.add(p);
+        elementList.add(e);
+        
+        for (Element ep : elementList) {            
+            try {
+                mode = ep.getAttribute("mode").getValue();
+                if (ep.getName().equals("resets")) {
+                    resetsModeFound = true;
+                } else if (resetsModeFound) {
+                    modeList.clear();
+                    resetsModeFound = false;
+                }
+                modeList.add(mode);
+                flagIfOpsMode(mode);
+            } catch (NullPointerException ex) {
+                mode = null;
+            }        
+
+           try {
+               elementModes = ep.getChildren("mode");
+                for (Element s : elementModes) {
+                if (ep.getName().equals("resets")) {
+                    resetsModeFound = true;
+                } else if (resetsModeFound) {
+                    modeList.clear();
+                    resetsModeFound = false;
+                }
+                modeList.add(s.getText());
+                flagIfOpsMode(s.getText());
+               }
+            } catch (NullPointerException ex) {
+                elementModes = null;
+            }        
+        }
+        
+        return modeList;
+    }
+
+    private ProgrammingMode savedMode;
+    private String decoderModel;
+
     protected void performReset(int row) {
+        savedMode = mProgrammer.getMode(); // In case we need to change modes
+        if (modeVector.get(row) != null) {
+            List<ProgrammingMode> modes = mProgrammer.getSupportedModes();
+            List<String> validModes = modeVector.get(row);
+
+            String programmerModeList = "";
+            for (ProgrammingMode m : modes) {
+                programmerModeList = programmerModeList + "," + m.toString();
+            }
+            if (programmerModeList.startsWith(",")) {
+                programmerModeList = programmerModeList.substring(1);
+            }
+
+            String resetModeList = "";
+            for (String mode : validModes) {
+                resetModeList = resetModeList + "," + new ProgrammingMode(mode).toString();
+            }
+            if (resetModeList.startsWith(",")) {
+                resetModeList = resetModeList.substring(1);
+            }
+
+            if (resetModeList.length() > 0) {
+
+                boolean modeFound = false;
+                search:
+                    for (ProgrammingMode m : modes) {
+                        for (String mode : validModes) {
+                            if (mode.equals(m.getStandardName())) {
+                                mProgrammer.setMode(m);
+                                modeFound = true;
+                                break search;
+                            }
+                        }
+                    }
+                if (!modeFound) {
+                    if (!userOK((savedMode.toString()), resetModeList, programmerModeList)) {
+                        return;
+                    }
+                    log.warn(labelVector.get(row)+ " for " + decoderModel + " was attempted in "+ savedMode.toString() + " mode.");
+                    log.warn("Recommended mode(s) were \"" + resetModeList + "\" but available modes were \"" + programmerModeList + "\"");
+                }
+            }
+        }
         CvValue cv = rowVector.get(row);
         if (log.isDebugEnabled()) {
             log.debug("performReset: " + cv + " with piCv \"" + cv.piCv() + "\"");
@@ -193,6 +310,7 @@ public class ResetTableModel extends AbstractTableModel implements ActionListene
             _iCv = cv;
             indexedWrite();
         } else {
+            _progState = WRITING_CV;
             cv.write(_status);
         }
     }
@@ -267,16 +385,45 @@ public class ResetTableModel extends AbstractTableModel implements ActionListene
                     if (log.isDebugEnabled()) {
                         log.debug("Finished writing the Indexed CV");
                     }
+                    mProgrammer.setMode(savedMode);            
                     _progState = IDLE;
                     return;
                 default:  // unexpected!
                     log.error("Unexpected state found: " + _progState);
+                    mProgrammer.setMode(savedMode);            
                     _progState = IDLE;
                     return;
             }
         }
     }
 
+    
+        /**
+     * Can provide some mechanism to prompt for user for one last chance to
+     * change his/her mind
+     *
+     * @return true if user says to continue
+     */
+    boolean userOK(String currentMode, String resetModes, String availableModes) {
+        String resetWarning =
+                ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn1")
+                + "\n\n"
+                + java.text.MessageFormat.format(ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn2"), resetModes)
+                + "\n"
+                + java.text.MessageFormat.format(ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn3"), availableModes)
+                + "\n"
+                + ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn4")
+                + "\n\n"
+                + java.text.MessageFormat.format(ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetModeWarn5"), currentMode)
+                ;
+        return (JOptionPane.YES_OPTION
+                == JOptionPane.showConfirmDialog(null,
+                        resetWarning,
+                        ResourceBundle.getBundle("jmri.jmrit.symbolicprog.SymbolicProgBundle").getString("FactoryResetTitle"),
+                        JOptionPane.YES_NO_OPTION,JOptionPane.WARNING_MESSAGE));
+    }
+
+    
     public void dispose() {
         if (log.isDebugEnabled()) {
             log.debug("dispose");
@@ -300,6 +447,9 @@ public class ResetTableModel extends AbstractTableModel implements ActionListene
 
         labelVector.removeAllElements();
         labelVector = null;
+
+        modeVector.removeAllElements();
+        modeVector = null;
 
         headers = null;
 

--- a/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle.properties
+++ b/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle.properties
@@ -227,3 +227,10 @@ FnMapOutLabelDefault_4 = Vlt/Brwn
 FnMapESUMoveUp = Move selected row up
 FnMapESUMoveDown = Move selected row down
 FnMapESURowSelect = To move a row, select here and use up/down arrows
+
+FactoryResetTitle = Caution: Factory Reset
+FactoryResetModeWarn1 = Warning: Recommended Reset Mode not available
+FactoryResetModeWarn2 = The recommended programming mode(s) for this reset are "{0}".
+FactoryResetModeWarn3 = The available programming mode(s) are "{0}".
+FactoryResetModeWarn4 = Use of a non-recommended mode may cause an improper reset.
+FactoryResetModeWarn5 = Do you wish to try anyway using the current programming mode ({0})?

--- a/xml/decoders/QSI_ver9.xml
+++ b/xml/decoders/QSI_ver9.xml
@@ -2333,7 +2333,7 @@
         </enumVal>
       </variable>
     </variables>
-    <resets>
+    <resets mode="PAGEMODE">
       <ifactReset label="Reset System Sound Control" CVname="56.128.51" CV="56" PI="128" SI="51" default="113" item="CV56.128.51"/>
       <ifactReset label="Reset Individual Sounds" CVname="56.128.52" CV="56" PI="128" SI="52" default="113" item="CV56.128.52"/>
       <ifactReset label="Reset Function Output Mappings" CVname="56.128.53" CV="56" PI="128" SI="53" default="113" item="CV56.128.53"/>

--- a/xml/schema/decoder.xsd
+++ b/xml/schema/decoder.xsd
@@ -107,7 +107,7 @@
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
-            <xs:element name="mode" minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="mode" type="modeType" minOccurs="0" maxOccurs="unbounded">
               <xs:annotation><xs:documentation>
               Content is the internal name of a supported programmer mode.
               Having at least one of these (or the 
@@ -766,24 +766,43 @@
 
   <xs:complexType name="ResetsType">
     <xs:sequence>
+      <xs:element name="mode" type="modeType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation><xs:documentation>
+          Content is the internal name of a supported programmer mode.
+        </xs:documentation></xs:annotation>
+      </xs:element>
       <xs:element name="factReset" minOccurs="0" maxOccurs="unbounded" >
         <xs:complexType>
           <xs:sequence minOccurs="0" maxOccurs="unbounded">
-            <xs:annotation><xs:documentation>Provide an internationalized label text</xs:documentation></xs:annotation>
-            <xs:element name="label" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="mode" type="modeType" minOccurs="0" maxOccurs="unbounded">
+              <xs:annotation><xs:documentation>
+                Content is the internal name of a supported programmer mode.
+              </xs:documentation></xs:annotation>
+            </xs:element>
+            <xs:element name="label" minOccurs="0" maxOccurs="unbounded" >
+                <xs:annotation><xs:documentation>Provide an internationalized label text</xs:documentation></xs:annotation>
+            </xs:element>
           </xs:sequence>
           <xs:attribute name="label" type="xs:string"/>
           <xs:attribute name="CV" type="cvNameType"/>
           <xs:attribute name="default" type="xs:string"/>
           <xs:attribute name="comment" type="xs:string"/>
           <xs:attribute name="item" type="xs:string"/>
+          <xs:attribute name="mode" type="modeType"/>
           <xs:attribute ref="xml:base" />
         </xs:complexType>
       </xs:element>
       <xs:element name="ifactReset" minOccurs="0" maxOccurs="unbounded" >
         <xs:complexType>
           <xs:sequence minOccurs="0" maxOccurs="unbounded">
-            <xs:element name="label" type="LabelType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="mode" type="modeType" minOccurs="0" maxOccurs="unbounded">
+              <xs:annotation><xs:documentation>
+                Content is the internal name of a supported programmer mode.
+              </xs:documentation></xs:annotation>
+            </xs:element>
+            <xs:element name="label" type="LabelType" minOccurs="0" maxOccurs="unbounded" >
+              <xs:annotation><xs:documentation>Provide an internationalized label text</xs:documentation></xs:annotation>
+            </xs:element>
           </xs:sequence>
           <xs:attribute name="label" type="xs:string"/>
           <xs:attribute name="CVname" type="cvNameType"/>
@@ -793,10 +812,12 @@
           <xs:attribute name="default" type="xs:string"/>
           <xs:attribute name="comment" type="xs:string"/>
           <xs:attribute name="item" type="xs:string"/>
+          <xs:attribute name="mode" type="modeType"/>
           <xs:attribute ref="xml:base" />
         </xs:complexType>
       </xs:element>
     </xs:sequence>
+    <xs:attribute name="mode" type="modeType"/>
     <xs:attribute ref="xml:base" />
   </xs:complexType>
 
@@ -884,6 +905,31 @@
       <xs:pattern value="(V|X)*"/>
       <xs:minLength value="8"/>
       <xs:maxLength value="16"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="modeType">
+    <xs:annotation>
+      <xs:documentation>
+        Content is the internal name of a supported programmer mode.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="PAGEMODE"/>
+      <xs:enumeration value="OPSBITMODE"/>
+      <xs:enumeration value="OPSACCEXTBYTEMODE"/>
+      <xs:enumeration value="OPSACCBITMODE"/>
+      <xs:enumeration value="OPSACCEXTBITMODE"/>
+      <xs:enumeration value="OPSACCBYTEMODE"/>
+      <xs:enumeration value="NONE"/>
+      <xs:enumeration value="ADDRESSMODE"/>
+      <xs:enumeration value="OPSBYTEMODE"/>
+      <xs:enumeration value="DIRECTBYTEMODE"/>
+      <xs:enumeration value="REGISTERMODE"/>
+      <xs:enumeration value="DIRECTBITMODE"/>
+      <xs:enumeration value="DIRECTMODE"/>
+      <xs:enumeration value="LOCONETSV1MODE"/>
+      <xs:enumeration value="LOCONETSV2MODE"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
Some decoders need a specific programming mode to work properly under all circumstances.

One or more modes can be specified for all or individual resets. If possible, the programmer switches modes while resetting.