### PR TITLE
Handle ERROR messages logged during AllTest

### DIFF
--- a/java/test/jmri/jmris/JmriServerTest.java
+++ b/java/test/jmri/jmris/JmriServerTest.java
@@ -1,4 +1,3 @@
-//JmriServerTest.java
 package jmri.jmris;
 
 import junit.framework.Assert;
@@ -10,7 +9,6 @@ import junit.framework.TestSuite;
  * Tests for the jmri.jmris.JmriServer class 
  *
  * @author Paul Bender
- * @version $Revision$
  */
 public class JmriServerTest extends TestCase {
 
@@ -27,6 +25,7 @@ public class JmriServerTest extends TestCase {
     public void testCtorPortAndTimeout() {
         JmriServer a = new JmriServer(25520,100);
         Assert.assertNotNull(a);
+        jmri.util.JUnitAppender.assertErrorMessage("Failed to connect to port 25520");
     }
 
     // from here down is testing infrastructure

--- a/java/test/jmri/jmris/simpleserver/SimpleServerTest.java
+++ b/java/test/jmri/jmris/simpleserver/SimpleServerTest.java
@@ -17,12 +17,13 @@ public class SimpleServerTest extends TestCase {
     public void testCtor() {
         SimpleServer a = new SimpleServer();
         Assert.assertNotNull(a);
+        jmri.util.JUnitAppender.assertErrorMessage("Failed to connect to port 2048");
     }
 
     public void testCtorwithParameter() {
         SimpleServer a = new SimpleServer(2048);
-        jmri.util.JUnitAppender.assertErrorMessage("Failed to connect to port 2048");
         Assert.assertNotNull(a);
+        jmri.util.JUnitAppender.assertErrorMessage("Failed to connect to port 2048");
     }
 
     // from here down is testing infrastructure

--- a/java/test/jmri/jmrit/operations/rollingstock/OperationsRollingStockTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/OperationsRollingStockTest.java
@@ -81,6 +81,8 @@ public class OperationsRollingStockTest extends OperationsTestCase {
         } catch(java.lang.NullPointerException npe) {
            Assert.fail("Null Pointer Exception while executing Xml Element Constructor");
         }
+        
+        jmri.util.JUnitAppender.assertErrorMessage("Tag 12345 Not Found");
     }
 
 
@@ -231,11 +233,16 @@ public class OperationsRollingStockTest extends OperationsTestCase {
         testtrack1.deleteRoadName("TESTROAD");
         testresult = rs1.setLocation(testlocation1, testtrack1);
         Assert.assertEquals("RollingStock Set null excluderoads", "okay", testresult);
+        
+        // Normally logged message
+        jmri.util.JUnitAppender.assertErrorMessage("Rolling stock (TESTROAD TESTNUMBER1) length () is not valid");
+        
     }
 
     // Ensure minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
+        apps.tests.Log4JFixture.setUp();
         super.setUp();
     }
 
@@ -258,6 +265,7 @@ public class OperationsRollingStockTest extends OperationsTestCase {
     // The minimal setup for log4J
     @Override
     protected void tearDown() throws Exception {
-       super.tearDown();
+        super.tearDown();
+        apps.tests.Log4JFixture.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/CarsTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/CarsTest.java
@@ -99,6 +99,8 @@ public class CarsTest extends OperationsTestCase {
         } catch(java.lang.NullPointerException npe) {
            Assert.fail("Null Pointer Exception while executing Xml Element Constructor");
         }
+
+        jmri.util.JUnitAppender.assertErrorMessage("Kernel TESTKERNEL does not exist");
     }
 
     

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/KernelTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/KernelTest.java
@@ -1,4 +1,3 @@
-// KernelTest.java
 package jmri.jmrit.operations.rollingstock.cars;
 
 import jmri.jmrit.operations.OperationsTestCase;
@@ -13,7 +12,6 @@ import junit.framework.TestSuite;
  * Still to do: Everything
  *
  * @author	Bob Coleman Copyright (C) 2008, 2009
- * @version $Revision$
  */
 public class KernelTest extends OperationsTestCase {
 

--- a/java/test/jmri/jmrit/operations/setup/OperationsBackupTest.java
+++ b/java/test/jmri/jmrit/operations/setup/OperationsBackupTest.java
@@ -422,7 +422,7 @@ public class OperationsBackupTest extends TestCase {
         createDummyXmlFile(operationsRoot, regularBackupSetFileNames[0]);
 
         backup.copyBackupSet(operationsRoot, setDir);
-//        jmri.util.JUnitAppender.assertWarnMessage("Only 1 file(s) found in directory "+operationsRoot.getPath());
+        jmri.util.JUnitAppender.assertWarnMessage("Only 1 file(s) found in directory "+operationsRoot.getAbsolutePath());
 
         // Should NOT throw an exception, and the destination dir should exist.
         Boolean exists = existsFile(defaultBackupRoot, setName);


### PR DESCRIPTION
It's better to _not_ have people routinely ignoring ERROR messages during CI tests, so this handles some of them.