### PR TITLE
Update non-ascii check

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -967,7 +967,7 @@
     <target name="checknonascii">
         <exec executable="sh" outputproperty="checknonascii.files">
             <arg value="-c" />
-            <arg value="grep -rlI -P '[^\x00-\x7f]' --exclude-dir={classes,help,jython,lib,nbproject,resources,scripts,web,xml} --include=*.properties" />
+            <arg value="grep -rIn '[^[:blank:] -~]' --exclude-dir={classes,help,jython,lib,nbproject,resources,scripts,web,xml} --include=*.properties" />
         </exec>
 
         <fail message="${checknonascii.files}">


### PR DESCRIPTION
This changes the regex to no longer rely on Perl syntax and, also, give a more useful output if failing.

Previously, it just gave the name of the file - now it give the line number and the line itself.