### PR TITLE
Get blocks occupied by roster entry

### DIFF
--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -1,9 +1,12 @@
 package jmri;
 
 import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
 import jmri.managers.AbstractManager;
 import jmri.implementation.SignalSpeedMap;
 
+import jmri.jmrit.roster.RosterEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -203,6 +206,32 @@ public class BlockManager extends AbstractManager
 
     public String getBeanTypeHandled() {
         return Bundle.getMessage("BeanNameBlock");
+    }
+    
+    /**
+     * Returns a list of blocks which the supplied roster entry appears to
+     * be occupying. A block is assumed to contain this roster entry if its value
+     * is the RosterEntry itself, or a string with the entry's id or dcc address.
+     * 
+     * @param re the roster entry
+     * @return list of block system names
+     */
+    public List<Block> getBlocksOccupiedByRosterEntry(RosterEntry re) {
+        List<Block> blockList = new ArrayList<>();
+        
+        for (String sysName : getSystemNameList()) {
+            Block b = getBySystemName(sysName);
+            Object o = b.getValue();
+            if (o != null) {
+                if (o instanceof jmri.jmrit.roster.RosterEntry && o == re) {
+                    blockList.add(b);
+                } else if (o.toString().equals(re.getId()) || o.toString().equals(re.getDccAddress())){
+                    blockList.add(b);
+                }
+            }
+        }
+        
+        return blockList;
     }
 
     private final static Logger log = LoggerFactory.getLogger(BlockManager.class.getName());

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -15,6 +15,8 @@ import jmri.SignalHead;
 import jmri.SignalMast;
 import jmri.Turnout;
 import jmri.managers.AbstractManager;
+import jmri.BlockManager;
+import jmri.jmrit.roster.RosterEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -2238,6 +2238,32 @@ public class LayoutBlockManager extends AbstractManager implements jmri.Instance
         return Bundle.getMessage("BeanNameLayoutBlock");
     }
 
+    /**
+     * Returns a list of layout blocks which this roster entry appears to
+     * be occupying. A layout block is assumed to contain this roster entry if the value
+     * of the underlying block is the RosterEntry itself, or a string with the entry's 
+     * id or dcc address.
+     * 
+     * @param re the roster entry
+     * @return list of layout block user names
+     */
+    public List<LayoutBlock> getLayoutBlocksOccupiedByRosterEntry(RosterEntry re) {
+        BlockManager bm = jmri.InstanceManager.blockManagerInstance();
+        List<Block> blockList = bm.getBlocksOccupiedByRosterEntry(re);
+        List<LayoutBlock> layoutBlockList = new ArrayList<>();
+        
+        for (Block block : blockList) {
+            if (block.getUserName() != null) {
+                LayoutBlock lb = getByUserName(block.getUserName());
+                if (lb != null) {
+                    layoutBlockList.add(lb);
+                }
+            }
+        }
+        
+        return layoutBlockList;
+    } 
+
     private final static Logger log = LoggerFactory.getLogger(LayoutBlockManager.class.getName());
 }
 


### PR DESCRIPTION
This is a revision of PR #1046. I've put the functionality into the block managers as suggested by @rhwood. There are two methods, one for BlockManager, one for LayoutBlockManager. In both cases they return a list of blocks occupied by a roster entry.

