### PR TITLE
Fix Loconet Emergency Stop issue

### DIFF
--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -147,7 +147,7 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
     @Override
     protected int intSpeed(float fSpeed) {
         int speed = super.intSpeed(fSpeed);
-        if (speed <= 0) {
+        if (speed <= 1) {
             return speed; // return idle and emergency stop
         }
         switch (this.getSpeedStepMode()) {


### PR DESCRIPTION
Emergency stops do not work in Loconet unless the mobile decoder is in 128 speed step mode.

LoconetThrottle's intSpeed() method returns without further modification after calling AbstractThrottle's intSpeed() if the speed returned from that is zero or less, apparently assuming that <0 means ESTOP and 0 means stop. In fact AbstractThrottle's intSpeed() never returns less than zero and correctly returns 1 for ESTOP.

Calling setSpeedSetting() with a value of -1 for a decoder in 28 speed step mode ends up with a speed value to Loconet of -100 (or 0xFFFFFF9C which ends up as 0x9C and the packet is dropped. The Locomotive does not stop.

This (tiny) PR fixes the problem by returning a value of 1 from intSpeed() unmolested. 