### PR TITLE
Fix to MemoryIconTest and PositionableLabel

### DIFF
--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -36,21 +36,25 @@
     <li><a href="#run">Running the Tests</a></li>
     <li><a href="#Continuous">Continuous Integration Test Execution</a></li>
     <li><a href="#write">Writing Tests</a></li>
-    <ul>
+        <ul>
         <li><a href="#writeAddl4ExistClass">Writing Additional Tests for an Existing Class</a></li>
         <li><a href="#write4NewClass">Writing Tests for a New Class</a></li>
         <li><a href="#Write4NewPackage">Writing Tests for a New Package</a></li>
-        <li><a href="#keyMetaphors">Key Metaphors</a></li>
-        <ul>
-            <li><a href="#HandlingLogOutput">Handling Log4J Output From Tests</a></li>
-            <li><a href="#ResetInstMgr">Resetting the InstanceManager</a></li>
-            <li><a href="#RunningListeners">Running Listeners</a></li>
-            <li><a href="#testSwingCode">Testing Swing Code</a></li>
-            <li><a href="#complicatedGuiTesting">Testing Complicated GUI code</a></li>
-            <li><a href="#tempFileCreation">Temporary File Creation in Tests</a></li>
         </ul>
-        <li><a href="#issues">Issues</a></li>
+    <li><a href="#keyMetaphors">Key Metaphors</a></li>
+        <ul>
+        <li><a href="#HandlingLogOutput">Handling Log4J Output From Tests</a></li>
+        <li><a href="#ResetInstMgr">Resetting the InstanceManager</a></li>
+        <li><a href="#RunningListeners">Running Listeners</a></li>
+        <li><a href="#io">Testing I/O</a></li>
+        <li><a href="#tempFileCreation">Temporary File Creation in Tests</a></li>
+        </ul>
+    <li><a href="#testSwingCode">Testing Swing Code</a></li>
+        <ul>
+        <li><a href="#complicatedGuiTesting">Testing Complicated GUI code</a></li>
+        </ul>
     </ul>
+    <li><a href="#issues">Issues</a></li>
 </ul>
 
 <a name="Introduction"></a>
@@ -91,7 +95,7 @@ of your test class, or the test class for your package, you
 can run that directly with the "runtest" script:
 <PRE>
 <CODE>
-   ant tests
+   ant tests<br/>
    ./runtest.csh jmri.jmrit.powerpanel.PowerPanelTest
 </CODE>
 </PRE>
@@ -164,9 +168,9 @@ don't forget to put an entry in the enclosing package's test suite)
 (Needs info here: basically, copy some other package, and
 don't forget to put an entry in the enclosing package's test suite)
 
-<h3><a name="keyMetaphors">Key Metaphors</a></h3>
+<h2><a name="keyMetaphors">Key Test Metaphors</a></h2>
 
-<h4><a name="HandlingLogOutput">Handling Log4J Output From Tests</a></h4>
+<h3><a name="HandlingLogOutput">Handling Log4J Output From Tests</a></h3>
 
 JMRI uses 
 <A HREF="http://logging.apache.org/log4j/docs/index.html">Log4j</a>
@@ -226,7 +230,7 @@ It will be a JUnit error if a log.warn(...) or log.error(...) message is
 produced that isn't matched to a JUnitAppender.assertWarnMessage(...) call.
 </OL>
 
-<h4><a name="ResetInstMgr">Resetting the InstanceManager</a></h4>
+<h3><a name="ResetInstMgr">Resetting the InstanceManager</a></h3>
 
 If you are testing code that is going to reference the InstanceManager, 
 you should
@@ -250,7 +254,7 @@ Your <code>tearDown()</code> should end with:
     super.tearDown();
 </PRE></code>
 
-<h4><a name="RunningListeners">Running Listeners</a></h4>
+<h3><a name="RunningListeners">Running Listeners</a></h3>
 
 JMRI is a multi-threaded application. Listeners for
 JMRI objects are notified on various threads.
@@ -272,80 +276,17 @@ Don't make this longer than really needed, though, because
 you colleagues will have to wait that long every time they run the tests.
 <p>
 Note that this should <b>not</b> be used to synchronize with
-Swing threads.  See the next section for that.
+Swing threads.  
+See the <a href="#testSwingCode">Testing Swing Code</a> section for that.
 
-<h4><a id="io" name="io"></a>I/O</h4>
+<h3><a id="io" name="io"></a>Testing I/O</h3>
 
 Some test environments don't automatically flush I/O operations such as 
 streams during testing.  If you're testing something that does I/O, for example
 a TrafficController, you'll need to add "flush()" statements on all your output streams.
 (Having to wait a long time to make a test reliable is a clue that this is happening somewhere in your code)
 
-<h4><a id="testSwingCode" name="testSwingCode"></a>Testing Swing Code</h4>
-
-AWT and Swing code runs on a separate thread from JUnit tests.
-Once a Swing or AWT object has been displayed (via
-<code>show()</code> or <code>setVisible(true)</code>),
-it cannot be reliably accessed from the JUnit thread.  Even using
-the listener delay technique described above isn't reliable.
-
-<p>
-For the simplest possible test, displaying a window 
-for manual interaction, it's OK to create and invoke a Swing
-object from a JUnit test.  Just don't try to interact with it once
-it's been displayed!
-
-<p>
-Because we run tests in "headless" mode during the
-<a href="ContinuousIntegration.shtml">continuous integration builds</a>,
-it's important that Swing (and AWT) access in tests
-be enclosed within a mode check:
-<p><CODE><PRE>
-        if (!System.getProperty("jmri.headlesstest","false").equals("true")) {<br/>
-            suite.addTest(myTest.suite());<br/>
-        }<br/>
-</PRE></code>
-<p>This will run the myTest suite of tests only when a display is available.
-
-<p>GUI tests should close windows when they're done, and in general clean up after themselves.
-If you want to keep windows around so you can manipulate them, e.g. for manual testing or debugging, 
-you can use the jmri.demo system parameter to control that:
-<p><CODE><PRE>
-        if (!System.getProperty("jmri.demo", "false").equals("false")) {<br/>
-            myFrame.setVisible(false);<br/>
-            myFrame.dispose();
-        }
-</PRE></code>
-
-<p>
-For many tests, you'll both make testing reliable and improve the structure 
-of your code by separating the GUI (Swing) code from the JMRI logic and
-communications.  This lets you check the logic code separately, but invoking
-those methods and checking the state them update.
-
-<h4><a name="complicatedGuiTesting">Testing Complicated GUI code</a></h4>
-<p>
-For more complicated GUI testing, we're starting to use
-<a href="http://jfcunit.sourceforge.net/">JFCUnit</a>.
-
-<p>
-For a very simple example of the use of JFCUnit, see the
-<a href="https://github.com/JMRI/JMRI/blob/master/java/test/jmri/util/SwingTestCaseTest.java">test/jmri/util/SwingTestCaseTest.java</a> file.
-
-<p>
-To use JFCUnit, you first inherit your class From
-<code>SwingTestCase</code> instead of <code>TestCase</code>.
-This is enough to get basic operation of Swing tests; the base class 
-pauses the test thread until Swing (actually, the AWT event mechanism)
-has completed all processing after every Swing call in the test.
-(For this reason, the tests will run much slower if you're e.g. moving the
-mouse cursor around while they're running)
-
-<p>
-For more complex GUI testing, you can invoke various aspects of the interface
-and check internal state using test code.
-
-<h4><a name="tempFileCreation">Temporary File Creation in Tests</a></h4>
+<h3><a name="tempFileCreation">Temporary File Creation in Tests</a></h3>
 
 Testcases which create temporary files must be carefully created so
 that there will not be any problems with file path, filesystem security, 
@@ -431,7 +372,73 @@ Here are some ideas which can help avoid these types of problems.
     here, the test became stable over multiple continuous integration executions 
     of "headlesstest".
 
-<h3><a name="issues">Issues</a></h3>
+<h2><a id="testSwingCode" name="testSwingCode"></a>Testing Swing Code</h2>
+
+AWT and Swing code runs on a separate thread from JUnit tests.
+Once a Swing or AWT object has been displayed (via
+<code>show()</code> or <code>setVisible(true)</code>),
+it cannot be reliably accessed from the JUnit thread.  Even using
+the listener delay technique described above isn't reliable.
+
+<p>
+For the simplest possible test, displaying a window 
+for manual interaction, it's OK to create and invoke a Swing
+object from a JUnit test.  Just don't try to interact with it once
+it's been displayed!
+
+<p>
+Because we run tests in "headless" mode during the
+<a href="ContinuousIntegration.shtml">continuous integration builds</a>,
+it's important that Swing (and AWT) access in tests
+be enclosed within a mode check:
+<p><CODE><PRE>
+        if (!System.getProperty("jmri.headlesstest","false").equals("true")) {<br/>
+            suite.addTest(myTest.suite());<br/>
+        }<br/>
+</PRE></code>
+<p>This will run the myTest suite of tests only when a display is available.
+
+<p>GUI tests should close windows when they're done, and in general clean up after themselves.
+If you want to keep windows around so you can manipulate them, e.g. for manual testing or debugging, 
+you can use the jmri.demo system parameter to control that:
+<p><CODE><PRE>
+        if (!System.getProperty("jmri.demo", "false").equals("false")) {<br/>
+            myFrame.setVisible(false);<br/>
+            myFrame.dispose();<br/>
+        }
+</PRE></code>
+
+<p>
+For many tests, you'll both make testing reliable and improve the structure 
+of your code by separating the GUI (Swing) code from the JMRI logic and
+communications.  This lets you check the logic code separately, but invoking
+those methods and checking the state them update.
+
+<h3><a name="complicatedGuiTesting">Testing Complicated GUI code</a></h3>
+<p>
+For more complicated GUI testing, we use
+<a href="http://jfcunit.sourceforge.net/">JFCUnit</a>
+to control interactions with Swing objects.
+
+<p>
+For a very simple example of the use of JFCUnit, see the
+<a href="https://github.com/JMRI/JMRI/blob/master/java/test/jmri/util/SwingTestCaseTest.java">test/jmri/util/SwingTestCaseTest.java</a> file.
+
+<p>
+To use JFCUnit, you first inherit your class From
+<code>SwingTestCase</code> instead of <code>TestCase</code>.
+This is enough to get basic operation of Swing tests; the base class 
+pauses the test thread until Swing (actually, the AWT event mechanism)
+has completed all processing after every Swing call in the test.
+(For this reason, the tests will run much slower if you're e.g. moving the
+mouse cursor around while they're running)
+
+<p>
+For more complex GUI testing, you can invoke various aspects of the interface
+and check internal state using test code.
+
+
+<h2><a name="issues">Issues</a></h2>
 
 JUnit uses a custom classloader, which can cause problems finding
 singletons and starting Swing.  If you get the error

--- a/java/src/jmri/jmrit/display/PositionableLabel.java
+++ b/java/src/jmri/jmrit/display/PositionableLabel.java
@@ -657,11 +657,13 @@ public class PositionableLabel extends JLabel implements Positionable {
     }
     
     public void rotate(int deg) {
+        log.debug("rotate({}) with _rotateText {}, _text {}, _icon {}", deg, _rotateText, _text, _icon);
         _degrees = deg;
-        if (_rotateText) {
+        if (_rotateText || deg==0) {
             if (deg == 0) {				// restore unrotated whatever
                 _rotateText = false;
                 if(_text) {
+                    log.debug("   super.setText(\"{}\");", _unRotatedText);
                     super.setText(_unRotatedText);
                     setOpaque( _popupUtil.hasBackground());
                     if (_icon) {
@@ -910,8 +912,10 @@ public class PositionableLabel extends JLabel implements Positionable {
         _unRotatedText = text;
         _text = (text !=null);
         if (/*_rotateText &&*/ !isIcon() && _namedIcon != null) {
+            log.debug("setText calls rotate({})", _degrees);
             rotate(_degrees);		//this will change text label as a icon with a new _namedIcon.
         } else {
+            log.debug("setText calls super.setText()");
             super.setText(text);
         }
     }

--- a/java/test/jmri/jmrit/display/MemoryIconTest.java
+++ b/java/test/jmri/jmrit/display/MemoryIconTest.java
@@ -13,6 +13,8 @@ import junit.extensions.jfcunit.finder.ComponentFinder;
 import junit.framework.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * MemoryIconTest.java
@@ -26,8 +28,7 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
 
     MemoryIcon to = null;
 
-    jmri.jmrit.display.panelEditor.PanelEditor panel
-            = new jmri.jmrit.display.panelEditor.PanelEditor("Test MemoryIcon Panel");
+    jmri.jmrit.display.panelEditor.PanelEditor panel;
 
     public void testShowContent() {
         JFrame jf = new JmriJFrame();
@@ -41,15 +42,9 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
 
         jf.getContentPane().add(new javax.swing.JLabel("| Expect \"Data Data\" text"));
 
-        jmri.InstanceManager i = new jmri.InstanceManager() {
-            protected void init() {
-                super.init();
-                root = this;
-            }
-        };
-        jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
-        Assert.assertNotNull("Instance exists", i);
         jmri.InstanceManager.memoryManagerInstance().provideMemory("IM1").setValue("Data Data");
+        flushAWT();
+
         to.setMemory("IM1");
 
         jf.pack();
@@ -70,6 +65,7 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
     }
 
     public void testShowBlank() {
+        log.debug("testShowBlank");
         JFrame jf = new JmriJFrame();
         jf.setTitle("Expect blank");
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
@@ -81,17 +77,13 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
 
         jf.getContentPane().add(new javax.swing.JLabel("| Expect blank: "));
 
-        jmri.InstanceManager i = new jmri.InstanceManager() {
-            protected void init() {
-                super.init();
-                root = this;
-            }
-        };
-        jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
-        Assert.assertNotNull("Instance exists", i);
         jmri.InstanceManager.memoryManagerInstance().provideMemory("IM2").setValue("");
+
+        log.debug("setMemory1");
         to.setMemory("IM2");
-        to.setMemory("IM2");
+        log.debug("setMemory2");
+        //to.setMemory("IM2");
+        log.debug("setMemoryDone");
                 
         jf.pack();
         jf.setVisible(true);
@@ -120,15 +112,9 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
 
         jf.getContentPane().add(new javax.swing.JLabel("| Expect red X default icon: "));
 
-        jmri.InstanceManager i = new jmri.InstanceManager() {
-            protected void init() {
-                super.init();
-                root = this;
-            }
-        };
-        jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
-        Assert.assertNotNull("Instance exists", i);
         jmri.InstanceManager.memoryManagerInstance().provideMemory("IM3");
+        flushAWT();
+
         to.setMemory("IM3");
 
         jf.pack();
@@ -199,6 +185,8 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
         super.setUp();
         apps.tests.Log4JFixture.setUp();
         JUnitUtil.resetInstanceManager();
+        jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
+        panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test MemoryIcon Panel");
     }
 
     protected void tearDown() throws Exception {
@@ -213,5 +201,5 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
         JUnitUtil.resetInstanceManager();
     }
 
-	// static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
+	static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
 }

--- a/java/test/jmri/jmrit/display/MemoryIconTest.java
+++ b/java/test/jmri/jmrit/display/MemoryIconTest.java
@@ -79,17 +79,14 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
 
         jmri.InstanceManager.memoryManagerInstance().provideMemory("IM2").setValue("");
 
-        log.debug("setMemory1");
         to.setMemory("IM2");
-        log.debug("setMemory2");
-        //to.setMemory("IM2");
-        log.debug("setMemoryDone");
                 
         jf.pack();
         jf.setVisible(true);
         flushAWT();
 
         int[] colors = getColor("Expect blank","| Expect blank",0,6,10);
+        //for (int i=0; i< 10; i++) System.out.println("   "+String.format("0x%8s", Integer.toHexString(colors[i])).replace(' ', '0'));
         boolean white = (colors[3]==0xffffffff)&&(colors[4]==0xffffffff);
         Assert.assertTrue("Expect white pixels", white);
         


### PR DESCRIPTION
PositionableLabel would sometimes now show the 1st update to a non-rotated test label.  MemoryIconTest had included a work-around that hid this. Fixed both.

The code in this area is convoluted, and there may be additional bugs.  This should not be included in 4.1.7/4.2.