### PR TITLE
Set Jython cache to user-writable location

### DIFF
--- a/java/src/jmri/script/JmriScriptEngineManager.java
+++ b/java/src/jmri/script/JmriScriptEngineManager.java
@@ -360,6 +360,7 @@ public final class JmriScriptEngineManager {
                         path = path.concat(File.pathSeparator);
                     }
                     properties.setProperty("python.path", path.concat(FileUtil.getScriptsPath().concat(File.pathSeparator).concat(FileUtil.getAbsoluteFilename("program:jython"))));
+                    properties.setProperty("python.cachedir", FileUtil.getAbsoluteFilename(properties.getProperty("python.cachedir", "settings:jython/cache"))); // NOI18N
                     execJython = Boolean.valueOf(properties.getProperty("jython.exec", Boolean.toString(false)));
                 } catch (IOException ex) {
                     log.error("Found, but unable to read python.properties: {}", ex.getMessage());


### PR DESCRIPTION
This makes the assumption that the JMRI portable location “settings:”
is writable by the user running JMRI. This can be overwritten by
settings the python.cachedir system property when launching JMRI or by
setting the python.cachedir system property in python.properties within
a profile.