### PR TITLE
Use SLF4J logging in JmriServerParser

### DIFF
--- a/java/src/jmri/jmris/simpleserver/JmriServerParser.jjt
+++ b/java/src/jmri/jmris/simpleserver/JmriServerParser.jjt
@@ -11,6 +11,9 @@ PARSER_BEGIN(JmriServerParser)
 
 package jmri.jmris.simpleserver.parser;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /* 
  * This file defines a JavaTree/JavaCC parser implementation for
  * the JMRI simple interconnection protocol.
@@ -24,7 +27,7 @@ package jmri.jmris.simpleserver.parser;
 
 public class JmriServerParser {
   
-   static org.apache.log4j.Logger log = org.apache.log4j.Logger.getLogger(JmriServerParser.class.getName());
+   static Logger log = LoggerFactory.getLogger(JmriServerParser.class.getName());
 
   }
 


### PR DESCRIPTION
This proposal makes the logging in the JmriServer identical to the logging in the SRCPServer.

Use of SLF4J makes it easy to include JMRI.jar as a library in another program and allow that program to use whatever logging framework it prefers.

Is this change acceptable?