### PR TITLE
Javadoc update

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1291,7 +1291,7 @@
             <packageset dir="${tmptarget}" defaultexcludes="yes">
                 <include name="jmri/**"/>
             </packageset>
-            <arg value="-Xdoclint:all,-missing,-accessibility,-html,-syntax"/> <!-- dropping some 1.8 warnings -->
+            <arg value="-Xdoclint:all,-missing,-accessibility,-html"/> <!-- dropping some 1.8 warnings -->
 
             <group title="Core" packages="jmri"/>
             <group title="Cross-system Tools" packages="jmri.jmrit:jmri.jmrit.*"/>
@@ -1354,7 +1354,7 @@
             <packageset dir="${tmptarget}" defaultexcludes="yes">
                 <include name="jmri/**"/>
             </packageset>
-            <arg value="-Xdoclint:all,-missing,-accessibility,-html,-syntax"/> <!-- dropping some 1.8 warnings -->
+            <arg value="-Xdoclint:all,-missing,-accessibility,-html"/> <!-- dropping some 1.8 warnings -->
             <doclet name="org.umlgraph.doclet.UmlGraphDoc"
                                   path="${libdir}/UmlGraph-5.7.jar">
                 <param name="-attributes"/>

--- a/help/en/html/doc/Technical/JavaDoc.shtml
+++ b/help/en/html/doc/Technical/JavaDoc.shtml
@@ -68,11 +68,15 @@ in documentation is available on the
 <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/javadoc/deprecation/deprecation.html">"How and When To Deprecate APIs" page</a>.
 
 <p>
-The JavaDoc content is interpreted as HTML 4.01, so it should be valid HTML 4.01.  For example
+The JavaDoc content is interpreted as HTML 4.01, so it should be valid HTML 4.01. If it's not,
+it probably won't display properly when somebody wants to understand your code, so it's in 
+your interest to get the JavaDoc comments right.
+For example, you have to properly handle &amp; and &lt; characters.
+You also have to (sometimes) end your paragraph tags:
 <code><pre>
  * Some text that forms a paragraph
  * &lt;p&gt;
- * Some more text. Note backslash on next line.
+ * Some more text. Note backslash on next line to end paragraph tag.
  * &lt;p/&gt;
  * Last text, start list
  * &lt;ul&gt;
@@ -87,14 +91,19 @@ Some error messages and their translations:
 <li>"bad use of '&gt;'": Probably using '&gt;' as a character, e.g. A -&gt; B. If so, replace with &gt; or wrap the line with @literal
 </ul>
 
-Finally, not that this JavaDoc line is malformed:
+Finally, note that this JavaDoc line is malformed:
 <code><pre>
  * @param foo
 </pre></code>
-because it doesn't include any explanatory text. That line needs to be more like:
+because it doesn't include any explanatory text. The line should be more like:
 <code><pre>
  * @param foo Holds the latest Bar instance
 </pre></code>
+
+We are currently suppressing the "accessibility" class of JavaDoc errors, which is 
+mostly about providing extra information on tables and images, and the "missing" class of 
+errors, which tags it if an @param or @return isn't provided in any places that could have 
+received comments.  There are so many of these that it's not practical to tag them.
 
 <h2>UML and UmlGraph for Developers</h2>
 

--- a/help/en/html/doc/Technical/JavaDoc.shtml
+++ b/help/en/html/doc/Technical/JavaDoc.shtml
@@ -67,6 +67,35 @@ A nice discussion of how to use the "deprecated" label
 in documentation is available on the
 <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/javadoc/deprecation/deprecation.html">"How and When To Deprecate APIs" page</a>.
 
+<p>
+The JavaDoc content is interpreted as HTML 4.01, so it should be valid HTML 4.01.  For example
+<code><pre>
+ * Some text that forms a paragraph
+ * &lt;p&gt;
+ * Some more text. Note backslash on next line.
+ * &lt;p/&gt;
+ * Last text, start list
+ * &lt;ul&gt;
+ *    &lt;li&gt;List item
+ * &lt;/ul&gt;
+</pre></code>
+Note that HTML 4.01 wants paragraph tags to be ended with &lt;/p&gt; or &lt;/p&gt;, and that you can't have a list inside a paragraph.
+<p>
+Some error messages and their translations:
+<ul>
+<li>"malformed HTML; bad HTML entity": Probably use of &amp;, &lt; or &gt; characters on the indicated line
+<li>"bad use of '&gt;'": Probably using '&gt;' as a character, e.g. A -&gt; B. If so, replace with &gt; or wrap the line with @literal
+</ul>
+
+Finally, not that this JavaDoc line is malformed:
+<code><pre>
+ * @param foo
+</pre></code>
+because it doesn't include any explanatory text. That line needs to be more like:
+<code><pre>
+ * @param foo Holds the latest Bar instance
+</pre></code>
+
 <h2>UML and UmlGraph for Developers</h2>
 
 UML is a broad and deep language for describing the 

--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -1,4 +1,3 @@
-// DCCppMessage.java
 package jmri.jmrix.dccpp;
 
 import java.util.regex.Matcher;
@@ -17,7 +16,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2002
  * @author	Paul Bender Copyright (C) 2003-2010
  * @author	Mark Underwood Copyright (C) 2015
- * @version	$Revision$
  *
  * Based on XNetMessage by Bob Jacobsen and Paul Bender
  */
@@ -2135,5 +2133,3 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
     private final static Logger log = LoggerFactory.getLogger(DCCppMessage.class.getName());
 
 }
-
-/* @(#)DCCppMessage.java */

--- a/java/src/jmri/jmrix/roco/z21/RocoZ21CommandStation.java
+++ b/java/src/jmri/jmrix/roco/z21/RocoZ21CommandStation.java
@@ -1,6 +1,3 @@
-/*
- * RocoZ21CommandStation.java
- */
 package jmri.jmrix.roco.z21;
 
 import org.slf4j.Logger;
@@ -337,6 +334,3 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
     private final static Logger log = LoggerFactory.getLogger(RocoZ21CommandStation.class.getName());
 
 }
-
-
-/* @(#)RocoCommandStation.java */

--- a/java/src/jmri/jmrix/roco/z21/RocoZ21CommandStation.java
+++ b/java/src/jmri/jmrix/roco/z21/RocoZ21CommandStation.java
@@ -54,7 +54,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
 
    /**
     * get the serial number.
-    * @return int serial number of the connected Z21 command station
+    * @return serial number of the connected Z21 command station
     */
    public int getSerialNumber(){
       return serial_number;
@@ -62,7 +62,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
 
    /**
     * set the serial number associated with this Z21 command station.
-    * @param int sn serial number
+    * @param sn serial number
     */
    public void setSerialNumber(int sn){
       serial_number = sn;
@@ -70,7 +70,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
  
   /**
     * get the software version.
-    * @return int software version of the connected Z21 command station
+    * @return software version of the connected Z21 command station
     */
    public float getSoftwareVersion(){
       return software_version;
@@ -78,7 +78,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
 
    /**
     * set the software version associated with this Z21 command station.
-    * @param int sv software version
+    * @param sv software version
     */
    public void setSoftwareVersion(float sv){
       software_version=sv;
@@ -86,7 +86,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
 
   /**
     * get the hardware version.
-    * @return int hardware version of the connected Z21 command station
+    * @return hardware version of the connected Z21 command station
     */
    public int getHardwareVersion(){
       return hardware_version;
@@ -94,7 +94,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
 
    /**
     * set the hardware version associated with this Z21 command station.
-    * @param int hv software version
+    * @param hv software version
     */
    public void setHardwareVersion(int hv){
       hardware_version=hv;
@@ -102,7 +102,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
 
    /**
     * get the current value of the broadcast flags as an int
-    * @return int value representing the broadcast flags. 
+    * @return value representing the broadcast flags. 
     */
    public int getZ21BroadcastFlags(){
         return broadcast_flags;
@@ -110,7 +110,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
 
    /**
     * set the current value of the broadcast flags as an int
-    * @param int value representing the broadcast flags. 
+    * @param flags representing the broadcast flags. 
     */
    public void setZ21BroadcastFlags(int flags){
         broadcast_flags = flags;
@@ -121,7 +121,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
     * XPressNet related information (track power on/off, programming 
     * mode, short circuit, broadcast stop, locomotive information, 
     * turnout information) set?
-    * @return boolean true if flag is set.
+    * @return true if flag is set.
     */
     public boolean getXPressNetMessagesFlag(){
         return((broadcast_flags & 0x00000001) == 0x00000001);
@@ -132,7 +132,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
     * XPressNet related information (track power on/off, programming 
     * mode, short circuit, broadcast stop, locomotive information, 
     * turnout information).
-    * @param boolean flag true if flag is to be set.
+    * @param flag true if flag is to be set.
     */
     public void setXPressNetMessagesFlag(boolean flag){
         if(flag) {
@@ -148,7 +148,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Is flag bit 0x00000002 which tells the command station to send 
     * data changes on the RMBus to the client set?
-    * @return boolean true if flag is set.
+    * @return true if flag is set.
     */
     public boolean getRMBusMessagesFlag(){
         return((broadcast_flags & 0x00000002) == 0x00000002);
@@ -157,7 +157,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Set flag bit 0x00000002 which tells the command station to send 
     * data changes on the RMBus to the client set?
-    * @param boolean flag true if flag is to be set.
+    * @param flag true if flag is to be set.
     */
     public void setRMBusMessagesFlag(boolean flag){
         if(flag) {
@@ -172,7 +172,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
     * Is flag bit 0x00000004, which tells the command station to 
     * send Railcom data to the client set (this flag may no longer
     * be supported by Roco). 
-    * @return boolean true if flag is set.
+    * @return true if flag is set.
     */
     public boolean getRailComMessagesFlag(){
         return((broadcast_flags & 0x00000004) == 0x00000004);
@@ -182,7 +182,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
     * Set flag bit 0x00000004, which tells the command station to 
     * send Railcom data to the client set (this flag may no longer
     * be supported by Roco). 
-    * @param boolean flag true if flag is to be set.
+    * @param flag true if flag is to be set.
     */
     public void setRailComMessagesFlag(boolean flag){
         if(flag) {
@@ -196,7 +196,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Is flag bit 0x00000100 which tells the command station to send 
     * changes in system state (such as track voltage) set?
-    * @return boolean true if flag is set.
+    * @return true if flag is set.
     */
     public boolean getSystemStatusMessagesFlag(){
         return((broadcast_flags & 0x00000100) == 0x00000100);
@@ -205,7 +205,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Set flag bit 0x00000100 which tells the command station to send 
     * changes in system state (such as track voltage).
-    * @param boolean flag true if flag is to be set.
+    * @param flag true if flag is to be set.
     */
     public void setSystemStatusMessagesFlag(boolean flag){
         if(flag) {
@@ -219,7 +219,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Is flag bit 0x00010000 which tells the command station to send 
     * XPressNet related locomoitve information to the client set?
-    * @return boolean true if flag is set.
+    * @return true if flag is set.
     */
     public boolean getXPressNetLocomotiveMessagesFlag(){
         return((broadcast_flags & 0x00010000) == 0x00010000);
@@ -228,7 +228,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Set flag bit 0x00010000 which tells the command station to send 
     * XPressNet related locomoitve information to the client.
-    * @param boolean flag true if flag is to be set.
+    * @param flag true if flag is to be set.
     */
     public void setXPressNetLocomotiveMessagesFlag(boolean flag){
         if(flag) {
@@ -242,7 +242,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Is flag bit 0x01000000 which tells the command station to send 
     * LocoNet data,except Locomotive and Turnout data, to the client set?
-    * @return boolean true if flag is set.
+    * @return true if flag is set.
     */
     public boolean getLocoNetMessagesFlag(){
         return((broadcast_flags & 0x01000000) == 0x01000000);
@@ -251,7 +251,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * set flag bit 0x01000000 which tells the command station to send 
     * LocoNet data,except Locomotive and Turnout data, to the client.
-    * @param boolean flag true if flag is to be set.
+    * @param flag true if flag is to be set.
     */
     public void setLocoNetMessagesFlag(boolean flag){
         if(flag) {
@@ -265,7 +265,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Is flag bit 0x02000000 which tells the command station to send 
     * Locomotive specific LocoNet data to the client set?
-    * @return boolean true if flag is set.
+    * @return true if flag is set.
     */
     public boolean getLocoNetLocomotiveMessagesFlag(){
         return((broadcast_flags & 0x02000000) == 0x02000000);
@@ -274,7 +274,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Set flag bit 0x02000000 which tells the command station to send 
     * Locomotive specific LocoNet data to the client.
-    * @param boolean flag true if flag is to be set.
+    * @param flag true if flag is to be set.
     */
     public void setLocoNetLocomotiveMessagesFlag(boolean flag){
         if(flag) {
@@ -288,7 +288,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Is flag bit 0x04000000 which tells the command station to send 
     * Turnout specific LocoNet data to the client set?
-    * @return boolean true if flag is set.
+    * @return true if flag is set.
     */
     public boolean getLocoNetTurnoutMessagesFlag(){
         return((broadcast_flags & 0x04000000) == 0x04000000);
@@ -297,7 +297,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Set flag bit 0x04000000 which tells the command station to send 
     * Turnout specific LocoNet data to the client set?
-    * @param boolean flag true if flag is to be set.
+    * @param flag true if flag is to be set.
     */
     public void setLocoNetTurnoutMessagesFlag(boolean flag){
         if(flag) {
@@ -311,7 +311,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Is flag bit 0x08000000 which tells the command station to send 
     * Occupancy information from LocoNet to the client set?
-    * @return boolean true if flag is set.
+    * @return true if flag is set.
     */
     public boolean getLocoNetOccupancyMessagesFlag(){
         return((broadcast_flags & 0x08000000) == 0x08000000);
@@ -320,7 +320,7 @@ public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation im
    /**
     * Set flag bit 0x08000000 which tells the command station to send 
     * Occupancy information from LocoNet to the client
-    * @param boolean flag true if flag is to be set.
+    * @param flag true if flag is to be set.
     */
     public void setLocoNetOccupancyMessagesFlag(boolean flag){
         if(flag) {

--- a/java/src/jmri/server/json/throttle/JsonThrottle.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottle.java
@@ -86,11 +86,11 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
      * Creates a new JsonThrottle or returns an existing one if the request is
      * for an existing throttle.
      *
-     * data can contain either a string {@link JSON#ID} node containing the ID
+     * data can contain either a string {@link jmri.jmris.json.JSON#ID} node containing the ID
      * of a {@link jmri.jmrit.roster.RosterEntry} or an integer
-     * {@link JSON#ADDRESS} node. If data contains an ADDRESS, the ID node is
+     * {@link jmri.jmris.json.JSON#ADDRESS} node. If data contains an ADDRESS, the ID node is
      * ignored. The ADDRESS may be accompanied by a boolean
-     * {@link JSON#IS_LONG_ADDRESS} node specifying the type of address, if
+     * {@link jmri.jmris.json.JSON#IS_LONG_ADDRESS} node specifying the type of address, if
      * IS_LONG_ADDRESS is not specified, the inverse of {@link jmri.ThrottleManager#canBeShortAddress(int)
      * } is used as the "best guess" of the address length.
      *

--- a/java/src/jmri/spi/PreferencesManager.java
+++ b/java/src/jmri/spi/PreferencesManager.java
@@ -15,7 +15,7 @@ import jmri.util.prefs.InitializationException;
  * {@link #initialize(jmri.profile.Profile)} is called as the PreferencesManager
  * may be constructed before the {@link jmri.profile.Profile} is known.
  *
- * @see jmri.util.prefs.AbstractPreferencesMananger for an abstract
+ * @see jmri.util.prefs.AbstractPreferencesManager for an abstract
  * implementation that is ready to extend.
  * @author Randall Wood 2015
  */


### PR DESCRIPTION
(See #1330 for background)

- improve [Documentation with JavaDoc and UML](http://jmri.org/help/en/html/doc/Technical/JavaDoc.shtml) page
- Fix existing JavaDoc errors and warnings (now clean)