### PR TITLE
Fixing the bad null check in java/src/jmri/jmrit/beantable/TransitTab…

### DIFF
--- a/java/src/jmri/jmrit/beantable/TransitTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TransitTableAction.java
@@ -5,7 +5,8 @@ import java.awt.Container;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.ResourceBundle;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
@@ -1220,7 +1221,8 @@ public class TransitTableAction extends AbstractTableAction {
         for (int i = 0; i < sectionList.size(); i++) {
             TransitSection ts = new TransitSection(sectionList.get(i),
                     sequence[i], direction[i], alternate[i]);
-            if (ts.equals(null)) {
+            // FIXME: Why is this null check here? We just instansiated ts as a new TransitSection, which should keep it from ever being null
+            if (null == ts) {
                 log.error("Trouble creating TransitSection");
                 return false;
             }


### PR DESCRIPTION
This is to fix the bad null check change I made. However, as my comment indicates, this null check should never return true since the previous line instantiates the variable. That instantiation should prevent null, unless something within the constructor should fail and return an exception. Perhaps this code should have an exception catch instead?