### PR TITLE
ECOS: MONITORING mode for turnouts

### DIFF
--- a/java/src/jmri/jmrix/ecos/EcosTurnout.java
+++ b/java/src/jmri/jmrix/ecos/EcosTurnout.java
@@ -53,8 +53,46 @@ public class EcosTurnout extends AbstractTurnout
         /*All messages from the Ecos regarding turnout status updates, 
          are initally handled by the turnout manager, this then forwards the message
          on to the correct Turnout*/
+        
+        // update feedback modes
+        _validFeedbackTypes |= MONITORING | EXACT | INDIRECT;
+        _activeFeedbackType = MONITORING;
+
+        // if needed, create the list of feedback mode
+        // names with additional LocoNet-specific modes
+        if (modeNames == null) {
+            initFeedbackModes();
+        }
+        _validFeedbackNames = modeNames;
+        _validFeedbackModes = modeValues;
     }
 
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
+            justification = "Only used during creation of 1st turnout")
+    private void initFeedbackModes() {
+        if (_validFeedbackNames.length != _validFeedbackModes.length) {
+            log.error("int and string feedback arrays different length");
+        }
+        String[] tempModeNames = new String[_validFeedbackNames.length + 3];
+        int[] tempModeValues = new int[_validFeedbackNames.length + 3];
+        for (int i = 0; i < _validFeedbackNames.length; i++) {
+            tempModeNames[i] = _validFeedbackNames[i];
+            tempModeValues[i] = _validFeedbackModes[i];
+        }
+        tempModeNames[_validFeedbackNames.length] = "MONITORING";
+        tempModeValues[_validFeedbackNames.length] = MONITORING;
+        tempModeNames[_validFeedbackNames.length + 1] = "INDIRECT";
+        tempModeValues[_validFeedbackNames.length + 1] = INDIRECT;
+        tempModeNames[_validFeedbackNames.length + 2] = "EXACT";
+        tempModeValues[_validFeedbackNames.length + 2] = EXACT;
+
+        modeNames = tempModeNames;
+        modeValues = tempModeValues;
+    }
+
+    static String[] modeNames = null;
+    static int[] modeValues = null;    
+    
     EcosTrafficController tc;
     EcosTurnoutManager tm;
     /*Extended is used to indicate that this Ecos accessory has a secondary address assigned to it.
@@ -79,9 +117,6 @@ public class EcosTurnout extends AbstractTurnout
     void setMasterObjectNumber(boolean o) {
         masterObjectNumber = o;
     }
-
-    static String[] modeNames = null;
-    static int[] modeValues = null;
 
     public int getNumber() {
         return _number;
@@ -180,6 +215,7 @@ public class EcosTurnout extends AbstractTurnout
      * @param closed State of the turnout to be sent to the command station
      */
     protected void sendMessage(boolean closed) {
+        newKnownState(Turnout.UNKNOWN);
         if (getInverted()) {
             closed = !closed;
         }
@@ -265,6 +301,8 @@ public class EcosTurnout extends AbstractTurnout
     }
 
     // to listen for status changes from Ecos system
+    int newstate = UNKNOWN;
+    int newstateext = UNKNOWN;
     public void reply(EcosReply m) {
 
         String msg = m.toString();
@@ -274,11 +312,29 @@ public class EcosTurnout extends AbstractTurnout
         if (m.getEcosObjectId() != objectNumber) {
             return; //message is not for our turnout address
         }
-        if ((m.isUnsolicited()) || (m.getReplyType().equals("get"))) {
+        if (msg.contains("switching[0]")) {
+            log.debug("Turnout switched - new state="+newstate);
+            /*log.debug("see new state "+newstate+" for "+_number);*/
+            //newCommandedState(newstate);
+            /*Using newKnownState, as any changes made on the ecos do not show
+              up on the panel. Therefore if an ecos route is fired the panel
+              doesn't change to reflect it.*/
+            if (extended == 0) {
+                newKnownState(newstate);
+            } else {
+                //The masterObjectNumber is used to determine if this the master or slave decoder
+                //address in an extended accessory object on the ecos.
+                if (masterObjectNumber) {
+                    newKnownState(newstate);
+                } else {
+                    newKnownState(newstateext);
+                }
+            }
+        }
+        if ((m.isUnsolicited()) || (m.getReplyType().equals("get")) || (m.getReplyType().equals("set"))) {
             //if (msg.startsWith("<REPLY get("+objectNumber+",") || msg.startsWith("<EVENT "+objectNumber+">")) {
             int start = msg.indexOf("state[");
             int end = msg.indexOf("]");
-            int newstate = UNKNOWN;
             if (start > 0 && end > 0) {
                 String val = msg.substring(start + 6, end);
                 //System.out.println("Extended - " + extended + " " + objectNumber);
@@ -290,15 +346,13 @@ public class EcosTurnout extends AbstractTurnout
                     } else {
                         log.warn("val |" + val + "| from " + msg);
                     }
-                    // now set state
-                    /*log.debug("see new state "+newstate+" for "+_number);*/
-                    //newCommandedState(newstate);
-                    /*Using newKnownState, as any changes made on the ecos do not show
-                     up on the panel. Therefore if an ecos route is fired the panel
-                     doesn't change to reflect it.*/
-                    newKnownState(newstate);
+                    log.debug("newstate found: "+newstate);
+                    if (m.getReplyType().equals("set")) {
+                       // wait to set the state until ECOS tells us to (by an event with the contents "switching[0]")
+                    } else {
+                        newKnownState(newstate);
+                    }
                 } else {
-                    int newstateext = UNKNOWN;
                     if (extended == THREEWAY) { //Three way Point.
                         if (val.equals("0")) {
                             newstate = CLOSED;
@@ -325,12 +379,14 @@ public class EcosTurnout extends AbstractTurnout
                             newstateext = THROWN;
                         }
                     }
-                    //The masterObjectNumber is used to determine if this the master or slave decoder
-                    //address in an extended accessory object on the ecos.
-                    if (masterObjectNumber) {
-                        newKnownState(newstate);
+                    if (m.getReplyType().equals("set")) {
+                       // wait to set the state until ECOS tells us to (by an event with the contents "switching[0]")
                     } else {
-                        newKnownState(newstateext);
+                        if (masterObjectNumber) {
+                            newKnownState(newstate);
+                        } else {
+                            newKnownState(newstateext);
+                        }
                     }
                 }
             }

--- a/java/src/jmri/jmrix/ecos/EcosTurnoutManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosTurnoutManager.java
@@ -75,11 +75,13 @@ public class EcosTurnoutManager extends jmri.managers.AbstractTurnoutManager
         }
         Turnout t = new EcosTurnout(addr, getSystemPrefix(), tc, this);
         t.setUserName(userName);
+        t.setFeedbackMode("MONITORING");
         return t;
     }
 
     // to listen for status changes from Ecos system
     public void reply(EcosReply m) {
+        log.debug("reply "+m);
         // is this a list of turnouts?
         EcosTurnout et;
 
@@ -121,13 +123,13 @@ public class EcosTurnoutManager extends jmri.managers.AbstractTurnoutManager
                 if (replyType.equals("queryObjects")) {
                     if (ecosObjectId == 11 && headerDetails.size() == 0) {
                         //if (lines[0].startsWith("<REPLY queryObjects(11)>")) {
-                        log.info("No sub details");
+                        log.debug("No sub details");
                         checkTurnoutList(msgContents);
                     } else if (headerDetails.contains("addr")) {
                         // yes, make sure TOs exist
                         //log.debug("found "+(lines.length-2)+" turnout objects");
                         for (String item : m.getContents()) {
-                            log.info("header " + item);
+                            log.debug("header " + item);
                             //for (int i = 1; i<lines.length-1; i++) {
                             if (item.contains("addr")) { // skip odd lines
                                 int object = GetEcosObjectNumber.getEcosObjectNumber(item, null, " ");
@@ -227,6 +229,19 @@ public class EcosTurnoutManager extends jmri.managers.AbstractTurnoutManager
                         }
                         if (name != null) {
                             et.setUserName(name);
+                        }
+                    }
+                } else if (ecosObjectId >= 20000 && ecosObjectId <= 30000) {
+                    log.debug("Reply for specific turnout");
+                    et = _tecos.get(ecosObjectId);
+                    if (et != null) {
+                        et.reply(m);
+                        //As the event will come from one object, we shall check to see if it is an extended address,
+                        // if it is we also forward the message onto the slaved address.
+                        if (et.getExtended() != 0) {
+                            log.debug("This is also an extended turnout so forwarding on change to " + et.getSlaveAddress());
+                            EcosTurnout etx = (EcosTurnout) provideTurnout(et.getSlaveAddress());
+                            etx.reply(m);
                         }
                     }
                 }


### PR DESCRIPTION
I have more or less merged the MONITORING mode functionality from LocoNet to ECOS.
This have the effect that with slow moving turnouts (such as my servo-controlled ones), signals etc. are not set until the turnout is again in a consistent state.