### PR TITLE
Support for simplified threading

### DIFF
--- a/help/en/html/doc/Technical/Threads.shtml
+++ b/help/en/html/doc/Technical/Threads.shtml
@@ -29,30 +29,15 @@
 
 	<div id="mainContent">
 	    <H1>JMRI: Threading</H1>
-The initial threading model for JMRI is quite simple: Everything interesting
-happens in 
-the GUI thread.  For example, once a 'message', e.g. a LocoNet packet, 
-is accumulated in a separate thread, the message is processed in the 
-GUI thread via:
-<PRE>
-	// message is complete, dispatch it !!<br/>
-	{ <br/>
-	final LocoNetMessage thisMsg = msg;<br/>
-	final LnTrafficController thisTC = this;<br/>
-	// return a notification via the queue to ensure end<br/>
-	Runnable r = new Runnable() {<br/>
-		LocoNetMessage msgForLater = thisMsg;<br/>
-		LnTrafficController myTC = thisTC;<br/>
-		public void run() { <br/>
-				log.debug("Delayed notify starts");<br/>
-           		myTC.notify(msgForLater);<br/>
-			}<br/>
-		};
-		javax.swing.SwingUtilities.invokeLater(r);<br/>
-	}<br/>
-</PRE>
 
-This does a nice job of serializing the activity from the layout.
+The vast majority of JMRI code (and programmers) don't have to 
+worry about threading.  Their code gets invoked, and invokes other code,
+and threading takes care of itself.  This is particularly true of event-based code,
+which responds to events from e.g. the GUI or a layout object changing, and 
+calls methods on other objects, which may in turn create more events.
+
+<p>
+This simplicity comes from using a single thread for processing most of JMRI's activity: The Java Swing event thread.
 <p>
 Note that this does <em>not</em> mean that other things can't be happening. For example, this script fragment:
 
@@ -63,6 +48,38 @@ Note that this does <em>not</em> mean that other things can't be happening. For 
 </code></pre>
 
 can print either true or false, because changing that turnout <em>can</em> change associated sensors instantaneously.
+
+<p>
+There are times when you might want to do something a bit more complex using an additional thread:
+<ul>
+<li>You might want to put long-running processing in a separate thread to keep the rest of JMRI responsive.
+<li>The easiest way to code a state machine that talks to layout hardware might be to use a separate thread.
+<li>You might be interfacing to some other existing code that uses threads.
+</ul>
+
+We would prefer that you handle the threading issues that arise in that case via the 
+<a href="http://jmri.org/JavaDoc/doc/jmri/util/ThreadingUtil.html">jmri.util.ThreadingUtil<a/> class.  
+ThreadingUtil provides utilities that make it easy
+to invoke needed functions on the right thread.
+<p>
+For example, if you want to read a bunch of data from a file, spend some time munging it, 
+and then create a window to present it all, you might want to do all that work on a 
+separate thread.  At the end, when it's time to set your new frame visible, you have to
+to that on the Swing (GUI) thread.  Here's the code to do that:
+<pre>
+    frame = new JmriJFrame();  // frame declared as instance variable<br/>
+    // spend a long time reading data and configuring the frame<br/>
+    ThreadingUtil.runOnGUI( ()-&gt;{  frame.setVisible(); });<br/>
+</pre>
+ThreadingUtil separates operations on the GUI (e.g. Java Swing) thread, and operations
+on the Layout (e.g. Sensors, Turnouts, etc) thread.  There's no real difference now, 
+but in the interest of perhaps someday needing to separate those, we've introduced the 
+two versions now.  Please try to pick the mostly-likely-right one when coding.
+<p>
+(N.B.: You'll find lots of older cases that use explicitly use javax.swing.SwingUtilities.invokeLater(r)
+or javax.swing.SwingUtilities.invokeAndWait(r); these should be migrated to the newer JMRI-specific methods
+as time is available to keep our code just a tiny bit cleaner and more flexible.)
+
 
 <!--#include virtual="/Footer" -->
 

--- a/java/src/jmri/util/ThreadingUtil.java
+++ b/java/src/jmri/util/ThreadingUtil.java
@@ -1,0 +1,108 @@
+package jmri.util;
+
+/**
+ * Utilities for handling JMRI's threading conventions
+ * <p>
+ * For background, see http://localhost/help/en/html/doc/Technical/Threads.shtml
+ * <p>
+ * Note this distinguished "on layout", e.g. setting a sensor, from
+ * "on GUI", e.g. manipulating the GUI. That may or may not be an important
+ * distinction now, but it might be later, so we build it into the calls.
+ *
+ * @author Bob Jacobsen   Copyright 2015
+ */
+public class ThreadingUtil {
+
+    static public interface ThreadAction extends Runnable {
+        /**
+         * Must handle it's own exceptions
+         */
+        public void run();
+    }
+
+    /** 
+     * Run some layout-specific code before returning
+     * <p>
+     * Typical uses:
+     * <p><code>ThreadUtil.runOnLayout( ()->{ sensor.setState(value); } );</code>
+     * 
+     * @param condition name of condition being waited for; will appear in Assert.fail if condition not true fast enough
+     */
+    static public void runOnLayout(ThreadAction ta) {
+        runOnGUI(ta);
+    }
+
+    /** 
+     * Run some layout-specific code at some later point.
+     * <p>
+     * Please note the operation may have happened before this returns. Or not.
+     * <p>
+     * Typical uses:
+     * <p><code>ThreadUtil.runOnLayoutEventually( ()->{ sensor.setState(value); } );</code>
+     * 
+     * @param condition name of condition being waited for; will appear in Assert.fail if condition not true fast enough
+     */
+    static public void runOnLayoutEventually(ThreadAction ta) {
+        runOnGUIEventually(ta);
+    }
+
+    /** 
+     * Check if on the layout-operation thread.
+     */
+    static public boolean isLayoutThread() {
+        return isGUIThread();
+    }
+
+    /** 
+     * Run some GUI-specific code before returning
+     * <p>
+     * Typical uses:
+     * <p><code>ThreadUtil.runOnGUI( ()->{ mine.setVisible(); } );</code>
+     * 
+     * @param condition name of condition being waited for; will appear in Assert.fail if condition not true fast enough
+     */
+    static public void runOnGUI(ThreadAction ta) {
+        if (isGUIThread()) {
+            // run now
+        } else {
+            // dispatch to Swing
+            try {
+                javax.swing.SwingUtilities.invokeAndWait(ta);
+            } catch (InterruptedException e) {
+                log.warn("While on GUI thread", e);
+                // we just continue from InterruptedException for now
+            } catch (java.lang.reflect.InvocationTargetException e) {
+                log.error("Error while on GUI thread", e);
+                // should have been handled inside the ThreadAction
+            }
+        }
+    }
+
+    /** 
+     * Run some layout-specific code at some later point.
+     * <p>
+     * Please note the operation may have happened before this returns. Or not.
+     * <p>
+     * Typical uses:
+     * <p><code>ThreadUtil.runOnGUIEventually( ()->{ mine.setVisible(); } );</code>
+     * 
+     * @param condition name of condition being waited for; will appear in Assert.fail if condition not true fast enough
+     */
+    static public void runOnGUIEventually(ThreadAction ta) {
+        if (isGUIThread()) {
+            // run now
+        } else {
+            // dispatch to Swing
+            javax.swing.SwingUtilities.invokeLater(ta);
+        }
+    }
+
+    /** 
+     * Check if on the GUI thread.
+     */
+    static public boolean isGUIThread() {
+        return javax.swing.SwingUtilities.isEventDispatchThread();
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(JUnitUtil.class.getName());
+}

--- a/java/src/jmri/util/ThreadingUtil.java
+++ b/java/src/jmri/util/ThreadingUtil.java
@@ -104,5 +104,5 @@ public class ThreadingUtil {
         return javax.swing.SwingUtilities.isEventDispatchThread();
     }
 
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(JUnitUtil.class.getName());
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ThreadingUtil.class.getName());
 }

--- a/java/test/jmri/util/PackageTest.java
+++ b/java/test/jmri/util/PackageTest.java
@@ -37,6 +37,7 @@ public class PackageTest extends TestCase {
         suite.addTest(OrderedHashtableTest.suite());
         suite.addTest(PreferNumericComparatorTest.suite());
         suite.addTest(StringUtilTest.suite());
+        suite.addTest(ThreadingUtilTest.suite());
         suite.addTest(I18NTest.suite());
         suite.addTest(ColorUtilTest.suite());
 

--- a/java/test/jmri/util/ThreadingUtilTest.java
+++ b/java/test/jmri/util/ThreadingUtilTest.java
@@ -1,0 +1,74 @@
+package jmri.util;
+
+import junit.framework.Assert;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Tests for ThreadingUtil class
+ *
+ * @author	Bob Jacobsen Copyright 2015
+ */
+public class ThreadingUtilTest extends TestCase {
+
+    boolean done;
+    
+    public void testToLayout() {
+        done = false;
+        
+        ThreadingUtil.runOnLayout( ()-> { done = true; } );
+        Assert.assertTrue(done);
+    }
+
+    public void testThreadingNesting() {
+        done = false;
+        
+        new Thread(
+            new Runnable() {
+                public void run() {
+                    // now on another thread
+                    // switch back to Layout thread
+                    ThreadingUtil.runOnLayout( ()-> { 
+                        // on layout thread, confirm
+                        Assert.assertTrue("on Layout thread", ThreadingUtil.isLayoutThread());
+                        // mark done so we known
+                        done = true; 
+                    } );
+                }
+            }
+        ).start();
+
+        JUnitUtil.waitFor( ()->{ return done; }, "Separate thread complete");
+    }
+
+
+    // from here down is testing infrastructure
+    public ThreadingUtilTest(String s) {
+        super(s);
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {"-noloading", ThreadingUtilTest.class.getName()};
+        junit.swingui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        TestSuite suite = new TestSuite(ThreadingUtilTest.class);
+        return suite;
+    }
+
+    // The minimal setup for log4J
+    protected void setUp() throws Exception {
+        super.setUp();
+        apps.tests.Log4JFixture.setUp();
+    }
+
+    protected void tearDown() throws Exception {
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+}


### PR DESCRIPTION
This is the initial part of some work on threading in response to issue #727 (and threading problems in other places). It's a new jmri.util.ThreadingUtil class to simplify moving to the right thread, along with a doc update and tests.

The additional changes to e.g. the Warrant code are not in this PR, and will come later.