### PR TITLE
Further armoring against NPEs during preference operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,7 @@ For more information, see [JMRI.org](http://jmri.org)
 
 For development information, see [Technical Info](http://jmri.org/help/en/html/doc/Technical)
 
+User discussions are on the [JMRIusers Yahoo group](https://groups.yahoo.com/neo/groups/jmriusers/info)
+
 [![Build Status](https://travis-ci.org/JMRI/JMRI.svg?branch=master)](https://travis-ci.org/JMRI/JMRI)
 [![Build status](https://ci.appveyor.com/api/projects/status/1wa25bdftg5241hk/branch/master?svg=true)](https://ci.appveyor.com/project/JMRI/jmri/branch/master)

--- a/java/src/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXml.java
@@ -38,6 +38,11 @@ abstract public class AbstractSerialConnectionConfigXml extends AbstractConnecti
         getInstance(object);
         Element e = new Element("connection");
 
+        if (adapter == null) {
+            log.warn("No adapter found while saving serial port configuration {}", object.toString());
+            return null;
+        }
+        
         // many of the following are required by the DTD; failing to include
         // them makes the XML file unreadable, but at least the next
         // invocation of the program can then continue.

--- a/java/src/jmri/jmrix/internal/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/ConnectionConfigXml.java
@@ -34,12 +34,13 @@ public class ConnectionConfigXml extends AbstractConnectionConfigXml {
         adapter = ((ConnectionConfig) object).getAdapter();
     }
 
-    /*protected void getInstance() {
-     log.error("unexpected call to getInstance");
-     new Exception().printStackTrace();
-     }*/
+
+    @Override
     public Element store(Object o) {
         getInstance(o);
+        
+        if (adapter == null) return null;
+        
         Element e = new Element("connection");
         storeCommon(e, adapter);
 


### PR DESCRIPTION
Added some protection against NPEs for cases where the "adapter" object reference is null by refusing to make a broken "connection" Element.

Tried to improve handling of that case in jmri.jmrix.ConnectionConfigManager, but the logic is so indirect that I have no confidence that's right. It had been throwing NPEs and treating those are routine; separated out (some) known cases, and made the rest into log.error.