### PR TITLE
Fix bug when loading preferences from an unconverted profile.

### DIFF
--- a/java/src/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXml.java
@@ -101,7 +101,7 @@ abstract public class AbstractSerialConnectionConfigXml extends AbstractConnecti
            adapter.configureBaudRate(baudRate);
         }
 
-        //loadCommon(shared, perNode, adapter);
+        loadCommon(shared, perNode, adapter);
         // register, so can be picked up next time
         register();
         // try to open the port

--- a/java/src/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXml.java
@@ -80,12 +80,28 @@ abstract public class AbstractSerialConnectionConfigXml extends AbstractConnecti
         boolean result = true;
         getInstance();
         // configure port name
-        String portName = perNode.getAttribute("port").getValue();
-        adapter.setPort(portName);
-        String baudRate = perNode.getAttribute("speed").getValue();
-        adapter.configureBaudRate(baudRate);
+        String portName = null;
+        try {
+           portName = perNode.getAttribute("port").getValue();
+           adapter.setPort(portName);
+        } catch (java.lang.NullPointerException npe) {
+           // when the storage format has not been upgraded to the new format,
+           // the portName incorrectly gets added to the shared attributes.
+           portName = shared.getAttribute("port").getValue();
+           adapter.setPort(portName);
+        }
+        String baudRate = null;
+        try {
+           baudRate = perNode.getAttribute("speed").getValue();
+           adapter.configureBaudRate(baudRate);
+        } catch (java.lang.NullPointerException npe) {
+           // when the storage format has not been upgraded to the new format,
+           // the baudRate incorrectly gets added to the shared attributes.
+           baudRate = shared.getAttribute("speed").getValue();
+           adapter.configureBaudRate(baudRate);
+        }
 
-        loadCommon(shared, perNode, adapter);
+        //loadCommon(shared, perNode, adapter);
         // register, so can be picked up next time
         register();
         // try to open the port


### PR DESCRIPTION
This PR fixes a bug loading a profile that was not previously converted to the new storage format.  When the profile is loaded, the portName and baudRate are incorrectly grouped with the shared preferences instead of the pernode preferences. 