### PR TITLE
Add getEntryByDccAddress() method to Roster

### DIFF
--- a/java/src/jmri/jmrit/roster/Roster.java
+++ b/java/src/jmri/jmrit/roster/Roster.java
@@ -321,6 +321,21 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
         return null;
     }
 
+     /**
+     * Return RosterEntry from a DCC address.
+     *
+     * @param a 
+     * @return The matching RosterEntry or null
+     */
+    public RosterEntry getEntryByDccAddress(String a) {
+        for (RosterEntry re : _list) {
+            if (re.getDccAddress().equals(a)) {
+                return re;
+            }
+        }
+        return null;
+    }
+
     /**
      * Return a specific entry by index
      *

--- a/java/src/jmri/jmrit/roster/Roster.java
+++ b/java/src/jmri/jmrit/roster/Roster.java
@@ -322,18 +322,20 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
     }
 
      /**
-     * Return RosterEntry from a DCC address.
+     * Return a list of RosterEntry which have a 
+     * particular DCC address.
      *
      * @param a 
-     * @return The matching RosterEntry or null
+     * @return an ArrayList of matching entries
      */
-    public RosterEntry getEntryByDccAddress(String a) {
+    public List<RosterEntry> getEntriesByDccAddress(String a) {
+        List<RosterEntry> list = new ArrayList<>(); 
         for (RosterEntry re : _list) {
             if (re.getDccAddress().equals(a)) {
-                return re;
+                list.add(re);
             }
         }
-        return null;
+        return list;
     }
 
     /**


### PR DESCRIPTION
Adds a method to Roster which returns a RosterEntry based on the DCC address.