### PR TITLE
Allow any script to be run at startup.

### DIFF
--- a/java/src/apps/PerformScriptPanel.java
+++ b/java/src/apps/PerformScriptPanel.java
@@ -16,6 +16,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import jmri.InstanceManager;
 import jmri.profile.ProfileManager;
+import jmri.script.ScriptFileChooser;
 import jmri.swing.PreferencesPanel;
 
 /**
@@ -79,7 +80,7 @@ public class PerformScriptPanel extends JPanel implements PreferencesPanel {
         }
     }
 
-    JFileChooser fc = jmri.jmrit.XmlFile.userFileChooser("Python script files", "py");
+    JFileChooser fc = new ScriptFileChooser();
 
     @Override
     public String getPreferencesItem() {


### PR DESCRIPTION
Any type of script could have been run at startup, but this allows a
user to actually select non-python scripts.