### PR TITLE
Fire property changes on Event dispatch thread

### DIFF
--- a/java/src/jmri/beans/ArbitraryBean.java
+++ b/java/src/jmri/beans/ArbitraryBean.java
@@ -25,7 +25,7 @@ public abstract class ArbitraryBean extends Bean {
         } else {
             Object oldValue = this.arbitraryPropertySupport.getProperty(key);
             this.arbitraryPropertySupport.setProperty(key, value);
-            this.propertyChangeSupport.firePropertyChange(key, oldValue, value);
+            this.firePropertyChange(key, oldValue, value);
         }
     }
 
@@ -36,7 +36,7 @@ public abstract class ArbitraryBean extends Bean {
         } else {
             Object oldValue = this.arbitraryPropertySupport.getIndexedProperty(key, index);
             this.arbitraryPropertySupport.setIndexedProperty(key, index, value);
-            this.propertyChangeSupport.fireIndexedPropertyChange(key, index, oldValue, value);
+            this.fireIndexedPropertyChange(key, index, oldValue, value);
         }
     }
 

--- a/java/src/jmri/beans/Bean.java
+++ b/java/src/jmri/beans/Bean.java
@@ -4,6 +4,7 @@ package jmri.beans;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
+import jmri.util.ThreadingUtil;
 
 /**
  * Generic implementation of {@link jmri.beans.BeanInterface} with a complete
@@ -44,102 +45,109 @@ public abstract class Bean extends UnboundBean implements PropertyChangeProvider
     }
 
     /**
+     * Fire an indexed property change on the Event dispatch (Swing) thread. Use
+     * {@link java.beans.PropertyChangeSupport#fireIndexedPropertyChange(java.lang.String, int, boolean, boolean)}
+     * directly to fire this notification on another thread.
      *
      * @param propertyName
      * @param index
      * @param oldValue
      * @param newValue
-     * @deprecated Use the
-     * {@link #propertyChangeSupport} {@link java.beans.PropertyChangeSupport#fireIndexedPropertyChange(java.lang.String, int, boolean, boolean)}
-     * directly
      */
-    @Deprecated
     protected void fireIndexedPropertyChange(String propertyName, int index, boolean oldValue, boolean newValue) {
-        propertyChangeSupport.fireIndexedPropertyChange(propertyName, index, oldValue, newValue);
+        ThreadingUtil.runOnGUIEventually(() -> {
+            propertyChangeSupport.fireIndexedPropertyChange(propertyName, index, oldValue, newValue);
+        });
     }
 
     /**
+     * Fire an indexed property change on the Event dispatch (Swing) thread. Use
+     * {@link java.beans.PropertyChangeSupport#fireIndexedPropertyChange(java.lang.String, int, int, int)}
+     * directly to fire this notification on another thread.
      *
      * @param propertyName
      * @param index
      * @param oldValue
      * @param newValue
-     * @deprecated Use the
-     * {@link #propertyChangeSupport} {@link java.beans.PropertyChangeSupport#fireIndexedPropertyChange(java.lang.String, int, int, int)}
-     * directly
      */
-    @Deprecated
     protected void fireIndexedPropertyChange(String propertyName, int index, int oldValue, int newValue) {
-        propertyChangeSupport.fireIndexedPropertyChange(propertyName, index, oldValue, newValue);
+        ThreadingUtil.runOnGUIEventually(() -> {
+            propertyChangeSupport.fireIndexedPropertyChange(propertyName, index, oldValue, newValue);
+        });
     }
 
     /**
+     * Fire an indexed property change on the Event dispatch (Swing) thread. Use
+     * {@link java.beans.PropertyChangeSupport#fireIndexedPropertyChange(java.lang.String, int, java.lang.Object, java.lang.Object)}
+     * directly to fire this notification on another thread.
      *
      * @param propertyName
      * @param index
      * @param oldValue
      * @param newValue
-     * @deprecated Use the
-     * {@link #propertyChangeSupport} {@link java.beans.PropertyChangeSupport#fireIndexedPropertyChange(java.lang.String, int, java.lang.Object, java.lang.Object)}
-     * directly
      */
-    @Deprecated
     protected void fireIndexedPropertyChange(String propertyName, int index, Object oldValue, Object newValue) {
-        propertyChangeSupport.fireIndexedPropertyChange(propertyName, index, oldValue, newValue);
+        ThreadingUtil.runOnGUIEventually(() -> {
+            propertyChangeSupport.fireIndexedPropertyChange(propertyName, index, oldValue, newValue);
+        });
     }
 
     /**
+     * Fire an indexed property change on the Event dispatch (Swing) thread. Use
+     * {@link java.beans.PropertyChangeSupport#firePropertyChange(java.lang.String, boolean, boolean)}
+     * directly to fire this notification on another thread.
      *
      * @param key
      * @param oldValue
      * @param value
-     * @deprecated Use the
-     * {@link #propertyChangeSupport} {@link java.beans.PropertyChangeSupport#firePropertyChange(java.lang.String, boolean, boolean)}
-     * directly
      */
-    @Deprecated
     protected void firePropertyChange(String key, boolean oldValue, boolean value) {
-        propertyChangeSupport.firePropertyChange(key, oldValue, value);
+        ThreadingUtil.runOnGUIEventually(() -> {
+            propertyChangeSupport.firePropertyChange(key, oldValue, value);
+        });
     }
 
     /**
+     * Fire an indexed property change on the Event dispatch (Swing) thread. Use
+     * {@link java.beans.PropertyChangeSupport#firePropertyChange(java.beans.PropertyChangeEvent)}
+     * directly to fire this notification on another thread.
      *
      * @param evt
-     * @deprecated Use the
-     * {@link #propertyChangeSupport} {@link java.beans.PropertyChangeSupport#firePropertyChange(java.beans.PropertyChangeEvent)}
-     * directly
      */
-    @Deprecated
     protected void firePropertyChange(PropertyChangeEvent evt) {
-        propertyChangeSupport.firePropertyChange(evt);
+        ThreadingUtil.runOnGUIEventually(() -> {
+            propertyChangeSupport.firePropertyChange(evt);
+        });
     }
 
     /**
+     * Fire an indexed property change on the Event dispatch (Swing) thread. Use
+     * {@link java.beans.PropertyChangeSupport#firePropertyChange(java.lang.String, int, int)}
+     * directly to fire this notification on another thread.
      *
      * @param key
      * @param value
      * @param oldValue
-     * @deprecated Use the
-     * {@link #propertyChangeSupport} {@link java.beans.PropertyChangeSupport#firePropertyChange(java.lang.String, int, int)}
-     * directly
      */
-    @Deprecated
     protected void firePropertyChange(String key, int oldValue, int value) {
-        propertyChangeSupport.firePropertyChange(key, oldValue, value);
+        ThreadingUtil.runOnGUIEventually(() -> {
+            propertyChangeSupport.firePropertyChange(key, oldValue, value);
+        });
     }
 
     /**
+     * Fire an indexed property change on the Event dispatch (Swing) thread. Use
+     * {@link java.beans.PropertyChangeSupport#firePropertyChange(java.lang.String, java.lang.Object, java.lang.Object)}
+     * directly to fire this notification on another thread.
      *
      * @param key
      * @param oldValue
      * @param value
-     * @deprecated Use the
-     * {@link #propertyChangeSupport} {@link java.beans.PropertyChangeSupport#firePropertyChange(java.lang.String, java.lang.Object, java.lang.Object)}
-     * directly
      */
-    @Deprecated
     protected void firePropertyChange(String key, Object oldValue, Object value) {
-        propertyChangeSupport.firePropertyChange(key, oldValue, value);
+        ThreadingUtil.runOnGUIEventually(() -> {
+            propertyChangeSupport.firePropertyChange(key, oldValue, value);
+        });
     }
 
     @Override

--- a/java/src/jmri/beans/ConstrainedArbitraryBean.java
+++ b/java/src/jmri/beans/ConstrainedArbitraryBean.java
@@ -18,13 +18,13 @@ public class ConstrainedArbitraryBean extends ConstrainedBean {
     @Override
     public void setProperty(String key, Object value) {
         try {
-            this.vetoableChangeSupport.fireVetoableChange(key, getProperty(key), value);
+            this.fireVetoableChange(key, getProperty(key), value);
             if (Beans.hasIntrospectedProperty(this, key)) {
                 Beans.setIntrospectedProperty(this, key, value);
             } else {
                 Object oldValue = this.arbitraryPropertySupport.getProperty(key);
                 this.arbitraryPropertySupport.setProperty(key, value);
-                this.propertyChangeSupport.firePropertyChange(key, oldValue, value);
+                this.firePropertyChange(key, oldValue, value);
             }
         } catch (PropertyVetoException ex) {
             // use the logger for the implementing class instead of a logger for ConstrainedBean
@@ -32,20 +32,20 @@ public class ConstrainedArbitraryBean extends ConstrainedBean {
             // fire a property change that does not have the new value to indicate
             // to any other listeners that the property was "reset" back to its
             // orginal value as a result of the veto
-            super.propertyChangeSupport.firePropertyChange(key, getProperty(key), getProperty(key));
+            this.firePropertyChange(key, getProperty(key), getProperty(key));
         }
     }
 
     @Override
     public void setIndexedProperty(String key, int index, Object value) {
         try {
-            this.vetoableChangeSupport.fireVetoableChange(new IndexedPropertyChangeEvent(this, key, this.getIndexedProperty(key, index), value, index));
+            this.fireVetoableChange(new IndexedPropertyChangeEvent(this, key, this.getIndexedProperty(key, index), value, index));
             if (Beans.hasIntrospectedIndexedProperty(this, key)) {
                 Beans.setIntrospectedIndexedProperty(this, key, index, value);
             } else {
                 Object oldValue = this.arbitraryPropertySupport.getIndexedProperty(key, index);
                 this.arbitraryPropertySupport.setIndexedProperty(key, index, value);
-                this.propertyChangeSupport.fireIndexedPropertyChange(key, index, oldValue, value);
+                this.fireIndexedPropertyChange(key, index, oldValue, value);
             }
         } catch (PropertyVetoException ex) {
             // use the logger for the implementing class instead of a logger for ConstrainedBean
@@ -53,7 +53,7 @@ public class ConstrainedArbitraryBean extends ConstrainedBean {
             // fire a property change that does not have the new value to indicate
             // to any other listeners that the property was "reset" back to its
             // orginal value as a result of the veto
-            super.propertyChangeSupport.fireIndexedPropertyChange(key, index, getProperty(key), getProperty(key));
+            this.fireIndexedPropertyChange(key, index, getProperty(key), getProperty(key));
         }
     }
 

--- a/java/src/jmri/beans/ConstrainedBean.java
+++ b/java/src/jmri/beans/ConstrainedBean.java
@@ -2,6 +2,7 @@
 package jmri.beans;
 
 import java.beans.IndexedPropertyChangeEvent;
+import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
 import java.beans.VetoableChangeSupport;
@@ -19,7 +20,7 @@ public abstract class ConstrainedBean extends Bean implements VetoableChangeProv
     @Override
     public void setProperty(String key, Object value) {
         try {
-            this.vetoableChangeSupport.fireVetoableChange(key, getProperty(key), value);
+            this.fireVetoableChange(key, getProperty(key), value);
             super.setProperty(key, value);
         } catch (PropertyVetoException ex) {
             // use the logger for the implementing class instead of a logger for ConstrainedBean
@@ -27,14 +28,14 @@ public abstract class ConstrainedBean extends Bean implements VetoableChangeProv
             // fire a property change that does not have the new value to indicate
             // to any other listeners that the property was "reset" back to its
             // orginal value as a result of the veto
-            super.propertyChangeSupport.firePropertyChange(key, getProperty(key), getProperty(key));
+            this.firePropertyChange(key, getProperty(key), getProperty(key));
         }
     }
 
     @Override
     public void setIndexedProperty(String key, int index, Object value) {
         try {
-            this.vetoableChangeSupport.fireVetoableChange(new IndexedPropertyChangeEvent(this, key, this.getIndexedProperty(key, index), value, index));
+            this.fireVetoableChange(new IndexedPropertyChangeEvent(this, key, this.getIndexedProperty(key, index), value, index));
             super.setIndexedProperty(key, index, value);
         } catch (PropertyVetoException ex) {
             // use the logger for the implementing class instead of a logger for ConstrainedBean
@@ -42,10 +43,10 @@ public abstract class ConstrainedBean extends Bean implements VetoableChangeProv
             // fire a property change that does not have the new value to indicate
             // to any other listeners that the property was "reset" back to its
             // orginal value as a result of the veto
-            super.propertyChangeSupport.fireIndexedPropertyChange(key, index, getProperty(key), getProperty(key));
+            this.fireIndexedPropertyChange(key, index, getProperty(key), getProperty(key));
         }
     }
-    
+
     @Override
     public void addVetoableChangeListener(VetoableChangeListener listener) {
         this.vetoableChangeSupport.addVetoableChangeListener(listener);
@@ -74,5 +75,71 @@ public abstract class ConstrainedBean extends Bean implements VetoableChangeProv
     @Override
     public void removeVetoableChangeListener(String propertyName, VetoableChangeListener listener) {
         this.vetoableChangeSupport.removeVetoableChangeListener(propertyName, listener);
+    }
+
+    /**
+     * Fire a vetoable property change on the current thread. Use
+     * {@link java.beans.VetoableChangeSupport#fireVetoableChange(java.beans.PropertyChangeEvent)}
+     * directly to fire this notification on another thread.
+     *
+     * If a PropertyVetoException is thrown, ensure the property change does not
+     * complete.
+     *
+     * @param event
+     * @throws PropertyVetoException
+     */
+    public void fireVetoableChange(PropertyChangeEvent event) throws PropertyVetoException {
+        this.vetoableChangeSupport.fireVetoableChange(event);
+    }
+
+    /**
+     * Fire a vetoable property change on the current thread. Use
+     * {@link java.beans.VetoableChangeSupport#fireVetoableChange(java.lang.String, java.lang.Object, java.lang.Object)}
+     * directly to fire this notification on another thread.
+     *
+     * If a PropertyVetoException is thrown, ensure the property change does not
+     * complete.
+     *
+     * @param propertyName
+     * @param oldValue
+     * @param newValue
+     * @throws PropertyVetoException
+     */
+    public void fireVetoableChange(String propertyName, Object oldValue, Object newValue) throws PropertyVetoException {
+        this.vetoableChangeSupport.fireVetoableChange(propertyName, oldValue, newValue);
+    }
+
+    /**
+     * Fire a vetoable property change on the current thread. Use
+     * {@link java.beans.VetoableChangeSupport#fireVetoableChange(java.lang.String, int, int)}
+     * directly to fire this notification on another thread.
+     *
+     * If a PropertyVetoException is thrown, ensure the property change does not
+     * complete.
+     *
+     * @param propertyName
+     * @param oldValue
+     * @param newValue
+     * @throws PropertyVetoException
+     */
+    public void fireVetoableChange(String propertyName, int oldValue, int newValue) throws PropertyVetoException {
+        this.vetoableChangeSupport.fireVetoableChange(propertyName, oldValue, newValue);
+    }
+
+    /**
+     * Fire a vetoable property change on the current thread. Use
+     * {@link java.beans.VetoableChangeSupport#fireVetoableChange(java.lang.String, boolean, boolean)}
+     * directly to fire this notification on another thread.
+     *
+     * If a PropertyVetoException is thrown, ensure the property change does not
+     * complete.
+     *
+     * @param propertyName
+     * @param oldValue
+     * @param newValue
+     * @throws PropertyVetoException
+     */
+    public void fireVetoableChange(String propertyName, boolean oldValue, boolean newValue) throws PropertyVetoException {
+        this.vetoableChangeSupport.fireVetoableChange(propertyName, oldValue, newValue);
     }
 }


### PR DESCRIPTION
Note that VetoablePropertyChanges fire on the current thread due to the
need to handle the API-specified exceptions appropriately.