### PR TITLE
Default to system look and feel

### DIFF
--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -45,6 +45,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.WindowConstants;
 import javax.swing.text.DefaultEditorKit;
 import javax.swing.text.JTextComponent;
@@ -126,6 +127,14 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
 
         super(true);
         long start = System.nanoTime();
+
+        try {
+            // Set default LookAndFeel to be platform-specific
+            // Can be overridden later in preferences
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | UnsupportedLookAndFeelException ex) {
+            log.error("Error setting system look and feel: {} ", ex);
+        }
 
         splash(false);
         splash(true, true);

--- a/java/src/apps/gui3/Apps3.java
+++ b/java/src/apps/gui3/Apps3.java
@@ -25,6 +25,8 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JToolBar;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.WindowConstants;
 import jmri.InstanceManager;
 import jmri.plaf.macosx.AboutHandler;
@@ -70,6 +72,14 @@ public abstract class Apps3 extends AppsBase {
         // Put this here rather than in apps.AppsBase as this is only relevant
         // for GUI applications - non-gui apps will use STDOUT & STDERR
         SystemConsole.create();
+
+        try {
+            // Set default LookAndFeel to be platform-specific
+            // Can be overridden later in preferences
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | UnsupportedLookAndFeelException ex) {
+            log.error("Error setting system look and feel: {} ", ex);
+        }
 
         splash(true);
 


### PR DESCRIPTION
Certainly on Windows, the default Look and Feel is Metal.

This always bugged me.

What this PR does is to set the LAF to the System LAF early on in the initialisation process.

This setting can be overridden later in GUI preferences but will only apply to swing objects created _after_ the profile has loaded.
