### PR TITLE
Remove ProgrammerMode.NONE

### DIFF
--- a/java/src/jmri/managers/DefaultProgrammerManager.java
+++ b/java/src/jmri/managers/DefaultProgrammerManager.java
@@ -7,14 +7,18 @@ import jmri.ProgrammerManager;
 import jmri.ProgrammingMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Provides a very-basic implementation of ProgrammerManager. You give it a
- * service-mode Programmer at construction time; Ops Mode requests get a null in
- * response.
+ * service-mode Programmer at construction time that it returns when requests; 
+ * Ops Mode requests get a null in response to a request, showing there's no programmer
+ * of that type.
+ *<p>
+ * This class also defines basic ProgrammingMode constants for the NMRA-defined modes
  *
  * @see jmri.ProgrammerManager
- * @author	Bob Jacobsen Copyright (C) 2001, 2015
+ * @author	Bob Jacobsen Copyright (C) 2001, 2015, 2016
  * @version	$Revision$
  */
 public class DefaultProgrammerManager implements ProgrammerManager {
@@ -55,11 +59,6 @@ public class DefaultProgrammerManager implements ProgrammerManager {
      * "normal", not "extended" addressing.
      */
     public static final ProgrammingMode OPSACCBYTEMODE = new ProgrammingMode("OPSACCBYTEMODE");
-
-    /**
-     * No programming mode available
-     */
-    public static final ProgrammingMode NONE = new ProgrammingMode("NONE");
 
     /**
      * NMRA "Address-only" mode. Often implemented as a proper subset of
@@ -106,13 +105,14 @@ public class DefaultProgrammerManager implements ProgrammerManager {
     //     public static final ProgrammingMode OPSACCBITMODE   = new ProgrammingMode("OPSACCBITMODE", 112);
     //     public static final ProgrammingMode OPSACCEXTBYTEMODE = new ProgrammingMode("OPSACCEXTBYTEMODE", 121);
     //     public static final ProgrammingMode OPSACCEXTBITMODE  = new ProgrammingMode("OPSACCEXTBITMODE", 122);
-    private Programmer mProgrammer;
+    
+    @NonNull private Programmer mProgrammer;
 
-    public DefaultProgrammerManager(Programmer pProgrammer) {
+    public DefaultProgrammerManager(@NonNull Programmer pProgrammer) {
         mProgrammer = pProgrammer;
     }
 
-    public DefaultProgrammerManager(Programmer pProgrammer, jmri.jmrix.SystemConnectionMemo memo) {
+    public DefaultProgrammerManager(@NonNull Programmer pProgrammer, jmri.jmrix.SystemConnectionMemo memo) {
         this(pProgrammer);
         this.userName = memo.getUserName();
     }
@@ -163,7 +163,7 @@ public class DefaultProgrammerManager implements ProgrammerManager {
     /**
      * Default programmer does not provide Ops Mode
      *
-     * @return false if there's no chance of getting one
+     * @return false since there's no chance of getting one
      */
     public boolean isAddressedModePossible() {
         return false;
@@ -172,7 +172,7 @@ public class DefaultProgrammerManager implements ProgrammerManager {
     /**
      * Default programmer doesn't depend on address
      *
-     * @return false if there's no chance of getting one
+     * @return false since there's no chance of getting one
      */
     public boolean isAddressedModePossible(jmri.LocoAddress l) {
         return isAddressedModePossible();

--- a/java/test/jmri/ProgrammingModeTest.java
+++ b/java/test/jmri/ProgrammingModeTest.java
@@ -17,8 +17,8 @@ public class ProgrammingModeTest extends TestCase {
 
     public void testStateCtors() {
         // tests that statics exist, are not equal
-        Assert.assertTrue(DefaultProgrammerManager.NONE.equals(DefaultProgrammerManager.NONE));
-        Assert.assertTrue(!DefaultProgrammerManager.NONE.equals(DefaultProgrammerManager.PAGEMODE));
+        Assert.assertTrue(DefaultProgrammerManager.PAGEMODE.equals(DefaultProgrammerManager.PAGEMODE));
+        Assert.assertTrue(!DefaultProgrammerManager.REGISTERMODE.equals(DefaultProgrammerManager.PAGEMODE));
     }
 
     // from here down is testing infrastructure


### PR DESCRIPTION
Remove ProgrammerMode.NONE, which is not currently used (except for JUnit tests)

The idea of "no programming possible" should be expressed by not having a Programmer object, not by having a Programmer object that can't program.