### PR TITLE
DecoderPro: load variable values in addition to CV values

### DIFF
--- a/java/src/jmri/jmrit/roster/LocoFile.java
+++ b/java/src/jmri/jmrit/roster/LocoFile.java
@@ -205,6 +205,7 @@ class LocoFile extends XmlFile {
         for (int i = 0; i < varModel.getRowCount(); i++) {
             log.debug("  map put {} to {}", varModel.getItem(i), varModel.getVariable(i));
             map.put(varModel.getItem(i), varModel.getVariable(i));
+            map.put(varModel.getLabel(i), varModel.getVariable(i));
         }
                 
         for (Element element : decoderDef.getChildren("varValue")) {

--- a/java/src/jmri/jmrit/roster/LocoFile.java
+++ b/java/src/jmri/jmrit/roster/LocoFile.java
@@ -2,11 +2,9 @@ package jmri.jmrit.roster;
 
 import java.io.*;
 import java.util.List;
+import java.util.HashMap;
 import jmri.jmrit.XmlFile;
-import jmri.jmrit.symbolicprog.CvTableModel;
-import jmri.jmrit.symbolicprog.CvValue;
-import jmri.jmrit.symbolicprog.IndexedCvTableModel;
-import jmri.jmrit.symbolicprog.VariableTableModel;
+import jmri.jmrit.symbolicprog.*;
 import org.jdom2.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -197,12 +195,43 @@ class LocoFile extends XmlFile {
         }
         
         
-        // get the CV values and load
+        // get the Variable values and load
         if (log.isDebugEnabled()) {
             log.debug("Found " + decoderDef.getChildren("varValue").size() + " varValue elements");
         }
 
+        // preload an index
+        HashMap<String, VariableValue> map = new HashMap<>();
+        for (int i = 0; i < varModel.getRowCount(); i++) {
+            log.debug("  map put {} to {}", varModel.getItem(i), varModel.getVariable(i));
+            map.put(varModel.getItem(i), varModel.getVariable(i));
+        }
+                
         for (Element element : decoderDef.getChildren("varValue")) {
+            // locate the row
+            if (element.getAttribute("item") == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("unexpected null in item {} {}", element, element.getAttributes());
+                }
+                break;
+            }
+            if (element.getAttribute("value") == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("unexpected null in value {} {}", element, element.getAttributes());
+                }
+                break;
+            }
+
+            String item = element.getAttribute("item").getValue();
+            String value = element.getAttribute("value").getValue();
+            log.debug("Variable \"{}\" has value: {}", item, value);
+            
+            VariableValue var = map.get(item);
+            if (var != null) {
+                var.setValue(value);
+            } else {
+                log.warn("Did not find locofile variable \"{}\" in decoder definition, not loading", item);
+            }
         }
 
     }

--- a/java/src/jmri/jmrit/roster/LocoFile.java
+++ b/java/src/jmri/jmrit/roster/LocoFile.java
@@ -173,6 +173,41 @@ class LocoFile extends XmlFile {
     }
 
     /**
+     * Load a VariableTableModel from the locomotive element in the File
+     *
+     * @param loco    A JDOM Element containing the locomotive definition
+     * @param varModel An existing VariableTableModel object
+     */
+    public static void loadVariableModel(Element loco, VariableTableModel varModel) {
+
+        Element values = loco.getChild("values");
+
+        if (values == null) {
+            String rosterName = loco.getAttributeValue("id");
+            log.error("no values element found in config file; Variable values not loaded for \"{}\"", loco.getAttributeValue("id"));
+            return;
+        }
+        
+        Element decoderDef = values.getChild("decoderDef");
+
+        if (decoderDef == null) {
+            String rosterName = loco.getAttributeValue("id");
+            log.error("no decoderDef element found in config file; Variable values not loaded for \"{}\"", loco.getAttributeValue("id"));
+            return;
+        }
+        
+        
+        // get the CV values and load
+        if (log.isDebugEnabled()) {
+            log.debug("Found " + decoderDef.getChildren("varValue").size() + " varValue elements");
+        }
+
+        for (Element element : decoderDef.getChildren("varValue")) {
+        }
+
+    }
+
+    /**
      * Write an XML version of this object, including also the RosterEntry
      * information, and memory-resident decoder contents.
      *

--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -113,9 +113,7 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
     protected int _maxSpeedPCT = 100;
 
     /**
-     *
-     * @return @deprecated since 4.1.4 use {@link jmri.jmrit.roster.RosterConfigManager#getDefaultOwner()
-     * } instead
+     * @deprecated since 4.1.4 use {@link jmri.jmrit.roster.RosterConfigManager#getDefaultOwner()} instead
      */
     @Deprecated
     public static String getDefaultOwner() {
@@ -123,9 +121,7 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
     }
 
     /**
-     *
-     * @deprecated since 4.1.4 use {@link jmri.jmrit.roster.RosterConfigManager#setDefaultOwner(java.lang.String)
-     * } instead
+     * @deprecated since 4.1.4 use {@link jmri.jmrit.roster.RosterConfigManager#setDefaultOwner(java.lang.String)} instead
      */
     @Deprecated
     public static void setDefaultOwner(String n) {
@@ -161,7 +157,6 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
 
     /**
      * Construct a blank object.
-     *
      */
     public RosterEntry() {
     }

--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -1214,12 +1214,12 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
     private Element mRootElement = null;
 
     /**
-     * Load a pre-existing CvTableModel object with the CV contents of this
+     * Load pre-existing Variable and CvTableModel object with the contents of this
      * entry
      *
      * @param cvModel  Model to load, must exist
      */
-    public void loadCvModel(CvTableModel cvModel, IndexedCvTableModel iCvModel) {
+    public void loadCvModel(VariableTableModel varModel, CvTableModel cvModel, IndexedCvTableModel iCvModel) {
         if (cvModel == null) {
             log.error("loadCvModel must be given a non-null argument");
             return;
@@ -1229,6 +1229,10 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
             return;
         }
         try {
+            if (varModel != null) {
+                LocoFile.loadVariableModel(mRootElement.getChild("locomotive"), varModel);
+            }
+
             LocoFile.loadCvModel(mRootElement.getChild("locomotive"), cvModel, iCvModel, getDecoderFamily());
         } catch (Exception ex) {
             log.error("Error reading roster entry", ex);

--- a/java/src/jmri/jmrit/symbolicprog/CompositeVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/CompositeVariableValue.java
@@ -131,11 +131,6 @@ public class CompositeVariableValue extends EnumVariableValue implements ActionL
      */
     static class SettingList extends ArrayList<Setting> {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = -931774092092164586L;
-
         public SettingList() {
             super();
             if (log.isDebugEnabled()) {

--- a/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
  * Decimal representation of a value.
  *
  * @author	Bob Jacobsen Copyright (C) 2001
- *
  */
 public class DecVariableValue extends VariableValue
         implements ActionListener, PropertyChangeListener, FocusListener {
@@ -386,14 +385,8 @@ public class DecVariableValue extends VariableValue
      * an underlying variable
      *
      * @author			Bob Jacobsen   Copyright (C) 2001
-     * @version
      */
     public class VarTextField extends JTextField {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 7844901319795104952L;
 
         VarTextField(Document doc, String text, int col, DecVariableValue var) {
             super(doc, text, col);

--- a/java/src/jmri/jmrit/symbolicprog/IndexedEnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/IndexedEnumVariableValue.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Howard G. Penny Copyright (C) 2005
  * @author	Bob Jacobsen Copyright (C) 2013
- * @deprecated // since 3.7.1
+ * @deprecated since 3.7.1
  *
  */
 @Deprecated // since 3.7.1
@@ -586,14 +586,9 @@ public class IndexedEnumVariableValue extends VariableValue
      * model between this object and the real JComboBox value.
      *
      * @author  Bob Jacobsen   Copyright (C) 2001
-     * @version $Revision$
      */
     public static class IVarComboBox extends JComboBox<String> {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = 2425259609787639833L;
         IndexedEnumVariableValue _var;
         transient java.beans.PropertyChangeListener _l = null;
 

--- a/java/src/jmri/jmrit/symbolicprog/IndexedPairVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/IndexedPairVariableValue.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Howard G. Penny Copyright (C) 2005
  * @author Bob Jacobsen Copyright (C) 2013
- * @deprecated // since 3.7.1
+ * @deprecated since 3.7.1
  *
  */
 @Deprecated // since 3.7.1
@@ -778,14 +778,8 @@ public class IndexedPairVariableValue extends VariableValue
      * an underlying variable
      *
      * @author	Bob Jacobsen   Copyright (C) 2001
-     * @version     $Revision$
      */
     public class VarTextField extends JTextField {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 1338720766156931900L;
 
         VarTextField(Document doc, String text, int col, IndexedPairVariableValue var) {
             super(doc, text, col);

--- a/java/src/jmri/jmrit/symbolicprog/IndexedVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/IndexedVariableValue.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Howard G. Penny Copyright (C) 2005
  * @author Bob Jacobsen Copyright (C) 2010, 2013
- * @deprecated // since 3.7.1
+ * @deprecated since 3.7.1
  */
 @Deprecated // since 3.7.1
 public class IndexedVariableValue extends VariableValue
@@ -587,14 +587,8 @@ public class IndexedVariableValue extends VariableValue
      * an underlying variable
      *
      * @author	Bob Jacobsen   Copyright (C) 2001
-     * @version     $Revision$
      */
     public class VarTextField extends JTextField {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 2882756295414352651L;
 
         VarTextField(Document doc, String text, int col, IndexedVariableValue var) {
             super(doc, text, col);

--- a/java/src/jmri/jmrit/symbolicprog/ResetTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/ResetTableModel.java
@@ -27,11 +27,6 @@ import org.slf4j.LoggerFactory;
  */
 public class ResetTableModel extends AbstractTableModel implements ActionListener, PropertyChangeListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5802447765323835861L;
-
     private String headers[] = {"Label", "Name",
         "PI", "PIvalue",
         "SI", "SIvalue",

--- a/java/src/jmri/jmrit/symbolicprog/SpeedTableVarValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SpeedTableVarValue.java
@@ -68,12 +68,9 @@ import org.slf4j.LoggerFactory;
  * from; it should be removed.
  * <P>
  * @author	Bob Jacobsen, Alex Shepherd Copyright (C) 2001, 2004, 2013
- * @author Dave Heap Copyright (C) 2012 Added support for Marklin mfx style
- * speed table
- * @author Dave Heap Copyright (C) 2013 Changes to fix mfx speed table issue
- * (Vstart {@literal &} Vhigh not written)
- * @author Dave Heap - generate cvList array to incorporate Vstart {@literal &}
- * Vhigh
+ * @author Dave Heap Copyright (C) 2012 Added support for Marklin mfx style speed table
+ * @author Dave Heap Copyright (C) 2013 Changes to fix mfx speed table issue (Vstart {@literal &} Vhigh not written)
+ * @author Dave Heap - generate cvList array to incorporate Vstart {@literal &} Vhigh
  *
  */
 public class SpeedTableVarValue extends VariableValue implements PropertyChangeListener, ChangeListener {
@@ -855,14 +852,8 @@ public class SpeedTableVarValue extends VariableValue implements PropertyChangeL
      * a CV state, not a variable.
      *
      * @author			Bob Jacobsen   Copyright (C) 2001
-     * @version
      */
     public class VarSlider extends JSlider {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 7077272684236102449L;
 
         VarSlider(BoundedRangeModel m, CvValue var, int step) {
             super(m);

--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -508,11 +508,6 @@ public class SplitVariableValue extends VariableValue
      */
     public class VarTextField extends JTextField {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = -4853000377889737952L;
-
         VarTextField(Document doc, String text, int col, SplitVariableValue var) {
             super(doc, text, col);
             _var = var;

--- a/java/src/jmri/jmrit/symbolicprog/ValueEditor.java
+++ b/java/src/jmri/jmrit/symbolicprog/ValueEditor.java
@@ -32,10 +32,6 @@ import org.slf4j.LoggerFactory;
  */
 public class ValueEditor extends JComboBox<Object> implements TableCellEditor, FocusListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8132350187940404655L;
     protected transient Vector<CellEditorListener> listeners;
     protected transient String originalValue = null;
     protected Object mValue;

--- a/java/src/jmri/jmrit/symbolicprog/VariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableValue.java
@@ -72,6 +72,22 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
      */
     abstract public void setIntValue(int i);
 
+    /** 
+     * Set value from a String value.
+     * <p>
+     * The current implementation is a stand-in.  Note that 
+     * e.g. Speed Tables don't use a single Int, so will 
+     * just be skipped. The solution to that is to overload this in 
+     * complicated variable types.
+     */
+    public void setValue(String value) {
+        try {
+            int val = Integer.parseInt(value);
+        } catch ( NumberFormatException e) {
+            log.debug("skipping set of non-integer value \"{}\"", value);
+        }
+    }
+    
     /**
      * Get the value as a single number.
      *

--- a/java/src/jmri/jmrit/symbolicprog/autospeed/AutoSpeedAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/autospeed/AutoSpeedAction.java
@@ -1,4 +1,3 @@
-// AutoSpeedAction.java
 package jmri.jmrit.symbolicprog.autospeed;
 
 import java.awt.event.ActionEvent;
@@ -28,14 +27,9 @@ import org.slf4j.LoggerFactory;
  * @see jmri.jmrit.symbolicprog.tabbedframe.PaneOpsProgAction
  *
  * @author	Bob Jacobsen Copyright (C) 2001
- * @version	$Revision$
  */
 public class AutoSpeedAction extends AbstractAction {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 9045736525279746469L;
     Object o1, o2, o3, o4;
     JLabel statusLabel;
 
@@ -70,11 +64,6 @@ public class AutoSpeedAction extends AbstractAction {
 
         // known loco on main track
         JPanel pane1 = new KnownLocoSelPane(false) {  // no ident in ops mode yet
-
-            /**
-             *
-             */
-            private static final long serialVersionUID = -4507849769156281853L;
 
             protected void startProgrammer(DecoderFile decoderFile, RosterEntry re,
                     String filename) {
@@ -112,5 +101,3 @@ public class AutoSpeedAction extends AbstractAction {
     private final static Logger log = LoggerFactory.getLogger(AutoSpeedAction.class.getName());
 
 }
-
-/* @(#)AutoSpeedAction.java */

--- a/java/src/jmri/jmrit/symbolicprog/symbolicframe/SymbolicProgAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/symbolicframe/SymbolicProgAction.java
@@ -1,23 +1,14 @@
-/**
- * SymbolicProgAction.java
- *
- * Description:	Swing action to create and register a SymbolicProg object
- *
- * @author	Bob Jacobsen Copyright (C) 2001
- * @version	$Revision$
- */
 package jmri.jmrit.symbolicprog.symbolicframe;
 
 import java.awt.event.ActionEvent;
 import javax.swing.AbstractAction;
 
+/**
+ * Swing action to create and register a SymbolicProg object
+ *
+ * @author	Bob Jacobsen Copyright (C) 2001
+ */
 public class SymbolicProgAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4028779777781438509L;
-
     public SymbolicProgAction(String s) {
         super(s);
     }
@@ -30,6 +21,3 @@ public class SymbolicProgAction extends AbstractAction {
 
     }
 }
-
-
-/* @(#)SymbolicProgAction.java */

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneEditAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneEditAction.java
@@ -57,10 +57,6 @@ public class PaneEditAction extends AbstractAction {
 
         // known entry, no programmer
         JPanel pane1 = new KnownLocoSelPane(false) {  // not programming
-            /**
-             *
-             */
-            private static final long serialVersionUID = 5342530851054805325L;
 
             protected void startProgrammer(DecoderFile decoderFile, RosterEntry re,
                     String filename) {
@@ -68,10 +64,6 @@ public class PaneEditAction extends AbstractAction {
                 JFrame p = new PaneProgFrame(decoderFile, re,
                         title, "programmers" + File.separator + filename + ".xml",
                         null, false) {
-                            /**
-                             *
-                             */
-                            private static final long serialVersionUID = 8759999350875150400L;
 
                             protected JPanel getModePane() {
                                 return null;

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneNewProgAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneNewProgAction.java
@@ -65,10 +65,6 @@ public class PaneNewProgAction extends AbstractAction {
 
         // new Loco on programming track
         JPanel pane1 = new LocoSelTreePane(null, null) {
-            /**
-             *
-             */
-            private static final long serialVersionUID = -3304246544040107635L;
 
             protected void startProgrammer(DecoderFile decoderFile, RosterEntry re,
                     String filename) {
@@ -76,10 +72,6 @@ public class PaneNewProgAction extends AbstractAction {
                 JFrame p = new PaneProgFrame(decoderFile, re,
                         title, "programmers" + File.separator + filename + ".xml",
                         null, false) {
-                            /**
-                             *
-                             */
-                            private static final long serialVersionUID = -4093978952107929146L;
 
                             protected JPanel getModePane() {
                                 return null;

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneOpsProgAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneOpsProgAction.java
@@ -76,11 +76,6 @@ public class PaneOpsProgAction extends AbstractAction {
         // known loco on main track
         JPanel pane1 = new KnownLocoSelPane(false) {  // no ident in ops mode yet
 
-            /**
-             *
-             */
-            private static final long serialVersionUID = 2816965509649056116L;
-
             protected void startProgrammer(DecoderFile decoderFile, RosterEntry re,
                     String filename) {
                 String title = java.text.MessageFormat.format(SymbolicProgBundle.getMessage("FrameOpsProgrammerTitle"),

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgAction.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgAction.java
@@ -36,10 +36,6 @@ import org.slf4j.LoggerFactory;
  */
 public class PaneProgAction extends AbstractAction {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6931284008411705904L;
     Object o1, o2, o3, o4;
     JLabel statusLabel;
     jmri.jmrit.progsupport.ProgModeSelector modePane = new jmri.jmrit.progsupport.ProgServiceModeComboBox();
@@ -93,10 +89,6 @@ public class PaneProgAction extends AbstractAction {
 
         // new Loco on programming track
         JPanel pane1 = new CombinedLocoSelTreePane(statusLabel, modePane) {
-            /**
-             *
-             */
-            private static final long serialVersionUID = -4214840180299703440L;
 
             protected void startProgrammer(DecoderFile decoderFile, RosterEntry re,
                     String filename) {

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
@@ -438,9 +438,9 @@ abstract public class PaneProgFrame extends JmriJFrame
         // save default values
         saveDefaults();
 
-        // finally fill the CV values from the specific loco file
+        // finally fill the Variable and CV values from the specific loco file
         if (_rosterEntry.getFileName() != null) {
-            _rosterEntry.loadCvModel(cvModel, iCvModel);
+            _rosterEntry.loadCvModel(variableModel, cvModel, iCvModel);
         }
 
         // mark file state as consistent

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneSet.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneSet.java
@@ -65,9 +65,9 @@ public class PaneSet {
         // load from decoder file
         loadDecoderFromLoco(re);
 
-        // fill the CV values from the specific loco file
+        // finally fill the Variable and CV values from the specific loco file
         if (re.getFileName() != null) {
-            re.loadCvModel(cvModel, iCvModel);
+            re.loadCvModel(variableModel, cvModel, iCvModel);
         }
     }
 

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneSet.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneSet.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Interface for the container of a set of PaneProgPanes. The panes use services
  * provided here to work with buttons and the busy cursor.
- *
+ * <p>
  * TODO: Several methods are copied from PaneProgFrame and should be refactored
  * No programmer support yet No glass pane support Need better support for
  * visible/non-visible panes Special panes (Roster entry, attributes, graphics)
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PaneSet {
 
-    List<PaneProgPane> paneList = new ArrayList<PaneProgPane>();
+    List<PaneProgPane> paneList = new ArrayList<>();
     PaneContainer container;
     Programmer mProgrammer;
     CvTableModel cvModel = null;

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/WatchingLabel.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/WatchingLabel.java
@@ -1,4 +1,3 @@
-// WatchingLabel.java
 package jmri.jmrit.symbolicprog.tabbedframe;
 
 /**
@@ -6,15 +5,8 @@ package jmri.jmrit.symbolicprog.tabbedframe;
  * other component is
  *
  * @author	Bob Jacobsen Copyright (C) 2010
- * @version	$Revision$
- *
  */
 public class WatchingLabel extends javax.swing.JLabel {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1571754037047065268L;
 
     public WatchingLabel(String name, javax.swing.JComponent c) {
         super(name);

--- a/java/src/jmri/jmrit/vsdecoder/VSDConfigPanel.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDConfigPanel.java
@@ -1,23 +1,5 @@
 package jmri.jmrit.vsdecoder;
 
-/*
- * <hr>
- * This file is part of JMRI.
- * <P>
- * JMRI is free software; you can redistribute it and/or modify it under 
- * the terms of version 2 of the GNU General Public License as published 
- * by the Free Software Foundation. See the "COPYING" file for a copy
- * of this license.
- * <P>
- * JMRI is distributed in the hope that it will be useful, but WITHOUT 
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
- * for more details.
- * <P>
- *
- * @author			Mark Underwood Copyright (C) 2011
- * @version			$Revision$
- */
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
@@ -44,7 +26,24 @@ import jmri.util.swing.JmriPanel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings({"serial", "deprecation"})
+/*
+ * <hr>
+ * This file is part of JMRI.
+ * <P>
+ * JMRI is free software; you can redistribute it and/or modify it under 
+ * the terms of version 2 of the GNU General Public License as published 
+ * by the Free Software Foundation. See the "COPYING" file for a copy
+ * of this license.
+ * <P>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
+ * for more details.
+ * <P>
+ *
+ * @author			Mark Underwood Copyright (C) 2011
+ */
+@SuppressWarnings("deprecation")
 public class VSDConfigPanel extends JmriPanel {
 
     private static final ResourceBundle vsdecoderBundle = VSDecoderBundle.bundle();
@@ -136,7 +135,7 @@ public class VSDConfigPanel extends JmriPanel {
         }
 
         // This is a bit tedious...
-        ArrayList<String> ce_list = new ArrayList<String>();
+        ArrayList<String> ce_list = new ArrayList<>();
         for (int i = 0; i < profileComboBox.getItemCount(); i++) {
             ce_list.add(profileComboBox.getItemAt(i).toString());
         }
@@ -173,7 +172,7 @@ public class VSDConfigPanel extends JmriPanel {
 
         log.warn("updating the profile list.");
 
-        profileComboBox.setModel(new DefaultComboBoxModel<Object>());
+        profileComboBox.setModel(new DefaultComboBoxModel<>());
         Iterator<String> itr = s.iterator();
         while (itr.hasNext()) {
 
@@ -275,10 +274,10 @@ public class VSDConfigPanel extends JmriPanel {
         addressSetButton = new javax.swing.JButton();
         addressSelector = new DccLocoAddressSelector();
 
-        profileComboBox = new javax.swing.JComboBox<Object>();
+        profileComboBox = new javax.swing.JComboBox<>();
         profileLabel = new javax.swing.JLabel();
 
-        profileComboBox.setModel(new javax.swing.DefaultComboBoxModel<Object>());
+        profileComboBox.setModel(new javax.swing.DefaultComboBoxModel<>());
         // Add any already-loaded profile names
         ArrayList<String> sl = VSDecoderManager.instance().getVSDProfileNames();
         if (sl.isEmpty()) {

--- a/java/src/jmri/jmrit/vsdecoder/VSDConfigPanel.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDConfigPanel.java
@@ -427,7 +427,7 @@ public class VSDConfigPanel extends JmriPanel {
         if (_rosterEntry.getFileName() != null) {
             // set the loco file name in the roster entry
             _rosterEntry.readFile();  // read, but don't yet process
-            _rosterEntry.loadCvModel(cvModel, iCvModel);
+            _rosterEntry.loadCvModel(variableModel, cvModel, iCvModel);
         }
 
         // id has to be set!

--- a/java/src/jmri/jmrit/vsdecoder/VSDConfigPanel.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDConfigPanel.java
@@ -417,7 +417,7 @@ public class VSDConfigPanel extends JmriPanel {
     protected boolean storeFile(RosterEntry _rosterEntry) {
         log.debug("storeFile starts");
         // We need to create a programmer, a cvTableModel, an iCvTableModel, and a variableTableModel.
-        // Doesn't matter which, so we'll use the LocoNet programmer.
+        // Doesn't matter which, so we'll use the Global programmer.
         Programmer p = InstanceManager.programmerManagerInstance().getGlobalProgrammer();
         CvTableModel cvModel = new CvTableModel(null, p);
         IndexedCvTableModel iCvModel = new IndexedCvTableModel(null, p);

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
@@ -1,29 +1,5 @@
 package jmri.jmrit.vsdecoder.swing;
 
-/**
- * class VSDConfigDialog
- *
- * Configuration dialog for setting up a new VSDecoder
- */
-
-/*
- * <hr>
- * This file is part of JMRI.
- * <P>
- * JMRI is free software; you can redistribute it and/or modify it under 
- * the terms of version 2 of the GNU General Public License as published 
- * by the Free Software Foundation. See the "COPYING" file for a copy
- * of this license.
- * <P>
- * JMRI is distributed in the hope that it will be useful, but WITHOUT 
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
- * for more details.
- * <P>
- *
- * @author			Mark Underwood Copyright (C) 2011
- * @version			$Revision: 21510 $
- */
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -61,20 +37,33 @@ import jmri.jmrit.vsdecoder.VSDecoderManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Configuration dialog for setting up a new VSDecoder
+ * <hr>
+ * This file is part of JMRI.
+ * <P>
+ * JMRI is free software; you can redistribute it and/or modify it under 
+ * the terms of version 2 of the GNU General Public License as published 
+ * by the Free Software Foundation. See the "COPYING" file for a copy
+ * of this license.
+ * <P>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
+ * for more details.
+ * <P>
+ *
+ * @author			Mark Underwood Copyright (C) 2011
+ */
 @SuppressWarnings("deprecation")
 public class VSDConfigDialog extends JDialog {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3891269629328182031L;
 
     private static final ResourceBundle rb = VSDSwingBundle.bundle();
 
     public static final String CONFIG_PROPERTY = "Config";
 
     // Map of Mnemonic KeyEvent values to GUI Components
-    private static final Map<String, Integer> Mnemonics = new HashMap<String, Integer>();
+    private static final Map<String, Integer> Mnemonics = new HashMap<>();
 
     static {
         Mnemonics.put("RosterTab", KeyEvent.VK_R);
@@ -192,7 +181,7 @@ public class VSDConfigDialog extends JDialog {
         // Profile select Pane
         profilePanel = new JPanel();
         profilePanel.setLayout(new BoxLayout(profilePanel, BoxLayout.PAGE_AXIS));
-        profileComboBox = new javax.swing.JComboBox<Object>();
+        profileComboBox = new javax.swing.JComboBox<>();
         profileComboBox.setToolTipText(rb.getString("ProfileComboBoxToolTip"));
         profileLabel = new javax.swing.JLabel();
         profileLoadButton = new JButton(rb.getString("LoadVSDFileButtonLabel"));
@@ -204,7 +193,7 @@ public class VSDConfigDialog extends JDialog {
         title.setTitlePosition(TitledBorder.DEFAULT_POSITION);
         profilePanel.setBorder(title2);
 
-        profileComboBox.setModel(new javax.swing.DefaultComboBoxModel<Object>());
+        profileComboBox.setModel(new javax.swing.DefaultComboBoxModel<>());
         // Add any already-loaded profile names
         ArrayList<String> sl = VSDecoderManager.instance().getVSDProfileNames();
         if (sl.isEmpty()) {
@@ -418,7 +407,7 @@ public class VSDConfigDialog extends JDialog {
 
         // This is a bit tedious...
         // Pull all of the existing names from the Profile ComboBox
-        ArrayList<String> ce_list = new ArrayList<String>();
+        ArrayList<String> ce_list = new ArrayList<>();
         for (int i = 0; i < profileComboBox.getItemCount(); i++) {
             ce_list.add(profileComboBox.getItemAt(i).toString());
         }

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
@@ -488,7 +488,7 @@ public class VSDConfigDialog extends JDialog {
         if (_rosterEntry.getFileName() != null) {
             // set the loco file name in the roster entry
             _rosterEntry.readFile();  // read, but don't yet process
-            _rosterEntry.loadCvModel(cvModel, iCvModel);
+            _rosterEntry.loadCvModel(variableModel, cvModel, iCvModel);
         }
 
         // id has to be set!

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDConfigDialog.java
@@ -478,7 +478,7 @@ public class VSDConfigDialog extends JDialog {
     protected boolean storeFile(RosterEntry _rosterEntry) {
         log.debug("storeFile starts");
         // We need to create a programmer, a cvTableModel, an iCvTableModel, and a variableTableModel.
-        // Doesn't matter which, so we'll use the LocoNet programmer.
+        // Doesn't matter which, so we'll use the Global programmer.
         Programmer p = InstanceManager.programmerManagerInstance().getGlobalProgrammer();
         CvTableModel cvModel = new CvTableModel(null, p);
         IndexedCvTableModel iCvModel = new IndexedCvTableModel(null, p);

--- a/java/src/jmri/jmrix/grapevine/GrapevineMenu.java
+++ b/java/src/jmri/jmrix/grapevine/GrapevineMenu.java
@@ -1,4 +1,3 @@
-// GrapevineMenu.java
 package jmri.jmrix.grapevine;
 
 import java.util.ResourceBundle;
@@ -8,14 +7,8 @@ import javax.swing.JMenu;
  * Create a "Systems" menu containing the Jmri Grapevine-specific tools
  *
  * @author	Bob Jacobsen Copyright 2003, 2006, 2007
- * @version $Revision$
  */
 public class GrapevineMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4017450895998949082L;
 
     public GrapevineMenu(String name) {
         this();

--- a/java/src/jmri/jmrix/grapevine/SerialLight.java
+++ b/java/src/jmri/jmrix/grapevine/SerialLight.java
@@ -1,4 +1,3 @@
-// SerialLight.java
 package jmri.jmrix.grapevine;
 
 import jmri.implementation.AbstractLight;
@@ -13,14 +12,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dave Duchamp Copyright (C) 2004
  * @author Bob Jacobsen Copyright (C) 2006, 2007, 2008
- * @version $Revision$
  */
 public class SerialLight extends AbstractLight {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1633282673542762421L;
 
     /**
      * Create a Light object, with only system name.
@@ -119,5 +112,3 @@ public class SerialLight extends AbstractLight {
 
     private final static Logger log = LoggerFactory.getLogger(SerialLight.class.getName());
 }
-
-/* @(#)SerialLight.java */

--- a/java/src/jmri/jmrix/jmriclient/swing/packetgen/PacketGenFrame.java
+++ b/java/src/jmri/jmrix/jmriclient/swing/packetgen/PacketGenFrame.java
@@ -1,4 +1,3 @@
-// JMRIClientPacketGenFrame.java
 package jmri.jmrix.jmriclient.swing.packetgen;
 
 import java.awt.Dimension;
@@ -11,14 +10,9 @@ import jmri.jmrix.jmriclient.JMRIClientTrafficController;
  * Description:	Frame for user input of JMRIClient messages
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version	$Revision$
  */
 public class PacketGenFrame extends jmri.util.JmriJFrame implements jmri.jmrix.jmriclient.JMRIClientListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5887061407912166629L;
     // member declarations
     javax.swing.JLabel jLabel1 = new javax.swing.JLabel();
     javax.swing.JButton sendButton = new javax.swing.JButton();

--- a/java/src/jmri/jmrix/lenz/XNetMessageException.java
+++ b/java/src/jmri/jmrix/lenz/XNetMessageException.java
@@ -1,21 +1,11 @@
-/**
- * XNetMessageException.java
- *
- * Description:		<describe the JmriException class here>
- *
- * @author	Bob Jacobsen Copyright (C) 2002
- * @version	$Revision$
- */
 package jmri.jmrix.lenz;
 
 import jmri.JmriException;
 
+/**
+ * @author	Bob Jacobsen Copyright (C) 2002
+ */
 public class XNetMessageException extends JmriException {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7598394462165501189L;
 
     public XNetMessageException(String s) {
         super(s);
@@ -24,6 +14,3 @@ public class XNetMessageException extends JmriException {
     public XNetMessageException() {
     }
 }
-
-
-/* @(#)XNetMessageException.java */

--- a/java/src/jmri/jmrix/lenz/XNetSensor.java
+++ b/java/src/jmri/jmrix/lenz/XNetSensor.java
@@ -1,4 +1,3 @@
-// XNetSensor.java
 package jmri.jmrix.lenz;
 
 import jmri.Sensor;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Extend jmri.AbstractSensor for XPressNet layouts.
  * <P>
  * @author	Paul Bender Copyright (C) 2003-2010
- * @version $Revision$
  */
 public class XNetSensor extends AbstractSensor implements XNetListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7452646637169609217L;
 
     private boolean statusRequested = false;
 
@@ -198,6 +191,3 @@ public class XNetSensor extends AbstractSensor implements XNetListener {
     private final static Logger log = LoggerFactory.getLogger(XNetSensor.class.getName());
 
 }
-
-
-/* @(#)XNetSensor.java */

--- a/java/src/jmri/jmrix/loconet/LnLight.java
+++ b/java/src/jmri/jmrix/loconet/LnLight.java
@@ -1,4 +1,3 @@
-// LnLight.java
 package jmri.jmrix.loconet;
 
 import jmri.implementation.AbstractLight;
@@ -13,14 +12,8 @@ import org.slf4j.LoggerFactory;
  * Based in part on SerialLight.java
  *
  * @author Dave Duchamp Copyright (C) 2006
- * @version $Revision$
  */
 public class LnLight extends AbstractLight {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 2993413165048057836L;
 
     /**
      * Create a Light object, with only system name.
@@ -86,5 +79,3 @@ public class LnLight extends AbstractLight {
 
     private final static Logger log = LoggerFactory.getLogger(LnLight.class.getName());
 }
-
-/* @(#)LnLight.java */

--- a/java/src/jmri/jmrix/loconet/SE8cSignalHead.java
+++ b/java/src/jmri/jmrix/loconet/SE8cSignalHead.java
@@ -1,4 +1,3 @@
-// SE8cSignalHead.java
 package jmri.jmrix.loconet;
 
 import jmri.implementation.DefaultSignalHead;
@@ -34,14 +33,8 @@ import org.slf4j.LoggerFactory;
  * Inc for separate permission.
  *
  * @author	Bob Jacobsen Copyright (C) 2002
- * @version	$Revision$
  */
 public class SE8cSignalHead extends DefaultSignalHead implements LocoNetListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6855220608807175722L;
 
     public SE8cSignalHead(int pNumber, String userName) {
         // create systemname
@@ -251,6 +244,3 @@ public class SE8cSignalHead extends DefaultSignalHead implements LocoNetListener
     private final static Logger log = LoggerFactory.getLogger(SE8cSignalHead.class.getName());
 
 }
-
-
-/* @(#)SE8cSignalHead.java */

--- a/java/src/jmri/jmrix/loconet/bdl16/BDL16Panel.java
+++ b/java/src/jmri/jmrix/loconet/bdl16/BDL16Panel.java
@@ -1,4 +1,3 @@
-// BDL16Panel.java
 package jmri.jmrix.loconet.bdl16;
 
 import javax.swing.JCheckBox;
@@ -22,14 +21,8 @@ import org.slf4j.LoggerFactory;
  * Inc for separate permission.
  *
  * @author	Bob Jacobsen Copyright (C) 2002, 2004, 2007, 2010
- * @version	$Revision$
  */
 public class BDL16Panel extends jmri.jmrix.loconet.AbstractBoardProgPanel {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -287798661310758892L;
 
     public BDL16Panel() {
         this(1);

--- a/java/src/jmri/jmrix/loconet/clockmon/ClockMonAction.java
+++ b/java/src/jmri/jmrix/loconet/clockmon/ClockMonAction.java
@@ -7,9 +7,4 @@ package jmri.jmrix.loconet.clockmon;
  */
 @Deprecated
 public class ClockMonAction extends ClockMonPane.Default {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3794982544109545375L;
 }

--- a/java/src/jmri/jmrix/loconet/clockmon/ClockMonPane.java
+++ b/java/src/jmri/jmrix/loconet/clockmon/ClockMonPane.java
@@ -1,4 +1,3 @@
-// ClockMonPane.java
 package jmri.jmrix.loconet.clockmon;
 
 import java.awt.FlowLayout;
@@ -31,14 +30,8 @@ import org.slf4j.LoggerFactory;
  * active items (Dave Duchamp 2007-2008).
  *
  * @author	Bob Jacobsen Copyright (C) 2003, 2004, 2010
- * @version	$Revision$
  */
 public class ClockMonPane extends LnPanel implements SlotListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 6741586521030027827L;
 
     public String getHelpTarget() {
         return "package.jmri.jmrix.loconet.clockmon.ClockMonFrame";

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/CmdStnConfigPane.java
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/CmdStnConfigPane.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Alex Shepherd Copyright (C) 2004
  * @author	Bob Jacobsen Copyright (C) 2006
- * @version	$Revision$
  */
 public class CmdStnConfigPane extends LnPanel implements LocoNetListener {
 

--- a/java/src/jmri/jmrix/loconet/ds64/DS64Panel.java
+++ b/java/src/jmri/jmrix/loconet/ds64/DS64Panel.java
@@ -1,4 +1,3 @@
-// DS64Panel.java
 package jmri.jmrix.loconet.ds64;
 
 import javax.swing.JCheckBox;
@@ -22,14 +21,8 @@ import org.slf4j.LoggerFactory;
  * Inc for separate permission.
  *
  * @author	Bob Jacobsen Copyright (C) 2002, 2004, 2005, 2007, 2010
- * @version	$Revision$
  */
 public class DS64Panel extends jmri.jmrix.loconet.AbstractBoardProgPanel {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8039300267592456122L;
 
     public DS64Panel() {
         this(1);

--- a/java/src/jmri/jmrix/loconet/duplexgroup/swing/DuplexGroupInfoPanel.java
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/swing/DuplexGroupInfoPanel.java
@@ -1,12 +1,5 @@
-// DuplexGroupInfoPanel.java
 package jmri.jmrix.loconet.duplexgroup.swing;
 
-/**
- * Defines a GUI and associated logic to read and update Digitrax Duplex Group
- * identity information.
- *
- * @author B. Milhaupt Copyright 2010, 2011
- */
 import java.util.ResourceBundle;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -34,15 +27,10 @@ import jmri.jmrix.loconet.duplexgroup.LnDplxGrpInfoImplConstants;
  * compatible with this tool.
  *
  * @author B. Milhaupt Copyright 2010, 2011
- * @version	$Revision: 1.0 $
  */
 public class DuplexGroupInfoPanel extends jmri.jmrix.loconet.swing.LnPanel
         implements java.beans.PropertyChangeListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8260273846859188033L;
     // member declarations
     JButton swingReadButton;
     JButton swingSetButton;

--- a/java/src/jmri/jmrix/loconet/duplexgroup/swing/DuplexGroupScanPanel.java
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/swing/DuplexGroupScanPanel.java
@@ -1,4 +1,3 @@
-// DuplexGroupScanPanel.java
 package jmri.jmrix.loconet.duplexgroup.swing;
 
 import java.awt.BasicStroke;

--- a/java/src/jmri/jmrix/loconet/locoio/LocoIOTableModel.java
+++ b/java/src/jmri/jmrix/loconet/locoio/LocoIOTableModel.java
@@ -1,4 +1,3 @@
-// LocoIOTableModel.java
 package jmri.jmrix.loconet.locoio;
 
 import java.beans.PropertyChangeEvent;
@@ -31,16 +30,11 @@ import org.slf4j.LoggerFactory;
  * though there are significant modifications.
  * <P>
  * @author	Bob Jacobsen Copyright (C) 2001
- * @version	$Revision$
  */
 public class LocoIOTableModel
         extends javax.swing.table.AbstractTableModel
         implements java.beans.PropertyChangeListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 145067099477782903L;
     private LocoIOData liodata;
     private boolean inHex;
     //private String maxSizeMode = "";

--- a/java/src/jmri/jmrix/loconet/locomon/LocoMonAction.java
+++ b/java/src/jmri/jmrix/loconet/locomon/LocoMonAction.java
@@ -7,9 +7,4 @@ package jmri.jmrix.loconet.locomon;
  */
 @Deprecated
 public class LocoMonAction extends LocoMonPane.Default {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6269053405934504463L;
 }

--- a/java/src/jmri/jmrix/loconet/locomon/LocoMonFrame.java
+++ b/java/src/jmri/jmrix/loconet/locomon/LocoMonFrame.java
@@ -1,4 +1,3 @@
-// LocoMonFrame.java
 package jmri.jmrix.loconet.locomon;
 
 import jmri.jmrix.loconet.LnTrafficController;
@@ -9,16 +8,10 @@ import jmri.jmrix.loconet.LocoNetMessage;
  * LocoNet Monitor Frame displaying (and logging) LocoNet messages
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2008
- * @version $Revision$
  * @deprecated 2.9.5
  */
 @Deprecated
 public class LocoMonFrame extends jmri.jmrix.AbstractMonFrame implements LocoNetListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1761967273446973451L;
 
     public LocoMonFrame(LnTrafficController tc) {
         super();

--- a/java/src/jmri/jmrix/loconet/locormi/LnMessageBuffer.java
+++ b/java/src/jmri/jmrix/loconet/locormi/LnMessageBuffer.java
@@ -1,12 +1,5 @@
 package jmri.jmrix.loconet.locormi;
 
-/**
- * Handle a RMI connection for a single remote client. Description: Copyright:
- * Copyright (c) 2002
- *
- * @author Alex Shepherd
- * @version $Revision$
- */
 import java.rmi.RemoteException;
 import java.rmi.server.UnicastRemoteObject;
 import java.util.LinkedList;
@@ -14,10 +7,14 @@ import jmri.jmrix.loconet.LnTrafficController;
 import jmri.jmrix.loconet.LocoNetListener;
 import jmri.jmrix.loconet.LocoNetMessage;
 
+/**
+ * Handle a RMI connection for a single remote client. Description: Copyright:
+ * Copyright (c) 2002
+ *
+ * @author Alex Shepherd
+ */
 public class LnMessageBuffer extends UnicastRemoteObject implements LnMessageBufferInterface, LocoNetListener {
 
-    // versioned Jul 17, 2003 - was CVS revision 1.5
-    static final long serialVersionUID = -8483947910723134277L;
     LinkedList<LocoNetMessage> messageList = null;
 
     public LnMessageBuffer() throws RemoteException {

--- a/java/src/jmri/jmrix/loconet/locormi/LnMessageClientAction.java
+++ b/java/src/jmri/jmrix/loconet/locormi/LnMessageClientAction.java
@@ -1,13 +1,5 @@
 package jmri.jmrix.loconet.locormi;
 
-/**
- * Opens a connection with a LnMessageServer on a remote machine. The remote
- * machine IP address is specified via a dialog box. Description: Copyright:
- * Copyright (c) 2002 Company:
- *
- * @author Bob Jacobsen
- * @version $Revision$
- */
 import java.awt.event.ActionEvent;
 import javax.swing.AbstractAction;
 import javax.swing.JOptionPane;
@@ -15,12 +7,15 @@ import jmri.jmrix.loconet.LocoNetException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Opens a connection with a LnMessageServer on a remote machine. The remote
+ * machine IP address is specified via a dialog box. Description: Copyright:
+ * Copyright (c) 2002 Company:
+ *
+ * @author Bob Jacobsen
+ */
 public class LnMessageClientAction extends AbstractAction {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8370182774389562857L;
     private final static Logger log = LoggerFactory.getLogger(LnMessageClientAction.class.getName());
 
     public LnMessageClientAction(String s) {

--- a/java/src/jmri/jmrix/loconet/se8/SE8Panel.java
+++ b/java/src/jmri/jmrix/loconet/se8/SE8Panel.java
@@ -1,4 +1,3 @@
-// SE8Panel.java
 package jmri.jmrix.loconet.se8;
 
 import java.awt.FlowLayout;
@@ -29,14 +28,8 @@ import org.slf4j.LoggerFactory;
  * Inc for separate permission.
  *
  * @author Bob Jacobsen Copyright (C) 2003, 2004, 2007, 2010
- * @version $Revision$
  */
 public class SE8Panel extends jmri.jmrix.loconet.AbstractBoardProgPanel {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 7400087827251524534L;
 
     public SE8Panel() {
         this(1);

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonAction.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonAction.java
@@ -8,8 +8,4 @@ package jmri.jmrix.loconet.slotmon;
 @Deprecated
 public class SlotMonAction extends SlotMonPane.Default {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -100223304807143866L;
 }

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonDataModel.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonDataModel.java
@@ -1,4 +1,3 @@
-// SlotMonDataModel.java
 package jmri.jmrix.loconet.slotmon;
 
 import java.awt.event.MouseEvent;

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
@@ -1,4 +1,3 @@
-// SlotMonPane.java
 package jmri.jmrix.loconet.slotmon;
 
 import java.awt.FlowLayout;

--- a/java/src/jmri/jmrix/loconet/soundloader/EditorFilePane.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/EditorFilePane.java
@@ -1,4 +1,3 @@
-// EditorFilePane.java
 package jmri.jmrix.loconet.soundloader;
 
 import java.io.File;
@@ -21,14 +20,8 @@ import org.slf4j.LoggerFactory;
  * Pane for editing Digitrax SPJ files
  *
  * @author	Bob Jacobsen Copyright (C) 2006, 2010
- * @version	$Revision$
  */
 public class EditorFilePane extends javax.swing.JPanel {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4194558549451699808L;
 
     // GUI member declarations
     static ResourceBundle res = ResourceBundle.getBundle("jmri.jmrix.loconet.soundloader.Editor");

--- a/java/src/jmri/jmrix/loconet/soundloader/EditorPane.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/EditorPane.java
@@ -1,4 +1,3 @@
-// EditorPane.java
 package jmri.jmrix.loconet.soundloader;
 
 import java.awt.FlowLayout;
@@ -23,14 +22,8 @@ import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
  * This handles file read/write.
  *
  * @author	Bob Jacobsen Copyright (C) 2006, 2007, 2008, 2010
- * @version $Revision$
  */
 public class EditorPane extends jmri.jmrix.loconet.swing.LnPanel {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4382326277234572738L;
 
     // GUI member declarations
     EditorFilePane pane;

--- a/java/src/jmri/jmrix/loconet/soundloader/EditorTableDataModel.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/EditorTableDataModel.java
@@ -1,4 +1,3 @@
-// EditorTableDataModel.java
 package jmri.jmrix.loconet.soundloader;
 
 import java.awt.Font;
@@ -26,14 +25,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright (C) 2003, 2006
  * @author Dennis Miller Copyright (C) 2006
- * @version	$Revision$
  */
 public class EditorTableDataModel extends javax.swing.table.AbstractTableModel {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6127498935819325767L;
     static public final int HEADERCOL = 0;
     static public final int TYPECOL = 1;
     static public final int MAPCOL = 2;

--- a/java/src/jmri/jmrix/loconet/soundloader/LoaderEngine.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/LoaderEngine.java
@@ -1,4 +1,3 @@
-// LoaderEngine.java
 package jmri.jmrix.loconet.soundloader;
 
 import jmri.jmrix.loconet.LnTrafficController;
@@ -13,7 +12,6 @@ import org.slf4j.LoggerFactory;
  * decoder.
  *
  * @author	Bob Jacobsen Copyright (C) 2006
- * @version	$Revision$
  */
 public class LoaderEngine {
 

--- a/java/src/jmri/jmrix/loconet/soundloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/LoaderPane.java
@@ -1,4 +1,3 @@
-// LoaderPane.java
 package jmri.jmrix.loconet.soundloader;
 
 import java.awt.FlowLayout;

--- a/java/src/jmri/jmrix/loconet/swing/LnNamedPaneAction.java
+++ b/java/src/jmri/jmrix/loconet/swing/LnNamedPaneAction.java
@@ -1,4 +1,3 @@
-// LnNamedPaneAction.java
 package jmri.jmrix.loconet.swing;
 
 import javax.swing.Icon;
@@ -55,5 +54,3 @@ public class LnNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction {
 
     private final static Logger log = LoggerFactory.getLogger(LnNamedPaneAction.class.getName());
 }
-
-/* @(#)LnNamedPaneAction.java */

--- a/java/src/jmri/jmrix/maple/assignment/ListAction.java
+++ b/java/src/jmri/jmrix/maple/assignment/ListAction.java
@@ -39,5 +39,3 @@ public class ListAction extends AbstractAction {
 
     private final static Logger log = LoggerFactory.getLogger(ListAction.class.getName());
 }
-
-/* @(#)ListAction.java */

--- a/java/src/jmri/jmrix/maple/assignment/ListFrame.java
+++ b/java/src/jmri/jmrix/maple/assignment/ListFrame.java
@@ -547,5 +547,3 @@ public class ListFrame extends jmri.util.JmriJFrame {
     private final static Logger log = LoggerFactory.getLogger(ListFrame.class.getName());
 
 }
-
-/* @(#)ListFrame.java */

--- a/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigAction.java
+++ b/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigAction.java
@@ -40,6 +40,3 @@ public class NodeConfigAction extends AbstractAction {
 
     private final static Logger log = LoggerFactory.getLogger(NodeConfigAction.class.getName());
 }
-
-
-/* @(#)SerialPacketGenAction.java */

--- a/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigFrame.java
+++ b/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigFrame.java
@@ -1,4 +1,3 @@
-// NodeConfigFrame.java
 package jmri.jmrix.maple.nodeconfig;
 
 import java.awt.Container;
@@ -25,15 +24,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright (C) 2004, 2008
  * @author	Dave Duchamp Copyright (C) 2004, 2009
- * @version	$Revision$
  */
 public class NodeConfigFrame extends jmri.util.JmriJFrame {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1694906139287195915L;
-
     ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.maple.nodeconfig.NodeConfigBundle");
 
     protected javax.swing.JTextField nodeAddrField = new javax.swing.JTextField(3);

--- a/java/src/jmri/jmrix/maple/packetgen/SerialPacketGenAction.java
+++ b/java/src/jmri/jmrix/maple/packetgen/SerialPacketGenAction.java
@@ -1,4 +1,3 @@
-// SerialPacketGenAction.java
 package jmri.jmrix.maple.packetgen;
 
 import java.awt.event.ActionEvent;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a SerialPacketGenFrame object
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version $Revision$
  */
 public class SerialPacketGenAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 9108403301774618719L;
 
     public SerialPacketGenAction(String s) {
         super(s);
@@ -38,6 +31,3 @@ public class SerialPacketGenAction extends AbstractAction {
     }
     private final static Logger log = LoggerFactory.getLogger(SerialPacketGenAction.class.getName());
 }
-
-
-/* @(#)SerialPacketGenAction.java */

--- a/java/src/jmri/jmrix/mrc/swing/packetgen/MrcPacketGenPanel.java
+++ b/java/src/jmri/jmrix/mrc/swing/packetgen/MrcPacketGenPanel.java
@@ -1,4 +1,3 @@
-// MrcPacketGenPanel.java
 package jmri.jmrix.mrc.swing.packetgen;
 
 import java.awt.Dimension;
@@ -14,15 +13,11 @@ import jmri.util.StringUtil;
  * @author	Ken Cameron	Copyright (C) 2010 derived from:
  * @author	Bob Jacobsen Copyright (C) 2001
  * @author Dan Boudreau Copyright (C) 2007
- * @version $Revision: 25018 $
  */
 public class MrcPacketGenPanel extends jmri.jmrix.mrc.swing.MrcPanel {
 
     //ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.mrc.packetgen.MrcPacketGenBundle");
-    /**
-     *
-     */
-    private static final long serialVersionUID = 491326388683242575L;
+
     // member declarations
     javax.swing.JLabel jLabel1 = new javax.swing.JLabel();
     javax.swing.JButton sendButton = new javax.swing.JButton();

--- a/java/src/jmri/jmrix/ncemonitor/NcePacketMonitorPanel.java
+++ b/java/src/jmri/jmrix/ncemonitor/NcePacketMonitorPanel.java
@@ -38,11 +38,6 @@ import org.slf4j.LoggerFactory;
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "serialStream is access from separate thread, and this class isn't used much")
 public class NcePacketMonitorPanel extends jmri.jmrix.AbstractMonPane implements NcePanelInterface {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8995209813681779828L;
-
     ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.ncemonitor.NcePacketMonitorBundle");
 
     Vector<String> portNameVector = null;

--- a/java/src/jmri/jmrix/oaktree/OakTreeMenu.java
+++ b/java/src/jmri/jmrix/oaktree/OakTreeMenu.java
@@ -1,4 +1,3 @@
-// OakTreeMenu.java
 package jmri.jmrix.oaktree;
 
 import java.util.ResourceBundle;
@@ -8,14 +7,8 @@ import javax.swing.JMenu;
  * Create a "Systems" menu containing the Jmri Oak Tree-specific tools
  *
  * @author	Bob Jacobsen Copyright 2003, 2006
- * @version $Revision$
  */
 public class OakTreeMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3502858569724894577L;
 
     public OakTreeMenu(String name) {
         this();

--- a/java/src/jmri/jmrix/oaktree/SerialLight.java
+++ b/java/src/jmri/jmrix/oaktree/SerialLight.java
@@ -1,4 +1,3 @@
-// SerialLight.java
 package jmri.jmrix.oaktree;
 
 import jmri.implementation.AbstractLight;
@@ -14,14 +13,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dave Duchamp Copyright (C) 2004
  * @author Bob Jacobsen Copyright (C) 2006
- * @version $Revision$
  */
 public class SerialLight extends AbstractLight {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 7684744147491761148L;
 
     /**
      * Create a Light object, with only system name.
@@ -82,5 +75,3 @@ public class SerialLight extends AbstractLight {
 
     private final static Logger log = LoggerFactory.getLogger(SerialLight.class.getName());
 }
-
-/* @(#)SerialLight.java */

--- a/java/src/jmri/jmrix/oaktree/SerialLightManager.java
+++ b/java/src/jmri/jmrix/oaktree/SerialLightManager.java
@@ -1,4 +1,3 @@
-// SerialLightManager.java
 package jmri.jmrix.oaktree;
 
 import jmri.Light;
@@ -15,15 +14,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Dave Duchamp Copyright (C) 2004
  * @author	Bob Jacobsen Copyright (C) 2006
- * @version	$Revision$
  */
 public class SerialLightManager extends AbstractLightManager {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1309071610469295115L;
-
     public SerialLightManager() {
 
     }
@@ -108,5 +100,3 @@ public class SerialLightManager extends AbstractLightManager {
     private final static Logger log = LoggerFactory.getLogger(SerialLightManager.class.getName());
 
 }
-
-/* @(#)SerialLighttManager.java */

--- a/java/src/jmri/jmrix/oaktree/SerialSensor.java
+++ b/java/src/jmri/jmrix/oaktree/SerialSensor.java
@@ -1,4 +1,3 @@
-// SerialSensor.java
 package jmri.jmrix.oaktree;
 
 import jmri.implementation.AbstractSensor;
@@ -7,14 +6,8 @@ import jmri.implementation.AbstractSensor;
  * Extend jmri.AbstractSensor for serial systems
  * <P>
  * @author	Bob Jacobsen Copyright (C) 2003, 2006
- * @version $Revision$
  */
 public class SerialSensor extends AbstractSensor {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 2538135903910579736L;
 
     public SerialSensor(String systemName) {
         super(systemName);
@@ -37,5 +30,3 @@ public class SerialSensor extends AbstractSensor {
     }
 
 }
-
-/* @(#)SerialSensor.java */

--- a/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigAction.java
+++ b/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigAction.java
@@ -1,4 +1,3 @@
-// NodeConfigAction.java
 package jmri.jmrix.oaktree.nodeconfig;
 
 import java.awt.event.ActionEvent;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a NodeConfigFrame object
  *
  * @author	Bob Jacobsen Copyright (C) 2006
- * @version	$Revision$
  */
 public class NodeConfigAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4262910926697011437L;
 
     public NodeConfigAction(String s) {
         super(s);
@@ -39,6 +32,3 @@ public class NodeConfigAction extends AbstractAction {
     }
     private final static Logger log = LoggerFactory.getLogger(NodeConfigAction.class.getName());
 }
-
-
-/* @(#)NodeConfigAction.java */

--- a/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigFrame.java
+++ b/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigFrame.java
@@ -1,4 +1,3 @@
-// NodeConfigFrame.java
 package jmri.jmrix.oaktree.nodeconfig;
 
 import java.awt.Container;
@@ -21,14 +20,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright (C) 2004
  * @author	Dave Duchamp Copyright (C) 2004, 2006
- * @version	$Revision$
  */
 public class NodeConfigFrame extends jmri.util.JmriJFrame {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4292271400312891621L;
 
     ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.oaktree.nodeconfig.NodeConfigBundle");
 

--- a/java/src/jmri/jmrix/oaktree/packetgen/SerialPacketGenAction.java
+++ b/java/src/jmri/jmrix/oaktree/packetgen/SerialPacketGenAction.java
@@ -1,12 +1,3 @@
-/**
- * SerialPacketGenAction.java
- *
- * Description:	Swing action to create and register a SerialPacketGenFrame
- * object
- *
- * @author	Bob Jacobsen Copyright (C) 2001
- * @version
- */
 package jmri.jmrix.oaktree.packetgen;
 
 import java.awt.event.ActionEvent;
@@ -14,12 +5,13 @@ import javax.swing.AbstractAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Swing action to create and register a SerialPacketGenFrame
+ * object
+ *
+ * @author	Bob Jacobsen Copyright (C) 2001
+ */
 public class SerialPacketGenAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -2562915589157959033L;
 
     public SerialPacketGenAction(String s) {
         super(s);
@@ -41,5 +33,3 @@ public class SerialPacketGenAction extends AbstractAction {
     private final static Logger log = LoggerFactory.getLogger(SerialPacketGenAction.class.getName());
 }
 
-
-/* @(#)SerialPacketGenAction.java */

--- a/java/src/jmri/jmrix/oaktree/packetgen/SerialPacketGenFrame.java
+++ b/java/src/jmri/jmrix/oaktree/packetgen/SerialPacketGenFrame.java
@@ -1,4 +1,3 @@
-// SerialPacketGenFrame.java
 package jmri.jmrix.oaktree.packetgen;
 
 import java.awt.Dimension;
@@ -16,14 +15,9 @@ import jmri.util.StringUtil;
  * Frame for user input of serial messages
  *
  * @author	Bob Jacobsen Copyright (C) 2002, 2003, 2006
- * @version	$Revision$
  */
 public class SerialPacketGenFrame extends jmri.util.JmriJFrame implements jmri.jmrix.oaktree.SerialListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7440833458945674404L;
     // member declarations
     javax.swing.JLabel jLabel1 = new javax.swing.JLabel();
     javax.swing.JButton sendButton = new javax.swing.JButton();

--- a/java/src/jmri/jmrix/oaktree/serialmon/SerialMonAction.java
+++ b/java/src/jmri/jmrix/oaktree/serialmon/SerialMonAction.java
@@ -1,4 +1,3 @@
-// SerialMonAction.java
 package jmri.jmrix.oaktree.serialmon;
 
 import java.awt.event.ActionEvent;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a SerialMonFrame object
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2006
- * @version	$Revision$
  */
 public class SerialMonAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6706589007187735934L;
 
     public SerialMonAction(String s) {
         super(s);
@@ -41,6 +34,3 @@ public class SerialMonAction extends AbstractAction {
     private final static Logger log = LoggerFactory.getLogger(SerialMonAction.class.getName());
 
 }
-
-
-/* @(#)SerialMonAction.java */

--- a/java/src/jmri/jmrix/oaktree/serialmon/SerialMonFrame.java
+++ b/java/src/jmri/jmrix/oaktree/serialmon/SerialMonFrame.java
@@ -1,4 +1,3 @@
-// SerialMonFrame.java
 package jmri.jmrix.oaktree.serialmon;
 
 import jmri.jmrix.oaktree.SerialListener;
@@ -10,14 +9,8 @@ import jmri.jmrix.oaktree.SerialTrafficController;
  * Frame displaying (and logging) serial command messages
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2006
- * @version $Revision$
  */
 public class SerialMonFrame extends jmri.jmrix.AbstractMonFrame implements SerialListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4175675095718284698L;
 
     public SerialMonFrame() {
         super();

--- a/java/src/jmri/jmrix/openlcb/OlcbSensor.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbSensor.java
@@ -1,4 +1,3 @@
-// OlcbSensor.java
 package jmri.jmrix.openlcb;
 
 import java.util.Timer;
@@ -156,6 +155,3 @@ public class OlcbSensor extends AbstractSensor implements CanListener {
     private final static Logger log = LoggerFactory.getLogger(OlcbSensor.class.getName());
 
 }
-
-
-/* @(#)OlcbSensor.java */

--- a/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
@@ -1,4 +1,3 @@
-// OlcbTurnout.java
 package jmri.jmrix.openlcb;
 
 import jmri.Turnout;
@@ -109,5 +108,3 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout
 
     private final static Logger log = LoggerFactory.getLogger(OlcbTurnout.class.getName());
 }
-
-/* @(#)OlcbTurnout.java */

--- a/java/src/jmri/jmrix/openlcb/OpenLcbMenu.java
+++ b/java/src/jmri/jmrix/openlcb/OpenLcbMenu.java
@@ -1,4 +1,3 @@
-// OpenLcbMenu.java
 package jmri.jmrix.openlcb;
 
 import java.util.ResourceBundle;

--- a/java/src/jmri/jmrix/openlcb/swing/hub/HubPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/hub/HubPane.java
@@ -1,4 +1,3 @@
-// HubPane.java
 package jmri.jmrix.openlcb.swing.hub;
 
 import java.net.InetAddress;

--- a/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorAction.java
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorAction.java
@@ -1,4 +1,3 @@
-// MonitorAction.java
 package jmri.jmrix.openlcb.swing.monitor;
 
 /**
@@ -14,5 +13,3 @@ public class MonitorAction extends MonitorPane.Default {
      */
     private static final long serialVersionUID = 7796221855291230843L;
 }
-
-/* @(#)MonitorAction.java */

--- a/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
@@ -1,4 +1,3 @@
-// MonitorPane.java
 package jmri.jmrix.openlcb.swing.monitor;
 
 import jmri.jmrix.can.CanListener;

--- a/java/src/jmri/jmrix/openlcb/swing/networktree/NetworkTreeAction.java
+++ b/java/src/jmri/jmrix/openlcb/swing/networktree/NetworkTreeAction.java
@@ -1,4 +1,3 @@
-// NetworkTreeAction.java
 package jmri.jmrix.openlcb.swing.networktree;
 
 /**
@@ -14,5 +13,3 @@ public class NetworkTreeAction extends NetworkTreePane.Default {
      */
     private static final long serialVersionUID = -8956847407603222742L;
 }
-
-/* @(#)NetworkTreeAction.java */

--- a/java/src/jmri/jmrix/openlcb/swing/networktree/NetworkTreePane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/networktree/NetworkTreePane.java
@@ -1,4 +1,3 @@
-// NetworkTreePane.java
 package jmri.jmrix.openlcb.swing.networktree;
 
 import java.awt.Dimension;

--- a/java/src/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendAction.java
+++ b/java/src/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendAction.java
@@ -1,4 +1,3 @@
-// OpenLcbCanSendAction.java
 package jmri.jmrix.openlcb.swing.send;
 
 /**
@@ -14,5 +13,3 @@ public class OpenLcbCanSendAction extends OpenLcbCanSendPane.Default {
      */
     private static final long serialVersionUID = -2653850619154579104L;
 }
-
-/* @(#)OpenLcbCanSendAction.java */

--- a/java/src/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPane.java
@@ -1,4 +1,3 @@
-// OpenLcbCanSendPane.java
 package jmri.jmrix.openlcb.swing.send;
 
 import java.awt.Dimension;

--- a/java/src/jmri/jmrix/powerline/simulator/SpecificX10Light.java
+++ b/java/src/jmri/jmrix/powerline/simulator/SpecificX10Light.java
@@ -1,4 +1,3 @@
-// SpecificX10Light.java
 package jmri.jmrix.powerline.simulator;
 
 import jmri.jmrix.powerline.SerialTrafficController;
@@ -27,14 +26,8 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2006, 2007, 2008, 2009, 2010
  * @author Ken Cameron Copyright (C) 2009, 2010 Converted to multiple connection
  * @author kcameron Copyright (C) 2011
- * @version $Revision$
  */
 public class SpecificX10Light extends jmri.jmrix.powerline.SerialX10Light {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8695363428929581739L;
 
     /**
      * Create a Light object, with only system name.
@@ -106,5 +99,3 @@ public class SpecificX10Light extends jmri.jmrix.powerline.SerialX10Light {
 
     private final static Logger log = LoggerFactory.getLogger(SpecificX10Light.class.getName());
 }
-
-/* @(#)SpecificX10Light.java */

--- a/java/src/jmri/jmrix/rps/RpsMenu.java
+++ b/java/src/jmri/jmrix/rps/RpsMenu.java
@@ -1,4 +1,3 @@
-// RpsMenu.java
 package jmri.jmrix.rps;
 
 import javax.swing.JMenu;
@@ -8,14 +7,8 @@ import javax.swing.JSeparator;
  * Create a "RPS" menu containing the Jmri RPS-specific tools.
  *
  * @author	Bob Jacobsen Copyright 2006, 2007, 2008
- * @version $Revision$
  */
 public class RpsMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4274427241421520434L;
 
     public RpsMenu(String name) {
         this();

--- a/java/src/jmri/jmrix/rps/RpsReporter.java
+++ b/java/src/jmri/jmrix/rps/RpsReporter.java
@@ -1,4 +1,3 @@
-// RpsReporter.java
 package jmri.jmrix.rps;
 
 import java.util.ArrayList;
@@ -15,10 +14,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * RPS implementation of the Reporter interface.
- * <P>
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version	$Revision$
  * @since 2.3.1
  */
 public class RpsReporter extends AbstractReporter implements MeasurementListener {
@@ -76,8 +73,6 @@ public class RpsReporter extends AbstractReporter implements MeasurementListener
             notifyLeaving(id);
         }
     }
-
-    private static final long serialVersionUID = 1L;
 
     transient Region region;
     ArrayList<Integer> contents = new ArrayList<Integer>();
@@ -192,5 +187,3 @@ public class RpsReporter extends AbstractReporter implements MeasurementListener
 
     private final static Logger log = LoggerFactory.getLogger(RpsReporter.class.getName());
 }
-
-/* @(#)AbstractReporter.java */

--- a/java/src/jmri/jmrix/rps/RpsSensor.java
+++ b/java/src/jmri/jmrix/rps/RpsSensor.java
@@ -1,4 +1,3 @@
-// RpsSensor.java
 package jmri.jmrix.rps;
 
 import java.util.ArrayList;
@@ -15,7 +14,6 @@ import org.slf4j.LoggerFactory;
  * example "RS(0,0,0);(1,0,0);(1,1,0);(0,1,0)".
  * <P>
  * @author	Bob Jacobsen Copyright (C) 2007
- * @version $Revision$
  */
 public class RpsSensor extends AbstractSensor
         implements MeasurementListener {
@@ -99,8 +97,6 @@ public class RpsSensor extends AbstractSensor
 
     transient Region region;
     ArrayList<Integer> contents = new ArrayList<Integer>();
-
-    private static final long serialVersionUID = 1L;
 
     /**
      * Notify parameter listeners that a device has left the region covered by

--- a/java/src/jmri/jmrix/rps/aligntable/AlignTableFrame.java
+++ b/java/src/jmri/jmrix/rps/aligntable/AlignTableFrame.java
@@ -1,4 +1,3 @@
-// AlignTableFrame.java
 package jmri.jmrix.rps.aligntable;
 
 import java.awt.Container;
@@ -14,14 +13,9 @@ import javax.swing.JDialog;
  * @see AlignTableAction
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version	$Revision$
  */
 public class AlignTableFrame extends jmri.util.JmriJFrame {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1010732755062965677L;
     ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.rps.aligntable.AlignTableBundle");
 
     /**

--- a/java/src/jmri/jmrix/rps/aligntable/AlignTablePane.java
+++ b/java/src/jmri/jmrix/rps/aligntable/AlignTablePane.java
@@ -1,4 +1,3 @@
-// AlignTableFrame.java
 package jmri.jmrix.rps.aligntable;
 
 import java.awt.Dimension;
@@ -30,14 +29,9 @@ import org.slf4j.LoggerFactory;
  * Pane for user management of RPS alignment.
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version	$Revision$
  */
 public class AlignTablePane extends javax.swing.JPanel {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3252695029810160130L;
     static ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.rps.aligntable.AlignTableBundle");
 
     /**

--- a/java/src/jmri/jmrix/rps/reversealign/AlignmentPanel.java
+++ b/java/src/jmri/jmrix/rps/reversealign/AlignmentPanel.java
@@ -1,4 +1,3 @@
-// AlignmentPanel.java
 package jmri.jmrix.rps.reversealign;
 
 import java.awt.event.ActionEvent;
@@ -27,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- *
  * Gather RPS Readings and use them to align the detector.
  * <P>
  * Note that algorithms have a bias to find transmitters with positive Z
@@ -36,15 +34,9 @@ import org.slf4j.LoggerFactory;
  * working for us.
  *
  * @author	Bob Jacobsen Copyright (C) 2007
- * @version $Revision$
  */
 public class AlignmentPanel extends javax.swing.JPanel
         implements ReadingListener, Constants {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7798693118150508821L;
 
     public AlignmentPanel() {
         super();

--- a/java/src/jmri/jmrix/rps/reversealign/AlignmentPanelAction.java
+++ b/java/src/jmri/jmrix/rps/reversealign/AlignmentPanelAction.java
@@ -1,4 +1,3 @@
-// AlignmentPanelAction.java
 package jmri.jmrix.rps.reversealign;
 
 import java.awt.event.ActionEvent;
@@ -9,14 +8,8 @@ import javax.swing.BoxLayout;
  * Swing action to create and register a RpsTrackingFrame object
  *
  * @author	Bob Jacobsen Copyright (C) 2006
- * @version $Revision$
  */
 public class AlignmentPanelAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8498519485972403715L;
 
     public AlignmentPanelAction(String s) {
         super(s);
@@ -43,6 +36,3 @@ public class AlignmentPanelAction extends AbstractAction {
     AlignmentPanel panel;
 
 }
-
-
-/* @(#)AlignmentPanelAction.java */

--- a/java/src/jmri/jmrix/rps/rpsmon/RpsMonAction.java
+++ b/java/src/jmri/jmrix/rps/rpsmon/RpsMonAction.java
@@ -1,22 +1,15 @@
-/**
- * RpsMonAction.java
- *
- * Description:	Swing action to create and register a RpsMonFrame object
- *
- * @author	Bob Jacobsen Copyright (C) 2006
- * @version
- */
 package jmri.jmrix.rps.rpsmon;
 
 import java.awt.event.ActionEvent;
 import javax.swing.AbstractAction;
 
+/**
+ * Swing action to create and register a RpsMonFrame object
+ *
+ * @author	Bob Jacobsen Copyright (C) 2006
+ * @version
+ */
 public class RpsMonAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8976860321295273855L;
 
     public RpsMonAction(String s) {
         super(s);
@@ -37,6 +30,3 @@ public class RpsMonAction extends AbstractAction {
     }
 
 }
-
-
-/* @(#)RpsMonAction.java */

--- a/java/src/jmri/jmrix/rps/rpsmon/RpsMonFrame.java
+++ b/java/src/jmri/jmrix/rps/rpsmon/RpsMonFrame.java
@@ -1,11 +1,3 @@
-/**
- * RpsMonFrame.java
- *
- * Description:	Frame displaying (and logging) RPS messages
- *
- * @author	Bob Jacobsen Copyright (C) 2006
- * @version $Revision$
- */
 package jmri.jmrix.rps.rpsmon;
 
 import jmri.jmrix.rps.Distributor;
@@ -14,13 +6,13 @@ import jmri.jmrix.rps.MeasurementListener;
 import jmri.jmrix.rps.Reading;
 import jmri.jmrix.rps.ReadingListener;
 
+/**
+ * Frame displaying (and logging) RPS messages
+ *
+ * @author	Bob Jacobsen Copyright (C) 2006
+ */
 public class RpsMonFrame extends jmri.jmrix.AbstractMonFrame
         implements ReadingListener, MeasurementListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3577651671435326280L;
 
     public RpsMonFrame() {
         super();

--- a/java/src/jmri/jmrix/rps/swing/AffineEntryPanel.java
+++ b/java/src/jmri/jmrix/rps/swing/AffineEntryPanel.java
@@ -1,4 +1,3 @@
-// AffineEntryPanel.java
 package jmri.jmrix.rps.swing;
 
 import java.awt.GridLayout;
@@ -15,14 +14,9 @@ import javax.swing.JTextField;
  * Panel for entry and modifiation of an Affine Transform
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version $Revision$
  */
 public class AffineEntryPanel extends javax.swing.JPanel {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1282006269847211098L;
     JTextField m00 = new JTextField(8);
     JTextField m01 = new JTextField(8);
     JTextField m02 = new JTextField(8);

--- a/java/src/jmri/jmrix/rps/swing/CsvExportAction.java
+++ b/java/src/jmri/jmrix/rps/swing/CsvExportAction.java
@@ -1,4 +1,3 @@
-// CsvExportAction.java
 package jmri.jmrix.rps.swing;
 
 import java.awt.event.ActionEvent;
@@ -20,15 +19,9 @@ import org.slf4j.LoggerFactory;
  * Action to export the incoming raw data to a CSV-format file
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version $Revision$
  * @since 2.3.1
  */
 public class CsvExportAction extends AbstractAction implements ReadingListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 2188047459182097454L;
 
     public CsvExportAction(String actionName) {
         super(actionName);

--- a/java/src/jmri/jmrix/rps/swing/CsvExportMeasurementAction.java
+++ b/java/src/jmri/jmrix/rps/swing/CsvExportMeasurementAction.java
@@ -1,4 +1,3 @@
-// CsvExportMeasurementAction.java
 package jmri.jmrix.rps.swing;
 
 import java.awt.event.ActionEvent;
@@ -21,15 +20,9 @@ import org.slf4j.LoggerFactory;
  * Action to export the incoming raw data to a CSV-format file
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version $Revision$
  * @since 2.3.1
  */
 public class CsvExportMeasurementAction extends AbstractAction implements MeasurementListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6932267895252672856L;
 
     public CsvExportMeasurementAction(String actionName) {
         super(actionName);

--- a/java/src/jmri/jmrix/rps/swing/LoadStorePanel.java
+++ b/java/src/jmri/jmrix/rps/swing/LoadStorePanel.java
@@ -1,4 +1,3 @@
-// LoadStorePanel.java
 package jmri.jmrix.rps.swing;
 
 import java.awt.event.ActionEvent;
@@ -15,14 +14,8 @@ import org.slf4j.LoggerFactory;
  * Panel for load/store of RPS setup
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version $Revision$
  */
 public class LoadStorePanel extends javax.swing.JPanel {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 2101684476801445613L;
 
     public LoadStorePanel() {
         super();

--- a/java/src/jmri/jmrix/rps/swing/debugger/DebuggerAction.java
+++ b/java/src/jmri/jmrix/rps/swing/debugger/DebuggerAction.java
@@ -1,4 +1,3 @@
-// DebuggerAction.java
 package jmri.jmrix.rps.swing.debugger;
 
 import java.awt.event.ActionEvent;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a DisplayFrame object
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version $Revision$
  */
 public class DebuggerAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6512666760743475128L;
 
     public DebuggerAction(String s) {
         super(s);
@@ -42,6 +35,3 @@ public class DebuggerAction extends AbstractAction {
     private final static Logger log = LoggerFactory.getLogger(DebuggerAction.class.getName());
 
 }
-
-
-/* @(#)DebuggerAction.java */

--- a/java/src/jmri/jmrix/rps/swing/debugger/DebuggerFrame.java
+++ b/java/src/jmri/jmrix/rps/swing/debugger/DebuggerFrame.java
@@ -1,4 +1,3 @@
-// DebuggerFrame.java
 package jmri.jmrix.rps.swing.debugger;
 
 import java.awt.FlowLayout;
@@ -26,15 +25,9 @@ import org.slf4j.LoggerFactory;
  * Frame for manual operation and debugging of the RPS system
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version $Revision$
  */
 public class DebuggerFrame extends jmri.util.JmriJFrame
         implements ReadingListener, MeasurementListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4663988863071182111L;
 
     public DebuggerFrame() {
         super();

--- a/java/src/jmri/jmrix/rps/swing/debugger/DebuggerTimePane.java
+++ b/java/src/jmri/jmrix/rps/swing/debugger/DebuggerTimePane.java
@@ -1,4 +1,3 @@
-// DebuggerTimePane.java
 package jmri.jmrix.rps.swing.debugger;
 
 import java.awt.FlowLayout;
@@ -23,15 +22,9 @@ import org.slf4j.LoggerFactory;
  * number.
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version $Revision$
  */
 public class DebuggerTimePane extends JPanel
         implements ReadingListener, MeasurementListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 7146556518025256466L;
 
     public DebuggerTimePane() {
         super();

--- a/java/src/jmri/jmrix/rps/swing/polling/PollTablePane.java
+++ b/java/src/jmri/jmrix/rps/swing/polling/PollTablePane.java
@@ -1,4 +1,3 @@
-// PollTablePane.java
 package jmri.jmrix.rps.swing.polling;
 
 import java.awt.Dimension;
@@ -30,7 +29,6 @@ import org.slf4j.LoggerFactory;
  * Pane for user management of RPS polling.
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version	$Revision$
  */
 public class PollTablePane extends javax.swing.JPanel {
 
@@ -72,11 +70,6 @@ public class PollTablePane extends javax.swing.JPanel {
 
         // status info on bottom
         JPanel p = new JPanel() {
-            /**
-             *
-             */
-            private static final long serialVersionUID = 2303477665465877882L;
-
             public Dimension getMaximumSize() {
                 int height = getPreferredSize().height;
                 int width = super.getMaximumSize().width;

--- a/java/src/jmri/jmrix/rps/swing/soundset/SoundSetAction.java
+++ b/java/src/jmri/jmrix/rps/swing/soundset/SoundSetAction.java
@@ -1,4 +1,3 @@
-// SoundSetAction.java
 package jmri.jmrix.rps.swing.soundset;
 
 import java.awt.event.ActionEvent;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a SoundSetFrame object
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version $Revision$
  */
 public class SoundSetAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3969609830068349700L;
 
     public SoundSetAction(String s) {
         super(s);
@@ -42,6 +35,3 @@ public class SoundSetAction extends AbstractAction {
     private final static Logger log = LoggerFactory.getLogger(SoundSetAction.class.getName());
 
 }
-
-
-/* @(#)SoundSetAction.java */

--- a/java/src/jmri/jmrix/rps/swing/soundset/SoundSetFrame.java
+++ b/java/src/jmri/jmrix/rps/swing/soundset/SoundSetFrame.java
@@ -1,4 +1,3 @@
-// SoundSetFrame.java
 package jmri.jmrix.rps.swing.soundset;
 
 import javax.swing.BoxLayout;
@@ -7,14 +6,8 @@ import javax.swing.BoxLayout;
  * Frame for controlling sound-speed calculation for RPS system.
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version $Revision$
  */
 public class SoundSetFrame extends jmri.util.JmriJFrame {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 6079518509404555599L;
 
     public SoundSetFrame() {
         super();

--- a/java/src/jmri/jmrix/rps/swing/soundset/SoundSetPane.java
+++ b/java/src/jmri/jmrix/rps/swing/soundset/SoundSetPane.java
@@ -1,4 +1,3 @@
-// SoundSetPane.java
 package jmri.jmrix.rps.swing.soundset;
 
 import java.awt.FlowLayout;
@@ -24,15 +23,9 @@ import org.slf4j.LoggerFactory;
  * Frame for control of the sound speed for the RPS system
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version $Revision$
  */
 public class SoundSetPane extends JPanel
         implements ReadingListener, MeasurementListener, PropertyChangeListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6186717308223634637L;
 
     public SoundSetPane() {
         super();

--- a/java/src/jmri/jmrix/rps/trackingpanel/RpsTrackingControlPane.java
+++ b/java/src/jmri/jmrix/rps/trackingpanel/RpsTrackingControlPane.java
@@ -1,4 +1,3 @@
-// RpsTrackingControlPane.java
 package jmri.jmrix.rps.trackingpanel;
 
 import java.awt.FlowLayout;
@@ -15,14 +14,9 @@ import javax.swing.JTextField;
  * Panel to control the scaling of a RpsTrackingPane
  *
  * @author	Bob Jacobsen Copyright (C) 2008
- * @version $Revision$
  */
 public class RpsTrackingControlPane extends JPanel {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1526969572941516857L;
     RpsTrackingPanel panel;
 
     public RpsTrackingControlPane(RpsTrackingPanel panel) {

--- a/java/src/jmri/jmrix/rps/trackingpanel/RpsTrackingFrame.java
+++ b/java/src/jmri/jmrix/rps/trackingpanel/RpsTrackingFrame.java
@@ -1,4 +1,3 @@
-// RpsTrackingFrame.java
 package jmri.jmrix.rps.trackingpanel;
 
 import java.awt.Dimension;
@@ -15,14 +14,8 @@ import javax.swing.JSeparator;
  * Frame containing the entire display tool
  *
  * @author	Bob Jacobsen Copyright (C) 2006, 2008
- * @version $Revision$
  */
 public class RpsTrackingFrame extends jmri.util.JmriJFrame {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 2932962639315165044L;
 
     public RpsTrackingFrame(String s) {
         super(s);
@@ -146,6 +139,3 @@ public class RpsTrackingFrame extends jmri.util.JmriJFrame {
         panel.clear();
     }
 }
-
-
-/* @(#)RpsTrackingFrame.java */

--- a/java/src/jmri/jmrix/rps/trackingpanel/RpsTrackingFrameAction.java
+++ b/java/src/jmri/jmrix/rps/trackingpanel/RpsTrackingFrameAction.java
@@ -1,4 +1,3 @@
-// RpsTrackingFrameAction.java
 package jmri.jmrix.rps.trackingpanel;
 
 import java.awt.event.ActionEvent;
@@ -8,14 +7,8 @@ import javax.swing.AbstractAction;
  * Swing action to create and register a RpsTrackingFrame object
  *
  * @author	Bob Jacobsen Copyright (C) 2006, 2008
- * @version $Revision$
  */
 public class RpsTrackingFrameAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 250425187172662597L;
 
     public RpsTrackingFrameAction(String s) {
         super(s);
@@ -32,6 +25,3 @@ public class RpsTrackingFrameAction extends AbstractAction {
         f.setVisible(true);
     }
 }
-
-
-/* @(#)RpsTrackingFrameAction.java */

--- a/java/src/jmri/jmrix/rps/trackingpanel/RpsTrackingPanel.java
+++ b/java/src/jmri/jmrix/rps/trackingpanel/RpsTrackingPanel.java
@@ -1,4 +1,3 @@
-// RpsTrackingPanel.java
 package jmri.jmrix.rps.trackingpanel;
 
 import java.awt.BasicStroke;
@@ -34,15 +33,9 @@ import org.slf4j.LoggerFactory;
  * @see jmri.jmrix.rps.Measurement
  *
  * @author	Bob Jacobsen Copyright (C) 2006, 2008
- * @version $Revision$
  */
 public class RpsTrackingPanel extends javax.swing.JPanel
         implements MeasurementListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5705944161292948723L;
 
     public RpsTrackingPanel() {
         super();

--- a/java/src/jmri/jmrix/secsi/SecsiMenu.java
+++ b/java/src/jmri/jmrix/secsi/SecsiMenu.java
@@ -1,4 +1,3 @@
-// SecsiMenu.java
 package jmri.jmrix.secsi;
 
 import java.util.ResourceBundle;

--- a/java/src/jmri/jmrix/secsi/SerialLight.java
+++ b/java/src/jmri/jmrix/secsi/SerialLight.java
@@ -1,4 +1,3 @@
-// SerialLight.java
 package jmri.jmrix.secsi;
 
 import jmri.implementation.AbstractLight;
@@ -80,5 +79,3 @@ public class SerialLight extends AbstractLight {
 
     private final static Logger log = LoggerFactory.getLogger(SerialLight.class.getName());
 }
-
-/* @(#)SerialLight.java */

--- a/java/src/jmri/jmrix/secsi/SerialLightManager.java
+++ b/java/src/jmri/jmrix/secsi/SerialLightManager.java
@@ -1,4 +1,3 @@
-// SerialLightManager.java
 package jmri.jmrix.secsi;
 
 import jmri.Light;
@@ -108,5 +107,3 @@ public class SerialLightManager extends AbstractLightManager {
     private final static Logger log = LoggerFactory.getLogger(SerialLightManager.class.getName());
 
 }
-
-/* @(#)SerialLighttManager.java */

--- a/java/src/jmri/jmrix/secsi/SerialSensor.java
+++ b/java/src/jmri/jmrix/secsi/SerialSensor.java
@@ -1,4 +1,3 @@
-// SerialSensor.java
 package jmri.jmrix.secsi;
 
 import jmri.implementation.AbstractSensor;

--- a/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigAction.java
+++ b/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigAction.java
@@ -1,4 +1,3 @@
-// NodeConfigAction.java
 package jmri.jmrix.secsi.nodeconfig;
 
 import java.awt.event.ActionEvent;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a NodeConfigFrame object
  *
  * @author	Bob Jacobsen Copyright (C) 2006, 2008
- * @version	$Revision$
  */
 public class NodeConfigAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5110730322384604465L;
 
     public NodeConfigAction(String s) {
         super(s);
@@ -39,6 +32,3 @@ public class NodeConfigAction extends AbstractAction {
     }
     private final static Logger log = LoggerFactory.getLogger(NodeConfigAction.class.getName());
 }
-
-
-/* @(#)NodeConfigAction.java */

--- a/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigFrame.java
+++ b/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigFrame.java
@@ -1,4 +1,3 @@
-// NodeConfigFrame.java
 package jmri.jmrix.secsi.nodeconfig;
 
 import java.awt.Container;
@@ -21,14 +20,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright (C) 2004, 2007, 2008
  * @author	Dave Duchamp Copyright (C) 2004, 2006
- * @version	$Revision$
  */
 public class NodeConfigFrame extends jmri.util.JmriJFrame {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3775018049333679363L;
 
     ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.secsi.nodeconfig.NodeConfigBundle");
 

--- a/java/src/jmri/jmrix/secsi/packetgen/SerialPacketGenAction.java
+++ b/java/src/jmri/jmrix/secsi/packetgen/SerialPacketGenAction.java
@@ -1,4 +1,3 @@
-// SerialPacketGenAction.java
 package jmri.jmrix.secsi.packetgen;
 
 import java.awt.event.ActionEvent;
@@ -38,6 +37,3 @@ public class SerialPacketGenAction extends AbstractAction {
     }
     private final static Logger log = LoggerFactory.getLogger(SerialPacketGenAction.class.getName());
 }
-
-
-/* @(#)SerialPacketGenAction.java */

--- a/java/src/jmri/jmrix/secsi/packetgen/SerialPacketGenFrame.java
+++ b/java/src/jmri/jmrix/secsi/packetgen/SerialPacketGenFrame.java
@@ -1,4 +1,3 @@
-// SerialPacketGenFrame.java
 package jmri.jmrix.secsi.packetgen;
 
 import java.awt.Dimension;

--- a/java/src/jmri/jmrix/secsi/serialmon/SerialMonAction.java
+++ b/java/src/jmri/jmrix/secsi/serialmon/SerialMonAction.java
@@ -1,4 +1,3 @@
-// SerialMonAction.java
 package jmri.jmrix.secsi.serialmon;
 
 import java.awt.event.ActionEvent;
@@ -41,6 +40,3 @@ public class SerialMonAction extends AbstractAction {
     private final static Logger log = LoggerFactory.getLogger(SerialMonAction.class.getName());
 
 }
-
-
-/* @(#)SerialMonAction.java */

--- a/java/src/jmri/jmrix/secsi/serialmon/SerialMonFrame.java
+++ b/java/src/jmri/jmrix/secsi/serialmon/SerialMonFrame.java
@@ -1,4 +1,3 @@
-// SerialMonFrame.java
 package jmri.jmrix.secsi.serialmon;
 
 import jmri.jmrix.secsi.SerialListener;

--- a/java/src/jmri/jmrix/sprog/swing/PowerPane.java
+++ b/java/src/jmri/jmrix/sprog/swing/PowerPane.java
@@ -1,4 +1,3 @@
-//PowerPane.java
 package jmri.jmrix.sprog.swing;
 
 import java.awt.GridLayout;
@@ -18,14 +17,9 @@ import org.slf4j.LoggerFactory;
  * Pane for power control
  *
  * @author	Bob Jacobsen Copyright (C) 2001
- * @version	$Revision$
  */
 public class PowerPane extends javax.swing.JPanel implements java.beans.PropertyChangeListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -9185281612199315791L;
     // GUI member declarations
     static ResourceBundle res = ResourceBundle.getBundle("jmri.jmrit.powerpanel.PowerPanelBundle");
     JLabel onOffStatus = new JLabel(res.getString("LabelUnknown"));

--- a/java/src/jmri/jmrix/sprog/swing/PowerPanelAction.java
+++ b/java/src/jmri/jmrix/sprog/swing/PowerPanelAction.java
@@ -1,4 +1,3 @@
-// PowerPanelAction.java
 package jmri.jmrix.sprog.swing;
 
 import java.awt.event.ActionEvent;
@@ -9,14 +8,9 @@ import javax.swing.AbstractAction;
  * Swing action to create and register a PowerPanelFrame object.
  *
  * @author	Bob Jacobsen Copyright (C) 2001
- * @version $Revision$
  */
 public class PowerPanelAction extends AbstractAction {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8975098374222170676L;
     static ResourceBundle res = ResourceBundle.getBundle("jmri.jmrit.powerpanel.PowerPanelBundle");
 
     public PowerPanelAction(String s) {

--- a/java/src/jmri/jmrix/sprog/swing/PowerPanelFrame.java
+++ b/java/src/jmri/jmrix/sprog/swing/PowerPanelFrame.java
@@ -1,4 +1,3 @@
-// PowerPanelFrame.java
 package jmri.jmrix.sprog.swing;
 
 import java.util.ResourceBundle;
@@ -8,14 +7,9 @@ import jmri.util.JmriJFrame;
  * Frame for controlling layout power via a PowerManager.
  *
  * @author	Bob Jacobsen Copyright (C) 2001
- * @version $Revision$
  */
 public class PowerPanelFrame extends JmriJFrame {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1253132940033685L;
     // GUI member declarations
     PowerPane pane = new PowerPane();
 

--- a/java/src/jmri/jmrix/sprog/update/SprogHexFile.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogHexFile.java
@@ -20,10 +20,6 @@ import org.slf4j.LoggerFactory;
  */
 public class SprogHexFile extends jmri.util.JmriJFrame {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4982055575560612793L;
     private File file;
     private FileInputStream in;
     private BufferedInputStream buffIn;

--- a/java/src/jmri/jmrix/sprog/update/SprogIIUpdateAction.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogIIUpdateAction.java
@@ -1,4 +1,3 @@
-//SprogIIUpdateAction.java
 package jmri.jmrix.sprog.update;
 
 import java.awt.event.ActionEvent;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a SprogIIUpdateFrame object
  *
  * @author	Andrew crosland Copyright (C) 2004
- * @version	$Revision$
  */
 public class SprogIIUpdateAction extends SprogUpdateAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 6594875472044292274L;
 
     public SprogIIUpdateAction(String s) {
         super(s);
@@ -45,6 +38,3 @@ public class SprogIIUpdateAction extends SprogUpdateAction {
     private final static Logger log = LoggerFactory.getLogger(SprogIIUpdateAction.class.getName());
 
 }
-
-
-/* @(#)SprogIIUpdateAction.java */

--- a/java/src/jmri/jmrix/tams/TamsSensor.java
+++ b/java/src/jmri/jmrix/tams/TamsSensor.java
@@ -1,4 +1,3 @@
-// TamsSensor.java
 package jmri.jmrix.tams;
 
 import jmri.implementation.AbstractSensor;
@@ -13,14 +12,8 @@ import jmri.implementation.AbstractSensor;
  * in one location.
  *
  * @author Kevin Dickerson (C) 2009
- * @version	$Revision: 20842 $
  */
 public class TamsSensor extends AbstractSensor {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -810400928174703675L;
 
     public TamsSensor(String systemName, String userName) {
         super(systemName, userName);
@@ -42,5 +35,3 @@ public class TamsSensor extends AbstractSensor {
     static int[] modeValues = null;
 
 }
-
-/* @(#)TamsSensor.java */

--- a/java/src/jmri/jmrix/tams/TamsTurnout.java
+++ b/java/src/jmri/jmrix/tams/TamsTurnout.java
@@ -1,4 +1,3 @@
-// TamsTurnout.java
 package jmri.jmrix.tams;
 
 import jmri.Turnout;
@@ -16,15 +15,10 @@ import org.slf4j.LoggerFactory;
  * Based on work by Bob Jacobsen
  *
  * @author	Kevin Dickerson Copyright (C) 2012
- * @version	$Revision: 18574 $
  */
 public class TamsTurnout extends AbstractTurnout
         implements TamsListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1921305278634163107L;
     String prefix;
 
     /**
@@ -226,5 +220,3 @@ public class TamsTurnout extends AbstractTurnout
 
     private final static Logger log = LoggerFactory.getLogger(TamsTurnout.class.getName());
 }
-
-/* @(#)TamsTurnout.java */

--- a/java/src/jmri/jmrix/tams/swing/TamsMenu.java
+++ b/java/src/jmri/jmrix/tams/swing/TamsMenu.java
@@ -14,11 +14,6 @@ import org.slf4j.LoggerFactory;
  */
 public class TamsMenu extends JMenu {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3647445955400088727L;
-
     public TamsMenu(TamsSystemConnectionMemo memo) {
         super();
 

--- a/java/src/jmri/jmrix/tams/swing/TamsNamedPaneAction.java
+++ b/java/src/jmri/jmrix/tams/swing/TamsNamedPaneAction.java
@@ -1,4 +1,3 @@
-// TamsNamedPaneAction.java
 package jmri.jmrix.tams.swing;
 
 import javax.swing.Icon;
@@ -14,14 +13,8 @@ import org.slf4j.LoggerFactory;
  * Based on work by Bob Jacobsen
  *
  * @author	Kevin Dickerson Copyright (C) 2012
- * @version	$Revision: 17977 $
  */
 public class TamsNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 203137175025143771L;
 
     /**
      * Enhanced constructor for placing the pane in various GUIs
@@ -58,5 +51,3 @@ public class TamsNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction {
 
     private final static Logger log = LoggerFactory.getLogger(TamsNamedPaneAction.class.getName());
 }
-
-/* @(#)TamsNamedPaneAction.java */

--- a/java/src/jmri/jmrix/tams/swing/TamsPanel.java
+++ b/java/src/jmri/jmrix/tams/swing/TamsPanel.java
@@ -1,4 +1,3 @@
-// TamsPanel.java
 package jmri.jmrix.tams.swing;
 
 import jmri.jmrix.tams.TamsSystemConnectionMemo;
@@ -12,14 +11,9 @@ import jmri.jmrix.tams.TamsSystemConnectionMemo;
  * Based on work by Bob Jacobsen
  *
  * @author	Kevin Dickerson Copyright (C) 2012
- * @version $Revision: 17977 $
  */
 abstract public class TamsPanel extends jmri.util.swing.JmriPanel implements TamsPanelInterface {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3918718731058984206L;
     /**
      * make "memo" object available as convenietams
      */

--- a/java/src/jmri/jmrix/tams/swing/locodatabase/LocoDataModel.java
+++ b/java/src/jmri/jmrix/tams/swing/locodatabase/LocoDataModel.java
@@ -1,4 +1,3 @@
-// LocoDataModel.java
 package jmri.jmrix.tams.swing.locodatabase;
 
 import java.awt.event.MouseEvent;
@@ -22,14 +21,9 @@ import org.slf4j.LoggerFactory;
  * Table data model for display the loco database of the Tams MC
  *
  * @author Kevin Dickerson Copyright (C) 2012
- * @version $Revision: 17977 $
  */
 public class LocoDataModel extends javax.swing.table.AbstractTableModel implements TamsListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8162723526280674206L;
     static public final int ADDRCOLUMN = 0;
     static public final int SPDCOLUMN = 1;
     static public final int FMTCOLUMN = 2;

--- a/java/src/jmri/jmrix/tams/swing/locodatabase/LocoDataPane.java
+++ b/java/src/jmri/jmrix/tams/swing/locodatabase/LocoDataPane.java
@@ -1,4 +1,3 @@
-// LocoDataPane.java
 package jmri.jmrix.tams.swing.locodatabase;
 
 import java.awt.FlowLayout;
@@ -24,14 +23,9 @@ import org.slf4j.LoggerFactory;
  * Frame provinging access to the loco database on the Tams MC
  *
  * @author	Kevin Dickerson Copyright (C) 2012
- * @version	$Revision: 17977 $
  */
 public class LocoDataPane extends jmri.jmrix.tams.swing.TamsPanel {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7652937506195229419L;
     LocoDataModel locoModel;
     JTable locoTable;
     JScrollPane locoScroll;
@@ -143,11 +137,6 @@ public class LocoDataPane extends jmri.jmrix.tams.swing.TamsPanel {
      * Nested class to create one of these using old-style defaults
      */
     static public class Default extends jmri.jmrix.tams.swing.TamsNamedPaneAction {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 8803207637297660717L;
 
         public Default() {
             super(rb.getString("Title"),

--- a/java/src/jmri/jmrix/tams/swing/monitor/TamsMonPane.java
+++ b/java/src/jmri/jmrix/tams/swing/monitor/TamsMonPane.java
@@ -1,13 +1,3 @@
-/**
- * TamsMonPane.java
- *
- * Description:	Swing action to create and register a MonFrame object
- *
- * Based on work by Bob Jacobsen
- *
- * @author	Kevin Dickerson Copyright (C) 2012
- * @version
- */
 package jmri.jmrix.tams.swing.monitor;
 
 import java.util.ResourceBundle;
@@ -19,12 +9,14 @@ import jmri.jmrix.tams.TamsReply;
 import jmri.jmrix.tams.TamsSystemConnectionMemo;
 import jmri.jmrix.tams.swing.TamsPanelInterface;
 
+/**
+ * Swing action to create and register a MonFrame object
+ *
+ * Based on work by Bob Jacobsen
+ *
+ * @author	Kevin Dickerson Copyright (C) 2012
+ */
 public class TamsMonPane extends jmri.jmrix.AbstractMonPane implements TamsListener, TamsPanelInterface {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4164141037445448914L;
 
     public TamsMonPane() {
         super();
@@ -126,6 +118,3 @@ public class TamsMonPane extends jmri.jmrix.AbstractMonPane implements TamsListe
     }
 
 }
-
-
-/* @(#)MonAction.java */

--- a/java/src/jmri/jmrix/tams/swing/packetgen/PacketGenPanel.java
+++ b/java/src/jmri/jmrix/tams/swing/packetgen/PacketGenPanel.java
@@ -1,4 +1,3 @@
-// PacketGenFrame.java
 package jmri.jmrix.tams.swing.packetgen;
 
 import java.awt.Dimension;
@@ -14,14 +13,9 @@ import jmri.util.StringUtil;
  * Frame for user input of Tams messages Based on work by Bob Jacobsen
  *
  * @author	Kevin Dickerson Copyright (C) 2012
- * @version $Revision: 17977 $
  */
 public class PacketGenPanel extends jmri.jmrix.tams.swing.TamsPanel implements TamsListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5155072043615176052L;
     // member declarations
     javax.swing.JLabel jLabel1 = new javax.swing.JLabel();
     javax.swing.JButton sendButton = new javax.swing.JButton();

--- a/java/src/jmri/jmrix/tams/swing/statusframe/StatusPanel.java
+++ b/java/src/jmri/jmrix/tams/swing/statusframe/StatusPanel.java
@@ -1,4 +1,3 @@
-// StatusPanel.java
 package jmri.jmrix.tams.swing.statusframe;
 
 import java.util.ResourceBundle;
@@ -18,14 +17,9 @@ import jmri.jmrix.tams.TamsTrafficController;
  * Based on work by Bob Jacobsen
  *
  * @author	Kevin Dickerson Copyright (C) 2012
- * @version	$Revision: 19655 $
  */
 public class StatusPanel extends jmri.jmrix.tams.swing.TamsPanel implements TamsListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5401219799607877348L;
     String appString = "Application Version : ";
     String serString = "Serial Number : ";
     JLabel appVersion = new JLabel(appString + "<unknown>");
@@ -120,6 +114,3 @@ public class StatusPanel extends jmri.jmrix.tams.swing.TamsPanel implements Tams
     }
 
 }
-
-
-/* @(#)StatusPane.java */

--- a/java/src/jmri/jmrix/tmcc/SerialTurnout.java
+++ b/java/src/jmri/jmrix/tmcc/SerialTurnout.java
@@ -1,4 +1,3 @@
-// SerialTurnout.java
 package jmri.jmrix.tmcc;
 
 import jmri.Turnout;
@@ -19,11 +18,6 @@ import org.slf4j.LoggerFactory;
  * @version	$Revision$
  */
 public class SerialTurnout extends AbstractTurnout {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5339532021030123183L;
 
     public SerialTurnout(int number) {
         super("TT" + number);
@@ -75,5 +69,3 @@ public class SerialTurnout extends AbstractTurnout {
 
     private final static Logger log = LoggerFactory.getLogger(SerialTurnout.class.getName());
 }
-
-/* @(#)SerialTurnout.java */

--- a/java/src/jmri/jmrix/tmcc/TMCCMenu.java
+++ b/java/src/jmri/jmrix/tmcc/TMCCMenu.java
@@ -1,4 +1,3 @@
-// TMCCMenu.java
 package jmri.jmrix.tmcc;
 
 import java.util.ResourceBundle;
@@ -8,14 +7,8 @@ import javax.swing.JMenu;
  * Create a "Systems" menu containing the Jmri TMCC-specific tools
  *
  * @author	Bob Jacobsen Copyright 2003, 2006
- * @version $Revision$
  */
 public class TMCCMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1759987972791093919L;
 
     public TMCCMenu(String name) {
         this();

--- a/java/src/jmri/jmrix/tmcc/packetgen/SerialPacketGenAction.java
+++ b/java/src/jmri/jmrix/tmcc/packetgen/SerialPacketGenAction.java
@@ -1,12 +1,3 @@
-/**
- * SerialPacketGenAction.java
- *
- * Description:	Swing action to create and register a SerialPacketGenFrame
- * object
- *
- * @author	Bob Jacobsen Copyright (C) 2001
- * @version
- */
 package jmri.jmrix.tmcc.packetgen;
 
 import java.awt.event.ActionEvent;
@@ -14,12 +5,13 @@ import javax.swing.AbstractAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Swing action to create and register a SerialPacketGenFrame
+ * object
+ *
+ * @author	Bob Jacobsen Copyright (C) 2001
+ */
 public class SerialPacketGenAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3962355656524638749L;
 
     public SerialPacketGenAction(String s) {
         super(s);
@@ -40,6 +32,3 @@ public class SerialPacketGenAction extends AbstractAction {
     }
     private final static Logger log = LoggerFactory.getLogger(SerialPacketGenAction.class.getName());
 }
-
-
-/* @(#)SerialPacketGenAction.java */

--- a/java/src/jmri/jmrix/tmcc/packetgen/SerialPacketGenFrame.java
+++ b/java/src/jmri/jmrix/tmcc/packetgen/SerialPacketGenFrame.java
@@ -1,4 +1,3 @@
-// SerialPacketGenFrame.java
 package jmri.jmrix.tmcc.packetgen;
 
 import java.awt.Dimension;
@@ -13,14 +12,9 @@ import jmri.util.StringUtil;
  * Frame for user input of serial messages
  *
  * @author	Bob Jacobsen Copyright (C) 2002, 2003, 2006
- * @version	$Revision$
  */
 public class SerialPacketGenFrame extends jmri.util.JmriJFrame implements jmri.jmrix.tmcc.SerialListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 6372326464393162756L;
     // member declarations
     javax.swing.JLabel jLabel1 = new javax.swing.JLabel();
     javax.swing.JButton sendButton = new javax.swing.JButton();

--- a/java/src/jmri/jmrix/tmcc/serialmon/SerialMonAction.java
+++ b/java/src/jmri/jmrix/tmcc/serialmon/SerialMonAction.java
@@ -1,4 +1,3 @@
-// SerialMonAction.java
 package jmri.jmrix.tmcc.serialmon;
 
 import java.awt.event.ActionEvent;
@@ -10,14 +9,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a SerialMonFrame object
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2006
- * @version	$Revision$
  */
 public class SerialMonAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3766538645555647422L;
 
     public SerialMonAction(String s) {
         super(s);
@@ -41,6 +34,3 @@ public class SerialMonAction extends AbstractAction {
     private final static Logger log = LoggerFactory.getLogger(SerialMonAction.class.getName());
 
 }
-
-
-/* @(#)SerialMonAction.java */

--- a/java/src/jmri/jmrix/tmcc/serialmon/SerialMonFrame.java
+++ b/java/src/jmri/jmrix/tmcc/serialmon/SerialMonFrame.java
@@ -1,4 +1,3 @@
-// SerialMonFrame.java
 package jmri.jmrix.tmcc.serialmon;
 
 import jmri.jmrix.tmcc.SerialListener;
@@ -10,14 +9,8 @@ import jmri.jmrix.tmcc.SerialTrafficController;
  * Frame displaying (and logging) TMCC serial command messages
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2006
- * @version $Revision$
  */
 public class SerialMonFrame extends jmri.jmrix.AbstractMonFrame implements SerialListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 6510323420215494043L;
 
     public SerialMonFrame() {
         super();

--- a/java/src/jmri/jmrix/wangrow/WangrowMenu.java
+++ b/java/src/jmri/jmrix/wangrow/WangrowMenu.java
@@ -1,4 +1,3 @@
-// WangrowMenu.java
 package jmri.jmrix.wangrow;
 
 import jmri.jmrix.nce.NceSystemConnectionMemo;
@@ -10,16 +9,10 @@ import jmri.jmrix.nce.NceSystemConnectionMemo;
  * package.
  *
  * @author	Bob Jacobsen Copyright 2003
- * @version $Revision$
  */
 @Deprecated
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS")
 public class WangrowMenu extends jmri.jmrix.nce.swing.NceMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3673055801676833967L;
 
     public WangrowMenu(NceSystemConnectionMemo memo) {
         super(memo);


### PR DESCRIPTION
Currently, when loading an existing roster entry, DecoderPro just loads the CV values.  This in turn loads the Variable values as the CVs change.

Because of DP's qualified-variable support, some Variables are not connected to specific CV contents at load time; they get the wrong values, and hilarity ensues.  (First pointed out by Dick Bronson) 

This PR first loads the Variable values from the file (they've been stored all along), then loads CV values as before.  

Also contains some misc cleanup of files around serialVersionID, filename comments, and @revision removal.