### PR TITLE
Simplify version number generation

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -37,7 +37,6 @@
 
     <!-- The Jenkins official release builds force: -->
     <!--    release.official=true                   -->
-    <!--    release.is_branched=true                -->
     <!--    nsis.home=/opt/nsis/nsis-2.46/          -->
     <!-- in their "invoke ant" step                 -->
     <!-- The Packages build (dev downloads) forces: -->
@@ -70,9 +69,6 @@
     <condition property="release.official" value="true" else="false">
       <isset property="RELEASED"/>
     </condition>
-
-    <!-- release.is_branched defaults to false unless release.properties file already set -->
-    <property name="release.is_branched" value="false"/>
 
     <!-- should compiler warn of use of deprecated APIs? (on/off) -->
     <property name="deprecation" value="off"/> <!-- off at start of 3.11 series, as we work through changes -->
@@ -288,7 +284,6 @@
             <filter token="release.build_user"     value="${release.build_user}"/>
             <filter token="release.official"       value="${release.official}"/>
             <filter token="release.build_date"     value="${release.build_date}"/>
-            <filter token="release.is_branched"    value="${release.is_branched}"/>
             <filter token="jmri.copyright.year"    value="${jmri.copyright.year}"/>
         </filterset>
     </target>
@@ -1634,39 +1629,22 @@
             <arg value="${branch-name}"/>
         </exec>
 
-        <!-- In the newly created release branch, we modify
-        release.properties to show that we have indeed branched -->
-        <propertyfile file="release.properties">
-            <entry key="release.is_branched" type="string" operation="=" value="true"/>
-        </propertyfile>
-        <!-- commit and push -->
-        <exec executable="git" failifexecutionfails="true">
-            <arg value="commit"/>
-            <arg value="-m'update release.is_branched for new release'"/>
-            <arg value="release.properties"/>
-        </exec>
-        <exec executable="git" failifexecutionfails="true">
-            <arg value="push"/>
-            <arg value="${jmri.repository.url}"/>
-            <arg value="${branch-name}"/>
-        </exec>
-
         <!-- return to master -->
         <exec executable="git" failifexecutionfails="true">
             <arg value="checkout"/>
             <arg value="master"/>
         </exec>
         
-        <!-- in the master release.properties file, we now increment
+        <!-- in the master release.properties file, increment
         the release.build value in order to point to the NEW next
-        release (the one after we're branching to create) -->
+        release (the one after the one we're creating now) -->
         <propertyfile file="release.properties">
             <entry key="release.build" type="int" operation="+" value="1"/>
         </propertyfile>
         <!-- commit and push -->
         <exec executable="git" failifexecutionfails="true">
             <arg value="commit"/>
-            <arg value="-m'update release.build to new value post-release'"/>
+            <arg value="-m'update release.build to value for next release'"/>
             <arg value="release.properties"/>
         </exec>
         <exec executable="git" failifexecutionfails="true">
@@ -1677,7 +1655,7 @@
             <arg value="pull"/>
         </exec>
 
-        <echo message="new release branch ${branch-name}"/>
+        <echo message="new release branch ${branch-name} created"/>
     </target>
 
 </project>

--- a/java/src/jmri/Version.java
+++ b/java/src/jmri/Version.java
@@ -4,7 +4,28 @@ import java.util.ResourceBundle;
 
 /**
  * Defines a simple place to get the JMRI version string.
- *
+ * <p>
+ * JMRI's version string comes in two forms, depending on whether it was built by an "official"
+ * process or not, which in turn is determined by the "release.official" property:
+ *<dl>
+ *<dt>Official<dd>
+ *<ul>
+ *<li>If the revision number e.g. 123abc (git hash) is available in release.revision_id, then 
+ * "4.1.1-R123abc". Note the "R".
+ *<li>Else "4.1.1-(date)", where the date comes from the release.build_date property.
+ *</ul>
+ *<dt>Unofficial<dd>
+ * Unofficial releases are marked by "ish" after the version number, and inclusion of the building user's ID.
+ *<ul>
+ *<li>If the revision number e.g. 123abc (git hash) is available in release.revision_id, then 
+ * "4.1.1ish-(user)-(date)-R123abc". Note the "R".
+ *<li>Else "4.1.1-(user)-(date)", where the date comes from the release.build_date property.
+ *</ul>
+ *</dl>
+ * The release.revision_id, release.build_user and release.build_date properties are set at build time by Ant.
+ * <p>
+ * Generally, JMRI updates its version string in the code repository right <b>after</b> a release. 
+ * Between formal release 1.2.3 and 1.2.4, the string will be 1.2.4ish. 
  * <hr>
  * This file is part of JMRI.
  * <P>
@@ -52,14 +73,11 @@ public class Version {
     /* Has this build been created as a possible "official" versionBundle? */
     static final public boolean official = Boolean.parseBoolean(versionBundle.getString("release.official")); // NOI18N
 
-    /* Has this build been created from a branch in Subversion? */
-    static final public boolean branched = Boolean.parseBoolean(versionBundle.getString("release.is_branched")); // NOI18N;
-
     /**
      * The Modifier is the third term in the
      * 1.2.3 version name.  It's not present in production
      * versions that set it to zero.
-     * Non-official branched versions get an "ish"
+     * Non-official versions get an "ish"
      */
     public static String getModifier() {
         StringBuilder modifier = new StringBuilder("");
@@ -68,7 +86,7 @@ public class Version {
             modifier.append(".").append(test);
         }
 
-        if (! (branched && official) ) {
+        if (! official) {
             modifier.append("ish");
         }
 
@@ -80,26 +98,26 @@ public class Version {
      * <P>
      * This string is built using various known build parameters, including the
      * versionBundle.{major,minor,build} values, the Git revision ID (if known)
-     * and the branched & official properties
+     * and the official property
      *
      * @return The current version string
      */
     static public String name() {
         String releaseName;
-        if (branched) {
+        if (official) {
             String addOn;
             if ("unknown".equals(revisionId)) {
-                addOn = buildDate + "-" + buildUser;
+                addOn = buildDate;
             } else {
                 addOn = "R" + revisionId;
             }
             releaseName = major + "." + minor + getModifier() + "-" + addOn;
-        } else { // not branched, so a local build that gets a user name
+        } else { // not official, so a development build that gets a user name
             String addOn;
             if ("unknown".equals(revisionId)) {
                 addOn = buildDate + "-" + buildUser;
             } else {
-                addOn = buildDate + (!official ? "-"+buildUser :"") + "-R" + revisionId;
+                addOn = buildDate + "-" + buildUser + "-R" + revisionId;
             }
             releaseName = major + "." + minor + getModifier() + "-" + addOn;
         }

--- a/release.properties
+++ b/release.properties
@@ -7,9 +7,6 @@ release.major=4
 release.minor=1
 release.build=4
 
-# set this to true if this tree has been branched from the trunk
-release.is_branched=true
-
 # set this to true if this is a JMRI-project official release candidate build
-# (normally, this is only set by the CI engine)
+# (normally, this is only set true by the CI build engine)
 release.official=false

--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -11,11 +11,11 @@ So our releases procedure is, in outline:
 
 * Do lots of updates and merge completely onto master
 
-* In an up-to-date Git repository, create a branch named "release-n.n.n" (note initial lower case). Commit an update to release.properties with release.is_branched=true
+* In an up-to-date Git repository, update the release.properties file with the new version number
 
-* Push the branch back to the JMRI/JMRI repository (you can't use a pull request until the branch exists)
+* Create a branch named "release-n.n.n" (note initial lower case). 
 
-* Switch to 'master' branch and update release.properties with new version number. Commit back and then switch checkout back to the release-n.n.n branch.
+* Push the branch back to the JMRI/JMRI repository (you can't use a pull request until the branch exists), then switch back to master so you don't accidentally change the release branch
 
 * Jenkins build from release-n.n.n branch.  (That’s basically the same Jenkins job, except for changing to checkout from Github)
 
@@ -158,16 +158,11 @@ This will do (more or less) the following actions:
 
     git checkout master
     git pull
+    (commit a version number increment to master)
+    git push JMRI/JMRI master
     git checkout -b {branch}
     git push JMRI/JMRI {branch}
-    
-    <commit a release.is_branched=true property to the new release branch>
-    git push JMRI/JMRI {branch}
-    
-    git checkout master
-    <commit a version number increment to master
-    git push JMRI/JMRI master
-    
+    git checkout master    
     git pull
     
 ================================================================================


### PR DESCRIPTION
Simplify and reorder version number generation, so that release branches don't need to have an incompatible HEAD.