### PR TITLE
Eliminate nasty Java lockup.

### DIFF
--- a/java/src/jmri/jmrit/operations/trains/TrainsTableModel.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainsTableModel.java
@@ -522,12 +522,14 @@ public class TrainsTableModel extends javax.swing.table.AbstractTableModel imple
                 log.debug("Update train table row: {} name: {}", row, train.getName());
             }
             if (row >= 0) {
-                // The following commented out line of code can sometimes cause a thread lock if the table sorter is active.
-                // It never seems to lock when the sorter is inactive.
-                // TODO Figure out a way to prevent the thread lock. Note this code was added recently to
-                // scroll the trains window to the line (train) where a change in the line was being made.
-                //                
-//                _table.scrollRectToVisible(_table.getCellRect(row, 0, true));
+                // The line "_table.scrollRectToVisible(_table.getCellRect(row, 0, true));"
+                // can cause a thread lock if the table sorter is active. That's the reason
+                // the code is wrapped in the invokeLater.
+                SwingUtilities.invokeLater(new Runnable() {
+                    public void run() {
+                        _table.scrollRectToVisible(_table.getCellRect(row, 0, true));
+                    }
+                });
                 fireTableRowsUpdated(row, row);
             }
         }

--- a/java/src/jmri/jmrit/operations/trains/TrainsTableModel.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainsTableModel.java
@@ -522,7 +522,12 @@ public class TrainsTableModel extends javax.swing.table.AbstractTableModel imple
                 log.debug("Update train table row: {} name: {}", row, train.getName());
             }
             if (row >= 0) {
-                _table.scrollRectToVisible(_table.getCellRect(row, 0, true));
+                // The following commented out line of code can sometimes cause a thread lock if the table sorter is active.
+                // It never seems to lock when the sorter is inactive.
+                // TODO Figure out a way to prevent the thread lock. Note this code was added recently to
+                // scroll the trains window to the line (train) where a change in the line was being made.
+                //                
+//                _table.scrollRectToVisible(_table.getCellRect(row, 0, true));
                 fireTableRowsUpdated(row, row);
             }
         }
@@ -553,11 +558,6 @@ public class TrainsTableModel extends javax.swing.table.AbstractTableModel imple
     }
 
     class MyTableCellRenderer extends DefaultTableCellRenderer {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 6030024446880261924L;
 
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,


### PR DESCRIPTION
Does anyone understand why this line of code could cause Java to lockup?  

_table.scrollRectToVisible(_table.getCellRect(row, 0, true));

When the lockup occurs it has it's own thread, not swing.  When the table sorter isn't active, everything works fine.  But if the table is sorting, a lockup can sometimes occur.