### PR TITLE
Fix non-HTML tag in JavaDoc

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -302,7 +302,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
     
     /**
      * toString() converts DCCppMessage to String format
-     * (without the <> brackets)
+     * (without the {@code <>} brackets)
      * 
      * @return String form of message.
      */
@@ -1165,7 +1165,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Stationary Decoder Message
      *
-     * Format: <a ADDRESS SUBADDRESS ACTIVATE>
+     * Format: {@code <a ADDRESS SUBADDRESS ACTIVATE>}
      *
      *    ADDRESS:  the primary address of the decoder (0-511)
      *    SUBADDRESS: the subaddress of the decoder (0-3)
@@ -1205,7 +1205,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Predefined Turnout Control Message
      *
-     * Format: <T ID THROW>
+     * Format: {@code <T ID THROW>}
      *
      *   ID: the numeric ID (0-32767) of the turnout to control
      *   THROW: 0 (unthrown) or 1 (thrown)
@@ -1317,16 +1317,16 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
 
     /** Create/Delete/Query Sensor
      * 
-     * ADD: <S ID PIN PULLUP>
+     * ADD: {@code <S ID PIN PULLUP>}
      *    ID (0-32767)
      *    PIN: Arduino Pin # of sensor
      *    PULLUP: TRUE if use internal pullup for PIN, FALSE if don't.
      *    RETURNS: <O> on success, <X> on failure
      *
-     * DELETE: <S ID>
+     * DELETE: {@code <S ID>}
      *    RETURNS: <O> on success, <X> on failure
      *
-     * LIST: <S>
+     * LIST: {@code <S>}
      *    RETURNS: <Q ID PIN PULLUP> for each defined sensor, or <X> if no sensors defined.
      */
     public static DCCppMessage makeSensorAddMsg(int id, int pin, int pullup) {
@@ -1363,7 +1363,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Write Direct CV Byte to Programming Track
      *
-     * Format: <W CV VALUE CALLBACKNUM CALLBACKSUB>
+     * Format: {@code <W CV VALUE CALLBACKNUM CALLBACKSUB>}
      *
      *   ID: the numeric ID (0-32767) of the turnout to control
      *   THROW: 0 (unthrown) or 1 (thrown)
@@ -1404,7 +1404,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Write Direct CV Bit to Programming Track
      *
-     * Format: <B CV BIT VALUE CALLBACKNUM CALLBACKSUB>
+     * Format: {@code <B CV BIT VALUE CALLBACKNUM CALLBACKSUB>}
      *
      *    writes, and then verifies, a single bit within a Configuration Variable to the decoder of an engine on the programming track
      *    
@@ -1448,7 +1448,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Read Direct CV Byte from Programming Track
      *
-     * Format: <R CV CALLBACKNUM CALLBACKSUB>
+     * Format: {@code <R CV CALLBACKNUM CALLBACKSUB>}
      *
      *    reads a Configuration Variable from the decoder of an engine on the programming track
      *    
@@ -1458,7 +1458,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
      *    
      * Note: The two-argument form embeds the opcode in CALLBACKSUB to aid in decoding the responses.
      *
-     *    returns: <r CALLBACKNUM|CALLBACKSUB|CV VALUE)
+     *    returns: {@code <r CALLBACKNUM|CALLBACKSUB|CV VALUE>}
      *    where VALUE is a number from 0-255 as read from the requested CV, or -1 if read could not be verified
      */    
     public static DCCppMessage makeReadDirectCVMsg(int cv) {
@@ -1488,7 +1488,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Write Direct CV Byte to Main Track
      *
-     * Format: <w CAB CV VALUE>
+     * Format: {@code <w CAB CV VALUE>}
      *
      *    writes, without any verification, a Configuration Variable to the decoder of an engine on the main operations track
      *    
@@ -1518,7 +1518,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Write Direct CV Bit to Main Track
      *
-     * Format: <b CAB CV BIT VALUE>
+     * Format: {@code <b CAB CV BIT VALUE>}
      *
      *    writes, without any verification, a single bit within a Configuration Variable to the decoder of an engine on the main operations track
      *    
@@ -1552,9 +1552,9 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Set Track Power ON or OFFf
      *
-     * Format: <1> (ON) or <0> (OFF)
+     * Format: {@code <1> (ON) or <0> (OFF)}
      *
-     * Returns <p1> (ON) or <p0> (OFF)
+     * Returns {@code <p1> (ON) or <p0> (OFF)}
      */
     public static DCCppMessage makeSetTrackPowerMsg(boolean on) {
 	//String s = new String(Character.toString((on ? DCCppConstants.TRACK_POWER_ON : DCCppConstants.TRACK_POWER_OFF)));
@@ -1575,11 +1575,11 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Read main operations track current
      *
-     * Format: <c>
+     * Format: {@code <c>}
      *
      *    reads current being drawn on main operations track
      *    
-     *    returns: <a CURRENT> 
+     *    returns: {@code <a CURRENT>}
      *    where CURRENT = 0-1024, based on exponentially-smoothed weighting scheme
      */
    public static DCCppMessage makeReadTrackCurrentMsg() {
@@ -1589,7 +1589,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
      /**
      * Read DCC++ Base Station Status
      *
-     * Format: <s>
+     * Format: {@code <s>}
      *
      *    returns status messages containing track power status, throttle status, turn-out status, and a version number
      *    NOTE: this is very useful as a first command for an interface to send to this sketch in order to verify connectivity and update any GUI to reflect actual throttle and turn-out settings
@@ -1629,7 +1629,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
      *              and 1).  A negative value indicates emergency stop.
      * @param isForward true for forward, false for reverse.
      *
-     * Format: <t REGISTER CAB SPEED DIRECTION>
+     * Format: {@code <t REGISTER CAB SPEED DIRECTION>}
      *
      *    sets the throttle for a given register/cab combination 
      *    
@@ -1638,7 +1638,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
      *    SPEED: throttle speed from 0-126, or -1 for emergency stop (resets SPEED to 0)
      *    DIRECTION: 1=forward, 0=reverse.  Setting direction when speed=0 or speed=-1 only effects directionality of cab lighting for a stopped train
      *    
-     *    returns: <T REGISTER SPEED DIRECTION>
+     *    returns: {@code <T REGISTER SPEED DIRECTION>}
      *    
      */
     public static DCCppMessage makeSpeedAndDirectionMsg(int register, int address, float speed, boolean isForward) {
@@ -1666,7 +1666,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
     /** 
      * Function Group Messages (common serial format)
      * 
-     * Format: <f CAB BYTE1 [BYTE2]>
+     * Format: {@code <f CAB BYTE1 [BYTE2]>}
      *
      *    turns on and off engine decoder functions F0-F28 (F0 is sometimes called FL)  
      *    NOTE: setting requests transmitted directly to mobile engine decoder --- current state of engine functions is not stored by this program


### PR DESCRIPTION
Added @code around BNF in JavaDoc for jmri.jmrix.dccpp.DCCppMessage to fix strange HTML artifacts in JavaDoc index, noticed by @KenC57 