### PR TITLE
Travis crash bypass (temporary)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script: 
- - travis_wait ant checklineends checknonascii ci-test 
+ - travis_wait ant checklineends checknonascii ci-test-travis
 
 jdk:
   - oraclejdk8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ build: off
 # AppVeyor's YAML processing
 test_script:
 - ps: >-
-    ant checkPropertiesFiles appveyor-ci-test
+    ant checkPropertiesFiles ci-test-appveyor
 
 on_finish:
 - ps: >-

--- a/build.xml
+++ b/build.xml
@@ -1070,7 +1070,7 @@
     </target>
 
 
-    <target name="ci-test" depends="tests, runtime-library-selection" description="run AllTest for e.g. Travis-CI">
+    <target name="ci-test" depends="tests, runtime-library-selection" description="run AllTest CI tests">
         <junit haltonerror="false" haltonfailure="false" printsummary="yes" fork="yes" dir="." errorProperty="test.failed" failureProperty="test.failed">
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
@@ -1091,7 +1091,30 @@
         </fail>
     </target>
 
-    <target name="appveyor-ci-test" depends="tests, runtime-library-selection" description="run AllTest using Appveyor">
+    <target name="ci-test-travis" depends="tests, runtime-library-selection" description="run ci-test using Travis-CI">
+        <junit haltonerror="false" haltonfailure="false" printsummary="yes" fork="yes" dir="." errorProperty="test.failed" failureProperty="test.failed">
+            <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
+            <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
+            <sysproperty key="log4j.ignoreTCL" path="true/"/>
+            <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
+            <sysproperty key="jinput.plugins" path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
+
+            <classpath refid="test.class.path"/>
+
+            <sysproperty key="jmri.skipschematests" value="true"/>  <!-- skip schema checks to improve speed -->
+
+            <test name="apps.tests.AllTest">
+                <formatter usefile="no" type="brief"/>
+            </test>
+        </junit>
+        <fail>
+            <condition>
+                <istrue value="${test.failed}" />
+            </condition>
+        </fail>
+    </target>
+
+    <target name="ci-test-appveyor" depends="tests, runtime-library-selection" description="run ci-test using Appveyor">
         <!-- identical to ci-test target except test output is different -->
         <junit haltonerror="false" haltonfailure="false" printsummary="yes" fork="yes" dir="." errorProperty="test.failed" failureProperty="test.failed">
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>


### PR DESCRIPTION
Some refactor & cleanup of Travis CI control files. 

For now, turn off the schema tests under to CI-test target for Travis to avoid crash. Still being run in Jenkns. 