### PR TITLE
Refactor startup actions

### DIFF
--- a/java/src/apps/AbstractActionPanel.java
+++ b/java/src/apps/AbstractActionPanel.java
@@ -62,9 +62,7 @@ abstract public class AbstractActionPanel extends JPanel implements PreferencesP
         });
 
         // are there any existing objects from reading existing config?
-        int n = rememberedObjects().size();
-        for (int i = 0; i < n; i++) {
-            AbstractActionModel m = (AbstractActionModel) rememberedObjects().get(i);
+        for (AbstractActionModel m : rememberedObjects()) {
             add(new Item(m));
             this.dirty = false; // reset to false - setting the model in the Item ctor sets this true
         }
@@ -80,13 +78,13 @@ abstract public class AbstractActionPanel extends JPanel implements PreferencesP
         });
     }
 
-    abstract List<?> rememberedObjects();
+    abstract List<? extends AbstractActionModel> rememberedObjects();
 
     protected void addItem() {
         synchronized (self) {
             Item i = new Item();
             add(i);
-            InstanceManager.getDefault(StartupActionsManager.class).addModel(i.model);
+            InstanceManager.getDefault(StartupActionsManager.class).addAction(i.model);
             revalidate();
             repaint();
             this.dirty = true;
@@ -204,7 +202,7 @@ abstract public class AbstractActionPanel extends JPanel implements PreferencesP
                 parent.repaint();
                 // unlink to encourage garbage collection
                 removeButton.removeActionListener(this);
-                InstanceManager.getDefault(StartupActionsManager.class).removeModel(model);
+                InstanceManager.getDefault(StartupActionsManager.class).removeAction(model);
                 model = null;
                 dirty = true;
             }

--- a/java/src/apps/AppsConfigBundle.properties
+++ b/java/src/apps/AppsConfigBundle.properties
@@ -138,4 +138,12 @@ QuitAlways = Always Quit
 QuitAfterSave = Quit after saving preferences
 Application = Application
 
+# StartupActionsPreferencesPanel
+apps.CreateButtonModel = Button
+apps.PerformActionModel = Action
+apps.PerformFileModel = File
+apps.PerformScriptModel = Script
+StartupActionsTableModel.name = Name
+StartupActionsTableModel.type = Type
+
 # PreferencesPanels moved to AppsStructureBundle.properties, as not for I8N

--- a/java/src/apps/ConfigBundle.java
+++ b/java/src/apps/ConfigBundle.java
@@ -1,0 +1,82 @@
+// Bundle.java
+package apps;
+
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+
+@DefaultAnnotation({NonNull.class, CheckReturnValue.class})
+@SuppressWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@net.jcip.annotations.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @version $Revision: 17977 $
+ * @since 3.3.1
+ */
+public class ConfigBundle extends apps.Bundle {
+
+    private final static String name = "apps.AppsConfigBundle"; // NOI18N
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return b.handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return b.handleGetMessage(key, subs);
+    }
+
+    private final static ConfigBundle b = new ConfigBundle();
+
+    @Override
+    @Nullable
+    protected String bundleName() {
+        return name;
+    }
+
+    @Override
+    protected jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(String key) {
+        return super.getBundle().handleGetMessage(key);
+    }
+
+}
+
+/* @(#)Bundle.java */

--- a/java/src/apps/CreateButtonModel.java
+++ b/java/src/apps/CreateButtonModel.java
@@ -1,9 +1,6 @@
 // CreateButtonModel.java
 package apps;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Creates a button when the program is started.
  * <P>
@@ -11,7 +8,7 @@ import java.util.List;
  * superclass.
  * <P>
  * This is a separate class, even though it has no additional behavior, so that
- * persistance systems realize the type of data being stored.
+ * persistence systems realize the type of data being stored.
  *
  * @author	Bob Jacobsen Copyright 2003
  * @version $Revision$
@@ -22,14 +19,4 @@ public class CreateButtonModel extends AbstractActionModel {
     public CreateButtonModel() {
         super();
     }
-
-    static public void rememberObject(CreateButtonModel m) {
-        l.add(m);
-    }
-
-    static public List<CreateButtonModel> rememberedObjects() {
-        return l;
-    }
-    static List<CreateButtonModel> l = new ArrayList<CreateButtonModel>();
-
 }

--- a/java/src/apps/CreateButtonPanel.java
+++ b/java/src/apps/CreateButtonPanel.java
@@ -2,6 +2,7 @@
 package apps;
 
 import java.util.List;
+import jmri.InstanceManager;
 
 /**
  * Provide a GUI for configuring start-up actions.
@@ -27,7 +28,7 @@ public class CreateButtonPanel extends AbstractActionPanel {
 
     @Override
     List<CreateButtonModel> rememberedObjects() {
-        return CreateButtonModel.rememberedObjects();
+        return InstanceManager.getDefault(StartupActionsManager.class).getActions(CreateButtonModel.class);
     }
 
     @Override

--- a/java/src/apps/PerformActionModel.java
+++ b/java/src/apps/PerformActionModel.java
@@ -1,9 +1,6 @@
 // PerformActionModel.java
 package apps;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Invokes a Swing Action when the program is started.
  * <P>
@@ -11,7 +8,7 @@ import java.util.List;
  * superclass.
  * <P>
  * This is a separate class, even though it has no additional behavior, so that
- * persistance systems realize the type of data being stored.
+ * persistence systems realize the type of data being stored.
  *
  * @author	Bob Jacobsen Copyright 2003
  * @version $Revision$
@@ -22,14 +19,4 @@ public class PerformActionModel extends AbstractActionModel {
     public PerformActionModel() {
         super();
     }
-
-    static public void rememberObject(PerformActionModel m) {
-        l.add(m);
-    }
-
-    static public List<PerformActionModel> rememberedObjects() {
-        return l;
-    }
-    static List<PerformActionModel> l = new ArrayList<PerformActionModel>();
-
 }

--- a/java/src/apps/PerformActionPanel.java
+++ b/java/src/apps/PerformActionPanel.java
@@ -2,6 +2,7 @@
 package apps;
 
 import java.util.List;
+import jmri.InstanceManager;
 
 /**
  * Provide a GUI for configuring PerformActionModel objects.
@@ -27,7 +28,7 @@ public class PerformActionPanel extends AbstractActionPanel {
 
     @Override
     List<PerformActionModel> rememberedObjects() {
-        return PerformActionModel.rememberedObjects();
+        return InstanceManager.getDefault(StartupActionsManager.class).getActions(PerformActionModel.class);
     }
 
     @Override

--- a/java/src/apps/PerformFileModel.java
+++ b/java/src/apps/PerformFileModel.java
@@ -1,9 +1,6 @@
 // PerformFileModel.java
 package apps;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * A PerformFileModel object loads an xml file when the program is started.
  * <P>
@@ -31,13 +28,4 @@ public class PerformFileModel implements StartupModel {
     public void setFileName(String n) {
         fileName = n;
     }
-
-    static public void rememberObject(PerformFileModel m) {
-        l.add(m);
-    }
-
-    static public List<PerformFileModel> rememberedObjects() {
-        return l;
-    }
-    static List<PerformFileModel> l = new ArrayList<PerformFileModel>();
 }

--- a/java/src/apps/PerformFilePanel.java
+++ b/java/src/apps/PerformFilePanel.java
@@ -58,11 +58,9 @@ public class PerformFilePanel extends JPanel implements PreferencesPanel {
         });
 
         // are there any existing objects from reading existing config?
-        int n = PerformFileModel.rememberedObjects().size();
-        for (int i = 0; i < n; i++) {
-            PerformFileModel m = PerformFileModel.rememberedObjects().get(i);
+        InstanceManager.getDefault(StartupActionsManager.class).getActions(PerformFileModel.class).stream().forEach((m) -> {
             add(new Item(m));
-        }
+        });
     }
 
     protected void addItem() {
@@ -71,7 +69,7 @@ public class PerformFilePanel extends JPanel implements PreferencesPanel {
             if (i.model.getFileName() == null) {
                 return;  // cancelled
             }
-            InstanceManager.getDefault(StartupActionsManager.class).addModel(i.model);
+            InstanceManager.getDefault(StartupActionsManager.class).addAction(i.model);
             add(i);
             revalidate();
             repaint();
@@ -187,7 +185,7 @@ public class PerformFilePanel extends JPanel implements PreferencesPanel {
                 parent.repaint();
                 // unlink to encourage garbage collection
                 removeButton.removeActionListener(this);
-                InstanceManager.getDefault(StartupActionsManager.class).removeModel(model);
+                InstanceManager.getDefault(StartupActionsManager.class).removeAction(model);
                 model = null;
                 dirty = true;
             }

--- a/java/src/apps/PerformScriptModel.java
+++ b/java/src/apps/PerformScriptModel.java
@@ -1,9 +1,6 @@
 // PerformScriptModel.java
 package apps;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * A PerformScriptModel object runs a script when the program is started.
  * <P>
@@ -31,13 +28,4 @@ public class PerformScriptModel implements StartupModel {
     public void setFileName(String n) {
         fileName = n;
     }
-
-    static public void rememberObject(PerformScriptModel m) {
-        l.add(m);
-    }
-
-    static public List<PerformScriptModel> rememberedObjects() {
-        return l;
-    }
-    static List<PerformScriptModel> l = new ArrayList<PerformScriptModel>();
 }

--- a/java/src/apps/PerformScriptPanel.java
+++ b/java/src/apps/PerformScriptPanel.java
@@ -59,11 +59,9 @@ public class PerformScriptPanel extends JPanel implements PreferencesPanel {
         });
 
         // are there any existing objects from reading existing config?
-        int n = PerformScriptModel.rememberedObjects().size();
-        for (int i = 0; i < n; i++) {
-            PerformScriptModel m = PerformScriptModel.rememberedObjects().get(i);
+        InstanceManager.getDefault(StartupActionsManager.class).getActions(PerformScriptModel.class).stream().forEach((m) -> {
             add(new Item(m));
-        }
+        });
     }
 
     protected void addItem() {
@@ -72,7 +70,7 @@ public class PerformScriptPanel extends JPanel implements PreferencesPanel {
             if (i.model.getFileName() == null) {
                 return;  // cancelled
             }
-            InstanceManager.getDefault(StartupActionsManager.class).addModel(i.model);
+            InstanceManager.getDefault(StartupActionsManager.class).addAction(i.model);
             add(i);
             revalidate();
             repaint();
@@ -188,7 +186,7 @@ public class PerformScriptPanel extends JPanel implements PreferencesPanel {
                 parent.repaint();
                 // unlink to encourage garbage collection
                 removeButton.removeActionListener(this);
-                InstanceManager.getDefault(StartupActionsManager.class).removeModel(model);
+                InstanceManager.getDefault(StartupActionsManager.class).removeAction(model);
                 model = null;
                 dirty = true;
             }

--- a/java/src/apps/configurexml/CreateButtonModelXml.java
+++ b/java/src/apps/configurexml/CreateButtonModelXml.java
@@ -81,8 +81,7 @@ public class CreateButtonModelXml extends jmri.configurexml.AbstractXmlAdapter {
         }
         CreateButtonModel m = new CreateButtonModel();
         m.setClassName(className);
-        CreateButtonModel.rememberObject(m);
-        InstanceManager.getDefault(StartupActionsManager.class).addModel(m);
+        InstanceManager.getDefault(StartupActionsManager.class).addAction(m);
         InstanceManager.configureManagerInstance().registerPref(new apps.CreateButtonPanel());
         return result;
     }

--- a/java/src/apps/configurexml/PerformActionModelXml.java
+++ b/java/src/apps/configurexml/PerformActionModelXml.java
@@ -78,8 +78,7 @@ public class PerformActionModelXml extends jmri.configurexml.AbstractXmlAdapter 
         }
         PerformActionModel m = new PerformActionModel();
         m.setClassName(className);
-        PerformActionModel.rememberObject(m);
-        InstanceManager.getDefault(StartupActionsManager.class).addModel(m);
+        InstanceManager.getDefault(StartupActionsManager.class).addAction(m);
         InstanceManager.configureManagerInstance().registerPref(new apps.PerformActionPanel());
         return result;
     }

--- a/java/src/apps/configurexml/PerformFileModelXml.java
+++ b/java/src/apps/configurexml/PerformFileModelXml.java
@@ -64,8 +64,7 @@ public class PerformFileModelXml extends jmri.configurexml.AbstractXmlAdapter {
         // leave an updated object around
         PerformFileModel m = new PerformFileModel();
         m.setFileName(fileName);
-        PerformFileModel.rememberObject(m);
-        InstanceManager.getDefault(StartupActionsManager.class).addModel(m);
+        InstanceManager.getDefault(StartupActionsManager.class).addAction(m);
         InstanceManager.configureManagerInstance().registerPref(new apps.PerformFilePanel());
         return result;
     }

--- a/java/src/apps/configurexml/PerformScriptModelXml.java
+++ b/java/src/apps/configurexml/PerformScriptModelXml.java
@@ -64,8 +64,7 @@ public class PerformScriptModelXml extends jmri.configurexml.AbstractXmlAdapter 
         // leave an updated object around
         PerformScriptModel m = new PerformScriptModel();
         m.setFileName(fileName);
-        PerformScriptModel.rememberObject(m);
-        InstanceManager.getDefault(StartupActionsManager.class).addModel(m);
+        InstanceManager.getDefault(StartupActionsManager.class).addAction(m);
         InstanceManager.configureManagerInstance().registerPref(new apps.PerformScriptPanel());
         return result;
     }

--- a/java/src/jmri/jmrit/mailreport/ReportPanel.java
+++ b/java/src/jmri/jmrit/mailreport/ReportPanel.java
@@ -2,6 +2,7 @@
 package jmri.jmrit.mailreport;
 
 import apps.PerformFileModel;
+import apps.StartupActionsManager;
 import java.awt.FlowLayout;
 import java.io.File;
 import java.io.FileInputStream;
@@ -22,6 +23,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
+import jmri.InstanceManager;
 import jmri.profile.Profile;
 import jmri.profile.ProfileManager;
 import jmri.util.MultipartMessage;
@@ -192,15 +194,12 @@ public class ReportPanel extends JPanel {
             if (checkPanel.isSelected()) {
                 log.debug("prepare panel attachment");
                 // Check that some startup panel files have been loaded
-                List <PerformFileModel>pfmList = PerformFileModel.rememberedObjects();
-                if (pfmList != null) {
-                    for (int i = 0; i < pfmList.size(); i++) {
-                        String fn = pfmList.get(i).getFileName();
-                        File f = new File(fn);
-                        log.debug("add startup panel file: {}", f);
-                        msg.addFilePart("logfileupload[]", f);
-                    }
-                }
+                for (PerformFileModel m : InstanceManager.getDefault(StartupActionsManager.class).getActions(PerformFileModel.class)) {
+                    String fn = m.getFileName();
+                    File f = new File(fn);
+                    log.debug("add startup panel file: {}", f);
+                    msg.addFilePart("logfileupload[]", f);
+                };
                 // Check that a manual panel file has been loaded
                 File file = jmri.configurexml.LoadXmlUserAction.getCurrentFile();
                 if (file != null) {

--- a/java/src/jmri/jmrit/mailreport/ReportPanel.java
+++ b/java/src/jmri/jmrit/mailreport/ReportPanel.java
@@ -199,7 +199,7 @@ public class ReportPanel extends JPanel {
                     File f = new File(fn);
                     log.debug("add startup panel file: {}", f);
                     msg.addFilePart("logfileupload[]", f);
-                };
+                }
                 // Check that a manual panel file has been loaded
                 File file = jmri.configurexml.LoadXmlUserAction.getCurrentFile();
                 if (file != null) {


### PR DESCRIPTION
This refactoring has no user-visible changes, but lays the ground work
for providing a single table of all startup actions that allows users
to reorder the actions within JMRI (so that, for example, a script
could be run both before and after a XML file is loaded).
This also
removes a number of static List objects.