### PR TITLE
Code cleanup & FindBugs fixes (no functional fixes this time)

### DIFF
--- a/java/src/jmri/jmrit/DccLocoAddressSelector.java
+++ b/java/src/jmri/jmrit/DccLocoAddressSelector.java
@@ -29,14 +29,9 @@ import org.slf4j.LoggerFactory;
  * configuring a loco to run somewhere else.
  *
  * @author Bob Jacobsen Copyright (C) 2005
- * @version $Revision$
  */
 public class DccLocoAddressSelector extends JPanel {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4741955850069067809L;
     JComboBox<String> box = null;
     JTextField text = new JTextField();
 

--- a/java/src/jmri/jmrit/DebugMenu.java
+++ b/java/src/jmri/jmrit/DebugMenu.java
@@ -1,4 +1,3 @@
-// DebugMenu.java
 package jmri.jmrit;
 
 import javax.swing.JMenu;
@@ -9,14 +8,8 @@ import javax.swing.JSeparator;
  * Create a "Debug" menu containing the JMRI system-independent debugging tools.
  *
  * @author	Bob Jacobsen Copyright 2003
- * @version $Revision$
  */
 public class DebugMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -954409766062724149L;
 
     public DebugMenu(String name, JPanel panel) {
         this(panel);

--- a/java/src/jmri/jmrit/LogixLoadAction.java
+++ b/java/src/jmri/jmrit/LogixLoadAction.java
@@ -1,4 +1,3 @@
-// LogixLoadAction.java
 package jmri.jmrit;
 
 import java.awt.event.ActionEvent;
@@ -14,14 +13,8 @@ import org.slf4j.LoggerFactory;
  * loaded
  *
  * @author	Dave Duchamp Copyright (C) 2007
- * @version	$Revision$
  */
 public class LogixLoadAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4280773749053470400L;
 
     public LogixLoadAction(String s, JPanel who) {
         super(s);

--- a/java/src/jmri/jmrit/MemoryContents.java
+++ b/java/src/jmri/jmrit/MemoryContents.java
@@ -704,7 +704,7 @@ public class MemoryContents {
             String message = "No Data Records found in file - aborting."; // NOI18N
             log.error(message);
             throw new MemoryFileNoDataRecordsException(message);
-        } else if (foundDataRecords && !foundEOFRecord) {
+        } else if (!foundEOFRecord) {  // found Data Records, but no EOF
             String message = "No EOF Record found in file - aborting."; // NOI18N
             log.error(message);
             throw new MemoryFileNoEOFRecordException(message);
@@ -838,7 +838,7 @@ public class MemoryContents {
                             int addrMidSByte = ((addressForAddressField) - (65536 * addrMostSByte)) / 256;
                             int addrLeastSByte = (addressForAddressField) - (256 * addrMidSByte) - (65536 * addrMostSByte);
                             int count = j - startOffset;
-                            if ((write == true) && (j == i + (blocksize - 1))) {
+                            if ( j == i + (blocksize - 1) ) {
                                 count++;
                             }
                             if (log.isDebugEnabled()) {

--- a/java/src/jmri/jmrit/MemoryContents.java
+++ b/java/src/jmri/jmrit/MemoryContents.java
@@ -1,4 +1,3 @@
-// MemoryContents.java
 package jmri.jmrit;
 
 import java.io.BufferedReader;
@@ -81,7 +80,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright (C) 2005, 2008
  * @author B. Milhaupt Copyright (C) 2014
- * @version $Revision$
  */
 public class MemoryContents {
 
@@ -1305,11 +1303,6 @@ public class MemoryContents {
      */
     public class MemoryFileException extends jmri.JmriException {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = -1842436277554257895L;
-
         public MemoryFileException() {
             super();
         }
@@ -1323,11 +1316,6 @@ public class MemoryContents {
      * An exception for a record which has incorrect checksum.
      */
     public class MemoryFileChecksumException extends MemoryFileException {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = -2557753591967552634L;
 
         public MemoryFileChecksumException() {
             super();
@@ -1343,11 +1331,6 @@ public class MemoryContents {
      * supported.
      */
     public class MemoryFileUnknownRecordType extends MemoryFileException {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 7780197492467941350L;
 
         public MemoryFileUnknownRecordType() {
             super();
@@ -1367,11 +1350,6 @@ public class MemoryContents {
      */
     public class MemoryFileRecordContentException extends MemoryFileException {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = 3879649549206375793L;
-
         public MemoryFileRecordContentException() {
             super();
         }
@@ -1388,11 +1366,6 @@ public class MemoryContents {
      */
     public class MemoryFileRecordLengthException extends MemoryFileException {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = -6154349477467623278L;
-
         public MemoryFileRecordLengthException() {
             super();
         }
@@ -1406,11 +1379,6 @@ public class MemoryContents {
      * An exception for an unsupported addressing format
      */
     public class MemoryFileAddressingFormatException extends MemoryFileException {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 4464776547895893181L;
 
         public MemoryFileAddressingFormatException() {
             super();
@@ -1426,11 +1394,6 @@ public class MemoryContents {
      */
     public class MemoryFileAddressingRangeException extends MemoryFileException {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = 4996513449040118695L;
-
         public MemoryFileAddressingRangeException() {
             super();
         }
@@ -1444,11 +1407,6 @@ public class MemoryContents {
      * An exception for a file with no data records
      */
     public class MemoryFileNoDataRecordsException extends MemoryFileException {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = -8046649275084033197L;
 
         public MemoryFileNoDataRecordsException() {
             super();
@@ -1464,11 +1422,6 @@ public class MemoryContents {
      */
     public class MemoryFileNoEOFRecordException extends MemoryFileException {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = -5011032819427318298L;
-
         public MemoryFileNoEOFRecordException() {
             super();
         }
@@ -1483,11 +1436,6 @@ public class MemoryContents {
      * record
      */
     public class MemoryFileRecordFoundAfterEOFRecord extends MemoryFileException {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 5921252212959638124L;
 
         public MemoryFileRecordFoundAfterEOFRecord() {
             super();
@@ -1514,5 +1462,3 @@ public class MemoryContents {
     
     private final static Logger log = LoggerFactory.getLogger(MemoryContents.class.getName());
 }
-
-/* @(#)MemoryContents.java */

--- a/java/src/jmri/jmrit/MemoryFrameAction.java
+++ b/java/src/jmri/jmrit/MemoryFrameAction.java
@@ -1,4 +1,3 @@
-// MemoryFrameAction.java
 package jmri.jmrit;
 
 import java.awt.Container;
@@ -17,14 +16,8 @@ import jmri.util.JmriJFrame;
  * Display memory usage on request
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2008, 2012
- * @version	$Revision$
  */
 public class MemoryFrameAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7755576646931522800L;
 
     public MemoryFrameAction(String s) {
         super(s);

--- a/java/src/jmri/jmrit/Sound.java
+++ b/java/src/jmri/jmrit/Sound.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * jmri.jmrix. It seems most like a "tool using JMRI", or perhaps a tool for use
  * with JMRI, so it was placed in jmri.jmrit.
  * <P>
- * S@see jmri.jmrit.sound
+ * @see jmri.jmrit.sound
  *
  * @author	Bob Jacobsen Copyright (C) 2004, 2006
  * @author Dave Duchamp Copyright (C) 2011 - add streaming play of large files
@@ -263,13 +263,9 @@ public class Sound {
             if (streamingSensor == null) {
                 streamingSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor("ISSOUNDSTREAMING");
             }
-            if (streamingSensor != null) {
-                try {
-                    streamingSensor.setState(jmri.Sensor.ACTIVE);
-                } catch (jmri.JmriException ex) {
-                    log.error("Exception while setting ISSOUNDSTREAMING sensor to ACTIVE");
-                }
-            }
+            
+            setSensor(jmri.Sensor.ACTIVE);
+            
             if (!streamingStop) {
                 // set up the SourceDataLine going to the JVM's mixer
                 try {
@@ -290,13 +286,7 @@ public class Sound {
             }
             if (streamingStop) {
                 line.close();
-                if (streamingSensor != null) {
-                    try {
-                        streamingSensor.setState(jmri.Sensor.INACTIVE);
-                    } catch (jmri.JmriException ex) {
-                        log.error("Exception while setting ISSOUNDSTREAMING sensor to INACTIVE - 2");
-                    }
-                }
+                setSensor(jmri.Sensor.INACTIVE);
                 return;
             }
             // Read  the sound file in chunks of bytes into buffer, and
@@ -321,14 +311,19 @@ public class Sound {
             line.drain();
             line.stop();
             line.close();
+            setSensor(jmri.Sensor.INACTIVE);
+        }
+
+        private void setSensor(int mode) {
             if (streamingSensor != null) {
                 try {
-                    streamingSensor.setState(jmri.Sensor.INACTIVE);
+                    streamingSensor.setState(mode);
                 } catch (jmri.JmriException ex) {
-                    log.error("Exception while setting ISSOUNDSTREAMING sensor to INACTIVE");
+                    log.error("Exception while setting ISSOUNDSTREAMING sensor {} to {}", streamingSensor.getDisplayName(), mode);
                 }
             }
         }
+
     }
 
     private final static Logger log = LoggerFactory.getLogger(Sound.class.getName());

--- a/java/src/jmri/jmrit/XmlFile.java
+++ b/java/src/jmri/jmrit/XmlFile.java
@@ -1,4 +1,3 @@
-// XmlFile.java
 package jmri.jmrit;
 
 import java.io.BufferedInputStream;
@@ -44,7 +43,6 @@ import org.slf4j.LoggerFactory;
  * {@link jmri.util.JmriLocalEntityResolver} class.
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2002, 2007, 2012, 2014
- * @version	$Revision$
  */
 public abstract class XmlFile {
 

--- a/java/src/jmri/jmrit/XmlFileCheckAction.java
+++ b/java/src/jmri/jmrit/XmlFileCheckAction.java
@@ -1,4 +1,3 @@
-// XmlFileCheckAction.java
 package jmri.jmrit;
 
 import java.awt.event.ActionEvent;
@@ -14,16 +13,10 @@ import org.slf4j.LoggerFactory;
  * Make sure an XML file is readable, without doing a DTD validation.
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2005, 2007
- * @version	$Revision$
  * @see jmri.jmrit.XmlFile
  * @see jmri.jmrit.XmlFileValidateAction
  */
 public class XmlFileCheckAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1237100382487992245L;
 
     public XmlFileCheckAction(String s, JPanel who) {
         super(s);

--- a/java/src/jmri/jmrit/XmlFileLocationAction.java
+++ b/java/src/jmri/jmrit/XmlFileLocationAction.java
@@ -1,4 +1,3 @@
-// XmlFileLocationAction.java
 package jmri.jmrit;
 
 import java.awt.Desktop;
@@ -28,14 +27,8 @@ import org.slf4j.LoggerFactory;
  * seen in the program directory </ul>
  *
  * @author	Bob Jacobsen Copyright (C) 2004, 2007
- * @version $Revision$
  */
 public class XmlFileLocationAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5884867804946089268L;
 
     public XmlFileLocationAction() {
         super();
@@ -209,5 +202,3 @@ public class XmlFileLocationAction extends AbstractAction {
 
     private static final Logger log = LoggerFactory.getLogger(XmlFileLocationAction.class.getName());
 }
-
-/* @(#)XmlFileLocationAction.java */

--- a/java/src/jmri/jmrit/XmlFileValidateAction.java
+++ b/java/src/jmri/jmrit/XmlFileValidateAction.java
@@ -1,4 +1,3 @@
-// XmlFileValidateAction.java
 package jmri.jmrit;
 
 import java.awt.event.ActionEvent;
@@ -24,16 +23,10 @@ import org.slf4j.LoggerFactory;
  * Make sure an XML file is readable, and validates OK
  *
  * @author	Bob Jacobsen Copyright (C) 2005, 2007
- * @version	$Revision$
  * @see jmri.jmrit.XmlFile
  * @see jmri.jmrit.XmlFileCheckAction
  */
 public class XmlFileValidateAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1565162336074463863L;
 
     public XmlFileValidateAction(String s, JPanel who) {
         super(s);

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -149,7 +149,7 @@ abstract public class AbstractManager
      * @throws java.beans.PropertyVetoException - If the recipient(s) wishes the
      *                                          delete to be aborted.
      */
-    public void deleteBean(@Nonnull NamedBean bean, @Nullable String property) throws java.beans.PropertyVetoException {
+    public void deleteBean(@Nonnull NamedBean bean, @Nonnull String property) throws java.beans.PropertyVetoException {
         try {
             fireVetoableChange(property, bean, null);
         } catch (java.beans.PropertyVetoException e) {

--- a/java/src/jmri/managers/configurexml/AbstractAudioManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractAudioManagerConfigXML.java
@@ -233,10 +233,8 @@ public abstract class AbstractAudioManagerConfigXML extends AbstractNamedBeanMan
 
                     ce = new Element("distances");
                     ce.setAttribute("ref", "" + as.getReferenceDistance());
-                    float f;
-                    if ((f = as.getMaximumDistance()) != Audio.MAX_DISTANCE) {
-                        ce.setAttribute("max", "" + f);
-                    }
+                    float f = as.getMaximumDistance();
+                    ce.setAttribute("max", "" + f);
                     e.addContent(ce);
 
                     ce = new Element("loops");

--- a/java/src/jmri/managers/configurexml/AbstractAudioManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractAudioManagerConfigXML.java
@@ -1,4 +1,3 @@
-// AbstractAudioManagerConfigXML.java
 package jmri.managers.configurexml;
 
 import java.util.List;
@@ -40,7 +39,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2002, 2008
  * @author Matthew Harris copyright (c) 2009, 2011
- * @version $Revision$
  */
 public abstract class AbstractAudioManagerConfigXML extends AbstractNamedBeanManagerConfigXML {
 
@@ -544,5 +542,3 @@ public abstract class AbstractAudioManagerConfigXML extends AbstractNamedBeanMan
 
     private static final Logger log = LoggerFactory.getLogger(AbstractAudioManagerConfigXML.class.getName());
 }
-
-/* $(#)AbstractAudioManagerConfigXML.java */

--- a/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
@@ -209,7 +209,7 @@ public abstract class AbstractNamedBeanManagerConfigXML extends jmri.configurexm
      */
     void storeProperties(NamedBean t, Element elem) {
         java.util.Set<String> s = t.getPropertyKeys();
-        if (s == null || s.size() == 0) {
+        if (s.size() == 0) {
             return;
         }
         Element ret = new Element("properties");

--- a/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
@@ -274,7 +274,9 @@ public abstract class AbstractNamedBeanManagerConfigXML extends jmri.configurexm
 
                 // store
                 t.setProperty(key, value);
-            } catch (Exception ex) {
+            } catch (ClassNotFoundException | NoSuchMethodException 
+                        | InstantiationException | IllegalAccessException 
+                        | java.lang.reflect.InvocationTargetException ex) {
                 log.error("Error loading properties", ex);
             }
         }

--- a/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
@@ -219,7 +219,7 @@ public abstract class AbstractNamedBeanManagerConfigXML extends jmri.configurexm
             Element p = new Element("property");
             ret.addContent(p);
             p.addContent(new Element("key")
-                    .setText(key.toString())
+                    .setText(key)
             );
             if (value != null) {
                 p.addContent(new Element("value")


### PR DESCRIPTION
Cleanup of syntax and FindBugs clarity issues; none of these (I think) are functional fixes, but they do clean up some little bits of code.

The first one, a Nullable -> Nonnull fix on an abstract class method parameter, may give rise to some downstream FindBugs warnings which I'll fix in turn.

When persisting AudioManagers, the code previously didn't write a "max distance" attribute it was at the default max value.  This default seems to have changed, perhaps with the move to Java 1.8, so I changed the code to always write the value.