### PR TITLE
Two FindBugs categories

### DIFF
--- a/java/src/jmri/jmrit/logix/NXFrame.java
+++ b/java/src/jmri/jmrit/logix/NXFrame.java
@@ -211,7 +211,7 @@ public class NXFrame extends WarrantRoute {
                 break;
             case SignalSpeedMap.SPEED_MPH:
                 float factor =  jmri.InstanceManager.getDefault(SignalSpeedMap.class).getDefaultThrottleFactor();
-                maxSpeed = Math.round(_maxSpeed*factor*_scale*2.2369363f*1000)/1000;
+                maxSpeed = Math.round(_maxSpeed*factor*_scale*2.2369363f*1000)/1000; // 2.2369363*1000 is 3600 converted by mile/km
                 maxSpeedLabel = "MaxMph";
                 throttleIncr = Math.round(_throttleIncr*factor*_scale*2.2369363f*1000)/1000;
                 throttleIncrLabel = "MinMph";

--- a/java/src/jmri/jmrit/signalling/entryexit/PointDetails.java
+++ b/java/src/jmri/jmrit/signalling/entryexit/PointDetails.java
@@ -332,7 +332,7 @@ public class PointDetails {
             public void run() {
                 try {
                     //Stage one default timer for the button if no other button has been pressed
-                    Thread.sleep(nxButtonTimeout * 1000);
+                    Thread.sleep(nxButtonTimeout * 1000L);
                     //Stage two if an extended time out has been requested
                     if (extendedtime) {
                         Thread.sleep(60000);  //timeout after a minute waiting for the sml to set.

--- a/java/src/jmri/jmrit/withrottle/DeviceServer.java
+++ b/java/src/jmri/jmrit/withrottle/DeviceServer.java
@@ -468,7 +468,7 @@ public class DeviceServer implements Runnable, ThrottleControllerListener, Contr
             }
 
         };
-        ekg.scheduleAtFixedRate(task, pulseInterval * 900, pulseInterval * 900);
+        ekg.scheduleAtFixedRate(task, pulseInterval * 900L, pulseInterval * 900L);
     }
 
     public void stopEKG() {

--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -607,7 +607,7 @@ abstract public class AbstractMRTrafficController {
     public AbstractPortController controller = null;
 
     public boolean status() {
-        return (ostream != null & istream != null);
+        return (ostream != null && istream != null);
     }
 
     protected Thread xmtThread = null;

--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -889,7 +889,7 @@ abstract public class AbstractMRTrafficController {
                             mCurrentState = AUTORETRYSTATE;
                             if (retransmitCount > 0) {
                                 try {
-                                    xmtRunnable.wait(retransmitCount * 100);
+                                    xmtRunnable.wait(retransmitCount * 100L);
                                 } catch (InterruptedException e) {
                                     Thread.currentThread().interrupt(); // retain if needed later
                                 }

--- a/java/src/jmri/jmrix/bachrus/SpeedoTrafficController.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoTrafficController.java
@@ -38,7 +38,7 @@ public class SpeedoTrafficController implements SpeedoInterface, SerialPortEvent
     protected Vector<SpeedoListener> cmdListeners = new Vector<SpeedoListener>();
 
     public boolean status() {
-        return (ostream != null & istream != null);
+        return (ostream != null && istream != null);
     }
 
     public synchronized void addSpeedoListener(SpeedoListener l) {

--- a/java/src/jmri/jmrix/cmri/CMRIMenu.java
+++ b/java/src/jmri/jmrix/cmri/CMRIMenu.java
@@ -1,4 +1,3 @@
-// CMRIMenu.java
 package jmri.jmrix.cmri;
 
 import java.util.ResourceBundle;
@@ -8,14 +7,8 @@ import javax.swing.JMenu;
  * Create a "Systems" menu containing the Jmri CMRI-specific tools
  *
  * @author	Bob Jacobsen Copyright 2003
- * @version $Revision$
  */
 public class CMRIMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4367233276261757531L;
 
     public CMRIMenu(String name) {
         this();

--- a/java/src/jmri/jmrix/cmri/serial/SerialLight.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialLight.java
@@ -1,4 +1,3 @@
-// SerialLight.java
 package jmri.jmrix.cmri.serial;
 
 import jmri.implementation.AbstractLight;
@@ -13,14 +12,8 @@ import org.slf4j.LoggerFactory;
  * Based in part on SerialTurnout.java
  *
  * @author Dave Duchamp Copyright (C) 2004
- * @version $Revision$
  */
 public class SerialLight extends AbstractLight {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 2525373718284737564L;
 
     /**
      * Create a Light object, with only system name.
@@ -81,5 +74,3 @@ public class SerialLight extends AbstractLight {
 
     private final static Logger log = LoggerFactory.getLogger(SerialLight.class.getName());
 }
-
-/* @(#)SerialLight.java */

--- a/java/src/jmri/jmrix/cmri/serial/SerialLightManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialLightManager.java
@@ -1,4 +1,3 @@
-// SerialLightManager.java
 package jmri.jmrix.cmri.serial;
 
 import jmri.Light;
@@ -14,14 +13,8 @@ import org.slf4j.LoggerFactory;
  * Based in part on SerialTurnoutManager.java
  *
  * @author	Dave Duchamp Copyright (C) 2004
- * @version	$Revision$
  */
 public class SerialLightManager extends AbstractLightManager {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6357999324956206115L;
 
     public SerialLightManager() {
 
@@ -134,5 +127,3 @@ public class SerialLightManager extends AbstractLightManager {
     private final static Logger log = LoggerFactory.getLogger(SerialLightManager.class.getName());
 
 }
-
-/* @(#)SerialLighttManager.java */

--- a/java/src/jmri/jmrix/cmri/serial/SerialSensor.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialSensor.java
@@ -1,4 +1,3 @@
-// SerialSensor.java
 package jmri.jmrix.cmri.serial;
 
 import jmri.implementation.AbstractSensor;
@@ -7,14 +6,8 @@ import jmri.implementation.AbstractSensor;
  * Extend jmri.AbstractSensor for C/MRI serial systems
  * <P>
  * @author	Bob Jacobsen Copyright (C) 2003
- * @version $Revision$
  */
 public class SerialSensor extends AbstractSensor {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7109954914253152537L;
 
     public SerialSensor(String systemName) {
         super(systemName);
@@ -37,5 +30,3 @@ public class SerialSensor extends AbstractSensor {
     }
 
 }
-
-/* @(#)SerialSensor.java */

--- a/java/src/jmri/jmrix/cmri/serial/SerialTurnout.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialTurnout.java
@@ -1,4 +1,3 @@
-// SerialTurnout.java
 package jmri.jmrix.cmri.serial;
 
 import jmri.Turnout;
@@ -46,14 +45,8 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2003, 2007, 2008
  * @author	David Duchamp Copyright (C) 2004, 2007
  * @author	Dan Boudreau Copyright (C) 2007
- * @version	$Revision$
  */
 public class SerialTurnout extends AbstractTurnout {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8788994513363830083L;
 
     /**
      * Create a Turnout object, with both system and user names.
@@ -262,5 +255,3 @@ public class SerialTurnout extends AbstractTurnout {
 
     private final static Logger log = LoggerFactory.getLogger(SerialTurnout.class.getName());
 }
-
-/* @(#)SerialTurnout.java */

--- a/java/src/jmri/jmrix/cmri/serial/assignment/ListAction.java
+++ b/java/src/jmri/jmrix/cmri/serial/assignment/ListAction.java
@@ -1,4 +1,3 @@
-// ListAction.java
 package jmri.jmrix.cmri.serial.assignment;
 
 import java.awt.event.ActionEvent;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a ListFrame object
  *
  * @author Dave Duchamp Copyright (C) 2006
- * @version	$Revision$
  */
 public class ListAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3347041053064760390L;
 
     public ListAction(String s) {
         super(s);
@@ -39,5 +32,3 @@ public class ListAction extends AbstractAction {
 
     private final static Logger log = LoggerFactory.getLogger(ListAction.class.getName());
 }
-
-/* @(#)ListAction.java */

--- a/java/src/jmri/jmrix/cmri/serial/assignment/ListFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/assignment/ListFrame.java
@@ -1,4 +1,3 @@
-// ListFrame.java
 package jmri.jmrix.cmri.serial.assignment;
 
 import java.awt.BorderLayout;
@@ -35,14 +34,8 @@ import org.slf4j.LoggerFactory;
  * Frame for running CMRI assignment list.
  *
  * @author	Dave Duchamp Copyright (C) 2006
- * @version	$Revision$
  */
 public class ListFrame extends jmri.util.JmriJFrame {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -465507473346396767L;
 
     ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.cmri.serial.assignment.ListBundle");
 
@@ -60,7 +53,7 @@ public class ListFrame extends jmri.util.JmriJFrame {
 
     // node select pane items
     JLabel nodeLabel = new JLabel(rb.getString("NodeBoxLabel") + " ");
-    JComboBox<String> nodeSelBox = new JComboBox<String>();
+    JComboBox<String> nodeSelBox = new JComboBox<>();
     ButtonGroup bitTypeGroup = new ButtonGroup();
     JRadioButton inputBits = new JRadioButton(rb.getString("ShowInputButton") + "   ", false);
     JRadioButton outputBits = new JRadioButton(rb.getString("ShowOutputButton"), true);
@@ -328,10 +321,6 @@ public class ListFrame extends jmri.util.JmriJFrame {
      */
     public class AssignmentTableModel extends AbstractTableModel {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = 1360475678715883889L;
         private String free = rb.getString("AssignmentFree");
         private int curRow = -1;
         private String curRowSysName = "";
@@ -554,5 +543,3 @@ public class ListFrame extends jmri.util.JmriJFrame {
     private final static Logger log = LoggerFactory.getLogger(ListFrame.class.getName());
 
 }
-
-/* @(#)ListFrame.java */

--- a/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticAction.java
+++ b/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticAction.java
@@ -1,4 +1,3 @@
-// DiagnosticAction.java
 package jmri.jmrix.cmri.serial.diagnostic;
 
 import java.awt.event.ActionEvent;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a DiagnosticFrame object
  *
  * @author Dave Duchamp Copyright (C) 2004
- * @version	$Revision$
  */
 public class DiagnosticAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1241617418393868830L;
 
     public DiagnosticAction(String s) {
         super(s);
@@ -39,5 +32,3 @@ public class DiagnosticAction extends AbstractAction {
 
     private final static Logger log = LoggerFactory.getLogger(DiagnosticAction.class.getName());
 }
-
-/* @(#)DiagnosticAction.java */

--- a/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/diagnostic/DiagnosticFrame.java
@@ -1,4 +1,3 @@
-// DiagnosticFrame.java
 package jmri.jmrix.cmri.serial.diagnostic;
 
 import java.awt.Container;
@@ -21,14 +20,9 @@ import jmri.jmrix.cmri.serial.SerialTrafficController;
  * Frame for running CMRI diagnostics
  *
  * @author	Dave Duchamp Copyright (C) 2004
- * @version	$Revision$
  */
 public class DiagnosticFrame extends jmri.util.JmriJFrame implements jmri.jmrix.cmri.serial.SerialListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 6464613055016868125L;
     // member declarations
     protected boolean outTest = true;
     protected boolean wrapTest = false;

--- a/java/src/jmri/jmrix/cmri/serial/nodeconfig/NodeConfigAction.java
+++ b/java/src/jmri/jmrix/cmri/serial/nodeconfig/NodeConfigAction.java
@@ -1,4 +1,3 @@
-// NodeConfigAction.java
 package jmri.jmrix.cmri.serial.nodeconfig;
 
 import java.awt.event.ActionEvent;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a NodeConfigFrame object
  *
  * @author	Bob Jacobsen Copyright (C) 2001
- * @version	$Revision$
  */
 public class NodeConfigAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6872293303665940983L;
 
     public NodeConfigAction(String s) {
         super(s);
@@ -39,6 +32,3 @@ public class NodeConfigAction extends AbstractAction {
     }
     private final static Logger log = LoggerFactory.getLogger(NodeConfigAction.class.getName());
 }
-
-
-/* @(#)SerialPacketGenAction.java */

--- a/java/src/jmri/jmrix/cmri/serial/nodeconfig/NodeConfigFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/nodeconfig/NodeConfigFrame.java
@@ -114,7 +114,7 @@ public class NodeConfigFrame extends jmri.util.JmriJFrame {
         panel11.add(nodeAddrStatic);
         nodeAddrStatic.setVisible(false);
         panel11.add(new JLabel("   " + rb.getString("LabelNodeType") + " "));
-        nodeTypeBox = new JComboBox<String>();
+        nodeTypeBox = new JComboBox<>();
         panel11.add(nodeTypeBox);
         nodeTypeBox.addItem("SMINI");
         nodeTypeBox.addItem("USIC_SUSIC");
@@ -148,7 +148,7 @@ public class NodeConfigFrame extends jmri.util.JmriJFrame {
         receiveDelayField.setToolTipText(rb.getString("TipDelay"));
         receiveDelayField.setText("0");
         panel12.add(cardSizeText);
-        cardSizeBox = new JComboBox<String>();
+        cardSizeBox = new JComboBox<>();
         panel12.add(cardSizeBox);
         cardSizeBox.addItem(rb.getString("CardSize24"));
         cardSizeBox.addItem(rb.getString("CardSize32"));
@@ -196,7 +196,7 @@ public class NodeConfigFrame extends jmri.util.JmriJFrame {
         cardConfigTable.setRowSelectionAllowed(false);
         cardConfigTable.setPreferredScrollableViewportSize(new java.awt.Dimension(180, 100));
 
-        JComboBox<String> cardTypeCombo = new JComboBox<String>();
+        JComboBox<String> cardTypeCombo = new JComboBox<>();
         cardTypeCombo.addItem(rb.getString("CardTypeOutput"));
         cardTypeCombo.addItem(rb.getString("CardTypeInput"));
         cardTypeCombo.addItem(rb.getString("CardTypeNone"));

--- a/java/src/jmri/jmrix/cmri/serial/packetgen/SerialPacketGenAction.java
+++ b/java/src/jmri/jmrix/cmri/serial/packetgen/SerialPacketGenAction.java
@@ -1,12 +1,3 @@
-/**
- * SerialPacketGenAction.java
- *
- * Description:	Swing action to create and register a SerialPacketGenFrame
- * object
- *
- * @author	Bob Jacobsen Copyright (C) 2001
- * @version
- */
 package jmri.jmrix.cmri.serial.packetgen;
 
 import java.awt.event.ActionEvent;
@@ -14,12 +5,13 @@ import javax.swing.AbstractAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Swing action to create and register a SerialPacketGenFrame
+ * object
+ *
+ * @author	Bob Jacobsen Copyright (C) 2001
+ */
 public class SerialPacketGenAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1235681553251130747L;
 
     public SerialPacketGenAction(String s) {
         super(s);
@@ -40,6 +32,3 @@ public class SerialPacketGenAction extends AbstractAction {
     }
     private final static Logger log = LoggerFactory.getLogger(SerialPacketGenAction.class.getName());
 }
-
-
-/* @(#)SerialPacketGenAction.java */

--- a/java/src/jmri/jmrix/cmri/serial/packetgen/SerialPacketGenFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/packetgen/SerialPacketGenFrame.java
@@ -1,4 +1,3 @@
-// SerialPacketGenFrame.java
 package jmri.jmrix.cmri.serial.packetgen;
 
 import java.awt.Dimension;
@@ -16,14 +15,9 @@ import jmri.util.StringUtil;
  * Frame for user input of CMRI serial messages
  *
  * @author	Bob Jacobsen Copyright (C) 2002, 2003
- * @version	$Revision$
  */
 public class SerialPacketGenFrame extends jmri.util.JmriJFrame implements jmri.jmrix.cmri.serial.SerialListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8913914338966964330L;
     // member declarations
     javax.swing.JLabel jLabel1 = new javax.swing.JLabel();
     javax.swing.JButton sendButton = new javax.swing.JButton();

--- a/java/src/jmri/jmrix/cmri/serial/serialmon/SerialMonAction.java
+++ b/java/src/jmri/jmrix/cmri/serial/serialmon/SerialMonAction.java
@@ -1,4 +1,3 @@
-// SerialMonAction.java
 package jmri.jmrix.cmri.serial.serialmon;
 
 import java.awt.event.ActionEvent;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a SerialMonFrame object
  *
  * @author	Bob Jacobsen Copyright (C) 2001
- * @version	$Revision$
  */
 public class SerialMonAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4006825776742617520L;
 
     public SerialMonAction(String s) {
         super(s);
@@ -41,6 +34,3 @@ public class SerialMonAction extends AbstractAction {
     private final static Logger log = LoggerFactory.getLogger(SerialMonAction.class.getName());
 
 }
-
-
-/* @(#)SerialMonAction.java */

--- a/java/src/jmri/jmrix/cmri/serial/serialmon/SerialMonFrame.java
+++ b/java/src/jmri/jmrix/cmri/serial/serialmon/SerialMonFrame.java
@@ -1,4 +1,3 @@
-// SerialMonFrame.java
 package jmri.jmrix.cmri.serial.serialmon;
 
 import jmri.jmrix.cmri.serial.SerialListener;
@@ -10,14 +9,8 @@ import jmri.jmrix.cmri.serial.SerialTrafficController;
  * Frame displaying (and logging) CMRI serial command messages
  *
  * @author	Bob Jacobsen Copyright (C) 2001
- * @version $Revision$
  */
 public class SerialMonFrame extends jmri.jmrix.AbstractMonFrame implements SerialListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4519092521835268245L;
 
     public SerialMonFrame() {
         super();

--- a/java/src/jmri/jmrix/cmri/serial/sim/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/cmri/serial/sim/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.cmri.serial.sim;
 
 import javax.swing.BoxLayout;
@@ -11,7 +10,6 @@ import jmri.jmrix.cmri.serial.nodeconfig.NodeConfigAction;
  * Simulator object.
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2003, 2008
- * @version	$Revision$
  */
 public class ConnectionConfig extends jmri.jmrix.AbstractSimulatorConnectionConfig {
 
@@ -49,7 +47,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSimulatorConnectionConf
     }
 
     /*protected Vector<String> getPortNames() {
-     Vector<String> portNameVector = new Vector<String>();
+     Vector<String> portNameVector = new Vector<>();
      portNameVector.addElement("(None)");
      return portNameVector;
      }*/

--- a/java/src/jmri/jmrix/direct/TrafficController.java
+++ b/java/src/jmri/jmrix/direct/TrafficController.java
@@ -112,7 +112,7 @@ public class TrafficController implements jmri.CommandStation {
     private AbstractSerialPortController controller = null;
 
     public boolean status() {
-        return (ostream != null & istream != null);
+        return (ostream != null && istream != null);
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/LnPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizer.java
@@ -55,7 +55,7 @@ public class LnPacketizer extends LnTrafficController {
 
     // The methods to implement the LocoNetInterface
     public boolean status() {
-        return (ostream != null & istream != null);
+        return (ostream != null && istream != null);
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/hexfile/LnHexFilePort.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/LnHexFilePort.java
@@ -166,7 +166,7 @@ public class LnHexFilePort extends LnPortController implements Runnable, jmri.jm
     }
 
     public boolean status() {
-        return (pout != null) & (pin != null);
+        return (pout != null) && (pin != null);
     }
 
     // to tell if we're currently putting out data

--- a/java/src/jmri/jmrix/mrc/MrcPacketizer.java
+++ b/java/src/jmri/jmrix/mrc/MrcPacketizer.java
@@ -70,7 +70,7 @@ public class MrcPacketizer extends MrcTrafficController {
 
     // The methods to implement the MrcInterface
     public boolean status() {
-        return (ostream != null & istream != null);
+        return (ostream != null && istream != null);
     }
 
     /**

--- a/java/src/jmri/jmrix/nce/consist/NceConsistEditPanel.java
+++ b/java/src/jmri/jmrix/nce/consist/NceConsistEditPanel.java
@@ -820,7 +820,7 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
         } catch (NumberFormatException e) {
             return -1;
         }
-        if (cN < CONSIST_MIN | cN > CONSIST_MAX) {
+        if (cN < CONSIST_MIN || cN > CONSIST_MAX) {
             return -1;
         } else {
             return cN;
@@ -838,7 +838,7 @@ public class NceConsistEditPanel extends jmri.jmrix.nce.swing.NcePanel implement
         } catch (NumberFormatException e) {
             lA = -1;
         }
-        if (lA < LOC_ADR_MIN | lA > LOC_ADR_MAX) {
+        if (lA < LOC_ADR_MIN || lA > LOC_ADR_MAX) {
             JOptionPane.showMessageDialog(this,
                     rb.getString("DIALOG_AddrRange"), rb.getString("DIALOG_NceConsist"),
                     JOptionPane.ERROR_MESSAGE);

--- a/java/src/jmri/jmrix/nce/macro/NceMacroEditPanel.java
+++ b/java/src/jmri/jmrix/nce/macro/NceMacroEditPanel.java
@@ -1152,7 +1152,7 @@ public class NceMacroEditPanel extends jmri.jmrix.nce.swing.NcePanel implements 
         } catch (NumberFormatException e) {
             accyNum = -1;
         }
-        if (accyNum < 1 | accyNum > 2044) {
+        if (accyNum < 1 || accyNum > 2044) {
             JOptionPane.showMessageDialog(this,
                     rb.getString("EnterAccessoryNumber"), rb.getString("NceMacroAddress"),
                     JOptionPane.ERROR_MESSAGE);
@@ -1253,7 +1253,7 @@ public class NceMacroEditPanel extends jmri.jmrix.nce.swing.NcePanel implements 
         } catch (NumberFormatException e) {
             return -1;
         }
-        if (mN < 0 | mN > maxNumMacros) {
+        if (mN < 0 || mN > maxNumMacros) {
             return -1;
         } else {
             return mN;

--- a/java/src/jmri/jmrix/nce/macro/NceMacroGenPanel.java
+++ b/java/src/jmri/jmrix/nce/macro/NceMacroGenPanel.java
@@ -151,7 +151,7 @@ public class NceMacroGenPanel extends jmri.jmrix.nce.swing.NcePanel implements j
             return null;
         }
 
-        if (macroNum < 0 | macroNum > 255) {
+        if (macroNum < 0 || macroNum > 255) {
             return null;
         }
 
@@ -191,7 +191,7 @@ public class NceMacroGenPanel extends jmri.jmrix.nce.swing.NcePanel implements j
             return null;
         }
 
-        if (macroNum < 0 | macroNum > 255) {
+        if (macroNum < 0 || macroNum > 255) {
             return null;
         }
 

--- a/java/src/jmri/jmrix/sprog/SprogTrafficController.java
+++ b/java/src/jmri/jmrix/sprog/SprogTrafficController.java
@@ -49,7 +49,7 @@ public class SprogTrafficController implements SprogInterface, SerialPortEventLi
     protected Vector<SprogListener> cmdListeners = new Vector<SprogListener>();
 
     public boolean status() {
-        return (ostream != null & istream != null);
+        return (ostream != null && istream != null);
     }
 
     public synchronized void addSprogListener(SprogListener l) {

--- a/java/src/jmri/jmrix/zimo/Mx1Packetizer.java
+++ b/java/src/jmri/jmrix/zimo/Mx1Packetizer.java
@@ -45,7 +45,7 @@ public class Mx1Packetizer extends Mx1TrafficController {
 
     // The methods to implement the Mx1Interface
     public boolean status() {
-        return (ostream != null & istream != null);
+        return (ostream != null && istream != null);
     }
 
     public final static boolean ASCII = false;
@@ -353,7 +353,7 @@ public class Mx1Packetizer extends Mx1TrafficController {
                             int b = istream.readByte() & 0xFF;
                             len = len + 1;
                             //if end of message
-                            if (b == 0x0D | b == 0x0A) {
+                            if (b == 0x0D || b == 0x0A) {
                                 msgn.setElement(i, b);
                                 break;
                             }


### PR DESCRIPTION
- NS_NON_SHORT_CIRCUIT (use of & or | instead of && or ||; the changes will improve error handling, but not normal operation)
- ICAST_INTEGER_MULTIPLY_CAST_TO_LONG (Shouldn't matter for normal use of the numbers, there aren't enough milliseconds in an operation session)
