### PR TITLE
PJC logging is configurable

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -214,6 +214,9 @@
         <pathelement location="${target}/"/>  <!-- last to check for name collisions -->
     </path>
     
+    <!-- PureJavaComm default log level - override in local.properties or Ant command line -->
+    <property name="purejavacomm.loglevel" value="0"/>
+    
     <macrodef name="quiet">
         <element name="body" implicit="yes"/>
         <sequential>
@@ -683,6 +686,7 @@
                          path=".:${arch.lib.path}:${libdir}"/>
             <sysproperty key="jinput.plugins"
                          path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
+            <sysproperty key="purejavacomm.loglevel" value="${purejavacomm.loglevel}"/>
             <jvmarg value="-Xms256m"/>
             <jvmarg value="-Xmx640m"/>
             <!-- <jvmarg value="-verbose"/> -->


### PR DESCRIPTION
PJC logging can be configured in the ant build scripts using the
```purejavacomm.loglevel``` property in local.properties or on the ant
command line.