### PR TITLE
Fix some Python issues.

### DIFF
--- a/java/src/jmri/script/JmriScriptEngineManager.java
+++ b/java/src/jmri/script/JmriScriptEngineManager.java
@@ -354,13 +354,14 @@ public final class JmriScriptEngineManager {
                 Properties properties;
                 try {
                     properties = new Properties(System.getProperties());
+                    properties.setProperty("python.console.encoding", "UTF-8"); // NOI18N
+                    properties.setProperty("python.cachedir", FileUtil.getAbsoluteFilename(properties.getProperty("python.cachedir", "settings:jython/cache"))); // NOI18N
                     properties.load(is);
                     String path = properties.getProperty("python.path", "");
                     if (path.length() != 0) {
                         path = path.concat(File.pathSeparator);
                     }
                     properties.setProperty("python.path", path.concat(FileUtil.getScriptsPath().concat(File.pathSeparator).concat(FileUtil.getAbsoluteFilename("program:jython"))));
-                    properties.setProperty("python.cachedir", FileUtil.getAbsoluteFilename(properties.getProperty("python.cachedir", "settings:jython/cache"))); // NOI18N
                     execJython = Boolean.valueOf(properties.getProperty("jython.exec", Boolean.toString(false)));
                 } catch (IOException ex) {
                     log.error("Found, but unable to read python.properties: {}", ex.getMessage());

--- a/python.properties
+++ b/python.properties
@@ -16,13 +16,14 @@
 # Extension modules cannot be imported from zipfiles.
 python.path=
 
-# Scan the classpath for Java packages if false. This allows Java packages to be
+# Scan the classpath for Java packages if False. This allows Java packages to be
 # imported into a Python script without using "import" statements for each Java
 # package at the cost of a slower initialization of the Python interpreter and
 # possibly more memory use.
-# The Jython default and recommended setting is true
-# The JMRI default is false for ease of use
-python.cachedir.skip=false
+# The Jython default and recommended setting is True.
+# The JMRI default is False for ease of use.
+# Note that the first character of True or False needs to be capitolized.
+python.cachedir.skip=False
 
 # Use the Jython PythonInterpreter.execfile() method to execute Python files
 # instead of using the PythonInterpreter.eval() method if set to true.
@@ -33,4 +34,5 @@ python.cachedir.skip=false
 # The recommended and default setting is false. If setting jython.exec to true,
 # you may need to also ensure that jmri_bindings.py is executed at application
 # start.
+# Note that the first character of true or false needs to be lowercase.
 jython.exec=false


### PR DESCRIPTION
Default the Python console to UTF-8.

True and False need to be capitalized in Python, but not in Java.

Allow users to override default settings except the ```python.path```, which gets the ```scripts:``` and ```program:jython``` paths appended to whatever the user sets for ```python.path```.