### PR TITLE
JavaDoc: remove content-free @throws, @return statements

### DIFF
--- a/java/src/jmri/implementation/DefaultConditionalAction.java
+++ b/java/src/jmri/implementation/DefaultConditionalAction.java
@@ -119,7 +119,6 @@ public class DefaultConditionalAction implements ConditionalAction {
     /**
      * If this is an indirect reference return the Memory bean
      *
-     * @return
      */
     private Memory getIndirectBean(String devName) {
         if (devName != null && devName.length() > 0 && devName.charAt(0) == '@') {
@@ -139,7 +138,6 @@ public class DefaultConditionalAction implements ConditionalAction {
     /**
      * Return the device bean that will do the action
      *
-     * @return
      */
     private NamedBean getActionBean(String devName) {
         NamedBean bean = null;

--- a/java/src/jmri/jmris/json/JsonThrottle.java
+++ b/java/src/jmri/jmris/json/JsonThrottle.java
@@ -75,8 +75,6 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
      * @param server     The server requesting this throttle on behalf of a
      *                   client
      * @return The throttle
-     * @throws JmriException
-     * @throws IOException
      */
     public static JsonThrottle getThrottle(String throttleId, JsonNode data, JsonThrottleServer server) throws JmriException, IOException {
         DccLocoAddress address = null;

--- a/java/src/jmri/jmris/json/JsonUtil.java
+++ b/java/src/jmri/jmris/json/JsonUtil.java
@@ -175,7 +175,6 @@ public class JsonUtil {
      * @param data    The JSON representation of the consist. See
      * {@link #getConsist(Locale, jmri.DccLocoAddress) } for the
      *                JSON structure.
-     * @throws JsonException
      */
     static public void putConsist(Locale locale, DccLocoAddress address, JsonNode data) throws JsonException {
         try {
@@ -194,7 +193,6 @@ public class JsonUtil {
      * @param locale The locale to throw exceptions in.
      * @return JSON array of consists as in the structure returned by
      * {@link #getConsist(Locale, jmri.DccLocoAddress) }
-     * @throws JsonException
      */
     static public JsonNode getConsists(Locale locale) throws JsonException {
         try {
@@ -229,7 +227,6 @@ public class JsonUtil {
      * @param locale  the locale to throw exceptions in
      * @param address the consist address
      * @param data    the consist as a JsonObject
-     * @throws JsonException
      */
     static public void setConsist(Locale locale, DccLocoAddress address, JsonNode data) throws JsonException {
         try {
@@ -804,7 +801,6 @@ public class JsonUtil {
      * @param locale The locale to throw exceptions in
      * @param name   The name of the route
      * @param data   A JsonNode containing route attributes to set
-     * @throws JsonException
      * @see jmri.Route#TOGGLE
      */
     static public void setRoute(Locale locale, String name, JsonNode data) throws JsonException {
@@ -1178,7 +1174,6 @@ public class JsonUtil {
      * @param locale The locale to throw exceptions in.
      * @param id     The id of the train.
      * @param data   Train data to change.
-     * @throws JsonException
      */
     static public void setTrain(Locale locale, String id, JsonNode data) throws JsonException {
         Train train = TrainManager.instance().getTrainById(id);

--- a/java/src/jmri/jmris/json/JsonUtil.java
+++ b/java/src/jmri/jmris/json/JsonUtil.java
@@ -1363,7 +1363,6 @@ public class JsonUtil {
      * JSON errors should be handled by throwing a
      * {@link jmri.server.json.JsonException}.
      *
-     * @return
      * @deprecated
      */
     @Deprecated

--- a/java/src/jmri/jmrit/consisttool/ConsistFile.java
+++ b/java/src/jmri/jmrit/consisttool/ConsistFile.java
@@ -203,8 +203,6 @@ public class ConsistFile extends XmlFile {
     /**
      * Read all consists from the default file name
      *
-     * @throws JDOMException
-     * @throws IOException
      */
     public void readFile() throws JDOMException, IOException {
         readFile(defaultConsistFilename());
@@ -214,8 +212,6 @@ public class ConsistFile extends XmlFile {
      * Read all consists from a file.
      *
      * @param fileName - with location and file type
-     * @throws JDOMException
-     * @throws IOException
      */
     @SuppressWarnings("unchecked")
     public void readFile(String fileName) throws JDOMException, IOException {
@@ -250,7 +246,6 @@ public class ConsistFile extends XmlFile {
     /**
      * Write all consists to the default file name
      *
-     * @throws IOException
      */
     public void writeFile(ArrayList<DccLocoAddress> consistList) throws IOException {
         writeFile(consistList, defaultConsistFilename());
@@ -261,7 +256,6 @@ public class ConsistFile extends XmlFile {
      *
      * @param consistList an ArrayList of consists to write
      * @param fileName    - with location and file type
-     * @throws IOException
      */
     public void writeFile(ArrayList<DccLocoAddress> consistList, String fileName) throws IOException {
         // create root element

--- a/java/src/jmri/jmrit/display/PositionableLabel.java
+++ b/java/src/jmri/jmrit/display/PositionableLabel.java
@@ -786,7 +786,6 @@ public class PositionableLabel extends JLabel implements Positionable {
     /**
      * create a text image whose bit map can be rotated
      *
-     * @return
      */
     private NamedIcon makeTextIcon(String text) {
         if (text == null || text.equals("")) {

--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/DrawPolygon.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/DrawPolygon.java
@@ -189,7 +189,6 @@ public class DrawPolygon extends DrawFrame {
 
     /**
      * @param pt is "startPoint" the upper left corner of the figure
-     * @return
      */
     private GeneralPath makePath(Point pt) {
         GeneralPath path = new GeneralPath(GeneralPath.WIND_EVEN_ODD, _vertices.size() + 1);
@@ -203,7 +202,6 @@ public class DrawPolygon extends DrawFrame {
     /**
      * "startPoint" will be the upper left corner of the figure
      *
-     * @return
      */
     private Point getStartPoint() {
         int x = _vertices.get(0).x;

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutEditorXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutEditorXml.java
@@ -239,7 +239,6 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
      * JFrame
      *
      * @param shared Top level Element to unpack.
-     * @return 
      */
     @Override
     public boolean load(Element shared, Element perNode) {

--- a/java/src/jmri/jmrit/logix/OBlock.java
+++ b/java/src/jmri/jmrit/logix/OBlock.java
@@ -351,7 +351,6 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
      * Called from setPath. looking for other warrants that may have allocated
      * blocks that share TO's with this block.
      *
-     * @return
      */
     private String checkSharedTO() {
         List<HashMap<OBlock, List<OPath>>> blockList = _sharedTO.get(_pathName);

--- a/java/src/jmri/jmrit/logix/Tracker.java
+++ b/java/src/jmri/jmrit/logix/Tracker.java
@@ -389,7 +389,6 @@ public class Tracker {
     /**
      * Called when _occupies is empty
      *
-     * @return
      */
     private boolean recovery(OBlock block) {
         if (_occupies.size()==0) {

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -367,7 +367,6 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
     /**
      * Sets dccAddress and fetches RosterEntry
      * @param id address as a String
-     * @return
      */
     public boolean setDccAddress(String id) {
         _train = Roster.instance().entryFromTitle(id);
@@ -1179,7 +1178,6 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
      * Called from propertyChange()
      * For the start block a return of true will allow warrant to acquire a throttle and
      * launch an engineer.  return ignored for all other blocks
-     * @return
      */
     private boolean checkStoppingBlock() {
         boolean ret = false;

--- a/java/src/jmri/jmrit/logix/WarrantFrame.java
+++ b/java/src/jmri/jmrit/logix/WarrantFrame.java
@@ -772,7 +772,6 @@ public class WarrantFrame extends WarrantRoute {
     /**
      * all non-null returns are fatal
      *
-     * @return
      */
     private String checkTrainId() {
         String msg = null;

--- a/java/src/jmri/jmrit/logix/WarrantRoute.java
+++ b/java/src/jmri/jmrit/logix/WarrantRoute.java
@@ -163,7 +163,6 @@ public abstract class WarrantRoute extends jmri.util.JmriJFrame implements Actio
      * Set the roster entry, if it exists, or train id string if not.
      * i.e. set enough info to get a dccLocoAddress
      * @param name may be roster Id or address
-     * @return
      */
     protected String setTrainInfo(String name) {
         if (log.isDebugEnabled()) {
@@ -1141,7 +1140,6 @@ public abstract class WarrantRoute extends jmri.util.JmriJFrame implements Actio
     *
     * @param vertical  Label orientation true = above, false = left
     * @param label String label message
-    * @return
     */
    static protected JPanel makeTextBoxPanel(boolean vertical, JComponent textField, String label, String tooltip) {
        JPanel panel = new JPanel();

--- a/java/src/jmri/jmrit/roster/FullBackupExportAction.java
+++ b/java/src/jmri/jmrit/roster/FullBackupExportAction.java
@@ -114,7 +114,6 @@ public class FullBackupExportAction
      * @param filename the file to copy
      * @param dirname  the zip file "directory" to place this file in
      * @param zipper   the ZipOutputStream
-     * @throws IOException
      */
     private void copyFileToStream(String filename, String dirname, ZipOutputStream zipper, String comment)
             throws IOException {

--- a/java/src/jmri/jmrit/roster/Roster.java
+++ b/java/src/jmri/jmrit/roster/Roster.java
@@ -584,7 +584,6 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
      * that finds the default location, does a backup and then calls this.
      *
      * @param file an op
-     * @throws IOException
      */
     void writeFile(File file) throws java.io.IOException {
         // create root element

--- a/java/src/jmri/jmrit/signalling/configurexml/EntryExitPairsXml.java
+++ b/java/src/jmri/jmrit/signalling/configurexml/EntryExitPairsXml.java
@@ -141,7 +141,6 @@ public class EntryExitPairsXml extends AbstractXmlAdapter {
      * pairs
      *
      * @param shared Top level Element to unpack.
-     * @return 
      */
     @Override
     public boolean load(Element shared, Element perNode) {

--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -840,7 +840,6 @@ abstract public class AbstractMRTrafficController {
      * <P>
      * (This is public for testing purposes) Runs in the "Receive" thread.
      *
-     * @throws IOException
      */
     public void handleOneIncomingReply() throws IOException {
             // we sit in this until the message is complete, relying on

--- a/java/src/jmri/jmrix/DCCManufacturerList.java
+++ b/java/src/jmri/jmrix/DCCManufacturerList.java
@@ -116,7 +116,6 @@ public class DCCManufacturerList {
      *
      * Note: No system should not be using a SystemConnectionMemo at this point.
      *
-     * @return
      * @deprecated Without replacement. Use
      * {@link jmri.util.ConnectionNameFromSystemName#getPrefixFromName(java.lang.String)}
      * for equivalent functionality.

--- a/java/src/jmri/jmrix/can/AbstractCanTrafficController.java
+++ b/java/src/jmri/jmrix/can/AbstractCanTrafficController.java
@@ -177,7 +177,6 @@ abstract public class AbstractCanTrafficController
      * <P>
      * Overridden to include translation form the CAN hardware format
      *
-     * @throws IOException
      */
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "DLS_DEAD_LOCAL_STORE")
     // Ignore false positive that msg is never used

--- a/java/src/jmri/jmrix/can/cbus/CbusOpCodes.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusOpCodes.java
@@ -64,7 +64,6 @@ public class CbusOpCodes {
      * @param msg CbusMessage to be decoded
      * @param ext flag for extended message Return String decoded message
      * @param header CAN Header
-     * @return 
      */
     public static String decode(AbstractMessage msg, Boolean ext, int header) {
         if (ext == false) {

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -865,7 +865,6 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
      * @param p        Who to notify on complete
      * @param addr     Address of the locomotive
      * @param longAddr true if a long address, false if short address
-     * @throws ProgrammerException
      */
     public void readCVOpsMode(int CV, jmri.ProgListener p, int addr, boolean longAddr) throws jmri.ProgrammerException {
         lopsa = addr & 0x7f;

--- a/java/src/jmri/jmrix/loconet/locomon/Llnmon.java
+++ b/java/src/jmri/jmrix/loconet/locomon/Llnmon.java
@@ -135,7 +135,6 @@ public class Llnmon {
      * addressLow & addressHigh in a form appropriate for the type of address (2
      * or 4 digit) using the Digitrax 'mixed mode' if necessary.
      *
-     * @return
      */
     private static String convertToMixed(int addressLow, int addressHigh) {
 

--- a/java/src/jmri/jmrix/nce/macro/NceMacroEditPanel.java
+++ b/java/src/jmri/jmrix/nce/macro/NceMacroEditPanel.java
@@ -657,7 +657,6 @@ public class NceMacroEditPanel extends jmri.jmrix.nce.swing.NcePanel implements 
      * Writes all bytes to NCE CS memory as long as there are no user input
      * errors
      *
-     * @return
      */
     private boolean saveMacro() {
         if (firstTime) {

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -379,7 +379,6 @@ abstract public class AbstractProxyManager implements Manager {
     /**
      * Get a list of all system names.
      *
-     * @return
      */
     @Override
     public List<String> getSystemNameList() {

--- a/java/src/jmri/profile/NullProfile.java
+++ b/java/src/jmri/profile/NullProfile.java
@@ -30,7 +30,6 @@ public class NullProfile extends Profile {
      * exist in storage on the computer.
      *
      * @param path The Profile's directory
-     * @throws IOException
      */
     public NullProfile(File path) throws IOException {
         super(path, false);
@@ -47,8 +46,6 @@ public class NullProfile extends Profile {
      *
      * @param id   If null, {@link jmri.profile.ProfileManager#createUniqueId()}
      *             will be used to generate the id.
-     * @throws IOException
-     * @throws IllegalArgumentException
      */
     public NullProfile(String name, String id, File path) throws IOException, IllegalArgumentException {
         this(path);

--- a/java/src/jmri/profile/Profile.java
+++ b/java/src/jmri/profile/Profile.java
@@ -37,7 +37,6 @@ public class Profile implements Comparable<Profile> {
      * in storage on the computer.
      *
      * @param path The Profile's directory
-     * @throws IOException
      */
     public Profile(File path) throws IOException {
         this(path, true);
@@ -52,8 +51,6 @@ public class Profile implements Comparable<Profile> {
      * read-only property of the Profile. The {@link ProfileManager} will only
      * load a single profile with a given id.
      *
-     * @throws IOException
-     * @throws IllegalArgumentException
      */
     public Profile(String name, String id, File path) throws IOException, IllegalArgumentException {
         if (!path.getName().equals(id)) {
@@ -90,7 +87,6 @@ public class Profile implements Comparable<Profile> {
      * This method exists purely to support subclasses.
      *
      * @param path       The Profile's directory
-     * @throws IOException
      */
     protected Profile(File path, boolean isReadable) throws IOException {
         this.path = path;

--- a/java/src/jmri/profile/ProfileManager.java
+++ b/java/src/jmri/profile/ProfileManager.java
@@ -188,7 +188,6 @@ public class ProfileManager extends Bean {
     /**
      * Save the active {@link Profile} and automatic start setting.
      *
-     * @throws IOException
      */
     public void saveActiveProfile() throws IOException {
         this.saveActiveProfile(this.getActiveProfile(), this.autoStartActiveProfile);
@@ -225,7 +224,6 @@ public class ProfileManager extends Bean {
      *
      * @see #getConfigFile()
      * @see #setConfigFile(java.io.File)
-     * @throws IOException
      */
     public void readActiveProfile() throws IOException {
         Properties p = new Properties();
@@ -560,7 +558,6 @@ public class ProfileManager extends Bean {
      * Create a default profile if no profiles exist.
      *
      * @return A new profile or null if profiles already exist.
-     * @throws IOException
      */
     public Profile createDefaultProfile() throws IllegalArgumentException, IOException {
         if (this.getAllProfiles().isEmpty()) {
@@ -582,8 +579,6 @@ public class ProfileManager extends Bean {
      * profile.
      *
      * @return The profile with the migrated configuration.
-     * @throws IllegalArgumentException
-     * @throws IOException
      */
     public Profile migrateConfigToProfile(File config, String name) throws IllegalArgumentException, IOException {
         String pid = FileUtil.sanitizeFilename(name);
@@ -632,8 +627,6 @@ public class ProfileManager extends Bean {
      * circumstances.
      *
      * @return true if a user's existing config was migrated, false otherwise
-     * @throws IllegalArgumentException
-     * @throws IOException
      */
     public boolean migrateToProfiles(String configFilename) throws IllegalArgumentException, IOException {
         File appConfigFile = new File(configFilename);
@@ -680,7 +673,6 @@ public class ProfileManager extends Bean {
      *                                included?
      * @param exportExternalRoster    It the roster is not within the profile
      *                                directory, should it be included?
-     * @throws IOException
      * @throws org.jdom2.JDOMException
      */
     public void export(Profile profile, File target, boolean exportExternalUserFiles, boolean exportExternalRoster) throws IOException, JDOMException {
@@ -775,7 +767,6 @@ public class ProfileManager extends Bean {
      * headless app launches.
      *
      * @return The active {@link Profile}
-     * @throws IOException
      * @see ProfileManagerDialog#getStartingProfile(java.awt.Frame)
      */
     public static Profile getStartingProfile() throws IOException {

--- a/java/src/jmri/profile/ProfileManagerDialog.java
+++ b/java/src/jmri/profile/ProfileManagerDialog.java
@@ -276,7 +276,6 @@ public class ProfileManagerDialog extends JDialog {
      *
      * @param f - The {@link java.awt.Frame} to display the dialog over.
      * @return the active or selected {@link Profile}
-     * @throws IOException
      * @see ProfileManager#getStartingProfile()
      */
     public static Profile getStartingProfile(Frame f) throws IOException {

--- a/java/src/jmri/script/JmriScriptEngineManager.java
+++ b/java/src/jmri/script/JmriScriptEngineManager.java
@@ -237,7 +237,6 @@ public final class JmriScriptEngineManager {
      * Evaluate a script using the given ScriptEngine.
      *
      * @return
-     * @throws ScriptException
      */
     public Object eval(String script, ScriptEngine engine) throws ScriptException {
         if (PYTHON.equals(engine.getFactory().getEngineName()) && this.jython != null) {
@@ -251,7 +250,6 @@ public final class JmriScriptEngineManager {
      * Evaluate a script using the given ScriptEngine.
      *
      * @return
-     * @throws ScriptException
      */
     public Object eval(Reader reader, ScriptEngine engine) throws ScriptException {
         return engine.eval(reader);
@@ -262,9 +260,6 @@ public final class JmriScriptEngineManager {
      * determine which ScriptEngine to use.
      *
      * @return
-     * @throws ScriptException
-     * @throws FileNotFoundException
-     * @throws IOException
      */
     public Object eval(File file) throws ScriptException, FileNotFoundException, IOException {
         ScriptEngine engine = this.getEngineByExtension(FilenameUtils.getExtension(file.getName()));
@@ -285,9 +280,6 @@ public final class JmriScriptEngineManager {
      * extension of the file to determine which ScriptEngine to use.
      *
      * @return
-     * @throws ScriptException
-     * @throws FileNotFoundException
-     * @throws IOException
      */
     public Object eval(File file, Bindings n) throws ScriptException, FileNotFoundException, IOException {
         ScriptEngine engine = this.getEngineByExtension(FilenameUtils.getExtension(file.getName()));
@@ -308,9 +300,6 @@ public final class JmriScriptEngineManager {
      * use.
      *
      * @return
-     * @throws ScriptException
-     * @throws FileNotFoundException
-     * @throws IOException
      */
     public Object eval(File file, ScriptContext context) throws ScriptException, FileNotFoundException, IOException {
         ScriptEngine engine = this.getEngineByExtension(FilenameUtils.getExtension(file.getName()));

--- a/java/src/jmri/script/JmriScriptEngineManager.java
+++ b/java/src/jmri/script/JmriScriptEngineManager.java
@@ -236,7 +236,6 @@ public final class JmriScriptEngineManager {
     /**
      * Evaluate a script using the given ScriptEngine.
      *
-     * @return
      */
     public Object eval(String script, ScriptEngine engine) throws ScriptException {
         if (PYTHON.equals(engine.getFactory().getEngineName()) && this.jython != null) {
@@ -249,7 +248,6 @@ public final class JmriScriptEngineManager {
     /**
      * Evaluate a script using the given ScriptEngine.
      *
-     * @return
      */
     public Object eval(Reader reader, ScriptEngine engine) throws ScriptException {
         return engine.eval(reader);
@@ -259,7 +257,6 @@ public final class JmriScriptEngineManager {
      * Evaluate a script contained in a file. Uses the extension of the file to
      * determine which ScriptEngine to use.
      *
-     * @return
      */
     public Object eval(File file) throws ScriptException, FileNotFoundException, IOException {
         ScriptEngine engine = this.getEngineByExtension(FilenameUtils.getExtension(file.getName()));
@@ -279,7 +276,6 @@ public final class JmriScriptEngineManager {
      * {@link javax.script.Bindings} to add to the script's context. Uses the
      * extension of the file to determine which ScriptEngine to use.
      *
-     * @return
      */
     public Object eval(File file, Bindings n) throws ScriptException, FileNotFoundException, IOException {
         ScriptEngine engine = this.getEngineByExtension(FilenameUtils.getExtension(file.getName()));
@@ -299,7 +295,6 @@ public final class JmriScriptEngineManager {
      * script. Uses the extension of the file to determine which ScriptEngine to
      * use.
      *
-     * @return
      */
     public Object eval(File file, ScriptContext context) throws ScriptException, FileNotFoundException, IOException {
         ScriptEngine engine = this.getEngineByExtension(FilenameUtils.getExtension(file.getName()));

--- a/java/src/jmri/server/json/JsonClientHandler.java
+++ b/java/src/jmri/server/json/JsonClientHandler.java
@@ -139,7 +139,6 @@ public class JsonClientHandler {
      * off in the form: <code>{"type":"goodbye"}</code> to which an identical
      * response is sent before the connection gets closed.</li></ul>
      *
-     * @throws IOException
      */
     public void onMessage(String string) throws IOException {
         log.debug("Received from client: {}", string);
@@ -157,7 +156,6 @@ public class JsonClientHandler {
      * See {@link #onMessage(java.lang.String) } for expected JSON objects.
      *
      * @see #onMessage(java.lang.String)
-     * @throws IOException
      */
     public void onMessage(JsonNode root) throws IOException {
         try {

--- a/java/src/jmri/server/json/JsonConnection.java
+++ b/java/src/jmri/server/json/JsonConnection.java
@@ -38,7 +38,6 @@ public class JsonConnection extends JmriConnection {
      * This method throws an IOException so the server or servlet holding the
      * connection open can respond to the exception.
      *
-     * @throws IOException
      */
     public void sendMessage(JsonNode message) throws IOException {
         super.sendMessage(this.getObjectMapper().writeValueAsString(message));

--- a/java/src/jmri/server/json/JsonHttpService.java
+++ b/java/src/jmri/server/json/JsonHttpService.java
@@ -36,7 +36,6 @@ public abstract class JsonHttpService {
      * @param name   the name of the requested object.
      * @param locale the requesting client's Locale.
      * @return a JSON description of the requested object.
-     * @throws JsonException
      */
     public abstract JsonNode doGet(String type, String name, Locale locale) throws JsonException;
 
@@ -53,7 +52,6 @@ public abstract class JsonHttpService {
      * @param locale the requesting client's Locale.
      * @return a JSON description of the requested object after updates have
      *         been applied.
-     * @throws JsonException
      */
     public abstract JsonNode doPost(String type, String name, JsonNode data, Locale locale) throws JsonException;
 
@@ -69,7 +67,6 @@ public abstract class JsonHttpService {
      *               created or updated.
      * @param locale the requesting client's Locale.
      * @return a JSON description of the requested object.
-     * @throws JsonException
      */
     public JsonNode doPut(String type, String name, JsonNode data, Locale locale) throws JsonException {
         throw new JsonException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, Bundle.getMessage(locale, "PutNotAllowed", type));
@@ -86,7 +83,6 @@ public abstract class JsonHttpService {
      * @param type   the type of the deleted object.
      * @param name   the name of the deleted object.
      * @param locale the requesting client's Locale.
-     * @throws JsonException
      */
     public void doDelete(String type, String name, Locale locale) throws JsonException {
         throw new JsonException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, Bundle.getMessage(locale, "DeleteNotAllowed", type));
@@ -104,7 +100,6 @@ public abstract class JsonHttpService {
      * @param type   the type of the requested list.
      * @param locale the requesting client's Locale.
      * @return a JSON list.
-     * @throws JsonException
      */
     public abstract JsonNode doGetList(String type, Locale locale) throws JsonException;
 }

--- a/java/src/jmri/server/json/route/JsonRouteHttpService.java
+++ b/java/src/jmri/server/json/route/JsonRouteHttpService.java
@@ -79,7 +79,6 @@ public class JsonRouteHttpService extends JsonHttpService {
      * @return a JSON description of the requested route. Since a route changes
      *         state on a separete thread, this may return a route in the state
      *         prior to this call, the target state, or an intermediate state.
-     * @throws JsonException
      */
     @Override
     public JsonNode doPost(String type, String name, JsonNode data, Locale locale) throws JsonException {

--- a/java/src/jmri/server/json/throttle/JsonThrottle.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottle.java
@@ -100,7 +100,6 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
      *                   client
      * @return The throttle
      * @throws jmri.server.json.JsonException
-     * @throws IOException
      */
     public static JsonThrottle getThrottle(String throttleId, JsonNode data, JsonThrottleSocketService server) throws JsonException, IOException {
         DccLocoAddress address = null;

--- a/java/src/jmri/util/FileUtil.java
+++ b/java/src/jmri/util/FileUtil.java
@@ -137,7 +137,6 @@ public final class FileUtil {
      * of returning null.
      *
      * @return {@link java.net.URL} at path
-     * @throws FileNotFoundException
      * @see #getFile(java.lang.String)
      * @see #getURI(java.lang.String)
      */
@@ -1016,8 +1015,6 @@ public final class FileUtil {
      *
      * @param file The text file.
      * @return The contents of the file.
-     * @throws FileNotFoundException
-     * @throws IOException
      */
     public static String readFile(File file) throws IOException {
         return FileUtil.readURL(FileUtil.fileToURL(file));
@@ -1029,8 +1026,6 @@ public final class FileUtil {
      *
      * @param url The text URL.
      * @return The contents of the file.
-     * @throws FileNotFoundException
-     * @throws IOException
      */
     public static String readURL(URL url) throws IOException {
         try {
@@ -1113,7 +1108,6 @@ public final class FileUtil {
      * for files.
      *
      * @param dest   must be the file, not the destination directory.
-     * @throws IOException
      */
     public static void copy(File source, File dest) throws IOException {
         if (!source.exists()) {

--- a/java/src/jmri/util/FileUtilSupport.java
+++ b/java/src/jmri/util/FileUtilSupport.java
@@ -278,7 +278,6 @@ public class FileUtilSupport extends Bean {
      * four revisions are retained. The lowest numbered revision is the most
      * recent.
      *
-     * @throws IOException
      */
     public void backup(File file) throws IOException {
         this.rotate(file, 4, "bak");
@@ -292,7 +291,6 @@ public class FileUtilSupport extends Bean {
      * @param extension The extension to use for the rotations. If null or an
      *                  empty string, the rotation number is used as the
      *                  extension.
-     * @throws IOException
      * @throws IllegalArgumentException if max is less than one
      * @see #backup(java.io.File) 
      */

--- a/java/src/jmri/util/Log4JUtil.java
+++ b/java/src/jmri/util/Log4JUtil.java
@@ -151,7 +151,6 @@ public class Log4JUtil {
      * This method sets the system property <i>jmri.log.path</i> to the JMRI
      * settings directory if not specified.
      *
-     * @throws IOException
      * @see jmri.util.FileUtil#getPreferencesPath()
      */
     static private void configureLogging(String config) throws IOException {

--- a/java/src/jmri/util/MultipartMessage.java
+++ b/java/src/jmri/util/MultipartMessage.java
@@ -53,7 +53,6 @@ public class MultipartMessage {
      *
      * @param requestURL URL to which this request should be sent
      * @param charSet    character set encoding of this message
-     * @throws IOException
      */
     public MultipartMessage(String requestURL, String charSet) throws IOException {
         this.charSet = charSet;
@@ -97,7 +96,6 @@ public class MultipartMessage {
      * @param fieldName  name attribute in form &lt;input name="{fieldName}"
      *                   type="file" /&gt;
      * @param uploadFile file to be uploaded
-     * @throws IOException
      */
     public void addFilePart(String fieldName, File uploadFile) throws IOException {
         addFilePart(fieldName, uploadFile, URLConnection.guessContentTypeFromName(uploadFile.getName()));
@@ -111,7 +109,6 @@ public class MultipartMessage {
      *                   type="file" /&gt;
      * @param uploadFile file to be uploaded
      * @param fileType   MIME type of file
-     * @throws IOException
      */
     public void addFilePart(String fieldName, File uploadFile, String fileType) throws IOException {
         log.debug("add file field: " + fieldName + "; file: " + uploadFile + "; type: " + fileType);

--- a/java/src/jmri/util/StringUtil.java
+++ b/java/src/jmri/util/StringUtil.java
@@ -273,7 +273,6 @@ public class StringUtil {
     /**
      * Sort String[] representing numbers, in ascending order.
      *
-     * @throws NumberFormatException
      */
     static public void numberSort(String[] values) throws NumberFormatException {
         for (int i = 0; i <= values.length - 2; i++) { // stop sort early to save time!

--- a/java/src/jmri/util/datatransfer/RosterEntrySelection.java
+++ b/java/src/jmri/util/datatransfer/RosterEntrySelection.java
@@ -94,8 +94,6 @@ public class RosterEntrySelection implements Transferable, ClipboardOwner {
      *
      * @param t - a Transferable object. This should be a RosterEntrySelection,
      *          but for simplicity, will accept any Transferable object.
-     * @throws UnsupportedFlavorException
-     * @throws IOException
      */
     public static ArrayList<RosterEntry> getRosterEntries(Transferable t) throws UnsupportedFlavorException, IOException {
         if (t.isDataFlavorSupported(rosterEntryFlavor)) {

--- a/java/src/jmri/util/davidflanagan/HardcopyWriter.java
+++ b/java/src/jmri/util/davidflanagan/HardcopyWriter.java
@@ -346,7 +346,6 @@ public class HardcopyWriter extends Writer {
      *
      * @param c the color desired for this String
      * @param s the String
-     * @throws IOException
      */
     public void write(Color c, String s) throws IOException {
         if (page != null) {

--- a/java/src/jmri/util/javamail/MailMessage.java
+++ b/java/src/jmri/util/javamail/MailMessage.java
@@ -128,7 +128,6 @@ public class MailMessage {
     /**
      * shows the protocol to be used connecting to the mailhost
      *
-     * @return
      */
     public String getProtocol() {
         return (this.pProtocol);
@@ -150,7 +149,6 @@ public class MailMessage {
     /**
      * shows if encryption will be used when connecting to the mailhost
      *
-     * @return
      */
     public boolean isTls() {
         return ((this.pTls.equals("true") ? true : false));
@@ -171,7 +169,6 @@ public class MailMessage {
     /**
      * shows if authorization will be used to the mailhost
      *
-     * @return
      */
     public boolean isAuth() {
         return ((this.pAuth.equals("true") ? true : false));

--- a/java/src/jmri/util/prefs/JmriPreferencesProvider.java
+++ b/java/src/jmri/util/prefs/JmriPreferencesProvider.java
@@ -137,7 +137,6 @@ public final class JmriPreferencesProvider {
      * Note that the first use of a node-specific setting can be different than
      * the first use of a multi-node setting.
      *
-     * @return
      */
     public boolean isFirstUse() {
         return this.firstUse;

--- a/java/src/jmri/util/xml/XMLUtil.java
+++ b/java/src/jmri/util/xml/XMLUtil.java
@@ -1012,7 +1012,6 @@ public final class XMLUtil extends Object {
      * 
      * @param from element to translate
      * @param namespace namespace to be translated to
-     * @return
      * 
      * @since 8.4
      */

--- a/java/src/jmri/web/servlet/ServletUtil.java
+++ b/java/src/jmri/web/servlet/ServletUtil.java
@@ -103,7 +103,6 @@ public class ServletUtil {
     /**
      * Write a file to the given response.
      *
-     * @throws IOException
      */
     public void writeFile(HttpServletResponse response, File file, String contentType) throws IOException {
         if (file.exists()) {

--- a/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
@@ -78,8 +78,6 @@ abstract class AbstractPanelServlet extends HttpServlet {
      * </li>
      * </ol>
      *
-     * @throws ServletException
-     * @throws IOException
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {

--- a/java/src/jmri/web/servlet/roster/RosterServlet.java
+++ b/java/src/jmri/web/servlet/roster/RosterServlet.java
@@ -76,8 +76,6 @@ public class RosterServlet extends HttpServlet {
     /**
      * Parse all HTTP GET requests and pass to appropriate method
      *
-     * @throws ServletException
-     * @throws IOException
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -103,8 +101,6 @@ public class RosterServlet extends HttpServlet {
     /**
      * Handle POST requests. POST requests are treated as GET requests.
      *
-     * @throws ServletException
-     * @throws IOException
      * @see #doGet(javax.servlet.http.HttpServletRequest,
      * javax.servlet.http.HttpServletResponse)
      */
@@ -130,8 +126,6 @@ public class RosterServlet extends HttpServlet {
      * <code>/roster/group/&lt;group%20name&gt;</code> with a JSON payload for
      * the filter.
      *
-     * @throws ServletException
-     * @throws IOException
      */
     protected void doGroup(HttpServletRequest request, HttpServletResponse response, String group) throws ServletException, IOException {
         log.debug("Getting group {}", group);
@@ -171,8 +165,6 @@ public class RosterServlet extends HttpServlet {
      * This method responds to POST URLs <code>/roster</code> and
      * <code>/roster/list</code> with a JSON payload for the filter.
      *
-     * @throws ServletException
-     * @throws IOException
      */
     protected void doList(HttpServletRequest request, HttpServletResponse response, Boolean groups) throws ServletException, IOException {
         ObjectNode data;
@@ -215,8 +207,6 @@ public class RosterServlet extends HttpServlet {
      * <li>height</li> <li>maxHeight</li> <li>minHeight</li> <li>width</li>
      * <li>maxWidth</li> <li>minWidth</li></ul>
      *
-     * @throws ServletException
-     * @throws IOException
      */
     protected void doEntry(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String[] pathInfo = request.getPathInfo().substring(1).split("/");
@@ -291,8 +281,6 @@ public class RosterServlet extends HttpServlet {
      * and {@link #doEntry(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
      * }.
      *
-     * @throws ServletException
-     * @throws IOException
      */
     protected void doRoster(HttpServletRequest request, HttpServletResponse response, JsonNode filter, Boolean groups) throws ServletException, IOException {
         ServletUtil.getInstance().setNonCachingHeaders(response);
@@ -378,8 +366,6 @@ public class RosterServlet extends HttpServlet {
      * returns a PNG image.
      *
      * @param file     {@link java.io.File} object containing an image
-     * @throws ServletException
-     * @throws IOException
      */
     void doImage(HttpServletRequest request, HttpServletResponse response, File file) throws ServletException, IOException {
         BufferedImage image;


### PR DESCRIPTION
Bulk remove of content-free @throws, @return statements, except for those in jmri.operations package.