### PR TITLE
Improve validation of XML files from the command line

### DIFF
--- a/help/en/html/doc/Technical/XmlSchema.shtml
+++ b/help/en/html/doc/Technical/XmlSchema.shtml
@@ -186,17 +186,20 @@ If we let too many problems build up,
 we'll eventually have a lot of back-fitting to do.
 The W3C online 
 <a href="http://www.w3.org/2001/03/webdata/xsv">schema validation tool</a>
-is a very good tool for checking that JMRI schema changes are still technically 
+is a very good tool for checking that changes to the JMRI schema are still technically 
 correct.  You should check your changes with it before commiting them to the repository.
 Unfortunately, it doesn't seem to to check compliance with nested schema elements,
-e.g. from DocBook (see below) or JMRIschema,
+e.g. from DocBook (see below) or JMRI schema,
 but it's still a very useful check.
 
 <p>
 Using the JMRI "Validate XML File" tool in the "Debug" menu to
 validate a .xml file ("instance file") that uses your new or 
 updated schema is an important check of both. Use it often during
-development.
+development. You can also use it from the command line via e.g.:
+<code><pre>
+./runtest.csh jmri/jmrit/XmlFileValidateAction xml/decoders/0NMRA.xml 
+</pre></code>
 
 <p>
 For a quick file check, Linux and Mac OS X users can validate from the

--- a/java/src/jmri/jmrit/XmlFileValidateAction.java
+++ b/java/src/jmri/jmrit/XmlFileValidateAction.java
@@ -62,7 +62,7 @@ public class XmlFileValidateAction extends AbstractAction {
         }
     }
             
-    private void processFile(File file) {
+    protected void processFile(File file) {
         if (log.isDebugEnabled()) {
             log.debug("located file " + file + " for XML processing");
         }
@@ -88,7 +88,7 @@ public class XmlFileValidateAction extends AbstractAction {
                 builder.setFeature("http://xml.org/sax/features/namespaces", true);
                 doc = builder.build(new BufferedInputStream(stream));
             } catch (Exception ex2) {
-                JOptionPane.showMessageDialog(_who, "Err(1): " + ex2);
+                showFailResults(_who, "Err(1): " + ex2);
                 return;
             }
             XMLOutputter outputter = new XMLOutputter();
@@ -99,7 +99,7 @@ public class XmlFileValidateAction extends AbstractAction {
             try {
                 outputter.output(doc, out);
             } catch (Exception ex2) {
-                JOptionPane.showMessageDialog(_who, "Err(4): " + ex2);
+                showFailResults(_who, "Err(4): " + ex2);
                 return;
             }
             StringReader input = new StringReader(new String(out.getBuffer()));
@@ -114,19 +114,27 @@ public class XmlFileValidateAction extends AbstractAction {
                 XmlFile.verify = true;
                 builder.build(input).getRootElement();
             } catch (Exception ex2) {
-                JOptionPane.showMessageDialog(_who, "Err(2): " + ex2);
+                showFailResults(_who, "Err(2): " + ex2);
                 return;
             }
 
-            JOptionPane.showMessageDialog(_who, "Err(3): " + ex);
+            showFailResults(_who, "Err(3): " + ex);
             return;
         } finally {
             XmlFile.verify = original;
         }
-        JOptionPane.showMessageDialog(_who, "OK");
+        showOkResults(_who, "OK");
         if (log.isDebugEnabled()) {
             log.debug("parsing complete");
         }
+    }
+    
+    protected void showOkResults(JPanel who, String text) {
+        JOptionPane.showMessageDialog(who, text);
+    }
+
+    protected void showFailResults(JPanel who, String text) {
+        JOptionPane.showMessageDialog(who, text);
     }
     
     /**
@@ -146,7 +154,15 @@ public class XmlFileValidateAction extends AbstractAction {
         if (args.length == 0 ) {
             new XmlFileValidateAction("", null).actionPerformed(null);
         } else {
-            new XmlFileValidateAction("", null).processFile(new File(args[0]));
+            jmri.util.Log4JUtil.initLogging("default.lcf");
+            new XmlFileValidateAction("", null){
+                protected void showFailResults(JPanel who, String text) {
+                    System.out.println(text);
+                }
+                protected void showOkResults(JPanel who, String text) {
+                    // silent if OK
+                }
+            }.processFile(new File(args[0]));
         }
     }
 

--- a/java/src/jmri/jmrit/XmlFileValidateAction.java
+++ b/java/src/jmri/jmrit/XmlFileValidateAction.java
@@ -20,7 +20,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Make sure an XML file is readable, and validates OK
+ * Make sure an XML file is readable, and validates OK.
+ *<p>
+ * Can also be run from the command line with e.g. 
+ *    ./runtest.csh jmri/jmrit/XmlFileValidateAction foo.xml 
+ * in which case if there's a filename argument, it checks that directly, otherwise
+ * it pops a file selection dialog. (The dialog form has to be manually canceled when done)
  *
  * @author	Bob Jacobsen Copyright (C) 2005, 2007
  * @see jmri.jmrit.XmlFile
@@ -51,77 +56,79 @@ public class XmlFileValidateAction extends AbstractAction {
         int retVal = fci.showOpenDialog(_who);
         // handle selection or cancel
         if (retVal == JFileChooser.APPROVE_OPTION) {
-            File file = fci.getSelectedFile();
-            if (log.isDebugEnabled()) {
-                log.debug("located file " + file + " for XML processing");
-            }
-            // handle the file (later should be outside this thread?)
-            boolean original = XmlFile.verify;
-            try {
-                XmlFile.verify = true;
-                readFile(file);
-            } catch (Exception ex) {
-                // because of XInclude, we're doing this
-                // again to validate the entire file
-                // without losing the error message
-                XmlFile.verify = false;
-                Document doc;
-                try {
-                    InputStream stream = new BufferedInputStream(new FileInputStream(file));
-                    SAXBuilder builder = new SAXBuilder("org.apache.xerces.parsers.SAXParser", false);
-                    builder.setEntityResolver(new jmri.util.JmriLocalEntityResolver());
-                    builder.setFeature("http://apache.org/xml/features/xinclude", true);
-                    builder.setFeature("http://apache.org/xml/features/xinclude/fixup-base-uris", false);
-                    builder.setFeature("http://apache.org/xml/features/validation/schema", false);
-                    builder.setFeature("http://apache.org/xml/features/validation/schema-full-checking", false);
-                    builder.setFeature("http://xml.org/sax/features/namespaces", true);
-                    doc = builder.build(new BufferedInputStream(stream));
-                } catch (Exception ex2) {
-                    JOptionPane.showMessageDialog(_who, "Err(1): " + ex2);
-                    return;
-                }
-                XMLOutputter outputter = new XMLOutputter();
-                outputter.setFormat(Format.getPrettyFormat()
-                        .setLineSeparator(System.getProperty("line.separator"))
-                        .setTextMode(Format.TextMode.PRESERVE));
-                StringWriter out = new StringWriter();
-                try {
-                    outputter.output(doc, out);
-                } catch (Exception ex2) {
-                    JOptionPane.showMessageDialog(_who, "Err(4): " + ex2);
-                    return;
-                }
-                StringReader input = new StringReader(new String(out.getBuffer()));
-                SAXBuilder builder = new SAXBuilder("org.apache.xerces.parsers.SAXParser", true);
-                builder.setEntityResolver(new jmri.util.JmriLocalEntityResolver());
-                builder.setFeature("http://apache.org/xml/features/xinclude", true);
-                builder.setFeature("http://apache.org/xml/features/xinclude/fixup-base-uris", false);
-                builder.setFeature("http://apache.org/xml/features/validation/schema", true);
-                builder.setFeature("http://apache.org/xml/features/validation/schema-full-checking", true);
-                builder.setFeature("http://xml.org/sax/features/namespaces", true);
-                try {
-                    XmlFile.verify = true;
-                    builder.build(input).getRootElement();
-                } catch (Exception ex2) {
-                    JOptionPane.showMessageDialog(_who, "Err(2): " + ex2);
-                    return;
-                }
-
-                JOptionPane.showMessageDialog(_who, "Err(3): " + ex);
-                return;
-            } finally {
-                XmlFile.verify = original;
-            }
-            JOptionPane.showMessageDialog(_who, "OK");
-            if (log.isDebugEnabled()) {
-                log.debug("parsing complete");
-            }
-
+            processFile(fci.getSelectedFile());
         } else {
             log.debug("XmlFileValidateAction cancelled in open dialog");
         }
     }
+            
+    private void processFile(File file) {
+        if (log.isDebugEnabled()) {
+            log.debug("located file " + file + " for XML processing");
+        }
+        // handle the file (later should be outside this thread?)
+        boolean original = XmlFile.verify;
+        try {
+            XmlFile.verify = true;
+            readFile(file);
+        } catch (Exception ex) {
+            // because of XInclude, we're doing this
+            // again to validate the entire file
+            // without losing the error message
+            XmlFile.verify = false;
+            Document doc;
+            try {
+                InputStream stream = new BufferedInputStream(new FileInputStream(file));
+                SAXBuilder builder = new SAXBuilder("org.apache.xerces.parsers.SAXParser", false);
+                builder.setEntityResolver(new jmri.util.JmriLocalEntityResolver());
+                builder.setFeature("http://apache.org/xml/features/xinclude", true);
+                builder.setFeature("http://apache.org/xml/features/xinclude/fixup-base-uris", false);
+                builder.setFeature("http://apache.org/xml/features/validation/schema", false);
+                builder.setFeature("http://apache.org/xml/features/validation/schema-full-checking", false);
+                builder.setFeature("http://xml.org/sax/features/namespaces", true);
+                doc = builder.build(new BufferedInputStream(stream));
+            } catch (Exception ex2) {
+                JOptionPane.showMessageDialog(_who, "Err(1): " + ex2);
+                return;
+            }
+            XMLOutputter outputter = new XMLOutputter();
+            outputter.setFormat(Format.getPrettyFormat()
+                    .setLineSeparator(System.getProperty("line.separator"))
+                    .setTextMode(Format.TextMode.PRESERVE));
+            StringWriter out = new StringWriter();
+            try {
+                outputter.output(doc, out);
+            } catch (Exception ex2) {
+                JOptionPane.showMessageDialog(_who, "Err(4): " + ex2);
+                return;
+            }
+            StringReader input = new StringReader(new String(out.getBuffer()));
+            SAXBuilder builder = new SAXBuilder("org.apache.xerces.parsers.SAXParser", true);
+            builder.setEntityResolver(new jmri.util.JmriLocalEntityResolver());
+            builder.setFeature("http://apache.org/xml/features/xinclude", true);
+            builder.setFeature("http://apache.org/xml/features/xinclude/fixup-base-uris", false);
+            builder.setFeature("http://apache.org/xml/features/validation/schema", true);
+            builder.setFeature("http://apache.org/xml/features/validation/schema-full-checking", true);
+            builder.setFeature("http://xml.org/sax/features/namespaces", true);
+            try {
+                XmlFile.verify = true;
+                builder.build(input).getRootElement();
+            } catch (Exception ex2) {
+                JOptionPane.showMessageDialog(_who, "Err(2): " + ex2);
+                return;
+            }
 
+            JOptionPane.showMessageDialog(_who, "Err(3): " + ex);
+            return;
+        } finally {
+            XmlFile.verify = original;
+        }
+        JOptionPane.showMessageDialog(_who, "OK");
+        if (log.isDebugEnabled()) {
+            log.debug("parsing complete");
+        }
+    }
+    
     /**
      * Ask SAX to read and verify a file
      */
@@ -135,7 +142,12 @@ public class XmlFileValidateAction extends AbstractAction {
 
     // Main entry point fires the action
     static public void main(String[] args) {
-        new XmlFileValidateAction("", null).actionPerformed(null);
+        // if a 1st argument provided, act
+        if (args.length == 0 ) {
+            new XmlFileValidateAction("", null).actionPerformed(null);
+        } else {
+            new XmlFileValidateAction("", null).processFile(new File(args[0]));
+        }
     }
 
     // initialize logging


### PR DESCRIPTION
Code and doc for validating XML files from the command line:  This handles JMRI's local look-up rules for included XML and XSL files.