### PR TITLE
Update Danish translation special characters

### DIFF
--- a/java/src/apps/ActionListBundle_da.properties
+++ b/java/src/apps/ActionListBundle_da.properties
@@ -11,113 +11,113 @@
 
 # some "popular" ones go right at the top
 
-jmri.jmrit.throttle.ThrottleCreationAction = Åbn Kørekontrol
+jmri.jmrit.throttle.ThrottleCreationAction = \u00c5bn K\u00f8rekontrol
 
 jmri.jmrix.loconet.locormi.LnMessageServerAction = Start LocoNet Server
 
 # this next group is the Tools menu
-jmri.jmrit.throttle.LoadDefaultXmlThrottlesLayoutAction = Indlæs Standard Kørekontrol Layout
+jmri.jmrit.throttle.LoadDefaultXmlThrottlesLayoutAction = Indl\u00e6s Standard K\u00f8rekontrol Layout
 
-jmri.jmrit.simpleprog.SimpleProgAction = Åbn Enkelt CV Programmering
-jmri.jmrit.symbolicprog.tabbedframe.PaneProgAction = Åbn DecoderPro Til Programmeringsspor (Service Mode)
-jmri.jmrit.symbolicprog.tabbedframe.PaneOpsProgAction = Åbn DecoderPro Til Programmering på Anlægget (Ops/PoM Mode)
-jmri.jmrit.dualdecoder.DualDecoderToolAction = Åbn Multi-Dekoder Kontrol
+jmri.jmrit.simpleprog.SimpleProgAction = \u00c5bn Enkelt CV Programmering
+jmri.jmrit.symbolicprog.tabbedframe.PaneProgAction = \u00c5bn DecoderPro Til Programmeringsspor (Service Mode)
+jmri.jmrit.symbolicprog.tabbedframe.PaneOpsProgAction = \u00c5bn DecoderPro Til Programmering p\u00e5 Anl\u00e6gget (Ops/PoM Mode)
+jmri.jmrit.dualdecoder.DualDecoderToolAction = \u00c5bn Multi-Dekoder Kontrol
 
-jmri.jmrit.powerpanel.PowerPanelAction = Åbn Power Kontrol
+jmri.jmrit.powerpanel.PowerPanelAction = \u00c5bn Power Kontrol
 jmri.jmrit.powerpanel.PowerButtonAction = Power Knap
 
-jmri.jmrit.speedometer.SpeedometerAction = Åbn Speedometer
-jmri.jmrit.simplelightctrl.SimpleLightCtrlAction = Åbn Lys Kontrol
-jmri.jmrit.simpleturnoutctrl.SimpleTurnoutCtrlAction = Åbn Sporskifte Kontrol
+jmri.jmrit.speedometer.SpeedometerAction = \u00c5bn Speedometer
+jmri.jmrit.simplelightctrl.SimpleLightCtrlAction = \u00c5bn Lys Kontrol
+jmri.jmrit.simpleturnoutctrl.SimpleTurnoutCtrlAction = \u00c5bn Sporskifte Kontrol
 
-jmri.jmrit.beanTabel.ListedTabelAction = Åbn Tabeller
-jmri.jmrit.beanTabel.TurnoutTabelAction = Åbn Sporskifte Tabel
-jmri.jmrit.beanTabel.SensorTabelAction = Åbn Sensor Tabel
-jmri.jmrit.beanTabel.SignalHeadTabelAction = Åbn Signal Hoved Tabel
-jmri.jmrit.beanTabel.SignalMastTabelAction = Åbn Signal Mast Tabel
-jmri.jmrit.beanTabel.ReporterTabelAction = Åbn Reporter Tabel
-jmri.jmrit.beanTabel.MemoryTabelAction = Åbn Hukommelses Tabel
-jmri.jmrit.beanTabel.RouteTabelAction = Åbn Rute Tabel
-jmri.jmrit.beanTabel.LightTabelAction = Åbn Lys Tabel
-jmri.jmrit.beanTabel.BlockTabelAction = Åbn Blok Tabel
-jmri.jmrit.beanTabel.LogixTabelAction = Åbn Logix Tabel
-jmri.jmrit.beanTabel.OBlockTabelAction = Åbn OBlok Tabel
-jmri.jmrit.beanTabel.SectionTabelAction = Åbn Sektions Tabel
-jmri.jmrit.beanTabel.TransitTabelAction = Åbn Transit Tabel
-jmri.jmrit.beanTabel.AudioTabelAction = Åbn Audio Tabel
-jmri.jmrit.beanTabel.IdTagTabelAction = Åbn ID Tag Tabel
-jmri.jmrit.blockboss.BlockBossAction = Åbn Signallogik-Panel
+jmri.jmrit.beanTabel.ListedTabelAction = \u00c5bn Tabeller
+jmri.jmrit.beanTabel.TurnoutTabelAction = \u00c5bn Sporskifte Tabel
+jmri.jmrit.beanTabel.SensorTabelAction = \u00c5bn Sensor Tabel
+jmri.jmrit.beanTabel.SignalHeadTabelAction = \u00c5bn Signal Hoved Tabel
+jmri.jmrit.beanTabel.SignalMastTabelAction = \u00c5bn Signal Mast Tabel
+jmri.jmrit.beanTabel.ReporterTabelAction = \u00c5bn Reporter Tabel
+jmri.jmrit.beanTabel.MemoryTabelAction = \u00c5bn Hukommelses Tabel
+jmri.jmrit.beanTabel.RouteTabelAction = \u00c5bn Rute Tabel
+jmri.jmrit.beanTabel.LightTabelAction = \u00c5bn Lys Tabel
+jmri.jmrit.beanTabel.BlockTabelAction = \u00c5bn Blok Tabel
+jmri.jmrit.beanTabel.LogixTabelAction = \u00c5bn Logix Tabel
+jmri.jmrit.beanTabel.OBlockTabelAction = \u00c5bn OBlok Tabel
+jmri.jmrit.beanTabel.SectionTabelAction = \u00c5bn Sektions Tabel
+jmri.jmrit.beanTabel.TransitTabelAction = \u00c5bn Transit Tabel
+jmri.jmrit.beanTabel.AudioTabelAction = \u00c5bn Audio Tabel
+jmri.jmrit.beanTabel.IdTagTabelAction = \u00c5bn ID Tag Tabel
+jmri.jmrit.blockboss.BlockBossAction = \u00c5bn Signallogik-Panel
 
-jmri.jmrit.consisttool.ConsistToolAction = Åbn Forspands Værktøj
-jmri.jmrit.sendpacket.SendPacketAction = Åbn DCC Pakke Værktøj
+jmri.jmrit.consisttool.ConsistToolAction = \u00c5bn Forspands V\u00e6rkt\u00f8j
+jmri.jmrit.sendpacket.SendPacketAction = \u00c5bn DCC Pakke V\u00e6rkt\u00f8j
 
-jmri.jmrit.nixieclock.NixieClockAction = Åbn Nixie Ur
-jmri.jmrit.lcdclock.LcdClockAction = Åbn LCD Ur
-jmri.jmrit.analogclock.AnalogClockAction = Åbn Analog Ur
-jmri.jmrit.simpleclock.SimpleClockAction = Åbn Hurtig Ur Konfiguration
+jmri.jmrit.nixieclock.NixieClockAction = \u00c5bn Nixie Ur
+jmri.jmrit.lcdclock.LcdClockAction = \u00c5bn LCD Ur
+jmri.jmrit.analogclock.AnalogClockAction = \u00c5bn Analog Ur
+jmri.jmrit.simpleclock.SimpleClockAction = \u00c5bn Hurtig Ur Konfiguration
 
 # Operations menu
-jmri.jmrit.operations.setup.OperationsSetupAction = Åbn Operations Setup Window
-jmri.jmrit.operations.locations.LocationsTabelAction = Åbn Operations Lokationer Window
-jmri.jmrit.operations.rollingstock.cars.CarsTabelAction = Åbn Operations Cars Window
-jmri.jmrit.operations.rollingstock.engines.EnginesTabelAction = Åbn Operations Engines Window
-jmri.jmrit.operations.routes.RoutesTabelAction = Åbn Operations Ruter Window
-jmri.jmrit.operations.trains.TrainsTabelAction = Åbn Operations Tog Window
+jmri.jmrit.operations.setup.OperationsSetupAction = \u00c5bn Operations Setup Window
+jmri.jmrit.operations.locations.LocationsTabelAction = \u00c5bn Operations Lokationer Window
+jmri.jmrit.operations.rollingstock.cars.CarsTabelAction = \u00c5bn Operations Cars Window
+jmri.jmrit.operations.rollingstock.engines.EnginesTabelAction = \u00c5bn Operations Engines Window
+jmri.jmrit.operations.routes.RoutesTabelAction = \u00c5bn Operations Ruter Window
+jmri.jmrit.operations.trains.TrainsTabelAction = \u00c5bn Operations Tog Window
 
 # Panels menu
 jmri.jmrit.display.PanelEditorAction = Nyt Panel
-jmri.configurexml.LoadXmlConfigAction = Åbn Panel Fil...
-jmri.jmrit.automat.monitor.AutomatTabelAction = Åbn Tråd Monitor
-jmri.jmrit.jython.JythonWindow = Åbn Jyton Script Udlæsning Window
-jmri.jmrit.jython.InputWindowAction = Åbn Jyton Script Indlæsning Window
+jmri.configurexml.LoadXmlConfigAction = \u00c5bn Panel Fil...
+jmri.jmrit.automat.monitor.AutomatTabelAction = \u00c5bn Tr\u00e5d Monitor
+jmri.jmrit.jython.JythonWindow = \u00c5bn Jyton Script Udl\u00e6sning Window
+jmri.jmrit.jython.InputWindowAction = \u00c5bn Jyton Script Indl\u00e6sning Window
 
 # selected items from systems menus
-jmri.jmrix.acela.acelamon.AcelaMonAction = Åbn Acela Monitor
+jmri.jmrix.acela.acelamon.AcelaMonAction = \u00c5bn Acela Monitor
 
-jmri.jmrix.can.cbus.swing.console.CbusConsolePane$Default = Åbn CBUS Konsol
-jmri.jmrix.can.cbus.swing.configtool.ConfigToolPane$Default = Åbn CBUS Konfig Værktøj
-jmri.jmrix.can.swing.monitor.MonitorPane$Default = Åbn CAN Monitor
+jmri.jmrix.can.cbus.swing.console.CbusConsolePane$Default = \u00c5bn CBUS Konsol
+jmri.jmrix.can.cbus.swing.configtool.ConfigToolPane$Default = \u00c5bn CBUS Konfig V\u00e6rkt\u00f8j
+jmri.jmrix.can.swing.monitor.MonitorPane$Default = \u00c5bn CAN Monitor
 
-jmri.jmrix.cmri.serial.serialmon.SerialMonAction = Åbn C/MRI Monitor
+jmri.jmrix.cmri.serial.serialmon.SerialMonAction = \u00c5bn C/MRI Monitor
 
-jmri.jmrix.easydcc.easydccmon.EasyDccMonAction = Åbn EasyDCC Monitor
+jmri.jmrix.easydcc.easydccmon.EasyDccMonAction = \u00c5bn EasyDCC Monitor
 
-jmri.jmrix.ecos.swing.monitor.EcosMonPane$Default = Åbn ECoS Monitor
-jmri.jmrix.ecos.swing.statusframe.StatusPanel$Default = Åbn ECoS Info
+jmri.jmrix.ecos.swing.monitor.EcosMonPane$Default = \u00c5bn ECoS Monitor
+jmri.jmrix.ecos.swing.statusframe.StatusPanel$Default = \u00c5bn ECoS Info
 
-jmri.jmrix.grapevine.serialmon.SerialMonAction = Åbn Grapevine Monitor
-jmri.jmrix.grapevine.nodeTabel.NodeTabelAction = Åbn Grapevine Node Tabel
-jmri.jmrix.grapevine.packetgen.SerialPacketGenAction = Åbn Grapevine Send Pakke
+jmri.jmrix.grapevine.serialmon.SerialMonAction = \u00c5bn Grapevine Monitor
+jmri.jmrix.grapevine.nodeTabel.NodeTabelAction = \u00c5bn Grapevine Node Tabel
+jmri.jmrix.grapevine.packetgen.SerialPacketGenAction = \u00c5bn Grapevine Send Pakke
 
-jmri.jmrix.lenz.swing.mon.XNetMonAction = Åbn XPressNet Monitor
+jmri.jmrix.lenz.swing.mon.XNetMonAction = \u00c5bn XPressNet Monitor
 
-jmri.jmrix.loconet.locomon.LocoMonPane$Default = Åbn LocoNet Monitor
-jmri.jmrix.loconet.slotmon.SlotMonPane$Default = Åbn LocoNet Slot Monitor
-jmri.jmrix.loconet.clockmon.ClockMonPane$Default = Åbn LocoNet Ur Monitor
-jmri.jmrix.loconet.locostats.LocoStatsPanel$Default = Åbn LocoNet Status Window
-jmri.jmrix.loconet.pr3.swing.Pr3SelectPane$Default = Åbn LocoNet PR3 Værktøj
+jmri.jmrix.loconet.locomon.LocoMonPane$Default = \u00c5bn LocoNet Monitor
+jmri.jmrix.loconet.slotmon.SlotMonPane$Default = \u00c5bn LocoNet Slot Monitor
+jmri.jmrix.loconet.clockmon.ClockMonPane$Default = \u00c5bn LocoNet Ur Monitor
+jmri.jmrix.loconet.locostats.LocoStatsPanel$Default = \u00c5bn LocoNet Status Window
+jmri.jmrix.loconet.pr3.swing.Pr3SelectPane$Default = \u00c5bn LocoNet PR3 V\u00e6rkt\u00f8j
 
-jmri.jmrix.nce.ncemon.NceMonPanel$Default = Åbn NCE Monitor
+jmri.jmrix.nce.ncemon.NceMonPanel$Default = \u00c5bn NCE Monitor
 
-jmri.jmrix.powerline.swing.serialmon.SerialMonPane$Default = Åbn Powerline Monitor
+jmri.jmrix.powerline.swing.serialmon.SerialMonPane$Default = \u00c5bn Powerline Monitor
 
-jmri.jmrix.qsi.qsimon.QsiMonAction = Åbn QSI Monitor
-jmri.jmrix.qsi.packetgen.PacketGenAction = Åbn QSI Send Pakke
+jmri.jmrix.qsi.qsimon.QsiMonAction = \u00c5bn QSI Monitor
+jmri.jmrix.qsi.packetgen.PacketGenAction = \u00c5bn QSI Send Pakke
 
-jmri.jmrix.rfid.swing.serialmon.SerialMonPane = Åbn Rfid Læse Monitor
+jmri.jmrix.rfid.swing.serialmon.SerialMonPane = \u00c5bn Rfid L\u00e6se Monitor
 
-jmri.jmrix.srcp.srcpmon.SRCPMonAction = Åbn SRCP Monitor
-jmri.jmrix.srcp.packetgen.PacketGenAction = Åbn SRCP Meddelelses Værktøj
+jmri.jmrix.srcp.srcpmon.SRCPMonAction = \u00c5bn SRCP Monitor
+jmri.jmrix.srcp.packetgen.PacketGenAction = \u00c5bn SRCP Meddelelses V\u00e6rkt\u00f8j
 
-jmri.jmrix.zimo.swing.monitor.Mx1MonPanel$Default = Åbn Zimo Monitor
+jmri.jmrix.zimo.swing.monitor.Mx1MonPanel$Default = \u00c5bn Zimo Monitor
 
-jmri.jmrix.jinput.treeKontrol.TreeAction = Åbn USB Input Kontrol
-jmri.jmrix.libusb.UsbViewAction = Åbn USB Device Viser
+jmri.jmrix.jinput.treeKontrol.TreeAction = \u00c5bn USB Input Kontrol
+jmri.jmrix.libusb.UsbViewAction = \u00c5bn USB Device Viser
 
 # web items
 jmri.web.server.WebServerAction = Start Web Server
 
-jmri.jmrit.MemoryFrameAction = Åbn Hukommelses Monitor
+jmri.jmrit.MemoryFrameAction = \u00c5bn Hukommelses Monitor
 
 # services
 jmri.jmrit.withrottle.WiThrottleCreationAction = Start WiThrottle Server
@@ -126,7 +126,7 @@ jmri.jmris.srcp.JmriSRCPServerAction = Start JMRI SRCP Server
 jmri.jmris.simpleserver.SimpleServerAction = Start Simple JMRI Server
 
 # system console
-apps.SystemConsoleAction = Åbn JMRI System Konsol
+apps.SystemConsoleAction = \u00c5bn JMRI System Konsol
 
 # restart JMRI
 apps.RestartAction = Genstart JMRI
@@ -135,10 +135,10 @@ apps.RestartAction = Genstart JMRI
 apps.CheckForUpdateAction = Check for Opdateringer
 
 # Roster
-jmri.jmrit.roster.swing.RosterFrameAction = Åbn Roster
+jmri.jmrit.roster.swing.RosterFrameAction = \u00c5bn Roster
 jmri.jmrit.roster.RecreateRosterAction = Gendan Roster
 
-jmri.jmrit.dispatcher.DispatcherAction = Åbn Dispatcher
+jmri.jmrit.dispatcher.DispatcherAction = \u00c5bn Dispatcher
 
 # Preferences
 apps.gui3.TabbedPreferencesAction = Indstillinger...


### PR DESCRIPTION
File had Unicode characters in it, but only ISO 8859-1 works properly.  Ran native2ascii to correct.

For more background, see the [JMRI internationalization page](http://jmri.org/help/en/html/doc/Technical/I8N.shtml)