### PR TITLE
Travis runs standalone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+# The next line forces Travis out of the containerized servers, fixing JMRI/JMRI #773
+sudo: true
+
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/build.xml
+++ b/build.xml
@@ -1101,8 +1101,6 @@
 
             <classpath refid="test.class.path"/>
 
-            <sysproperty key="jmri.skipschematests" value="true"/>  <!-- skip schema checks to improve speed -->
-
             <test name="apps.tests.AllTest">
                 <formatter usefile="no" type="brief"/>
             </test>


### PR DESCRIPTION
This changes the Travis YML control file to run the Travis CI tests in a standalone VM, instead of a container.  This _may_ fix #773.

Note: because the standalone VM is slower to start up, this form may take about 90 seconds more clock time to run.

No changes to Appveyor infrastructure.
