### PR TITLE
Allow web index to show more types

### DIFF
--- a/resources/showIcons.php
+++ b/resources/showIcons.php
@@ -44,7 +44,13 @@ function showFiles() {
 
     $d = dir(".");
     while (false !== ($entry = $d->read())) {
-       if (endswith($entry, ".gif") || endswith($entry, ".jpg") || endswith($entry, ".png")) {
+       if (endswith($entry, ".gif") 
+            || endswith($entry, ".jpg") 
+            || endswith($entry, ".png")
+            || endswith($entry, ".EPS")
+            || endswith($entry, ".PSD")
+            || endswith($entry, ".md")
+            ) {
          $list[] = $entry;
        }
     }


### PR DESCRIPTION
index.php on web directories only shows enumerated types. This adds a couple more image formats, plus Markdown.