### PR TITLE
fix multiple copies of a switch list when there are "similar" location

### DIFF
--- a/java/src/jmri/jmrit/operations/locations/Location.java
+++ b/java/src/jmri/jmrit/operations/locations/Location.java
@@ -458,7 +458,7 @@ public class Location implements java.beans.PropertyChangeListener {
         int old = _switchListState;
         _switchListState = state;
         if (old != state) {
-            setDirtyAndFirePropertyChange("SwitchListState", old, state); // NOI18N
+            setDirtyAndFirePropertyChange("switchListState", old, state); // NOI18N
         }
     }
 


### PR DESCRIPTION
names.