### PR TITLE
Allow network connections based on the AbstractNetworkPortController …

### DIFF
--- a/java/src/jmri/jmrix/AbstractNetworkPortController.java
+++ b/java/src/jmri/jmrix/AbstractNetworkPortController.java
@@ -27,6 +27,8 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
     protected int m_port = 0;
     // keep the socket provides our connection.
     protected Socket socketConn = null;
+    protected int connTimeout = 0; // connection timeout for read operations. 
+                                   // Default is 0, an infinite timeout.
 
     protected AbstractNetworkPortController(SystemConnectionMemo connectionMemo) {
         super(connectionMemo);
@@ -55,6 +57,7 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
         try {
             socketConn = new Socket(getHostAddress(), m_port);
             socketConn.setKeepAlive(true);
+            socketConn.setSoTimeout(getConnectionTimeout());
             opened = true;
         } catch (IOException e) {
             log.error("error opening network connection: " + e);
@@ -375,6 +378,31 @@ abstract public class AbstractNetworkPortController extends AbstractPortControll
                 }
             }
         }
+    }
+
+    /*
+     * Set the connection timeout to the specified value.
+     * If the socket is not null, set the SO_TIMEOUT option on the 
+     * socket as well.
+     * @param t timeout value in milliseconds.
+     */
+    protected void setConnectionTimeout(int t){ 
+       connTimeout= t;
+       try { 
+          if(socketConn !=null){
+             socketConn.setSoTimeout(getConnectionTimeout());
+          }
+       } catch(java.net.SocketException se){
+           log.debug("Unable to set socket timeout option on socket");
+       }
+    }
+
+    /*
+     * Get the connection timeout value.
+     * @return timeout value in milliseconds.
+     */
+    protected int getConnectionTimeout(){
+        return connTimeout;
     }
 
     final static protected Logger log = LoggerFactory.getLogger(AbstractNetworkPortController.class.getName());

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientPortController.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientPortController.java
@@ -15,6 +15,7 @@ public abstract class JMRIClientPortController extends jmri.jmrix.AbstractNetwor
     protected JMRIClientPortController(JMRIClientSystemConnectionMemo connectionMemo) {
         super(connectionMemo);
         allowConnectionRecovery=true;
+        setConnectionTimeout(30000);
     }
 
     @Override
@@ -24,6 +25,8 @@ public abstract class JMRIClientPortController extends jmri.jmrix.AbstractNetwor
 
     @Override
     protected void resetupConnection() {
+       // reconnect the port to the traffic controller.
+       getSystemConnectionMemo().getJMRIClientTrafficController().connectPort(this);
        // notify the memo that we've restarted, so it can ask the associated 
        // managers to refresh status
        getSystemConnectionMemo().requestAllStatus();       


### PR DESCRIPTION
…to specify the SO_TIMEOUT socket option.

Improve recovery after timeout for jmriclient connections.