### PR TITLE
Link the roster location to the user files path

### DIFF
--- a/java/src/jmri/jmrit/roster/JmritRosterBundle.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle.properties
@@ -160,3 +160,6 @@ NotImplemented = Not Implemented
 # {1} - RosterEntry RoadName
 # {2} - RosterEntry RoadNumber
 RosterEntryDisplayName = {1} {2} ({0})
+
+# Errors
+IllegalRosterLocation = "{0}" is not a valid path

--- a/java/src/jmri/jmrit/roster/Roster.java
+++ b/java/src/jmri/jmrit/roster/Roster.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
+import javax.annotation.Nonnull;
 import javax.swing.JOptionPane;
 import jmri.InstanceManager;
 import jmri.UserPreferencesManager;
@@ -73,7 +74,7 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
     /*
      * This should only be non-null if explictly set to a non-default location.
      */
-    private String rosterLocation = null;
+    private String rosterLocation = FileUtil.getUserFilesPath();
     private String rosterIndexFileName = Roster.DEFAULT_ROSTER_INDEX;
     // since we can't do a "super(this)" in the ctor to inherit from PropertyChangeSupport, we'll
     // reflect to it.
@@ -143,8 +144,8 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
     public Roster() {
         super();
         FileUtilSupport.getDefault().addPropertyChangeListener((PropertyChangeEvent evt) -> {
-            // rosterLocation == null if location is default location
-            if (Roster.this.rosterLocation == null) {
+            if (Roster.this.getRosterLocation().equals(evt.getOldValue())) {
+                Roster.this.setRosterLocation((String) evt.getNewValue());
                 Roster.this.reloadRosterFile();
             }
         });
@@ -970,19 +971,34 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
      * locomotive files.
      *
      * @param f Absolute pathname to use. A null or "" argument flags a return
-     *          to the original default in the user's files directory.
+     *          to the original default in the user's files directory. This
+     *          parameter must be a potentially valid path on the system.
      */
     public void setRosterLocation(String f) {
-        if (f != null) {
-            if (f.isEmpty()) {
-                f = null;
-            } else if (!f.endsWith(File.separator)) {
-                f = f + File.separator;
+        String oldRosterLocation = this.rosterLocation;
+        String p = f;
+        if (p != null) {
+            if (p.isEmpty()) {
+                p = null;
+            } else {
+                p = FileUtil.getAbsoluteFilename(p);
+                if (p == null) {
+                    throw new IllegalArgumentException(Bundle.getMessage("IllegalRosterLocation", f)); // NOI18N
+                }
+                if (!p.endsWith(File.separator)) {
+                    p = p + File.separator;
+                }
             }
         }
-        this.rosterLocation = f;
-        if (this.rosterLocation == null) {
+        if (p == null) {
+            p = FileUtil.getUserFilesPath();
+        }
+        this.rosterLocation = p;
+        if (this.rosterLocation.equals(FileUtil.getUserFilesPath())) {
             log.debug("Roster location reset to default");
+        }
+        if (!this.rosterLocation.equals(oldRosterLocation)) {
+            this.firePropertyChange(RosterConfigManager.DIRECTORY, oldRosterLocation, this.rosterLocation);
         }
         this.reloadRosterFile();
     }
@@ -995,10 +1011,8 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
      * @return location of the Roster file
      * @see jmri.util.FileUtil#getUserFilesPath()
      */
-    public String getRosterLocation() {
-        if (this.rosterLocation == null) {
-            return FileUtil.getUserFilesPath();
-        }
+    public @Nonnull
+    String getRosterLocation() {
         return this.rosterLocation;
     }
 

--- a/java/src/jmri/jmrit/roster/RosterConfigManager.java
+++ b/java/src/jmri/jmrit/roster/RosterConfigManager.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.roster;
 
+import java.beans.PropertyChangeEvent;
+import java.util.Locale;
 import java.util.Set;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
@@ -11,6 +13,7 @@ import jmri.spi.AbstractPreferencesProvider;
 import jmri.spi.InitializationException;
 import jmri.spi.PreferencesProvider;
 import jmri.util.FileUtil;
+import jmri.util.FileUtilSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,19 +28,35 @@ import org.slf4j.LoggerFactory;
  */
 public class RosterConfigManager extends AbstractPreferencesProvider {
 
-    private String directory = FileUtil.PREFERENCES;
+    private String directory = FileUtil.getAbsoluteFilename(FileUtil.PREFERENCES);
     private String defaultOwner = "";
 
-    private static final String DIRECTORY = "directory";
-    private static final String DEFAULT_OWNER = "defaultOwner";
+    public static final String DIRECTORY = "directory";
+    public static final String DEFAULT_OWNER = "defaultOwner";
     private static final Logger log = LoggerFactory.getLogger(RosterConfigManager.class);
+
+    public RosterConfigManager() {
+        FileUtilSupport.getDefault().addPropertyChangeListener((PropertyChangeEvent evt) -> {
+            if (RosterConfigManager.this.getDirectory().equals(evt.getOldValue())) {
+                RosterConfigManager.this.setDirectory((String) evt.getNewValue());
+            }
+        });
+    }
 
     @Override
     public void initialize(Profile profile) throws InitializationException {
         if (!this.isInitialized(profile)) {
             Preferences preferences = ProfileUtils.getPreferences(profile, this.getClass(), true);
-            this.setDirectory(preferences.get(DIRECTORY, this.getDirectory()));
             this.setDefaultOwner(preferences.get(DEFAULT_OWNER, this.getDefaultOwner()));
+            try {
+                this.setDirectory(preferences.get(DIRECTORY, this.getDirectory()));
+            } catch (IllegalArgumentException ex) {
+                this.setIsInitialized(profile, true);
+                throw new InitializationException(
+                        Bundle.getMessage(Locale.ENGLISH, "IllegalRosterLocation", preferences.get(DIRECTORY, this.getDirectory())),
+                        ex.getMessage(),
+                        ex);
+            }
             Roster.getDefault().setRosterLocation(this.getDirectory());
             this.setIsInitialized(profile, true);
         }
@@ -56,16 +75,17 @@ public class RosterConfigManager extends AbstractPreferencesProvider {
     }
 
     @Override
-    public Set<Class <? extends PreferencesProvider>> getRequires() {
+    public Set<Class<? extends PreferencesProvider>> getRequires() {
         Set<Class<? extends PreferencesProvider>> requires = super.getRequires();
         requires.add(FileLocationsPreferences.class);
         return requires;
     }
-    
+
     /**
      * @return the defaultOwner
      */
-    public @Nonnull String getDefaultOwner() {
+    public @Nonnull
+    String getDefaultOwner() {
         // defaultOwner should never be null, but check anyway to ensure its not
         if (defaultOwner == null) {
             defaultOwner = "";
@@ -100,6 +120,9 @@ public class RosterConfigManager extends AbstractPreferencesProvider {
             directory = FileUtil.PREFERENCES;
         }
         String oldDirectory = this.directory;
+        if (directory != null && FileUtil.getAbsoluteFilename(directory) == null) {
+            throw new IllegalArgumentException(Bundle.getMessage("IllegalRosterLocation", directory));
+        }
         this.directory = FileUtil.getAbsoluteFilename(directory);
         propertyChangeSupport.firePropertyChange(DIRECTORY, oldDirectory, directory);
     }

--- a/java/src/jmri/jmrit/roster/configurexml/RosterConfigPaneXml.java
+++ b/java/src/jmri/jmrit/roster/configurexml/RosterConfigPaneXml.java
@@ -53,7 +53,6 @@ public class RosterConfigPaneXml extends jmri.configurexml.AbstractXmlAdapter {
     public boolean load(Element shared, Element perNode) {
         boolean result = true;
         if (shared.getAttribute("directory") != null) {
-            Roster.getDefault().setRosterLocation(shared.getAttribute("directory").getValue());
             InstanceManager.getDefault(RosterConfigManager.class).setDirectory(shared.getAttribute("directory").getValue());
             if (log.isDebugEnabled()) {
                 log.debug("set roster location (1): " + shared.getAttribute("directory").getValue());

--- a/java/test/jmri/jmrit/roster/RosterTest.java
+++ b/java/test/jmri/jmrit/roster/RosterTest.java
@@ -155,9 +155,11 @@ public class RosterTest extends TestCase {
         // the resulting files go into the test tree area.
 
         // create a file in "temp"
+        String rosterDir = FileUtil.getUserFilesPath() + "temp" + File.separator;
+        FileUtil.createDirectory(rosterDir);
+        Roster.getDefault().setRosterLocation(rosterDir);
         FileUtil.createDirectory(FileUtil.getUserFilesPath() + "temp");
-        Roster.setFileLocation("temp");
-        File f = new File(FileUtil.getUserFilesPath() + "temp" + File.separator + "roster.xml");
+        File f = new File(rosterDir + "roster.xml");
         // remove it if its there
         f.delete();
         // load a new one
@@ -166,19 +168,20 @@ public class RosterTest extends TestCase {
         p.println(contents);
         p.close();
         // delete previous backup file if there's one
-        File bf = new File(FileUtil.getUserFilesPath() + "temp" + File.separator + "rosterBackupTest");
+        File bf = new File(rosterDir + "rosterBackupTest");
         bf.delete();
 
         // now do the backup
         Roster r = new Roster() {
+            @Override
             public String backupFileName(String name) {
-                return FileUtil.getUserFilesPath() + "temp" + File.separator + "rosterBackupTest";
+                return rosterDir + "rosterBackupTest";
             }
         };
-        r.makeBackupFile("temp" + File.separator + "roster.xml");
+        r.makeBackupFile(rosterDir + "roster.xml");
 
         // and check
-        InputStream in = new FileInputStream(new File(FileUtil.getUserFilesPath() + "temp" + File.separator + "rosterBackupTest"));
+        InputStream in = new FileInputStream(new File(rosterDir + "rosterBackupTest"));
         Assert.assertEquals("read 0 ", contents.charAt(0), in.read());
         Assert.assertEquals("read 1 ", contents.charAt(1), in.read());
         Assert.assertEquals("read 2 ", contents.charAt(2), in.read());
@@ -192,10 +195,10 @@ public class RosterTest extends TestCase {
         p.close();
 
         // now do the backup
-        r.makeBackupFile("temp" + File.separator + "roster.xml");
+        r.makeBackupFile(rosterDir + "roster.xml");
 
         // and check
-        in = new FileInputStream(new File(FileUtil.getUserFilesPath() + "temp" + File.separator + "rosterBackupTest"));
+        in = new FileInputStream(new File(rosterDir + "rosterBackupTest"));
         Assert.assertEquals("read 4 ", contents.charAt(0), in.read());
         Assert.assertEquals("read 5 ", contents.charAt(1), in.read());
         Assert.assertEquals("read 6 ", contents.charAt(2), in.read());
@@ -210,7 +213,7 @@ public class RosterTest extends TestCase {
 
         // create new roster & read
         Roster t = new Roster();
-        t.readFile(Roster.defaultRosterFilename());
+        t.readFile(Roster.getDefault().getRosterIndexPath());
 
         // check contents
         Assert.assertEquals("search for 0 ", 0, t.matchingList(null, "321", null, null, null, null, null).size());
@@ -271,11 +274,12 @@ public class RosterTest extends TestCase {
         // the resulting files go into the test tree area.
 
         // store files in "temp"
-        FileUtil.createDirectory(FileUtil.getUserFilesPath() + "temp");
-        Roster.setFileLocation("temp" + File.separator);
-        Roster.setRosterFileName("rosterTest.xml");
+        String rosterDir = FileUtil.getUserFilesPath() + "temp" + File.separator;
+        FileUtil.createDirectory(rosterDir);
+        Roster.getDefault().setRosterLocation(rosterDir);
+        Roster.getDefault().setRosterIndexFileName("rosterTest.xml");
 
-        File f = new File(FileUtil.getUserFilesPath() + "temp" + File.separator + "rosterTest.xml");
+        File f = new File(rosterDir + "rosterTest.xml");
         // remove existing roster if its there
         f.delete();
 
@@ -310,7 +314,7 @@ public class RosterTest extends TestCase {
         r.addEntry(e);
 
         // write it
-        r.writeFile(Roster.defaultRosterFilename());
+        r.writeFile(Roster.getDefault().getRosterIndexPath());
 
         return r;
     }
@@ -333,10 +337,12 @@ public class RosterTest extends TestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
     }
 
+    @Override
     protected void tearDown() {
         apps.tests.Log4JFixture.tearDown();
     }


### PR DESCRIPTION
If the roster location is set to the UserFilesPath via any means,
future changes to the UserFilesPath cause the roster location to also
change.

This differs from the previous behavior that allowed users to use two
different methods to set the roster location to the UserFilesPath,
where one method would cause the roster location to change with the
UserFilePath (clicking the Reset button), and one method would not
allow that change to be followed (setting the path the same using the
file chooser).