### PR TITLE
Updates to Internal system

### DIFF
--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -73,6 +73,7 @@ public class InstanceManager {
      *             the key to retrieve the object later.
      */
     static public <T> void store(T item, Class<T> type) {
+        log.debug("Store item of type {}", type.getName());
         ArrayList<Object> l = managerLists.get(type);
         if (l == null) {
             l = new ArrayList<>();
@@ -89,6 +90,7 @@ public class InstanceManager {
      */
     @SuppressWarnings("unchecked") // the cast here is protected by the structure of the managerLists
     static public <T> List<T> getList(Class<T> type) {
+        log.debug("Get list of type {}", type.getName());
         return (List<T>) managerLists.get(type);
     }
 
@@ -98,6 +100,7 @@ public class InstanceManager {
      * @param type The class Object for the items to be removed.
      */
     static public <T> void reset(Class<T> type) {
+        log.debug("Reset type {}", type.getName());
         managerLists.put(type, null);
     }
 
@@ -109,6 +112,7 @@ public class InstanceManager {
      * @param type The class Object for the item's type.
      */
     static public <T> void deregister(T item, Class<T> type) {
+        log.debug("Remove item type {}", type.getName());
         ArrayList<Object> l = managerLists.get(type);
         if (l != null) {
             l.remove(item);
@@ -124,7 +128,7 @@ public class InstanceManager {
      */
     @SuppressWarnings("unchecked")   // checked by construction
     static public <T> T getDefault(Class<T> type) {
-        log.trace("getDefault {}", type.getName());
+        log.trace("getDefault of type {}", type.getName());
         ArrayList<Object> l = managerLists.get(type);
         if (l == null || l.size() < 1) {
             // see if can autocreate
@@ -138,7 +142,16 @@ public class InstanceManager {
                 try {
                     l.add(type.getConstructor((Class[]) null).newInstance((Object[]) null));
                     log.debug("      auto-created default of {}", type.getName());
-                } catch (Exception e) {
+                } catch (NoSuchMethodException e) {
+                    log.error("Exception creating auto-default object", e); // unexpected
+                    return null;
+                } catch (InstantiationException e) {
+                    log.error("Exception creating auto-default object", e); // unexpected
+                    return null;
+                } catch (IllegalAccessException e) {
+                    log.error("Exception creating auto-default object", e); // unexpected
+                    return null;
+                } catch (java.lang.reflect.InvocationTargetException e) {
                     log.error("Exception creating auto-default object", e); // unexpected
                     return null;
                 }
@@ -172,6 +185,7 @@ public class InstanceManager {
      * {@link #getDefault} method
      */
     static public <T> void setDefault(Class<T> type, T val) {
+        log.trace("setDefault for type {}", type.getName());
         List<T> l = getList(type);
         if (l == null || (l.size() < 1)) {
             store(val, type);

--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -53,12 +53,12 @@ import org.slf4j.LoggerFactory;
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  * <P>
- * @author	Bob Jacobsen Copyright (C) 2001, 2008, 2013
+ * @author	Bob Jacobsen Copyright (C) 2001, 2008, 2013, 2016
  * @author Matthew Harris copyright (c) 2009
  */
 public class InstanceManager {
 
-    static final private HashMap<Class<?>, ArrayList<Object>> managerLists = new HashMap<Class<?>, ArrayList<Object>>();
+    static final private HashMap<Class<?>, ArrayList<Object>> managerLists = new HashMap<>();
 
     /* properties */
     public static String CONSIST_MANAGER = "consistmanager"; // NOI18N
@@ -75,7 +75,7 @@ public class InstanceManager {
     static public <T> void store(T item, Class<T> type) {
         ArrayList<Object> l = managerLists.get(type);
         if (l == null) {
-            l = new ArrayList<Object>();
+            l = new ArrayList<>();
             managerLists.put(type, l);
         }
         l.add(item);
@@ -132,7 +132,7 @@ public class InstanceManager {
             if (InstanceManagerAutoDefault.class.isAssignableFrom(type)) {
                 // yes, make sure list is present before creating object
                 if (l == null) {
-                    l = new ArrayList<Object>();
+                    l = new ArrayList<>();
                     managerLists.put(type, l);
                 }
                 try {
@@ -150,7 +150,7 @@ public class InstanceManager {
             if (obj != null) {
                 log.debug("      initializer created default of {}", type.getName());
                 if (l == null) {
-                    l = new ArrayList<Object>();
+                    l = new ArrayList<>();
                     managerLists.put(type, l);
                 }
                 l.add(obj);
@@ -252,7 +252,7 @@ public class InstanceManager {
         // make a copy of the listener vector to synchronized not needed for transmit
         Vector<PropertyChangeListener> v;
         synchronized (InstanceManager.class) {
-            v = new Vector<PropertyChangeListener>(listeners);
+            v = new Vector<>(listeners);
         }
         // forward to all listeners
         int cnt = v.size();
@@ -263,7 +263,7 @@ public class InstanceManager {
     }
 
     // data members to hold contact with the property listeners
-    final private static Vector<PropertyChangeListener> listeners = new Vector<PropertyChangeListener>();
+    final private static Vector<PropertyChangeListener> listeners = new Vector<>();
 
     // Simplification order - for each type, starting with those not in the jmri package:
     //   1) Remove it from jmri.managers.DefaultInstanceInitializer, get tests to build & run

--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -74,6 +74,7 @@ public class InstanceManager {
      */
     static public <T> void store(T item, Class<T> type) {
         log.debug("Store item of type {}", type.getName());
+        if (item == null) log.error("Should not store null value of type {}", type.getName(), new Exception("Traceback"));
         ArrayList<Object> l = managerLists.get(type);
         if (l == null) {
             l = new ArrayList<>();

--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -1,4 +1,3 @@
-// InstanceManager.java
 package jmri;
 
 import apps.gui3.TabbedPreferences;
@@ -56,7 +55,6 @@ import org.slf4j.LoggerFactory;
  * <P>
  * @author	Bob Jacobsen Copyright (C) 2001, 2008, 2013
  * @author Matthew Harris copyright (c) 2009
- * @version	$Revision$
  */
 public class InstanceManager {
 
@@ -692,5 +690,3 @@ public class InstanceManager {
     /* *************************************************************************** */
     private final static Logger log = LoggerFactory.getLogger(InstanceManager.class.getName());
 }
-
-/* @(#)InstanceManager.java */

--- a/java/src/jmri/TurnoutOperationManager.java
+++ b/java/src/jmri/TurnoutOperationManager.java
@@ -6,6 +6,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,11 +29,19 @@ public class TurnoutOperationManager {
     public TurnoutOperationManager() {
     }
 
+    private boolean initialized = false;
+    private void initialize() {
+        initialized = true;
+        // create the default instances of each of the known operation types
+        loadOperationTypes();
+    }
+    
     public void dispose() {
     }
 
     public TurnoutOperation[] getTurnoutOperations() {
         synchronized (this) {
+            if (!initialized) initialize();
             Collection<TurnoutOperation> entries = turnoutOperations.values();
             return entries.toArray(new TurnoutOperation[0]);
         }
@@ -44,12 +53,13 @@ public class TurnoutOperationManager {
      *
      * @param op
      */
-    protected void addOperation(TurnoutOperation op) {
+    protected void addOperation(@Nonnull TurnoutOperation op) {
         TurnoutOperation previous;
         if (op == null || op.getName() == null) {
             log.warn("null operation or name in addOperation");
         } else {
             synchronized (this) {
+                if (!initialized) initialize();
                 previous = turnoutOperations.put(op.getName(), op);
                 if (op.isDefinitive()) {
                     updateTypes(op);
@@ -62,11 +72,12 @@ public class TurnoutOperationManager {
         firePropertyChange("Content", null, null);
     }
 
-    protected void removeOperation(TurnoutOperation op) {
+    protected void removeOperation(@Nonnull TurnoutOperation op) {
         if (op == null || op.getName() == null) {
             log.warn("null operation or name in removeOperation");
         } else {
             synchronized (this) {
+                if (!initialized) initialize();
                 turnoutOperations.remove(op.getName());
             }
         }
@@ -79,8 +90,9 @@ public class TurnoutOperationManager {
      * @param name
      * @return	the operation
      */
-    public TurnoutOperation getOperation(String name) {
+    public TurnoutOperation getOperation(@Nonnull String name) {
         synchronized (this) {
+            if (!initialized) initialize();
             return turnoutOperations.get(name);
         }
     }
@@ -92,7 +104,8 @@ public class TurnoutOperationManager {
      *
      * @param op	new or updated operation
      */
-    private void updateTypes(TurnoutOperation op) {
+    private void updateTypes(@Nonnull TurnoutOperation op) {
+        if (!initialized) initialize();
         LinkedList<TurnoutOperation> newTypes = new LinkedList<TurnoutOperation>();
         Iterator<TurnoutOperation> iter = operationTypes.iterator();
         boolean found = false;
@@ -125,15 +138,11 @@ public class TurnoutOperationManager {
      *
      * @return	the TurnoutOperationManager
      */
-    public synchronized static TurnoutOperationManager getInstance() {
+    public synchronized static @Nonnull TurnoutOperationManager getInstance() {
         if (theInstance == null) {
 
             // and make available
             theInstance = new TurnoutOperationManager();
-
-            // create the default instances of each of the known operation types
-            theInstance.loadOperationTypes();
-
         }
         return theInstance;
     }
@@ -165,6 +174,9 @@ public class TurnoutOperationManager {
             } else if (getOperation(validTypes[i]) == null) {
                 try {
                     Class<?> thisClass = Class.forName(thisClassName);
+                    // creating the instance invokes the TurnoutOperation ctor,
+                    // which calls addOperation here, which adds it to the 
+                    // turnoutOperations map.
                     thisClass.newInstance();
                     if (log.isDebugEnabled()) {
                         log.debug("loaded TurnoutOperation class " + thisClassName);
@@ -187,7 +199,8 @@ public class TurnoutOperationManager {
      * @param t	           turnout
      * @param apparentMode	mode(s) to be used when finding a matching operation
      */
-    public TurnoutOperation getMatchingOperationAlways(Turnout t, int apparentMode) {
+    public TurnoutOperation getMatchingOperationAlways(@Nonnull Turnout t, int apparentMode) {
+        if (!initialized) initialize();
         Iterator<TurnoutOperation> iter = operationTypes.iterator();
         TurnoutOperation currentMatch = null;
         /* The loop below always returns the LAST operation 
@@ -216,14 +229,15 @@ public class TurnoutOperationManager {
      * @param apparentMode	mode(s) to be used when finding a matching operation
      * @return operation
      */
-    public TurnoutOperation getMatchingOperation(Turnout t, int apparentMode) {
+    public TurnoutOperation getMatchingOperation(@Nonnull Turnout t, int apparentMode) {
+        if (!initialized) initialize();
         if (doOperations) {
             return getMatchingOperationAlways(t, apparentMode);
         }
         return null;
     }
 
-    public TurnoutOperation getMatchingOperationAlways(Turnout t) {
+    public TurnoutOperation getMatchingOperationAlways(@Nonnull Turnout t) {
         return getMatchingOperationAlways(t, t.getFeedbackMode());
     }
 
@@ -231,10 +245,12 @@ public class TurnoutOperationManager {
      * get/change status of whether operations are in use
      */
     public boolean getDoOperations() {
+        if (!initialized) initialize();
         return doOperations;
     }
 
     public void setDoOperations(boolean b) {
+        if (!initialized) initialize();
         boolean oldValue = doOperations;
         doOperations = b;
         firePropertyChange("doOperations", Boolean.valueOf(oldValue), Boolean.valueOf(b));
@@ -249,7 +265,7 @@ public class TurnoutOperationManager {
      * @param types	list of types possibly containing dupliactes
      * @return list reduced as described above
      */
-    static public String[] concatenateTypeLists(String[] types) {
+    static public String[] concatenateTypeLists(@Nonnull String[] types) {
         List<String> outTypes = new LinkedList<String>();
         boolean noFeedbackWanted = false;
         for (int i = 0; i < types.length; ++i) {
@@ -272,15 +288,15 @@ public class TurnoutOperationManager {
      */
     java.beans.PropertyChangeSupport pcs = new java.beans.PropertyChangeSupport(this);
 
-    public synchronized void addPropertyChangeListener(java.beans.PropertyChangeListener l) {
+    public synchronized void addPropertyChangeListener(@Nonnull java.beans.PropertyChangeListener l) {
         pcs.addPropertyChangeListener(l);
     }
 
-    public synchronized void removePropertyChangeListener(java.beans.PropertyChangeListener l) {
+    public synchronized void removePropertyChangeListener(@Nonnull java.beans.PropertyChangeListener l) {
         pcs.removePropertyChangeListener(l);
     }
 
-    protected void firePropertyChange(String p, Object old, Object n) {
+    protected void firePropertyChange(@Nonnull String p, Object old, Object n) {
         pcs.firePropertyChange(p, old, n);
     }
 

--- a/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
@@ -22,11 +22,6 @@ import org.slf4j.LoggerFactory;
 
 abstract public class AbstractTableTabAction extends AbstractTableAction {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7423371299023131468L;
-
     protected JPanel dataPanel;
     protected JTabbedPane dataTabs;
 

--- a/java/src/jmri/jmrix/SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/SystemConnectionMemo.java
@@ -31,6 +31,7 @@ abstract public class SystemConnectionMemo {
     private String userNameAsLoaded;
 
     protected SystemConnectionMemo(String prefix, String userName) {
+        log.debug("SystemConnectionMemo created for prefix \"{}\" user name \"{}\"", prefix, userName);
         initialise();
         if (!setSystemPrefix(prefix)) {
             for (int x = 2; x < 50; x++) {
@@ -152,6 +153,7 @@ abstract public class SystemConnectionMemo {
             notifyPropertyChangeListener("ConnectionPrefixChanged", oldPrefix, systemPrefix);
             return true;
         }
+        log.debug("setSystemPrefix false for \"{}\"", systemPrefix);
         return false;
     }
 

--- a/java/src/jmri/jmrix/SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/SystemConnectionMemo.java
@@ -1,4 +1,3 @@
-// SystemConnectionMemo.java
 package jmri.jmrix;
 
 import apps.startup.StartupActionModelUtil;
@@ -21,7 +20,6 @@ import org.slf4j.LoggerFactory;
  * activate their particular system.
  *
  * @author	Bob Jacobsen Copyright (C) 2010
- * @version $Revision$
  */
 abstract public class SystemConnectionMemo {
 
@@ -326,6 +324,3 @@ abstract public class SystemConnectionMemo {
 
     private final static Logger log = LoggerFactory.getLogger(SystemConnectionMemo.class.getName());
 }
-
-
-/* @(#)SystemConnectionMemo.java */

--- a/java/src/jmri/jmrix/SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/SystemConnectionMemo.java
@@ -62,14 +62,25 @@ abstract public class SystemConnectionMemo {
      */
     private static void initialise() {
         if (!initialised) {
-            addUserName("Internal");
-            addSystemPrefix("I");
-            initialised = true;
+//             addUserName("Internal");
+//             addSystemPrefix("I");
+//             initialised = true;
         }
     }
 
-    final protected static ArrayList<String> userNames = new ArrayList<>();
-    final protected static ArrayList<String> sysPrefixes = new ArrayList<>();
+    /**
+     * For use in testing, undo any initialization that's been done.
+     */
+    public static void reset() {
+        userNames = new ArrayList<>();
+        sysPrefixes = new ArrayList<>();
+        listeners = new HashSet<>();
+        
+        initialised = false;
+    }
+    
+    protected static ArrayList<String> userNames = new ArrayList<>();
+    protected static ArrayList<String> sysPrefixes = new ArrayList<>();
 
     private synchronized static boolean addUserName(String userName) {
         if (userNames.contains(userName)) {
@@ -322,7 +333,7 @@ abstract public class SystemConnectionMemo {
     }
 
     // data members to hold contact with the property listeners
-    final private static Set<PropertyChangeListener> listeners = new HashSet<>();
+    private static Set<PropertyChangeListener> listeners = new HashSet<>();
 
     private final static Logger log = LoggerFactory.getLogger(SystemConnectionMemo.class.getName());
 }

--- a/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
@@ -1,4 +1,3 @@
-// CanSystemConnectionMemo.java
 package jmri.jmrix.can;
 
 import java.util.ResourceBundle;
@@ -14,7 +13,6 @@ import jmri.InstanceManager;
  * passed on to the relevant ConfigurationManager to handle.
  * <p>
  * @author	Kevin Dickerson Copyright (C) 2012
- * @version $Revision: 19602 $
  */
 public class CanSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
@@ -116,6 +114,3 @@ public class CanSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
     }
 }
-
-
-/* @(#)CanSystemConnectionMemo.java */

--- a/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
@@ -12,6 +12,8 @@ public class CMRISystemConnectionMemo extends SystemConnectionMemo {
 
     public CMRISystemConnectionMemo() {
         super("C", CMRIConnectionTypeList.CMRI);
+        register(); // registers general type
+        jmri.InstanceManager.store(this, CMRISystemConnectionMemo.class); // also register as specific type
     }
 
     @Override

--- a/java/src/jmri/jmrix/ieee802154/IEEE802154TrafficController.java
+++ b/java/src/jmri/jmrix/ieee802154/IEEE802154TrafficController.java
@@ -1,4 +1,3 @@
-// IEEE802154TrafficController.java
 package jmri.jmrix.ieee802154;
 
 import jmri.jmrix.AbstractMRListener;
@@ -26,7 +25,6 @@ import org.slf4j.LoggerFactory;
  * multiple connection
  * @author kcameron Copyright (C) 2011
  * @author Paul Bender Copyright (C) 2013
- * @version	$Revision$
  */
 abstract public class IEEE802154TrafficController extends AbstractMRNodeTrafficController implements IEEE802154Interface {
 
@@ -49,7 +47,7 @@ abstract public class IEEE802154TrafficController extends AbstractMRNodeTrafficC
      */
     @Deprecated
     public void setInstance() {
-        log.warn("Deprecated Method setInstance called");
+        log.error("Deprecated Method setInstance called");
     }
 
     /**
@@ -289,6 +287,3 @@ abstract public class IEEE802154TrafficController extends AbstractMRNodeTrafficC
     private final static Logger log = LoggerFactory.getLogger(IEEE802154TrafficController.class);
 
 }
-
-
-/* @(#)IEEE802154TrafficController.java */

--- a/java/src/jmri/jmrix/ieee802154/IEEE802154TrafficController.java
+++ b/java/src/jmri/jmrix/ieee802154/IEEE802154TrafficController.java
@@ -49,7 +49,7 @@ abstract public class IEEE802154TrafficController extends AbstractMRNodeTrafficC
      */
     @Deprecated
     public void setInstance() {
-        log.error("Deprecated Method setInstance called");
+        log.warn("Deprecated Method setInstance called");
     }
 
     /**

--- a/java/src/jmri/jmrix/internal/InternalConnectionTypeList.java
+++ b/java/src/jmri/jmrix/internal/InternalConnectionTypeList.java
@@ -1,4 +1,3 @@
-// InternalConnectionTypeList.java
 package jmri.jmrix.internal;
 
 /**
@@ -6,7 +5,6 @@ package jmri.jmrix.internal;
  * <P>
  * @author Bob Jacobsen Copyright (C) 2010
  * @author Kevin Dickerson Copyright (C) 2010
- * @version	$Revision$
  *
  */
 public class InternalConnectionTypeList implements jmri.jmrix.ConnectionTypeList {

--- a/java/src/jmri/jmrix/internal/InternalLightManager.java
+++ b/java/src/jmri/jmrix/internal/InternalLightManager.java
@@ -1,0 +1,52 @@
+package jmri.jmrix.internal;
+
+import jmri.Light;
+import jmri.implementation.AbstractVariableLight;
+
+/**
+ * Implement a light manager for "Internal" (virtual) lights.
+ *
+ * @author	Bob Jacobsen Copyright (C) 2009
+ */
+public class InternalLightManager extends jmri.managers.AbstractLightManager {
+
+    /**
+     * Create and return an internal (no layout connection) Light
+     */
+    protected Light createNewLight(String systemName, String userName) {
+        return new AbstractVariableLight(systemName, userName) {
+
+            //protected void forwardCommandChangeToLayout(int s) {}
+            protected void sendIntensity(double intensity) {
+            }
+
+            protected void sendOnOffCommand(int newState) {
+            }
+
+            protected int getNumberOfSteps() {
+                return 100;
+            }
+        };
+    }
+
+    public String getSystemPrefix() {
+        return "I";
+    }
+
+    public boolean validSystemNameConfig(String systemName) {
+        return true;
+    }
+
+    public boolean validSystemNameFormat(String systemName) {
+        return true;
+    }
+
+    public boolean supportsVariableLights(String systemName) {
+        return true;
+    }
+
+    public boolean allowMultipleAdditions(String systemName) {
+        return true;
+    }
+
+}

--- a/java/src/jmri/jmrix/internal/InternalReporterManager.java
+++ b/java/src/jmri/jmrix/internal/InternalReporterManager.java
@@ -1,0 +1,40 @@
+package jmri.jmrix.internal;
+
+import jmri.Reporter;
+import jmri.implementation.AbstractReporter;
+
+/**
+ * Implementation of the InternalReporterManager interface.
+ *
+ * @author	Bob Jacobsen Copyright (C) 2010
+ * @since 2.9.4
+ */
+public class InternalReporterManager extends AbstractReporterManager {
+
+    /**
+     * Create an internal (dummy) reporter object
+     *
+     * @return new null
+     */
+    protected Reporter createNewReporter(String systemName, String userName) {
+        return new AbstractReporter(systemName, userName) {
+            public int getState() {
+                return state;
+            }
+
+            public void setState(int s) {
+                state = s;
+            }
+            int state = 0;
+        };
+    }
+
+    @Override
+    public boolean allowMultipleAdditions(String systemName) {
+        return true;
+    }
+
+    public String getSystemPrefix() {
+        return "I";
+    }
+}

--- a/java/src/jmri/jmrix/internal/InternalReporterManager.java
+++ b/java/src/jmri/jmrix/internal/InternalReporterManager.java
@@ -9,7 +9,7 @@ import jmri.implementation.AbstractReporter;
  * @author	Bob Jacobsen Copyright (C) 2010
  * @since 2.9.4
  */
-public class InternalReporterManager extends AbstractReporterManager {
+public class InternalReporterManager extends jmri.managers.AbstractReporterManager {
 
     /**
      * Create an internal (dummy) reporter object

--- a/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
@@ -20,6 +20,8 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
         register();
     }
 
+    boolean configured = false;
+    
     /**
      * Configure the common managers for Internal connections. This puts the
      * common manager config in one place. This method is static so that it can
@@ -28,6 +30,9 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
      */
     public void configureManagers() {
 
+        log.debug("Do configureManagers");
+        if (configured) log.warn("configureManagers called for a second time", new Exception("traceback"));
+        
         turnoutManager = new InternalTurnoutManager(getSystemPrefix());
         InstanceManager.setTurnoutManager(turnoutManager);
 
@@ -46,6 +51,7 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
         jmri.InstanceManager.setThrottleManager(throttleManager
         );
 
+        configured = true;
     }
 
     private InternalSensorManager sensorManager;
@@ -55,22 +61,27 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
     private jmri.progdebugger.DebugProgrammerManager programManager;
 
     public InternalTurnoutManager getTurnoutManager() {
+        if (!configured) configureManagers();
         return turnoutManager;
     }
 
     public InternalSensorManager getSensorManager() {
+        if (!configured) configureManagers();
         return sensorManager;
     }
 
     public jmri.jmrix.debugthrottle.DebugThrottleManager getThrottleManager() {
+        if (!configured) configureManagers();
         return throttleManager;
     }
 
     public jmri.managers.DefaultPowerManager getPowerManager() {
+        if (!configured) configureManagers();
         return powerManager;
     }
 
     public jmri.progdebugger.DebugProgrammerManager getProgrammerManager() {
+        if (!configured) configureManagers();
         return programManager;
     }
 
@@ -78,6 +89,9 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
         if (getDisabled()) {
             return false;
         }
+
+        if (!configured) configureManagers();
+
         if (type.equals(jmri.ProgrammerManager.class)) {
             return true;
         }
@@ -109,6 +123,9 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
         if (getDisabled()) {
             return null;
         }
+
+        if (!configured) configureManagers();
+
         if (T.equals(jmri.ProgrammerManager.class)) {
             return (T) getProgrammerManager();
         }
@@ -150,5 +167,7 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
         }
         super.dispose();
     }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(InternalSystemConnectionMemo.class.getName());
 }
 

--- a/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
@@ -33,6 +33,11 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
         log.debug("Do configureManagers");
         if (configured) log.warn("configureManagers called for a second time", new Exception("traceback"));
         
+        if (lightManager == null) {
+            lightManager = new InternalLightManager();
+            InstanceManager.setLightManager(lightManager);
+        }
+        
         if (sensorManager == null) {
             sensorManager = new InternalSensorManager(getSystemPrefix());
             InstanceManager.setSensorManager(sensorManager);
@@ -54,6 +59,11 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
             jmri.InstanceManager.setProgrammerManager(programManager);
         }
         
+        if (reporterManager == null) {
+            reporterManager = new InternalReporterManager();
+            InstanceManager.setReporterManager(reporterManager);
+        }
+        
         if (throttleManager == null) {
             // Install a debug throttle manager
             throttleManager = new jmri.jmrix.debugthrottle.DebugThrottleManager(this);
@@ -63,19 +73,21 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
         configured = true;
     }
 
+    private InternalLightManager lightManager;
     private InternalSensorManager sensorManager;
+    private InternalReporterManager reporterManager;
     private InternalTurnoutManager turnoutManager;
     private jmri.jmrix.debugthrottle.DebugThrottleManager throttleManager;
     private jmri.managers.DefaultPowerManager powerManager;
     private jmri.progdebugger.DebugProgrammerManager programManager;
 
-    public InternalTurnoutManager getTurnoutManager() {
-        if (turnoutManager == null) {
-            log.debug("Create InternalTurnoutManager \"{}\" by request", getSystemPrefix());
-            turnoutManager = new InternalTurnoutManager(getSystemPrefix());
-            InstanceManager.setTurnoutManager(turnoutManager);
+    public InternalLightManager getLightManager() {
+        if (lightManager == null) {
+            log.debug("Create InternalLightManager by request");
+            lightManager = new InternalLightManager();
+            InstanceManager.setLightManager(lightManager);
         }
-        return turnoutManager;
+        return lightManager;
     }
 
     public InternalSensorManager getSensorManager() {
@@ -85,6 +97,24 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
             InstanceManager.setSensorManager(sensorManager);
         }
         return sensorManager;
+    }
+
+    public InternalReporterManager getReporterManager() {
+        if (reporterManager == null) {
+            log.debug("Create InternalReporterManager by request");
+            reporterManager = new InternalReporterManager();
+            InstanceManager.setReporterManager(reporterManager);
+        }
+        return reporterManager;
+    }
+
+    public InternalTurnoutManager getTurnoutManager() {
+        if (turnoutManager == null) {
+            log.debug("Create InternalTurnoutManager \"{}\" by request", getSystemPrefix());
+            turnoutManager = new InternalTurnoutManager(getSystemPrefix());
+            InstanceManager.setTurnoutManager(turnoutManager);
+        }
+        return turnoutManager;
     }
 
     public jmri.jmrix.debugthrottle.DebugThrottleManager getThrottleManager() {
@@ -142,6 +172,12 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
         if (type.equals(jmri.SensorManager.class)) {
             return true;
         }
+        if (type.equals(jmri.LightManager.class)) {
+            return true;
+        }
+        if (type.equals(jmri.ReporterManager.class)) {
+            return true;
+        }
         if (type.equals(jmri.TurnoutManager.class)) {
             return true;
         }
@@ -173,8 +209,14 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
         if (T.equals(jmri.PowerManager.class)) {
             return (T) getPowerManager();
         }
+        if (T.equals(jmri.LightManager.class)) {
+            return (T) getLightManager();
+        }
         if (T.equals(jmri.SensorManager.class)) {
             return (T) getSensorManager();
+        }
+        if (T.equals(jmri.ReporterManager.class)) {
+            return (T) getReporterManager();
         }
         if (T.equals(jmri.TurnoutManager.class)) {
             return (T) getTurnoutManager();

--- a/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
@@ -14,7 +14,7 @@ import jmri.InstanceManager;
  * @author	Bob Jacobsen Copyright (C) 2010
  * @version $Revision$
  */
-public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
+public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo implements jmri.InstanceManagerAutoDefault {
 
     public InternalSystemConnectionMemo() {
         super("I", "Internal");

--- a/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
@@ -71,7 +71,7 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
 
     public InternalTurnoutManager getTurnoutManager() {
         if (turnoutManager == null) {
-            log.debug("Create InternalTurnoutManager \"{}\" by request", getSystemPrefix(), new Exception("traceback"));
+            log.debug("Create InternalTurnoutManager \"{}\" by request", getSystemPrefix());
             turnoutManager = new InternalTurnoutManager(getSystemPrefix());
             InstanceManager.setTurnoutManager(turnoutManager);
         }

--- a/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
@@ -24,33 +24,42 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
     
     /**
      * Configure the common managers for Internal connections. This puts the
-     * common manager config in one place. This method is static so that it can
-     * be referenced from classes that don't inherit, including
-     * hexfile.HexFileFrame and locormi.LnMessageClient
+     * common manager config in one place. 
+     * <p> Note: The Proxy system can cause some managers to be created early.
+     * We don't call configureManagers in that case, as it causes an infinite loop.
      */
     public void configureManagers() {
 
         log.debug("Do configureManagers");
         if (configured) log.warn("configureManagers called for a second time", new Exception("traceback"));
         
-        turnoutManager = new InternalTurnoutManager(getSystemPrefix());
-        InstanceManager.setTurnoutManager(turnoutManager);
-
-        sensorManager = new InternalSensorManager(getSystemPrefix());
-        InstanceManager.setSensorManager(sensorManager);
-
-        powerManager = new jmri.managers.DefaultPowerManager();
-        jmri.InstanceManager.setPowerManager(powerManager);
-
-        // Install a debug programmer
-        programManager = new jmri.progdebugger.DebugProgrammerManager();
-        jmri.InstanceManager.setProgrammerManager(programManager);
-
-        // Install a debug throttle manager
-        throttleManager = new jmri.jmrix.debugthrottle.DebugThrottleManager(this);
-        jmri.InstanceManager.setThrottleManager(throttleManager
-        );
-
+        if (sensorManager == null) {
+            sensorManager = new InternalSensorManager(getSystemPrefix());
+            InstanceManager.setSensorManager(sensorManager);
+        }
+        
+        if (turnoutManager == null) {
+            turnoutManager = new InternalTurnoutManager(getSystemPrefix());
+            InstanceManager.setTurnoutManager(turnoutManager);
+        }
+        
+        if (powerManager == null) {
+            powerManager = new jmri.managers.DefaultPowerManager();
+            jmri.InstanceManager.setPowerManager(powerManager);
+        }
+        
+        if (programManager == null) {
+            // Install a debug programmer
+            programManager = new jmri.progdebugger.DebugProgrammerManager();
+            jmri.InstanceManager.setProgrammerManager(programManager);
+        }
+        
+        if (throttleManager == null) {
+            // Install a debug throttle manager
+            throttleManager = new jmri.jmrix.debugthrottle.DebugThrottleManager(this);
+            jmri.InstanceManager.setThrottleManager(throttleManager);
+        }
+        
         configured = true;
     }
 
@@ -61,27 +70,49 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
     private jmri.progdebugger.DebugProgrammerManager programManager;
 
     public InternalTurnoutManager getTurnoutManager() {
-        if (!configured) configureManagers();
+        if (turnoutManager == null) {
+            log.debug("Create InternalTurnoutManager \"{}\" by request", getSystemPrefix(), new Exception("traceback"));
+            turnoutManager = new InternalTurnoutManager(getSystemPrefix());
+            InstanceManager.setTurnoutManager(turnoutManager);
+        }
         return turnoutManager;
     }
 
     public InternalSensorManager getSensorManager() {
-        if (!configured) configureManagers();
+        if (sensorManager == null) {
+            log.debug("Create InternalSensorManager \"{}\" by request", getSystemPrefix());
+            sensorManager = new InternalSensorManager(getSystemPrefix());
+            InstanceManager.setSensorManager(sensorManager);
+        }
         return sensorManager;
     }
 
     public jmri.jmrix.debugthrottle.DebugThrottleManager getThrottleManager() {
-        if (!configured) configureManagers();
+        if (throttleManager == null) {
+            log.debug("Create DebugThrottleManager by request");
+            // Install a debug throttle manager
+            throttleManager = new jmri.jmrix.debugthrottle.DebugThrottleManager(this);
+            jmri.InstanceManager.setThrottleManager(throttleManager);
+        }
         return throttleManager;
     }
 
     public jmri.managers.DefaultPowerManager getPowerManager() {
-        if (!configured) configureManagers();
+        if (powerManager == null) {
+            log.debug("Create DefaultPowerManager by request");
+            powerManager = new jmri.managers.DefaultPowerManager();
+            jmri.InstanceManager.setPowerManager(powerManager);
+        }
         return powerManager;
     }
 
     public jmri.progdebugger.DebugProgrammerManager getProgrammerManager() {
-        if (!configured) configureManagers();
+        if (programManager == null) {
+            log.debug("Create DebugProgrammerManager by request");
+            // Install a debug programmer
+            programManager = new jmri.progdebugger.DebugProgrammerManager();
+            jmri.InstanceManager.setProgrammerManager(programManager);
+        }
         return programManager;
     }
 

--- a/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/internal/InternalSystemConnectionMemo.java
@@ -1,4 +1,3 @@
-// InternalSystemConnectionMemo.java
 package jmri.jmrix.internal;
 
 import java.util.ResourceBundle;
@@ -12,7 +11,6 @@ import jmri.InstanceManager;
  * activate their particular system.
  *
  * @author	Bob Jacobsen Copyright (C) 2010
- * @version $Revision$
  */
 public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo implements jmri.InstanceManagerAutoDefault {
 
@@ -154,5 +152,3 @@ public class InternalSystemConnectionMemo extends jmri.jmrix.SystemConnectionMem
     }
 }
 
-
-/* @(#)InternalSystemConnectionMemo.java */

--- a/java/src/jmri/jmrix/internal/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/ConnectionConfigXml.java
@@ -14,7 +14,6 @@ import org.jdom2.Element;
  * attribute in the XML.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2003, 2010
- * @version $Revision$
  */
 public class ConnectionConfigXml extends AbstractConnectionConfigXml {
 

--- a/java/src/jmri/jmrix/internal/configurexml/InternalLightManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalLightManagerXml.java
@@ -10,7 +10,8 @@ import org.slf4j.LoggerFactory;
  * Uses the store method from the abstract base class, but provides a load
  * method here.
  *
- * @author Bob Jacobsen Copyright: Copyright (c) 2009
+ * @author Bob Jacobsen Copyright: Copyright (c) 2016
+ * @since 4.3.5
  */
 public class InternalLightManagerXml extends jmri.managers.configurexml.AbstractLightManagerConfigXML {
 

--- a/java/src/jmri/jmrix/internal/configurexml/InternalLightManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalLightManagerXml.java
@@ -1,0 +1,37 @@
+package jmri.jmrix.internal.configurexml;
+
+import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides load and store functionality for configuring InternalLightManagers.
+ * <P>
+ * Uses the store method from the abstract base class, but provides a load
+ * method here.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2009
+ */
+public class InternalLightManagerXml extends jmri.managers.configurexml.AbstractLightManagerConfigXML {
+
+    public InternalLightManagerXml() {
+        super();
+    }
+
+    public void setStoreElementClass(Element lights) {
+        lights.setAttribute("class", this.getClass().getName());
+    }
+
+    public void load(Element element, Object o) {
+        log.error("Invalid method called");
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) {
+        // load individual lights
+        loadLights(shared);
+        return true;
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(InternalLightManagerXml.class.getName());
+}

--- a/java/src/jmri/jmrix/internal/configurexml/InternalReporterManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalReporterManagerXml.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
  * method here.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2010
+ * @since 4.3.5
  */
 public class InternalReporterManagerXml extends jmri.managers.configurexml.AbstractReporterManagerConfigXML {
 

--- a/java/src/jmri/jmrix/internal/configurexml/InternalReporterManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalReporterManagerXml.java
@@ -1,0 +1,37 @@
+package jmri.jmrix.internal.configurexml;
+
+import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides load and store functionality for configuring
+ * InternalReporterManagers.
+ * <P>
+ * Uses the store method from the abstract base class, but provides a load
+ * method here.
+ *
+ * @author Bob Jacobsen Copyright: Copyright (c) 2010
+ */
+public class InternalReporterManagerXml extends jmri.managers.configurexml.AbstractReporterManagerConfigXML {
+
+    public InternalReporterManagerXml() {
+        super();
+    }
+
+    public void setStoreElementClass(Element sensors) {
+        sensors.setAttribute("class", this.getClass().getName());
+    }
+
+    public void load(Element element, Object o) {
+        log.error("Invalid method called");
+    }
+
+    @Override
+    public boolean load(Element shared, Element perNode) {
+        // load individual reporters
+        return loadReporters(shared);
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(InternalReporterManagerXml.class.getName());
+}

--- a/java/src/jmri/jmrix/internal/configurexml/InternalSensorManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalSensorManagerXml.java
@@ -9,7 +9,6 @@ import org.jdom2.Element;
  * method here.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2006
- * @version $Revision$
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "name assigned historically")
 public class InternalSensorManagerXml extends jmri.managers.configurexml.InternalSensorManagerXml {

--- a/java/src/jmri/jmrix/internal/configurexml/InternalTurnoutManagerXml.java
+++ b/java/src/jmri/jmrix/internal/configurexml/InternalTurnoutManagerXml.java
@@ -10,7 +10,6 @@ import org.jdom2.Element;
  * method here.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2006
- * @version $Revision$
  */
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "name assigned historically")
 public class InternalTurnoutManagerXml extends jmri.managers.configurexml.InternalTurnoutManagerXml {

--- a/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
@@ -1,4 +1,3 @@
-// LocoNetSystemConnectionMemo.java
 package jmri.jmrix.loconet;
 
 import java.util.ResourceBundle;
@@ -16,7 +15,6 @@ import org.slf4j.LoggerFactory;
  * activate their particular system.
  *
  * @author	Bob Jacobsen Copyright (C) 2010
- * @version $Revision$
  */
 public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
@@ -417,6 +415,3 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
 
     private final static Logger log = LoggerFactory.getLogger(LocoNetSystemConnectionMemo.class.getName());
 }
-
-
-/* @(#)LocoNetSystemConnectionMemo.java */

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -1,4 +1,3 @@
-// AbstractProxyManager.java
 package jmri.managers;
 
 import java.util.ArrayList;
@@ -24,7 +23,6 @@ import org.slf4j.LoggerFactory;
  * separate reference to the internal manager.
  *
  * @author	Bob Jacobsen Copyright (C) 2003, 2010
- * @version	$Revision$
  */
 abstract public class AbstractProxyManager implements Manager {
 
@@ -77,7 +75,7 @@ abstract public class AbstractProxyManager implements Manager {
         return internalManager;
     }
 
-    private java.util.ArrayList<AbstractManager> mgrs = new java.util.ArrayList<AbstractManager>();
+    private java.util.ArrayList<AbstractManager> mgrs = new java.util.ArrayList<>();
     private AbstractManager internalManager = null;
 
     abstract protected AbstractManager makeInternalManager();
@@ -284,8 +282,8 @@ abstract public class AbstractProxyManager implements Manager {
         }
     }
 
-    ArrayList<java.beans.PropertyChangeListener> propertyListenerList = new ArrayList<java.beans.PropertyChangeListener>(5);
-    ArrayList<java.beans.VetoableChangeListener> propertyVetoListenerList = new ArrayList<java.beans.VetoableChangeListener>(5);
+    ArrayList<java.beans.PropertyChangeListener> propertyListenerList = new ArrayList<>(5);
+    ArrayList<java.beans.VetoableChangeListener> propertyVetoListenerList = new ArrayList<>(5);
 
     /**
      * @return The system-specific prefix letter for the primary implementation
@@ -324,7 +322,7 @@ abstract public class AbstractProxyManager implements Manager {
     }
 
     public String[] getSystemNameArray() {
-        TreeSet<String> ts = new TreeSet<String>(new SystemNameComparator());
+        TreeSet<String> ts = new TreeSet<>(new SystemNameComparator());
         for (int i = 0; i < nMgrs(); i++) {
             ts.addAll(getMgr(i).getSystemNameList());
         }
@@ -341,23 +339,21 @@ abstract public class AbstractProxyManager implements Manager {
      * Get a list of all system names.
      */
     public List<String> getSystemNameList() {
-        TreeSet<String> ts = new TreeSet<String>(new SystemNameComparator());
+        TreeSet<String> ts = new TreeSet<>(new SystemNameComparator());
         for (int i = 0; i < nMgrs(); i++) {
             ts.addAll(getMgr(i).getSystemNameList());
         }
-        return new ArrayList<String>(ts);
+        return new ArrayList<>(ts);
     }
 
     public List<NamedBean> getNamedBeanList() {
-        TreeSet<NamedBean> ts = new TreeSet<NamedBean>(new SystemNameComparator());
+        TreeSet<NamedBean> ts = new TreeSet<>(new SystemNameComparator());
         for (AbstractManager m : mgrs) {
             ts.addAll(m.getNamedBeanList());
         }
-        return new ArrayList<NamedBean>(ts);
+        return new ArrayList<>(ts);
     }
 
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(AbstractProxyManager.class.getName());
 }
-
-/* @(#)AbstractProxyManager.java */

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -31,14 +31,15 @@ abstract public class AbstractProxyManager implements Manager {
      * including the Internal manager
      */
     protected int nMgrs() {
-        return mgrs.size() + 1;
+        return mgrs.size();
     }
 
     protected AbstractManager getMgr(int index) {
+        // make sure internal present
+        initInternal();
+
         if (index < mgrs.size()) {
             return mgrs.get(index);
-        } else if (index == mgrs.size()) {
-            return getInternal();
         } else {
             throw new IllegalArgumentException("illegal index " + index);
         }
@@ -49,9 +50,11 @@ abstract public class AbstractProxyManager implements Manager {
      * not a live list.
      */
     public List<Manager> getManagerList() {
+        // make sure internal present
+        initInternal();
+        
         @SuppressWarnings("unchecked")
         List<Manager> retval = (List<Manager>) mgrs.clone();
-        retval.add(getInternal());
         return retval;
     }
 
@@ -68,7 +71,7 @@ abstract public class AbstractProxyManager implements Manager {
         }
     }
 
-    private AbstractManager getInternal() {
+    private AbstractManager initInternal() {
         if (internalManager == null) {
             log.debug("create internal manager when first requested");
             internalManager = makeInternalManager();

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -70,6 +70,7 @@ abstract public class AbstractProxyManager implements Manager {
 
     private AbstractManager getInternal() {
         if (internalManager == null) {
+            log.debug("create internal manager when first requested");
             internalManager = makeInternalManager();
         }
         return internalManager;
@@ -78,6 +79,9 @@ abstract public class AbstractProxyManager implements Manager {
     private java.util.ArrayList<AbstractManager> mgrs = new java.util.ArrayList<>();
     private AbstractManager internalManager = null;
 
+    /**
+     * Create specific internal manager as needed for concrete type.
+     */
     abstract protected AbstractManager makeInternalManager();
 
     /**

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -31,6 +31,9 @@ abstract public class AbstractProxyManager implements Manager {
      * including the Internal manager
      */
     protected int nMgrs() {
+        // make sure internal present
+        initInternal();
+
         return mgrs.size();
     }
 
@@ -113,6 +116,9 @@ abstract public class AbstractProxyManager implements Manager {
      * @return Never null under normal circumstances
      */
     protected NamedBean provideNamedBean(String name) {
+        // make sure internal present
+        initInternal();
+
         NamedBean t = getNamedBean(name);
         if (t != null) {
             return t;
@@ -184,6 +190,9 @@ abstract public class AbstractProxyManager implements Manager {
      * @return requested NamedBean object (never null)
      */
     public NamedBean newNamedBean(String systemName, String userName) {
+        // make sure internal present
+        initInternal();
+
         // if the systemName is specified, find that system
         int i = matchTentative(systemName);
         if (i >= 0) {
@@ -223,6 +232,9 @@ abstract public class AbstractProxyManager implements Manager {
      * there is no match, here considered to be an error that must be reported.
      */
     protected int match(String systemname) {
+        // make sure internal present
+        initInternal();
+
         int index = matchTentative(systemname);
         if (index < 0) {
             throw new IllegalArgumentException("System name " + systemname + " failed to match");

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -1,4 +1,3 @@
-// AbstractSensorManager.java
 package jmri.managers;
 
 import java.util.Enumeration;
@@ -13,7 +12,6 @@ import org.slf4j.LoggerFactory;
  * Abstract base implementation of the SensorManager interface.
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2003
- * @version	$Revision$
  */
 public abstract class AbstractSensorManager extends AbstractManager implements SensorManager {
 
@@ -258,5 +256,3 @@ public abstract class AbstractSensorManager extends AbstractManager implements S
 
     private final static Logger log = LoggerFactory.getLogger(AbstractSensorManager.class.getName());
 }
-
-/* @(#)AbstractSensorManager.java */

--- a/java/src/jmri/managers/AbstractTurnoutManager.java
+++ b/java/src/jmri/managers/AbstractTurnoutManager.java
@@ -1,4 +1,3 @@
-// AbstractTurnoutManager.java
 package jmri.managers;
 
 import jmri.JmriException;
@@ -13,7 +12,6 @@ import org.slf4j.LoggerFactory;
  * Abstract partial implementation of a TurnoutManager.
  *
  * @author	Bob Jacobsen Copyright (C) 2001
- * @version	$Revision$
  */
 public abstract class AbstractTurnoutManager extends AbstractManager
         implements TurnoutManager, java.beans.VetoableChangeListener {
@@ -27,7 +25,6 @@ public abstract class AbstractTurnoutManager extends AbstractManager
     public int getXMLOrder() {
         return Manager.TURNOUTS;
     }
-    //protected int xmlorder = 20;
 
     public char typeLetter() {
         return 'T';
@@ -343,5 +340,3 @@ public abstract class AbstractTurnoutManager extends AbstractManager
 
     private final static Logger log = LoggerFactory.getLogger(AbstractTurnoutManager.class.getName());
 }
-
-/* @(#)AbstractTurnoutManager.java */

--- a/java/src/jmri/managers/InternalLightManager.java
+++ b/java/src/jmri/managers/InternalLightManager.java
@@ -1,4 +1,3 @@
-// InternalLightManager.java
 package jmri.managers;
 
 import jmri.Light;
@@ -8,25 +7,15 @@ import jmri.implementation.AbstractVariableLight;
  * Implement a light manager for "Internal" (virtual) lights.
  *
  * @author	Bob Jacobsen Copyright (C) 2009
- * @version	$Revision$
  */
 public class InternalLightManager extends AbstractLightManager {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 2678277271494071178L;
 
     /**
      * Create and return an internal (no layout connection) Light
      */
     protected Light createNewLight(String systemName, String userName) {
         return new AbstractVariableLight(systemName, userName) {
-            /**
-             *
-             */
-            private static final long serialVersionUID = -5913007273311395912L;
-
+ 
             //protected void forwardCommandChangeToLayout(int s) {}
             protected void sendIntensity(double intensity) {
             }
@@ -61,5 +50,3 @@ public class InternalLightManager extends AbstractLightManager {
     }
 
 }
-
-/* @(#)InternalLightManager.java */

--- a/java/src/jmri/managers/InternalLightManager.java
+++ b/java/src/jmri/managers/InternalLightManager.java
@@ -7,7 +7,9 @@ import jmri.implementation.AbstractVariableLight;
  * Implement a light manager for "Internal" (virtual) lights.
  *
  * @author	Bob Jacobsen Copyright (C) 2009
+ * @deprecated As of 4.3.5, use jmri.jmrix.internal classes
  */
+@Deprecated
 public class InternalLightManager extends AbstractLightManager {
 
     /**

--- a/java/src/jmri/managers/InternalReporterManager.java
+++ b/java/src/jmri/managers/InternalReporterManager.java
@@ -1,4 +1,3 @@
-// InternalReporterManager.java
 package jmri.managers;
 
 import jmri.Reporter;
@@ -8,7 +7,6 @@ import jmri.implementation.AbstractReporter;
  * Implementation of the InternalReporterManager interface.
  *
  * @author	Bob Jacobsen Copyright (C) 2010
- * @version	$Revision$
  * @since 2.9.4
  */
 public class InternalReporterManager extends AbstractReporterManager {
@@ -20,10 +18,6 @@ public class InternalReporterManager extends AbstractReporterManager {
      */
     protected Reporter createNewReporter(String systemName, String userName) {
         return new AbstractReporter(systemName, userName) {
-            /**
-             *
-             */
-            private static final long serialVersionUID = -2544443870907571291L;
 
             public int getState() {
                 return state;
@@ -46,4 +40,3 @@ public class InternalReporterManager extends AbstractReporterManager {
     }
 }
 
-/* @(#)InternalReporterManager.java */

--- a/java/src/jmri/managers/InternalReporterManager.java
+++ b/java/src/jmri/managers/InternalReporterManager.java
@@ -8,7 +8,9 @@ import jmri.implementation.AbstractReporter;
  *
  * @author	Bob Jacobsen Copyright (C) 2010
  * @since 2.9.4
+ * @deprecated As of 4.3.5, use jmri.jmrix.internal classes
  */
+@Deprecated
 public class InternalReporterManager extends AbstractReporterManager {
 
     /**

--- a/java/src/jmri/managers/InternalSensorManager.java
+++ b/java/src/jmri/managers/InternalSensorManager.java
@@ -9,7 +9,9 @@ import org.slf4j.LoggerFactory;
  * Implementation of the InternalSensorManager interface.
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2003, 2006
+ * @deprecated As of 4.3.5, use jmri.jmrix.internal classes
  */
+@Deprecated
 public class InternalSensorManager extends AbstractSensorManager {
 
     public InternalSensorManager() {

--- a/java/src/jmri/managers/InternalSensorManager.java
+++ b/java/src/jmri/managers/InternalSensorManager.java
@@ -1,4 +1,3 @@
-// InternalSensorManager.java
 package jmri.managers;
 
 import jmri.Sensor;
@@ -10,7 +9,6 @@ import org.slf4j.LoggerFactory;
  * Implementation of the InternalSensorManager interface.
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2003, 2006
- * @version	$Revision$
  */
 public class InternalSensorManager extends AbstractSensorManager {
 
@@ -103,5 +101,3 @@ public class InternalSensorManager extends AbstractSensorManager {
 
     private final static Logger log = LoggerFactory.getLogger(InternalSensorManager.class);
 }
-
-/* @(#)InternalSensorManager.java */

--- a/java/src/jmri/managers/InternalTurnoutManager.java
+++ b/java/src/jmri/managers/InternalTurnoutManager.java
@@ -7,7 +7,9 @@ import jmri.implementation.AbstractTurnout;
  * Implement a turnout manager for "Internal" (virtual) turnouts.
  *
  * @author	Bob Jacobsen Copyright (C) 2006
+ * @deprecated As of 4.3.5, use jmri.jmrix.internal classes
  */
+@Deprecated
 public class InternalTurnoutManager extends AbstractTurnoutManager {
 
     /**

--- a/java/src/jmri/managers/InternalTurnoutManager.java
+++ b/java/src/jmri/managers/InternalTurnoutManager.java
@@ -1,4 +1,3 @@
-// InternalTurnoutManager.java
 package jmri.managers;
 
 import jmri.Turnout;
@@ -8,7 +7,6 @@ import jmri.implementation.AbstractTurnout;
  * Implement a turnout manager for "Internal" (virtual) turnouts.
  *
  * @author	Bob Jacobsen Copyright (C) 2006
- * @version	$Revision$
  */
 public class InternalTurnoutManager extends AbstractTurnoutManager {
 
@@ -17,10 +15,6 @@ public class InternalTurnoutManager extends AbstractTurnoutManager {
      */
     protected Turnout createNewTurnout(String systemName, String userName) {
         return new AbstractTurnout(systemName, userName) {
-            /**
-             *
-             */
-            private static final long serialVersionUID = -7745266016274027809L;
 
             protected void forwardCommandChangeToLayout(int s) {
             }
@@ -47,5 +41,3 @@ public class InternalTurnoutManager extends AbstractTurnoutManager {
         return new String[]{"NoFeedback"};
     }
 }
-
-/* @(#)InternalTurnoutManager.java */

--- a/java/src/jmri/managers/ProxyLightManager.java
+++ b/java/src/jmri/managers/ProxyLightManager.java
@@ -1,4 +1,3 @@
-// ProxyLightManager.java
 package jmri.managers;
 
 import jmri.Light;
@@ -11,7 +10,6 @@ import jmri.NamedBean;
  *
  * @author	Bob Jacobsen Copyright (C) 2010
  * @author	Dave Duchamp Copyright (C) 2004
- * @version	$Revision$
  */
 public class ProxyLightManager extends AbstractProxyManager
         implements LightManager {
@@ -201,5 +199,3 @@ public class ProxyLightManager extends AbstractProxyManager
         return Bundle.getMessage("BeanNameLight");
     }
 }
-
-/* @(#)ProxyLightManager.java */

--- a/java/src/jmri/managers/ProxyLightManager.java
+++ b/java/src/jmri/managers/ProxyLightManager.java
@@ -23,7 +23,7 @@ public class ProxyLightManager extends AbstractProxyManager
     }
 
     protected AbstractManager makeInternalManager() {
-        return new InternalLightManager();
+        return jmri.InstanceManager.getDefault(jmri.jmrix.internal.InternalSystemConnectionMemo.class).getLightManager();
     }
 
     /**

--- a/java/src/jmri/managers/ProxyReporterManager.java
+++ b/java/src/jmri/managers/ProxyReporterManager.java
@@ -17,7 +17,7 @@ public class ProxyReporterManager extends AbstractProxyManager implements Report
     }
 
     protected AbstractManager makeInternalManager() {
-        return new InternalReporterManager();
+        return jmri.InstanceManager.getDefault(jmri.jmrix.internal.InternalSystemConnectionMemo.class).getReporterManager();
     }
 
     public int getXMLOrder() {

--- a/java/src/jmri/managers/ProxyReporterManager.java
+++ b/java/src/jmri/managers/ProxyReporterManager.java
@@ -1,4 +1,3 @@
-// ProxyReporterManager.java
 package jmri.managers;
 
 import jmri.NamedBean;
@@ -10,7 +9,6 @@ import jmri.ReporterManager;
  * system-specific implementations.
  *
  * @author	Bob Jacobsen Copyright (C) 2003, 2010
- * @version	$Revision$
  */
 public class ProxyReporterManager extends AbstractProxyManager implements ReporterManager {
 
@@ -130,5 +128,3 @@ public class ProxyReporterManager extends AbstractProxyManager implements Report
         return Bundle.getMessage("BeanNameReporter");
     }
 }
-
-/* @(#)ProxyReporterManager.java */

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -19,7 +19,7 @@ public class ProxySensorManager extends AbstractProxyManager
     }
 
     protected AbstractManager makeInternalManager() {
-        return new InternalSensorManager();
+        return jmri.InstanceManager.getDefault(jmri.jmrix.internal.InternalSystemConnectionMemo.class).getSensorManager();
     }
 
     /**

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -1,4 +1,3 @@
-// ProxySensorManager.java
 package jmri.managers;
 
 import jmri.Sensor;
@@ -11,7 +10,6 @@ import org.slf4j.LoggerFactory;
  * system-specific implementations.
  *
  * @author	Bob Jacobsen Copyright (C) 2003, 2010
- * @version	$Revision$
  */
 public class ProxySensorManager extends AbstractProxyManager
         implements SensorManager {
@@ -166,5 +164,3 @@ public class ProxySensorManager extends AbstractProxyManager
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(ProxySensorManager.class.getName());
 }
-
-/* @(#)ProxySensorManager.java */

--- a/java/src/jmri/managers/ProxyTurnoutManager.java
+++ b/java/src/jmri/managers/ProxyTurnoutManager.java
@@ -1,4 +1,3 @@
-// ProxyTurnoutManager.java
 package jmri.managers;
 
 import java.util.Arrays;
@@ -17,7 +16,6 @@ import org.slf4j.LoggerFactory;
  * system-specific implementations.
  *
  * @author	Bob Jacobsen Copyright (C) 2003, 2010
- * @version	$Revision$
  */
 public class ProxyTurnoutManager extends AbstractProxyManager implements TurnoutManager {
 
@@ -275,5 +273,3 @@ public class ProxyTurnoutManager extends AbstractProxyManager implements Turnout
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(ProxyTurnoutManager.class.getName());
 }
-
-/* @(#)ProxyTurnoutManager.java */

--- a/java/src/jmri/managers/ProxyTurnoutManager.java
+++ b/java/src/jmri/managers/ProxyTurnoutManager.java
@@ -24,7 +24,7 @@ public class ProxyTurnoutManager extends AbstractProxyManager implements Turnout
     }
 
     protected AbstractManager makeInternalManager() {
-        return new InternalTurnoutManager();
+        return jmri.InstanceManager.getDefault(jmri.jmrix.internal.InternalSystemConnectionMemo.class).getTurnoutManager();
     }
 
     /**

--- a/java/src/jmri/managers/configurexml/InternalLightManagerXml.java
+++ b/java/src/jmri/managers/configurexml/InternalLightManagerXml.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
  * method here.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2009
- * @version $Revision$
  */
 public class InternalLightManagerXml extends jmri.managers.configurexml.AbstractLightManagerConfigXML {
 

--- a/java/src/jmri/managers/configurexml/InternalLightManagerXml.java
+++ b/java/src/jmri/managers/configurexml/InternalLightManagerXml.java
@@ -11,7 +11,9 @@ import org.slf4j.LoggerFactory;
  * method here.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2009
+ * @deprecated As of 4.3.5, see jmri.jmrix.internal.configurexml classes
  */
+@Deprecated
 public class InternalLightManagerXml extends jmri.managers.configurexml.AbstractLightManagerConfigXML {
 
     public InternalLightManagerXml() {

--- a/java/src/jmri/managers/configurexml/InternalReporterManagerXml.java
+++ b/java/src/jmri/managers/configurexml/InternalReporterManagerXml.java
@@ -12,7 +12,9 @@ import org.slf4j.LoggerFactory;
  * method here.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2010
+ * @deprecated As of 4.3.5, see jmri.jmrix.internal.configurexml classes
  */
+@Deprecated
 public class InternalReporterManagerXml extends jmri.managers.configurexml.AbstractReporterManagerConfigXML {
 
     public InternalReporterManagerXml() {

--- a/java/src/jmri/managers/configurexml/InternalReporterManagerXml.java
+++ b/java/src/jmri/managers/configurexml/InternalReporterManagerXml.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
  * method here.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2010
- * @version $Revision$
  */
 public class InternalReporterManagerXml extends jmri.managers.configurexml.AbstractReporterManagerConfigXML {
 

--- a/java/src/jmri/managers/configurexml/InternalSensorManagerXml.java
+++ b/java/src/jmri/managers/configurexml/InternalSensorManagerXml.java
@@ -12,7 +12,9 @@ import org.slf4j.LoggerFactory;
  * method here.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2006
+ * @deprecated As of 4.3.5, see jmri.jmrix.internal.configurexml classes
  */
+@Deprecated
 public class InternalSensorManagerXml extends jmri.managers.configurexml.AbstractSensorManagerConfigXML {
 
     public InternalSensorManagerXml() {

--- a/java/src/jmri/managers/configurexml/InternalSensorManagerXml.java
+++ b/java/src/jmri/managers/configurexml/InternalSensorManagerXml.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
  * method here.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2006
- * @version $Revision$
  */
 public class InternalSensorManagerXml extends jmri.managers.configurexml.AbstractSensorManagerConfigXML {
 

--- a/java/src/jmri/managers/configurexml/InternalTurnoutManagerXml.java
+++ b/java/src/jmri/managers/configurexml/InternalTurnoutManagerXml.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
  * method here.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2006
- * @version $Revision$
  */
 public class InternalTurnoutManagerXml extends jmri.managers.configurexml.AbstractTurnoutManagerConfigXML {
 

--- a/java/src/jmri/managers/configurexml/InternalTurnoutManagerXml.java
+++ b/java/src/jmri/managers/configurexml/InternalTurnoutManagerXml.java
@@ -12,7 +12,9 @@ import org.slf4j.LoggerFactory;
  * method here.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2006
+ * @deprecated As of 4.3.5, see jmri.jmrix.internal.configurexml classes
  */
+@Deprecated
 public class InternalTurnoutManagerXml extends jmri.managers.configurexml.AbstractTurnoutManagerConfigXML {
 
     public InternalTurnoutManagerXml() {

--- a/java/src/jmri/util/ConnectionNameFromSystemName.java
+++ b/java/src/jmri/util/ConnectionNameFromSystemName.java
@@ -8,7 +8,6 @@ import jmri.jmrix.SystemConnectionMemo;
  * System Name Prefix
  *
  * @author Kevin Dickerson Copyright 2010
- * @version $Revision$
  */
 public class ConnectionNameFromSystemName {
 
@@ -32,10 +31,6 @@ public class ConnectionNameFromSystemName {
         return DCCManufacturerList.getDCCSystemFromType(prefix.charAt(0));
 
     }
-    /*
-     *  Returns the System prefix of a connection given the system name.
-     */
-
     /**
      * Locates the connected systems prefix from a given System name.
      *

--- a/java/test/jmri/configurexml/LoadAndStoreTestBase.java
+++ b/java/test/jmri/configurexml/LoadAndStoreTestBase.java
@@ -93,6 +93,7 @@ public class LoadAndStoreTestBase extends TestCase {
                     log.error("match failed in testLoadStoreCurrent line " + count);
                     log.error("   inLine = \"" + inLine + "\"");
                     log.error("  outLine = \"" + outLine + "\"");
+                    log.error("     comparing \"" + inFile.getName() + "\" and \"" + outFile.getName() + "\"");
                 }
                 Assert.assertEquals(inLine, outLine);
             }

--- a/java/test/jmri/configurexml/loadref/BlockAndSignalMastTest.xml
+++ b/java/test/jmri/configurexml/loadref/BlockAndSignalMastTest.xml
@@ -8,7 +8,7 @@
     <test>0</test>
     <modifier />
   </jmriversion>
-  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <defaultclosedspeed>Normal</defaultclosedspeed>
     <defaultthrownspeed>Restricted</defaultthrownspeed>
     <turnout systemName="IT1" userName="Turnout:1" feedback="DIRECT" inverted="false" automate="Default">

--- a/java/test/jmri/configurexml/loadref/BlockManagerXmlTest.xml
+++ b/java/test/jmri/configurexml/loadref/BlockManagerXmlTest.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="ISBO1" inverted="false" userName="blocknorthwestoccupied">
       <systemName>ISBO1</systemName>
@@ -202,7 +202,7 @@
       <systemName>ISSSTOPR9</systemName>
     </sensor>
   </sensors>
-  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
       <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />

--- a/java/test/jmri/configurexml/loadref/LeadingTrailingSpaceTest.xml
+++ b/java/test/jmri/configurexml/loadref/LeadingTrailingSpaceTest.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/xml/XSLT/panelfile-2-9-6.xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-2-9-6.xsd">
+  <jmriversion>
+    <major>3</major>
+    <minor>9</minor>
+    <test>2</test>
+    <modifier>.2</modifier>
+  </jmriversion>
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
+    <defaultInitialState>unknown</defaultInitialState>
+    <sensor systemName="IS1" inverted="false" userName="Sensor No Spaces">
+      <systemName>IS1</systemName>
+      <userName>Sensor No Spaces</userName>
+    </sensor>
+    <sensor systemName="IS2" inverted="false" userName="Sensor Trailing Space">
+      <systemName>IS2</systemName>
+      <userName>Sensor Trailing Space</userName>
+    </sensor>
+    <sensor systemName="IS3" inverted="false" userName="Sensor Leading Space">
+      <systemName>IS3</systemName>
+      <userName>Sensor Leading Space</userName>
+    </sensor>
+  </sensors>
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
+    <operations automate="false">
+      <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
+      <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
+      <operation name="Sensor" class="jmri.configurexml.turnoutoperations.SensorTurnoutOperationXml" interval="300" maxtries="3" />
+    </operations>
+    <defaultclosedspeed>Normal</defaultclosedspeed>
+    <defaultthrownspeed>Restricted</defaultthrownspeed>
+    <turnout systemName="IT1" userName="Turnout No Spaces" feedback="DIRECT" inverted="false" automate="Default">
+      <systemName>IT1</systemName>
+      <userName>Turnout No Spaces</userName>
+    </turnout>
+    <turnout systemName="IT2" userName="Turnout Trailing Space" feedback="DIRECT" inverted="false" automate="Default">
+      <systemName>IT2</systemName>
+      <userName>Turnout Trailing Space</userName>
+    </turnout>
+    <turnout systemName="IT3" userName="Turnout Leading Space" feedback="DIRECT" inverted="false" automate="Default">
+      <systemName>IT3</systemName>
+      <userName>Turnout Leading Space</userName>
+    </turnout>
+  </turnouts>
+  <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
+  <signalgroups class="jmri.managers.configurexml.DefaultSignalGroupManagerXml" />
+  <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
+  <warrants class="jmri.jmrit.logix.configurexml.WarrantManagerXml" />
+  <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
+    <logicDelay>500</logicDelay>
+  </signalmastlogics>
+  <!--Written by JMRI version 20140805-1643-jake on Tue Aug 05 12:46:47 EDT 2014 $Id: XmlFile.java 26366 2014-06-20 03:34:25Z ken_c $-->
+</layout-config>
+

--- a/java/test/jmri/configurexml/loadref/LoadFileTest.xml
+++ b/java/test/jmri/configurexml/loadref/LoadFileTest.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="IS1" inverted="false" userName="User 1">
       <systemName>IS1</systemName>
@@ -25,7 +25,7 @@
       <systemName>ISCLOCKRUNNING</systemName>
     </sensor>
   </sensors>
-  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
       <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
@@ -71,7 +71,7 @@
       <systemName>IT4</systemName>
     </turnout>
   </turnouts>
-  <lights class="jmri.managers.configurexml.InternalLightManagerXml">
+  <lights class="jmri.jmrix.internal.configurexml.InternalLightManagerXml">
     <light systemName="IL1" userName="User 1" minIntensity="0.0" maxIntensity="1.0" transitionTime="0.0">
       <systemName>IL1</systemName>
       <userName>User 1</userName>

--- a/java/test/jmri/configurexml/loadref/LoadFileTest277.xml
+++ b/java/test/jmri/configurexml/loadref/LoadFileTest277.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="IS1" inverted="false" userName="User 1">
       <systemName>IS1</systemName>
@@ -25,7 +25,7 @@
       <systemName>ISCLOCKRUNNING</systemName>
     </sensor>
   </sensors>
-  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
       <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
@@ -65,7 +65,7 @@
       <systemName>IT4</systemName>
     </turnout>
   </turnouts>
-  <lights class="jmri.managers.configurexml.InternalLightManagerXml">
+  <lights class="jmri.jmrix.internal.configurexml.InternalLightManagerXml">
     <light systemName="IL1" userName="User 1" minIntensity="0.0" maxIntensity="1.0" transitionTime="0.0">
       <systemName>IL1</systemName>
       <userName>User 1</userName>

--- a/java/test/jmri/configurexml/loadref/LoadFileTest295.xml
+++ b/java/test/jmri/configurexml/loadref/LoadFileTest295.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="IS1" inverted="false" userName="User 1">
       <systemName>IS1</systemName>
@@ -25,7 +25,7 @@
       <systemName>ISCLOCKRUNNING</systemName>
     </sensor>
   </sensors>
-  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
       <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
@@ -65,7 +65,7 @@
       <systemName>IT4</systemName>
     </turnout>
   </turnouts>
-  <lights class="jmri.managers.configurexml.InternalLightManagerXml">
+  <lights class="jmri.jmrix.internal.configurexml.InternalLightManagerXml">
     <light systemName="IL1" userName="User 1" minIntensity="0.0" maxIntensity="1.0" transitionTime="0.0">
       <systemName>IL1</systemName>
       <userName>User 1</userName>

--- a/java/test/jmri/configurexml/loadref/LoadMultipleSystems.xml
+++ b/java/test/jmri/configurexml/loadref/LoadMultipleSystems.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="IS0" inverted="false">
       <systemName>IS0</systemName>
@@ -28,7 +28,7 @@
       <systemName>ISCLOCKRUNNING</systemName>
     </sensor>
   </sensors>
-  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
       <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
@@ -88,13 +88,13 @@
       <systemName>IT9</systemName>
     </turnout>
   </turnouts>
-  <lights class="jmri.managers.configurexml.InternalLightManagerXml">
+  <lights class="jmri.jmrix.internal.configurexml.InternalLightManagerXml">
     <light systemName="IL0" userName="light0" minIntensity="0.0" maxIntensity="1.0" transitionTime="0.0">
       <systemName>IL0</systemName>
       <userName>light0</userName>
     </light>
   </lights>
-  <reporters class="jmri.managers.configurexml.InternalReporterManagerXml">
+  <reporters class="jmri.jmrix.internal.configurexml.InternalReporterManagerXml">
     <reporter systemName="IR0" userName="Report0">
       <systemName>IR0</systemName>
       <userName>Report0</userName>

--- a/java/test/jmri/configurexml/loadref/PanelFileSchemaTest.xml
+++ b/java/test/jmri/configurexml/loadref/PanelFileSchemaTest.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="IS1" inverted="false" userName="User 1">
       <systemName>IS1</systemName>
@@ -25,7 +25,7 @@
       <systemName>ISCLOCKRUNNING</systemName>
     </sensor>
   </sensors>
-  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
       <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
@@ -65,7 +65,7 @@
       <systemName>IT4</systemName>
     </turnout>
   </turnouts>
-  <lights class="jmri.managers.configurexml.InternalLightManagerXml">
+  <lights class="jmri.jmrix.internal.configurexml.InternalLightManagerXml">
     <light systemName="IL1" userName="User 1" minIntensity="0.0" maxIntensity="1.0" transitionTime="0.0">
       <systemName>IL1</systemName>
       <userName>User 1</userName>

--- a/java/test/jmri/configurexml/loadref/PanelFileSchemaTest295.xml
+++ b/java/test/jmri/configurexml/loadref/PanelFileSchemaTest295.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="IS1" inverted="false" userName="User 1">
       <systemName>IS1</systemName>
@@ -25,7 +25,7 @@
       <systemName>ISCLOCKRUNNING</systemName>
     </sensor>
   </sensors>
-  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
       <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
@@ -65,7 +65,7 @@
       <systemName>IT4</systemName>
     </turnout>
   </turnouts>
-  <lights class="jmri.managers.configurexml.InternalLightManagerXml">
+  <lights class="jmri.jmrix.internal.configurexml.InternalLightManagerXml">
     <light systemName="IL1" userName="User 1" minIntensity="0.0" maxIntensity="1.0" transitionTime="0.0">
       <systemName>IL1</systemName>
       <userName>User 1</userName>

--- a/java/test/jmri/configurexml/loadref/PanelFileSchemaTest382.xml
+++ b/java/test/jmri/configurexml/loadref/PanelFileSchemaTest382.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="IS1" inverted="false" userName="User 1">
       <systemName>IS1</systemName>
@@ -25,7 +25,7 @@
       <systemName>ISCLOCKRUNNING</systemName>
     </sensor>
   </sensors>
-  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
       <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
@@ -65,7 +65,7 @@
       <systemName>IT4</systemName>
     </turnout>
   </turnouts>
-  <lights class="jmri.managers.configurexml.InternalLightManagerXml">
+  <lights class="jmri.jmrix.internal.configurexml.InternalLightManagerXml">
     <light systemName="IL1" userName="User 1" minIntensity="0.0" maxIntensity="1.0" transitionTime="0.0">
       <systemName>IL1</systemName>
       <userName>User 1</userName>

--- a/java/test/jmri/configurexml/loadref/RevHistTest.xml
+++ b/java/test/jmri/configurexml/loadref/RevHistTest.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="ISCLOCKRUNNING" inverted="false">
       <systemName>ISCLOCKRUNNING</systemName>

--- a/java/test/jmri/configurexml/loadref/SectionManagerXmlTest.xml
+++ b/java/test/jmri/configurexml/loadref/SectionManagerXmlTest.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="ISBO1" inverted="false" userName="blocknorthwestoccupied">
       <systemName>ISBO1</systemName>
@@ -202,7 +202,7 @@
       <systemName>ISSSTOPR9</systemName>
     </sensor>
   </sensors>
-  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
       <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />

--- a/java/test/jmri/jmrit/display/configurexml/loadref/OldScaledIconTest.xml
+++ b/java/test/jmri/jmrit/display/configurexml/loadref/OldScaledIconTest.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="ISCLOCKRUNNING" inverted="false">
       <systemName>ISCLOCKRUNNING</systemName>

--- a/java/test/jmri/jmrit/display/configurexml/loadref/OneOfEach.3.3.3.xml
+++ b/java/test/jmri/jmrit/display/configurexml/loadref/OneOfEach.3.3.3.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="IS0" inverted="false">
       <systemName>IS0</systemName>
@@ -28,7 +28,7 @@
       <systemName>ISCLOCKRUNNING</systemName>
     </sensor>
   </sensors>
-  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
       <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
@@ -73,13 +73,13 @@
       <systemName>IT9</systemName>
     </turnout>
   </turnouts>
-  <lights class="jmri.managers.configurexml.InternalLightManagerXml">
+  <lights class="jmri.jmrix.internal.configurexml.InternalLightManagerXml">
     <light systemName="IL0" userName="light0" minIntensity="0.0" maxIntensity="1.0" transitionTime="0.0">
       <systemName>IL0</systemName>
       <userName>light0</userName>
     </light>
   </lights>
-  <reporters class="jmri.managers.configurexml.InternalReporterManagerXml">
+  <reporters class="jmri.jmrix.internal.configurexml.InternalReporterManagerXml">
     <reporter systemName="IR0" userName="Report0">
       <systemName>IR0</systemName>
       <userName>Report0</userName>

--- a/java/test/jmri/jmrit/display/configurexml/loadref/OneOfEach.xml
+++ b/java/test/jmri/jmrit/display/configurexml/loadref/OneOfEach.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="IS0" inverted="false">
       <systemName>IS0</systemName>
@@ -28,7 +28,7 @@
       <systemName>ISCLOCKRUNNING</systemName>
     </sensor>
   </sensors>
-  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
       <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
@@ -88,13 +88,13 @@
       <systemName>IT9</systemName>
     </turnout>
   </turnouts>
-  <lights class="jmri.managers.configurexml.InternalLightManagerXml">
+  <lights class="jmri.jmrix.internal.configurexml.InternalLightManagerXml">
     <light systemName="IL0" userName="light0" minIntensity="0.0" maxIntensity="1.0" transitionTime="0.0">
       <systemName>IL0</systemName>
       <userName>light0</userName>
     </light>
   </lights>
-  <reporters class="jmri.managers.configurexml.InternalReporterManagerXml">
+  <reporters class="jmri.jmrix.internal.configurexml.InternalReporterManagerXml">
     <reporter systemName="IR0" userName="Report0">
       <systemName>IR0</systemName>
       <userName>Report0</userName>

--- a/java/test/jmri/jmrit/display/configurexml/loadref/ScaledIconTest.3.8.xml
+++ b/java/test/jmri/jmrit/display/configurexml/loadref/ScaledIconTest.3.8.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="ISCLOCKRUNNING" inverted="false">
       <systemName>ISCLOCKRUNNING</systemName>

--- a/java/test/jmri/jmrit/display/configurexml/loadref/ScaledIconTest.xml
+++ b/java/test/jmri/jmrit/display/configurexml/loadref/ScaledIconTest.xml
@@ -7,7 +7,7 @@
     <test>2</test>
     <modifier>.2</modifier>
   </jmriversion>
-  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
     <defaultInitialState>unknown</defaultInitialState>
     <sensor systemName="ISCLOCKRUNNING" inverted="false">
       <systemName>ISCLOCKRUNNING</systemName>

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -24,6 +24,7 @@ public class AbstractThrottleTest extends TestCase {
     protected void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp(); 
         super.setUp();
+        jmri.util.JUnitUtil.resetInstanceManager();
         InstanceManager.setThrottleManager(new AbstractThrottleManager() {
 
             @Override
@@ -49,7 +50,6 @@ public class AbstractThrottleTest extends TestCase {
 
     @Override
     protected void tearDown() throws Exception {
-        InstanceManager.setThrottleManager(null);
         super.tearDown();
         apps.tests.Log4JFixture.tearDown(); 
     }

--- a/java/test/jmri/jmrix/PackageTest.java
+++ b/java/test/jmri/jmrix/PackageTest.java
@@ -1,4 +1,3 @@
-//JmrixTest.java
 package jmri.jmrix;
 
 import junit.framework.Test;
@@ -9,7 +8,6 @@ import junit.framework.TestSuite;
  * Set of tests for the jmri.jmrix package
  *
  * @author	Bob Jacobsen Copyright 2003, 2007
- * @version $Revision$
  */
 public class PackageTest extends TestCase {
 
@@ -20,7 +18,7 @@ public class PackageTest extends TestCase {
 
     // Main entry point
     static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
+        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
         junit.swingui.TestRunner.main(testCaseName);
     }
 

--- a/java/test/jmri/jmrix/ieee802154/IEEE802154ReplyTest.java
+++ b/java/test/jmri/jmrix/ieee802154/IEEE802154ReplyTest.java
@@ -11,7 +11,6 @@ import junit.framework.TestSuite;
  * Description:	tests for the jmri.jmrix.ieee802154.IEEE802154Reply class
  *
  * @author	Paul Bender
- * @version $Revision$
  */
 public class IEEE802154ReplyTest extends TestCase {
 
@@ -27,6 +26,8 @@ public class IEEE802154ReplyTest extends TestCase {
         };
         IEEE802154Reply m = new IEEE802154Reply(tc);
         Assert.assertNotNull(m);
+        
+        jmri.util.JUnitAppender.assertErrorMessage("Deprecated Method setInstance called");
     }
 
     // from here down is testing infrastructure

--- a/java/test/jmri/jmrix/lenz/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/PackageTest.java
@@ -20,7 +20,7 @@ public class PackageTest extends TestCase {
 
     // Main entry point
     static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
+        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
         junit.swingui.TestRunner.main(testCaseName);
     }
 

--- a/java/test/jmri/jmrix/lenz/XNetTurnoutTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetTurnoutTest.java
@@ -121,6 +121,7 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTest {
         // prepare an interface
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalSensorManager();
+        jmri.util.JUnitUtil.initInternalTurnoutManager();
         t = new XNetTurnout("XT", 21, lnis);
 
         // set thrown
@@ -145,7 +146,7 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTest {
             log.error("TO exception: " + x);
         }
         // check to see if the turnout state changes.
-        Assert.assertTrue(t.getKnownState() == jmri.Turnout.THROWN);
+        jmri.util.JUnitUtil.waitFor(()->{return t.getKnownState() == jmri.Turnout.THROWN;}, "Turnout goes THROWN");
     }
 
     @Override
@@ -177,6 +178,7 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTest {
     // The minimal setup for log4J
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
+        
         // prepare an interface
         lnis = new XNetInterfaceScaffold(new LenzCommandStation());
 

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -164,6 +164,9 @@ public class JUnitUtil {
     }
     
     public static void resetInstanceManager() {
+        // clear system connections
+        jmri.jmrix.SystemConnectionMemo.reset();
+
         // create a new instance manager
         new InstanceManager() {
             @Override
@@ -193,27 +196,15 @@ public class JUnitUtil {
     }
 
     public static void initInternalTurnoutManager() {
-        InstanceManager.setTurnoutManager(new InternalTurnoutManager());
-        if (InstanceManager.configureManagerInstance() != null) {
-            InstanceManager.configureManagerInstance().registerConfig(
-                    InstanceManager.turnoutManagerInstance(), jmri.Manager.TURNOUTS);
-        }
+        // now done automatically by InstanceManager's autoinit
     }
 
     public static void initInternalLightManager() {
-        InternalLightManager m = new InternalLightManager();
-        InstanceManager.setLightManager(m);
-        if (InstanceManager.configureManagerInstance() != null) {
-            InstanceManager.configureManagerInstance().registerConfig(m, jmri.Manager.LIGHTS);
-        }
+        // now done automatically by InstanceManager's autoinit
     }
 
     public static void initInternalSensorManager() {
-        InternalSensorManager m = new InternalSensorManager();
-        InstanceManager.setSensorManager(m);
-        if (InstanceManager.configureManagerInstance() != null) {
-            InstanceManager.configureManagerInstance().registerConfig(m, jmri.Manager.SENSORS);
-        }
+        // now done automatically by InstanceManager's autoinit
     }
 
     public static void initMemoryManager() {

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -197,14 +197,17 @@ public class JUnitUtil {
 
     public static void initInternalTurnoutManager() {
         // now done automatically by InstanceManager's autoinit
+        jmri.InstanceManager.turnoutManagerInstance();
     }
 
     public static void initInternalLightManager() {
         // now done automatically by InstanceManager's autoinit
-    }
+         jmri.InstanceManager.lightManagerInstance();
+   }
 
     public static void initInternalSensorManager() {
         // now done automatically by InstanceManager's autoinit
+        jmri.InstanceManager.sensorManagerInstance();
     }
 
     public static void initMemoryManager() {


### PR DESCRIPTION
See also Issue #973 

This switches to using the jmri.jmrix.internal managers for "Internal" (system letter I) objects, from the individual managers in jmri.managers.  In turn, this provides the correct system structure:  An Internal SystemConnectionMemo, etc.

