### PR TITLE
Additional FindBugs tuning

### DIFF
--- a/.findbugs.xml
+++ b/.findbugs.xml
@@ -17,7 +17,16 @@
      </Match>
 
      <Match>
-       <!-- Efficiency issue, bu hard to ensure refactor doesn't introduce
+       <!-- Most of these are non-I18N, JMRI-specific file operations.
+            We should find the I18N ones, but it seems excessive
+            to track down and annotate all the others first thing.
+            Suppressed for now to focus attention on 
+            other high-priority items.  -->
+       <Bug pattern="DM_DEFAULT_ENCODING" />
+     </Match>
+
+     <Match>
+       <!-- Efficiency issue, but hard to ensure refactor doesn't introduce
             bugs, so leaving for later -->
        <Bug pattern="WMI_WRONG_MAP_ITERATOR" />
      </Match>
@@ -35,6 +44,14 @@
      <Match>
        <!-- Minor clean-up issue, for later -->
        <Bug pattern="RI_REDUNDANT_INTERFACES" />
+     </Match>
+
+     <Match>
+       <!-- This is marked as high priority, but is
+            really just a minor efficiency issue. 
+            Suppressed for now to focus attention on 
+            other high-priority items.  -->
+       <Bug pattern="DM_BOXED_PRIMITIVE_FOR_PARSING" />
      </Match>
 
      <Match>

--- a/.findbugs.xml
+++ b/.findbugs.xml
@@ -10,6 +10,19 @@
      </Match>
 
      <Match>
+       <!-- Most of these are non-I18N, internal changes of case.
+            We should find the I18N ones, but it seems excessive
+            to track down and annotate all the others first thing -->
+       <Bug pattern="DM_CONVERT_CASE" />
+     </Match>
+
+     <Match>
+       <!-- Efficiency issue, bu hard to ensure refactor doesn't introduce
+            bugs, so leaving for later -->
+       <Bug pattern="WMI_WRONG_MAP_ITERATOR" />
+     </Match>
+
+     <Match>
        <!-- Design issue, for later -->
        <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_NEEDS_THIS" />
      </Match>


### PR DESCRIPTION
Next in a series of PRs meant to converge on a reasonable set of FindBugs warnings that we can then (incremementally, quasi-statically, perhaps even adiabatically) push out of the code.

This one: Suppressing two FindBugs warnings that are currently really verbose, hard to fix without risk of adding bugs (in areas without JUnit coverage at times), and of limited importance.

- DM_CONVERT_CASE
- WMI_WRONG_MAP_ITERATOR