### PR TITLE
Improve decoder index XSLT

### DIFF
--- a/xml/XSLT/DecoderID.xsl
+++ b/xml/XSLT/DecoderID.xsl
@@ -135,7 +135,11 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 </xsl:template>
 
 <!-- do nothing with the following elements -->
+<xsl:template match="comment"/>
+<xsl:template match="soundlabel"/>
 <xsl:template match="functionlabel"/>
 <xsl:template match="protocol"/>
+<xsl:template match="output"/>
+<xsl:template match="label"/>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Add new decoder index XML elements to the XSLT to clean up the appearance of http://jmri.org/xml/XSLT/pages/DecoderId.html