### PR TITLE
Remove old jetty files in Windows installer for 4.3.1

### DIFF
--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -50,6 +50,9 @@
 ; -------------------------------------------------------------------------
 ; - Version History
 ; -------------------------------------------------------------------------
+; - Version 0.1.22.4
+; - Remove more outmoded jetty files
+; -------------------------------------------------------------------------
 ; - Version 0.1.22.3
 ; - Fix decpro5 file name (.ico missing)
 ; -------------------------------------------------------------------------
@@ -261,7 +264,7 @@
   ; -- usually, this will be determined by the build.xml ant script
   !define JRE_VER   "1.8"                       ; Required JRE version
 !endif
-!define INST_VER  "0.1.22.3"                    ; Installer version
+!define INST_VER  "0.1.22.4"                    ; Installer version
 !define PNAME     "${APP}.${JMRI_VER}"          ; Name of installer.exe
 !define SRCDIR    "."                           ; Path to head of sources
 InstallDir        "$PROGRAMFILES\JMRI"          ; Default install directory
@@ -449,7 +452,6 @@ SectionGroup "JMRI Core Files" SEC_CORE
     Delete "$OUTDIR\lib\log4j.jar"
     Delete "$OUTDIR\lib\jspWin.dll"
 
-
     ; -- Delete outmoded jetty .jar and outmoded servlet files, as of JMRI 3.11.3
     Delete "$OUTDIR\lib\jetty-continuation-8.1.11.v20130520.jar"
     Delete "$OUTDIR\lib\jetty-http-8.1.11.v20130520.jar"
@@ -460,6 +462,19 @@ SectionGroup "JMRI Core Files" SEC_CORE
     Delete "$OUTDIR\lib\jetty-util-8.1.11.v20130520.jar"
     Delete "$OUTDIR\lib\jetty-websocket-8.1.11.v20130520.jar"
     Delete "$OUTDIR\lib\servlet-api-3.0.jar"
+
+    ; -- Delete outmoded jetty .jar and outmoded servlet files, as of JMRI 4.3.1
+    Delete "$OUTDIR\lib\jetty-http-9.2.7.v20150116.jar"
+    Delete "$OUTDIR\lib\jetty-io-9.2.7.v20150116.jar"
+    Delete "$OUTDIR\lib\jetty-security-9.2.7.v20150116.jar"
+    Delete "$OUTDIR\lib\jetty-server-9.2.7.v20150116.jar"
+    Delete "$OUTDIR\lib\jetty-servlet-9.2.7.v20150116.jar"
+    Delete "$OUTDIR\lib\jetty-util-9.2.7.v20150116.jar"
+    Delete "$OUTDIR\lib\websocket-api-9.2.7.v20150116.jar"
+    Delete "$OUTDIR\lib\websocket-client-9.2.7.v20150116.jar"
+    Delete "$OUTDIR\lib\websocket-common-9.2.7.v20150116.jar"
+    Delete "$OUTDIR\lib\websocket-server-9.2.7.v20150116.jar"
+    Delete "$OUTDIR\lib\websocket-servlet-9.2.7.v20150116.jar"
 
     ; -- Delete XmlIO-related files, as of JMRI 3.11.3
     Delete "$OUTDIR\help\en\package\jmri\jmrit\inControl\images\2Throttles.png"


### PR DESCRIPTION
Doing it this way so that we can get 4.3.1 out of the door. Will come back to #359 later.