### PR TITLE
Rework GUI Preferences to better handle defaults and large fonts.

### DIFF
--- a/java/src/apps/AppsConfigBundle.properties
+++ b/java/src/apps/AppsConfigBundle.properties
@@ -61,6 +61,7 @@ Yes = Yes
 No = No
 RestartNow = Restart
 RestartLater = Later
+ResetDefault =  Reset to Default
 
 # messages from PerformActionPanel
 
@@ -102,6 +103,7 @@ ScriptDir = Jython Script Location
 GUIToolTipDismissDelay = Tool tip display time
 GUIToolTipDismissDelayUoM = seconds
 GUIToolTipDismissDelayToolTip = <html>The number of seconds tool tips will be displayed.<br>The time must be between {0} and {1} seconds.</html>
+GUIFontSizeReset = Reset font size to the default for this appearance
 
 # messages from SystemConsole config panel
 ConsoleScheme = Console color scheme

--- a/java/src/apps/GuiLafConfigPane.java
+++ b/java/src/apps/GuiLafConfigPane.java
@@ -15,6 +15,7 @@ import java.util.ResourceBundle;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
 import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
@@ -165,35 +166,6 @@ public class GuiLafConfigPane extends JPanel implements PreferencesPanel {
         return (desired != null) ? desired : Locale.getDefault();
     }
 
-    static int fontSize = 0;
-
-    public static void setFontSize(int size) {
-        fontSize = size == 0 ? 0 : size < 9 ? 9 : size > 20 ? 20 : size;
-        //fontSizeComboBox.setSelectedItem(fontSize);
-    }
-
-    public static int getFontSize() {
-        return fontSize;
-    }
-
-    private int getDefaultFontSize() {
-        if (getFontSize() == 0) {
-            java.util.Enumeration<Object> keys = UIManager.getDefaults().keys();
-            while (keys.hasMoreElements()) {
-                Object key = keys.nextElement();
-                Object value = UIManager.get(key);
-
-                if (value instanceof javax.swing.plaf.FontUIResource && key.toString().equals("List.font")) {
-                    Font f = UIManager.getFont(key);
-                    log.debug("Key:" + key.toString() + " Font: " + f.getName() + " size: " + f.getSize());
-                    return f.getSize();
-                }
-            }
-            return 11;	// couldn't find the default return a reasonable font size
-        }
-        return getFontSize();
-    }
-
     private static final Integer fontSizes[] = {
         9,
         10,
@@ -212,21 +184,28 @@ public class GuiLafConfigPane extends JPanel implements PreferencesPanel {
     static ActionListener listener;
 
     public void doFontSize(JPanel panel) {
-
+        GuiLafPreferencesManager manager = InstanceManager.getDefault(GuiLafPreferencesManager.class);
         JLabel fontSizeLabel = new JLabel(rb.getString("ConsoleFontSize"));
         fontSizeComboBox.removeActionListener(listener);
-        fontSizeComboBox.setSelectedItem(getDefaultFontSize());
+        fontSizeComboBox.setSelectedItem(manager.getFontSize());
         JLabel fontSizeUoM = new JLabel(rb.getString("ConsoleFontSizeUoM"));
+        JButton resetButton = new JButton(rb.getString("ResetDefault"));
+        resetButton.setToolTipText(rb.getString("GUIFontSizeReset"));
 
         panel.add(fontSizeLabel);
         panel.add(fontSizeComboBox);
         panel.add(fontSizeUoM);
+        panel.add(resetButton);
 
         fontSizeComboBox.addActionListener(listener = (ActionEvent e) -> {
-            setFontSize((int) fontSizeComboBox.getSelectedItem());
-            InstanceManager.getDefault(GuiLafPreferencesManager.class).setFontSize((int) fontSizeComboBox.getSelectedItem());
+            manager.setFontSize((int) fontSizeComboBox.getSelectedItem());
             this.dirty = true;
             this.restartRequired = true;
+        });
+        resetButton.addActionListener(listener = (ActionEvent e) -> {
+            if ((int) GuiLafConfigPane.fontSizeComboBox.getSelectedItem() != manager.getDefaultFontSize()) {
+                GuiLafConfigPane.fontSizeComboBox.setSelectedItem(manager.getDefaultFontSize());
+            }
         });
     }
 

--- a/java/src/apps/configurexml/GuiLafConfigPaneXml.java
+++ b/java/src/apps/configurexml/GuiLafConfigPaneXml.java
@@ -37,6 +37,7 @@ public class GuiLafConfigPaneXml extends jmri.configurexml.AbstractXmlAdapter {
      * @param o Object to store, of type GuiLafConfigPane
      * @return Element containing the complete info
      */
+    @Override
     public Element store(Object o) {
         Element e = new Element("gui");
         GuiLafConfigPane g = (GuiLafConfigPane) o;
@@ -50,8 +51,9 @@ public class GuiLafConfigPaneXml extends jmri.configurexml.AbstractXmlAdapter {
         e.setAttribute("LocaleCountry", l.getCountry());
         e.setAttribute("LocaleVariant", l.getVariant());
 
-        if (GuiLafConfigPane.getFontSize() != 0) {
-            e.setAttribute("fontsize", Integer.toString(GuiLafConfigPane.getFontSize()));
+        GuiLafPreferencesManager manager = InstanceManager.getDefault(GuiLafPreferencesManager.class);
+        if (manager.getFontSize() != manager.getDefaultFontSize()) {
+            e.setAttribute("fontsize", Integer.toString(manager.getFontSize()));
         }
 
         e.setAttribute("nonStandardMouseEvent",
@@ -106,7 +108,6 @@ public class GuiLafConfigPaneXml extends jmri.configurexml.AbstractXmlAdapter {
         Attribute fontsize = shared.getAttribute("fontsize");
         if (fontsize != null) {
             int size = Integer.parseInt(fontsize.getValue());
-            GuiLafConfigPane.setFontSize(size);
             InstanceManager.getDefault(GuiLafPreferencesManager.class).setFontSize(size);
             this.setUIFontSize(size);
         }
@@ -145,6 +146,7 @@ public class GuiLafConfigPaneXml extends jmri.configurexml.AbstractXmlAdapter {
      * @param element Top level Element to unpack.
      * @param o       ignored
      */
+    @Override
     public void load(Element element, Object o) {
         log.error("Unexpected call of load(Element, Object)");
     }

--- a/java/src/apps/gui/GuiLafPreferencesManager.java
+++ b/java/src/apps/gui/GuiLafPreferencesManager.java
@@ -37,6 +37,7 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesProvide
     // preferences with default values
     private Locale locale = Locale.getDefault();
     private int fontSize = 0;
+    private int defaultFontSize = 0;
     private boolean nonStandardMouseEvent = false;
     private String lookAndFeel = UIManager.getLookAndFeel().getClass().getName();
     private int toolTipDismissDelay = ToolTipManager.sharedInstance().getDismissDelay();
@@ -52,13 +53,16 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesProvide
     public void initialize(Profile profile) throws InitializationException {
         if (!this.initialized) {
             Preferences preferences = ProfileUtils.getPreferences(profile, this.getClass(), true);
-            this.setFontSize(preferences.getInt(FONT_SIZE, this.getFontSize()));
             this.setLocale(Locale.forLanguageTag(preferences.get(LOCALE, this.getLocale().toLanguageTag())));
             this.setLookAndFeel(preferences.get(LOOK_AND_FEEL, this.getLookAndFeel()));
+            this.setDefaultFontSize(); // before we change anything
+            this.setFontSize(preferences.getInt(FONT_SIZE, this.getDefaultFontSize()));
+            if (this.getFontSize() == 0) {
+                this.setFontSize(this.getDefaultFontSize());
+            }
             this.setNonStandardMouseEvent(preferences.getBoolean(NONSTANDARD_MOUSE_EVENT, this.isNonStandardMouseEvent()));
             this.setToolTipDismissDelay(preferences.getInt(SHOW_TOOL_TIP_TIME, this.getToolTipDismissDelay()));
             Locale.setDefault(this.getLocale());
-            GuiLafConfigPane.setFontSize(this.getFontSize()); // This is backwards - GuiLafConfigPane should be getting our fontSize when it needs it
             this.applyLookAndFeel();
             this.applyFontSize();
             SwingSettings.setNonStandardMouseEvent(this.isNonStandardMouseEvent());
@@ -88,7 +92,13 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesProvide
         Preferences preferences = ProfileUtils.getPreferences(profile, this.getClass(), true);
         preferences.put(LOCALE, this.getLocale().toLanguageTag());
         preferences.put(LOOK_AND_FEEL, this.getLookAndFeel());
-        preferences.putInt(FONT_SIZE, this.getFontSize());
+        int temp = this.getFontSize();
+        if (temp == this.getDefaultFontSize()) {
+            temp = 0;
+        }
+        if (temp != preferences.getInt(FONT_SIZE, -1)) {
+            preferences.putInt(FONT_SIZE, temp);
+        }
         preferences.putBoolean(NONSTANDARD_MOUSE_EVENT, this.isNonStandardMouseEvent());
         preferences.putInt(SHOW_TOOL_TIP_TIME, this.getToolTipDismissDelay());
         try {
@@ -115,28 +125,71 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesProvide
     }
 
     /**
-     * @return the fontSize
+     * @return the currently selected font size
      */
     public int getFontSize() {
         return fontSize;
     }
 
     /**
-     * @param fontSize the fontSize to set
+     * Sets a new font size
+     *
+     * @param newFontSize the new font size to set
      */
-    public void setFontSize(int fontSize) {
+    public void setFontSize(int newFontSize) {
         int oldFontSize = this.fontSize;
-        this.fontSize = (fontSize == 0) ? 0 : ((fontSize < 9) ? 9 : ((fontSize > 20) ? 20 : fontSize));
+        this.fontSize = (newFontSize == 0) ? 0 : ((newFontSize < 9) ? 9 : ((newFontSize > 20) ? 20 : newFontSize));
         if (this.fontSize != oldFontSize) {
             propertyChangeSupport.firePropertyChange(FONT_SIZE, oldFontSize, this.fontSize);
         }
     }
 
+   /**
+     * @return the current Look & Feel default font size
+     */
+    public int getDefaultFontSize() {
+        return defaultFontSize;
+    }
+
+   /**
+     * Called to load the current Look & Feel default font size, based on looking up the "List.font" size
+     * <br><br>
+     * The value can be can be read by calling {@link #getDefaultFontSize()}
+     */
+    public void setDefaultFontSize() {
+        java.util.Enumeration<Object> keys = UIManager.getDefaults().keys();
+        while (keys.hasMoreElements()) {
+            Object key = keys.nextElement();
+            Object value = UIManager.get(key);
+
+            if (value instanceof javax.swing.plaf.FontUIResource && key.toString().equals("List.font")) {
+                Font f = UIManager.getFont(key);
+                log.debug("Key:" + key.toString() + " Font: " + f.getName() + " size: " + f.getSize());
+                defaultFontSize = f.getSize();
+                return;
+            }
+        }
+        defaultFontSize = 11;	// couldn't find the default return a reasonable font size
+    }
+
+    private void listLAFfonts() {
+        log.info("******** LAF=" + UIManager.getLookAndFeel().getClass().getName());
+        java.util.Enumeration<Object> keys = UIManager.getDefaults().keys();
+        while (keys.hasMoreElements()) {
+            Object key = keys.nextElement();
+            Object value = UIManager.get(key);
+            if (value instanceof javax.swing.plaf.FontUIResource || value instanceof java.awt.Font || key.toString().endsWith(".font")) {
+                Font f = UIManager.getFont(key);
+                log.info("Class=" + value.getClass().getName() + ";Key:" + key.toString() + " Font: " + f.getName() + " size: " + f.getSize());
+            }
+        }
+    }
+
     /**
      * Sets the time a tooltip is displayed before it goes away.
-     * 
+     *
      * Note that this preference takes effect immediately.
-     * 
+     *
      * @param time the delay in seconds.
      */
     public void setToolTipDismissDelay(int time) {
@@ -213,22 +266,38 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesProvide
         }
     }
 
+    /**
+     * Applies a new calculated font size to all found fonts.
+     * <br><br>
+     * Calls {@link #getCalcFontSize(int) getCalcFontSize} to calculate new size for each.
+     */
     private void applyFontSize() {
-        if (this.getFontSize() != 0) {
+        if (log.isDebugEnabled()) {
+            listLAFfonts();
+        }
+        if (this.getFontSize() != this.getDefaultFontSize()) {
 //            UIManager.getDefaults().keySet().stream().forEach((key) -> {
-//                Object value = UIManager.get(key);
-//                if (value instanceof FontUIResource) {
-//                    UIManager.put(key, UIManager.getFont(key).deriveFont(((Font)value).getStyle(), (float) this.getFontSize()));
-//                }
-//            });
             Enumeration<Object> keys = UIManager.getDefaults().keys();
             while (keys.hasMoreElements()) {
                 Object key = keys.nextElement();
                 Object value = UIManager.get(key);
-                if (value instanceof FontUIResource) {
-                    UIManager.put(key, UIManager.getFont(key).deriveFont(((Font) value).getStyle(), this.getFontSize()));
+                if (value instanceof javax.swing.plaf.FontUIResource || value instanceof java.awt.Font || key.toString().endsWith(".font")) {
+                    UIManager.put(key, UIManager.getFont(key).deriveFont(((Font) value).getStyle(), getCalcFontSize(((Font) value).getSize())));
                 }
             }
+            if (log.isDebugEnabled()) {
+                listLAFfonts();
+            }
         }
+    }
+
+    /**
+     * @return a new calculated font size based on difference between default
+     * size and selected size
+     *
+     * @param oldSize the old font size
+     */
+    private int getCalcFontSize(int oldSize) {
+        return oldSize + (this.getFontSize() - this.getDefaultFontSize());
     }
 }

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -1,6 +1,7 @@
 // BeanTableFrame.java
 package jmri.jmrit.roster.swing;
 
+import apps.gui.GuiLafPreferencesManager;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -21,6 +22,7 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableColumn;
+import jmri.InstanceManager;
 import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
 import jmri.jmrit.roster.RosterEntrySelector;
@@ -68,6 +70,7 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
         dataTable = new JTable(sorter);
         sorter.setTableHeader(dataTable.getTableHeader());
         dataScroll = new JScrollPane(dataTable);
+        dataTable.setRowHeight(InstanceManager.getDefault(GuiLafPreferencesManager.class).getFontSize() + 4);
 
         // set initial sort
         TableSorter tmodel = ((TableSorter) dataTable.getModel());

--- a/java/src/jmri/util/swing/multipane/TwoPaneTBWindow.java
+++ b/java/src/jmri/util/swing/multipane/TwoPaneTBWindow.java
@@ -1,6 +1,7 @@
 // TwoPaneTBWindow.java
 package jmri.util.swing.multipane;
 
+import apps.gui.GuiLafPreferencesManager;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.FlowLayout;
@@ -16,6 +17,7 @@ import javax.swing.JSeparator;
 import javax.swing.JSplitPane;
 import javax.swing.JToolBar;
 import javax.swing.border.BevelBorder;
+import jmri.InstanceManager;
 import jmri.util.swing.JMenuUtil;
 import jmri.util.swing.JToolBarUtil;
 
@@ -155,7 +157,7 @@ abstract public class TwoPaneTBWindow extends jmri.util.JmriJFrame {
         JPanel statusItemPanel = new JPanel();
         statusItemPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 5, 0));
         //Set the font size of the status bar text to be 1points less than the default configured, also set as plain
-        int fontSize = apps.GuiLafConfigPane.getFontSize() - 1;
+        int fontSize = InstanceManager.getDefault(GuiLafPreferencesManager.class).getFontSize() - 1;
         if (title != null) {
             if (fontSize <= 4) {
                 fontSize = title.getFont().getSize() - 1;


### PR DESCRIPTION
Display GUI Font Preferences had issues:
- Not all Fonts were changing.
- Once changed, true defaults were not restorable.
- Methods were in wrong classes.
- Poor display with large fonts and Look & Feel combinations (such as 20 points added by @AlanUS).
- False setting of dirty preferences.

Added a "Reset to Default" font button that truly resets to Look & Feel defaults, as does selecting original font size in dropdown.