### PR TITLE
Add ant target to check for properties files with non-ascii characters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
 
-script: travis_wait ant checklineends ci-test
+script: travis_wait ant checklineends checknonascii ci-test
 
 jdk:
   - oraclejdk8

--- a/build.xml
+++ b/build.xml
@@ -962,6 +962,21 @@
         </resourceCheck>
     </target>
 
+    <!-- check for non-ASCII characters in properties files -->
+
+    <target name="checknonascii">
+        <exec executable="sh" outputproperty="checknonascii.files">
+            <arg value="-c" />
+            <arg value="grep -rlI -P '[^\x00-\x7f]' --exclude-dir={classes,help,jython,lib,nbproject,resources,scripts,web,xml} --include=*.properties" />
+        </exec>
+
+        <fail message="${checknonascii.files}">
+            <condition>
+                <length string="${checknonascii.files}" when="greater" length="0" />
+            </condition>
+        </fail>
+    </target>
+
     <!-- check for bad line ends, e.g. not ready to go into Git -->
     <!-- May not (probably will not) work on Windows -->
 


### PR DESCRIPTION
This ant target will check .properties files for non-ascii characters.

It relies on Perl regex syntax that not all `grep`'s have.