### PR TITLE
Run properties file check

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ build: off
 # AppVeyor's YAML processing
 test_script:
 - ps: >-
-    ant appveyor-ci-test
+    ant checkPropertiesFiles appveyor-ci-test
 
 on_finish:
 - ps: >-


### PR DESCRIPTION
Appveryor CI runs (but not the standalone Ant target) will also do a propertiesCheck to check for problems in the .properties files.

Not added to Travis (.travis.yml) because there's no need to do it in both CI systems, and Travis is already getting a bit long.