### PR TITLE
Icon background test fix

### DIFF
--- a/java/src/jmri/jmrit/display/MemoryIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryIcon.java
@@ -317,9 +317,8 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
      * Drive the current state of the display from the state of the Memory.
      */
     public void displayState() {
-        if (log.isDebugEnabled()) {
-            log.debug("displayState");
-        }
+        log.debug("displayState()");
+
         if (namedMemory == null) {  // use default if not connected yet
             setIcon(defaultIcon);
             updateSize();
@@ -334,6 +333,7 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
     }
 
     protected void displayState(Object key) {
+        log.debug("displayState({})", key);
         if (key != null) {
             if (map == null) {
                 Object val = key;
@@ -353,24 +353,14 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
                     setText(str);
                     updateIcon(null);
                     if (log.isDebugEnabled()) {
-                        log.debug("String str= \"" + str + "\" str.trim().length()= " + str.trim().length()
-                                + ", maxWidth()= " + maxWidth() + ", maxHeight()= " + maxHeight());
-                    }
-                    /*  MemoryIconTest says empty strings should show blank */
-                    if (str.trim().length() == 0) {
-                        if (getBackground().equals(_editor.getTargetPanel().getBackground())) {
-                            _saveColor = getPopupUtility().getBackground();
-                            if (_editor.getTargetPanel().getBackground().equals(Color.white)) {
-                                getPopupUtility().setBackgroundColor(Color.gray);
-                            } else {
-                                getPopupUtility().setBackgroundColor(Color.white);
-                            }
-                        }
-                    } else {
-                        if (_saveColor != null) {
-                            getPopupUtility().setBackgroundColor(_saveColor);
-                            _saveColor = null;
-                        }
+                        log.debug("String str= \"" + str + "\" str.trim().length()= " + str.trim().length());
+                        log.debug("  maxWidth()= " + maxWidth() + ", maxHeight()= " + maxHeight());
+                        log.debug("  getBackground(): {}", getBackground());
+                        log.debug("  _editor.getTargetPanel().getBackground(): {}", _editor.getTargetPanel().getBackground());
+                        log.debug("  setAttributes to getPopupUtility({}) with", getPopupUtility());
+                        log.debug("     hasBackground() {}", getPopupUtility().hasBackground());
+                        log.debug("     getBackground() {}", getPopupUtility().getBackground());
+                        log.debug("    on editor {}", _editor);
                     }
                     _editor.setAttributes(getPopupUtility(), this);
                 } else if (val instanceof javax.swing.ImageIcon) {

--- a/java/test/jmri/jmrit/display/MemoryIconTest.java
+++ b/java/test/jmri/jmrit/display/MemoryIconTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.display;
 
 import java.awt.Graphics2D;
 import java.awt.Point;
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
@@ -32,9 +33,11 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
         JFrame jf = new JmriJFrame();
         jf.setTitle("Expect \"Data Data\" as text");
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
+        jf.getContentPane().setBackground(Color.white);
 
         to = new MemoryIcon("MemoryTest1", panel);
         jf.getContentPane().add(to);
+        to.getPopupUtility().setBackgroundColor(Color.white);
 
         jf.getContentPane().add(new javax.swing.JLabel("| Expect \"Data Data\" text"));
 
@@ -57,10 +60,10 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
         int r = ((colors[1]>>16)&0xFF)+((colors[2]>>16)&0xFF)+((colors[3]>>16)&0xFF)+((colors[4]>>16)&0xFF);
         int g = ((colors[1]>>8)&0xFF)+((colors[2]>>8)&0xFF)+((colors[3]>>8)&0xFF)+((colors[4]>>8)&0xFF);
         int b = ((colors[1])&0xFF)+((colors[2])&0xFF)+((colors[3])&0xFF)+((colors[4])&0xFF);
-        Assert.assertTrue("Expect gray/black ", r==g & g==b); // gray pixels
+        Assert.assertTrue("Expect gray/black text", r==g & g==b); // gray pixels
         Assert.assertTrue("Expect blacker than grey", r<4*0xee); // gray pixels
 
-        if (!System.getProperty("jmri.demo", "false").equals("false")) {
+        if (System.getProperty("jmri.demo", "false").equals("false")) {
             jf.setVisible(false);
             jf.dispose();
         }
@@ -70,9 +73,11 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
         JFrame jf = new JmriJFrame();
         jf.setTitle("Expect blank");
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
+        jf.getContentPane().setBackground(Color.white);
 
         to = new MemoryIcon("MemoryTest2", panel);
         jf.getContentPane().add(to);
+        to.getPopupUtility().setBackgroundColor(Color.white);
 
         jf.getContentPane().add(new javax.swing.JLabel("| Expect blank: "));
 
@@ -92,11 +97,10 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
         flushAWT();
 
         int[] colors = getColor("Expect blank","| Expect blank",0,6,10);
-//        Assert.assertTrue("Expect gray pixels", (colors[3]==0xffeeeeee)&&(colors[4]==0xffeeeeee)); // gray pixels
-        Assert.assertTrue("Expect white pixels", (colors[3]==0xffffffff)&&(colors[4]==0xffffffff)); // white pixels
-        Assert.assertTrue("Expect gray pixels", (colors[7]==0xffeeeeee)&&(colors[8]==0xffeeeeee)); // gray pixels
+        boolean white = (colors[3]==0xffffffff)&&(colors[4]==0xffffffff);
+        Assert.assertTrue("Expect white pixels", white);
         
-        if (!System.getProperty("jmri.demo", "false").equals("false")) {
+        if (System.getProperty("jmri.demo", "false").equals("false")) {
             jf.setVisible(false);
             jf.dispose();
         }
@@ -107,9 +111,11 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
         JFrame jf = new JmriJFrame();
         jf.setTitle("Expect empty");
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
+        jf.getContentPane().setBackground(Color.white);
 
         to = new MemoryIcon("MemoryTest3", panel);
         jf.getContentPane().add(to);
+        to.getPopupUtility().setBackgroundColor(Color.white);
 
         jf.getContentPane().add(new javax.swing.JLabel("| Expect red X default icon: "));
 
@@ -131,7 +137,7 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
         int colors[] = getColor("Expect empty","| Expect empty",0,6,10);
         Assert.assertTrue("Expect red X", (colors[3]==0xff800000)||(colors[4]==0xff800000)||(colors[5]==0xff800000));
 
-        if (!System.getProperty("jmri.demo", "false").equals("false")) {
+        if (System.getProperty("jmri.demo", "false").equals("false")) {
             jf.setVisible(false);
             jf.dispose();
         }

--- a/java/test/jmri/jmrit/display/PositionableLabelTest.java
+++ b/java/test/jmri/jmrit/display/PositionableLabelTest.java
@@ -78,15 +78,13 @@ public class PositionableLabelTest extends jmri.util.SwingTestCase {
         // Find color in label by frame name
         int color1 = getColor("F Bkg none, label Bkg none"); // white background
 
-        int color2 = getColor("F Bkg blue, label Bkg none"); // white background
+        int color2 = getColor("F Bkg blue, label Bkg none"); // blue background
 
         int color3 = getColor("F Bkg none, label Bkg yellow"); // yellow
 
         int color4 = getColor("F Bkg blue, label Bkg yellow");
 
-//        Assert.assertEquals("F Bkg none, label Bkg none color", "0xffffffff",   // white background pre Java 1.8
-//                            String.format("0x%8s", Integer.toHexString(color1)).replace(' ', '0'));
-        Assert.assertEquals("F Bkg none, label Bkg none color", "0xffeeeeee",   // light grey background
+        Assert.assertEquals("F Bkg none, label Bkg none color", "0xffffffff",   // white background
                             String.format("0x%8s", Integer.toHexString(color1)).replace(' ', '0'));
         Assert.assertEquals("F Bkg blue, label Bkg none color", "0xff0000ff",   // blue background
                             String.format("0x%8s", Integer.toHexString(color2)).replace(' ', '0')); // no blue, looking at transparent label

--- a/java/test/jmri/jmrit/display/configurexml/verify/backgrounds.xml
+++ b/java/test/jmri/jmrit/display/configurexml/verify/backgrounds.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/panelfile-2-9-6.xsl" type="text/xsl"?>
 <layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-2-9-6.xsd">
-  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="F Bkg none, label Bkg none" x="1" y="23" height="150" width="350" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="yes" panelmenu="yes" scrollable="both">
+  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="F Bkg none, label Bkg none" x="1" y="23" height="150" width="350" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="yes" panelmenu="yes" scrollable="both" redBackground="255" greenBackground="255" blueBackground="255" >
     <positionablelabel x="0" y="0" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" text="...." size="13" style="0" red="0" green="0" blue="0" justification="centre" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
   </paneleditor>
   <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="F Bkg blue, label Bkg none" x="1" y="200" height="150" width="350" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="yes" panelmenu="yes" scrollable="both" redBackground="0" greenBackground="0" blueBackground="255">
     <positionablelabel x="0" y="0" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" text="...." size="13" style="0" red="0" green="0" blue="0" justification="centre" class="jmri.jmrit.display.configurexml.PositionableLabelXml" />
   </paneleditor>
-  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="F Bkg none, label Bkg yellow" x="400" y="23" height="150" width="350" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="yes" panelmenu="yes" scrollable="both">
+  <paneleditor class="jmri.jmrit.display.panelEditor.configurexml.PanelEditorXml" name="F Bkg none, label Bkg yellow" x="400" y="23" height="150" width="350" editable="yes" positionable="yes" showtooltips="yes" controlling="yes" hide="yes" panelmenu="yes" scrollable="both" redBackground="255" greenBackground="255" blueBackground="255" >
     <positionablelabel x="0" y="0" level="4" forcecontroloff="false" hidden="no" positionable="true" showtooltip="true" editable="true" text="...." size="13" style="0" red="0" green="0" blue="0" redBack="255" greenBack="255" blueBack="0" justification="centre" class="jmri.jmrit.display.configurexml.PositionableLabelXml">
       <tooltip>Text Label</tooltip>
     </positionablelabel>


### PR DESCRIPTION
This is a fix to how empty (null String) MemoryIcons appear on Mac OS X. This is intended to go on the main master; I'll make about PR as a patch to 4.1.5 to be included in 4.1.6.