### PR TITLE
JavaDoc improvements

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1359,7 +1359,7 @@
             <packageset dir="${tmptarget}" defaultexcludes="yes">
                 <include name="jmri/**"/>
             </packageset>
-            <arg value="-Xdoclint:all,-missing,-accessibility,-html"/> <!-- dropping some 1.8 warnings -->
+            <arg value="-Xdoclint:all,-missing,-accessibility"/> <!-- dropping some 1.8 warnings -->
             <arg value="-Xmaxwarns"/>
             <arg value="500"/><!-- change from default 100 warnings -->
             <arg value="-Xmaxerrs"/>
@@ -1428,7 +1428,14 @@
             <packageset dir="${tmptarget}" defaultexcludes="yes">
                 <include name="jmri/**"/>
             </packageset>
-            <arg value="-Xdoclint:all,-missing,-accessibility,-html"/> <!-- dropping some 1.8 warnings -->
+            <arg value="-Xdoclint:all,-missing,-accessibility"/> <!-- dropping some 1.8 warnings -->
+            <arg value="-Xmaxwarns"/>
+            <arg value="500"/><!-- change from default 100 warnings -->
+            <arg value="-Xmaxerrs"/>
+            <arg value="500"/><!-- change from default 100 errors -->
+            <!-- disable output of custom @navassoc tag - used for UML image generation -->
+            <tag name="navassoc" enabled="false"/>
+
             <doclet name="org.umlgraph.doclet.UmlGraphDoc"
                                   path="${libdir}/UmlGraph-5.7.jar">
                 <param name="-attributes"/>

--- a/help/en/html/doc/Technical/JavaDoc.shtml
+++ b/help/en/html/doc/Technical/JavaDoc.shtml
@@ -71,19 +71,22 @@ in documentation is available on the
 The JavaDoc content is interpreted as HTML 4.01, so it should be valid HTML 4.01. If it's not,
 it probably won't display properly when somebody wants to understand your code, so it's in 
 your interest to get the JavaDoc comments right.
-For example, you have to properly handle &amp; and &lt; characters.
-You also have to (sometimes) end your paragraph tags:
+<p>
+For example, you have to properly handle &amp; and &lt; character, e.g. to show a generic type.
+To do that, place the test in {@literal ...} or {@code ...} blocks.
+<p>
+You also have to (sometimes) end your paragraph tags to start another type of element, e.g. lists: 
 <code><pre>
  * Some text that forms a paragraph
  * &lt;p&gt;
- * Some more text. Note backslash on next line to end paragraph tag.
- * &lt;p/&gt;
- * Last text, start list
- * &lt;ul&gt;
+ * Some more text. 
+ * &lt;p&gt;
+ * Last text, start list. Note end-paragraph tag.
+ * &lt;/p&gt;&lt;ul&gt;
  *    &lt;li&gt;List item
  * &lt;/ul&gt;
 </pre></code>
-Note that HTML 4.01 wants paragraph tags to be ended with &lt;/p&gt; or &lt;/p&gt;, and that you can't have a list inside a paragraph.
+Note that HTML 4.01 wants paragraph tags to be ended with &lt;/p&gt;, and that you can't have a list inside a paragraph.
 <p>
 Some error messages and their translations:
 <dl>
@@ -99,7 +102,9 @@ because it doesn't include any explanatory text. The line should be more like:
 <code><pre>
  * @param foo Holds the latest Bar instance
 </pre></code>
+or just omitted.
 
+<p>
 We are currently suppressing the "accessibility" class of JavaDoc errors, which is 
 mostly about providing extra information on tables and images, and the "missing" class of 
 errors, which tags it if an @param or @return isn't provided in any places that could have 

--- a/java/src/apps/JmriFaceless.java
+++ b/java/src/apps/JmriFaceless.java
@@ -9,19 +9,18 @@ package apps;
  * all ui-related elements NOTE: JMRI "server" functions based on ui components
  * (such as JmriJFrames) may need to be modified to check isHeadless() and
  * adjust their behavior as needed.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
+ * </P>
  * @author	Steve Todd Copyright 2012
  */
 public class JmriFaceless extends apps.AppsBase {

--- a/java/src/apps/gui3/dp3/DecoderPro3.java
+++ b/java/src/apps/gui3/dp3/DecoderPro3.java
@@ -1,4 +1,3 @@
-// Paned.java
 package apps.gui3.dp3;
 
 import java.io.File;
@@ -11,20 +10,20 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The JMRI application for developing the DecoderPro 3 GUI
- * <P>
- *
- * <hr> This file is part of JMRI.
+ * <BR>
+ * <hr>
+ * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * </P>
  *
  * @author	Bob Jacobsen Copyright 2003, 2004, 2007, 2009, 2010
- * @version $Revision$
  */
 public class DecoderPro3 extends apps.gui3.Apps3 {
 

--- a/java/src/apps/gui3/mdi/MDI.java
+++ b/java/src/apps/gui3/mdi/MDI.java
@@ -1,4 +1,3 @@
-// MDI.java
 package apps.gui3.mdi;
 
 import java.util.ResourceBundle;
@@ -7,21 +6,19 @@ import jmri.util.swing.mdi.MdiMainFrame;
 
 /**
  * The JMRI application for developing the 3rd GUI
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
+ * </P>
  * @author	Bob Jacobsen Copyright 2003, 2004, 2007, 2009, 2010
- * @version $Revision$
  */
 public class MDI extends apps.gui3.Apps3 {
 

--- a/java/src/apps/gui3/paned/Paned.java
+++ b/java/src/apps/gui3/paned/Paned.java
@@ -1,4 +1,3 @@
-// Paned.java
 package apps.gui3.paned;
 
 import java.util.ResourceBundle;
@@ -7,21 +6,20 @@ import jmri.util.swing.multipane.MultiPaneWindow;
 
 /**
  * The JMRI application for developing the 3rd GUI
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * </P>
  *
  * @author	Bob Jacobsen Copyright 2003, 2004, 2007, 2009, 2010
- * @version $Revision$
  */
 public class Paned extends apps.gui3.Apps3 {
 

--- a/java/src/jmri/Audio.java
+++ b/java/src/jmri/Audio.java
@@ -15,19 +15,18 @@ package jmri;
  * can be used for any purpose. The "system" name is provided by the
  * system-specific implementations, and provides a unique mapping to the layout
  * control system (e.g. LocoNet, NCE, etc) and address within that system.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author Matthew Harris copyright (c) 2009
  */

--- a/java/src/jmri/CatalogTree.java
+++ b/java/src/jmri/CatalogTree.java
@@ -16,19 +16,18 @@ import jmri.jmrit.catalog.CatalogTreeNode;
  * Each CatalogTree object has a two names. The "user" name is entirely free
  * form, and can be used for any purpose. The "system" name is provided by the
  * purpose-specific implementations.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author	Pete Cressman Copyright (C) 2009
  *

--- a/java/src/jmri/FastClock.java
+++ b/java/src/jmri/FastClock.java
@@ -2,19 +2,18 @@ package jmri;
 
 /**
  * Provide access to fast clock capabilities in hardware or software.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  * @author	Bob Jacobsen Copyright (C) 2001
  */
 public interface FastClock {

--- a/java/src/jmri/Memory.java
+++ b/java/src/jmri/Memory.java
@@ -15,19 +15,18 @@ package jmri;
  * and can be used for any purpose. The "system" name is provided by the
  * system-specific implementations, and provides a unique mapping to the layout
  * control system (e.g. LocoNet, NCE, etc) and address within that system.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author	Bob Jacobsen Copyright (C) 2001
  * @see jmri.implementation.AbstractMemory

--- a/java/src/jmri/Metadata.java
+++ b/java/src/jmri/Metadata.java
@@ -10,17 +10,18 @@ import java.util.List;
  * provides a single container for listing and storing JMRI meta data. This
  * class is used by the DefaultXmlIOServer object.
  *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author	Randall Wood Copyright (C) 2011
  */

--- a/java/src/jmri/Metadata.java
+++ b/java/src/jmri/Metadata.java
@@ -10,7 +10,6 @@ import java.util.List;
  * provides a single container for listing and storing JMRI meta data. This
  * class is used by the DefaultXmlIOServer object.
  *
- * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
@@ -78,9 +77,7 @@ public class Metadata {
     }
 
     /**
-     * A list of known meta data names.
-     *
-     * @return List<String>
+     * Get the list of known meta-data names.
      */
     public static List<String> getSystemNameList() {
         return Arrays.asList(Metadata.getSystemNameArray());

--- a/java/src/jmri/Reporter.java
+++ b/java/src/jmri/Reporter.java
@@ -22,19 +22,18 @@ package jmri;
  * A Reporter might also not be able to report all the time. The previous value
  * remains available, but it's also possible to distinquish this case by using
  * the getCurrentReport member function.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author	Bob Jacobsen Copyright (C) 2001
  * @author Matthew Harris Copyright (C) 2011

--- a/java/src/jmri/SectionManager.java
+++ b/java/src/jmri/SectionManager.java
@@ -18,19 +18,18 @@ import org.slf4j.LoggerFactory;
  * string, usually, but not always, a number. All alphabetic characters in a
  * Section system name must be upper case. This is enforced when a Section is
  * created.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  * @author Dave Duchamp Copyright (C) 2008
  */
 public class SectionManager extends AbstractManager

--- a/java/src/jmri/TransitManager.java
+++ b/java/src/jmri/TransitManager.java
@@ -15,18 +15,18 @@ import jmri.managers.AbstractManager;
  * string, usually, but not always, a number. All alphabetic characters in a
  * Transit system name must be upper case. This is enforced when a Transit is
  * created.
- * <P>
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  * @author Dave Duchamp Copyright (C) 2008, 2011
  */
 public class TransitManager extends AbstractManager

--- a/java/src/jmri/implementation/AbstractVariableLight.java
+++ b/java/src/jmri/implementation/AbstractVariableLight.java
@@ -1,4 +1,3 @@
-// AbstractVariableLight.java
 package jmri.implementation;
 
 import java.util.Date;
@@ -18,14 +17,14 @@ import org.slf4j.LoggerFactory;
  * The structure is in part dictated by the limitations of the X10 protocol and
  * implementations. However, it is not limited to X10 devices only. Other
  * interfaces that have a way to provide a dimmable light should use it.
- *
+ * <p>
  * X10 has on/off commands, and separate commands for setting a variable
  * intensity via "dim" commands. Some X10 implementations use relative dimming,
  * some use absolute dimming. Some people set the dim level of their Lights and
  * then just use on/off to turn control the lamps; in that case we don't want to
  * send dim commands. Further, X10 communications is very slow, and sending a
- * complete set of dim operations can take a long time. So the algorithm is:
- * <ol>
+ * complete set of dim operations can take a long time. So the algorithm is: </p>
+ * <ul>
  * <li>Until the intensity has been explicitly set different from 1.0 or 0.0, no
  * intensity commands are to be sent over the power line.
  * </ul>
@@ -36,7 +35,6 @@ import org.slf4j.LoggerFactory;
  * @author	Dave Duchamp Copyright (C) 2004
  * @author	Ken Cameron Copyright (C) 2008,2009
  * @author	Bob Jacobsen Copyright (C) 2008,2009
- * @version $Revision$
  */
 public abstract class AbstractVariableLight extends AbstractLight
         implements java.io.Serializable {
@@ -408,5 +406,3 @@ public abstract class AbstractVariableLight extends AbstractLight
     }
 
 }
-
-/* @(#)AbstractVariableLight.java */

--- a/java/src/jmri/jmrit/MemoryContents.java
+++ b/java/src/jmri/jmrit/MemoryContents.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Support for some .hex files emitted by some tool-sets requires support for
  * the Extended Segment Address record type (record type "02"), which may be
- * used in I16HEX format files. This version of the <code>readHex</code> method
+ * used in I16HEX format files. This version of the {@link #readHex} method
  * supports the Extended Segment Address record type ONLY when the segment
  * specified in the data field is 0x0000.
  * <p>
@@ -65,11 +65,11 @@ import org.slf4j.LoggerFactory;
  * <p>
  * The class does not have to know anything about filenames or filename
  * extensions. Instead, to read a file, an instantiating method will create a
- * <code>File</code> object and pass that object to <code>readHex</code>.
+ * {@link File} object and pass that object to {@link #readHex}.
  * Similarly, when writing the contents of data storage to a file, the
- * instantiating method will create a <code>File</code> and an associated
- * <code>Writer</code> and pass the <code>Writer</code> object to
- * <code>writeHex</code>. The mechanisms implemented within this class do not
+ * instantiating method will create a {@link File} and an associated
+ * {@link Writer} and pass the {@link Writer} object to
+ * {@link writeHex}. The mechanisms implemented within this class do not
  * know about or care about the filename or its extension and do not use that
  * information as part of its file interpretation or file creation.
  * <p>
@@ -77,6 +77,62 @@ import org.slf4j.LoggerFactory;
  * to 256 pages of up to 65536 bytes per page. A "sparse" implementation of
  * memory is modeled, where only occupied pages are allocated within the JAVA
  * system's memory.
+ * <hr>
+ * The Intel "Hexadecimal Object File Format File Format Specification"
+ * uses the following terms for the fields of the record:
+ * <dl>
+ * <dt>RECORD MARK</dt><dd>first character of a record.  ':'</dd>
+ * 
+ * <dt>RECLEN</dt><dd>a two-character specifier of the number of bytes of information 
+ *          in the "INFO or DATA" field.  Immediately follows the RECORD 
+ *          MARK charcter. Since each byte within the "INFO or DATA" field is 
+ *          represented by two ASCII characters, the data field contains twice
+ *          the RECLEN value number of ASCII characters.</dd>
+ * 
+ * <dt>LOAD OFFSET</dt><dd>specifies the 16-bit starting load offset of the data bytes.
+ *          This applies only to "Data" records, so this class requires that
+ *          this field must encode 0x0000 for all other record types.  The LOAD
+ *          OFFSET field immediately follows the RECLEN field.
+ * <p>
+ *          Note that for the 24-bit addressing format used with ".DMF" 
+ *          files, this field is a 24-bit starting load offset, represented by
+ *          six ASCII characters, rather than the four ASCII characters 
+ *          specified in the Intel specification.</dd>
+ * 
+ * <dt>RECTYP</dt><dd>RECord TYPe - indicates the record type for this record.  The 
+ *          RECTYPE field immediately follows the LOAD OFFSET field.</dd>
+ * 
+ * <dt>INFO or DATA</dt><dd>(Optional) field containing information or data which is 
+ *          appropriate to the RECTYP.  Immediately follows the RECTYP field.
+ *          contains RECLEN times 2 characters, where consecutive pairs of
+ *          characters represent one byte of info or data.</dd>
+ * 
+ * <dt>CHKSUM</dt><dd>8-bit Checksum, computed using the hexadecimal byte values represented 
+ *          by the character pairs in RECLEN, LOAD OFFSET, RECTYP, and INFO 
+ *          or DATA fields, such that the computed sum, when added to the 
+ *          CKSUM value, sums to an 8-bit value of 0x00.</dd>
+ * </dl>
+ * This information based on the Intel document "Hexadecimal Object File Format
+ * Specification", Revision A, January 6, 1988.
+ * <p>
+ * Mnemonically, a properly formatted record would appear as:
+ * </p><pre>
+ *     :lloooott{dd}cc
+ * where:
+ *      ':'     is the RECORD MARK
+ *      "ll"    is the RECLEN
+ *      "oooo"  is the 16-bit LOAD OFFSET
+ *      "tt"    is the RECTYP
+ *      "{dd}"  is the INFO or DATA field, containing zero or more pairs of 
+ *                  characters of Info or Data associated with the record
+ *      "cc"    is the CHKSUM
+ * </pre><p>
+ * and a few examples of complaint record would be:
+ * </p><ul>
+ *     <li>:02041000FADE07
+ *     <li>:020000024010AC
+ *     <li>:00000001FF
+ * </ul>
  *
  * @author	Bob Jacobsen Copyright (C) 2005, 2008
  * @author B. Milhaupt Copyright (C) 2014
@@ -87,8 +143,7 @@ public class MemoryContents {
 
     /* For convenience, a page of local storage of data is sized to equal one 
      * "segment" within an input file.  As such, the terms "page" and "segment" 
-     * are used interchangeably throughout the <code>MemotyContents</code> class 
-     * code.
+     * are used interchangeably throughout here.
      * 
      * The number of pages is chosen to match the 24-bit address space.
      */
@@ -119,7 +174,7 @@ public class MemoryContents {
      *
      * Implemented as a two-dimensional array where the first dimension
      * represents the "page" number, and the second dimension represents the
-     * byte within the page of <code>PAGESIZE</code> bytes.
+     * byte within the page of {@link #PAGESIZE} bytes.
      */
     private final int[][] pageArray;
     private int currentPage;
@@ -138,67 +193,16 @@ public class MemoryContents {
      * Defines the LOAD OFFSET field type used/expected for records in "I8HEX"
      * and ".DMF" file formats.
      * <p>
-     * When reading a file using the <code>readHex</code> method, the value is
+     * When reading a file using the {@link #readHex} method, the value is
      * inferred from the first record and then used to validate the remaining
      * records in the file.
      * <p>
-     * This value must be properly set before invoking the <code>writeHex</code>
+     * This value must be properly set before invoking the {@link #writeHex}
      * method.
      */
     private LoadOffsetFieldType loadOffsetFieldType = LoadOffsetFieldType.UNDEFINED;
 
-    /*
-     * The Intel "Hexadecimal Object File Format File Format Specification"
-     * uses the following terms for the fields of the record:
-     * 
-     * RECORD MARK - first character of a record.  ':'
-     * 
-     * RECLEN - a two-character specifier of the number of bytes of information 
-     *          in the "INFO or DATA" field.  Immediately follows the RECORD 
-     *          MARK charcter. Since each byte within the "INFO or DATA" field is 
-     *          represented by two ASCII characters, the data field contains twice
-     *          the RECLEN value number of ASCII characters.
-     * 
-     * LOAD OFFSET - specifies the 16-bit starting load offset of the data bytes.
-     *          This applies only to "Data" records, so this class requires that
-     *          this field must encode 0x0000 for all other record types.  The LOAD
-     *          OFFSET field immediately follows the RECLEN field.
-     * 
-     *          Note that for the 24-bit addressing format used with ".DMF" 
-     *          files, this field is a 24-bit starting load offset, represented by
-     *          six ASCII characters, rather than the four ASCII characters 
-     *          specified in the Intel specification.
-     * 
-     * RECTYP - RECord TYPe - indicates the record type for this record.  The 
-     *          RECTYPE field immediately follows the LOAD OFFSET field.
-     * 
-     * INFO or DATA - (Optional) field containing information or data which is 
-     *          appropriate to the RECTYP.  Immediately follows the RECTYP field.
-     *          contains RECLEN times 2 characters, where consecutive pairs of
-     *          characters represent one byte of info or data.
-     * 
-     * CHKSUM - 8-bit Checksum, computed using the hexadecimal byte values represented 
-     *          by the character pairs in RECLEN, LOAD OFFSET, RECTYP, and INFO 
-     *          or DATA fields, such that the computed sum, when added to the 
-     *          CKSUM value, sums to an 8-bit value of 0x00.
-     * 
-     * This information based on the Intel document "Hexadecimal Object File Format
-     * Specification", Revisoin A, January 6, 1988.
-     * 
-     * Mnemonically, a properly formatted record would appear as:
-     *     :lloooott{dd}cc
-     * where:
-     *      ':'     is the RECORD MARK
-     *      "ll"    is the RECLEN
-     *      "oooo"  is the 16-bit LOAD OFFSET
-     *      "tt"    is the RECTYP
-     *      "{dd}"  is the INFO or DATA field, containing zero or more pairs of 
-     *                  characters of Info or Data associated with the record
-     *      "cc"    is the CHKSUM
-     * and a few examples of complaint recorsd would be:
-     *      :02041000FADE07
-     *      :020000024010AC
-     *      :00000001FF
+    /**
      */
     public MemoryContents() {
         pageArray = new int[PAGES][];
@@ -243,7 +247,7 @@ public class MemoryContents {
      * comments for use by the invoking method.
      * <p>
      * Integrity checks include:
-     * <ul>
+     * </p><ul>
      * <li>Identification of LOAD OFFSET field type from first record
      * <li>Verification that all subsequent records use the same LOAD OFFSET
      * field type
@@ -255,8 +259,8 @@ public class MemoryContents {
      * <li>Identification of a file without any data record
      * <li>Identification of any records which have extra characters after the
      * checksum
-     * <ul>
-     * When reading the file, <code>readHex</code> infers the addressing format
+     * </ul><p>
+     * When reading the file, {@link #readHex} infers the addressing format
      * from the first record found in the file, and future records are
      * interpreted using that addressing format. It is not necessary to
      * pre-configure the addressing format before reading the file. This is a
@@ -271,13 +275,12 @@ public class MemoryContents {
      * information. Such Key/Value pair information is used within the .DMF
      * format to provide configuration information for firmware update
      * mechanism. This class also extracts key/value pair comments "I8HEX"
-     * format files. After successful completion of this <code>readHex</code>,
-     * the the <code>getValue(String
-     * keyName)</code> method may be used to inspect individual key values.
+     * format files. After successful completion of this {@link readHex},
+     * then the {@link #extractValueOfKey(String keyName)} method may be used to inspect individual key values.
      * <p>
      * Key/Value pair definition comment lines are of the format:
      * <p>
-     * <code>! KeyName: Value</code>
+     * {@code ! KeyName: Value}
      *
      * @param filename string containing complete filename with path
      * @throws FileNotFoundException               if the file does not exist
@@ -333,8 +336,8 @@ public class MemoryContents {
      * <li>Identification of a file without any data record
      * <li>Identification of any records which have extra characters after the
      * checksum
-     * <ul>
-     * When reading the file, <code>readHex</code> infers the addressing format
+     * </ul><p>
+     * When reading the file, {@link #readHex} infers the addressing format
      * from the first record found in the file, and future records are
      * interpreted using that addressing format. It is not necessary to
      * pre-configure the addressing format before reading the file. This is a
@@ -349,13 +352,12 @@ public class MemoryContents {
      * information. Such Key/Value pair information is used within the .DMF
      * format to provide configuration information for firmware update
      * mechanism. This class also extracts key/value pair comments "I8HEX"
-     * format files. After successful completion of this <code>readHex</code>,
-     * the the <code>getValue(String
-     * keyName)</code> method may be used to inspect individual key values.
+     * format files. After successful completion of this method,
+     * then the {@code #extractValueOfKey(String keyName)} method may be used to inspect individual key values.
      * <p>
      * Key/Value pair definition comment lines are of the format:
      * <p>
-     * <code>! KeyName: Value</code>
+     * {@code ! KeyName: Value}
      *
      * @param file
      * @throws FileNotFoundException               if the file does not exist
@@ -736,9 +738,9 @@ public class MemoryContents {
      * beginning of the character stream. Note that comments of the key/value
      * format implemented here is not in compliance with the "I8HEX" format.
      * <p>
-     * The "I8HEX" format is used when the <code>loadOffsetFieldType</code> is
+     * The "I8HEX" format is used when the {@link #loadOffsetFieldType} is
      * configured for 16-bit addresses in the record LOAD OFFSET field. The
-     * ".DMF" format is used when the <code>loadOffsetFieldType</code> is
+     * ".DMF" format is used when the {@link #loadOffsetFieldType} is
      * configured for 24-bit addresses in the record LOAD OFFSET field.
      * <p>
      * The method generates only RECTYPs "00" and "01", and does not generate
@@ -765,9 +767,9 @@ public class MemoryContents {
      * memory in either the Intel "I8HEX" or Digitrax ".DMF" file format to a
      * Writer.
      * <p>
-     * The "I8HEX" format is used when the <code>loadOffsetFieldType</code> is
+     * The "I8HEX" format is used when the{@link #loadOffsetFieldType} is
      * configured for 16-bit addresses in the record LOAD OFFSET field. The
-     * ".DMF" format is used when the <code>loadOffsetFieldType</code> is
+     * ".DMF" format is used when the {@link #loadOffsetFieldType} is
      * configured for 24-bit addresses in the record LOAD OFFSET field.
      * <p>
      * The method generates only RECTYPs "00" and "01", and does not generate
@@ -948,7 +950,7 @@ public class MemoryContents {
      *
      * @param location location within programmatic representation of memory to
      *                 report
-     * @return the value found at the specified location.\
+     * @return value found at the specified location.
      */
     public int getLocation(int location) {
         currentPage = location / PAGESIZE;
@@ -1141,7 +1143,7 @@ public class MemoryContents {
      * <p>
      * Key/value pair information is extractable only from comments of the form:
      * <p>
-     * <code>! Key/Value</code>
+     * {@code ! Key/Value}
      *
      * @param keyName Key/value comment line, including the leading "! "
      * @return String containing Key name
@@ -1218,9 +1220,9 @@ public class MemoryContents {
 
     /**
      * Configures the Addressing format used in the LOAD OFFSET field when
-     * writing to a .hex file using the <code>writeHex</code> method.
+     * writing to a .hex file using the {@link #writeHex} method.
      * <p>
-     * Note that the <code>readHex</code> method infers the addressing format
+     * Note that the {@link #readHex} method infers the addressing format
      * from the first record in the file and updates the stored address format
      * based on the format found in the file.
      *
@@ -1232,8 +1234,8 @@ public class MemoryContents {
 
     /**
      * Returns the current addressing format setting. The current setting is
-     * established by the last occurrence of the <code>setAddressFormat</code>
-     * method or <code>readHex</code> method invocation.
+     * established by the last occurrence of the {@link #setAddressFormat}
+     * method or {@link #readHex} method invocation.
      *
      * @return the current Addressing format setting
      */

--- a/java/src/jmri/jmrit/audio/AbstractAudioBuffer.java
+++ b/java/src/jmri/jmrit/audio/AbstractAudioBuffer.java
@@ -11,19 +11,18 @@ import org.slf4j.LoggerFactory;
  * Base implementation of the AudioBuffer class.
  * <p>
  * Specific implementations will extend this base class.
- * <p>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
- * <p>
+ * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <p>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <p>
+ * </P>
  *
  * @author Matthew Harris copyright (c) 2009, 2011
  */

--- a/java/src/jmri/jmrit/audio/AbstractAudioListener.java
+++ b/java/src/jmri/jmrit/audio/AbstractAudioListener.java
@@ -11,19 +11,18 @@ import org.slf4j.LoggerFactory;
  * Base implementation of the AudioListener class.
  * <P>
  * Specific implementations will extend this base class.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author Matthew Harris copyright (c) 2009
  */

--- a/java/src/jmri/jmrit/audio/AbstractAudioSource.java
+++ b/java/src/jmri/jmrit/audio/AbstractAudioSource.java
@@ -15,19 +15,18 @@ import org.slf4j.LoggerFactory;
  * Base implementation of the AudioSource class.
  * <P>
  * Specific implementations will extend this base class.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author Matthew Harris copyright (c) 2009
  */

--- a/java/src/jmri/jmrit/audio/AudioBuffer.java
+++ b/java/src/jmri/jmrit/audio/AudioBuffer.java
@@ -19,19 +19,18 @@ import jmri.Audio;
  * form, and can be used for any purpose. The "system" name is provided by the
  * system-specific implementations, and provides a unique mapping to the layout
  * control system (e.g. LocoNet, NCE, etc) and address within that system.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author Matthew Harris copyright (c) 2009, 2011
  */

--- a/java/src/jmri/jmrit/audio/AudioListener.java
+++ b/java/src/jmri/jmrit/audio/AudioListener.java
@@ -18,19 +18,18 @@ import jmri.Audio;
  * form, and can be used for any purpose. The "system" name is provided by the
  * system-specific implementations, and provides a unique mapping to the layout
  * control system (e.g. LocoNet, NCE, etc) and address within that system.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author Matthew Harris copyright (c) 2009
  */

--- a/java/src/jmri/jmrit/audio/AudioSource.java
+++ b/java/src/jmri/jmrit/audio/AudioSource.java
@@ -19,7 +19,6 @@ import jmri.Audio;
  * form, and can be used for any purpose. The "system" name is provided by the
  * system-specific implementations, and provides a unique mapping to the layout
  * control system (e.g. LocoNet, NCE, etc) and address within that system.
- * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
@@ -311,10 +310,10 @@ public interface AudioSource extends Audio {
      * Default value = 1.0f
      * <p>
      * Applies only to sub-types:
-     * <ul>
+     * </p><ul>
      * <li>Listener
      * <li>Source
-     * <ul>
+     * </ul>
      *
      * @param gain the gain of this AudioSource
      */
@@ -328,7 +327,7 @@ public interface AudioSource extends Audio {
      * Default value = 1.0f
      * <p>
      * Applies only to sub-types:
-     * <ul>
+     * </p><ul>
      * <li>Source
      * </ul>
      *
@@ -344,7 +343,7 @@ public interface AudioSource extends Audio {
      * Default value = 1.0f
      * <p>
      * Applies only to sub-types:
-     * <ul>
+     * </p><ul>
      * <li>Source
      * </ul>
      *
@@ -358,7 +357,7 @@ public interface AudioSource extends Audio {
      * Default value = 1.0f
      * <p>
      * Applies only to sub-types:
-     * <ul>
+     * </p><ul>
      * <li>Source
      * </ul>
      *
@@ -379,7 +378,7 @@ public interface AudioSource extends Audio {
      * a quarter volume, etc ...
      * <p>
      * Applies only to sub-types:
-     * <ul>
+     * </p><ul>
      * <li>Source
      * </ul>
      *
@@ -396,7 +395,7 @@ public interface AudioSource extends Audio {
      * be zero.
      * <p>
      * Applies only to sub-types:
-     * <ul>
+     * </p><ul>
      * <li>Source
      * </ul>
      */

--- a/java/src/jmri/jmrit/audio/AudioSource.java
+++ b/java/src/jmri/jmrit/audio/AudioSource.java
@@ -19,19 +19,18 @@ import jmri.Audio;
  * form, and can be used for any purpose. The "system" name is provided by the
  * system-specific implementations, and provides a unique mapping to the layout
  * control system (e.g. LocoNet, NCE, etc) and address within that system.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author Matthew Harris copyright (c) 2009
  */

--- a/java/src/jmri/jmrit/beantable/Maintenance.java
+++ b/java/src/jmri/jmrit/beantable/Maintenance.java
@@ -44,19 +44,18 @@ import org.slf4j.LoggerFactory;
  * to inform users where and how the various elements are used. In particular to
  * identify useless elements ('orphans'). Currently, called only from the Logix
  * JFrame, which is probably not its ultimate UI.
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  * @author Pete Cressman Copyright 2009
  */
 public class Maintenance {

--- a/java/src/jmri/jmrit/beantable/OBlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/OBlockTableAction.java
@@ -6,18 +6,18 @@ import jmri.jmrit.beantable.oblock.TableFrames;
 
 /**
  * GUI to define OBlocks, OPaths and Portals
- * <P>
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author	Pete Cressman (C) 2009, 2010
  */

--- a/java/src/jmri/jmrit/beantable/oblock/TableFrames.java
+++ b/java/src/jmri/jmrit/beantable/oblock/TableFrames.java
@@ -49,18 +49,18 @@ import org.slf4j.LoggerFactory;
 
 /**
  * GUI to define OBlocks
- * <P>
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author  Pete Cressman (C) 2010
  */

--- a/java/src/jmri/jmrit/catalog/DirectorySearcher.java
+++ b/java/src/jmri/jmrit/catalog/DirectorySearcher.java
@@ -17,21 +17,18 @@ import jmri.CatalogTreeManager;
 /**
  * A file system directory searcher to locate Image files to include in an Image
  * Catalog. This is a singleton class.
- * <P>
- *
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
- *
+ * </P>
  * @author	Pete Cressman Copyright 2010
  *
  */

--- a/java/src/jmri/jmrit/catalog/DragJLabel.java
+++ b/java/src/jmri/jmrit/catalog/DragJLabel.java
@@ -19,20 +19,18 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Gives a JLabel the capability to Drag and Drop
- * <P>
- *
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author	Pete Cressman Copyright 2009
  *

--- a/java/src/jmri/jmrit/catalog/ImageIndexEditor.java
+++ b/java/src/jmri/jmrit/catalog/ImageIndexEditor.java
@@ -28,20 +28,18 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A JFrame for creating and editing an Image Index. This is a singleton class.
- * <P>
- *
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author	Pete Cressman Copyright 2009
  *

--- a/java/src/jmri/jmrit/catalog/PreviewDialog.java
+++ b/java/src/jmri/jmrit/catalog/PreviewDialog.java
@@ -33,21 +33,18 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Create a Dialog to display the images in a file system directory.
- * <P>
- *
- *
+ * <BR>
  * <hr>
- * This file is part of JMRI. Displays filtered files from a file system
- * directory. May be modal or modeless. Modeless has dragging enabled.
+ * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author	Pete Cressman Copyright 2009
  *

--- a/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
@@ -51,16 +51,18 @@ import org.slf4j.LoggerFactory;
  * AllocationPlan objects are discarded.
  * <P>
  *
- * <P>
+ * <BR>
+ * <hr>
  * This file is part of JMRI.
  * <P>
- * JMRI is open source software; you can redistribute it and/or modify it under
- * the terms of version 2 of the GNU General Public License as published by the
- * Free Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * </P>
  *
  * @author	Dave Duchamp Copyright (C) 2011
  * @version	$Revision$

--- a/java/src/jmri/jmrit/display/Positionable.java
+++ b/java/src/jmri/jmrit/display/Positionable.java
@@ -10,12 +10,12 @@ import javax.swing.JPopupMenu;
  * Defines display objects.
  * <P>
  * These are capable of:
- * <UL>
+ * </p><UL>
  * <LI>Being positioned by being dragged around on the screen. (See
  * {@link #setPositionable})
  * <LI>Being hidden. (See {@link #setHidden})
  * <LI>Controlling the layout. (See {@link #setControlling})
- * </OL>
+ * </UL><p>
  * These are manipulated externally, for example by a subclass of
  * {@link Editor}. They are generally not stored directly as part of the state
  * of the object, though they could be, but as part of the state of the external
@@ -80,8 +80,9 @@ public interface Positionable extends Cloneable {
     /**
      * Make a deep copy of Positional object. Implementation should create a new
      * object and immediately pass the object to finishClone() returning the
-     * result of finishClone(). i.e. implementation must be: <br/>
-     * public Positionable deepClone() { Subtype t = new Subtype(); return finishClone(t); } <br/>
+     * result of finishClone(). i.e. implementation must be:
+     * <p>
+     * {@code public Positionable deepClone() { Subtype t = new Subtype(); return finishClone(t); } }
      * <p>
      * Then finishClone() finishes the deep Copy of a Positional object. Implementation should make
      * deep copies of the additional members of this sub class and then pass

--- a/java/src/jmri/jmrit/display/palette/DragJComponent.java
+++ b/java/src/jmri/jmrit/display/palette/DragJComponent.java
@@ -20,19 +20,18 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Gives a JComponent the capability to Drag and Drop
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author	Pete Cressman Copyright 2011
  *

--- a/java/src/jmri/jmrit/logix/Calibrater.java
+++ b/java/src/jmri/jmrit/logix/Calibrater.java
@@ -28,18 +28,18 @@ import org.slf4j.LoggerFactory;
  * <P>
  * The route can be defined in a form or by mouse clicking on the OBlock
  * IndicatorTrack icons.
- * <P>
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author  Pete Cressman  Copyright (C) 2009, 2010, 2015
  */

--- a/java/src/jmri/jmrit/logix/NXFrame.java
+++ b/java/src/jmri/jmrit/logix/NXFrame.java
@@ -27,18 +27,18 @@ import org.slf4j.LoggerFactory;
  * <P>
  * The route can be defined in a form or by mouse clicking on the OBlock
  * IndicatorTrack icons.
- * <P>
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author  Pete Cressman  Copyright (C) 2009, 2010, 2015
  */

--- a/java/src/jmri/jmrit/logix/OBlock.java
+++ b/java/src/jmri/jmrit/logix/OBlock.java
@@ -46,19 +46,18 @@ import org.slf4j.LoggerFactory;
  * the block. Paths are contained within the Block boundaries. Names of OPath
  * objects only need be unique within an OBlock.
  *
- * <P>
- *
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author	Pete Cressman (C) 2009
  */

--- a/java/src/jmri/jmrit/logix/WarrantFrame.java
+++ b/java/src/jmri/jmrit/logix/WarrantFrame.java
@@ -37,20 +37,18 @@ import org.slf4j.LoggerFactory;
 
 /**
  * WarrantFame creates and edits Warrants
- * <P>
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
- * This class is a window for creating and editing Warrants.
- * <p>
+ * </P>
  * @author  Pete Cressman Copyright (C) 2009, 2010
  */
 public class WarrantFrame extends WarrantRoute {

--- a/java/src/jmri/jmrit/logix/WarrantTableAction.java
+++ b/java/src/jmri/jmrit/logix/WarrantTableAction.java
@@ -36,20 +36,18 @@ import org.slf4j.LoggerFactory;
  * a train to proceed from an Origin to a Destination.
  * WarrantTableAction provides the menu for panels to List, Edit and Create
  * Warrants.  It launches the appropriate frame for each action.
- * <P>
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
- * JMRI is free software; you can redistribute it and/or modify it under 
- * the terms of version 2 of the GNU General Public License as published 
- * by the Free Software Foundation. See the "COPYING" file for a copy
- * of this license.
- * <P>
- * JMRI is distributed in the hope that it will be useful, but WITHOUT 
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
- * for more details.
- * <P>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * </P><P>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * </P>
  *
  * @author  Pete Cressman  Copyright (C) 2009, 2010
  */

--- a/java/src/jmri/jmrit/logix/WarrantTableFrame.java
+++ b/java/src/jmri/jmrit/logix/WarrantTableFrame.java
@@ -39,20 +39,18 @@ import org.slf4j.LoggerFactory;
  * train IDs launch them and control their running (halt, resume, abort. etc.
  * 
  *  The WarrantTableFrame also can initiate NX (eNtry/eXit) warrants
- * <P>
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
- * JMRI is free software; you can redistribute it and/or modify it under 
- * the terms of version 2 of the GNU General Public License as published 
- * by the Free Software Foundation. See the "COPYING" file for a copy
- * of this license.
- * <P>
- * JMRI is distributed in the hope that it will be useful, but WITHOUT 
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
- * for more details.
- * <P>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * </P><P>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * </P>
  *
  * @author  Pete Cressman  Copyright (C) 2009, 2010
  */

--- a/java/src/jmri/jmrit/logix/WarrantTableModel.java
+++ b/java/src/jmri/jmrit/logix/WarrantTableModel.java
@@ -19,18 +19,18 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Table Model for the Warrant List
- * <P>
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * <P>
+ * </P>
  *
  * @author Pete Cressman Copyright (C) 2009, 2010
  */

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
@@ -2423,11 +2423,9 @@ public class PaneProgPane extends javax.swing.JPanel
      * Pick an appropriate function map panel depending on model attribute.
      * <dl>
      * <dt>If attribute extFnsESU="yes":</dt>
-     * <dd>Invoke FnMapPanelESU(VariableTableModel v, List<Integer> varsUsed,
-     * Element model)</dd>
+     * <dd>Invoke {@code FnMapPanelESU(VariableTableModel v, List<Integer> varsUsed, Element model)}</dd>
      * <dt>Otherwise:</dt>
-     * <dd>Invoke FnMapPanel(VariableTableModel v, List<Integer> varsUsed,
-     * Element model)</dd>
+     * <dd>Invoke {@code FnMapPanel(VariableTableModel v, List<Integer> varsUsed, Element model)}</dd>
      * </dl>
      */
     void pickFnMapPanel(JPanel c, GridBagLayout g, GridBagConstraints cs, Element modelElem) {
@@ -2638,8 +2636,8 @@ public class PaneProgPane extends javax.swing.JPanel
     /**
      * Appends text to a String possibly in HTML format (as used in many Swing
      * components).
-     *
-     * Ensures any appended text is added prior to the closing </html> tag, if
+     * <p>
+     * Ensures any appended text is added prior to the closing {@code </html>} tag, if
      * there is one.
      *
      * @param baseText  original text
@@ -2664,7 +2662,7 @@ public class PaneProgPane extends javax.swing.JPanel
     /**
      * Optionally add CV numbers and bit numbers to tool tip text based on
      * Roster Preferences setting.
-     *
+     * <p>
      * Needs to be independent of VariableValue methods to allow use by
      * non-standard elements such as SpeedTableVarValue, DccAddressPanel,
      * FnMapPanel.

--- a/java/src/jmri/jmrix/loconet/AbstractBoardProgPanel.java
+++ b/java/src/jmri/jmrix/loconet/AbstractBoardProgPanel.java
@@ -1,4 +1,3 @@
-// AbstractBoardProgPanel.java
 package jmri.jmrix.loconet;
 
 import java.awt.FlowLayout;
@@ -45,15 +44,10 @@ import org.slf4j.LoggerFactory;
  * Inc for separate permission.
  *
  * @author Bob Jacobsen Copyright (C) 2004, 2007
- * @version $Revision$
  */
 abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.LnPanel
         implements LocoNetListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8539447083900083082L;
     JPanel contents = new JPanel();
     java.util.ResourceBundle rb = java.util.ResourceBundle.getBundle("jmri.jmrix.loconet.LocoNetBundle");
 
@@ -161,7 +155,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
 
     /**
      * Set the Board ID number (also known as board address number)
-     * <p>
+     *
      * @param boardId
      */
     public void setBoardIdValue(Integer boardId) {
@@ -242,7 +236,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
 
     /**
      * Handle GUI layout details during construction.
-     * <P>
+     *
      * @param c component to put on a single line
      */
     protected void appendLine(JComponent c) {
@@ -281,7 +275,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
      * Configure the type word in the LocoNet messages.
      * <P>
      * Known values:
-     * <UL>
+     * </P><UL>
      * <LI>0x70 - PM4
      * <LI>0x71 - BDL16
      * <LI>0x72 - SE8
@@ -440,7 +434,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
      * writeOne() is intended to provide a mechanism to write a single OpSw
      * value (specified by opswIndex), rather than a sequence of OpSws as done
      * by writeAll().
-     * <p>
+     *
      * @param opswIndex <p>
      * @see jmri.jmrix.loconet.AbstractBoardProgPanel#writeAll()
      */
@@ -474,7 +468,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
      * Processes incoming LocoNet message m for OpSw responses to read and write
      * operation messages, and automatically advances to the next OpSw operation
      * as directed by nextState().
-     * <p>
+     *
      * @param m
      */
     public void message(LocoNetMessage m) {

--- a/java/src/jmri/jmrix/modbus/common/package-info.java
+++ b/java/src/jmri/jmrix/modbus/common/package-info.java
@@ -1,7 +1,6 @@
 /**
  * Common classes to provide JMRI access as master and slave nodes on Modbus
  * networks.
- * <p>
  *
  * <h2>Related Documentation</h2>
  *

--- a/java/src/jmri/jmrix/modbus/master/package-info.java
+++ b/java/src/jmri/jmrix/modbus/master/package-info.java
@@ -1,6 +1,5 @@
 /**
  * Provide JMRI access as a master node on Modbus networks.
- * <p>
  *
  * <h2>Related Documentation</h2>
  *

--- a/java/src/jmri/jmrix/modbus/package-info.java
+++ b/java/src/jmri/jmrix/modbus/package-info.java
@@ -1,6 +1,5 @@
 /**
  * Provides JMRI access to Modbus networks.
- * <p>
  *
  * <h2>Related Documentation</h2>
  *

--- a/java/src/jmri/jmrix/modbus/slave/package-info.java
+++ b/java/src/jmri/jmrix/modbus/slave/package-info.java
@@ -1,6 +1,5 @@
 /**
  * Provide JMRI access as a slave node on Modbus networks.
- * <p>
  *
  * <h2>Related Documentation</h2>
  *

--- a/java/src/jmri/jmrix/mrc/MrcClockControl.java
+++ b/java/src/jmri/jmrix/mrc/MrcClockControl.java
@@ -14,17 +14,18 @@ import org.slf4j.LoggerFactory;
  * Implementation of the Hardware Fast Clock for Mrc
  * <P>
  * This module is based on the NCE version.
- * <P>
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * </P>
  *
  * @author Ken Cameron Copyright (C) 2014
  * @author Dave Duchamp Copyright (C) 2007

--- a/java/src/jmri/jmrix/nce/NceClockControl.java
+++ b/java/src/jmri/jmrix/nce/NceClockControl.java
@@ -21,17 +21,18 @@ import org.slf4j.LoggerFactory;
  * internal in sync to the Nce clock. The following of the Nce clock is better
  * than the other way around due to the fine tuning available on the internal
  * clock while the Nce clock doesn't.
- * <P>
+ * <BR>
  * <hr>
  * This file is part of JMRI.
  * <P>
  * JMRI is free software; you can redistribute it and/or modify it under the
  * terms of version 2 of the GNU General Public License as published by the Free
  * Software Foundation. See the "COPYING" file for a copy of this license.
- * <P>
+ * </P><P>
  * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * </P>
  *
  * @author Ken Cameron Copyright (C) 2007
  * @author Dave Duchamp Copyright (C) 2007

--- a/java/src/jmri/util/JTextPaneAppender.java
+++ b/java/src/jmri/util/JTextPaneAppender.java
@@ -149,7 +149,7 @@ public class JTextPaneAppender extends AppenderSkeleton {
 
     /**
      * Set current TextPane
-     * <p>
+     * 
      * @param aTextpane
      */
     public void setTextPane(JTextPane aTextpane) {
@@ -169,7 +169,7 @@ public class JTextPaneAppender extends AppenderSkeleton {
     // option setters and getters
     /**
      * setColorEmerg
-     * <p>
+     * 
      * @param color
      */
     public void setColorEmerg(Color color) {
@@ -185,7 +185,7 @@ public class JTextPaneAppender extends AppenderSkeleton {
 
     /**
      * setColorError
-     * <p>
+     * 
      * @param color
      */
     public void setColorError(Color color) {
@@ -201,7 +201,7 @@ public class JTextPaneAppender extends AppenderSkeleton {
 
     /**
      * setColorWarn
-     * <p>
+     * 
      * @param color
      */
     public void setColorWarn(Color color) {
@@ -217,7 +217,7 @@ public class JTextPaneAppender extends AppenderSkeleton {
 
     /**
      * setColorInfo
-     * <p>
+     * 
      * @param color
      */
     public void setColorInfo(Color color) {
@@ -233,7 +233,7 @@ public class JTextPaneAppender extends AppenderSkeleton {
 
     /**
      * setColorDebug
-     * <p>
+     * 
      * @param color
      */
     public void setColorDebug(Color color) {
@@ -249,7 +249,7 @@ public class JTextPaneAppender extends AppenderSkeleton {
 
     /**
      * Sets the font size of all Level's
-     * <p>
+     *
      * @param aSize
      */
     public void setFontSize(int aSize) {
@@ -262,7 +262,7 @@ public class JTextPaneAppender extends AppenderSkeleton {
 
     /**
      * Sets the font size of a particular Level
-     * <p>
+     *
      * @param aSize
      * @param aLevel
      */
@@ -275,7 +275,7 @@ public class JTextPaneAppender extends AppenderSkeleton {
 
     /**
      * Get the font size for a particular logging level
-     * <p>
+     *
      * @param aLevel
      */
     public int getFontSize(Level aLevel) {
@@ -289,7 +289,7 @@ public class JTextPaneAppender extends AppenderSkeleton {
 
     /**
      * Sets the font name of all known Level's
-     * <p>
+     *
      * @param aName
      */
     public void setFontName(String aName) {
@@ -302,7 +302,7 @@ public class JTextPaneAppender extends AppenderSkeleton {
 
     /**
      * setFontName
-     * <p>
+     *
      * @param aName
      * @param aLevel
      */
@@ -316,7 +316,7 @@ public class JTextPaneAppender extends AppenderSkeleton {
 
     /**
      * Retrieves the font name of a particular Level
-     * <p>
+     *
      * @param aLevel
      */
     public String getFontName(Level aLevel) {

--- a/java/src/jmri/util/iharder/dnd/FileDrop.java
+++ b/java/src/jmri/util/iharder/dnd/FileDrop.java
@@ -13,11 +13,11 @@ import java.util.List;
  * a Java program. Any <tt>java.awt.Component</tt> can be dropped onto, but only
  * <tt>javax.swing.JComponent</tt>s will indicate the drop event with a changed
  * border.
- * <p/>
+ * <p>
  * To use this class, construct a new <tt>FileDrop</tt> by passing it the target
  * component and a <tt>Listener</tt> to receive notification when file(s) have
  * been dropped. Here is an example:
- * <p/>
+ * </p>
  * <code><pre>
  *      JPanel myPanel = new JPanel();
  *      new FileDrop( myPanel, new FileDrop.Listener()
@@ -28,16 +28,16 @@ import java.util.List;
  *          }   // end filesDropped
  *      }); // end FileDrop.Listener
  * </pre></code>
- * <p/>
+ * 
  * You can specify the border that will appear when files are being dragged by
  * calling the constructor with a <tt>javax.swing.border.Border</tt>. Only
  * <tt>JComponent</tt>s will show any indication with a border.
- * <p/>
+ * <p>
  * You can turn on some debugging features by passing a <tt>PrintStream</tt>
  * object (such as <tt>System.out</tt>) into the full constructor. A
  * <tt>null</tt>
  * value will result in no extra debugging information being output.
- * <p/>
+ * 
  *
  * <p>
  * I'm releasing this code into the Public Domain. Enjoy.


### PR DESCRIPTION
See #1330 for background

- turn on "html" format errors in the Ant javadoc targets
- align javadoc and javadoc-ci targets
- add some [documentation](http://jmri.sourceforge.net/help/en/html/doc/Technical/JavaDoc.shtml)
- fix a bunch of formatting, along with some minor cleanup

