### PR TITLE
Patch 1087 Zimo MX633 and MX634 (M Waters)

### DIFF
--- a/xml/decoders/Zimo_Unified_software_MX633v31.xml
+++ b/xml/decoders/Zimo_Unified_software_MX633v31.xml
@@ -12,59 +12,53 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <version author="Mark Waters mark16jmri@mybtinternet.com" version="1" lastUpdated="20150207"/>
+  <version author="Mark Waters mark16w-jmri@yahoo.co.uk" version="1" lastUpdated="20151227"/>
   <!-- Based on the "2014 04 20" English version of the ZIMO "Small decoder manual	     -->
   <!--                                                                                       -->
   <!-- This decoder XML is meant to be used with the "Comprehensive" programmer format.      -->
   <!-- Continued the practice of using unrelated "item" names to place Zimo unique           -->
   <!-- variables on the proper pane of the Comprehensive programmer.                         -->
-  <!-- V 1 new file - Mark Waters - 7 Feb 2015-->
-  <!-- V 1.1 updated file - Mark Waters - 28 Dec 2015 - superceeded by Zimo_Unified_software_MX634v31 file, Hidden in decoder tree  -->
+  <!-- V 1 new file - Mark Waters - 27 Dec 2015 -->
   <decoder>
-    <family name="Zimo Unified software (version 32+)" mfg="Zimo">
-      <model show="no" model="MX634 version 32+" replacementModel="MX634 version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" numOuts="8" numFns="14" productID="240">
+    <family name="Zimo Unified software (version 25+)" mfg="Zimo">
+      <model model="MX633 version 25+" lowVersionID="30" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="1.2A" formFactor="HO" numOuts="10" numFns="14" productID="237">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
         <output name="3" label="FO 1"/>
         <output name="4" label="FO 2"/>
         <output name="5" label="FO 3"/>
         <output name="6" label="FO 4"/>
-        <output name="7" label="FO 5 (+5v)"/>
-        <output name="8" label="FO 6 (+5v)"/>
-        <size length="20.5" width="15.5" height="4" units="mm"/>
+        <output name="7" label="FO 5"/>
+        <output name="8" label="FO 6"/>
+        <output name="9" label="FO 7"/>
+        <output name="10" label="FO 8"/>
+        <size length="22" width="15" height="3.5" units="mm"/>
       </model>
-      <model show="no" model="MX634R version 32+" replacementModel="MX634R version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="NMRAmedium" numOuts="8" numFns="14" productID="240">
+      <model model="MX633R version 25+" lowVersionID="30" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="1.2A" formFactor="HO" connector="NMRAmedium" numOuts="10" numFns="14" productID="237">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
         <output name="3" label="FO 1"/>
         <output name="4" label="FO 2"/>
         <output name="5" label="FO 3"/>
         <output name="6" label="FO 4"/>
-        <output name="7" label="FO 5 (+5v)"/>
-        <output name="8" label="FO 6 (+5v)"/>
-        <size length="20.5" width="15.5" height="4" units="mm"/>
+        <output name="7" label="FO 5"/>
+        <output name="8" label="FO 6"/>
+        <output name="9" label="FO 7"/>
+        <output name="10" label="FO 8"/>
+        <size length="22" width="15" height="3.5" units="mm"/>
       </model>
-      <model show="no" model="MX634F version 32+" replacementModel="MX634F version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="NMRAsmall" numOuts="8" numFns="14" productID="240">
+      <model model="MX633P22 version 25+" lowVersionID="30" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="1.2A" formFactor="HO" connector="PluX22" numOuts="10" numFns="14" productID="237">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
         <output name="3" label="FO 1"/>
         <output name="4" label="FO 2"/>
         <output name="5" label="FO 3"/>
         <output name="6" label="FO 4"/>
-        <output name="7" label="FO 5 (+5v)"/>
-        <output name="8" label="FO 6 (+5v)"/>
-        <size length="20.5" width="15.5" height="4" units="mm"/>
-      </model>
-      <model show="no" model="MX634D version 32+" replacementModel="MX634D version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="21MTC" numOuts="8" numFns="14" productID="240">
-        <output name="1" label="Front Light"/>
-        <output name="2" label="Rear Light"/>
-        <output name="3" label="FO 1"/>
-        <output name="4" label="FO 2"/>
-        <output name="5" label="FO 3"/>
-        <output name="6" label="FO 4"/>
-        <output name="7" label="FO 5 (+5v)"/>
-        <output name="8" label="FO 6 (+5v)"/>
-        <size length="20.5" width="15.5" height="4" units="mm"/>
+        <output name="7" label="FO 5"/>
+        <output name="8" label="FO 6"/>
+        <output name="9" label="FO 7"/>
+        <output name="10" label="FO 8"/>
+        <size length="22" width="15" height="3.5" units="mm"/>
       </model>
     </family>
     <programming direct="yes" paged="yes" register="yes" ops="yes"/>
@@ -73,9 +67,8 @@
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV100-CV152version30.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV153-CV157version28.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV158version32.xml"/>
-      <xi:include href="http://jmri.org/xml/decoders/zimo/CV159-CV160.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV161-CV185Servo.xml"/>
-      <variable item="Decoder ID 1" CV="250" default="240" readOnly="yes">
+      <variable item="Decoder ID 1" CV="250" default="237" readOnly="yes">
         <decVal/>
         <label>Decoder ID 1</label>
         <label xml:lang="it">ID 1 Decoder: </label>
@@ -87,7 +80,7 @@
   </decoder>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneAccelDecel.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneShuntUncouple.xml"/>
-  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneAltFunctionMap6+2.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneAltFunctionMap8+.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSwissMapping.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneFunctionOutput.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSmoke.xml"/>

--- a/xml/decoders/Zimo_Unified_software_MX634Cv31.xml
+++ b/xml/decoders/Zimo_Unified_software_MX634Cv31.xml
@@ -18,50 +18,16 @@
   <!-- This decoder XML is meant to be used with the "Comprehensive" programmer format.      -->
   <!-- Continued the practice of using unrelated "item" names to place Zimo unique           -->
   <!-- variables on the proper pane of the Comprehensive programmer.                         -->
-  <!-- V 1 new file - Mark Waters - 7 Feb 2015-->
-  <!-- V 1.1 updated file - Mark Waters - 28 Dec 2015 - superceeded by Zimo_Unified_software_MX634v31 file, Hidden in decoder tree  -->
+  <!-- V 1 new file - Mark Waters - 27 Dec 2015 -->
   <decoder>
-    <family name="Zimo Unified software (version 32+)" mfg="Zimo">
-      <model show="no" model="MX634 version 32+" replacementModel="MX634 version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" numOuts="8" numFns="14" productID="240">
+    <family name="Zimo Unified software (version 25+)" mfg="Zimo">
+      <model model="MX634C version 25+" lowVersionID="30" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="21MTC" numOuts="8" numFns="14" productID="240">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
         <output name="3" label="FO 1"/>
         <output name="4" label="FO 2"/>
-        <output name="5" label="FO 3"/>
-        <output name="6" label="FO 4"/>
-        <output name="7" label="FO 5 (+5v)"/>
-        <output name="8" label="FO 6 (+5v)"/>
-        <size length="20.5" width="15.5" height="4" units="mm"/>
-      </model>
-      <model show="no" model="MX634R version 32+" replacementModel="MX634R version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="NMRAmedium" numOuts="8" numFns="14" productID="240">
-        <output name="1" label="Front Light"/>
-        <output name="2" label="Rear Light"/>
-        <output name="3" label="FO 1"/>
-        <output name="4" label="FO 2"/>
-        <output name="5" label="FO 3"/>
-        <output name="6" label="FO 4"/>
-        <output name="7" label="FO 5 (+5v)"/>
-        <output name="8" label="FO 6 (+5v)"/>
-        <size length="20.5" width="15.5" height="4" units="mm"/>
-      </model>
-      <model show="no" model="MX634F version 32+" replacementModel="MX634F version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="NMRAsmall" numOuts="8" numFns="14" productID="240">
-        <output name="1" label="Front Light"/>
-        <output name="2" label="Rear Light"/>
-        <output name="3" label="FO 1"/>
-        <output name="4" label="FO 2"/>
-        <output name="5" label="FO 3"/>
-        <output name="6" label="FO 4"/>
-        <output name="7" label="FO 5 (+5v)"/>
-        <output name="8" label="FO 6 (+5v)"/>
-        <size length="20.5" width="15.5" height="4" units="mm"/>
-      </model>
-      <model show="no" model="MX634D version 32+" replacementModel="MX634D version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="21MTC" numOuts="8" numFns="14" productID="240">
-        <output name="1" label="Front Light"/>
-        <output name="2" label="Rear Light"/>
-        <output name="3" label="FO 1"/>
-        <output name="4" label="FO 2"/>
-        <output name="5" label="FO 3"/>
-        <output name="6" label="FO 4"/>
+        <output name="5" label="FO 3 (+5v)"/>
+        <output name="6" label="FO 4 (+5v)"/>
         <output name="7" label="FO 5 (+5v)"/>
         <output name="8" label="FO 6 (+5v)"/>
         <size length="20.5" width="15.5" height="4" units="mm"/>
@@ -87,7 +53,7 @@
   </decoder>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneAccelDecel.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneShuntUncouple.xml"/>
-  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneAltFunctionMap6+2.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneAltFunctionMap4+4.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSwissMapping.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneFunctionOutput.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneSmoke.xml"/>

--- a/xml/decoders/Zimo_Unified_software_MX634v31.xml
+++ b/xml/decoders/Zimo_Unified_software_MX634v31.xml
@@ -18,11 +18,10 @@
   <!-- This decoder XML is meant to be used with the "Comprehensive" programmer format.      -->
   <!-- Continued the practice of using unrelated "item" names to place Zimo unique           -->
   <!-- variables on the proper pane of the Comprehensive programmer.                         -->
-  <!-- V 1 new file - Mark Waters - 7 Feb 2015-->
-  <!-- V 1.1 updated file - Mark Waters - 28 Dec 2015 - superceeded by Zimo_Unified_software_MX634v31 file, Hidden in decoder tree  -->
+  <!-- V 1 new file - Mark Waters - 27 Dec 2015 -->
   <decoder>
-    <family name="Zimo Unified software (version 32+)" mfg="Zimo">
-      <model show="no" model="MX634 version 32+" replacementModel="MX634 version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" numOuts="8" numFns="14" productID="240">
+    <family name="Zimo Unified software (version 25+)" mfg="Zimo">
+      <model model="MX634 version 25+" lowVersionID="30" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" numOuts="8" numFns="14" productID="240">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
         <output name="3" label="FO 1"/>
@@ -33,7 +32,7 @@
         <output name="8" label="FO 6 (+5v)"/>
         <size length="20.5" width="15.5" height="4" units="mm"/>
       </model>
-      <model show="no" model="MX634R version 32+" replacementModel="MX634R version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="NMRAmedium" numOuts="8" numFns="14" productID="240">
+      <model model="MX634R version 25+" lowVersionID="30" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="NMRAmedium" numOuts="8" numFns="14" productID="240">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
         <output name="3" label="FO 1"/>
@@ -44,7 +43,7 @@
         <output name="8" label="FO 6 (+5v)"/>
         <size length="20.5" width="15.5" height="4" units="mm"/>
       </model>
-      <model show="no" model="MX634F version 32+" replacementModel="MX634F version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="NMRAsmall" numOuts="8" numFns="14" productID="240">
+      <model model="MX634F version 25+" lowVersionID="30" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="NMRAsmall" numOuts="8" numFns="14" productID="240">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
         <output name="3" label="FO 1"/>
@@ -55,7 +54,7 @@
         <output name="8" label="FO 6 (+5v)"/>
         <size length="20.5" width="15.5" height="4" units="mm"/>
       </model>
-      <model show="no" model="MX634D version 32+" replacementModel="MX634D version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="21MTC" numOuts="8" numFns="14" productID="240">
+      <model model="MX634D version 25+" lowVersionID="30" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="21MTC" numOuts="8" numFns="14" productID="240">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
         <output name="3" label="FO 1"/>

--- a/xml/decoders/Zimo_Unified_software_v32_MX633.xml
+++ b/xml/decoders/Zimo_Unified_software_v32_MX633.xml
@@ -18,10 +18,11 @@
   <!-- This decoder XML is meant to be used with the "Comprehensive" programmer format.      -->
   <!-- Continued the practice of using unrelated "item" names to place Zimo unique           -->
   <!-- variables on the proper pane of the Comprehensive programmer.                         -->
-  <!-- V 1 new file - Mark Waters - 31 Jan 2015-->
+  <!-- V 1 new file - Mark Waters - 31 Jan 2015 -->
+  <!-- V 1.1 updated file - Mark Waters - 28 Dec 2015 - superceeded by Zimo_Unified_software_MX633v31 file, Hidden in decoder tree  -->
   <decoder>
     <family name="Zimo Unified software (version 32+)" mfg="Zimo">
-      <model model="MX633 version 32+" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="1.2A" formFactor="HO" numOuts="10" numFns="14" productID="237">
+      <model show="no" model="MX633 version 32+" replacementModel="MX633 version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="1.2A" formFactor="HO" numOuts="10" numFns="14" productID="237">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
         <output name="3" label="FO 1"/>
@@ -34,7 +35,7 @@
         <output name="10" label="FO 8"/>
         <size length="22" width="15" height="3.5" units="mm"/>
       </model>
-      <model model="MX633R version 32+" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="1.2A" formFactor="HO" connector="NMRAmedium" numOuts="10" numFns="14" productID="237">
+      <model show="no" model="MX633R version 32+" replacementModel="MX633R version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="1.2A" formFactor="HO" connector="NMRAmedium" numOuts="10" numFns="14" productID="237">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
         <output name="3" label="FO 1"/>
@@ -47,7 +48,7 @@
         <output name="10" label="FO 8"/>
         <size length="22" width="15" height="3.5" units="mm"/>
       </model>
-      <model model="MX633P22 version 32+" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="1.2A" formFactor="HO" connector="PluX22" numOuts="10" numFns="14" productID="237">
+      <model show="no" model="MX633P22 version 32+" replacementModel="MX633P22 version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="1.2A" formFactor="HO" connector="PluX22" numOuts="10" numFns="14" productID="237">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
         <output name="3" label="FO 1"/>
@@ -73,21 +74,6 @@
         <label>Decoder ID 1</label>
         <label xml:lang="it">ID 1 Decoder: </label>
       </variable>
-      <variable item="Decoder ID 2" CV="251" readOnly="yes">
-        <decVal/>
-        <label>Decoder ID 2</label>
-        <label xml:lang="it">ID 2 Decoder: </label>
-      </variable>
-      <variable item="Decoder ID 3" CV="252" readOnly="yes">
-        <decVal/>
-        <label>Decoder ID 3</label>
-        <label xml:lang="it">ID 3 Decoder: </label>
-      </variable>
-      <variable item="Decoder ID 4" CV="253" readOnly="yes">
-        <decVal/>
-        <label>Decoder ID 4</label>
-        <label xml:lang="it">ID 4 Decoder: </label>
-      </variable>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV400-CV428.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV430-CV489.xml"/>
     </variables>
@@ -106,4 +92,5 @@
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneServos2.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneDecoderlock.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneInputMapping.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneLoadCode.xml"/>
 </decoder-config>

--- a/xml/decoders/Zimo_Unified_software_v32_MX634C.xml
+++ b/xml/decoders/Zimo_Unified_software_v32_MX634C.xml
@@ -19,9 +19,10 @@
   <!-- Continued the practice of using unrelated "item" names to place Zimo unique           -->
   <!-- variables on the proper pane of the Comprehensive programmer.                         -->
   <!-- V 1 new file - Mark Waters - 7 Feb 2015-->
+  <!-- V 1.1 updated file - Mark Waters - 28 Dec 2015 - superceeded by Zimo_Unified_software_MX634Cv31 file, Hidden in decoder tree  -->
   <decoder>
     <family name="Zimo Unified software (version 32+)" mfg="Zimo">
-      <model model="MX634C version 32+" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="21MTC" numOuts="8" numFns="14" productID="240">
+      <model show="no" model="MX634C version 32+" replacementModel="MX634C version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="2.5A" formFactor="HO" connector="21MTC" numOuts="8" numFns="14" productID="240">
         <output name="1" label="Front Light"/>
         <output name="2" label="Rear Light"/>
         <output name="3" label="FO 1"/>
@@ -46,21 +47,6 @@
         <label>Decoder ID 1</label>
         <label xml:lang="it">ID 1 Decoder: </label>
       </variable>
-      <variable item="Decoder ID 2" CV="251" readOnly="yes">
-        <decVal/>
-        <label>Decoder ID 2</label>
-        <label xml:lang="it">ID 2 Decoder: </label>
-      </variable>
-      <variable item="Decoder ID 3" CV="252" readOnly="yes">
-        <decVal/>
-        <label>Decoder ID 3</label>
-        <label xml:lang="it">ID 3 Decoder: </label>
-      </variable>
-      <variable item="Decoder ID 4" CV="253" readOnly="yes">
-        <decVal/>
-        <label>Decoder ID 4</label>
-        <label xml:lang="it">ID 4 Decoder: </label>
-      </variable>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV400-CV428.xml"/>
       <xi:include href="http://jmri.org/xml/decoders/zimo/CV430-CV489.xml"/>
     </variables>
@@ -79,4 +65,5 @@
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneServos2.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneDecoderlock.xml"/>
   <xi:include href="http://jmri.org/xml/decoders/zimo/PaneInputMapping.xml"/>
+  <xi:include href="http://jmri.org/xml/decoders/zimo/PaneLoadCode.xml"/>
 </decoder-config>


### PR DESCRIPTION
New XML files for Zimo MX633 and MX634 decoders covering earlier firmware versions
Updates for the existing MX633 and MX634 XML files to hide them in the decoder tree

Changes to be committed:
	new file:   xml/decoders/Zimo_Unified_software_MX633v31.xml
	new file:   xml/decoders/Zimo_Unified_software_MX634Cv31.xml
	new file:   xml/decoders/Zimo_Unified_software_MX634v31.xml
	modified:   xml/decoders/Zimo_Unified_software_v32_MX633.xml
	modified:   xml/decoders/Zimo_Unified_software_v32_MX634.xml
	modified:   xml/decoders/Zimo_Unified_software_v32_MX634C.xml