### PR TITLE
Always load panel files on proper thread

### DIFF
--- a/java/src/jmri/JmriException.java
+++ b/java/src/jmri/JmriException.java
@@ -16,6 +16,10 @@ public class JmriException extends Exception {
         super(s);
     }
 
+    public JmriException(Exception s) {
+        super(s);
+    }
+
     public JmriException() {
     }
 

--- a/java/src/jmri/JmriException.java
+++ b/java/src/jmri/JmriException.java
@@ -1,4 +1,3 @@
-// JmriException.java
 package jmri;
 
 /**
@@ -6,14 +5,8 @@ package jmri;
  * type-safety.
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2008, 2010
- * @version	$Revision$
  */
 public class JmriException extends Exception {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 2804039803790645735L;
 
     public JmriException(String s, Throwable t) {
         super(s, t);
@@ -27,5 +20,3 @@ public class JmriException extends Exception {
     }
 
 }
-
-/* @(#)JmriException.java */

--- a/java/src/jmri/configurexml/BlockManagerXml.java
+++ b/java/src/jmri/configurexml/BlockManagerXml.java
@@ -1,4 +1,3 @@
-// BlockManagerXml.java
 package jmri.configurexml;
 
 import java.util.List;
@@ -24,7 +23,6 @@ import org.slf4j.LoggerFactory;
  * elements.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2008
- * @version $Revision$
  * @since 2.1.2
  *
  */

--- a/java/src/jmri/configurexml/BlockManagerXml.java
+++ b/java/src/jmri/configurexml/BlockManagerXml.java
@@ -95,75 +95,71 @@ public class BlockManagerXml extends jmri.managers.configurexml.AbstractMemoryMa
             // write out again with contents
             iter = tm.getSystemNameList().iterator();
             while (iter.hasNext()) {
-                try {
-                    String sname = iter.next();
-                    if (sname == null) {
-                        log.error("System name null during store skipped for this block");
+                String sname = iter.next();
+                if (sname == null) {
+                    log.error("System name null during store skipped for this block");
+                } else {
+                    Block b = tm.getBySystemName(sname);
+                    // the following null check is to catch a null pointer exception that sometimes was found to happen
+                    if (b == null) {
+                        log.error("Null Block during store - second store skipped for this block - " + sname);
                     } else {
-                        Block b = tm.getBySystemName(sname);
-                        // the following null check is to catch a null pointer exception that sometimes was found to happen
-                        if (b == null) {
-                            log.error("Null Block during store - second store skipped for this block - " + sname);
-                        } else {
-                            String uname = b.getUserName();
-                            if (uname == null) {
-                                uname = "";
-                            }
-                            Element elem = new Element("block")
-                                    .setAttribute("systemName", sname);
-                            elem.addContent(new Element("systemName").addContent(sname));
-                            if (log.isDebugEnabled()) {
-                                log.debug("second store Block " + sname + ":" + uname);
-                            }
-                            // store length and curvature attributes
-                            elem.setAttribute("length", Float.toString(b.getLengthMm()));
-                            elem.setAttribute("curve", Integer.toString(b.getCurvature()));
-                            // store common parts
-                            storeCommon(b, elem);
-
-                            if ((b.getBlockSpeed() != null) && (!b.getBlockSpeed().equals("")) && !b.getBlockSpeed().contains("Global")) {
-                                elem.addContent(new Element("speed").addContent(b.getBlockSpeed()));
-                            }
-                            String perm = "no";
-                            if (b.getPermissiveWorking()) {
-                                perm = "yes";
-                            }
-                            elem.addContent(new Element("permissive").addContent(perm));
-                            // Add content. First, the sensor.
-                            if (b.getNamedSensor() != null) {
-                                elem.addContent(new Element("occupancysensor").addContent(b.getNamedSensor().getName()));
-                            }
-
-                            if (b.getDeniedBlocks().size() > 0) {
-                                Element denied = new Element("deniedBlocks");
-                                for (String deniedBlock : b.getDeniedBlocks()) {
-                                    denied.addContent(new Element("block").addContent(deniedBlock));
-                                }
-                                elem.addContent(denied);
-                            }
-
-                            // Now the Reporter
-                            Reporter r = b.getReporter();
-                            if (r != null) {
-                                Element re = new Element("reporter");
-                                re.setAttribute("systemName", r.getSystemName());
-                                re.setAttribute("useCurrent", b.isReportingCurrent() ? "yes" : "no");
-                                elem.addContent(re);
-                            }
-
-                            if (tm.savePathInfo()) {
-                                // then the paths
-                                List<Path> paths = b.getPaths();
-                                for (int i = 0; i < paths.size(); i++) {
-                                    addPath(elem, paths.get(i));
-                                }
-                                // and put this element out
-                            }
-                            blocks.addContent(elem);
+                        String uname = b.getUserName();
+                        if (uname == null) {
+                            uname = "";
                         }
+                        Element elem = new Element("block")
+                                .setAttribute("systemName", sname);
+                        elem.addContent(new Element("systemName").addContent(sname));
+                        if (log.isDebugEnabled()) {
+                            log.debug("second store Block " + sname + ":" + uname);
+                        }
+                        // store length and curvature attributes
+                        elem.setAttribute("length", Float.toString(b.getLengthMm()));
+                        elem.setAttribute("curve", Integer.toString(b.getCurvature()));
+                        // store common parts
+                        storeCommon(b, elem);
+
+                        if ((b.getBlockSpeed() != null) && (!b.getBlockSpeed().equals("")) && !b.getBlockSpeed().contains("Global")) {
+                            elem.addContent(new Element("speed").addContent(b.getBlockSpeed()));
+                        }
+                        String perm = "no";
+                        if (b.getPermissiveWorking()) {
+                            perm = "yes";
+                        }
+                        elem.addContent(new Element("permissive").addContent(perm));
+                        // Add content. First, the sensor.
+                        if (b.getNamedSensor() != null) {
+                            elem.addContent(new Element("occupancysensor").addContent(b.getNamedSensor().getName()));
+                        }
+
+                        if (b.getDeniedBlocks().size() > 0) {
+                            Element denied = new Element("deniedBlocks");
+                            for (String deniedBlock : b.getDeniedBlocks()) {
+                                denied.addContent(new Element("block").addContent(deniedBlock));
+                            }
+                            elem.addContent(denied);
+                        }
+
+                        // Now the Reporter
+                        Reporter r = b.getReporter();
+                        if (r != null) {
+                            Element re = new Element("reporter");
+                            re.setAttribute("systemName", r.getSystemName());
+                            re.setAttribute("useCurrent", b.isReportingCurrent() ? "yes" : "no");
+                            elem.addContent(re);
+                        }
+
+                        if (tm.savePathInfo()) {
+                            // then the paths
+                            List<Path> paths = b.getPaths();
+                            for (int i = 0; i < paths.size(); i++) {
+                                addPath(elem, paths.get(i));
+                            }
+                            // and put this element out
+                        }
+                        blocks.addContent(elem);
                     }
-                } catch (Exception e) {
-                    log.error(e.toString());
                 }
             }
         }

--- a/java/src/jmri/configurexml/ConfigXmlManager.java
+++ b/java/src/jmri/configurexml/ConfigXmlManager.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
  * @see <A HREF="package-summary.html">Package summary for details of the
  * overall structure</A>
  * @author Bob Jacobsen Copyright (c) 2002, 2008
- * @version $Revision$
  */
 public class ConfigXmlManager extends jmri.jmrit.XmlFile
         implements jmri.ConfigureManager {

--- a/java/src/jmri/configurexml/ConfigXmlManager.java
+++ b/java/src/jmri/configurexml/ConfigXmlManager.java
@@ -529,25 +529,6 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
         );
     }
 
-//     private void loadVersion(Element root, XmlAdapter adapter) {
-//         int majorRelease = 0;
-//         int minorRelease = 0;
-//         int testRelease = 0;
-//         Element v = root.getChild("jmriversion");
-//         if (v!=null) {
-//             try {
-//                 majorRelease = Integer.parseInt(v.getChild("major").getText());
-//                 minorRelease = Integer.parseInt(v.getChild("minor").getText());
-//                 testRelease = Integer.parseInt(v.getChild("test").getText());
-//             } catch (NullPointerException npe) {
-//             } catch ( NumberFormatException nfe) {
-//             }
-//         }
-//         adapter.setConfigXmlManager(this);
-//         adapter.setMajorRelease(majorRelease);
-//         adapter.setMinorRelease(minorRelease);
-//         adapter.setTestRelease(testRelease);
-//     }
     /**
      * Load a file.
      * <p>

--- a/java/src/jmri/configurexml/ConfigXmlManager.java
+++ b/java/src/jmri/configurexml/ConfigXmlManager.java
@@ -693,9 +693,21 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
             creationErrorEncountered(null, "parsing file " + url.getFile(),
                     "Parse error", null, null, e);
             result = false;
-        } catch (java.lang.Exception e) {
+        } catch (java.io.IOException e) {
             creationErrorEncountered(null, "loading from file " + url.getFile(),
-                    "Unknown error (Exception)", null, null, e);
+                    "IOException", null, null, e);
+            result = false;
+        } catch (java.lang.ClassNotFoundException e) {
+            creationErrorEncountered(null, "loading from file " + url.getFile(),
+                    "ClassNotFoundException", null, null, e);
+            result = false;
+        } catch (java.lang.InstantiationException e) {
+            creationErrorEncountered(null, "loading from file " + url.getFile(),
+                    "InstantiationException", null, null, e);
+            result = false;
+        } catch (java.lang.IllegalAccessException e) {
+            creationErrorEncountered(null, "loading from file " + url.getFile(),
+                    "IllegalAccessException", null, null, e);
             result = false;
         } finally {
             // no matter what, close error reporting

--- a/java/src/jmri/configurexml/DefaultJavaBeanConfigXML.java
+++ b/java/src/jmri/configurexml/DefaultJavaBeanConfigXML.java
@@ -109,10 +109,13 @@ public class DefaultJavaBeanConfigXML extends jmri.configurexml.AbstractXmlAdapt
                 p.addContent(v);
                 e.addContent(p);
             }
-        } catch (Exception ex) {
-            log.error("Partial store due to exception: " + ex);
-            ex.printStackTrace();
-        }
+         } catch (java.beans.IntrospectionException ex) {
+             log.error("Partial store due to IntrospectionException: " + ex);
+         } catch (java.lang.reflect.InvocationTargetException ex) {
+             log.error("Partial store due to InvocationTargetException: " + ex);
+         } catch (IllegalAccessException ex) {
+             log.error("Partial store due to IllegalAccessException: " + ex);
+         }
 
         return e;
     }

--- a/java/src/jmri/configurexml/DefaultJavaBeanConfigXML.java
+++ b/java/src/jmri/configurexml/DefaultJavaBeanConfigXML.java
@@ -38,43 +38,38 @@ public class DefaultJavaBeanConfigXML extends jmri.configurexml.AbstractXmlAdapt
 
         Object o = ctor.newInstance(new Object[]{});
 
-        try {
-            // reflect through and add parameters
-            BeanInfo b = Introspector.getBeanInfo(o.getClass());
-            PropertyDescriptor[] properties = b.getPropertyDescriptors();
+        // reflect through and add parameters
+        BeanInfo b = Introspector.getBeanInfo(o.getClass());
+        PropertyDescriptor[] properties = b.getPropertyDescriptors();
 
-            // add properties
-            List<Element> children = e.getChildren("property");
-            for (int i = 0; i < children.size(); i++) {
-                // unpack XML
-                Element property = children.get(i);
-                Element eName = property.getChild("name");
-                Element eValue = property.getChild("value");
-                String name = eName.getText();
-                String value = eValue.getText();
-                String type = eName.getAttributeValue("type");
+        // add properties
+        List<Element> children = e.getChildren("property");
+        for (int i = 0; i < children.size(); i++) {
+            // unpack XML
+            Element property = children.get(i);
+            Element eName = property.getChild("name");
+            Element eValue = property.getChild("value");
+            String name = eName.getText();
+            String value = eValue.getText();
+            String type = eName.getAttributeValue("type");
 
-                // find matching method
-                for (int j = 0; j < properties.length; j++) {
-                    if (properties[j].getName().equals(name)) {
-                        // match, set this one by first finding method
-                        Method m = properties[j].getWriteMethod();
+            // find matching method
+            for (int j = 0; j < properties.length; j++) {
+                if (properties[j].getName().equals(name)) {
+                    // match, set this one by first finding method
+                    Method m = properties[j].getWriteMethod();
 
-                        // sort by type
-                        if (type.equals("class java.lang.String")) {
-                            m.invoke(o, new Object[]{value});
-                        } else if (type.equals("int")) {
-                            m.invoke(o, new Object[]{Integer.valueOf(value)});
-                        } else {
-                            log.error("Can't handle type: " + type);
-                        }
-                        break;
+                    // sort by type
+                    if (type.equals("class java.lang.String")) {
+                        m.invoke(o, new Object[]{value});
+                    } else if (type.equals("int")) {
+                        m.invoke(o, new Object[]{Integer.valueOf(value)});
+                    } else {
+                        log.error("Can't handle type: " + type);
                     }
+                    break;
                 }
             }
-        } catch (Exception ex) {
-            log.error("Partial load due to exception: " + ex);
-            ex.printStackTrace();
         }
 
         return o;

--- a/java/src/jmri/configurexml/DefaultJavaBeanConfigXML.java
+++ b/java/src/jmri/configurexml/DefaultJavaBeanConfigXML.java
@@ -1,4 +1,3 @@
-// DefaultJavaBeanConfigXML.java
 package jmri.configurexml;
 
 import java.beans.BeanInfo;
@@ -16,7 +15,6 @@ import org.slf4j.LoggerFactory;
  * Provides services for storing Java Beans to XML using reflection.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2009
- * @version $Revision$
  * @since 2.3.1
  */
 public class DefaultJavaBeanConfigXML extends jmri.configurexml.AbstractXmlAdapter {

--- a/java/src/jmri/configurexml/JmriConfigureXmlException.java
+++ b/java/src/jmri/configurexml/JmriConfigureXmlException.java
@@ -1,4 +1,3 @@
-// JmriConfigureXmlException.java
 package jmri.configurexml;
 
 /**
@@ -6,14 +5,8 @@ package jmri.configurexml;
  * to confirm type-safety.
  *
  * @author	Bob Jacobsen Copyright (C) 2009, 2010
- * @version	$Revision$
  */
 public class JmriConfigureXmlException extends jmri.JmriException {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1321961285382362044L;
 
     public JmriConfigureXmlException(String s, Throwable t) {
         super(s, t);
@@ -28,4 +21,3 @@ public class JmriConfigureXmlException extends jmri.JmriException {
     }
 }
 
-/* @(#)JmriConfigureXmlException.java */

--- a/java/src/jmri/configurexml/JmriConfigureXmlException.java
+++ b/java/src/jmri/configurexml/JmriConfigureXmlException.java
@@ -16,6 +16,10 @@ public class JmriConfigureXmlException extends jmri.JmriException {
         super(s);
     }
 
+    public JmriConfigureXmlException(Exception s) {
+        super(s);
+    }
+
     public JmriConfigureXmlException() {
         super();
     }

--- a/java/src/jmri/configurexml/TransitManagerXml.java
+++ b/java/src/jmri/configurexml/TransitManagerXml.java
@@ -185,39 +185,31 @@ public class TransitManagerXml extends jmri.managers.configurexml.AbstractNamedB
                         alt = true;
                     }
                     TransitSection ts = new TransitSection(sectionName, seq, dir, alt);
-                    if (ts == null) {
-                        log.error("Trouble creation TransitSection for Transit - " + sysName);
-                    } else {
-                        x.addTransitSection(ts);
-                        // load transitsectionaction children, if any
-                        List<Element> transitTransitSectionActionList = transitTransitSectionList.get(n).
-                                getChildren("transitsectionaction");
-                        for (int m = 0; m < transitTransitSectionActionList.size(); m++) {
-                            Element elemx = transitTransitSectionActionList.get(m);
-                            int tWhen = 1;
-                            int tWhat = 1;
-                            int tWhenData = 0;
-                            String tWhenString = elemx.getAttribute("whenstring").getValue();
-                            int tWhatData1 = 0;
-                            int tWhatData2 = 0;
-                            String tWhatString = elemx.getAttribute("whatstring").getValue();
-                            try {
-                                tWhen = elemx.getAttribute("whencode").getIntValue();
-                                tWhat = elemx.getAttribute("whatcode").getIntValue();
-                                tWhenData = elemx.getAttribute("whendata").getIntValue();
-                                tWhatData1 = elemx.getAttribute("whatdata1").getIntValue();
-                                tWhatData2 = elemx.getAttribute("whatdata2").getIntValue();
-                            } catch (Exception e) {
-                                log.error("Data Conversion Exception when loading transit section action - " + e);
-                            }
-                            TransitSectionAction tsa = new TransitSectionAction(tWhen, tWhat, tWhenData,
-                                    tWhatData1, tWhatData2, tWhenString, tWhatString);
-                            if (tsa == null) {
-                                log.error("Trouble creating TransitSectionAction for Transit - " + sysName);
-                            } else {
-                                ts.addAction(tsa);
-                            }
+                    x.addTransitSection(ts);
+                    // load transitsectionaction children, if any
+                    List<Element> transitTransitSectionActionList = transitTransitSectionList.get(n).
+                            getChildren("transitsectionaction");
+                    for (int m = 0; m < transitTransitSectionActionList.size(); m++) {
+                        Element elemx = transitTransitSectionActionList.get(m);
+                        int tWhen = 1;
+                        int tWhat = 1;
+                        int tWhenData = 0;
+                        String tWhenString = elemx.getAttribute("whenstring").getValue();
+                        int tWhatData1 = 0;
+                        int tWhatData2 = 0;
+                        String tWhatString = elemx.getAttribute("whatstring").getValue();
+                        try {
+                            tWhen = elemx.getAttribute("whencode").getIntValue();
+                            tWhat = elemx.getAttribute("whatcode").getIntValue();
+                            tWhenData = elemx.getAttribute("whendata").getIntValue();
+                            tWhatData1 = elemx.getAttribute("whatdata1").getIntValue();
+                            tWhatData2 = elemx.getAttribute("whatdata2").getIntValue();
+                        } catch (Exception e) {
+                            log.error("Data Conversion Exception when loading transit section action - " + e);
                         }
+                        TransitSectionAction tsa = new TransitSectionAction(tWhen, tWhat, tWhenData,
+                                tWhatData1, tWhatData2, tWhenString, tWhatString);
+                        ts.addAction(tsa);
                     }
                 }
             }

--- a/java/src/jmri/configurexml/TransitManagerXml.java
+++ b/java/src/jmri/configurexml/TransitManagerXml.java
@@ -1,4 +1,3 @@
-// TransitManagerXML.java
 package jmri.configurexml;
 
 import java.util.ArrayList;
@@ -18,7 +17,6 @@ import org.slf4j.LoggerFactory;
  * <P>
  *
  * @author Dave Duchamp Copyright (c) 2008
- * @version $Revision$
  */
 public class TransitManagerXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
 


### PR DESCRIPTION
In a ConfigureXML load is invoked from the wrong thread (currently, from off the Swing thread), switch and do the load properly, waiting for completion.

- JmriException and subclasses can now be constructed from another exception, good for tunneling between threads
- Fix some FindBugs issues in jmri.configurexml
