### PR TITLE
Instance manager returns last item instead of first for default

### DIFF
--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -174,7 +174,8 @@ public class InstanceManager {
             // don't have, can't make
             return null;
         }
-        return (T) l.get(l.size() - 1);
+        // first one is default.
+        return (T) l.get(0);
     }
 
     /**


### PR DESCRIPTION
This is a temp fix. As I dont know if the first item should be the default or not. If it shouldnt be then the error is upstream from here. It would be better to flag default