### PR TITLE
Add a Windows CI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ For more information, see [JMRI.org](http://jmri.org)
 For development information, see [Technical Info](http://jmri.org/help/en/html/doc/Technical)
 
 [![Build Status](https://travis-ci.org/JMRI/JMRI.svg?branch=master)](https://travis-ci.org/JMRI/JMRI)
+[![Build status](https://ci.appveyor.com/api/projects/status/1wa25bdftg5241hk/branch/master?svg=true)](https://ci.appveyor.com/project/JMRI/jmri/branch/master)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,25 @@
 version: '{build}'
 clone_depth: 50
+build_script:
+- cmd: >-
+    java -version
+    javac -version
+    where javac
+    choco -y install ant
+    echo ON
+    echo PATH %PATH%
+    echo JAVA_HOME %JAVA_HOME%
+    echo ANT_HOME %ANT_HOME%
+    SET ANT_HOME=C:\tools\apache-ant-1.9.4
+    SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
+    SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+    echo PATH %PATH%
+    echo JAVA_HOME %JAVA_HOME%
+    echo ANT_HOME %ANT_HOME%
+    java -version
+    javac -version
+    ant -version
+    ant debug
 test_script:
 - cmd: >-
     java -version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,22 +3,22 @@ clone_depth: 50
 build: off
 test_script:
 - cmd:
-  - java -version
-  - javac -version
-  - where javac
-  - choco -y install ant
-  - echo ON
-  - echo PATH %PATH%
-  - echo JAVA_HOME %JAVA_HOME%
-  - echo ANT_HOME %ANT_HOME%
-  - SET ANT_HOME=C:\tools\apache-ant-1.9.4
-  - SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
-  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-  - echo PATH %PATH%
-  - echo JAVA_HOME %JAVA_HOME%
-  - echo ANT_HOME %ANT_HOME%
-  - java -version
-  - javac -version
-  - ant -version
-  - ant ci-test
+ - java -version
+ - javac -version
+ - where javac
+ - choco -y install ant
+ - echo ON
+ - echo PATH %PATH%
+ - echo JAVA_HOME %JAVA_HOME%
+ - echo ANT_HOME %ANT_HOME%
+ - SET ANT_HOME=C:\tools\apache-ant-1.9.4
+ - SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
+ - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+ - echo PATH %PATH%
+ - echo JAVA_HOME %JAVA_HOME%
+ - echo ANT_HOME %ANT_HOME%
+ - java -version
+ - javac -version
+ - ant -version
+ - ant ci-test
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,6 @@ clone_depth: 50
 install:
 - choco install ant
 - echo JAVA_HOME %JAVA_HOME%
-- echo ANT_HOME %ANT_HOME%
-- SET ANT_HOME=C:\tools\apache-ant-1.9.4
 - SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
 - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
 - echo PATH %PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,43 +1,24 @@
 version: '{build}'
 clone_depth: 50
-build_script:
-- cmd: >-
-    java -version
-    javac -version
-    where javac
-    choco -y install ant
-    echo ON
-    echo PATH %PATH%
-    echo JAVA_HOME %JAVA_HOME%
-    echo ANT_HOME %ANT_HOME%
-    SET ANT_HOME=C:\tools\apache-ant-1.9.4
-    SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
-    SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-    echo PATH %PATH%
-    echo JAVA_HOME %JAVA_HOME%
-    echo ANT_HOME %ANT_HOME%
-    java -version
-    javac -version
-    ant -version
-    ant debug
+build: off
 test_script:
-- cmd: >-
-    java -version
-    javac -version
-    where javac
-    choco -y install ant
-    echo ON
-    echo PATH %PATH%
-    echo JAVA_HOME %JAVA_HOME%
-    echo ANT_HOME %ANT_HOME%
-    SET ANT_HOME=C:\tools\apache-ant-1.9.4
-    SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
-    SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-    echo PATH %PATH%
-    echo JAVA_HOME %JAVA_HOME%
-    echo ANT_HOME %ANT_HOME%
-    java -version
-    javac -version
-    ant -version
-    ant ci-test
+- cmd:
+  - java -version
+  - javac -version
+  - where javac
+  - choco -y install ant
+  - echo ON
+  - echo PATH %PATH%
+  - echo JAVA_HOME %JAVA_HOME%
+  - echo ANT_HOME %ANT_HOME%
+  - SET ANT_HOME=C:\tools\apache-ant-1.9.4
+  - SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
+  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+  - echo PATH %PATH%
+  - echo JAVA_HOME %JAVA_HOME%
+  - echo ANT_HOME %ANT_HOME%
+  - java -version
+  - javac -version
+  - ant -version
+  - ant ci-test
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,15 @@
 version: '{build}'
 clone_depth: 50
 install:
-- choco install ant
-- echo JAVA_HOME %JAVA_HOME%
-- SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
-- SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-- echo PATH %PATH%
-- echo JAVA_HOME %JAVA_HOME%
-- echo ANT_HOME %ANT_HOME%
-- java -version
-- javac -version
-- ant -version
+  - choco install ant --limit-output
+#  - echo JAVA_HOME %JAVA_HOME%
+  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+#  - echo PATH %PATH%
+#  - echo JAVA_HOME %JAVA_HOME%
+#  - echo ANT_HOME %ANT_HOME%
+  - java -version
+#  - javac -version
+  - ant -version
 build: off
 test_script:
 - cmd: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,23 +2,40 @@ version: '{build}'
 clone_depth: 50
 build: off
 test_script:
-- cmd:
- - java -version
- - javac -version
- - where javac
- - choco -y install ant
- - echo ON
- - echo PATH %PATH%
- - echo JAVA_HOME %JAVA_HOME%
- - echo ANT_HOME %ANT_HOME%
- - SET ANT_HOME=C:\tools\apache-ant-1.9.4
- - SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
- - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
- - echo PATH %PATH%
- - echo JAVA_HOME %JAVA_HOME%
- - echo ANT_HOME %ANT_HOME%
- - java -version
- - javac -version
- - ant -version
- - ant ci-test
+- cmd: >-
+    java -version
+
+    javac -version
+
+    where javac
+
+    choco -y install ant
+
+    echo ON
+
+    echo PATH %PATH%
+
+    echo JAVA_HOME %JAVA_HOME%
+
+    echo ANT_HOME %ANT_HOME%
+
+    SET ANT_HOME=C:\tools\apache-ant-1.9.4
+
+    SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
+
+    SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+
+    echo PATH %PATH%
+
+    echo JAVA_HOME %JAVA_HOME%
+
+    echo ANT_HOME %ANT_HOME%
+
+    java -version
+
+    javac -version
+
+    ant -version
+
+    ant ci-test
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,41 +1,20 @@
 version: '{build}'
 clone_depth: 50
+install:
+- choco install ant
+- echo JAVA_HOME %JAVA_HOME%
+- echo ANT_HOME %ANT_HOME%
+- SET ANT_HOME=C:\tools\apache-ant-1.9.4
+- SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
+- SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+- echo PATH %PATH%
+- echo JAVA_HOME %JAVA_HOME%
+- echo ANT_HOME %ANT_HOME%
+- java -version
+- javac -version
+- ant -version
 build: off
 test_script:
 - cmd: >-
-    java -version
-
-    javac -version
-
-    where javac
-
-    choco -y install ant
-
-    echo ON
-
-    echo PATH %PATH%
-
-    echo JAVA_HOME %JAVA_HOME%
-
-    echo ANT_HOME %ANT_HOME%
-
-    SET ANT_HOME=C:\tools\apache-ant-1.9.4
-
-    SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
-
-    SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-
-    echo PATH %PATH%
-
-    echo JAVA_HOME %JAVA_HOME%
-
-    echo ANT_HOME %ANT_HOME%
-
-    java -version
-
-    javac -version
-
-    ant -version
-
     ant ci-test
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+version: '{build}'
+clone_depth: 50
+test_script:
+- cmd: >-
+    java -version
+    javac -version
+    where javac
+    choco -y install ant
+    echo ON
+    echo PATH %PATH%
+    echo JAVA_HOME %JAVA_HOME%
+    echo ANT_HOME %ANT_HOME%
+    SET ANT_HOME=C:\tools\apache-ant-1.9.4
+    SET PATH=%PATH%;C:\tools\apache-ant-1.9.4\bin
+    SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+    echo PATH %PATH%
+    echo JAVA_HOME %JAVA_HOME%
+    echo ANT_HOME %ANT_HOME%
+    java -version
+    javac -version
+    ant -version
+    ant ci-test
+deploy: off


### PR DESCRIPTION
By not using a Windows CI server, we managed to have a test failing in Windows that went unnoticed for a long time (I think 3 years). Adding AppVeyor as a CI service will avoid that.