### PR TITLE
ECOS power setting:

### DIFF
--- a/java/src/jmri/jmrix/ecos/EcosPowerManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosPowerManager.java
@@ -3,6 +3,8 @@ package jmri.jmrix.ecos;
 
 import jmri.JmriException;
 import jmri.PowerManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * PowerManager implementation for controlling layout power.
@@ -85,11 +87,13 @@ public class EcosPowerManager implements PowerManager, EcosListener {
     public void reply(EcosReply m) {
         // power message?
         String msg = m.toString();
-        if (msg.contains("<EVENT 1>") || msg.contains("REPLY get(1,")) {
-            if (msg.contains("status[GO]")) {
+        if (msg.contains("<EVENT 1>") || msg.contains("REPLY get(1,") || msg.contains("REPLY set(1,")) {
+            if (msg.contains("status[GO]") || msg.contains("et(1, go)")) {
+                log.debug("POWER ON DETECTED");
                 power = ON;
                 firePropertyChange("Power", null, null);
-            } else if (msg.contains("status[STOP]")) {
+            } else if (msg.contains("status[STOP]") || msg.contains("et(1, stop)")) {
+                log.debug("POWER OFF DETECTED");
                 power = OFF;
                 firePropertyChange("Power", null, null);
             }
@@ -100,6 +104,7 @@ public class EcosPowerManager implements PowerManager, EcosListener {
         // messages are ignored
     }
 
+    static Logger log = LoggerFactory.getLogger(EcosPowerManager.class.getName());
 }
 
 


### PR DESCRIPTION
JMRI did not properly track the power on/off setting of the ECOS.