### PR TITLE
Monitor panes not obeying "always on top" preference

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Ant build.xml file for JMRI development                                -->
-<!-- Bob Jacobsen, Copyright 2002-2015                                      -->
+<!-- Bob Jacobsen, Copyright 2002-2016                                      -->
 
 <!-- This file is part of JMRI.                                             -->
 <!--                                                                        -->
@@ -24,7 +24,7 @@
     Provides build services for JMRI libraries and applications
     </description>
 
-    <property name="jmri.copyright.year" value="1997-2015"/>
+    <property name="jmri.copyright.year" value="1997-2016"/>
 
     <property environment="env"/>
 

--- a/help/en/index.html
+++ b/help/en/index.html
@@ -2,7 +2,7 @@
 <!-- $Id$ -->
 <html>
 <head>
-   <meta name="Author" content="Bob Jacobsen, LBL, Egbert Broerse">
+   <meta name="Author" content="Bob Jacobsen, Egbert Broerse">
 <title>JMRI Help</title>
 
 <!-- Style -->

--- a/help/fr/index.html
+++ b/help/fr/index.html
@@ -4,7 +4,7 @@
 <html>
 <head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-   <meta name="Author" content="Bob Jacobsen, LBL">
+   <meta name="Author" content="Bob Jacobsen, JMRI">
    <meta name="GENERATOR" content="Mozilla/4.75C-CCK-MCD {C-UDP; EBM-APPLE} (Macintosh; U; PPC) [Netscape]">
    <meta name="Content-Type" content="text/html; charset=utf-8">
    <title>JMRI Help</title>

--- a/java/src/jmri/jmrit/dualdecoder/DualDecoderToolAction.java
+++ b/java/src/jmri/jmrit/dualdecoder/DualDecoderToolAction.java
@@ -13,7 +13,6 @@ import jmri.util.swing.WindowInterface;
  * Swing action to create and register a DualDecoderTool
  *
  * @author Bob Jacobsen Copyright (C) 2001
- * @version $Revision$
  */
 public class DualDecoderToolAction extends JmriAbstractAction {
 
@@ -43,15 +42,16 @@ public class DualDecoderToolAction extends JmriAbstractAction {
     }
 
     public DualDecoderToolAction() {
-
         this(Bundle.getMessage("MenuItemMultiDecoderControl"));
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
-
         new DualDecoderSelectFrame().setVisible(true);
-
     }
+
+    @Override
+    public jmri.util.swing.JmriPanel makePanel() { return null; } // not used by this classes actionPerformed, not migrated to new form yet
 
 }
 

--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfileAction.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfileAction.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register the Add Entry Exit Pair
  *
  * @author	Kevin Dickerson Copyright (C) 2011
- * @version	$Revision: 1.4 $
  */
 public class SpeedProfileAction extends JmriAbstractAction {
 
@@ -33,6 +32,7 @@ public class SpeedProfileAction extends JmriAbstractAction {
         super(s);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
         SpeedProfileFrame f = new SpeedProfileFrame();
         try {
@@ -43,6 +43,10 @@ public class SpeedProfileAction extends JmriAbstractAction {
         }
         f.setVisible(true);
     }
+
+    @Override
+    public jmri.util.swing.JmriPanel makePanel() { return null; } // not used by this classes actionPerformed, not migrated to new form yet
+
     static Logger log = LoggerFactory.getLogger(SpeedProfileAction.class);
 }
 

--- a/java/src/jmri/util/swing/JmriAbstractAction.java
+++ b/java/src/jmri/util/swing/JmriAbstractAction.java
@@ -121,10 +121,10 @@ abstract public class JmriAbstractAction extends javax.swing.AbstractAction {
     public void setParameter(String parameter, Object value) {
     }
 
-    public JmriPanel makePanel() {
+    abstract public JmriPanel makePanel(); /* {
         log.error("makePanel must be overridden", new Exception());
         return null;
-    }
+    } */
 }
 
 /*

--- a/java/src/jmri/web/server/WebServerAction.java
+++ b/java/src/jmri/web/server/WebServerAction.java
@@ -9,10 +9,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Action to start a web server
+ * Action to start a web server. Doesn't show a panel.
  *
  * @author	Randall Wood Copyright (C) 2012
- * @version $Revision$
  */
 public class WebServerAction extends JmriAbstractAction {
 
@@ -42,6 +41,9 @@ public class WebServerAction extends JmriAbstractAction {
         }
     }
 
+    @Override
+    public jmri.util.swing.JmriPanel makePanel() { return null; } // not used by this classes actionPerformed, as it doesn't show anything
+    
     static class ServerThread extends Thread {
 
         @Override

--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -61,9 +61,9 @@ If you're attempting to perform this on MS Windows, refer to the MS Windows note
 
 - Go to the master branch on your local repository. Pull back from the main JMRI/JMRI repository to make sure you're up to date.
 
-- If it's a new year, update copyright dates (done for 2015):
+- If it's a new year, update copyright dates (done for 2016):
     JMRI:
-    * build.xml (3) in the jmri.copyright.years property value
+    * build.xml in the jmri.copyright.years property value
     * xml/XSLT/build.xml in the property value, index.html, CSVindex.html
     website:
     * Copyright.html (3 places)

--- a/xml/XSLT/CSVindex.html
+++ b/xml/XSLT/CSVindex.html
@@ -3,7 +3,7 @@
 <html>
 <head>
    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-   <meta name="Author" content="Bob Jacobsen, LBL">
+   <meta name="Author" content="Bob Jacobsen, JMRI">
    <meta name="GENERATOR" content="Mozilla/4.75C-CCK-MCD {C-UDP; EBM-APPLE} (Macintosh; U; PPC) [Netscape]">
    <meta name="Content-Type" content="text/html; charset=iso-8859-1">
    <title>JMRI decoder Comma-Separated-Variables files</title>
@@ -28,7 +28,7 @@ If you find this information useful, we encourage you to
 <a href="http://jmri.sf.net/donations.shtml">donate to support JMRI</a>.
 
 <HR>
-	<p>Copyright &copy; 1997 - 2015 JMRI Community. 
+	<p>Copyright &copy; 1997 - 2016 JMRI Community. 
 	<P>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 	<P><A href="/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</a></p>
 

--- a/xml/XSLT/build.xml
+++ b/xml/XSLT/build.xml
@@ -23,7 +23,7 @@
   Provides build services for JMRI web pages
   </description>
 
-  <property name="jmri.copyright.year" value="1997-2015"/>
+  <property name="jmri.copyright.year" value="1997-2016"/>
 
   <!-- set global properties for this build -->
   <property name="xml" value=".."/>

--- a/xml/XSLT/decoder.xsl
+++ b/xml/XSLT/decoder.xsl
@@ -7,7 +7,7 @@
 <!-- This XSLT transform is used when a JMRI decoder definition -->
 <!-- file is displayed by a web browser -->
 
-<!-- This file is part of JMRI.  Copyright 2007-2013.                       -->
+<!-- This file is part of JMRI.  Copyright 2007-2016.                       -->
 <!--                                                                        -->
 <!-- JMRI is free software; you can redistribute it and/or modify it under  -->
 <!-- the terms of version 2 of the GNU General Public License as published  -->
@@ -21,7 +21,7 @@
  
 <xsl:stylesheet	version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:docbook="http://docbook.org/ns/docbook">
       <xsl:param name="JmriCopyrightYear">
-        2000 - 2015
+        2000 - 2016
       </xsl:param>
 
 <!-- Need to instruct the XSLT processor to use HTML output rules.

--- a/xml/XSLT/index.html
+++ b/xml/XSLT/index.html
@@ -3,7 +3,7 @@
 <html>
 <head>
    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-   <meta name="Author" content="Bob Jacobsen, LBL">
+   <meta name="Author" content="Bob Jacobsen, JMRI">
    <meta name="Content-Type" content="text/html; charset=iso-8859-1">
    <title>JMRI Decoder Information</title>
 </head>
@@ -48,7 +48,7 @@ If you find this information useful, we encourage you to
 <a href="http://jmri.sf.net/donations.shtml">donate to support JMRI</a>.
 
 <HR>
-	<p>Copyright &copy; 1997 - 2015 JMRI Community. 
+	<p>Copyright &copy; 1997 - 2016 JMRI Community. 
 	<P>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 	<P><A href="/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</a></p>
 <P>Site hosted by: <BR>


### PR DESCRIPTION
Monitor panes wouldn't actually always be on top if that checkbox option was checked when they opened.  The problem was that the Pane was trying to handle the option before being in a Frame (which has to handle it).  Fixed.

Also, refactored a method-you-should-know-to implement to the better pattern, an abstract method.