### PR TITLE
Include stack trace when loading preferences

### DIFF
--- a/java/src/apps/AppsBase.java
+++ b/java/src/apps/AppsBase.java
@@ -119,7 +119,7 @@ public abstract class AppsBase {
                     try {
                         InstanceManager.tabbedPreferencesInstance().init();
                     } catch (Exception ex) {
-                        log.error(ex.toString());
+                        log.error(ex.toString(), ex);
                     }
                 }
             };


### PR DESCRIPTION
When an error happens at this point, it's impossible to track it down without throwing the full stack trace.

This does not need to be in release notes, so no milestone.