### PR TITLE
Defer turnout manager init in RouteTableAction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,10 @@ language: java
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - "ulimit"
   - sleep 3 # give xvfb some time to start
 
 script: 
-#  - travis_wait ant ci-test checklineends checknonascii 
-  - ant ci-test
-  - ant checklineends
-  - ant checknonascii 
-
-after_script:
-  - "head -120 /home/travis/build.sh"
+ - travis_wait ant ci-test checklineends checknonascii 
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script: 
-  - travis_wait ant -version
-  - travis_wait ant checklineends checknonascii 
-  - travis_wait ant ci-test
+  - travis_wait ant ci-test checklineends checknonascii 
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script: 
+  - travis_wait ant -version
   - travis_wait ant checklineends checknonascii 
   - travis_wait ant ci-test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script: 
- - travis_wait ant ci-test checklineends checknonascii 
+ - travis_wait ant checklineends checknonascii ci-test 
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script: 
-  - travis_wait ant ci-test checklineends checknonascii 
+#  - travis_wait ant ci-test checklineends checknonascii 
+  - ant ci-test
+  - ant checklineends
+  - ant checknonascii 
 
 after_script:
   - "head -120 /home/travis/build.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ before_script:
 script: 
   - travis_wait ant ci-test checklineends checknonascii 
 
+after_script:
+  - "ls -la"
+
 jdk:
   - oraclejdk8
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
 
 after_script:
   - "ls -la"
+  - "cat travis_wait*"
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ script:
   - travis_wait ant ci-test checklineends checknonascii 
 
 after_script:
-  - "ls -la"
-  - "cat travis_wait*"
+  - "head -120 /home/travis/build.sh"
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: java
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+  - "ulimit"
   - sleep 3 # give xvfb some time to start
 
 script: 

--- a/build.xml
+++ b/build.xml
@@ -1070,8 +1070,8 @@
     </target>
 
 
-    <target name="ci-test" depends="tests, runtime-library-selection" description="run headless test suite using Travis-CI default target">
-        <junit haltonerror="false" haltonfailure="false" printsummary="yes" fork="no" dir="." errorProperty="test.failed" failureProperty="test.failed" showoutput="yes">
+    <target name="ci-test" depends="tests, runtime-library-selection" description="run AllTest for e.g. Travis-CI">
+        <junit haltonerror="false" haltonfailure="false" printsummary="yes" fork="yes" dir="." errorProperty="test.failed" failureProperty="test.failed">
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
@@ -1091,8 +1091,8 @@
         </fail>
     </target>
 
-    <target name="appveyor-ci-test" depends="tests, runtime-library-selection" description="run headless test suite using Appveyor default target">
-        <!-- setup identical to CI Test except test output is different -->
+    <target name="appveyor-ci-test" depends="tests, runtime-library-selection" description="run AllTest using Appveyor">
+        <!-- identical to ci-test target except test output is different -->
         <junit haltonerror="false" haltonfailure="false" printsummary="yes" fork="yes" dir="." errorProperty="test.failed" failureProperty="test.failed">
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>

--- a/build.xml
+++ b/build.xml
@@ -1084,6 +1084,10 @@
                 <formatter usefile="no" type="brief"/>
             </test>
         </junit>
+		  <exec executable="sh">
+			<arg value="-c" />
+			<arg value="ls -la" />
+		  </exec>      
         <fail>
             <condition>
                 <istrue value="${test.failed}" />

--- a/build.xml
+++ b/build.xml
@@ -1084,10 +1084,6 @@
                 <formatter usefile="no" type="brief"/>
             </test>
         </junit>
-		  <exec executable="sh">
-			<arg value="-c" />
-			<arg value="ls -la" />
-		  </exec>      
         <fail>
             <condition>
                 <istrue value="${test.failed}" />

--- a/build.xml
+++ b/build.xml
@@ -1071,7 +1071,7 @@
 
 
     <target name="ci-test" depends="tests, runtime-library-selection" description="run headless test suite using Travis-CI default target">
-        <junit haltonerror="false" haltonfailure="false" printsummary="yes" fork="yes" dir="." errorProperty="test.failed" failureProperty="test.failed">
+        <junit haltonerror="false" haltonfailure="false" printsummary="yes" fork="no" dir="." errorProperty="test.failed" failureProperty="test.failed" showoutput="yes">
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
@@ -1092,16 +1092,17 @@
     </target>
 
     <target name="appveyor-ci-test" depends="tests, runtime-library-selection" description="run headless test suite using Appveyor default target">
-        <!-- identical to CI Test except test output is different -->
+        <!-- setup identical to CI Test except test output is different -->
         <junit haltonerror="false" haltonfailure="false" printsummary="yes" fork="yes" dir="." errorProperty="test.failed" failureProperty="test.failed">
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jinput.plugins" path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
-            <sysproperty key="jmri.skipschematests" value="true"/>  <!-- skip schema checks to improve speed -->
 
             <classpath refid="test.class.path"/>
+
+            <sysproperty key="jmri.skipschematests" value="true"/>  <!-- skip schema checks to improve speed -->
 
             <test name="apps.tests.AllTest" outfile="junit-results">
                 <formatter type="xml"/>

--- a/java/src/jmri/jmrit/beantable/RouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableAction.java
@@ -101,6 +101,21 @@ public class RouteTableAction extends AbstractTableAction {
      * of Routes
      */
     protected void createModel() {
+
+        // late initialization of string "constants" so that TurnoutManager 
+        // has time to be fully configured
+        SET_TO_CLOSED = rbx.getString("Set") + " "
+            + InstanceManager.turnoutManagerInstance().getClosedText();
+        SET_TO_THROWN = rbx.getString("Set") + " "
+            + InstanceManager.turnoutManagerInstance().getThrownText();
+        turnoutInputModes = new String[]{"On " + InstanceManager.turnoutManagerInstance().getClosedText(),
+            "On " + InstanceManager.turnoutManagerInstance().getThrownText(),
+            "On Change", "Veto Closed", "Veto Thrown"};
+        lockTurnoutInputModes = new String[]{"On " + InstanceManager.turnoutManagerInstance().getClosedText(),
+            "On " + InstanceManager.turnoutManagerInstance().getThrownText(),
+            "On Change"};
+
+
         m = new BeanTableDataModel() {
             /**
              *
@@ -1985,26 +2000,30 @@ public class RouteTableAction extends AbstractTableAction {
         rbx.getString("ColumnLabelSetState")};
     private static String SET_TO_ACTIVE = rbx.getString("Set") + " " + rbx.getString("SensorActive");
     private static String SET_TO_INACTIVE = rbx.getString("Set") + " " + rbx.getString("SensorInactive");
-    private static String SET_TO_CLOSED = rbx.getString("Set") + " "
-            + InstanceManager.turnoutManagerInstance().getClosedText();
-    private static String SET_TO_THROWN = rbx.getString("Set") + " "
-            + InstanceManager.turnoutManagerInstance().getThrownText();
+
     private static String SET_TO_TOGGLE = rbx.getString("Set") + " " + rbx.getString("Toggle");
 
     private static String[] sensorInputModes = new String[]{"On Active", "On Inactive", "On Change", "Veto Active", "Veto Inactive"};
     private static int[] sensorInputModeValues = new int[]{Route.ONACTIVE, Route.ONINACTIVE, Route.ONCHANGE,
         Route.VETOACTIVE, Route.VETOINACTIVE};
-
-    private static String[] turnoutInputModes = new String[]{"On " + InstanceManager.turnoutManagerInstance().getClosedText(),
-        "On " + InstanceManager.turnoutManagerInstance().getThrownText(),
+    
+    // This group will get runtime updates to system-specific contents at 
+    // the start of buildModel() above.  This is done to prevent
+    // invoking the TurnoutManager at class construction time, 
+    // when it hasn't been configured yet
+    private static String SET_TO_CLOSED = rbx.getString("Set") + " "
+            + Bundle.getMessage("TurnoutStateClosed");
+    private static String SET_TO_THROWN = rbx.getString("Set") + " "
+            + Bundle.getMessage("TurnoutStateThrown");
+    private static String[] turnoutInputModes = new String[]{"On " + Bundle.getMessage("TurnoutStateClosed"),
+        "On " + Bundle.getMessage("TurnoutStateThrown"),
         "On Change", "Veto Closed", "Veto Thrown"};
+    private static String[] lockTurnoutInputModes = new String[]{"On " + Bundle.getMessage("TurnoutStateClosed"),
+        "On " + Bundle.getMessage("TurnoutStateThrown"),
+        "On Change"};
+
     private static int[] turnoutInputModeValues = new int[]{Route.ONCLOSED, Route.ONTHROWN, Route.ONCHANGE,
         Route.VETOCLOSED, Route.VETOTHROWN};
-
-    private static String[] lockTurnoutInputModes = new String[]{"On " + InstanceManager.turnoutManagerInstance().getClosedText(),
-        "On " + InstanceManager.turnoutManagerInstance().getThrownText(),
-        "On Change"};
-    //private static int[] lockTurnoutInputModeValues = new int[]{Route.ONCLOSED, Route.ONTHROWN, Route.ONCHANGE};    
 
     private ArrayList<RouteTurnout> _turnoutList;      // array of all Turnouts
     private ArrayList<RouteTurnout> _includedTurnoutList;

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -38,9 +38,10 @@ abstract public class AbstractManager
      *
      */
     protected void registerSelf() {
+        log.debug("registerSelf for config of type {}", getClass());
         if (InstanceManager.configureManagerInstance() != null) {
             InstanceManager.configureManagerInstance().registerConfig(this, getXMLOrder());
-            log.debug("register for config of type {}", getClass());
+            log.debug("registering for config of type {}", getClass());
         }
     }
 


### PR DESCRIPTION
(See #764)

The internal TurnoutManager is being created too early because RouteTableInstance has lines like:
```` Java
    private static String SET_TO_CLOSED = rbx.getString("Set") + " "
            + InstanceManager.turnoutManagerInstance().getClosedText();
    private static String SET_TO_THROWN = rbx.getString("Set") + " "
            + InstanceManager.turnoutManagerInstance().getThrownText();
````
which gets (and therefore creates) the main TurnoutManager at class-load time.

That's probably getting the wrong text, because it's meant to get the language used by the default _real_ TurnoutManager, which is the layout's terminology, not the internal one. Doing that at class initialization time isn't going to be right. 

This PR changes it to get static (I18N'd) content via Bundle at class-load time, and then updates those when the table is (re)-displayed.