### PR TITLE
Fix bug 540 reported on Sourceforge

### DIFF
--- a/java/src/apps/AbstractActionPanel.java
+++ b/java/src/apps/AbstractActionPanel.java
@@ -158,6 +158,8 @@ abstract public class AbstractActionPanel extends JPanel implements PreferencesP
                     model.setName((String) selections.getSelectedItem());
                 }
             });
+            // set the model name to the first item in selections
+            model.setName(selections.getItemAt(0));
         }
 
         Item(AbstractActionModel m) {

--- a/java/src/apps/StartupActionsManager.java
+++ b/java/src/apps/StartupActionsManager.java
@@ -82,7 +82,7 @@ public class StartupActionsManager extends AbstractPreferencesProvider {
                 }
             } else {
                 // get an error with a stack trace if this occurs
-                log.error("model cannot have a name.", new Exception());
+                log.error("model does not have a name.", new Exception());
             }
         }
         try {


### PR DESCRIPTION
Fixes [bug 540](https://sourceforge.net/p/jmri/bugs/540/) on SourceForge.

Issue was that the StartupModel’s name was only being set after an item
was selected from the combo box of Startup Actions or Startup Buttons.
The fix is to set the model’s name to the first item in the combo box.