### PR TITLE
Default to showing power state as text in buttons.

### DIFF
--- a/java/src/jmri/jmrit/throttle/PowerManagerButton.java
+++ b/java/src/jmri/jmrit/throttle/PowerManagerButton.java
@@ -29,7 +29,7 @@ public abstract class PowerManagerButton extends JButton implements PropertyChan
     protected NamedIcon powerOnIcon;
 
     public PowerManagerButton() {
-        this(false);
+        this(true);
     }
 
     public PowerManagerButton(Boolean fullText) {


### PR DESCRIPTION
This addresses an issue discussed on the users group by defaulting to including the power state as text on the power manager button. This allows the power state toggle icon to remain a constant, unchanging shape to indicate "power control", while accommodating color blindness by indicating state in text.