### PR TITLE
Fix for ops mode programming packet burst through SPROG command station

### DIFF
--- a/java/src/jmri/jmrix/sprog/SprogCommandStation.java
+++ b/java/src/jmri/jmrix/sprog/SprogCommandStation.java
@@ -85,6 +85,9 @@ public class SprogCommandStation implements CommandStation, SprogListener, Runna
             log.error("Maximum 6-byte packets accepted: " + packet.length);
         }
         final SprogMessage m = new SprogMessage(packet);
+        if (log.isDebugEnabled()) {
+            log.debug("Sending packet " + m.toString());
+        }
         for (int i = 0; i < repeats; i++) {
             final SprogTrafficController thisTC = SprogTrafficController.instance();
 
@@ -128,6 +131,9 @@ public class SprogCommandStation implements CommandStation, SprogListener, Runna
     private SprogSlot findFree() {
         for (SprogSlot s : slots) {
             if (s.isFree()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Found free slot " + s.getSlotNumber());
+                }
                 return s;
             }
         }
@@ -282,11 +288,17 @@ public class SprogCommandStation implements CommandStation, SprogListener, Runna
         }
     }
 
-    public void opsModepacket(int address, boolean longAddr, int cv, int val) {
+    public SprogSlot opsModepacket(int address, boolean longAddr, int cv, int val) {
         SprogSlot s = findFree();
         if (s != null) {
             s.setOps(address, longAddr, cv, val);
+            if (log.isDebugEnabled()) {
+                log.debug("opsModePacket() Notify ops mode packet for address " + address);
+            }
             notifySlotListeners(s);
+            return (s);
+        } else {
+             return (null);
         }
     }
 
@@ -317,7 +329,7 @@ public class SprogCommandStation implements CommandStation, SprogListener, Runna
      * @param s SprogSlot to eStop
      */
     private void eStopSlot(SprogSlot s) {
-        log.debug("Estop slot: " + s.getSlotNumber() + " for address: " + s.locoAddr());
+        log.debug("Estop slot: " + s.getSlotNumber() + " for address: " + s.getAddr());
         s.eStop();
         notifySlotListeners(s);
     }
@@ -353,8 +365,8 @@ public class SprogCommandStation implements CommandStation, SprogListener, Runna
      */
     private synchronized void notifySlotListeners(SprogSlot s) {
         if (log.isDebugEnabled()) {
-            log.debug("notify " + slotListeners.size()
-                    + " SlotListeners about slot for address"
+            log.debug("notifySlotListeners() notify " + slotListeners.size()
+                    + " SlotListeners about slot for address "
                     + s.getAddr());
         }
 

--- a/java/src/jmri/jmrix/sprog/SprogSlot.java
+++ b/java/src/jmri/jmrix/sprog/SprogSlot.java
@@ -352,10 +352,10 @@ public class SprogSlot {
 
     private int doRepeat() {
         if (repeat > 0) {
-            log.debug("Slot " + slot + "repeats");
+            log.debug("Slot " + slot + " repeats");
             repeat--;
             if (repeat == 0) {
-                log.debug("Clear slot " + slot + "due to repeats exhausted");
+                log.debug("Clear slot " + slot + " due to repeats exhausted");
                 this.clear();
             }
         }
@@ -366,12 +366,17 @@ public class SprogSlot {
         return spd;
     }
 
+    @SuppressWarnings("unused")
     public int locoAddr() {
         return addr;
     }
 
     public int getAddr() {
-        return addr;
+        if (opsPkt == false) {
+            return addr;
+        } else {
+            return addressFromPacket();
+        }
     }
 
     public void setAddr(int a) {
@@ -379,7 +384,11 @@ public class SprogSlot {
     }
 
     public boolean getIsLong() {
-        return isLong;
+        if (opsPkt == false) {
+            return isLong;
+        } else {
+            return ((payload[0] & 0xC0) >= 0xC0);
+        }
     }
 
     public void setIsLong(boolean a) {
@@ -441,14 +450,13 @@ public class SprogSlot {
      *
      * @return int
      */
-    @SuppressWarnings("unused")
     private int addressFromPacket() {
         if (isFree()) {
             return -1;
         }
         // First deal with possible extended address
         if ((payload[0] & 0xC0) == 0xC0) {
-            return ((payload[0] & 0xFF) << 8 | (payload[1] & 0xFF));
+            return ((payload[0] & 0x3F) << 8 | (payload[1] & 0xFF));
         }
         return payload[0];
     }

--- a/java/src/jmri/jmrix/sprog/sprogslotmon/SprogSlotMonDataModel.java
+++ b/java/src/jmri/jmrix/sprog/sprogslotmon/SprogSlotMonDataModel.java
@@ -133,7 +133,7 @@ public class SprogSlotMonDataModel extends javax.swing.table.AbstractTableModel 
             case ADDRCOLUMN:  //
                     switch (s.slotStatus()) {
                         case SprogConstants.SLOT_IN_USE:
-                            return Integer.toString(s.locoAddr()) + "("+ (s.getIsLong() ? "L" : "S") + ")";
+                            return Integer.toString(s.getAddr()) + "("+ (s.getIsLong() ? "L" : "S") + ")";
                         case SprogConstants.SLOT_FREE:
                             return "-";
                         default:


### PR DESCRIPTION
Added a delay between ops mode packets and also handle the case where there is no free slot available for the packet, by reporting a timeout back to the programmer