### PR TITLE
When a warrant is being instantiated while reading the layout XML fil…

### DIFF
--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -384,7 +384,11 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
                 List<RosterEntry> l = Roster.instance().matchingList(null, null, numId, null, null, null, null);
                 if (l.size() > 0) {
                     _train = l.get(0);
-                    _trainId = _train.getId();
+                    if (_trainId == null) {
+                        // In some systems, such as Märklin MFX or ESU ECOS M4, the DCC address is always 0.
+                        // That should not make us overwrite the _trainId.
+                        _trainId = _train.getId();
+                    }
                 } else {
                     _train = null;
                     _trainId = null;


### PR DESCRIPTION
…e, the TrainId is being set from the information in the XML file whereafter the DCCAddress is also set as defined in the XML file.

However, the setting of the DCC Address for Märklin MFX and for ESU ECOS M4 decoders (where the DCC Address is always 0), the setting of the DCC address also sets the TranId to the first MFX or M4 entry being found in the roster, i.e. the first locomotive with DCC Address 0.
This little patch corrects that problem.