### PR TITLE
Improve loco ident handling

### DIFF
--- a/java/src/jmri/jmrit/roster/swing/Bundle.java
+++ b/java/src/jmri/jmrit/roster/swing/Bundle.java
@@ -1,4 +1,3 @@
-// Bundle.java
 package jmri.jmrit.roster.swing;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -19,7 +18,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * the local resource bundle name.
  *
  * @author Bob Jacobsen Copyright (C) 2012
- * @version $Revision: 17977 $
  * @since 3.3.1
  */
 public class Bundle extends jmri.jmrit.roster.Bundle {
@@ -79,5 +77,3 @@ public class Bundle extends jmri.jmrit.roster.Bundle {
     }
 
 }
-
-/* @(#)Bundle.java */

--- a/java/src/jmri/jmrit/roster/swing/CopyRosterGroupAction.java
+++ b/java/src/jmri/jmrit/roster/swing/CopyRosterGroupAction.java
@@ -1,4 +1,3 @@
-// DeleteRosterGroupAction.java
 package jmri.jmrit.roster.swing;
 
 import java.awt.Component;
@@ -33,14 +32,8 @@ import jmri.util.swing.WindowInterface;
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  * <P>
  * @author	Kevin Dickerson Copyright (C) 2009
- * @version	$Revision$
  */
 public class CopyRosterGroupAction extends JmriAbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3490415977207449861L;
 
     public CopyRosterGroupAction(String s, WindowInterface wi) {
         super(s, wi);

--- a/java/src/jmri/jmrit/roster/swing/CreateRosterGroupAction.java
+++ b/java/src/jmri/jmrit/roster/swing/CreateRosterGroupAction.java
@@ -1,4 +1,3 @@
-// CreateRosterGroupAction.java
 package jmri.jmrit.roster.swing;
 
 import java.awt.Component;
@@ -30,14 +29,8 @@ import org.slf4j.LoggerFactory;
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  * <P>
  * @author	Kevin Dickerson Copyright (C) 2009
- * @version	$Revision$
  */
 public class CreateRosterGroupAction extends JmriAbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8222098783980850363L;
 
     public CreateRosterGroupAction(String s, WindowInterface wi) {
         super(s, wi);

--- a/java/src/jmri/jmrit/roster/swing/DeleteRosterGroupAction.java
+++ b/java/src/jmri/jmrit/roster/swing/DeleteRosterGroupAction.java
@@ -1,4 +1,3 @@
-// DeleteRosterGroupAction.java
 package jmri.jmrit.roster.swing;
 
 import java.awt.Component;
@@ -26,14 +25,8 @@ import jmri.util.swing.WindowInterface;
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  * <P>
  * @author	Kevin Dickerson Copyright (C) 2009
- * @version	$Revision$
  */
 public class DeleteRosterGroupAction extends JmriAbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5645990386314165982L;
 
     public DeleteRosterGroupAction(String s, WindowInterface wi) {
         super(s, wi);

--- a/java/src/jmri/jmrit/roster/swing/GlobalRosterEntryComboBox.java
+++ b/java/src/jmri/jmrit/roster/swing/GlobalRosterEntryComboBox.java
@@ -1,4 +1,3 @@
-// RosterEntryComboBox.java
 package jmri.jmrit.roster.swing;
 
 import jmri.jmrit.roster.Roster;
@@ -8,15 +7,9 @@ import jmri.jmrit.roster.Roster;
  * without respect to a roster group.
  *
  * @author Randall Wood Copyright (C) 2011
- * @version $Revision: $
  * @see RosterEntryComboBox
  */
 public class GlobalRosterEntryComboBox extends RosterEntryComboBox {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7160579198258524537L;
 
     /**
      * Create a combo box with all roster entries in the default Roster.

--- a/java/src/jmri/jmrit/roster/swing/RemoveRosterEntryToGroupAction.java
+++ b/java/src/jmri/jmrit/roster/swing/RemoveRosterEntryToGroupAction.java
@@ -1,4 +1,3 @@
-// RemoveRosterEntryToGroupAction.java
 package jmri.jmrit.roster.swing;
 
 import java.awt.Component;
@@ -33,14 +32,9 @@ import org.slf4j.LoggerFactory;
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  * <P>
  * @author	Kevin Dickerson Copyright (C) 2009
- * @version	$Revision$
  */
 public class RemoveRosterEntryToGroupAction extends AbstractAction {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3631492408927497941L;
 
     /**
      * @param s   Name of this action, e.g. in menus

--- a/java/src/jmri/jmrit/roster/swing/RenameRosterGroupAction.java
+++ b/java/src/jmri/jmrit/roster/swing/RenameRosterGroupAction.java
@@ -1,4 +1,3 @@
-// DeleteRosterGroupAction.java
 package jmri.jmrit.roster.swing;
 
 import java.awt.Component;
@@ -29,15 +28,9 @@ import jmri.util.swing.WindowInterface;
  * <P>
  * @author	Kevin Dickerson Copyright (C) 2009
  * @author Randall Wood Copyright (C) 2011
- * @version	$Revision$
  * @see Roster
  */
 public class RenameRosterGroupAction extends JmriAbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1370317330367764168L;
 
     public RenameRosterGroupAction(String s, WindowInterface wi) {
         super(s, wi);

--- a/java/src/jmri/jmrit/roster/swing/RosterEntryComboBox.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterEntryComboBox.java
@@ -1,4 +1,3 @@
-// RosterEntryComboBox.java
 package jmri.jmrit.roster.swing;
 
 import java.awt.event.ActionEvent;
@@ -24,17 +23,12 @@ import org.slf4j.LoggerFactory;
  * display if a RosterEntry is added, removed, or changes.
  *
  * @author Randall Wood Copyright (C) 2011
- * @version $Revision: $
  * @see jmri.jmrit.roster.Roster
  * @see jmri.jmrit.roster.RosterEntry
  * @see javax.swing.JComboBox
  */
 public class RosterEntryComboBox extends JComboBox<Object> implements RosterEntrySelector {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3147210325149684853L;
     protected Roster _roster;
     protected String _group;
     protected String _roadName;

--- a/java/src/jmri/jmrit/roster/swing/RosterEntryListCellRenderer.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterEntryListCellRenderer.java
@@ -15,11 +15,6 @@ import jmri.jmrit.roster.RosterEntry;
  */
 public class RosterEntryListCellRenderer extends JLabel implements ListCellRenderer<Object> {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1256109351736867211L;
-
     public RosterEntryListCellRenderer() {
         super();
         setOpaque(true);

--- a/java/src/jmri/jmrit/roster/swing/RosterEntrySelectorPanel.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterEntrySelectorPanel.java
@@ -1,4 +1,3 @@
-// RosterEntrySelectorPanel.java
 package jmri.jmrit.roster.swing;
 
 import java.awt.FlowLayout;
@@ -17,10 +16,6 @@ import jmri.jmrit.roster.rostergroup.RosterGroupSelector;
  */
 public class RosterEntrySelectorPanel extends JPanel implements RosterEntrySelector, RosterGroupSelector {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3641274360656995669L;
     private RosterEntryComboBox entryCombo;
     private RosterGroupComboBox groupCombo;
 

--- a/java/src/jmri/jmrit/roster/swing/RosterEntryToGroupAction.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterEntryToGroupAction.java
@@ -1,4 +1,3 @@
-// RosterEntryToGroupAction.java
 package jmri.jmrit.roster.swing;
 
 import java.awt.Component;
@@ -28,14 +27,8 @@ import org.slf4j.LoggerFactory;
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  * <P>
  * @author	Kevin Dickerson Copyright (C) 2009
- * @version	$Revision$
  */
 public class RosterEntryToGroupAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 583406343893394954L;
 
     /**
      * @param s Name of this action, e.g. in menus

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -1388,12 +1388,18 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
             @Override
             protected void done(int dccAddress) {
                 // if Done, updated the selected decoder
-                who.selectLoco(dccAddress, !shortAddr, cv8val, cv7val);
+                // on the GUI thread, right now
+                jmri.util.ThreadingUtil.runOnGUI(()->{
+                    who.selectLoco(dccAddress, !shortAddr, cv8val, cv7val);
+                });
             }
 
             @Override
             protected void message(String m) {
-                statusField.setText(m);
+                // on the GUI thread, right now
+                jmri.util.ThreadingUtil.runOnGUI(()->{
+                    statusField.setText(m);
+                });
             }
 
             @Override

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -122,11 +122,6 @@ import org.slf4j.LoggerFactory;
  */
 public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector, RosterGroupSelector {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1L;
-    private final static Logger log = LoggerFactory.getLogger(RosterFrame.class.getName());
     static ArrayList<RosterFrame> frameInstances = new ArrayList<>();
     protected boolean allowQuit = true;
     protected String baseTitle = "Roster";
@@ -534,10 +529,6 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
         ((DefaultRowSorter<?, ?>) rtable.getTable().getRowSorter()).sort();
         rtable.getTable().setDragEnabled(true);
         rtable.getTable().setTransferHandler(new TransferHandler() {
-            /**
-             *
-             */
-            private static final long serialVersionUID = 1L;
 
             @Override
             public int getSourceActions(JComponent c) {
@@ -1426,24 +1417,13 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
             JFrame progFrame = null;
             if (edit.isSelected()) {
                 progFrame = new PaneProgFrame(decoderFile, re, title, "programmers" + File.separator + filename + ".xml", null, false) {
-                    /**
-                     *
-                     */
-                    private static final long serialVersionUID = 1L;
-
                     @Override
                     protected JPanel getModePane() {
                         return null;
                     }
                 };
             } else if (service.isSelected()) {
-                progFrame = new PaneServiceProgFrame(decoderFile, re, title, "programmers" + File.separator + filename + ".xml", modePanel.getProgrammer()) {
-
-                    /**
-                     *
-                     */
-                    private static final long serialVersionUID = 1L;
-                };
+                progFrame = new PaneServiceProgFrame(decoderFile, re, title, "programmers" + File.separator + filename + ".xml", modePanel.getProgrammer()) {};
             } else if (ops.isSelected()) {
                 int address = Integer.parseInt(re.getDccAddress());
                 boolean longAddr = re.isLongAddress();
@@ -1691,11 +1671,6 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
 
     static class ExportRosterItem extends ExportRosterItemAction {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = 1L;
-
         ExportRosterItem(String pName, Component pWho, RosterEntry re) {
             super(pName, pWho);
             setExistingEntry(re);
@@ -1708,12 +1683,6 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
     }
 
     static class CopyRosterItem extends CopyRosterItemAction {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 1L;
-
         CopyRosterItem(String pName, Component pWho, RosterEntry re) {
             super(pName, pWho);
             setExistingEntry(re);
@@ -1724,4 +1693,5 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
             return true;
         }
     }
+    private final static Logger log = LoggerFactory.getLogger(RosterFrame.class.getName());
 }

--- a/java/src/jmri/jmrit/roster/swing/RosterFrameAction.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrameAction.java
@@ -1,4 +1,3 @@
-// RosterFrameAction.java
 package jmri.jmrit.roster.swing;
 
 import java.awt.Dimension;
@@ -19,11 +18,6 @@ import jmri.util.swing.WindowInterface;
  * @author Randall Wood Copyright (C) 2012
  */
 public class RosterFrameAction extends JmriAbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3393320955672226931L;
 
     public RosterFrameAction(String s, WindowInterface wi) {
         super(s, wi);

--- a/java/src/jmri/jmrit/roster/swing/RosterGroupComboBox.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterGroupComboBox.java
@@ -1,4 +1,3 @@
-// RosterGroupComboBox.java
 package jmri.jmrit.roster.swing;
 
 import java.beans.PropertyChangeEvent;
@@ -14,15 +13,10 @@ import jmri.jmrit.roster.rostergroup.RosterGroupSelector;
  * A JComboBox of Roster Groups.
  *
  * @author Randall Wood Copyright (C) 2011, 2014
- * @version	$Revision: $
  * @see jmri.jmrit.roster.Roster
  */
 public class RosterGroupComboBox extends JComboBox<String> implements RosterGroupSelector {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1817542492929278953L;
     private Roster _roster;
     private boolean allEntriesEnabled = true;
 

--- a/java/src/jmri/jmrit/roster/swing/RosterMenu.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterMenu.java
@@ -1,4 +1,3 @@
-// RosterMenu.java
 package jmri.jmrit.roster.swing;
 
 import java.awt.Component;
@@ -22,16 +21,10 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2002, 2008
  * @author Dennis Miller Copyright (C) 2005
- * @version	$Revision$
  * @see jmri.jmrit.roster.RosterEntry
  * @see jmri.jmrit.roster.Roster
  */
 public class RosterMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1386179387265677639L;
 
     /**
      * Ctor argument defining that the menu object will be used as part of the

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -1,4 +1,3 @@
-// BeanTableFrame.java
 package jmri.jmrit.roster.swing;
 
 import apps.gui.GuiLafPreferencesManager;
@@ -40,14 +39,9 @@ import jmri.util.swing.XTableColumnModel;
  *
  * @author	Bob Jacobsen Copyright (C) 2003, 2010
  * @author Randall Wood Copyright (C) 2013
- * @version	$Revision$
  */
 public class RosterTable extends JmriPanel implements RosterEntrySelector, RosterGroupSelector {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4642772877556156627L;
     RosterTableModel dataModel;
     TableRowSorter<RosterTableModel> sorter;
     JTable dataTable;

--- a/java/src/jmri/jmrit/roster/swing/RosterTableModel.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTableModel.java
@@ -1,4 +1,3 @@
-// RosterTableModel.java
 package jmri.jmrit.roster.swing;
 
 import java.beans.PropertyChangeEvent;
@@ -26,15 +25,10 @@ import org.slf4j.LoggerFactory;
  * fields. But it's a start....
  *
  * @author Bob Jacobsen Copyright (C) 2009, 2010
- * @version $Revision$
  * @since 2.7.5
  */
 public class RosterTableModel extends DefaultTableModel implements PropertyChangeListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 994579600898713052L;
     public static final int IDCOL = 0;
     static final int ADDRESSCOL = 1;
     static final int ICONCOL = 2;


### PR DESCRIPTION
Make sure RosterFrame's handling of loco identification ends on the GUI thread. Intended to help with #1111 