### PR TITLE
Standalone // NOI18N comment

### DIFF
--- a/help/en/html/doc/Technical/I8N.shtml
+++ b/help/en/html/doc/Technical/I8N.shtml
@@ -279,9 +279,13 @@ than providing multiple lines in the code itself.
 <p>
 Some parts of JMRI remain English only due to our developer population.
 In particular, comments and variable names in the code should remain in
-English, as should messages sent to the logging system.  
+English, as should messages sent to the logging system. Keys for 
+the translation bundles are another example. 
 In the Java code, these strings can be marked with a "<code>// NOI18N</code>"
-comment at the end of the line.
+comment at the end of the line. If needed, put that after another comment:
+<pre><code>
+  firePropertyChange("size", oldSize, newSize); // promptly! // NOI18N
+</code></pre>
 
 <h3>Adding a new Bundle</h3>
 <p>

--- a/java/src/jmri/LocoAddress.java
+++ b/java/src/jmri/LocoAddress.java
@@ -30,7 +30,7 @@ public interface LocoAddress {
     public enum Protocol {
 
         DCC_SHORT("dcc_short", "ProtocolDCC_Short"), // NOI18N
-        DCC_LONG("dcc_long", "ProtocolDCC_Long"), // NOI18N 
+        DCC_LONG("dcc_long", "ProtocolDCC_Long"), // NOI18N
         DCC("dcc", "ProtocolDCC"), // NOI18N
         SELECTRIX("selectrix", "ProtocolSelectrix"), // NOI18N
         MOTOROLA("motorola", "ProtocolMotorola"), // NOI18N

--- a/java/src/jmri/implementation/JmriConfigurationManager.java
+++ b/java/src/jmri/implementation/JmriConfigurationManager.java
@@ -204,7 +204,7 @@ public class JmriConfigurationManager implements ConfigureManager {
                         JOptionPane.showMessageDialog(null,
                                 new Object[]{
                                     list,
-                                    "<html><br></html>", // NOI18N // Add a visual break between list of errors and notes
+                                    "<html><br></html>", // Add a visual break between list of errors and notes // NOI18N
                                     Bundle.getMessage("InitExMessageLogs"), // NOI18N
                                     Bundle.getMessage("InitExMessagePrefs"), // NOI18N
                                 },

--- a/java/src/jmri/jmrit/operations/OperationsXml.java
+++ b/java/src/jmri/jmrit/operations/OperationsXml.java
@@ -123,7 +123,7 @@ public abstract class OperationsXml extends XmlFile {
         return operationsFileName;
     }
 
-    private String operationsFileName = "DefaultOperations.xml"; // NOI18N should be overridden
+    private String operationsFileName = "DefaultOperations.xml"; // should be overridden // NOI18N
 
     /**
      * Absolute path to location of Operations files.

--- a/java/src/jmri/jmrit/operations/locations/SetPhysicalLocationAction.java
+++ b/java/src/jmri/jmrit/operations/locations/SetPhysicalLocationAction.java
@@ -109,7 +109,7 @@ public class SetPhysicalLocationAction extends AbstractAction {
             getContentPane().add(pControl);
 
             // add help menu to window
-            addHelpMenu("package.jmri.jmrit.operations.Operations_SetTrainIconCoordinates", true); // NOI18N fix this
+            addHelpMenu("package.jmri.jmrit.operations.Operations_SetTrainIconCoordinates", true); // fix this // NOI18N
             // later
 
             // setup buttons

--- a/java/src/jmri/jmrit/operations/locations/SetPhysicalLocationFrame.java
+++ b/java/src/jmri/jmrit/operations/locations/SetPhysicalLocationFrame.java
@@ -80,7 +80,7 @@ public class SetPhysicalLocationFrame extends OperationsFrame {
         getContentPane().add(pControl);
 
         // add help menu to window
-        addHelpMenu("package.jmri.jmrit.operations.Operations_SetTrainIconCoordinates", true); // NOI18N fix this later
+        addHelpMenu("package.jmri.jmrit.operations.Operations_SetTrainIconCoordinates", true); // fix this later // NOI18N
 
         // setup buttons
         addButtonAction(saveButton);

--- a/java/src/jmri/jmrit/operations/locations/Track.java
+++ b/java/src/jmri/jmrit/operations/locations/Track.java
@@ -81,10 +81,10 @@ public class Track {
     protected String _dropOption = ANY; // controls which route or train can set out cars
     protected String _pickupOption = ANY; // controls which route or train can pick up cars
     public static final String ANY = "Any"; // track accepts any train or route
-    public static final String TRAINS = "trains"; // NOI18N track only accepts certain trains
-    public static final String ROUTES = "routes"; // NOI18N track only accepts certain routes
-    public static final String EXCLUDE_TRAINS = "excludeTrains"; // NOI18N track excludes certain trains
-    public static final String EXCLUDE_ROUTES = "excludeRoutes"; // NOI18N track excludes certain routes
+    public static final String TRAINS = "trains"; // track only accepts certain trains // NOI18N
+    public static final String ROUTES = "routes"; // track only accepts certain routes // NOI18N
+    public static final String EXCLUDE_TRAINS = "excludeTrains"; // track excludes certain trains // NOI18N
+    public static final String EXCLUDE_ROUTES = "excludeRoutes"; // track excludes certain routes // NOI18N
 
     // load options
     protected int _loadOptions = 0;
@@ -109,7 +109,7 @@ public class Track {
     public static final String STAGING = "Staging";
     public static final String INTERCHANGE = "Interchange";
     public static final String YARD = "Yard";
-    public static final String SPUR = "Siding"; // NOI18N note that early code used Siding as the spur type
+    public static final String SPUR = "Siding"; // note that early code used Siding as the spur type // NOI18N
 
     // train directions serviced by this track
     public static final int EAST = 1;

--- a/java/src/jmri/jmrit/operations/locations/Xml.java
+++ b/java/src/jmri/jmrit/operations/locations/Xml.java
@@ -46,7 +46,7 @@ public class Xml {
 
     static final String PHYSICAL_LOCATION = "physicalLocation"; // NOI18N
     static final String SWITCH_LIST_COMMENT = "switchListComment"; // NOI18N
-    static final String SECONDARY = "secondary"; // NOI18N early version of operations called tracks "secondary"
+    static final String SECONDARY = "secondary"; // early version of operations called tracks "secondary" // NOI18N
 
     // SccheduleManager.java
     static final String SCHEDULES = "schedules"; // NOI18N

--- a/java/src/jmri/jmrit/operations/rollingstock/RollingStock.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/RollingStock.java
@@ -69,9 +69,9 @@ public class RollingStock implements java.beans.PropertyChangeListener {
 
     protected int number = 0; // used by rolling stock manager for sort by number
 
-    public static final String ERROR_TRACK = "ERROR wrong track for location"; // NOI18N checks for coding error
+    public static final String ERROR_TRACK = "ERROR wrong track for location"; // checks for coding error // NOI18N
 
-    public static final String LOCATION_CHANGED_PROPERTY = "rolling stock location"; // NOI18N 
+    public static final String LOCATION_CHANGED_PROPERTY = "rolling stock location"; // NOI18N
     public static final String TRACK_CHANGED_PROPERTY = "rolling stock track location"; // NOI18N
     public static final String DESTINATION_CHANGED_PROPERTY = "rolling stock destination"; // NOI18N
     public static final String DESTINATION_TRACK_CHANGED_PROPERTY = "rolling stock track destination"; // NOI18N

--- a/java/src/jmri/jmrit/operations/rollingstock/RollingStockAttribute.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/RollingStockAttribute.java
@@ -50,7 +50,7 @@ public class RollingStockAttribute {
     }
 
     protected String getDefaultNames() {
-        return "Error"; //  NOI18N overridden
+        return "Error"; // overridden //  NOI18N
     }
 
     public void setNames(String[] names) {

--- a/java/src/jmri/jmrit/operations/rollingstock/Xml.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/Xml.java
@@ -71,7 +71,7 @@ public class Xml {
 //	static final String SOUTH_TRAIN_ICON_Y = "southTrainIconY"; // NOI18N
 //	static final String PHYSICAL_LOCATION = "physicalLocation"; // NOI18N
 //	static final String SWITCH_LIST_COMMENT = "switchListComment"; // NOI18N
-//	static final String SECONDARY = "secondary"; // NOI18N early version of operations called tracks "secondary"
+//	static final String SECONDARY = "secondary"; // early version of operations called tracks "secondary" // NOI18N
     // ScheduleItem.java
 //	static final String ITEM = "item"; // NOI18N
 //	static final String SEQUENCE_ID = "ScheduleId"; // NOI18N
@@ -87,7 +87,7 @@ public class Xml {
 //	static final String LOC_TYPE = "locType"; // NOI18N
 //	
 //	
-//	static final String CAR_ROAD_OPERATION = "carRoadOperation"; // NOI18N misspelled should have been carRoadOption
+//	static final String CAR_ROAD_OPERATION = "carRoadOperation"; //  misspelled should have been carRoadOption // NOI18N
 //	static final String CAR_ROADS = "carRoads"; // NOI18N
 //	static final String CAR_LOAD_OPTION = "carLoadOption"; // NOI18N
 //	static final String CAR_LOADS = "carLoads"; // NOI18N

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/Car.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/Car.java
@@ -46,7 +46,7 @@ public class Car extends RollingStock {
     protected String _pickupScheduleId = NONE;
     protected String _nextPickupScheduleId = NONE; // when the car needs to be pulled
 
-    public static final String LOAD_CHANGED_PROPERTY = "Car load changed"; // NOI18N property change descriptions
+    public static final String LOAD_CHANGED_PROPERTY = "Car load changed"; // property change descriptions // NOI18N
     public static final String WAIT_CHANGED_PROPERTY = "Car wait changed"; // NOI18N
     public static final String NEXT_WAIT_CHANGED_PROPERTY = "Car next wait changed"; // NOI18N
     public static final String FINAL_DESTINATION_CHANGED_PROPERTY = "Car final destination changed"; // NOI18N

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/Xml.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/Xml.java
@@ -49,7 +49,7 @@ public class Xml {
     static final String OPTIONS = "options"; // NOI18N
     static final String CARS = "cars"; // NOI18N
     static final String CARS_OPTIONS = "carsOptions"; // NOI18N
-    static final String COLUMN_WIDTHS = "columnWidths"; // NOI18N backwards compatible TODO remove in 2013 after production release
+    static final String COLUMN_WIDTHS = "columnWidths"; // backwards compatible TODO remove in 2013 after production release // NOI18N
     static final String KERNELS = "kernels"; // NOI18N
     static final String NEW_KERNELS = "newKernels"; // NOI18N
 

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/Xml.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/Xml.java
@@ -30,7 +30,7 @@ public class Xml {
 
     // EngineManager.java
     static final String ENGINES_OPTIONS = "enginesOptions"; // NOI18N
-    static final String COLUMN_WIDTHS = "columnWidths"; // NOI18N backwards compatible TODO remove in 2013 after production release
+    static final String COLUMN_WIDTHS = "columnWidths"; // backwards compatible TODO remove in 2013 after production release // NOI18N
     static final String OPTIONS = "options"; // NOI18N
     static final String CONSISTS = "consists";  // NOI18N
     static final String NEW_CONSISTS = "newConsists";  // NOI18N

--- a/java/src/jmri/jmrit/operations/trains/TrainCsvCommon.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainCsvCommon.java
@@ -22,8 +22,8 @@ import org.slf4j.LoggerFactory;
  */
 public class TrainCsvCommon extends TrainCommon {
 
-    protected final static String DEL = ","; // NOI18N delimiter
-    protected final static String ESC = "\""; // NOI18N escape
+    protected final static String DEL = ","; // delimiter // NOI18N
+    protected final static String ESC = "\""; // escape // NOI18N
 
     protected final static String HEADER = Bundle.getMessage("csvOperator") + DEL + Bundle.getMessage("csvDescription")
             + DEL + Bundle.getMessage("csvParameters");

--- a/java/src/jmri/jmrit/operations/trains/TrainLogger.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainLogger.java
@@ -30,7 +30,7 @@ public class TrainLogger extends XmlFile implements java.beans.PropertyChangeLis
     File _fileLogger;
     private boolean _trainLog = false; // when true logging train movements
     static final String DEL = ","; // delimiter
-    static final String ESC = "\""; // NOI18N escape
+    static final String ESC = "\""; // escape // NOI18N
 
     public TrainLogger() {
     }

--- a/java/src/jmri/jmrit/operations/trains/Xml.java
+++ b/java/src/jmri/jmrit/operations/trains/Xml.java
@@ -26,7 +26,7 @@ public class Xml {
     static final String ROUTE = "route"; // NOI18N
     static final String SKIPS = "skips"; // NOI18N
     static final String LOCATION = "location"; // NOI18N
-    static final String ROUTE_ID = "routeId"; // NOI18N old format
+    static final String ROUTE_ID = "routeId"; // old format // NOI18N
     static final String SKIP = "skip"; // NOI18N
     static final String CAR_TYPES = "carTypes"; // NOI18N
     static final String TYPES = "types"; // NOI18N
@@ -114,7 +114,7 @@ public class Xml {
     static final String OPEN_FILE = "openFile"; // NOI18N
     static final String TRAIN_ACTION = "trainAction"; // NOI18N
 
-    static final String COLUMN_WIDTHS = "columnWidths"; // NOI18N TODO This here is for backwards compatibility, remove after next major release
+    static final String COLUMN_WIDTHS = "columnWidths"; // TODO This here is for backwards compatibility, remove after next major release // NOI18N
 
     static final String TRAIN_SCHEDULE_OPTIONS = "trainScheduleOptions"; // NOI18N
     static final String ACTIVE_ID = "activeId"; // NOI18N
@@ -198,7 +198,7 @@ public class Xml {
 
     // TrainManifestHeaderText.jafa
     static final String MANIFEST_HEADER_TEXT_STRINGS = "manifestHeaderTextStrings"; // NOI18N
-    static final String ROAD = "road"; // the supported message format options NOI18N 
+    static final String ROAD = "road"; // the supported message format options // NOI18N
     static final String NUMBER = "number"; // NOI18N
     static final String ENGINE_NUMBER = "engineNumber"; // NOI18N
     static final String TYPE = "type"; // NOI18N

--- a/java/src/jmri/jmrix/dccpp/swing/ConfigSensorsAndTurnoutsFrame.java
+++ b/java/src/jmri/jmrix/dccpp/swing/ConfigSensorsAndTurnoutsFrame.java
@@ -587,9 +587,9 @@ public class ConfigSensorsAndTurnoutsFrame extends JmriJFrame implements DCCppLi
             columnNames[1] = Bundle.getMessage("FieldTablePinColumn");
             columnNames[2] = Bundle.getMessage("FieldTablePullupColumn");
             columnNames[3] = Bundle.getMessage("FieldTableDeleteColumn");
-            columnNames[4] = "isNew"; // NOI18N -- hidden column;
-            columnNames[5] = "isDirty"; // NOI18N -- hidden column;
-            columnNames[6] = "isDelete"; // NOI18N -- hidden column;
+            columnNames[4] = "isNew";       // hidden column // NOI18N
+            columnNames[5] = "isDirty";     // hidden column // NOI18N
+            columnNames[6] = "isDelete";    // hidden column // NOI18N
             rowData = new Vector();
         }
 
@@ -740,9 +740,9 @@ public class ConfigSensorsAndTurnoutsFrame extends JmriJFrame implements DCCppLi
             columnNames[1] = Bundle.getMessage("FieldTableAddressColumn");
             columnNames[2] = Bundle.getMessage("FieldTableSubaddrColumn");
             columnNames[3] = Bundle.getMessage("FieldTableDeleteColumn");
-            columnNames[4] = "isNew"; // NOI18N -- hidden column;
-            columnNames[5] = "isDirty"; // NOI18N -- hidden column;
-            columnNames[6] = "isDelete"; // NOI18N -- hidden column;
+            columnNames[4] = "isNew";        // hidden column // NOI18N
+            columnNames[5] = "isDirty";      // hidden column // NOI18N
+            columnNames[6] = "isDelete";     // hidden column // NOI18N
             rowData = new Vector();
         }
 
@@ -887,9 +887,9 @@ public class ConfigSensorsAndTurnoutsFrame extends JmriJFrame implements DCCppLi
             columnNames[3] = Bundle.getMessage("FieldTableOutputRestoreStateColumn");
             columnNames[4] = Bundle.getMessage("FieldTableOutputForceToColumn");
             columnNames[5] = Bundle.getMessage("FieldTableDeleteColumn");
-            columnNames[6] = "isNew"; // NOI18N -- hidden column;
-            columnNames[7] = "isDirty"; // NOI18N -- hidden column;
-            columnNames[8] = "isDelete"; // NOI18N -- hidden column;
+            columnNames[6] = "isNew";        // hidden column // NOI18N
+            columnNames[7] = "isDirty";      // hidden column // NOI18N
+            columnNames[8] = "isDelete";     // hidden column // NOI18N
             rowData = new Vector();
         }
 

--- a/java/src/jmri/jmrix/loconet/LnCommandStationType.java
+++ b/java/src/jmri/jmrix/loconet/LnCommandStationType.java
@@ -46,7 +46,7 @@ public enum LnCommandStationType {
 
     COMMAND_STATION_PR3_ALONE("PR3 standalone programmer", true, false, "LnThrottleManager", "SlotManager"), // NOI18N
     COMMAND_STATION_PR2_ALONE("PR2 standalone programmer", true, false, "LnThrottleManager", "SlotManager"), // NOI18N
-    COMMAND_STATION_STANDALONE("Stand-alone LocoNet", false, false, "LnThrottleManager", "SlotManager");  // NOI18N  
+    COMMAND_STATION_STANDALONE("Stand-alone LocoNet", false, false, "LnThrottleManager", "SlotManager");  // NOI18N
 
     // Note that the convention is that the first word (space-separated token) of the name is the
     // name of a configuration file for loconet.cmdstnconfig

--- a/java/src/jmri/util/xml/XMLUtil.java
+++ b/java/src/jmri/util/xml/XMLUtil.java
@@ -165,7 +165,7 @@ public final class XMLUtil extends Object {
         try {
             return factory.newSAXParser().getXMLReader();
         } catch (ParserConfigurationException ex) {
-            throw new SAXException("Cannot create parser satisfying configuration parameters", ex); //NOI18N                        
+            throw new SAXException("Cannot create parser satisfying configuration parameters", ex); // NOI18N
         }
     }
 

--- a/java/src/jmri/web/servlet/operations/HtmlConductor.java
+++ b/java/src/jmri/web/servlet/operations/HtmlConductor.java
@@ -38,7 +38,7 @@ public class HtmlConductor extends HtmlTrainCommon {
                     "ConductorSnippet.html"))), train.getIconName(), StringEscapeUtils.escapeHtml4(train
                             .getDescription()), StringEscapeUtils.escapeHtml4(train.getComment()), Setup
                     .isPrintRouteCommentsEnabled() ? train.getRoute().getComment() : "", strings
-                    .getProperty("Terminated"), "", // NOI18N terminated train has nothing to do
+                    .getProperty("Terminated"), "", // terminated train has nothing to do // NOI18N
                     "", // engines in separate section
                     "", // pickup=true, local=false
                     "", // pickup=false, local=false


### PR DESCRIPTION
Due to some concern as to whether IDE(s) would see a NOI18N comment buried in another comment line:

- added some discussion and an example to the documentation
- did a quick sweep through for examples and updated them by moving the // NOI18N to end of line (not entirely systematic, it's possible some snuck through)
