### PR TITLE
Extend AbstractAutomaton's ability to wait for multiple things

### DIFF
--- a/help/en/html/tools/scripting/FAQ.shtml
+++ b/help/en/html/tools/scripting/FAQ.shtml
@@ -360,11 +360,15 @@ import myImport
 myImport.x = x # make x available to myImport
 </pre>
 
-<h2><a id="severa" name="several"></a>Can a script wait for more than one thing to change?</h2>
+<h2><a id="several" name="several"></a>Can a script wait for more than one thing to change?</h2>
 
 <div class="para">
-If your script is based on a Siglet or AbstractAutomaton class (e.g. if you're
-writing a "handle" routine"), there's a general "waitChange" routine which waits
+If your script is based on a Siglet or 
+<a href="http://jmri.org/JavaDoc/doc/jmri/jmrit/automat/AbstractAutomaton.html">AbstractAutomaton</a>
+class (e.g. if you're
+writing a "handle" routine"), there's a general
+"<a href="http://jmri.org/JavaDoc/doc/jmri/jmrit/automat/AbstractAutomaton.html#waitChange-jmri.NamedBean:A-">waitChange</a>"
+routine which waits
 for any of several sensors to change before returning to you. Note that more
 than one may change at the same time, so you can't assume that just one has a
 different value! And you'll then have to check whether they've become some

--- a/help/en/html/tools/scripting/FAQ.shtml
+++ b/help/en/html/tools/scripting/FAQ.shtml
@@ -360,11 +360,11 @@ import myImport
 myImport.x = x # make x available to myImport
 </pre>
 
-<h2>Can a script wait for more than one thing to change?</h2>
+<h2><a id="severa" name="several"></a>Can a script wait for more than one thing to change?</h2>
 
 <div class="para">
 If your script is based on a Siglet or AbstractAutomaton class (e.g. if you're
-writing a "handle" routine", there's a general "waitChange" routine which waits
+writing a "handle" routine"), there's a general "waitChange" routine which waits
 for any of several sensors to change before returning to you. Note that more
 than one may change at the same time, so you can't assume that just one has a
 different value! And you'll then have to check whether they've become some
@@ -380,8 +380,14 @@ You can then check for various combinations like:
         print "Would you believe a really fast bird?"
    else
         print "Nothing to see here, move along..."</pre>
-(I haven't actually typed these into a script &amp; run it, so there might be
-typos, sorry) </div>
+You can also wait for any changes in objects of multiple types:
+<pre>    self.waitChange([self.sensorA, self.turnoutB, self.signalC])</pre>
+Finally, you can specify the maximum time to wait before continuing
+even though nothing has changed:
+<pre>    self.waitChange([self.sensorA, self.sensorB, self.sensorC], 5000)</pre>
+will wait a maximum of 5000 milliseconds, e.g. 5 seconds. If nothing has 
+changed, the script will continue anyway.
+</div>
 
 <h2>Can a script listen to more than one Turnout?</h2>
 

--- a/java/test/jmri/jmrit/automat/AutomatTest.java
+++ b/java/test/jmri/jmrit/automat/AutomatTest.java
@@ -43,11 +43,10 @@ public class AutomatTest extends TestCase {
         // now run it
         a.start();
 
-        // wait so thread can exec
-        jmri.util.JUnitUtil.releaseThread(this);
+        // wait for thread to exec, failing if not
+        jmri.util.JUnitUtil.waitFor(()->{return initDone;},"initDone after run");
 
         // and check
-        Assert.assertTrue("initDone after run", initDone);
         Assert.assertTrue("handleDone after run", handleDone);
     }
 
@@ -70,13 +69,10 @@ public class AutomatTest extends TestCase {
         // now run it
         a.start();
 
-        // wait so thread can exec
-        synchronized (this) {
-            wait(100);
-        }
+        // wait for thread to exec, failing if not
+        jmri.util.JUnitUtil.waitFor(()->{return initDone;},"initDone after run");
 
         // and check
-        Assert.assertTrue("initDone after run", initDone);
         Assert.assertTrue("handleDone after run", handleDone);
 
         // restart
@@ -88,13 +84,10 @@ public class AutomatTest extends TestCase {
         // now run it again
         a.start();
 
-        // wait so thread can exec
-        synchronized (this) {
-            wait(100);
-        }
+        // wait for thread to exec, failing if not
+        jmri.util.JUnitUtil.waitFor(()->{return initDone;},"initDone after 2nd run");
 
         // and check
-        Assert.assertTrue("initDone after 2nd run", initDone);
         Assert.assertTrue("handleDone after 2nd run", handleDone);
     }
 


### PR DESCRIPTION
Add a variant of waitChange that allows user to specify max time to wait

Improve speed of tests using JUnitUtil.waitFor(..) to only wait until thread is done, not some arbitrary time

Update docs