### PR TITLE
Fix CVs 3 & 4  max. some decoders

### DIFF
--- a/xml/decoders/0NMRA.xml
+++ b/xml/decoders/0NMRA.xml
@@ -25,7 +25,7 @@
     <programming direct="yes" paged="yes" register="yes" ops="yes"/>
     <variables>
       <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
-      <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/vStartHighMid.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
     <variable item="Total PWM Period" CV="9">

--- a/xml/decoders/0NMRA_registers.xml
+++ b/xml/decoders/0NMRA_registers.xml
@@ -34,7 +34,7 @@
         <label xml:lang="de">Anfahrspannung</label>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <!-- Register 5 -->
       <xi:include href="http://jmri.org/xml/decoders/nmra/cv29direction.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/cv29speedSteps.xml"/>

--- a/xml/decoders/NCE_D13SR.xml
+++ b/xml/decoders/NCE_D13SR.xml
@@ -51,7 +51,7 @@
     <variables>
       <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/vStartHighMid.xml"/>
-      <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
       <variable CV="9" item="Total PWM Period" comment="1-255 PWM drive freq in 128us increments; 0 = frequency is 15,625 Hz" tooltip="When set to 0, frequency is 15,625 Hz">
         <decVal/>

--- a/xml/decoders/NCE_D13SR_TC.xml
+++ b/xml/decoders/NCE_D13SR_TC.xml
@@ -301,7 +301,7 @@
     <variables>
       <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/vStartHighMid.xml"/>
-      <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
       <variable CV="11" item="Packet Time-out Value" tooltip="Time the decoder will wait before braking to a stop after running into a section of track with DC power">
         <decVal/>

--- a/xml/decoders/NCE_E.xml
+++ b/xml/decoders/NCE_E.xml
@@ -36,7 +36,7 @@
     <variables>
       <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/vStartHighMid.xml"/>
-      <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
       <variable CV="11" item="Packet Time-out Value" tooltip="Time the decoder will wait before braking to a stop after running into a section of track with DC power">
         <decVal/>

--- a/xml/decoders/QSI_Articulated_Steam.xml
+++ b/xml/decoders/QSI_Articulated_Steam.xml
@@ -115,7 +115,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_Articulated_Steam_ver6.xml
+++ b/xml/decoders/QSI_Articulated_Steam_ver6.xml
@@ -107,7 +107,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_Articulated_Steam_ver7.xml
+++ b/xml/decoders/QSI_Articulated_Steam_ver7.xml
@@ -155,7 +155,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
      <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_Diesel.xml
+++ b/xml/decoders/QSI_Diesel.xml
@@ -46,7 +46,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_Diesel_Ver6.xml
+++ b/xml/decoders/QSI_Diesel_Ver6.xml
@@ -86,7 +86,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_Diesel_Ver7.xml
+++ b/xml/decoders/QSI_Diesel_Ver7.xml
@@ -635,7 +635,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_Electric.xml
+++ b/xml/decoders/QSI_Electric.xml
@@ -39,7 +39,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_Electric_Ver7.xml
+++ b/xml/decoders/QSI_Electric_Ver7.xml
@@ -109,7 +109,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_Gas_Turbine.xml
+++ b/xml/decoders/QSI_Gas_Turbine.xml
@@ -43,7 +43,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_Gas_Turbine_Ver7.xml
+++ b/xml/decoders/QSI_Gas_Turbine_Ver7.xml
@@ -101,7 +101,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_Steam.xml
+++ b/xml/decoders/QSI_Steam.xml
@@ -76,7 +76,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_Steam_ver6.xml
+++ b/xml/decoders/QSI_Steam_ver6.xml
@@ -59,7 +59,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_Steam_ver7.xml
+++ b/xml/decoders/QSI_Steam_ver7.xml
@@ -327,7 +327,7 @@
         <comment>A value of 255 corresponds to 100%</comment>
       </variable>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <variable CV="5" item="Vhigh" default="1" tooltip="range 2-255, 1 = not used">
         <decVal min="1" max="255"/>
         <label>Max Volts</label>

--- a/xml/decoders/QSI_ver8.xml
+++ b/xml/decoders/QSI_ver8.xml
@@ -121,7 +121,7 @@
       </variable>
       <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/vStartHighMid.xml"/>
-      <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
       <variable item="Packet Time-out Value" CV="11">
         <decVal/>

--- a/xml/decoders/QSI_ver9.xml
+++ b/xml/decoders/QSI_ver9.xml
@@ -70,7 +70,7 @@
       </variable>
       <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/vStartHighMid.xml"/>
-      <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
       <variable item="Packet Time-out Value" CV="11">
         <decVal/>

--- a/xml/decoders/SoundTraxx_DSX_Diesel.xml
+++ b/xml/decoders/SoundTraxx_DSX_Diesel.xml
@@ -49,7 +49,7 @@
     <variables>
       <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
       <!-- CV 3-4 -->
-     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+     <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
       <variable CV="11" item="Packet Time-out Value">
         <decVal/>

--- a/xml/decoders/nmra/accelDecel_31.xml
+++ b/xml/decoders/nmra/accelDecel_31.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<!-- $Id$ -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2010</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname>
+        <firstname>Bob</firstname>
+        <surname>Jacobsen</surname>
+      </personname>
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>7</revnumber>
+      <date>2013-07-29</date>
+      <authorinitials>PB</authorinitials>
+      <revremark>Added German, corrected French</revremark>
+    </revision>
+    <revision>
+      <revnumber>6</revnumber>
+      <date>2010-03-12</date>
+      <authorinitials>BJ</authorinitials>
+      <revremark>Initial release as separate file</revremark>
+    </revision>
+    <revision>
+      <revnumber>5</revnumber>
+      <date>2003-12-05</date>
+      <authorinitials>BJ</authorinitials>
+      <revremark>Revision in original 0NMRA.xml file</revremark>
+    </revision>
+  </revhistory>
+  <variable CV="3" item="Accel">
+    <decVal max="31"/>
+    <label xml:lang="it">Accellerazione (0-31)</label>
+    <label xml:lang="fr">Accelération (0-31)</label>
+    <label xml:lang="de">Anfahrverzögerung (0-31)</label>
+    <label>Acceleration Rate</label>
+  </variable>
+  <variable CV="4" item="Decel">
+    <decVal max="31"/>
+    <label>Deceleration Rate</label>
+    <label xml:lang="it">Decellerazione (0-31)</label>
+    <label xml:lang="fr">Décélération (0-31)</label>
+    <label xml:lang="de">Bremszeit (0-31)</label>
+  </variable>
+</variables>

--- a/xml/decoders/zimo/CV1-CV99.xml
+++ b/xml/decoders/zimo/CV1-CV99.xml
@@ -6,7 +6,7 @@
 -->
 <variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
   <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
-  <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/nmra/accelDecel_255.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/nmra/vStartHighMid.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>
   <variable item="Motor Frequency and EMF sample Rate" CV="9" default="0">


### PR DESCRIPTION
There were 2 files:
- xml/decoders/nmra/accelDecel.xml with a max of 31
- xml/decoders/nmra/accelDecel_255.xml with a max of 255

 Have copied:
xml/decoders/nmra/accelDecel.xml
 to:
xml/decoders/nmra/accelDecel_31.xml with a max of 31

Have started deprecating xml/decoders/nmra/accelDecel.xml as ambiguous.

31 files remain to do (Atlas, Digitrax, Doehler und Haas, Hornby, Kato, Lenz, MRC, Wangrow & ZTC). 
Maybe anyone familiar with these could change to one or other (or a new accelDecel_xx file) as appropriate?