### PR TITLE
Fix for NCE programming mode issues.

### DIFF
--- a/java/src/jmri/jmrix/nce/NceSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/nce/NceSystemConnectionMemo.java
@@ -152,10 +152,17 @@ public class NceSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
             return (T) getProgrammerManager();
         }
         if (T.equals(jmri.GlobalProgrammerManager.class)) {
-            return (T) getProgrammerManager();
+            ProgrammerManager pm = getProgrammerManager();
+            if ((pm != null) && pm.isGlobalProgrammerAvailable()) {
+                return (T) getProgrammerManager();
+            }
         }
+        
         if (T.equals(jmri.AddressedProgrammerManager.class)) {
-            return (T) getProgrammerManager();
+            ProgrammerManager pm = getProgrammerManager();
+            if ((pm != null) && pm.isAddressedModePossible()) {
+                return (T) getProgrammerManager();
+            }
         }
 
         if (T.equals(jmri.ThrottleManager.class)) {


### PR DESCRIPTION
A simple fix to registration of valid NCE programmer modes. #814 refers.

It works fine with all NCE configurations and multiple connection combinations (including combinations with SPROG) I tested around a dozen permutations.