### PR TITLE
Initialize HelpUtil on demand if needed.

### DIFF
--- a/java/src/jmri/util/HelpUtil.java
+++ b/java/src/jmri/util/HelpUtil.java
@@ -183,6 +183,9 @@ public class HelpUtil {
     }
 
     static public HelpBroker getGlobalHelpBroker() {
+        if (globalHelpBroker == null) {
+            HelpUtil.initOK();
+        }
         return globalHelpBroker;
     }
 


### PR DESCRIPTION
PreferencesProviders might require that this be initialized prior to
creating the Help menu on the main application window, so allow
initialization on demand.