### PR TITLE
updates to the ability to create UML diagrams.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1273,7 +1273,7 @@
         </jar>
     </target>
 
-    <target name="javadoc" depends="init, jjdoc, compile-generated-source" description="create JavaDocs">
+    <target name="javadoc" depends="init, jjdoc, compile-generated-source, plantuml" description="create JavaDocs">
         <javadoc packagenames="jmri.*, apps.*"
            maxmemory="512m"
            overview="${source}/jmri/overview.html"
@@ -1336,7 +1336,7 @@
   <!-- use of the public option in the main task definition, and -->
   <!-- the execution of "dot" at the bottom.                     -->
   <!-- Requires Graphviz from http://www.graphviz.org            -->
-    <target name="javadoc-uml" depends="init, jjdoc, compile-generated-source" description="create JavaDocs with UML">
+    <target name="javadoc-uml" depends="init, jjdoc, compile-generated-source, plantuml" description="create JavaDocs with UML">
         <javadoc packagenames="jmri.*, apps.*"
            maxmemory="512m"
            overview="${source}/jmri/overview.html"
@@ -1409,6 +1409,17 @@
             <fileset dir="${doctarget}" includes="*.dot"/>
             <mapper type="glob" from="*.dot" to="*.png"/>
         </apply>
+    </target>
+
+    <taskdef name="plantuml" classname="net.sourceforge.plantuml.ant.PlantUmlTask" classpath="${libdir}/plantuml.jar" />
+
+    <target name="plantuml">
+        <plantuml output="${doctarget}" >
+        <fileset dir="${source}">
+                <include name="jmri/**/*.java"/>
+                <include name="apps/**/*.java"/>
+        </fileset>
+        </plantuml>
     </target>
 
     <target name="uploadjavadoc" description="upload existing JavaDocs to jmri.org without recreating">

--- a/java/src/jmri/jmrix/lenz/XNetProgrammer.java
+++ b/java/src/jmri/jmrix/lenz/XNetProgrammer.java
@@ -1,7 +1,3 @@
-/**
- * XNetProgrammer.java
- */
- // Convert the jmri.Programmer interface into commands for the Lenz XpressNet
 package jmri.jmrix.lenz;
 
 import java.util.ArrayList;
@@ -13,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Programmer support for Lenz XpressNet.
+ * Convert the jmri.Programmer interface into commands for the Lenz XpressNet
  * <P>
  * The read operation state sequence is:
  * <UL>
@@ -24,11 +20,60 @@ import org.slf4j.LoggerFactory;
  * <LI>Send Resume Operations request
  * <LI>Wait for Normal Operations Resumed broadcast
  * </UL>
+ * <img src="doc-files/XPressNetProgrammer-StateDiagram.png">
+ * <img src="doc-files/XPressNetProgrammer-SequenceDiagram.png">
  *
  * @author Bob Jacobsen Copyright (c) 2002, 2007
  * @author Paul Bender Copyright (c) 2003-2010
  * @author Giorgio Terdina Copyright (c) 2007
- * @version $Revision$
+ */
+
+/*
+ * @startuml jmri/jmrix/lenz/doc-files/XPressNetProgrammer-StateDiagram.png
+ * state NormalMode{
+ * [*] --> initialREQUESTSENT: readCV()
+ * [*] --> initialREQUESTSENT: writeCV()
+ * }
+ * [*] --> NormalMode
+ * state ServiceMode{
+ * [*] --> INQUIRESENT 
+ * REQUESTSENT --> INQUIRESENT : Command Successfully Received
+ * REQUESTSENT --> NOTPROGRAMMING : timeout()
+ * INQUIRESENT --> NOTPROGRAMMING : Result Received
+ * INQUIRESENT --> NOTPROGRAMMING : timeout()
+ * NOTPROGRAMMING --> REQUESTSENT : readCV()
+ * NOTPROGRAMMING --> REQUESTSENT : writeCV()
+ * NOTPROGRAMMING --> RequestNormalOps : timeout()
+ * RequestNormalOps --> [*]
+ * }
+ * NormalMode --> ServiceMode : Service Mode Entry Received
+ * ServiceMode --> [*] : Normal Operations Resumed
+ * @enduml
+ *
+ * @startuml jmri/jmrix/lenz/doc-files/XPressNetProgrammer-SequenceDiagram.png
+ * actor user
+ * control programmer
+ * user -> programmer:read/write CV
+ * programmer -> XNetProgrammer:readCV()/writeCV()
+ * XNetProgrammer -> CommandStation: Read/Write CV in appropriate mode.
+ * CommandStation -> XNetProgrammer: Service Mode Entry.
+ * XNetProgrammer -> CommandStation: Request Service Mode Results.
+ * CommandStation -> XNetProgrammer: Service Mode Result or Error Message
+ * XNetProgrammer -> programmer: CV Value or Error Message
+ * programmer -> user: CV value or Error Message
+ * loop 0 or more times
+ * user -> programmer:read/write CV
+ * programmer -> XNetProgrammer:readCV()/writeCV()
+ * XNetProgrammer -> CommandStation: Read/Write CV in appropriate mode.
+ * CommandStation -> XNetProgrammer: Command Successfully Received.
+ * XNetProgrammer -> CommandStation: Request Service Mode Results.
+ * CommandStation -> XNetProgrammer: Service Mode Result or Error Message
+ * XNetProgrammer -> programmer: CV Value or Error Message
+ * programmer -> user: CV value or Error Message
+ * end
+ * XNetProgrammer -> CommandStation: Resume Normal Operations
+ * CommandStation -> XNetProgrammer: Normal Operations Resumed
+ * @enduml
  */
 public class XNetProgrammer extends AbstractProgrammer implements XNetListener {
 

--- a/java/src/jmri/jmrix/lenz/XNetProgrammerManager.java
+++ b/java/src/jmri/jmrix/lenz/XNetProgrammerManager.java
@@ -10,7 +10,8 @@ import jmri.managers.DefaultProgrammerManager;
  *
  * @see jmri.ProgrammerManager
  * @author	Paul Bender Copyright (C) 2003
- * @version	$Revision$
+ * @navassoc - - 1..1 jmri.jmrix.lenz.XNetProgrammer
+ * @navassoc - - 1..* jmri.jmrix.lenz.XNetOpsModeProgrammer
  */
 public class XNetProgrammerManager extends DefaultProgrammerManager {
 


### PR DESCRIPTION
Adds the ability to draw UML diagrams with plantuml.  This allows us to generate UML diagrams other than class diagrams for use in either the javadoc or on the website.  This uses graphviz to generate the images just like umlgraph does.

Note: this does not replace umlgraph for generating the UML class diagrams that are automatically included with the javadoc.  There is a doclet associated with plantuml that can do this, but it only renders the class diagrams differently, it does not add any features over umlgraph.