### PR TITLE
Correct Regexes

### DIFF
--- a/java/src/jmri/jmrix/PortNamePatterns.properties
+++ b/java/src/jmri/jmrix/PortNamePatterns.properties
@@ -6,11 +6,11 @@
 # BSDs (including OS X) should only show cu.* devices since tty.* devices are
 # for waiting for externially initiated connections
 # http://stackoverflow.com/questions/8632586/macos-whats-the-difference-between-dev-tty-and-dev-cu
-purejavacomm.portnamepattern.jtermios.freebsd.JTermiosImpl = ^(cu\.).*
-purejavacomm.portnamepattern.jtermios.macosx.JTermiosImpl = ^(cu\.).*
+purejavacomm.portnamepattern.jtermios.freebsd.JTermiosImpl = ^(cu\\.).*
+purejavacomm.portnamepattern.jtermios.macosx.JTermiosImpl = ^(cu\\.).*
 
 # We don't want the default TTY devices
-purejavacomm.portnamepattern.jtermios.linux.JTermiosImpl = ^(ttyS|ttyUSB|ttyACM|ttyAMA|tty\.)*
+purejavacomm.portnamepattern.jtermios.linux.JTermiosImpl = ^(ttyS|ttyUSB|ttyACM|ttyAMA|tty\\.).*
 
 # Defaults suffice, but are listed for reference
 #purejavacomm.portnamepattern.jtermios.solaris.JTermiosImpl = .*


### PR DESCRIPTION
Fix error where escape characters (backslashes) in regular expressions
were not being passed because they are also escape characters in the
Java .properties file syntax as well.
Also correct bad Linux regular expression that was missing the “match
any” (dot) character.