### PR TITLE
Add python.cachedir to context report

### DIFF
--- a/java/src/jmri/jmrit/mailreport/ReportContext.java
+++ b/java/src/jmri/jmrit/mailreport/ReportContext.java
@@ -120,6 +120,7 @@ public class ReportContext {
 
         addProperty("python.home");
         addProperty("python.path");
+        addProperty("python.cachedir");
         addProperty("python.startup");
 
         addProperty("user.name");


### PR DESCRIPTION
The python.cachedir variable defines where Jython writes its cache data.