### PR TITLE
Fix to RR CirKits LNCP definition

### DIFF
--- a/xml/decoders/RR-CirKits-LNCP-basic.xml
+++ b/xml/decoders/RR-CirKits-LNCP-basic.xml
@@ -2664,7 +2664,7 @@
         <label>MA16 C PR</label>
       </variable>
       <variable CV="638" mask="XXXVVVVV" default="8" item="MA16 D">
-        <xi:include href="http://jmri.org/xml/decoders/rr/cirkits/ChoiceLamp.xml"/>
+        <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceLamp.xml"/>
         <label>Lamp D</label>
       </variable>
       <variable item="MA16 D PR" CV="638" mask="VVVXXXXX" default="0">


### PR DESCRIPTION
There was a typo in an include statement in the LNCP-basic definition near line 2669.  This wasn't being detected until now, even though it's been around for a while