### PR TITLE
Ignore backups created when unstashing a change.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ session.log
 /nbproject/private
 /.idea/workspace.xml
 local.properties
+*.original~
 
 # CATS source, sometimes present for test
 /java/src/cats


### PR DESCRIPTION
When NetBeans restores a change previously stashed it tends to create a *.original~ copy of the file. I don't know if this is a function of the IDE or of Egit (the Java Git implementation used by NetBeans and Eclipse).
[skip ci]