### PR TITLE
Flush output after Roster write to ensure operation complete

### DIFF
--- a/java/src/jmri/jmrit/XmlFile.java
+++ b/java/src/jmri/jmrit/XmlFile.java
@@ -218,6 +218,7 @@ public abstract class XmlFile {
                     .setLineSeparator(System.getProperty("line.separator"))
                     .setTextMode(Format.TextMode.TRIM_FULL_WHITE));
             fmt.output(doc, o);
+            o.flush();
         } finally {
             o.close();
         }

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -1603,7 +1603,7 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
         if ((curBlock.getState() & (OBlock.OCCUPIED | OBlock.DARK))==0 && !_tempRunBlind) {
             _engineer.setHalt(true);        // immediate setspeed = 0
             // should not happen, but...what if...
-            log.error("checkCurrentBlock, block \""+curBlock.getDisplayName()+"\" not occupied! warrant "+getDisplayName());
+            log.error("checkCurrentBlock, block \""+curBlock.getDisplayName()+"\" not occupied! warrant "+getDisplayName(), new Exception("traceback"));
             return true;
         }
         // An estimate for how far to look ahead for a possible speed change

--- a/java/test/jmri/jmrit/logix/NXFrameTest.java
+++ b/java/test/jmri/jmrit/logix/NXFrameTest.java
@@ -179,19 +179,20 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
     }
 
     /**
+     * works through a list of sensors, activating one, then the next, then 
+     * inactivating the first and continuing. Leaves last ACTIVE.
      * @param sensor - active start sensor
      * @return - active end sensor
      * @throws Exception
      */
     private Sensor runtimes(Sensor sensor, String[] sensors) throws Exception {
         flushAWT();
-        for (int i=0; i<sensors.length; i++) {
+        _sensorMgr.getSensor(sensors[0]).setState(Sensor.ACTIVE);
+        for (int i=1; i<sensors.length; i++) {
             flushAWT();
-            Sensor sensorNext = _sensorMgr.getSensor(sensors[i]);
-            sensorNext.setState(Sensor.ACTIVE);
+            _sensorMgr.getSensor(sensors[i]).setState(Sensor.ACTIVE);
             flushAWT();           
-            sensor.setState(Sensor.INACTIVE);
-            sensor = sensorNext;
+            _sensorMgr.getSensor(sensors[i-i]).setState(Sensor.INACTIVE);
         }
         return sensor;
     }


### PR DESCRIPTION
Intended to clear up intermittent Jenkins fault; make quick written-and-reread more reliable.