### PR TITLE
Fix to NPE with simulated connections

### DIFF
--- a/java/src/jmri/jmrix/AbstractSimulatorConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractSimulatorConnectionConfig.java
@@ -47,6 +47,7 @@ abstract public class AbstractSimulatorConnectionConfig extends AbstractConnecti
      * subclass setInstance() will fill the adapter member.
      */
     public AbstractSimulatorConnectionConfig() {
+        log.debug("AbstractSimulatorConnectionConfig null ctor used");
         adapter = null;
     }
 
@@ -244,7 +245,7 @@ abstract public class AbstractSimulatorConnectionConfig extends AbstractConnecti
     }
 
     public String getConnectionName() {
-        if (adapter.getSystemConnectionMemo() != null) {
+        if (adapter != null && adapter.getSystemConnectionMemo() != null) {
             return adapter.getSystemConnectionMemo().getUserName();
         } else {
             return null;


### PR DESCRIPTION
There seems to be several things going on that are causing various NPEs in the configuration process, see e.g. #232 and #236.

One is that, for some as-yet unknown reason, calls to AbstractSimulatorConnectionConfig.setInstance(..) that used to happen no longer are. That's the underlying cause of NPEs when AbstractSimulatorConnectionConfig.getConnectionName() is called. It seems to be hitting all simulator connections I've checked.

This bypasses the symptom by protecting against the NPE. But there's something more basic going on.