### PR TITLE
Improve code (based on Jenkins warnings)

### DIFF
--- a/java/src/apps/GuiLafConfigPane.java
+++ b/java/src/apps/GuiLafConfigPane.java
@@ -128,7 +128,7 @@ public class GuiLafConfigPane extends JPanel implements PreferencesPanel {
                 //localeBox.setModel(new javax.swing.DefaultComboBoxModel(locale.keySet().toArray()));
                 localeBox.setSelectedItem(Locale.getDefault().getDisplayName());
                 localeBox.addActionListener((ActionEvent e) -> {
-                    InstanceManager.getDefault(GuiLafPreferencesManager.class).setLocale(locale.getOrDefault((String) localeBox.getSelectedItem(), Locale.getDefault()));
+                    InstanceManager.getDefault(GuiLafPreferencesManager.class).setLocale(locale.getOrDefault(localeBox.getSelectedItem(), Locale.getDefault()));
                 });
             };
             SwingUtilities.invokeLater(update);

--- a/java/src/jmri/jmrit/beantable/LRouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LRouteTableAction.java
@@ -1791,7 +1791,10 @@ public class LRouteTableAction extends AbstractTableAction {
         return false;
     }
 
-    @SuppressWarnings("null")
+    /**
+     * @throw IllegalArgumentException if "user input no good"
+     * @return The number of conditionals after the creation.
+     */
     int makeRouteConditional(int numConds, /*boolean onChange,*/ ArrayList<ConditionalAction> actionList,
             ArrayList<ConditionalVariable> triggerList, ArrayList<ConditionalVariable> vetoList,
             Logix logix, String sName, String uName, String type) {
@@ -1850,7 +1853,8 @@ public class LRouteTableAction extends AbstractTableAction {
         } catch (Exception ex) {
             // user input no good
             handleCreateException(sName);
-            return (Integer)null;
+            // throw without creating any 
+            throw new IllegalArgumentException("user input no good");
         }
         c.setStateVariables(varList);
         //int option = onChange ? Conditional.ACTION_OPTION_ON_CHANGE : Conditional.ACTION_OPTION_ON_CHANGE_TO_TRUE;
@@ -1874,7 +1878,11 @@ public class LRouteTableAction extends AbstractTableAction {
                 rb.getString("ErrorTitle"),
                 javax.swing.JOptionPane.ERROR_MESSAGE);
     }
-    @SuppressWarnings("null")
+
+    /**
+     * @throw IllegalArgumentException if "user input no good"
+     * @return The number of conditionals after the creation.
+     */
     int makeAlignConditional(int numConds, ArrayList<ConditionalAction> actionList,
             ArrayList<ConditionalVariable> triggerList,
             Logix logix, String sName, String uName) {
@@ -1889,7 +1897,8 @@ public class LRouteTableAction extends AbstractTableAction {
         } catch (Exception ex) {
             // user input no good
             handleCreateException(sName);
-            return (Integer) null;
+            // throw without creating any 
+            throw new IllegalArgumentException("user input no good");
         }
         c.setStateVariables(triggerList);
         //c.setAction(cloneActionList(actionList, Conditional.ACTION_OPTION_ON_CHANGE_TO_TRUE));

--- a/java/src/jmri/jmrit/beantable/RouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableAction.java
@@ -1561,7 +1561,10 @@ public class RouteTableAction extends AbstractTableAction {
         return false;
     }
 
-    @SuppressWarnings("null")
+    /**
+     * @throw IllegalArgumentException if "user input no good"
+     * @return The number of conditionals after the creation.
+     */
     int makeSensorConditional(JmriBeanComboBox jmriBox, JComboBox<String> sensorbox, int numConds,
             boolean onChange, ArrayList<ConditionalAction> actionList,
             ArrayList<ConditionalVariable> vetoList, Logix logix, String prefix, String uName) {
@@ -1580,7 +1583,8 @@ public class RouteTableAction extends AbstractTableAction {
             } catch (Exception ex) {
                 // user input no good
                 handleCreateException(cSystemName);
-                return (Integer) null; // without creating any 
+                // throw without creating any 
+                throw new IllegalArgumentException("user input no good");
             }
             c.setStateVariables(varList);
             int option = onChange ? Conditional.ACTION_OPTION_ON_CHANGE : Conditional.ACTION_OPTION_ON_CHANGE_TO_TRUE;
@@ -1593,7 +1597,10 @@ public class RouteTableAction extends AbstractTableAction {
         return numConds;
     }
 
-    @SuppressWarnings("null")
+    /**
+     * @throw IllegalArgumentException if "user input no good"
+     * @return The number of conditionals after the creation.
+     */
     int makeTurnoutConditional(JmriBeanComboBox jmriBox, JComboBox<String> box, int numConds,
             boolean onChange, ArrayList<ConditionalAction> actionList,
             ArrayList<ConditionalVariable> vetoList, Logix logix, String prefix, String uName) {
@@ -1612,7 +1619,8 @@ public class RouteTableAction extends AbstractTableAction {
             } catch (Exception ex) {
                 // user input no good
                 handleCreateException(cSystemName);
-                return (Integer) null; // without creating any 
+                // throw without creating any 
+                throw new IllegalArgumentException("user input no good");
             }
             c.setStateVariables(varList);
             int option = onChange ? Conditional.ACTION_OPTION_ON_CHANGE : Conditional.ACTION_OPTION_ON_CHANGE_TO_TRUE;

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -1706,7 +1706,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
                 if (!pl.isIcon()) {
                     popupSet |= setTextAttributes(pl, popup);
                 } else if (p instanceof SensorIcon) {
-                    popup.add(CoordinateEdit.getTextEditAction((SensorIcon)p, "OverlayText"));
+                    popup.add(CoordinateEdit.getTextEditAction(p, "OverlayText"));
                 } else {
                     popupSet = p.setTextEditMenu(popup);                
                 }

--- a/java/src/jmri/util/xml/XMLUtil.java
+++ b/java/src/jmri/util/xml/XMLUtil.java
@@ -727,7 +727,7 @@ public final class XMLUtil extends Object {
         for (int i = 0; i < chars.length(); i++) {
             char ch = chars.charAt(i);
 
-            if (((int) ch) <= 93) { // we are UNICODE ']'
+            if (ch <= 93) { // we are UNICODE ']'
 
                 switch (ch) {
                 case 0x9:
@@ -746,7 +746,7 @@ public final class XMLUtil extends Object {
 
                 default:
 
-                    if (((int) ch) < 0x20) {
+                    if (ch < 0x20) {
                         throw new CharConversionException("Invalid XML character &#" + ((int) ch) + ";.");
                     }
                 }
@@ -768,7 +768,7 @@ public final class XMLUtil extends Object {
         for (int i = 0; i < chars.length(); i++) {
             char ch = chars.charAt(i);
 
-            if (((int) ch) <= 93) { // we are UNICODE ']'
+            if (ch <= 93) { // we are UNICODE ']'
 
                 switch (ch) {
                 case 0x9:
@@ -795,7 +795,7 @@ public final class XMLUtil extends Object {
 
                 default:
 
-                    if (((int) ch) < 0x20) {
+                    if (ch < 0x20) {
                         throw new CharConversionException("Invalid XML character &#" + ((int) ch) + ";.");
                     }
                 }

--- a/java/test/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXMLTest.java
+++ b/java/test/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXMLTest.java
@@ -233,5 +233,5 @@ public class AbstractNamedBeanManagerConfigXMLTest extends TestCase {
         public Element store(Object o) {
             return null;
         }
-    };
+    }
 }


### PR DESCRIPTION
Remove some unnecessary casts; remove extraneous semicolon.

Fix four odd cases where an integer-valued method had a
```java
   return (Integer) null;
```
which was "working" by immediately throwing an NPE.