### PR TITLE
Handle intermittent ERROR messages during test

### DIFF
--- a/java/test/jmri/jmris/JmriServerTest.java
+++ b/java/test/jmri/jmris/JmriServerTest.java
@@ -25,7 +25,7 @@ public class JmriServerTest extends TestCase {
     public void testCtorPortAndTimeout() {
         JmriServer a = new JmriServer(25520,100);
         Assert.assertNotNull(a);
-        jmri.util.JUnitAppender.assertErrorMessage("Failed to connect to port 25520");
+        jmri.util.JUnitAppender.suppressErrorMessage("Failed to connect to port 25520");
     }
 
     // from here down is testing infrastructure

--- a/java/test/jmri/jmris/simpleserver/SimpleServerTest.java
+++ b/java/test/jmri/jmris/simpleserver/SimpleServerTest.java
@@ -17,13 +17,13 @@ public class SimpleServerTest extends TestCase {
     public void testCtor() {
         SimpleServer a = new SimpleServer();
         Assert.assertNotNull(a);
-        jmri.util.JUnitAppender.assertErrorMessage("Failed to connect to port 2048");
+        jmri.util.JUnitAppender.suppressErrorMessage("Failed to connect to port 2048");
     }
 
     public void testCtorwithParameter() {
         SimpleServer a = new SimpleServer(2048);
         Assert.assertNotNull(a);
-        jmri.util.JUnitAppender.assertErrorMessage("Failed to connect to port 2048");
+        jmri.util.JUnitAppender.suppressErrorMessage("Failed to connect to port 2048");
     }
 
     // from here down is testing infrastructure

--- a/java/test/jmri/util/JUnitAppender.java
+++ b/java/test/jmri/util/JUnitAppender.java
@@ -141,6 +141,35 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
     }
 
     /**
+     * If there's a next matching message of Error severity, just ignore it.
+     * Not an error if not present; mismatch is an error
+     */
+    public static void suppressErrorMessage(String msg) {
+        if (list.isEmpty()) {
+            return;
+        }
+
+        LoggingEvent evt = list.remove(0);
+
+        while ((evt.getLevel() == Level.INFO) || (evt.getLevel() == Level.DEBUG)) {
+            if (list.isEmpty()) {
+                Assert.fail("Only debug/info messages present: " + msg);
+                return;
+            }
+            evt = list.remove(0);
+        }
+
+        // check the remaining message, if any
+        if (evt.getLevel() != Level.ERROR) {
+            Assert.fail("Level mismatch when looking for ERROR message: \"" + msg + "\" found \"" + (String) evt.getMessage() + "\"");
+        }
+
+        if (!compare((String) evt.getMessage(), msg)) {
+            Assert.fail("Looking for ERROR message \"" + msg + "\" got \"" + evt.getMessage() + "\"");
+        }
+    }
+
+    /**
      * Check that the next queued message was of Warn severity, and has a
      * specific message.
      * <P>


### PR DESCRIPTION
@rhwood pointed out that some of the jmri.jmris test messages aren't consistently issued.  This adds support for optionally-present messages, and applies it to that case.