### PR TITLE
JUnit test improvements

### DIFF
--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -70,7 +70,6 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
             }
             if (getPortNames().size() <= 0) {
                 log.error("No usable ports returned");
-                new Exception("travis test traceback").printStackTrace();
                 return null;
             }
             return null;

--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -70,6 +70,7 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
             }
             if (getPortNames().size() <= 0) {
                 log.error("No usable ports returned");
+                new Exception("travis test traceback").printStackTrace();
                 return null;
             }
             return null;

--- a/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
+++ b/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
@@ -34,16 +34,13 @@ public class BlockBossLogicTest extends TestCase {
         Assert.assertEquals("driven signal name", "IH1", p.getDrivenSignal());
 
         h2.setAppearance(SignalHead.RED);
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("red sets yellow", SignalHead.YELLOW, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "red sets yellow");  // wait and test
 
         h2.setAppearance(SignalHead.YELLOW);
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("yellow sets green", SignalHead.GREEN, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "yellow sets green");  // wait and test
 
         h2.setAppearance(SignalHead.GREEN);
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("green sets green", SignalHead.GREEN, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "green sets green");  // wait and test
 
         p.stop();
     }
@@ -58,16 +55,13 @@ public class BlockBossLogicTest extends TestCase {
         Assert.assertEquals("driven signal name", "IH1", p.getDrivenSignal());
 
         h2.setAppearance(SignalHead.RED);
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("red sets red", SignalHead.RED, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "red sets red");  // wait and test
 
         h2.setAppearance(SignalHead.YELLOW);
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("yellow sets yellow", SignalHead.YELLOW, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "yellow sets yellow");  // wait and test
 
         h2.setAppearance(SignalHead.GREEN);
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("green sets green", SignalHead.GREEN, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "green sets green");  // wait and test
 
         p.stop();
     }
@@ -82,16 +76,13 @@ public class BlockBossLogicTest extends TestCase {
         p.start();
 
         h2.setAppearance(SignalHead.RED);
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("red sets yellow", SignalHead.YELLOW, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "red sets yellow");  // wait and test
 
         h2.setAppearance(SignalHead.YELLOW);
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("yellow sets yellow", SignalHead.YELLOW, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "yellow sets yellow");  // wait and test
 
         h2.setAppearance(SignalHead.GREEN);
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("green sets yellow", SignalHead.YELLOW, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "green sets yellow");  // wait and test
 
         p.stop();
     }
@@ -106,16 +97,13 @@ public class BlockBossLogicTest extends TestCase {
         p.start();
 
         h2.setAppearance(SignalHead.RED);
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("red sets red", SignalHead.RED, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "red sets red");  // wait and test
 
         h2.setAppearance(SignalHead.YELLOW);
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("yellow sets yellow", SignalHead.YELLOW, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "yellow sets yellow");  // wait and test
 
         h2.setAppearance(SignalHead.GREEN);
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("green sets yellow", SignalHead.YELLOW, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "green sets yellow");  // wait and test
 
         p.stop();
     }
@@ -126,8 +114,7 @@ public class BlockBossLogicTest extends TestCase {
         p.setMode(BlockBossLogic.SINGLEBLOCK);
         p.start();
 
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("missing signal is green", SignalHead.GREEN, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "missing signal is green");  // wait and test
         p.stop();
     }
 
@@ -138,8 +125,7 @@ public class BlockBossLogicTest extends TestCase {
         p.setLimitSpeed1(true);
         p.start();
 
-        JUnitUtil.releaseThread(this);  // release control
-        Assert.assertEquals("missing signal is green, show yellow", SignalHead.YELLOW, h1.getAppearance());
+        JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "missing signal is green, show yellow");  // wait and test
         p.stop();
     }
 

--- a/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
+++ b/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
@@ -30,16 +30,22 @@ public class BlockBossLogicTest extends TestCase {
         BlockBossLogic p = new BlockBossLogic("IH1");
         p.setMode(BlockBossLogic.SINGLEBLOCK);
         p.setWatchedSignal1("IH2", false);
+        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+
         p.start();
         Assert.assertEquals("driven signal name", "IH1", p.getDrivenSignal());
-
-        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
         
         h2.setAppearance(SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "yellow sets green");  // wait and test
 
+        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "reset to red");  // ensure ready for next test
+
         h2.setAppearance(SignalHead.RED);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "red sets yellow");  // wait and test
+
+        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "reset to red");  // ensure ready for next test
 
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "green sets green");  // wait and test
@@ -53,16 +59,22 @@ public class BlockBossLogicTest extends TestCase {
         p.setMode(BlockBossLogic.SINGLEBLOCK);
         p.setWatchedSignal1("IH2", false);
         p.setDistantSignal(true);
+        h1.setAppearance(SignalHead.GREEN); // starting point, to ensure it really changes
+
         p.start();
         Assert.assertEquals("driven signal name", "IH1", p.getDrivenSignal());
-
-        h1.setAppearance(SignalHead.GREEN); // starting point, to ensure it really changes
 
         h2.setAppearance(SignalHead.RED);
         JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "red sets red");  // wait and test
 
+        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "reset to red");  // ensure ready for next test
+
         h2.setAppearance(SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "yellow sets yellow");  // wait and test
+
+        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "reset to red");  // ensure ready for next test
 
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "green sets green");  // wait and test
@@ -77,9 +89,9 @@ public class BlockBossLogicTest extends TestCase {
         p.setMode(BlockBossLogic.SINGLEBLOCK);
         p.setWatchedSignal1("IH2", false);
         p.setLimitSpeed1(true);
-        p.start();
-
         h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+
+        p.start();
 
         h2.setAppearance(SignalHead.RED);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "red sets yellow");  // wait and test
@@ -106,9 +118,9 @@ public class BlockBossLogicTest extends TestCase {
         p.setWatchedSignal1("IH2", false);
         p.setDistantSignal(true);
         p.setLimitSpeed1(true);
-        p.start();
-
         h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+
+        p.start();
 
         h2.setAppearance(SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "yellow sets yellow");  // wait and test
@@ -137,6 +149,7 @@ public class BlockBossLogicTest extends TestCase {
         BlockBossLogic p = new BlockBossLogic("IH1");
         p.setMode(BlockBossLogic.SINGLEBLOCK);
         p.setLimitSpeed1(true);
+
         p.start();
 
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "missing signal is green, show yellow");  // wait and test

--- a/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
+++ b/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
@@ -33,11 +33,13 @@ public class BlockBossLogicTest extends TestCase {
         p.start();
         Assert.assertEquals("driven signal name", "IH1", p.getDrivenSignal());
 
-        h2.setAppearance(SignalHead.RED);
-        JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "red sets yellow");  // wait and test
-
+        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+        
         h2.setAppearance(SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "yellow sets green");  // wait and test
+
+        h2.setAppearance(SignalHead.RED);
+        JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "red sets yellow");  // wait and test
 
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "green sets green");  // wait and test
@@ -53,6 +55,8 @@ public class BlockBossLogicTest extends TestCase {
         p.setDistantSignal(true);
         p.start();
         Assert.assertEquals("driven signal name", "IH1", p.getDrivenSignal());
+
+        h1.setAppearance(SignalHead.GREEN); // starting point, to ensure it really changes
 
         h2.setAppearance(SignalHead.RED);
         JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "red sets red");  // wait and test
@@ -75,11 +79,19 @@ public class BlockBossLogicTest extends TestCase {
         p.setLimitSpeed1(true);
         p.start();
 
+        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+
         h2.setAppearance(SignalHead.RED);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "red sets yellow");  // wait and test
 
+        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "reset to red");  // ensure ready for next test
+
         h2.setAppearance(SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "yellow sets yellow");  // wait and test
+
+        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "reset to red");  // ensure ready for next test
 
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "green sets yellow");  // wait and test
@@ -96,11 +108,13 @@ public class BlockBossLogicTest extends TestCase {
         p.setLimitSpeed1(true);
         p.start();
 
-        h2.setAppearance(SignalHead.RED);
-        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "red sets red");  // wait and test
+        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
 
         h2.setAppearance(SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "yellow sets yellow");  // wait and test
+
+        h2.setAppearance(SignalHead.RED);
+        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "red sets red");  // wait and test
 
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "green sets yellow");  // wait and test
@@ -108,7 +122,7 @@ public class BlockBossLogicTest extends TestCase {
         p.stop();
     }
 
-    // if no next signal, it's considered green
+    // if no next signal, next signal considered green
     public void testSimpleBlockNoNext() {
         BlockBossLogic p = new BlockBossLogic("IH1");
         p.setMode(BlockBossLogic.SINGLEBLOCK);
@@ -118,7 +132,7 @@ public class BlockBossLogicTest extends TestCase {
         p.stop();
     }
 
-    // if no next signal, it's considered green
+    // if no next signal, next signal is considered green
     public void testSimpleBlockNoNextLimited() {
         BlockBossLogic p = new BlockBossLogic("IH1");
         p.setMode(BlockBossLogic.SINGLEBLOCK);

--- a/java/test/jmri/jmrit/logix/LearnWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LearnWarrantTest.java
@@ -96,6 +96,10 @@ public class LearnWarrantTest extends jmri.util.SwingTestCase {
         // Dialog has popped up, so handle that. First, locate it.
         List<JDialog> dialogList = new DialogFinder(null).findAll(panel);
         TestHelper.disposeWindow(dialogList.get(0), this);
+
+        flushAWT();
+        // confirm one message logged
+        jmri.util.JUnitAppender.assertWarnMessage("RosterSpeedProfile not found. Using default ThrottleFactor 0.75");
     }
     
     private javax.swing.AbstractButton pressButton(java.awt.Container frame, String text) {
@@ -158,6 +162,7 @@ public class LearnWarrantTest extends jmri.util.SwingTestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
+        apps.tests.Log4JFixture.setUp(); 
         super.setUp();
          // set the locale to US English
         Locale.setDefault(Locale.ENGLISH);
@@ -167,6 +172,7 @@ public class LearnWarrantTest extends jmri.util.SwingTestCase {
         JUnitUtil.initInternalLightManager();
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalSignalHeadManager();
+        JUnitUtil.initDebugPowerManager();
         JUnitUtil.initDebugThrottleManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initOBlockManager();
@@ -179,6 +185,7 @@ public class LearnWarrantTest extends jmri.util.SwingTestCase {
     protected void tearDown() throws Exception {
         JUnitUtil.resetInstanceManager();
         super.tearDown();
+        apps.tests.Log4JFixture.tearDown(); 
     }
 
 }

--- a/java/test/jmri/jmrit/logix/LearnWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LearnWarrantTest.java
@@ -62,7 +62,6 @@ public class LearnWarrantTest extends jmri.util.SwingTestCase {
         // occupy starting block
         Sensor sensor = _sensorMgr.getBySystemName("IS1");
         sensor.setState(Sensor.ACTIVE);
-        connectThrottle();
         pressButton(frame, Bundle.getMessage("Start"));
 
         Assert.assertNotNull("Throttle not found", frame._learnThrottle.getThrottle());
@@ -115,15 +114,6 @@ public class LearnWarrantTest extends jmri.util.SwingTestCase {
         pressButton(pane, text);
     }
     
-    private static void connectThrottle() {
-        jmri.jmrix.nce.simulator.SimulatorAdapter nceSimulator = new jmri.jmrix.nce.simulator.SimulatorAdapter();
-        Assert.assertNotNull("Nce SimulatorAdapter", nceSimulator);
-        jmri.jmrix.nce.NceSystemConnectionMemo memo = nceSimulator.getSystemConnectionMemo();
-        nceSimulator.openPort("(None Selected)", "JMRI test");
-        nceSimulator.configure();
-        Assert.assertNotNull("NceSystemConnectionMemo", memo);        
-    }
-
     /**
      * @param sensor - active start sensor
      * @return - active end sensor
@@ -177,6 +167,7 @@ public class LearnWarrantTest extends jmri.util.SwingTestCase {
         JUnitUtil.initInternalLightManager();
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalSignalHeadManager();
+        JUnitUtil.initDebugThrottleManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initOBlockManager();
         JUnitUtil.initLogixManager();

--- a/java/test/jmri/jmrit/logix/LearnWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LearnWarrantTest.java
@@ -77,7 +77,7 @@ public class LearnWarrantTest extends jmri.util.SwingTestCase {
         sensor = runtimes(sensor, null);
         while (w.getThrottle() != null) {
             // Sometimes the engineer is blocked
-            jmri.util.JUnitUtil.releaseThread(this);           
+            flushAWT();          
         }        
         String msg = w.getRunModeMessage();
         Assert.assertEquals("run finished", Bundle.getMessage("NotRunning", w.getDisplayName()), msg);
@@ -130,15 +130,15 @@ public class LearnWarrantTest extends jmri.util.SwingTestCase {
      * @throws Exception
      */
     private Sensor runtimes(Sensor sensor, DccThrottle throttle) throws Exception {
-        jmri.util.JUnitUtil.releaseThread(this); 
+        flushAWT();
         if (throttle!=null) {
             throttle.setSpeedSetting(0.5f);
         }
         for (int i=2; i<=5; i++) {
-            jmri.util.JUnitUtil.releaseThread(this); 
+            flushAWT();
             Sensor sensorNext = _sensorMgr.getBySystemName("IS"+i);
             sensorNext.setState(Sensor.ACTIVE);
-            jmri.util.JUnitUtil.releaseThread(this);            
+            flushAWT();          
             sensor.setState(Sensor.INACTIVE);
             sensor = sensorNext;
         }

--- a/java/test/jmri/jmrit/logix/NXWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/NXWarrantTest.java
@@ -203,6 +203,7 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
         JUnitUtil.initInternalLightManager();
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalSignalHeadManager();
+        JUnitUtil.initDebugPowerManager();
         JUnitUtil.initDebugThrottleManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initOBlockManager();

--- a/java/test/jmri/jmrit/logix/NXWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/NXWarrantTest.java
@@ -40,7 +40,6 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
     
     @SuppressWarnings("unchecked") // For types from DialogFinder().findAll(..)
     public void testNXWarrant() throws Exception {
-        jmri.util.JUnitAppender.clearBacklog();
 
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/NXWarrantTest.xml");
@@ -60,7 +59,6 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
         nxFrame.init();
         nxFrame.setVisible(true);
         nxFrame._maxSpeedBox.setText("0.30");
-        connectThrottle();
         
         nxFrame._origin.blockBox.setText("OB0");
         nxFrame._destination.blockBox.setText("OB10");
@@ -149,16 +147,7 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
         }
         pressButton(pane, buttonLabel);
     }
-    
-    private static void connectThrottle() {
-        jmri.jmrix.nce.simulator.SimulatorAdapter nceSimulator = new jmri.jmrix.nce.simulator.SimulatorAdapter();
-        Assert.assertNotNull("Nce SimulatorAdapter", nceSimulator);
-        jmri.jmrix.nce.NceSystemConnectionMemo memo = nceSimulator.getSystemConnectionMemo();
-        nceSimulator.openPort("(None Selected)", "JMRI test");
-        nceSimulator.configure();
-        Assert.assertNotNull("NceSystemConnectionMemo", memo);        
-    }
-    
+        
     @SuppressWarnings("unchecked") // For types from DialogFinder().findAll(..)
     private static List<JRadioButton> getRadioButtons(java.awt.Container frame) {
         ComponentFinder finder = new ComponentFinder(JRadioButton.class);
@@ -214,6 +203,7 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
         JUnitUtil.initInternalLightManager();
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalSignalHeadManager();
+        JUnitUtil.initDebugThrottleManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initOBlockManager();
         JUnitUtil.initLogixManager();

--- a/java/test/jmri/jmrit/logix/NXWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/NXWarrantTest.java
@@ -101,14 +101,12 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
         sensor = _sensorMgr.getBySystemName("IS10");
         Assert.assertEquals("Train in last block", sensor, runtimes(sensor, route));
         
-        jmri.util.JUnitUtil.releaseThread(this);             
+        flushAWT();
+        flushAWT();   // let calm down before running abort
+                
         warrant.controlRunTrain(Warrant.ABORT);
-        jmri.util.JUnitUtil.releaseThread(this);            
-/*        while (warrant.getEngineer()!=null) {
-          jmri.util.JUnitUtil.releaseThread(this);             
-        }
-        Assert.assertEquals("Script done.", Bundle.getMessage("Idle"), warrant.getRunningMessage());
-*/
+        flushAWT();
+        
         // passed test - cleanup.  Do it here so failure leaves traces.
         TestHelper.disposeWindow(tableFrame, this);
         ControlPanelEditor panel = (ControlPanelEditor)jmri.util.JmriJFrame.getFrame("NXWarrantTest");
@@ -117,6 +115,9 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
         // Dialog has popped up, so handle that. First, locate it.
         List<JDialog> dialogList = new DialogFinder(null).findAll(panel);
         TestHelper.disposeWindow(dialogList.get(0), this);
+        
+        // confirm one message logged
+        jmri.util.JUnitAppender.assertWarnMessage("RosterSpeedProfile not found. Using default ThrottleFactor 0.75");
     }
     
     private javax.swing.AbstractButton pressButton(java.awt.Container frame, String text) {
@@ -170,12 +171,12 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
      * @throws Exception
      */
     private Sensor runtimes(Sensor sensor, String[] sensors) throws Exception {
-        jmri.util.JUnitUtil.releaseThread(this); 
+        flushAWT();
         for (int i=0; i<sensors.length; i++) {
-            jmri.util.JUnitUtil.releaseThread(this); 
+            flushAWT();
             Sensor sensorNext = _sensorMgr.getSensor(sensors[i]);
             sensorNext.setState(Sensor.ACTIVE);
-            jmri.util.JUnitUtil.releaseThread(this);            
+            flushAWT();           
             sensor.setState(Sensor.INACTIVE);
             sensor = sensorNext;
         }
@@ -201,6 +202,7 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+        apps.tests.Log4JFixture.setUp();
          // set the locale to US English
         Locale.setDefault(Locale.ENGLISH);
         JUnitUtil.resetInstanceManager();
@@ -219,6 +221,7 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
     @Override
     protected void tearDown() throws Exception {
         JUnitUtil.resetInstanceManager();
+        apps.tests.Log4JFixture.tearDown();
         super.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logix/NXWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/NXWarrantTest.java
@@ -40,6 +40,8 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
     
     @SuppressWarnings("unchecked") // For types from DialogFinder().findAll(..)
     public void testNXWarrant() throws Exception {
+        jmri.util.JUnitAppender.clearBacklog();
+
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/NXWarrantTest.xml");
         InstanceManager.getDefault(ConfigureManager.class).load(f);
@@ -190,6 +192,7 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
 
     // Main entry point
     static public void main(String[] args) {
+        apps.tests.Log4JFixture.initLogging();
         String[] testCaseName = {"-noloading", NXWarrantTest.class.getName()};
         junit.swingui.TestRunner.main(testCaseName);
     }
@@ -201,8 +204,8 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
 
     @Override
     protected void setUp() throws Exception {
-        super.setUp();
         apps.tests.Log4JFixture.setUp();
+        super.setUp();
          // set the locale to US English
         Locale.setDefault(Locale.ENGLISH);
         JUnitUtil.resetInstanceManager();
@@ -221,8 +224,8 @@ public class NXWarrantTest extends jmri.util.SwingTestCase {
     @Override
     protected void tearDown() throws Exception {
         JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
         super.tearDown();
+        apps.tests.Log4JFixture.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrit/logix/PackageTest.java
+++ b/java/test/jmri/jmrit/logix/PackageTest.java
@@ -20,6 +20,7 @@ public class PackageTest extends TestCase {
 
     // Main entry point
     static public void main(String[] args) {
+        apps.tests.Log4JFixture.initLogging();
         String[] testCaseName = {"-noloading", PackageTest.class.getName()};
         junit.swingui.TestRunner.main(testCaseName);
     }

--- a/java/test/jmri/jmrit/logix/WarrantTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantTest.java
@@ -189,13 +189,6 @@ public class WarrantTest extends TestCase {
         Assert.assertNotNull("PropertyChangeListener", listener);
         warrant.addPropertyChangeListener(listener);
         
-        jmri.jmrix.nce.simulator.SimulatorAdapter nceSimulator = new jmri.jmrix.nce.simulator.SimulatorAdapter();
-        Assert.assertNotNull("Nce SimulatorAdapter", nceSimulator);
-        jmri.jmrix.nce.NceSystemConnectionMemo memo = nceSimulator.getSystemConnectionMemo();
-        nceSimulator.openPort("(None Selected)", "JMRI test");
-        nceSimulator.configure();
-        Assert.assertNotNull("NceSystemConnectionMemo", memo);
-
         msg = warrant.setRunMode(Warrant.MODE_RUN, null, null, null, false);
         Assert.assertNull("setRunMode - "+msg, msg);
         try {
@@ -269,6 +262,7 @@ public class WarrantTest extends TestCase {
         JUnitUtil.initInternalLightManager();
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalSignalHeadManager();
+        JUnitUtil.initDebugThrottleManager();
         JUnitUtil.initMemoryManager();
         JUnitUtil.initOBlockManager();
         JUnitUtil.initLogixManager();

--- a/java/test/jmri/jmrit/logix/WarrantTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantTest.java
@@ -201,6 +201,9 @@ public class WarrantTest extends TestCase {
             System.out.println(e);            
         }
 
+        // confirm one message logged
+        jmri.util.JUnitAppender.assertWarnMessage("RosterSpeedProfile not found. Using default ThrottleFactor 0.75");
+
         // wait for done
         jmri.util.JUnitUtil.waitFor(()->{return warrant.getThrottle()==null;}, "engineer blocked");
 

--- a/java/test/jmri/jmrit/logix/WarrantTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantTest.java
@@ -199,7 +199,7 @@ public class WarrantTest extends TestCase {
         msg = warrant.setRunMode(Warrant.MODE_RUN, null, null, null, false);
         Assert.assertNull("setRunMode - "+msg, msg);
         try {
-            jmri.util.JUnitUtil.releaseThread(this);            
+            jmri.util.JUnitUtil.releaseThread(this); // nothing specific to wait for...
             sWest.setState(Sensor.ACTIVE);
             jmri.util.JUnitUtil.releaseThread(this);             
             sSouth.setState(Sensor.ACTIVE);

--- a/java/test/jmri/jmrix/AbstractMonPaneTest.java
+++ b/java/test/jmri/jmrix/AbstractMonPaneTest.java
@@ -84,7 +84,7 @@ public class AbstractMonPaneTest extends jmri.util.SwingTestCase {
         a.enterButtonActionPerformed(null);
         
         a.freezeButton.setSelected(true);
-        jmri.util.JUnitUtil.releaseThread(this);
+        flushAWT();
         
         a.entryField.setText("bar");
         a.enterButtonActionPerformed(null);

--- a/java/test/jmri/jmrix/AbstractProgrammerTest.java
+++ b/java/test/jmri/jmrix/AbstractProgrammerTest.java
@@ -31,7 +31,7 @@ public class AbstractProgrammerTest extends TestCase {
         abstractprogrammer = new AbstractProgrammer() {
 
             public List<ProgrammingMode> getSupportedModes() {
-                java.util.ArrayList retval = new java.util.ArrayList<ProgrammingMode>();
+                java.util.ArrayList<ProgrammingMode> retval = new java.util.ArrayList<ProgrammingMode>();
                 
                 retval.add(DefaultProgrammerManager.DIRECTMODE);
                 retval.add(DefaultProgrammerManager.PAGEMODE);
@@ -126,7 +126,7 @@ public class AbstractProgrammerTest extends TestCase {
         abstractprogrammer = new AbstractProgrammer() {
 
             public List<ProgrammingMode> getSupportedModes() {
-                java.util.ArrayList retval = new java.util.ArrayList<ProgrammingMode>();
+                java.util.ArrayList<ProgrammingMode> retval = new java.util.ArrayList<ProgrammingMode>();
                 
                 retval.add(DefaultProgrammerManager.DIRECTMODE);
                 retval.add(DefaultProgrammerManager.PAGEMODE);

--- a/java/test/jmri/jmrix/lenz/XNetProgrammerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetProgrammerTest.java
@@ -62,10 +62,9 @@ public class XNetProgrammerTest extends TestCase {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
 
-        //failure in this test occurs with the next line.
-        Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
+        // failure in this test occurs with the next line.
+        jmri.util.JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;}, "Receive Called by Programmer");
         Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
     }
 
@@ -114,11 +113,9 @@ public class XNetProgrammerTest extends TestCase {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
 
-        //failure in this test occurs with the next line.
-        Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
-
+        // failure in this test occurs with the next line.
+        jmri.util.JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;}, "Receive Called by Programmer");
         Assert.assertEquals("Register mode received value", 12, l.getRcvdValue());
     }
 
@@ -164,11 +161,9 @@ public class XNetProgrammerTest extends TestCase {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
 
-        //failure in this test occurs with the next line.
-        Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
-
+        // failure in this test occurs with the next line.
+        jmri.util.JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;}, "Receive Called by Programmer");
         Assert.assertEquals("Register mode received value", 34, l.getRcvdValue());
     }
 
@@ -216,10 +211,9 @@ public class XNetProgrammerTest extends TestCase {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
 
-        //failure in this test occurs with the next line.
-        Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
+        // failure in this test occurs with the next line.
+        jmri.util.JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;}, "Receive Called by Programmer");
         Assert.assertEquals("Register mode received value", 34, l.getRcvdValue());
     }
 
@@ -267,10 +261,9 @@ public class XNetProgrammerTest extends TestCase {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
 
         //failure in this test occurs with the next line.
-        Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
+        jmri.util.JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;}, "Receive Called by Programmer");
         Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
     }
 
@@ -319,11 +312,9 @@ public class XNetProgrammerTest extends TestCase {
         // traffic controller to exit from service mode.  We just
         // need to wait a few seconds and see that the listener we
         // registered earlier received the values we expected.
-        jmri.util.JUnitUtil.releaseThread(this);
 
         //failure in this test occurs with the next line.
-        Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
-
+        jmri.util.JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;}, "Receive Called by Programmer");
         Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
     }
 


### PR DESCRIPTION
1) Annotate (suppress) some routine warnings messages

2) use waitFor for delays

3) Use a debug Throttle manager instead of opening NCE Simulator connections in tests