### PR TITLE
Fix issue with non-English DecoderPro

### DIFF
--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -176,8 +176,11 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
     JButton prog2Button = new JButton(Bundle.getMessage("BasicProgrammer"));
     ActionListener programModeListener;
     ProgDebugger progDebugger = new ProgDebugger();
-    String programmer1 = Bundle.getMessage("Comprehensive");
-    String programmer2 = Bundle.getMessage("Basic");
+    
+    // These are the names of the programmer _files_, not what should be displayed to the user
+    String programmer1 = "Comprehensive"; // NOI18N
+    String programmer2 = "Basic"; // NOI18N
+    
     java.util.ResourceBundle rb = java.util.ResourceBundle.getBundle("apps.AppsBundle");
     //current selected loco
     RosterEntry re;


### PR DESCRIPTION
DecoderPro in i.e. French couldn't open roster window.  

Problem was "Comprehensive" was going through Bundle internationalization.  I don't see anywhere that the string in programmer1, programmer2 appears (now in English) in the UI, but if there is then a more detailed fix is needed to keep the internal file name separate from the user name.