### PR TITLE
Uhlenbrock MONITORING mode turnout robustness:

### DIFF
--- a/java/src/jmri/jmrix/loconet/LnTurnout.java
+++ b/java/src/jmri/jmrix/loconet/LnTurnout.java
@@ -173,9 +173,11 @@ public class LnTurnout extends AbstractTurnout implements LocoNetListener {
         
         if (_useOffSwReqAsConfirmation) {
              // Start a timer to resend the command in a couple of seconds in case consistency is not obtained before then
+             noConsistencyTimersRunning++;
              consistencyTimer.schedule(new java.util.TimerTask(){
                 public void run() {
-                    if (!isConsistentState()) {
+                    noConsistencyTimersRunning--;
+                    if (!isConsistentState() && noConsistencyTimersRunning==0) {
                         log.debug("LnTurnout resending command for turnout "+_number);
                         forwardCommandChangeToLayout(getCommandedState());
     }
@@ -370,6 +372,7 @@ public class LnTurnout extends AbstractTurnout implements LocoNetListener {
 
     static final int CONSISTENCYTIMER = 3000; // msec wait for command to take effect
     static java.util.Timer consistencyTimer = new java.util.Timer();
+    int noConsistencyTimersRunning = 0;
     
     static Logger log = LoggerFactory.getLogger(LnTurnout.class.getName());
 


### PR DESCRIPTION
If more than one command has been sent to the Uhlenbrock IB-COM / Intellibox II layout for the same turnout, all commands have to time out before the last command is being re-sent. This is to avoid endless loops in heavy traffic situations.