### PR TITLE
Quick fix for issues selecting ports on OS X

### DIFF
--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -326,7 +326,7 @@ if [ -n "$JMRI_SERIAL_PORTS" ] ; then
 fi
 
 # locate alternate serial ports
-ALTPORTS=$( echo "$JMRI_SERIAL_PORTS $( ls -fm /dev/cu\.* /dev/tty\.* /dev/ttyS* /dev/ttyUSB* /dev/ttyACM* /dev/ttyAMA* 2>/dev/null )" | tr -d " \n" | tr "," ":" )
+ALTPORTS=$( echo "$JMRI_SERIAL_PORTS $( ls -fm /dev/ttyS* /dev/ttyUSB* /dev/ttyACM* /dev/ttyAMA* 2>/dev/null )" | tr -d " \n" | tr "," ":" )
 if [ "${ALTPORTS}" ] ; then
     ALTPORTS=-Dgnu.io.rxtx.SerialPorts=${ALTPORTS}
 fi


### PR DESCRIPTION
For reasons unknown, we are unable to enumerate ports on OS X if the gnu.io.rxtx.SerialPorts system property is set.

This needs to be included in 4.2.1 if that gets created.