### PR TITLE
fix URF_UNREAD_FIELD on the tc field in RfidReply.

### DIFF
--- a/java/src/jmri/jmrix/rfid/RfidReply.java
+++ b/java/src/jmri/jmrix/rfid/RfidReply.java
@@ -10,7 +10,8 @@ package jmri.jmrix.rfid;
  */
 abstract public class RfidReply extends jmri.jmrix.AbstractMRReply {
 
-    RfidTrafficController tc = null;
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "used by derived classes to fetch protocol in use")
+    protected RfidTrafficController tc = null;
 
     // create a new one
     public RfidReply(RfidTrafficController tc) {

--- a/java/src/jmri/jmrix/rfid/generic/standalone/StandaloneReply.java
+++ b/java/src/jmri/jmrix/rfid/generic/standalone/StandaloneReply.java
@@ -14,31 +14,26 @@ import jmri.jmrix.rfid.RfidTrafficController;
  */
 public class StandaloneReply extends RfidReply {
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "Kept to conform with common RFID framework")
-    RfidTrafficController tc = null;
     RfidProtocol pr = null;
 
     // create a new one
     public StandaloneReply(RfidTrafficController tc) {
         super(tc);
-        this.tc = tc;
-        this.pr = tc.getAdapterMemo().getProtocol();
+        this.pr = this.tc.getAdapterMemo().getProtocol();
         setBinary(true);
         setUnsolicited();
     }
 
     public StandaloneReply(RfidTrafficController tc, String s) {
         super(tc, s);
-        this.tc = tc;
-        this.pr = tc.getAdapterMemo().getProtocol();
+        this.pr = this.tc.getAdapterMemo().getProtocol();
         setBinary(true);
         setUnsolicited();
     }
 
     public StandaloneReply(RfidTrafficController tc, RfidReply l) {
         super(tc, l);
-        this.tc = tc;
-        this.pr = tc.getAdapterMemo().getProtocol();
+        this.pr = this.tc.getAdapterMemo().getProtocol();
         setBinary(true);
         setUnsolicited();
     }

--- a/java/src/jmri/jmrix/rfid/merg/concentrator/ConcentratorReply.java
+++ b/java/src/jmri/jmrix/rfid/merg/concentrator/ConcentratorReply.java
@@ -15,30 +15,26 @@ import jmri.jmrix.rfid.protocol.coreid.CoreIdRfidProtocol;
  */
 public class ConcentratorReply extends RfidReply {
 
-    RfidTrafficController tc = null;
     RfidProtocol pr = null;
 
     // create a new one
     public ConcentratorReply(RfidTrafficController tc) {
         super(tc);
-        this.tc = tc;
-        this.pr = tc.getAdapterMemo().getProtocol();
+        this.pr = this.tc.getAdapterMemo().getProtocol();
         setBinary(true);
         setUnsolicited();
     }
 
     public ConcentratorReply(RfidTrafficController tc, String s) {
         super(tc, s);
-        this.tc = tc;
-        this.pr = tc.getAdapterMemo().getProtocol();
+        this.pr = this.tc.getAdapterMemo().getProtocol();
         setBinary(true);
         setUnsolicited();
     }
 
     public ConcentratorReply(RfidTrafficController tc, RfidReply l) {
         super(tc, l);
-        this.tc = tc;
-        this.pr = tc.getAdapterMemo().getProtocol();
+        this.pr = this.tc.getAdapterMemo().getProtocol();
         setBinary(true);
         setUnsolicited();
     }


### PR DESCRIPTION
Change protection on the tc field to be protected.  Refactor derived classes to use the version of tc in RfidReply instead of having several package protected versions of the same value.