### PR TITLE
updates of JUnit tests

### DIFF
--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -242,7 +242,7 @@ If you are testing code that is going to reference the InstanceManager,
 you should
 clear and reset it to ensure you get reproducible results.
 <p>
-Your <code>setUp()</code> implementation should start with:
+Depending on what managers your code uses, your <code>setUp()</code> implementation should start with:
 <p><CODE><PRE>
     super.setUp();<br/>
     jmri.util.JUnitUtil.resetInstanceManager();<br/>
@@ -250,8 +250,10 @@ Your <code>setUp()</code> implementation should start with:
     jmri.util.JUnitUtil.initInternalLightManager();<br/>
     jmri.util.JUnitUtil.initInternalSensorManager();<br/>
 </PRE></code>
-<p>
 (You can omit the initialization managers you don't need)
+See the jmri.util.JUnitUtil class for the full list of available ones, and please add 
+more if you need one that's not there yet.
+
 <p>
 Your <code>tearDown()</code> should end with:
 <p>
@@ -260,17 +262,11 @@ Your <code>tearDown()</code> should end with:
     super.tearDown();
 </PRE></code>
 
-<h3><a name="RunningListeners">Running Listeners</a></h3>
+<h3><a name="RunningListeners">Working with Listeners</a></h3>
 
 JMRI is a multi-threaded application. Listeners for
 JMRI objects are notified on various threads.
 Sometimes you have to wait for that to take place.
-To do that, after you invoke a something that will notifylisteners, 
-but before you check the results, do
-<pre><code>
-    JUnitUtil.releaseThread(this);
-</code></pre>
-This uses a nominal delay.
 <p>
 If you want to wait for some specific condition to be true, e.g. 
 receiving a reply object, you can use 
@@ -284,12 +280,60 @@ be evaluated repeatedly until true.  The String second argument is the
 text of the assertion (error message) you'll get if the condition
 doesn't come true in a reasonable length of time.
 <p>
+Waiting for a specific result is fastest and most reliable.
+If you can't do that for some reason, 
+you can do a short time-based wait:
+<pre><code>
+    JUnitUtil.releaseThread(this);
+</code></pre>
+This uses a nominal delay.
+<p>
 Note that this should <b>not</b> be used to synchronize with
 Swing threads.  
 See the <a href="#testSwingCode">Testing Swing Code</a> section for that.
 <p>
 In general, you should not have calls to sleep(), wait() or yield() in your code.
 Use the JUnitUtil and JFCUtil support for those instead.
+
+<h3><a name="threads">Working with Threads</a></h3>
+
+(See a 
+<a href="#testSwingCode">following section<a/>
+for how to work with 
+<a href="#testSwingCode">Swing (GUI) objects<a/>
+and the
+<a href="#testSwingCode">Swing/AWT thread</a>)
+<p>
+Some tests will need to start threads, for example to test signal controls
+or aspects of layout I/O.
+<p>
+General principles your tests must obey for reliable operation:
+<ul>
+<li>At the end of each test, you need to stop() any threads you started.
+Doing this in tearDown() can be most reliable, because tearDown runs
+even if your test method exists due to an error.
+<p>
+If you're doing multiple tests with threads, you should
+wait for thread to actually stop before moving on to the next operation.
+You can do that with a <code>JUnitUtil.waitFor(..)</code> call
+that waits on some flag in the thread.
+<li>If your thread does any operations at <code>code()</code>
+that need to happen before you test its operation, you also have to wait for those to complete.
+</ul>
+<p>
+For example, if creating a thread based on
+<a href="http://jmri.sourceforge.net/JavaDoc/doc/jmri/jmrit/automat/AbstractAutomaton.html">AbstractAutomat</a>, 
+you can check the start with:
+<pre><code>
+    AbsractAutomat p = new MyThreadClass();<br/>
+    p.start();<br/>
+    JUnitUtil.waitFor(()->{return p.isRunning();}, "logic running");
+</code></pre>
+and ensure termination with
+<pre><code>
+    p.stop();<br/>
+    JUnitUtil.waitFor(()->{return !p.isRunning();}, "logic stopped");
+</code></pre>
 
 <h3><a id="io" name="io"></a>Testing I/O</h3>
 

--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -116,6 +116,9 @@ public class AbstractAutomaton implements Runnable {
         count = 0;
     }
 
+    private boolean running = false;
+    public boolean isRunning() { return running; }
+    
     /**
      * Part of the implementation; not for general use.
      * <p>
@@ -127,6 +130,7 @@ public class AbstractAutomaton implements Runnable {
             init();
             // the real processing in the next statement is in handle();
             // and the loop call is just doing accounting
+            running = true;
             while (handle()) {
                 count++;
                 summary.loop(this);
@@ -139,6 +143,7 @@ public class AbstractAutomaton implements Runnable {
         } catch (Exception e2) {
             log.warn("Exception ends AbstractAutomaton thread: " + e2, e2);
         }
+        running = false;
     }
 
     /**

--- a/java/test/jmri/jmrit/beantable/SensorTableWindowTest.java
+++ b/java/test/jmri/jmrit/beantable/SensorTableWindowTest.java
@@ -30,7 +30,8 @@ public class SensorTableWindowTest extends jmri.util.SwingTestCase {
         a.actionPerformed(new java.awt.event.ActionEvent(a, 1, ""));
 
         // Find new table window by name
-        JmriJFrame ft = JmriJFrame.getFrame("Sensor Table");
+        JmriJFrame ft = JmriJFrame.getFrame("Sensors Table");
+        flushAWT();
 
         // Find the add button
         AbstractButtonFinder abfinder = new AbstractButtonFinder("Add...");

--- a/java/test/jmri/jmrit/beantable/SignalHeadTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/SignalHeadTableActionTest.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright 2004, 2007, 2008, 2009
  * @version	$Revision$
  */
-public class SignalHeadTableActionTest extends TestCase {
+public class SignalHeadTableActionTest extends jmri.util.SwingTestCase {
 
     public void testCreate() {
         new SignalHeadTableAction();
@@ -55,11 +55,9 @@ public class SignalHeadTableActionTest extends TestCase {
         );
 
         new SignalHeadTableAction().actionPerformed(null);
+        flushAWT();
 
-//    }
-//  test order isn't guaranteed!
-//    public void testX() {
-        JFrame f = jmri.util.JmriJFrame.getFrame("Signal Head Table");
+        JFrame f = jmri.util.JmriJFrame.getFrame("Signal Heads Table");
         Assert.assertTrue("found frame", f != null);
         f.dispose();
     }

--- a/java/test/jmri/jmrit/beantable/TurnoutTableWindowTest.java
+++ b/java/test/jmri/jmrit/beantable/TurnoutTableWindowTest.java
@@ -30,7 +30,8 @@ public class TurnoutTableWindowTest extends jmri.util.SwingTestCase {
         a.actionPerformed(new java.awt.event.ActionEvent(a, 1, ""));
 
         // Find new table window by name
-        JmriJFrame ft = JmriJFrame.getFrame("Turnout Table");
+        JmriJFrame ft = JmriJFrame.getFrame("Turnouts Table");
+        flushAWT();
 
         // Find the add button
         AbstractButtonFinder abfinder = new AbstractButtonFinder("Add...");

--- a/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
+++ b/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
@@ -19,6 +19,20 @@ import junit.framework.TestSuite;
  */
 public class BlockBossLogicTest extends TestCase {
 
+    void setAndWait(SignalHead sig, int appearance) {
+        JUnitUtil.setBeanState(sig, appearance);
+        JUnitUtil.waitFor(()->{return appearance == sig.getAppearance();}, "setAndWait "+sig.getSystemName()+": "+appearance);
+    }
+    
+    BlockBossLogic p;
+    void setupSimpleBlock() {
+        p = new BlockBossLogic("IH1");
+        p.setMode(BlockBossLogic.SINGLEBLOCK);
+        p.setWatchedSignal1("IH2", false);
+        p.start();
+        JUnitUtil.waitFor(()->{return p.isRunning();}, "logic running");
+    }
+    
     // test creation
     public void testCreate() {
         BlockBossLogic p = new BlockBossLogic("IH2");
@@ -27,133 +41,131 @@ public class BlockBossLogicTest extends TestCase {
 
     // test simplest block, just signal following
     public void testSimpleBlock() {
-        BlockBossLogic p = new BlockBossLogic("IH1");
-        p.setMode(BlockBossLogic.SINGLEBLOCK);
-        p.setWatchedSignal1("IH2", false);
-        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+        setupSimpleBlock();
 
-        p.start();
+        setAndWait(h1, SignalHead.RED); // ensure starting point
         Assert.assertEquals("driven signal name", "IH1", p.getDrivenSignal());
         
-        h2.setAppearance(SignalHead.YELLOW);
+        JUnitUtil.setBeanState(h2, SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "yellow sets green");  // wait and test
 
-        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
-        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "reset to red");  // ensure ready for next test
+        setAndWait(h1, SignalHead.RED); // ensure starting point
 
-        h2.setAppearance(SignalHead.RED);
+        JUnitUtil.setBeanState(h2, SignalHead.RED);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "red sets yellow");  // wait and test
 
-        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
-        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "reset to red");  // ensure ready for next test
+        setAndWait(h1, SignalHead.RED); // ensure starting point
 
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "green sets green");  // wait and test
 
-        p.stop();
     }
 
+    // test that initial conditions are set right
+    public void testSimpleBlockInitial() {
+        setAndWait(h1, SignalHead.RED); // ensure starting point
+        setAndWait(h2, SignalHead.RED); // ensure starting point
+
+        setupSimpleBlock();
+
+        JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "initial red sets yellow");  // wait and test
+
+    }
+    
     // test signal following in distant simple block
     public void testSimpleBlockDistant() {
-        BlockBossLogic p = new BlockBossLogic("IH1");
-        p.setMode(BlockBossLogic.SINGLEBLOCK);
-        p.setWatchedSignal1("IH2", false);
-        p.setDistantSignal(true);
-        h1.setAppearance(SignalHead.GREEN); // starting point, to ensure it really changes
+        setupSimpleBlock();
 
-        p.start();
+        p.setDistantSignal(true);
+        setAndWait(h1, SignalHead.GREEN); // ensure starting point
         Assert.assertEquals("driven signal name", "IH1", p.getDrivenSignal());
 
         h2.setAppearance(SignalHead.RED);
         JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "red sets red");  // wait and test
 
-        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
-        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "reset to red");  // ensure ready for next test
+        setAndWait(h1, SignalHead.RED); // ensure starting point
 
         h2.setAppearance(SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "yellow sets yellow");  // wait and test
 
-        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
-        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "reset to red");  // ensure ready for next test
+        setAndWait(h1, SignalHead.RED); // ensure starting point
 
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "green sets green");  // wait and test
 
-        p.stop();
     }
 
     // test signal following in limited simple block
     // (not particularly interesting, as next signal can't set red)
     public void testSimpleBlockLimited() {
-        BlockBossLogic p = new BlockBossLogic("IH1");
-        p.setMode(BlockBossLogic.SINGLEBLOCK);
-        p.setWatchedSignal1("IH2", false);
-        p.setLimitSpeed1(true);
-        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+        setupSimpleBlock();
 
-        p.start();
+        setAndWait(h1, SignalHead.RED); // ensure starting point
+
+        p.setLimitSpeed1(true);
+
+        setAndWait(h1, SignalHead.RED); // ensure starting point
 
         h2.setAppearance(SignalHead.RED);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "red sets yellow");  // wait and test
 
-        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
-        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "reset to red");  // ensure ready for next test
+        setAndWait(h1, SignalHead.RED); // ensure starting point
 
         h2.setAppearance(SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "yellow sets yellow");  // wait and test
 
-        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
-        JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "reset to red");  // ensure ready for next test
+        setAndWait(h1, SignalHead.RED); // ensure starting point
 
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "green sets yellow");  // wait and test
 
-        p.stop();
     }
 
     // test signal following in distant, limited simple block
     public void testSimpleBlockDistantLimited() {
-        BlockBossLogic p = new BlockBossLogic("IH1");
+        p = new BlockBossLogic("IH1");
         p.setMode(BlockBossLogic.SINGLEBLOCK);
         p.setWatchedSignal1("IH2", false);
         p.setDistantSignal(true);
         p.setLimitSpeed1(true);
-        h1.setAppearance(SignalHead.RED); // starting point, to ensure it really changes
+
+        setAndWait(h1, SignalHead.RED); // ensure starting point
 
         p.start();
 
         h2.setAppearance(SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "yellow sets yellow");  // wait and test
 
+        setAndWait(h1, SignalHead.RED); // ensure starting point
+
         h2.setAppearance(SignalHead.RED);
         JUnitUtil.waitFor(()->{return SignalHead.RED == h1.getAppearance();}, "red sets red");  // wait and test
+
+        setAndWait(h1, SignalHead.RED); // ensure starting point
 
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "green sets yellow");  // wait and test
 
-        p.stop();
     }
 
     // if no next signal, next signal considered green
     public void testSimpleBlockNoNext() {
-        BlockBossLogic p = new BlockBossLogic("IH1");
+        p = new BlockBossLogic("IH1");
         p.setMode(BlockBossLogic.SINGLEBLOCK);
         p.start();
 
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "missing signal is green");  // wait and test
-        p.stop();
     }
 
     // if no next signal, next signal is considered green
     public void testSimpleBlockNoNextLimited() {
-        BlockBossLogic p = new BlockBossLogic("IH1");
+        p = new BlockBossLogic("IH1");
         p.setMode(BlockBossLogic.SINGLEBLOCK);
         p.setLimitSpeed1(true);
 
         p.start();
 
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "missing signal is green, show yellow");  // wait and test
-        p.stop();
     }
 
     // check that user names were preserved
@@ -309,6 +321,7 @@ public class BlockBossLogicTest extends TestCase {
 
     // Main entry point
     static public void main(String[] args) {
+        apps.tests.Log4JFixture.initLogging();
         String[] testCaseName = {"-noloading", BlockBossLogicTest.class.getName()};
         junit.swingui.TestRunner.main(testCaseName);
     }
@@ -321,6 +334,11 @@ public class BlockBossLogicTest extends TestCase {
 
     // The minimal setup for log4J
     protected void tearDown() {
+        if (p!=null) {
+            p.stop();
+            JUnitUtil.waitFor(()->{return !p.isRunning();}, "logic stopped");
+            p=null;
+        }
         apps.tests.Log4JFixture.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
+++ b/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
@@ -123,9 +123,8 @@ public class BlockBossLogicTest extends TestCase {
 
     // test signal following in distant, limited simple block
     public void testSimpleBlockDistantLimited() {
-        p = new BlockBossLogic("IH1");
-        p.setMode(BlockBossLogic.SINGLEBLOCK);
-        p.setWatchedSignal1("IH2", false);
+        setupSimpleBlock();
+
         p.setDistantSignal(true);
         p.setLimitSpeed1(true);
 

--- a/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
+++ b/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
@@ -33,6 +33,14 @@ public class BlockBossLogicTest extends TestCase {
         JUnitUtil.waitFor(()->{return p.isRunning();}, "logic running");
     }
     
+    protected void tearDownSimpleBlock() {
+        if (p!=null) {
+            p.stop();
+            JUnitUtil.waitFor(()->{return !p.isRunning();}, "logic stopped");
+            p=null;
+        }
+    }
+    
     // test creation
     public void testCreate() {
         BlockBossLogic p = new BlockBossLogic("IH2");
@@ -58,7 +66,6 @@ public class BlockBossLogicTest extends TestCase {
 
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "green sets green");  // wait and test
-
     }
 
     // test that initial conditions are set right
@@ -69,7 +76,6 @@ public class BlockBossLogicTest extends TestCase {
         setupSimpleBlock();
 
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "initial red sets yellow");  // wait and test
-
     }
     
     // test signal following in distant simple block
@@ -92,7 +98,6 @@ public class BlockBossLogicTest extends TestCase {
 
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "green sets green");  // wait and test
-
     }
 
     // test signal following in limited simple block
@@ -118,7 +123,6 @@ public class BlockBossLogicTest extends TestCase {
 
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "green sets yellow");  // wait and test
-
     }
 
     // test signal following in distant, limited simple block
@@ -129,8 +133,6 @@ public class BlockBossLogicTest extends TestCase {
         p.setLimitSpeed1(true);
 
         setAndWait(h1, SignalHead.RED); // ensure starting point
-
-        p.start();
 
         h2.setAppearance(SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "yellow sets yellow");  // wait and test
@@ -145,6 +147,7 @@ public class BlockBossLogicTest extends TestCase {
         h2.setAppearance(SignalHead.GREEN);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "green sets yellow");  // wait and test
 
+        tearDownSimpleBlock(); // not just in standalone tearDown so we know where failed.
     }
 
     // if no next signal, next signal considered green
@@ -152,8 +155,11 @@ public class BlockBossLogicTest extends TestCase {
         p = new BlockBossLogic("IH1");
         p.setMode(BlockBossLogic.SINGLEBLOCK);
         p.start();
+        JUnitUtil.waitFor(()->{return p.isRunning();}, "logic running");
 
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "missing signal is green");  // wait and test
+
+        tearDownSimpleBlock(); // not just in standalone tearDown so we know where failed.
     }
 
     // if no next signal, next signal is considered green
@@ -163,6 +169,7 @@ public class BlockBossLogicTest extends TestCase {
         p.setLimitSpeed1(true);
 
         p.start();
+        JUnitUtil.waitFor(()->{return p.isRunning();}, "logic running");
 
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "missing signal is green, show yellow");  // wait and test
     }
@@ -333,11 +340,7 @@ public class BlockBossLogicTest extends TestCase {
 
     // The minimal setup for log4J
     protected void tearDown() {
-        if (p!=null) {
-            p.stop();
-            JUnitUtil.waitFor(()->{return !p.isRunning();}, "logic stopped");
-            p=null;
-        }
+        tearDownSimpleBlock();
         apps.tests.Log4JFixture.tearDown();
     }
 }

--- a/java/test/jmri/progdebugger/DebugProgrammerTest.java
+++ b/java/test/jmri/progdebugger/DebugProgrammerTest.java
@@ -111,9 +111,7 @@ public class DebugProgrammerTest extends TestCase {
 
     // from here down is testing infrastructure
     synchronized void waitReply() throws InterruptedException {
-        while (!replied) {
-            wait(200);
-        }
+        jmri.util.JUnitUtil.waitFor(()->{return replied;}, "reply received");
         replied = false;
     }
 

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1,11 +1,14 @@
 package jmri.util;
 
 import java.beans.PropertyChangeListener;
+import java.lang.reflect.InvocationTargetException;
+
 import jmri.ConditionalManager;
 import jmri.ConfigureManager;
 import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.LogixManager;
+import jmri.NamedBean;
 import jmri.MemoryManager;
 import jmri.PowerManager;
 import jmri.SignalHeadManager;
@@ -24,6 +27,7 @@ import jmri.managers.DefaultSignalMastLogicManager;
 import jmri.managers.InternalLightManager;
 import jmri.managers.InternalSensorManager;
 import jmri.managers.InternalTurnoutManager;
+
 import junit.framework.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,10 +131,38 @@ public class JUnitUtil {
         }
     }
 
-    public interface ReleaseUntil {
+    static public interface ReleaseUntil {
         public boolean ready() throws Exception;
     }
 
+    /** 
+     * Set a NamedBean (Turnout, Sensor, SignalHead, ...)
+     * to a specific value in a thread-safe way.
+     * 
+     * You can't assume that all the consequences of that setting
+     * will have propagated through when this returns; those might
+     * take a long time.  But the set operation itself will be complete.
+     * @param NamedBean
+     * @param state
+     */
+    static public void setBeanState(NamedBean bean, int state) {
+        try {
+            javax.swing.SwingUtilities.invokeAndWait(
+                () -> {
+                    try {
+                        bean.setState(state);
+                    } catch (JmriException e) {
+                        log.error("Threw exception while setting state: ", e);
+                    }
+                }
+            );
+        } catch (InterruptedException e) {
+            log.warn("Interrupted while setting state: ", e);
+        } catch (InvocationTargetException e) {
+            log.warn("Failed during invocation while setting state: ", e);
+        }
+    }
+    
     public static void resetInstanceManager() {
         // create a new instance manager
         new InstanceManager() {

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -103,7 +103,7 @@ public class JUnitUtil {
      * Typical use:
      * waitFor(()->{return replyVariable != null;},"reply not received")
      *
-     * @param name label for Assert.fail if condition not true fast enough
+     * @param condition name of condition being waited for; will appear in Assert.fail if condition not true fast enough
      */
     static public void waitFor(ReleaseUntil condition, String name) {
         if (javax.swing.SwingUtilities.isEventDispatchThread()) {
@@ -125,9 +125,9 @@ public class JUnitUtil {
                     Thread.currentThread().setPriority(priority);
                 }
             }
-            Assert.fail(name);
+            Assert.fail("\""+name+"\" did not occur in time");
         } catch (Exception ex) {
-            Assert.fail("Exception while  looking for "+name+" "+ex);
+            Assert.fail("Exception while waiting for \""+name+"\" "+ex);
         }
     }
 


### PR DESCRIPTION
Fix three test failing due to properties changes: some of the GUI tests navigate via e.g. table and button names.  Changes to properties files can cause persistent failures because "Turnout Table" != "Turnouts Table"

Improve the thread synch of the BlockBossManager tests, including some thread-testing utilities and an update to the docs

Improve speed of programmer test by using the waitFor instead of waitSomeReallyLongTime
