### PR TITLE
Improve patch and contribution discussion

### DIFF
--- a/help/en/html/doc/Technical/NetBeans.shtml
+++ b/help/en/html/doc/Technical/NetBeans.shtml
@@ -41,11 +41,11 @@
         <li><a href="#updating">Updating the code from Git</a>
         <li><a href="#buildandrun">Building and running JMRI</a>
         <li><a href="#jar">Making a Jar File</a>
-        <li><a href="#patch">Making a Patch File</a>
         <li><a href="#nsis">Making a release package for Windows using NSIS</a></li>
         <li><a href="#xmltools">Using NetBeans XML tools</a></li>
         <li><a href="#findbugs">Running FindBugs</a></li>
         <li><a href="#compileIndividualFile">NetBeans and compiling individual files</a></li>            
+        <li><a href="#patch">Making a Patch File</a>
     </ul>
 <a href="#SeeAlso">See Also</a>    
     <h2><a id="intro">Introduction</a></h2>
@@ -277,7 +277,7 @@
         the path to a report file in HTML format.  Open that file with a browser 
         to review the FindBugs results.</p>        
 
-        <h2><a id="compileIndividualFile">NetBeans and compiling individual files</a></h2>
+    <h2><a id="compileIndividualFile">NetBeans and compiling individual files</a></h2>
         <p>The NetBeans IDE shows icons to the side of each object in the Projects window,
             and to the side of each file in the Files window.  These icons can reflect the
             status of each item, including local change and proper compilation status.</p>
@@ -299,6 +299,29 @@
         <p><a href="http://sourceforge.net/projects/nsis">The NSIS project web site</a></p>
         <p><a href="http://findbugs.sourceforge.net">The FindBugs web site</a></p>
 
+ <h2><a id="patch">Making a Patch File</a></h2>
+    
+    <p>A "diff patch file" is an easy way to gather up all your changes, even
+    if they span multiple files, into one file.
+    This can be used to e.g. submit a patch.
+    Now that we're using Git and GitHub, hoever, we prefer that you 
+    contribute your code changes 
+    <a href="gitdeveloper.shtml">via GitHub Pull Requests</a>.
+    </p>
+
+    <p>
+    To create the "diff patch file":
+    <ul>
+ 
+    <li>From the [Team] menu, select "Export Diff Patch ..."
+    <li>A file browser will open; enter a new file name
+        in your preferred location and hit "Save" or "Open", 
+        depending on what the dialog shows. 
+    <li>After it finishes calculating the diffs, the file you selected will contain
+        the patches, along with an information header.
+    </ul>
+
+    
   <!--#include virtual="/Footer" -->
 
   </div><!-- closes #mainContent-->

--- a/help/en/html/doc/Technical/index.shtml
+++ b/help/en/html/doc/Technical/index.shtml
@@ -165,11 +165,11 @@ We encourage contributions of code, decoder definitions, improvements to
 web pages, etc, to the JMRI project so that 
 we can distribute them to the rest of the community.
 <p>
-For your first small contributions, e.g. a new decoder file or small bug fix,
-please fill out a new "Patches" entry on SourceForge using 
+For initial and/or small contributions, e.g. a new decoder file or small bug fix,
+you can fill out a new "Patches" entry on SourceForge using 
 <a href="http://sourceforge.net/tracker/?group_id=26788&atid=388315">our patches page</a>
 (click new on the middle-left, then fill out the resulting form).
-You can attach the entire file there.  If it's multiple files,
+You can attach the entire file there.  If it's more than one files,
 and you're using an IDE like
 <a href="NetBeans.shtml">NetBeans</a>, it's very easy to create a "diff patch file"
 to carry your changes, and that will save us a significant amount of
@@ -181,9 +181,14 @@ It saves us a lot of work if, before you create and send the patch file,
 you make sure that your copy of the code is up to date, and that the
 <a href="JUnit.shtml#run">unit tests<a/>
 all work.
+
 <p>
-If you are doing a significant amount of development, please
-see the page on 
+If you're contributing multiple changes, or working on a larger project,
+JMRI has tools and procedures that make it easy and reliable to 
+connect your work to the rest of the JMRI community.  Basically, you
+work in a local copy of the JMRI code repository, and you're changes
+can be "pulled" in when you're ready to contribute them.
+See our page on
 "<a href="gitdeveloper.shtml">Being A JMRI Developer</a>"
 for instructions on how to more effectively contribute code changes.
 


### PR DESCRIPTION
Added the discussion of creating a patch back into NetBeans page; included a pointer to using GitHub PR method.

Tried to clarify discussion on front page of how to contribute.