### PR TITLE
ECOS programmer

### DIFF
--- a/help/en/html/hardware/ecos/index.shtml
+++ b/help/en/html/hardware/ecos/index.shtml
@@ -29,7 +29,7 @@ Support for the ECoS s88 Feedback Sensors was first available in <a href="http:/
 Support for the ECoS RailCom Feedback was first available in <a href="http://jmri.sf.net/releasenotes/jmri2.99.7.shtml">JMRI 2.99.7</a>.    
 
 <a name="limitations"></a><h2>Limitations</h2>
-<p>Programming is currently not supported by the Ecos. Additional information on the ECoS can be found
+<p>Programming is supported by the Ecos from firmware version 4.1. However this goes only for the programming track. Programming on main is only available directly on the ECOS. Additional information on the ECoS can be found
 on the <a href="http://www.esu.eu/us/index.php?showId=205">ESU web site</a>.
 <p>Consisting is not yet supported.</p>
 

--- a/java/src/jmri/jmrix/ecos/EcosProgrammer.java
+++ b/java/src/jmri/jmrix/ecos/EcosProgrammer.java
@@ -187,9 +187,7 @@ public class EcosProgrammer extends AbstractProgrammer implements EcosListener {
             notifyProgListenerEnd(_val, jmri.ProgListener.OK);
             
         } else {
-            if (log.isDebugEnabled()) {
-                log.debug("reply in un-decoded state");
-            }
+            log.debug("reply in un-decoded state");
         }
     }
 
@@ -204,7 +202,9 @@ public class EcosProgrammer extends AbstractProgrammer implements EcosListener {
             }
             // perhaps no loco present? Fail back to end of programming
             progState = NOTPROGRAMMING;
-            tc.sendEcosMessage(EcosMessage.getExitProgMode(), this);
+            EcosMessage m;
+            m = new EcosMessage("release(5,view)");
+            tc.sendEcosMessage(m, this);
             notifyProgListenerEnd(_val, jmri.ProgListener.FailedTimeout);
         }
     }

--- a/java/src/jmri/jmrix/ecos/EcosProgrammer.java
+++ b/java/src/jmri/jmrix/ecos/EcosProgrammer.java
@@ -1,0 +1,232 @@
+// EcosProgrammer.java
+package jmri.jmrix.ecos;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import jmri.PowerManager;
+import jmri.*;
+import jmri.jmrix.AbstractProgrammer;
+import jmri.jmrix.ecos.utilities.GetEcosObjectNumber;
+
+import java.util.*;
+import jmri.managers.DefaultProgrammerManager;
+
+/**
+ * Implements the jmri.Programmer interface via commands for the Ecos
+ * programmer. This provides a service mode programmer.
+ *
+ * @author Karl Johan Lisby Copyright (C) 2015
+ * @version	$Revision$
+ */
+public class EcosProgrammer extends AbstractProgrammer implements EcosListener {
+
+    public EcosProgrammer(EcosTrafficController etc) {
+        tc = etc;
+    }
+
+    EcosTrafficController tc; 
+    
+    /**
+     * Types implemented here.
+     */
+    @Override
+    public List<ProgrammingMode> getSupportedModes() {
+        List<ProgrammingMode> ret = new ArrayList<ProgrammingMode>();
+        ret.add(DefaultProgrammerManager.DIRECTBYTEMODE);
+        return ret;
+    }
+
+    // members for handling the programmer interface
+    int progState = 0;
+    static final int NOTPROGRAMMING = 0;// is notProgramming
+    static final int MODESENT = 1; 	// waiting reply to command to go into programming mode
+    static final int COMMANDSENT = 2; 	// read/write command sent, waiting reply
+    boolean _progRead = false;
+    int _val;	// remember the value being read/written for confirmative reply
+    int _cv;	// remember the cv being read/written
+
+    // programming interface
+    synchronized public void writeCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+        if (log.isDebugEnabled()) {
+            log.debug("writeCV " + CV + " listens " + p);
+        }
+        useProgrammer(p);
+        _progRead = false;
+        // set commandPending state
+        progState = MODESENT;
+        _val = val;
+        _cv = CV;
+
+        // start the error timer
+        startShortTimer();
+
+        // format and send message to go to program mode
+        // ECOS is in program mode by default but we need to subscribe to events
+        EcosMessage m;
+        m = new EcosMessage("request(5,view)");
+        tc.sendEcosMessage(m, this);
+    }
+
+    synchronized public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+        readCV(CV, p);
+    }
+
+    synchronized public void readCV(int CV, jmri.ProgListener p) throws jmri.ProgrammerException {
+        if (log.isDebugEnabled()) {
+            log.debug("readCV " + CV + " listens " + p);
+        }
+        useProgrammer(p);
+        _progRead = true;
+        // set commandPending state
+        // set commandPending state
+        progState = MODESENT;
+        _cv = CV;
+
+        // start the error timer
+        startShortTimer();
+
+        // format and send message to go to program mode
+        // ECOS is in program mode by default but we need to subscribe to events
+        EcosMessage m;
+        m = new EcosMessage("request(5,view)");
+        tc.sendEcosMessage(m, this);
+    }
+    
+    private jmri.ProgListener _usingProgrammer = null;
+
+    // internal method to remember who's using the programmer
+    protected void useProgrammer(jmri.ProgListener p) throws jmri.ProgrammerException {
+        // test for only one!
+        if (_usingProgrammer != null && _usingProgrammer != p) {
+            if (log.isInfoEnabled()) {
+                log.info("programmer already in use by " + _usingProgrammer);
+            }
+            throw new jmri.ProgrammerException("programmer in use");
+        } else {
+            _usingProgrammer = p;
+            return;
+        }
+    }
+
+    public void message(EcosMessage m) {
+        log.info("message: "+m);
+    }
+
+    synchronized public void reply(EcosReply reply) {
+        log.info("reply: "+reply);
+        if (progState == NOTPROGRAMMING) {
+            // we get the complete set of replies now, so ignore these
+            if (log.isDebugEnabled()) {
+                log.debug("reply in NOTPROGRAMMING state");
+            }
+            return;
+        } else if (progState == MODESENT) {
+            log.debug("reply in MODESENT state");
+            // see if reply is the acknowledge of requesting view of events; if not, wait
+            if (reply.match("<REPLY request(5,view)>") == -1) {
+                return;
+            }
+            if (reply.match("<END 0 (OK)>") == -1) {
+                return;
+            }
+            // here ready to send the read/write command
+            progState = COMMANDSENT;
+            // send the command for reading or writing CV
+            try {
+                startLongTimer();
+                EcosMessage m;
+                if (_progRead) {
+                    // read was in progress - send read command
+                    m = new EcosMessage("set(5,mode[readdccdirect],cv["+_cv+"])");
+                } else {
+                    // write was in progress - send write command
+                    m = new EcosMessage("set(5,mode[writedccdirect],cv["+_cv+","+_val+"])");
+                }
+                tc.sendEcosMessage(m, this);
+            } catch (Exception e) {
+                // program op failed, go straight to end
+                log.error("program operation failed, exception " + e);
+                progState = NOTPROGRAMMING;
+                EcosMessage m;
+                m = new EcosMessage("release(5,view)");
+                tc.sendEcosMessage(m, this);
+                notifyProgListenerEnd(-1, jmri.ProgListener.NoLocoDetected);
+                return;
+            }
+        } else if (progState == COMMANDSENT) {
+            if (log.isDebugEnabled()) {
+                log.debug("reply in COMMANDSENT state");
+            }
+            // The real reply comes in an event; if this is not that event, wait
+            if (reply.match("<EVENT 5>") == -1) {
+                return;
+            }
+            // operation done, capture result, then leave programming mode
+            progState = NOTPROGRAMMING;
+            stopTimer();
+            EcosMessage m;
+            m = new EcosMessage("release(5,view)");
+            tc.sendEcosMessage(m, this);
+            // check for errors
+            if (reply.match("error") >= 0 || reply.match(",ok]") == -1) {
+                log.debug("ERROR during programming " + reply);
+                // ECOS is not very informative about the precise nature of errors.
+                // We might guess that there is no loco present
+                notifyProgListenerEnd(-1, jmri.ProgListener.NoLocoDetected);
+                return;
+            }
+            // Get the CV value from the reply if reading
+            if (_progRead) {
+                // read was in progress - get return value
+                _val = GetEcosObjectNumber.getEcosObjectNumber(reply.toString(),",",",ok]");
+                log.debug("read CV "+_cv+" value: "+_val);
+            }
+            
+            // if this was a read, we cached the value earlier.  If its a
+            // write, we're to return the original write value
+            notifyProgListenerEnd(_val, jmri.ProgListener.OK);
+            
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("reply in un-decoded state");
+            }
+        }
+    }
+
+    /**
+     * Internal routine to handle a timeout
+     */
+    synchronized protected void timeout() {
+        if (progState != NOTPROGRAMMING) {
+            // we're programming, time to stop
+            if (log.isDebugEnabled()) {
+                log.debug("timeout!");
+            }
+            // perhaps no loco present? Fail back to end of programming
+            progState = NOTPROGRAMMING;
+            tc.sendEcosMessage(EcosMessage.getExitProgMode(), this);
+            notifyProgListenerEnd(_val, jmri.ProgListener.FailedTimeout);
+        }
+    }
+
+    // internal method to notify of the final result
+    protected void notifyProgListenerEnd(int value, int status) {
+        if (log.isDebugEnabled()) {
+            log.debug("notifyProgListenerEnd value " + value + " status " + status);
+        }
+        // the programmingOpReply handler might send an immediate reply, so
+        // clear the current listener _first_
+        if (_usingProgrammer == null) {
+            log.error("No listener to notify");
+        } else {
+            jmri.ProgListener temp = _usingProgrammer;
+            _usingProgrammer = null;
+            temp.programmingOpReply(value, status);
+        }
+    }
+
+    static Logger log = LoggerFactory.getLogger(EcosProgrammer.class.getName());
+
+}
+
+/* @(#)EcosProgrammer.java */

--- a/java/src/jmri/jmrix/ecos/EcosProgrammerManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosProgrammerManager.java
@@ -1,0 +1,42 @@
+/* EcosProgrammerManager.java */
+package jmri.jmrix.ecos;
+
+import jmri.AddressedProgrammer;
+import jmri.ProgrammingMode;
+import jmri.managers.DefaultProgrammerManager;
+
+import java.util.*;
+import jmri.Programmer;
+
+/**
+ * Extend DefaultProgrammerManager to provide ops mode programmers on LocoNet
+ *
+ * @see jmri.ProgrammerManager
+ * @author	Karl Johan Lisby Copyright (C) 2015
+ * @version	$Revision$
+ */
+public class EcosProgrammerManager extends DefaultProgrammerManager {
+
+    //private Programmer mProgrammer;
+    public EcosProgrammerManager(Programmer serviceModeProgrammer, EcosSystemConnectionMemo memo) {
+        super(serviceModeProgrammer, memo);
+    }
+    
+    /**
+     * Ecos command station does not provide Ops Mode on the LAN interface
+     *
+     * @return false
+     */
+    public boolean isAddressedModePossible() {
+        return false;
+    }
+
+    public java.util.List<ProgrammingMode> getDefaultModes() {
+        java.util.ArrayList<ProgrammingMode> retval = new java.util.ArrayList<>();
+        retval.add(DIRECTBYTEMODE);
+        return retval;
+    } 
+}
+
+
+/* @(#)DefaultProgrammerManager.java */

--- a/java/src/jmri/jmrix/ecos/EcosSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/ecos/EcosSystemConnectionMemo.java
@@ -76,6 +76,8 @@ public class EcosSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
         reporterManager = new jmri.jmrix.ecos.EcosReporterManager(this);
         jmri.InstanceManager.setReporterManager(reporterManager);
+        
+        jmri.InstanceManager.setProgrammerManager(getProgrammerManager());
 
     }
 
@@ -90,6 +92,7 @@ public class EcosSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
     private EcosDccThrottleManager throttleManager;
     private EcosPowerManager powerManager;
     private EcosReporterManager reporterManager;
+    private EcosProgrammerManager programmerManager;
 
     public EcosLocoAddressManager getLocoAddressManager() {
         return locoManager;
@@ -119,6 +122,13 @@ public class EcosSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
         return reporterManager;
     }
 
+    public EcosProgrammerManager getProgrammerManager() {
+        if (programmerManager == null) {
+            programmerManager = new EcosProgrammerManager(new EcosProgrammer(getTrafficController()), this);
+        }
+        return programmerManager;
+    }
+
     /**
      * Tells which managers this provides by class
      */
@@ -139,6 +149,12 @@ public class EcosSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
             return true;
         }
         if (type.equals(jmri.ReporterManager.class)) {
+            return true;
+        }
+        if (type.equals(jmri.ProgrammerManager.class)) {
+            return true;
+        }
+        if (type.equals(jmri.GlobalProgrammerManager.class)) {
             return true;
         }
         return false; // nothing, by default
@@ -164,6 +180,12 @@ public class EcosSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
         if (T.equals(jmri.ReporterManager.class)) {
             return (T) getReporterManager();
         }
+        if (T.equals(jmri.ProgrammerManager.class)) {
+            return (T) getProgrammerManager();
+        }
+        if (T.equals(jmri.GlobalProgrammerManager.class)) {
+            return (T) getProgrammerManager();
+        }
         return null; // nothing, by default
     }
 
@@ -180,6 +202,9 @@ public class EcosSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
         if (reporterManager != null) {
             reporterManager.dispose();
             reporterManager = null;
+        }
+        if (programmerManager != null) {
+            InstanceManager.deregister(programmerManager, jmri.jmrix.ecos.EcosProgrammerManager.class);
         }
 
         if (powerManager != null) {


### PR DESCRIPTION
With the newest firmware from ESU, it is now possible to use some of the programming facilities in the ECOS from its network interface. One of the last lines from the release note states this:

- Access to the ECoS programming track. Please note: You need a view on the programming track, because the data will be returned in an update event. At this moment, we implemented DCC direct mode read/write and Motorola 6021 write. For example: request(5,view) set(5,mode[readdccdirect],cv[1],cv[2]). Please note that you shall use set instead of get, even when reading Cvs. Further information shows help(5,set,all).

This pull request is a JMRI implementation of the DCC direct mode read/write.