### PR TITLE
Initial ConnectionConfigManager tests

### DIFF
--- a/java/test/jmri/jmrix/ConnectionConfigManagerTest.java
+++ b/java/test/jmri/jmrix/ConnectionConfigManagerTest.java
@@ -9,7 +9,6 @@
 package jmri.jmrix;
 
 import apps.tests.Log4JFixture;
-import jmri.InstanceManager;
 import jmri.jmrix.internal.InternalConnectionTypeList;
 import jmri.util.JUnitUtil;
 import junit.framework.Test;
@@ -18,29 +17,17 @@ import junit.framework.TestSuite;
 
 public abstract class ConnectionConfigManagerTest extends TestCase {
 
-    public ConnectionConfigManagerTest(String s) {
-        super(s);
-    }
-
-    public void testGetConnectionManufacturers() throws ClassNotFoundException {
+    public void testGetConnectionManufacturers() {
         ConnectionConfigManager manager = new ConnectionConfigManager();
-        // ConnectionTypeManager is private within ConnectionConfigManager
-        Class<?> typeManager = Class.forName(ConnectionConfigManager.class.getCanonicalName() + "$ConnectionTypeManager");
-        assertNull(InstanceManager.getDefault(typeManager));
         String[] result = manager.getConnectionManufacturers();
-        assertNotNull(InstanceManager.getDefault(typeManager));
         assertTrue(result.length > 1);
         assertEquals(result[0], InternalConnectionTypeList.NONE);
         JUnitUtil.resetInstanceManager();
     }
 
-    public void testGetConnectionTypes() throws ClassNotFoundException {
+    public void testGetConnectionTypes() {
         ConnectionConfigManager manager = new ConnectionConfigManager();
-        // ConnectionTypeManager is private within ConnectionConfigManager
-        Class<?> typeManager = Class.forName(ConnectionConfigManager.class.getCanonicalName() + "$ConnectionTypeManager");
-        assertNull(InstanceManager.getDefault(typeManager));
         String[] result = manager.getConnectionTypes(InternalConnectionTypeList.NONE);
-        assertNotNull(InstanceManager.getDefault(typeManager));
         assertEquals(1, result.length);
         assertEquals(result[0], "jmri.jmrix.internal.ConnectionConfig");
         JUnitUtil.resetInstanceManager();
@@ -48,8 +35,7 @@ public abstract class ConnectionConfigManagerTest extends TestCase {
 
     // test suite from all defined tests
     public static Test suite() {
-        TestSuite suite = new TestSuite(ConnectionConfigManagerTest.class);
-        return suite;
+        return new TestSuite(ConnectionConfigManagerTest.class);
     }
 
     @Override

--- a/java/test/jmri/jmrix/ConnectionConfigManagerTest.java
+++ b/java/test/jmri/jmrix/ConnectionConfigManagerTest.java
@@ -15,7 +15,7 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
-public abstract class ConnectionConfigManagerTest extends TestCase {
+public class ConnectionConfigManagerTest extends TestCase {
 
     public void testGetConnectionManufacturers() {
         ConnectionConfigManager manager = new ConnectionConfigManager();

--- a/java/test/jmri/jmrix/ConnectionConfigManagerTest.java
+++ b/java/test/jmri/jmrix/ConnectionConfigManagerTest.java
@@ -1,0 +1,69 @@
+/**
+ * AbstractPowerManagerTest.java
+ *
+ * Description:	AbsBaseClass for PowerManager tests in specific jmrix. packages
+ *
+ * @author	Bob Jacobsen Copyright 2007
+ * @version	$Revision$
+ */
+package jmri.jmrix;
+
+import apps.tests.Log4JFixture;
+import jmri.InstanceManager;
+import jmri.jmrix.internal.InternalConnectionTypeList;
+import jmri.util.JUnitUtil;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+public abstract class ConnectionConfigManagerTest extends TestCase {
+
+    public ConnectionConfigManagerTest(String s) {
+        super(s);
+    }
+
+    public void testGetConnectionManufacturers() throws ClassNotFoundException {
+        ConnectionConfigManager manager = new ConnectionConfigManager();
+        // ConnectionTypeManager is private within ConnectionConfigManager
+        Class<?> typeManager = Class.forName(ConnectionConfigManager.class.getCanonicalName() + "$ConnectionTypeManager");
+        assertNull(InstanceManager.getDefault(typeManager));
+        String[] result = manager.getConnectionManufacturers();
+        assertNotNull(InstanceManager.getDefault(typeManager));
+        assertTrue(result.length > 1);
+        assertEquals(result[0], InternalConnectionTypeList.NONE);
+        JUnitUtil.resetInstanceManager();
+    }
+
+    public void testGetConnectionTypes() throws ClassNotFoundException {
+        ConnectionConfigManager manager = new ConnectionConfigManager();
+        // ConnectionTypeManager is private within ConnectionConfigManager
+        Class<?> typeManager = Class.forName(ConnectionConfigManager.class.getCanonicalName() + "$ConnectionTypeManager");
+        assertNull(InstanceManager.getDefault(typeManager));
+        String[] result = manager.getConnectionTypes(InternalConnectionTypeList.NONE);
+        assertNotNull(InstanceManager.getDefault(typeManager));
+        assertEquals(1, result.length);
+        assertEquals(result[0], "jmri.jmrix.internal.ConnectionConfig");
+        JUnitUtil.resetInstanceManager();
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        TestSuite suite = new TestSuite(ConnectionConfigManagerTest.class);
+        return suite;
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        Log4JFixture.setUp();
+        super.setUp();
+        JUnitUtil.resetInstanceManager();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        Log4JFixture.tearDown();
+        JUnitUtil.resetInstanceManager();
+    }
+
+}

--- a/java/test/jmri/jmrix/PackageTest.java
+++ b/java/test/jmri/jmrix/PackageTest.java
@@ -35,6 +35,7 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.jmrix.AbstractMRReplyTest.suite());
         suite.addTest(new TestSuite(jmri.jmrix.AbstractThrottleTest.class));
         suite.addTest(jmri.jmrix.BundleTest.suite());
+        suite.addTest(jmri.jmrix.ConnectionConfigManagerTest.suite());
 
         suite.addTest(jmri.jmrix.acela.PackageTest.suite());
         suite.addTest(jmri.jmrix.can.PackageTest.suite());


### PR DESCRIPTION
These tests ensure that #974 continues to work correctly.