### PR TITLE
Fix for MERG Concentrator init string

### DIFF
--- a/java/src/jmri/jmrix/rfid/protocol/coreid/CoreIdRfidProtocol.java
+++ b/java/src/jmri/jmrix/rfid/protocol/coreid/CoreIdRfidProtocol.java
@@ -122,6 +122,9 @@ public class CoreIdRfidProtocol extends RfidProtocol {
                 log.debug("Not a correctly formed message");
             }
             return true;
+        } else if (isConcentrator && (msg.getNumDataElements() == 1) && (msg.getElement(0) & 0xFF) == 0x3E) {
+            log.debug("Init message from Concentrator: {}", msg);
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
Missed the init string sent at power up by MERG concentrator.

This is only seen if JMRI is started before power is applied to the concentrator.