### PR TITLE
Warrant code threading update

### DIFF
--- a/java/src/jmri/jmrit/logix/Engineer.java
+++ b/java/src/jmri/jmrit/logix/Engineer.java
@@ -6,11 +6,16 @@ import jmri.InstanceManager;
 import jmri.Sensor;
 import jmri.implementation.SignalSpeedMap;
 import jmri.jmrit.roster.RosterSpeedProfile;
+import jmri.util.ThreadingUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Execute a throttle command script for a warrant
+ * Execute a throttle command script for a warrant.
+ * <p>
+ * This generally operates on it's own thread, but switches back to the 
+ * Layout thread when asking the Warrant to perform actions.
  *
  * @author  Pete Cressman  Copyright (C) 2009, 2010, 2011
  */
@@ -59,12 +64,14 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
         }
     }
 
+    int cmdBlockIdx = 0;
+
     @Override
     public void run() {
         _debug = log.isDebugEnabled();
         if (_debug) log.debug("Engineer started warrant "+_warrant.getDisplayName());
 
-        int cmdBlockIdx = 0;
+        cmdBlockIdx = 0;
         float timeRatio = 1.0f;     // ratio to extend scripted time when speed is modified
         while (_idxCurrentCommand < _warrant._commands.size()) {
             long et = System.currentTimeMillis();
@@ -105,7 +112,9 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
                             if (_debug) log.debug("Wait for train to enter \""+ts.getBlockName()+
                                                       "\".  Warrant "+_warrant.getDisplayName());
                             _waitForSync = true;
-                            _warrant.fireRunStatus("Command", Integer.valueOf(_idxCurrentCommand-1), Integer.valueOf(_idxCurrentCommand));
+                            ThreadingUtil.runOnLayout(()->{
+                                _warrant.fireRunStatus("Command", Integer.valueOf(_idxCurrentCommand-1), Integer.valueOf(_idxCurrentCommand));
+                            });
                             wait();
                         }
                     //}
@@ -145,7 +154,9 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
                             timeRatio = 1.0f;                            
                         }
                         setSpeed(speedMod);
-                        _warrant.fireRunStatus("SpeedChange", null, _speedType);
+                        ThreadingUtil.runOnLayout(()->{
+                            _warrant.fireRunStatus("SpeedChange", null, _speedType);
+                        });
                     } finally {
                       _lock.unlock();
                     }
@@ -168,13 +179,19 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
                 } else if (command.equals("WAIT SENSOR")) {
                     getSensor(ts.getBlockName(), ts.getValue());
                 } else if (command.equals("START TRACKER")) {
-                    _warrant.startTracker();
+                    ThreadingUtil.runOnLayout(()->{
+                        _warrant.startTracker();
+                    });
                 } else if (command.equals("RUN WARRANT")) {
                     runWarrant(ts);
                 } else if (_runOnET && command.equals("NOOP")) {    // let warrant know engineer expects entry into dark block
-                    _warrant.goingActive(_warrant.getBlockAt(cmdBlockIdx));
+                    ThreadingUtil.runOnLayout(()->{
+                        _warrant.goingActive(_warrant.getBlockAt(cmdBlockIdx));
+                    });
                 }
-                _warrant.fireRunStatus("Command", Integer.valueOf(_idxCurrentCommand), Integer.valueOf(_idxCurrentCommand));
+                ThreadingUtil.runOnLayout(()->{
+                    _warrant.fireRunStatus("Command", Integer.valueOf(_idxCurrentCommand), Integer.valueOf(_idxCurrentCommand));
+                });
                 _idxCurrentCommand++;
                 et = System.currentTimeMillis()-et;
                 if (_debug) log.debug("Cmd #"+(_idxCurrentCommand)+": "+
@@ -549,7 +566,9 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
                 _waitForSensor = true;              
                 while (_waitForSensor) {
                     try {
-                        _warrant.fireRunStatus("Command", Integer.valueOf(_idxCurrentCommand-1), Integer.valueOf(_idxCurrentCommand));
+                        ThreadingUtil.runOnLayout(()->{
+                            _warrant.fireRunStatus("Command", Integer.valueOf(_idxCurrentCommand-1), Integer.valueOf(_idxCurrentCommand));
+                        });
                         wait();
                         clearSensor();
                     } catch (InterruptedException ie) {
@@ -748,7 +767,9 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
             _speedOverride = true;
             String old = _speedType;
             _speedType = endSpeedType;   // transition
-            _warrant.fireRunStatus("SpeedRestriction", old, _speedType);
+            ThreadingUtil.runOnLayout(()->{
+                _warrant.fireRunStatus("SpeedRestriction", old, _speedType);
+            });
             try {
                 
                 synchronized(this) {
@@ -764,9 +785,10 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
                 } else {
                     float endSpeed = modifySpeed(_normalSpeed, endSpeedType);
                     float speed = _throttle.getSpeedSetting();
-//                    _warrant.fireRunStatus("SpeedRestriction", old, 
+//                    ThreadingUtil.runOnLayout(()->{
+//                        _warrant.fireRunStatus("SpeedRestriction", old, 
 //                                       (endSpeed > speed ? "increasing" : "decreasing"));
-
+//                    });
                     float incr = _speedMap.getStepIncrement();
                     int delay = _speedMap.getStepDelay();
                     
@@ -815,7 +837,9 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
             } finally {
                 _speedOverride = false;
                 _warrant.setSpeedType(_speedType);
-                _warrant.fireRunStatus("SpeedChange", old, _speedType);
+                ThreadingUtil.runOnLayout(()->{
+                    _warrant.fireRunStatus("SpeedChange", old, _speedType);
+                });
                 _lock.unlock();
             }
             if (_debug) log.debug("rampSpeed complete to \""+endSpeedType+

--- a/java/src/jmri/jmrit/logix/Engineer.java
+++ b/java/src/jmri/jmrit/logix/Engineer.java
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Execute a throttle command script for a warrant
  *
- * @version $Revision$
  * @author  Pete Cressman  Copyright (C) 2009, 2010, 2011
  */
  

--- a/java/src/jmri/jmrit/logix/OBlock.java
+++ b/java/src/jmri/jmrit/logix/OBlock.java
@@ -60,7 +60,6 @@ import org.slf4j.LoggerFactory;
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  * <P>
  *
- * @version $Revision$
  * @author	Pete Cressman (C) 2009
  */
 public class OBlock extends jmri.Block implements java.beans.PropertyChangeListener {

--- a/java/src/jmri/jmrit/logix/OBlock.java
+++ b/java/src/jmri/jmrit/logix/OBlock.java
@@ -12,6 +12,7 @@ import jmri.NamedBeanHandle;
 import jmri.Path;
 import jmri.Sensor;
 import jmri.Turnout;
+import jmri.util.ThreadingUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -843,7 +844,9 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
         setState((getState() & ~(OCCUPIED | RUNNING)) | UNOCCUPIED);
         setValue(null);
         if (_warrant != null) {
-            _warrant.goingInactive(this);
+            ThreadingUtil.runOnLayout(()->{
+                _warrant.goingInactive(this);
+            });
         }
     }
 
@@ -857,7 +860,9 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
 //        if (log.isDebugEnabled()) log.debug("Allocated OBlock \""+getSystemName()+
 //                                            "\" goes OCCUPIED. state= "+getState());
         if (_warrant != null) {
-            _warrant.goingActive(this);
+            ThreadingUtil.runOnLayout(()->{
+                _warrant.goingActive(this);
+            });
         }
         if (log.isDebugEnabled()) {
             log.debug("Block \"" + getSystemName() + " went active, path= "

--- a/java/src/jmri/jmrit/logix/OBlock.java
+++ b/java/src/jmri/jmrit/logix/OBlock.java
@@ -569,6 +569,7 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
                 removePropertyChangeListener(_warrant);
             } catch (Exception ex) {
                 // disposed warrant may throw null pointer - continue deallocation
+                log.warn("Perhaps normal? Code not clear.", e);
             }
         }
         if (_pathName != null) {

--- a/java/src/jmri/jmrit/logix/OBlock.java
+++ b/java/src/jmri/jmrit/logix/OBlock.java
@@ -569,7 +569,7 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
                 removePropertyChangeListener(_warrant);
             } catch (Exception ex) {
                 // disposed warrant may throw null pointer - continue deallocation
-                log.warn("Perhaps normal? Code not clear.", e);
+                log.warn("Perhaps normal? Code not clear.", ex);
             }
         }
         if (_pathName != null) {

--- a/java/src/jmri/jmrit/logix/OPath.java
+++ b/java/src/jmri/jmrit/logix/OPath.java
@@ -272,7 +272,19 @@ public class OPath extends jmri.Path {
      * Override to indicate logical equality for use as paths in OBlocks.
      *
      */
-    public boolean equals(OPath path) {
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+    
+        if (!(getClass() == obj.getClass())) {
+            return false;
+        }
+        
+        OPath path = (OPath) obj;
         if (_fromPortal != null && !_fromPortal.equals(path.getFromPortal())) {
             return false;
         }

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -8,6 +8,7 @@ import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.NamedBean;
 import jmri.ThrottleListener;
+import jmri.util.ThreadingUtil;
 import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
 import org.slf4j.Logger;
@@ -434,6 +435,9 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
      * Engineer reports its status
      */
     protected void fireRunStatus(String property, Object old, Object status) {
+        // error if not on Layout thread
+        if (!ThreadingUtil.isLayoutThread()) log.error("invoked on wrong thread", new Exception("traceback"));
+        
         firePropertyChange(property, old, status);
     }
 
@@ -605,6 +609,9 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
     }
 
     protected void startTracker() {
+        // error if not on Layout thread
+        if (!ThreadingUtil.isLayoutThread()) log.error("invoked on wrong thread", new Exception("traceback"));
+        
         TrackerTableAction.markNewTracker(getCurrentBlockOrder().getBlock(), _trainName);
     }
 
@@ -1267,11 +1274,16 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
     }
 
     /**
-     * Block in the route is going active. check if this is the next block of
+     * Block in the route is going active. Check if this is the next block of
      * the train moving under the warrant Learn mode assumes route is set and
-     * clear
+     * clear.
+     *<p>
+     * Must be called on GUI thread.
      */
     protected void goingActive(OBlock block) {
+        // error if not on Layout thread
+        if (!ThreadingUtil.isLayoutThread()) log.error("invoked on wrong thread", new Exception("traceback"));
+
         if (_runMode == MODE_NONE) {
             return;
         }

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -568,11 +568,9 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
                         msg = Bundle.getMessage("reRetry", blockName, cmdIdx, speed);
                         break;
                     case Warrant.ABORT:
-                        if (_engineer != null) {
-                            if (cmdIdx == _commands.size() - 1) {
-                                _engineer = null;
-                                return Bundle.getMessage("endOfScript", _trainName);
-                            }
+                        if (cmdIdx == _commands.size() - 1) {
+                            _engineer = null;
+                            return Bundle.getMessage("endOfScript", _trainName);
                         }
                         msg = Bundle.getMessage("Aborted", blockName, cmdIdx);
                         break;

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
  * </p><P>
  * Version 1.11 - remove setting of SignalHeads
  *
- * @version $Revision$
  * @author  Pete Cressman Copyright (C) 2009, 2010
  */
 public class Warrant extends jmri.implementation.AbstractNamedBean

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -808,7 +808,7 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
                         ret = false;
                         if (bo != null) {
                             OBlock b = bo.getBlock();
-                            if (b.allocate(this) == null && (b.getState() & OBlock.OCCUPIED) > 0) {
+                            if (b.allocate(this) == null && (b.getState() & OBlock.OCCUPIED) != 0) {
                                 _idxCurrentOrder++;
                                 if (b.equals(_stoppingBlock)) {
                                     _stoppingBlock.removePropertyChangeListener(this);
@@ -952,7 +952,7 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
         for (int i = index; i < _orders.size(); i++) {
             BlockOrder bo = _orders.get(i);
             OBlock block = bo.getBlock();
-             if ((block.getState() & OBlock.OCCUPIED) > 0 && !stoppingBlockSet) {
+             if ((block.getState() & OBlock.OCCUPIED) != 0 && !stoppingBlockSet) {
                 setStoppingBlock(block);
                 stoppingBlockSet = true;
                 log.info(block.getDisplayName() + " not allocated, but Occupied.");
@@ -1024,7 +1024,7 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
         for (int i = 1; i < _orders.size(); i++) {
             bo = _orders.get(i);
             OBlock block = bo.getBlock();
-            if ((block.getState() & OBlock.OCCUPIED) > 0) {
+            if ((block.getState() & OBlock.OCCUPIED) != 0) {
                 _message = Bundle.getMessage("BlockRougeOccupied", block.getDisplayName());
                 _routeSet = false;
                 return null;
@@ -1083,7 +1083,7 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
         OBlock startBlock = _orders.get(0).getBlock();
         for (BlockOrder bo : _orders) {
             OBlock block = bo.getBlock();
-            if ((block.getState() & OBlock.OCCUPIED) > 0 && !startBlock.equals(block)) {
+            if ((block.getState() & OBlock.OCCUPIED) != 0 && !startBlock.equals(block)) {
                 msg = Bundle.getMessage("BlockRougeOccupied", block.getDisplayName());
                 _totalAllocated = false;
             }
@@ -1381,7 +1381,7 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
                 if (b.allocate(this) != null) {
                     break;
                 }
-                if ((b.getState() & OBlock.OCCUPIED) > 0) {
+                if ((b.getState() & OBlock.OCCUPIED) != 0) {
                     break;
                 }
             }
@@ -1897,7 +1897,7 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
         }
         OBlock block = bo.getBlock();
         String blockMsg = block.allocate(this);
-        if (blockMsg != null || (block.getState() & OBlock.OCCUPIED) > 0) {
+        if (blockMsg != null || (block.getState() & OBlock.OCCUPIED) != 0) {
             setStoppingBlock(block);
             log.info("allocateNextBlock "+(blockMsg != null ? blockMsg : (block.getDisplayName() + " allocated, but Occupied.")));
             return false;

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -1851,7 +1851,7 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
                 " time= "+blkTime+" from "+firstIdx+" to "+(_commands.size()-1));
     }
     
-    class BlockSpeedInfo {
+    static class BlockSpeedInfo {
         float entranceSpeed;
         float maxSpeed;
         float exitSpeed;

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -1929,7 +1929,7 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
             }
         } else {    //  if signal is configured, ignore block
             nextSpeed = nextBlock.getBlockSpeed();
-            if (nextSpeed=="") {
+            if (nextSpeed.equals("")) {
                 nextSpeed = null;
             }                
          }

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -1982,8 +1982,10 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
                     }
                 }
                 if(_debug) log.debug("CommandDelay: after wait of "+_startWait+" ms, did Ramp to "+nextSpeedType);
-                _engineer.rampSpeedTo(nextSpeedType);                      
-                _engineer.setCurrentCommandIndex(_cmdIndex);
+                jmri.util.ThreadingUtil.runOnLayout(() ->{ // move to layout-handling thread
+                    _engineer.rampSpeedTo(nextSpeedType);                      
+                    _engineer.setCurrentCommandIndex(_cmdIndex);
+                });
             }
         }
     }

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -1436,6 +1436,9 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
             return;
         }
 
+        // error if not on Layout thread
+        if (!ThreadingUtil.isLayoutThread()) log.error("invoked on wrong thread", new Exception("traceback"));
+
         int idx = getIndexOfBlock(block, _idxLastOrder);  // if idx >= 0, it is in this warrant
         if (_debug) {
             log.debug("Block \"" + block.getDisplayName() + "\" goingInactive. idx= "

--- a/java/src/jmri/jmrit/logix/WarrantPreferencesPanel.java
+++ b/java/src/jmri/jmrit/logix/WarrantPreferencesPanel.java
@@ -513,7 +513,7 @@ public class WarrantPreferencesPanel extends JPanel implements PreferencesPanel,
             for (int i=0; i<_appearanceMap.size(); i++) {
                 DataPair<String, String> dp = _appearanceMap.get(i);
                 String name = dp.getKey();
-                if (_preferences.getAppearanceValue(name)==null || _preferences.getAppearanceValue(name)!= dp.getValue()) {
+                if (_preferences.getAppearanceValue(name)==null || !_preferences.getAppearanceValue(name).equals(dp.getValue())) {
                     different = true;
                     break;
                 }

--- a/java/src/jmri/jmrit/logix/WarrantPreferencesPanel.java
+++ b/java/src/jmri/jmrit/logix/WarrantPreferencesPanel.java
@@ -128,6 +128,8 @@ public class WarrantPreferencesPanel extends JPanel implements PreferencesPanel,
         panel.add(p);
         return panel;
     }
+
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "FE_FLOATING_POINT_EQUALITY", justification = "fixed number of possible values")
     private ScaleData makeCustomItem(float scale) {
         int cnt = 0;
         while (cnt <_layoutScales.getItemCount()) {
@@ -421,9 +423,10 @@ public class WarrantPreferencesPanel extends JPanel implements PreferencesPanel,
     }*/
 
     /**
-     * Compare GUI vaules with Preferences.  When different, update Preferences
+     * Compare GUI values with Preferences.  When different, update Preferences
      * and set _isDirty flag.
      */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "FE_FLOATING_POINT_EQUALITY", justification = "fixed number of possible values")
     private void setValues() {
         int depth = _preferences.getSearchDepth();
         try {

--- a/java/src/jmri/jmrit/logix/WarrantPreferencesPanel.java
+++ b/java/src/jmri/jmrit/logix/WarrantPreferencesPanel.java
@@ -601,7 +601,7 @@ public class WarrantPreferencesPanel extends JPanel implements PreferencesPanel,
         return true; // no validity checking performed
     }
 
-    class DataPair<K, V> {
+    static class DataPair<K, V> {
         K key;
         V value;
         

--- a/java/src/jmri/jmrit/logix/WarrantTableAction.java
+++ b/java/src/jmri/jmrit/logix/WarrantTableAction.java
@@ -93,7 +93,9 @@ public class WarrantTableAction extends AbstractAction {
             CreateWarrantFrame f = new CreateWarrantFrame();
             try {
                 f.initComponents();
-            } catch (Exception ex ) {/*bogus*/ }
+            } catch (Exception ex ) {
+                log.error("During initComponents", ex);
+            }
             f.setVisible(true);
         }
         initPathPortalCheck();

--- a/java/src/jmri/jmrit/logix/configurexml/WarrantManagerXml.java
+++ b/java/src/jmri/jmrit/logix/configurexml/WarrantManagerXml.java
@@ -155,7 +155,6 @@ public class WarrantManagerXml //extends XmlFile
         Element elem = new Element(type);
 
         String time = String.valueOf(command.getTime());
-        if (time==null) time = "";
         elem.setAttribute("time", time);
 
         String str = command.getCommand();

--- a/java/test/jmri/jmrit/logix/OPathTest.java
+++ b/java/test/jmri/jmrit/logix/OPathTest.java
@@ -58,6 +58,21 @@ public class OPathTest extends TestCase {
         Assert.assertEquals("block", null, op.getBlock());
     }
 
+    public void testEquals() {
+        Block b1 = new Block("IB1");
+
+        OPath op1 = new OPath(b1, "name");
+        op1.setBlock(null);
+        OPath op2 = new OPath(b1, "name");
+        op2.setBlock(null);
+        
+        Assert.assertFalse("not equals null", op1.equals(null));
+        Assert.assertFalse("not equals string", op1.equals(""));
+        
+        Assert.assertTrue("equals self", op1.equals(op1));
+        Assert.assertTrue("on contents", op1.equals(op2));
+    }
+    
     // from here down is testing infrastructure
     public OPathTest(String s) {
         super(s);


### PR DESCRIPTION
Update the Warrant code in jmrit.logix to switch from the package-specific thread(s) to the Layout thread. Uses the recently-added jmri.util.ThreadingUtil class.

Also:
- JavaDoc updates
- minor file clean up
- fix bug in OPath.equals()
- other FindBugs-indicated fixes (see commit comments)
