### PR TITLE
Fix issues found by Jenkins

### DIFF
--- a/java/src/apps/gui/GuiLafPreferencesManager.java
+++ b/java/src/apps/gui/GuiLafPreferencesManager.java
@@ -201,7 +201,7 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesProvide
                 Object key = keys.nextElement();
                 Object value = UIManager.get(key);
                 if (value instanceof FontUIResource) {
-                    UIManager.put(key, UIManager.getFont(key).deriveFont(((Font) value).getStyle(), (float) this.getFontSize()));
+                    UIManager.put(key, UIManager.getFont(key).deriveFont(((Font) value).getStyle(), this.getFontSize()));
                 }
             }
         }

--- a/java/src/jmri/implementation/JmriConfigurationManager.java
+++ b/java/src/jmri/implementation/JmriConfigurationManager.java
@@ -35,6 +35,7 @@ public class JmriConfigurationManager implements ConfigureManager {
     private final ConfigXmlManager legacy = new ConfigXmlManager();
     private final HashMap<PreferencesProvider, InitializationException> initializationExceptions = new HashMap<>();
 
+    @SuppressWarnings("unchecked") // For types in InstanceManager.store()
     public JmriConfigurationManager() {
         ServiceLoader<PreferencesProvider> sl = ServiceLoader.load(PreferencesProvider.class);
         for (PreferencesProvider pp : sl) {

--- a/java/src/jmri/jmrit/beantable/SectionTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SectionTableAction.java
@@ -1263,14 +1263,15 @@ public class SectionTableAction extends AbstractTableAction {
                     panel = null;
                     return false;
                 }
-                if (panelName == null) {
-                    log.error("panelName is null!");
-                }
-                for (int j = 0; j < layoutEditorList.size(); j++) {
-                    if (panelName.equals(choices[j])) {
-                        panel = layoutEditorList.get(j);
-                        return true;
+                if (panelName != null) {
+                    for (int j = 0; j < layoutEditorList.size(); j++) {
+                        if (panelName.equals(choices[j])) {
+                            panel = layoutEditorList.get(j);
+                            return true;
+                        }
                     }
+                } else {
+                    log.error("panelName is null!");
                 }
                 return false;
             } else if (layoutEditorList.size() == 1) {

--- a/java/src/jmri/jmrit/display/MemoryComboIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryComboIcon.java
@@ -66,7 +66,7 @@ public class MemoryComboIcon extends PositionableJPanel
         setPopupUtility(new PositionablePopupUtil(this, _comboBox));
     }
     
-    public javax.swing.JComponent getTextComponent() {
+    public JComboBox<String> getTextComponent() {
         return _comboBox;
     }
 

--- a/java/src/jmri/jmrit/display/palette/DecoratorPanel.java
+++ b/java/src/jmri/jmrit/display/palette/DecoratorPanel.java
@@ -257,7 +257,7 @@ public class DecoratorPanel extends JPanel implements ChangeListener, ItemListen
                 sample.setText(field.getText());
                 addtextField = false;
             } else if (pos instanceof jmri.jmrit.display.MemoryComboIcon) {
-                JComboBox<String> box = (JComboBox<String>)((jmri.jmrit.display.MemoryComboIcon)pos).getTextComponent();
+                JComboBox<String> box = ((jmri.jmrit.display.MemoryComboIcon)pos).getTextComponent();
                 sample.setText(box.getSelectedItem().toString());
                 addtextField = false;
             } else if (pos instanceof jmri.jmrit.display.MemorySpinnerIcon) {

--- a/java/src/jmri/jmrit/symbolicprog/ResetTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/ResetTableModel.java
@@ -41,11 +41,11 @@ public class ResetTableModel extends AbstractTableModel implements ActionListene
         "CV", "Value",
         "Write", "State"};
 
-    private Vector<CvValue> rowVector = new Vector<CvValue>(); // vector of Reset items
-    private Vector<String> labelVector = new Vector<String>(); // vector of related labels
-    private Vector<List> modeVector = new Vector<List>(); // vector of related modes
+    private Vector<CvValue> rowVector = new Vector<>(); // vector of Reset items
+    private Vector<String> labelVector = new Vector<>(); // vector of related labels
+    private Vector<List<String>> modeVector = new Vector<>(); // vector of related modes
 
-    private Vector<JButton> _writeButtons = new Vector<JButton>();
+    private Vector<JButton> _writeButtons = new Vector<>();
 
     private CvValue _iCv = null;
     private JLabel _status = null;

--- a/java/src/jmri/jmrix/roco/z21/simulator/z21SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/roco/z21/simulator/z21SimulatorAdapter.java
@@ -83,7 +83,8 @@ public class z21SimulatorAdapter extends z21Adapter implements Runnable {
      try {
          s = new DatagramSocket(COMMUNICATION_UDP_PORT);
      } catch (Exception ex0 ) {
-       log.error("Exception opening socket");
+       log.error("Exception opening socket", ex0);
+       return; // can't continue from this
      }
 
      log.debug("socket created, starting loop");

--- a/java/src/jmri/util/prefs/JmriPreferencesProvider.java
+++ b/java/src/jmri/util/prefs/JmriPreferencesProvider.java
@@ -151,7 +151,7 @@ public final class JmriPreferencesProvider {
                 result.append(c);
             } else {
                 result.append("_");
-                result.append(Integer.toHexString((int) c));
+                result.append(Integer.toHexString(c));
                 result.append("_");
             }
         }

--- a/java/test/jmri/jmrit/logix/LearnWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LearnWarrantTest.java
@@ -20,6 +20,7 @@ import junit.extensions.jfcunit.finder.DialogFinder;
 import junit.framework.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+
 /**
  * Tests for the Warrant creation
  *
@@ -35,6 +36,7 @@ public class LearnWarrantTest extends jmri.util.SwingTestCase {
     SensorManager _sensorMgr;
     TurnoutManager _turnoutMgr;
     
+    @SuppressWarnings("unchecked") // For types from DialogFinder().findAll(..)
     public void testLearnWarrant() throws Exception {
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/LearnWarrantTest.xml");

--- a/java/test/jmri/jmrit/logix/NXWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/NXWarrantTest.java
@@ -22,6 +22,7 @@ import junit.extensions.jfcunit.finder.DialogFinder;
 import junit.framework.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+
 /**
  * Tests for the Warrant creation
  *
@@ -37,6 +38,7 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
     SensorManager _sensorMgr;
     TurnoutManager _turnoutMgr;
     
+    @SuppressWarnings("unchecked") // For types from DialogFinder().findAll(..)
     public void testNXWarrant() throws Exception {
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/NXWarrantTest.xml");
@@ -126,6 +128,7 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
         return button;
     }
 
+    @SuppressWarnings("unchecked") // For types from DialogFinder().findAll(..)
     private void confirmJOptionPane(java.awt.Container frame, String title, String message, String buttonLabel) {
         ComponentFinder finder = new ComponentFinder(JOptionPane.class);
         JOptionPane pane;
@@ -154,6 +157,7 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
         Assert.assertNotNull("NceSystemConnectionMemo", memo);        
     }
     
+    @SuppressWarnings("unchecked") // For types from DialogFinder().findAll(..)
     private static List<JRadioButton> getRadioButtons(java.awt.Container frame) {
         ComponentFinder finder = new ComponentFinder(JRadioButton.class);
         List<JRadioButton> list = finder.findAll(frame);

--- a/java/test/jmri/jmrix/cmri/serial/SerialAddressTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialAddressTest.java
@@ -25,7 +25,7 @@ public class SerialAddressTest extends TestCase {
         super.setUp();
 
         // replace the SerialTrafficController
-        SerialTrafficController t = new SerialTrafficController() {
+        new SerialTrafficController() {
             SerialTrafficController test() {
                 setInstance();
                 return this;


### PR DESCRIPTION
Multiple small changes to clean up code based on warnings generated by Jenkins:

- remove unchecked code constructs
- when unchecked required by 3rd-party JFC library, annotate them to reduce confusion
- removed unneeded cases
- protect against NPE-after-diagnosed-error (if it's worth checking, it's worth handling)

Not for inclusion in 4.1.6

