### PR TITLE
quick fix for memory icon fixed size NPE

### DIFF
--- a/java/src/jmri/jmrit/display/MemoryIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryIcon.java
@@ -455,7 +455,7 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
             setSize(maxWidth(), maxHeight());
         } else {
             super.updateSize();
-            if (_icon) {
+            if (_icon && _namedIcon != null) {
                 _namedIcon.reduceTo(maxWidthTrue(), maxHeightTrue(), 0.2);
             }
         }


### PR DESCRIPTION
This fix definitely works but it might be masking another issue. The problem is that if _icon is true then _namedIcon is assumed not to be null, but it is. This code has not changed since 4.3.2 so this assumption was apparently safe. I have not yet been able to work out which change has got _icon and _namedIcon out of sync.