### PR TITLE
Close out FindBugs on some small packages

### DIFF
--- a/java/src/jmri/jmrix/dcc/DccTurnout.java
+++ b/java/src/jmri/jmrix/dcc/DccTurnout.java
@@ -1,4 +1,3 @@
-// DccTurnout.java
 package jmri.jmrix.dcc;
 
 import jmri.CommandStation;
@@ -19,14 +18,8 @@ import org.slf4j.LoggerFactory;
  * Description:	extend jmri.AbstractTurnout for DCC-only layouts
  *
  * @author	Bob Jacobsen Copyright (C) 2014
- * @version	$Revision$
  */
 public class DccTurnout extends AbstractTurnout {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 2120643169908605976L;
 
     /**
      * DCC turnouts use the NMRA number (0-511) as their numerical
@@ -94,5 +87,3 @@ public class DccTurnout extends AbstractTurnout {
 
 }
 
-
-/* @(#)DccTurnout.java */

--- a/java/src/jmri/jmrix/dcc/DccTurnout.java
+++ b/java/src/jmri/jmrix/dcc/DccTurnout.java
@@ -44,9 +44,9 @@ public class DccTurnout extends AbstractTurnout {
     // Handle a request to change state by sending a formatted DCC packet
     protected void forwardCommandChangeToLayout(int s) {
         // sort out states
-        if ((s & Turnout.CLOSED) > 0) {
+        if ((s & Turnout.CLOSED) != 0) {
             // first look for the double case, which we can't handle
-            if ((s & Turnout.THROWN) > 0) {
+            if ((s & Turnout.THROWN) != 0) {
                 // this is the disaster case!
                 log.error("Cannot command both CLOSED and THROWN " + s);
                 return;

--- a/java/src/jmri/jmrix/dcc/DccTurnoutManager.java
+++ b/java/src/jmri/jmrix/dcc/DccTurnoutManager.java
@@ -33,7 +33,7 @@ public class DccTurnoutManager extends jmri.managers.AbstractTurnoutManager {
         }
         return _instance;
     }
-    static DccTurnoutManager _instance = null;
+    static volatile DccTurnoutManager _instance = null;
 
 }
 

--- a/java/src/jmri/jmrix/dcc/DccTurnoutManager.java
+++ b/java/src/jmri/jmrix/dcc/DccTurnoutManager.java
@@ -1,4 +1,3 @@
-// EasyDccTurnoutManager.java
 package jmri.jmrix.dcc;
 
 import jmri.Turnout;
@@ -9,7 +8,6 @@ import jmri.Turnout;
  * System names are "BTnnn", where nnn is the turnout number without padding.
  *
  * @author	Bob Jacobsen Copyright (C) 2014
- * @version	$Revision$
  */
 public class DccTurnoutManager extends jmri.managers.AbstractTurnoutManager {
 
@@ -39,4 +37,3 @@ public class DccTurnoutManager extends jmri.managers.AbstractTurnoutManager {
 
 }
 
-/* @(#)DccTurnoutManager.java */

--- a/java/src/jmri/jmrix/qsi/QsiTrafficController.java
+++ b/java/src/jmri/jmrix/qsi/QsiTrafficController.java
@@ -36,7 +36,7 @@ public class QsiTrafficController implements QsiInterface, Runnable {
     protected Vector<QsiListener> cmdListeners = new Vector<QsiListener>();
 
     public boolean status() {
-        return (ostream != null & istream != null);
+        return (ostream != null && istream != null);
     }
 
     public synchronized void addQsiListener(QsiListener l) {

--- a/java/src/jmri/jmrix/qsi/QsiTrafficController.java
+++ b/java/src/jmri/jmrix/qsi/QsiTrafficController.java
@@ -1,4 +1,3 @@
-// QsiTrafficController.java
 package jmri.jmrix.qsi;
 
 import gnu.io.SerialPort;
@@ -21,7 +20,6 @@ import org.slf4j.LoggerFactory;
  * content.
  *
  * @author	Bob Jacobsen Copyright (C) 2007, 2008
- * @version	$Revision$
  */
 public class QsiTrafficController implements QsiInterface, Runnable {
 
@@ -350,6 +348,3 @@ public class QsiTrafficController implements QsiInterface, Runnable {
 
     private final static Logger log = LoggerFactory.getLogger(QsiTrafficController.class.getName());
 }
-
-
-/* @(#)QsiTrafficController.java */

--- a/java/src/jmri/layout/Layout.java
+++ b/java/src/jmri/layout/Layout.java
@@ -4,7 +4,6 @@ import java.util.TreeMap;
 
 /**
  * @author Alex Shepherd Copyright (c) 2002
- * @version $Revision$
  */
 public class Layout implements LayoutEventListener, LayoutEventInterface {
 

--- a/java/src/jmri/layout/Layout.java
+++ b/java/src/jmri/layout/Layout.java
@@ -4,7 +4,9 @@ import java.util.TreeMap;
 
 /**
  * @author Alex Shepherd Copyright (c) 2002
+ * @deprecated 4.3.5
  */
+@Deprecated
 public class Layout implements LayoutEventListener, LayoutEventInterface {
 
     private TreeMap<LayoutAddress, LayoutElement> mElementMap = new TreeMap<LayoutAddress, LayoutElement>();

--- a/java/src/jmri/layout/LayoutAddress.java
+++ b/java/src/jmri/layout/LayoutAddress.java
@@ -4,7 +4,9 @@ package jmri.layout;
  * Define an address consisting of a layout name, a type, and an offset number.
  *
  * @author Alex Shepherd Copyright (c) 2002
+ * @deprecated 4.3.5
  */
+@Deprecated
 public class LayoutAddress implements Comparable<Object> {
 
     public static final int ELEMENT_TYPE_FIRST = 0;

--- a/java/src/jmri/layout/LayoutAddress.java
+++ b/java/src/jmri/layout/LayoutAddress.java
@@ -4,7 +4,6 @@ package jmri.layout;
  * Define an address consisting of a layout name, a type, and an offset number.
  *
  * @author Alex Shepherd Copyright (c) 2002
- * @version $Revision$
  */
 public class LayoutAddress implements Comparable<Object> {
 
@@ -51,11 +50,8 @@ public class LayoutAddress implements Comparable<Object> {
     }
 
     public int hashCode() {
-        if (hash == 0) {
-            hash = mLayoutName.hashCode() ^ mType ^ mOffset;
-        }
-
-        return hash;
+        assert false : "hashCode not designed";
+        return 42; // any arbitrary constant will do
     }
 
     public String getLayoutName() {

--- a/java/src/jmri/layout/LayoutElement.java
+++ b/java/src/jmri/layout/LayoutElement.java
@@ -2,7 +2,9 @@ package jmri.layout;
 
 /**
  * @author Alex Shepherd Copyright (c) 2002
+ * @deprecated 4.3.5
  */
+@Deprecated
 public class LayoutElement extends javax.swing.tree.DefaultMutableTreeNode implements LayoutEventInterface {
 
     /**

--- a/java/src/jmri/layout/LayoutElement.java
+++ b/java/src/jmri/layout/LayoutElement.java
@@ -2,7 +2,6 @@ package jmri.layout;
 
 /**
  * @author Alex Shepherd Copyright (c) 2002
- * @version $Revision$
  */
 public class LayoutElement extends javax.swing.tree.DefaultMutableTreeNode implements LayoutEventInterface {
 

--- a/java/src/jmri/layout/LayoutEventData.java
+++ b/java/src/jmri/layout/LayoutEventData.java
@@ -2,6 +2,10 @@ package jmri.layout;
 
 import java.util.Date;
 
+/**
+ * @deprecated 4.3.5
+ */
+@Deprecated
 public class LayoutEventData {
 
     private Date mTimeStamp;

--- a/java/src/jmri/layout/LayoutEventData.java
+++ b/java/src/jmri/layout/LayoutEventData.java
@@ -1,11 +1,5 @@
 package jmri.layout;
 
-/**
- * Title: Description: Copyright: Copyright (c) 2002 Company:
- *
- * @author
- * @version $Revision$
- */
 import java.util.Date;
 
 public class LayoutEventData {

--- a/java/src/jmri/layout/LayoutEventInterface.java
+++ b/java/src/jmri/layout/LayoutEventInterface.java
@@ -3,7 +3,9 @@ package jmri.layout;
 /**
  * @author Alex Shepherd Copyright (c) 2002
  * @see jmri.layout.LayoutEventListener
+ * @deprecated 4.3.5
  */
+@Deprecated
 public interface LayoutEventInterface {
 
     public void addEventListener(LayoutEventListener pListener);

--- a/java/src/jmri/layout/LayoutEventInterface.java
+++ b/java/src/jmri/layout/LayoutEventInterface.java
@@ -2,7 +2,6 @@ package jmri.layout;
 
 /**
  * @author Alex Shepherd Copyright (c) 2002
- * @version $Revision$
  * @see jmri.layout.LayoutEventListener
  */
 public interface LayoutEventInterface {

--- a/java/src/jmri/layout/LayoutEventListener.java
+++ b/java/src/jmri/layout/LayoutEventListener.java
@@ -4,7 +4,6 @@ import java.util.EventListener;
 
 /**
  * @author Alex Shepherd Copyright (c) 2002
- * @version $Revision$
  * @see jmri.layout.LayoutEventInterface
  */
 public interface LayoutEventListener extends EventListener {

--- a/java/src/jmri/layout/LayoutEventListener.java
+++ b/java/src/jmri/layout/LayoutEventListener.java
@@ -5,7 +5,9 @@ import java.util.EventListener;
 /**
  * @author Alex Shepherd Copyright (c) 2002
  * @see jmri.layout.LayoutEventInterface
+ * @deprecated 4.3.5
  */
+@Deprecated
 public interface LayoutEventListener extends EventListener {
 
     public void message(LayoutEventData pLayoutEvent);

--- a/java/src/jmri/layout/LayoutEventSource.java
+++ b/java/src/jmri/layout/LayoutEventSource.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 
 /**
  * @author Alex Shepherd Copyright (c) 2002
- * @version $Revision$
  */
 public class LayoutEventSource implements LayoutEventInterface {
 

--- a/java/src/jmri/layout/LayoutEventSource.java
+++ b/java/src/jmri/layout/LayoutEventSource.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 
 /**
  * @author Alex Shepherd Copyright (c) 2002
+ * @deprecated 4.3.5
  */
+@Deprecated
 public class LayoutEventSource implements LayoutEventInterface {
 
     private ArrayList<LayoutEventListener> mListeners = new ArrayList<LayoutEventListener>();

--- a/java/src/jmri/layout/package.html
+++ b/java/src/jmri/layout/package.html
@@ -13,6 +13,9 @@
     <body bgcolor="white">
 
         Create and manage a tree of the JMRI objects representing a layout.
+        
+        <p>
+        Not used since 2002, this package was deprecated in JMRI 4.3.5 (April 2016)
 
         <h2>Related Documentation</h2>
 

--- a/java/src/jmri/util/davidflanagan/HardcopyWriter.java
+++ b/java/src/jmri/util/davidflanagan/HardcopyWriter.java
@@ -1,4 +1,3 @@
-// HardcopyWriter.java
 package jmri.util.davidflanagan;
 
 import java.awt.BorderLayout;
@@ -38,7 +37,6 @@ import jmri.util.JmriJFrame;
  * alligator on the front.
  *
  * @author David Flanagan
- * @version $Revision$
  */
 public class HardcopyWriter extends Writer {
 
@@ -150,11 +148,6 @@ public class HardcopyWriter extends Writer {
             if (jobAttributes.getDefaultSelection().equals(DefaultSelectionType.RANGE)) {
                 prFirst = jobAttributes.getPageRanges()[0][0];
             }
-        }
-
-        // Bug workaround
-        if (System.getProperty("os.name").regionMatches(true, 0, "windows", 0, 7)) {
-            //
         }
 
         x0 = (int) (leftmargin * pagedpi);
@@ -453,7 +446,7 @@ public class HardcopyWriter extends Writer {
                 // compute lines and columns within margins
                 chars_per_line = width / charwidth;
                 lines_per_page = height / lineheight;
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 font = current;
             }
             // if a page is pending, set the new font, else newpage() will

--- a/java/src/jmri/util/javamail/MailMessage.java
+++ b/java/src/jmri/util/javamail/MailMessage.java
@@ -55,11 +55,13 @@ import java.util.Properties;
 import javax.mail.Authenticator;
 import javax.mail.Folder;
 import javax.mail.Message;
+import javax.mail.MessagingException;
 import javax.mail.PasswordAuthentication;
 import javax.mail.Session;
 import javax.mail.Store;
 import javax.mail.Transport;
 import javax.mail.URLName;
+import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
@@ -225,7 +227,7 @@ public class MailMessage {
             // We need a multipart message to hold attachment.
             mp = new MimeMultipart();
 
-        } catch (Exception e) {
+        } catch (MessagingException e) {
             log.warn("Exception in prepare", e);
         }
     }
@@ -240,7 +242,7 @@ public class MailMessage {
             MimeBodyPart mbp1 = new MimeBodyPart();
             mbp1.setText(text);
             mp.addBodyPart(mbp1);
-        } catch (Exception e) {
+        } catch (MessagingException e) {
             log.warn("Exception in setText", e);
         }
     }
@@ -257,7 +259,7 @@ public class MailMessage {
             mbp2.attachFile(file);
             mp.addBodyPart(mbp2);
 
-        } catch (Exception e) {
+        } catch (java.io.IOException | MessagingException e) {
             log.error("Exception in setAttachment", e);
         }
     }
@@ -317,7 +319,7 @@ public class MailMessage {
                 }
             }
 
-        } catch (Exception e) {
+        } catch (MessagingException e) {
             e.printStackTrace();
         }
     }

--- a/java/src/jmri/util/javamail/MailMessage.java
+++ b/java/src/jmri/util/javamail/MailMessage.java
@@ -1,4 +1,3 @@
-// MailMessage.java
 package jmri.util.javamail;
 
 /**
@@ -16,7 +15,6 @@ package jmri.util.javamail;
  *
  * @author Bob Jacobsen Copyright 2008, 2009
  * @author kcameron Copyright 2015
- * @version $Revision$
  *
  */
 


### PR DESCRIPTION
- multiple individual updates for FindBugs in packages with just one or two warnings
- deprecate the jmri.layout package contents. It hasn't been used since about 2002, and was a non-successful experiment in describing the entire layout (e.g. hardware) in one tree.
