### PR TITLE
Remove JavaDoc warnings in jmrit.operations code

### DIFF
--- a/java/src/jmri/jmrit/operations/CommonConductorYardmasterPanel.java
+++ b/java/src/jmri/jmrit/operations/CommonConductorYardmasterPanel.java
@@ -364,8 +364,6 @@ public class CommonConductorYardmasterPanel extends OperationsPanel implements P
      * car and which pane to use, they are placed in the list "rollingStock"
      * with the prefix "p", "s" or "m" and the car's unique id.
      *
-     * @param rl
-     * @param isManifest
      */
     protected void blockCars(RouteLocation rl, boolean isManifest) {
         if (Setup.isPrintHeadersEnabled()) {

--- a/java/src/jmri/jmrit/operations/ExceptionDisplayFrame.java
+++ b/java/src/jmri/jmrit/operations/ExceptionDisplayFrame.java
@@ -90,7 +90,6 @@ public class ExceptionDisplayFrame extends JDialog {
     /**
      * Constructor that takes just an Exception and defaults everything else.
      *
-     * @param ex
      */
     public ExceptionDisplayFrame(Exception ex) {
         this.context = new ExceptionContext(ex, "Operation unavailable", // NOI18N

--- a/java/src/jmri/jmrit/operations/OperationsFrame.java
+++ b/java/src/jmri/jmrit/operations/OperationsFrame.java
@@ -155,8 +155,6 @@ public class OperationsFrame extends JmriJFrame implements AncestorListener {
      * Will modify the character column width of a TextArea box to 90% of a
      * panels width. ScrollPane is set to 95% of panel width.
      *
-     * @param scrollPane
-     * @param textArea
      */
     protected void adjustTextAreaColumnWidth(JScrollPane scrollPane, JTextArea textArea) {
         ((OperationsPanel) this.getContentPane()).adjustTextAreaColumnWidth(scrollPane, textArea, this.getPreferredSize());

--- a/java/src/jmri/jmrit/operations/OperationsPanel.java
+++ b/java/src/jmri/jmrit/operations/OperationsPanel.java
@@ -222,8 +222,6 @@ public class OperationsPanel extends JPanel implements AncestorListener {
      * Will modify the character column width of a TextArea box to 90% of a
      * panels width. ScrollPane is set to 95% of panel width.
      *
-     * @param scrollPane
-     * @param textArea
      */
     protected void adjustTextAreaColumnWidth(JScrollPane scrollPane, JTextArea textArea) {
         this.adjustTextAreaColumnWidth(scrollPane, textArea, this.getPreferredSize());

--- a/java/src/jmri/jmrit/operations/OperationsXml.java
+++ b/java/src/jmri/jmrit/operations/OperationsXml.java
@@ -72,8 +72,6 @@ public abstract class OperationsXml extends XmlFile {
     }
 
     /**
-     * @throws FileNotFoundException
-     * @throws IOException
      */
     protected void writeFile(String filename) throws FileNotFoundException, IOException {
         log.error("writeFile not overridden");

--- a/java/src/jmri/jmrit/operations/OperationsXml.java
+++ b/java/src/jmri/jmrit/operations/OperationsXml.java
@@ -190,8 +190,7 @@ public abstract class OperationsXml extends XmlFile {
     }
     
     /**
-     * Checks name for the file control characters: 
-     * @param name
+     * Checks name for the file control characters:
      * @return true if name is okay, false if name contains a control character.
      */
     public static boolean checkFileName(String name) {

--- a/java/src/jmri/jmrit/operations/automation/Automation.java
+++ b/java/src/jmri/jmrit/operations/automation/Automation.java
@@ -327,7 +327,6 @@ public class Automation implements java.beans.PropertyChangeListener {
      * Allowable sequence numbers are 0 to max size of automation. 0 = start of
      * list.
      *
-     * @param sequence
      * @return automation item
      */
     public AutomationItem addItem(int sequence) {
@@ -361,7 +360,6 @@ public class Automation implements java.beans.PropertyChangeListener {
     /**
      * Delete a AutomationItem
      *
-     * @param item
      */
     public void deleteItem(AutomationItem item) {
         if (item != null) {
@@ -396,7 +394,6 @@ public class Automation implements java.beans.PropertyChangeListener {
     /**
      * Get a AutomationItem by id
      *
-     * @param id
      * @return automation item
      */
     public AutomationItem getItemById(String id) {
@@ -455,7 +452,6 @@ public class Automation implements java.beans.PropertyChangeListener {
     /**
      * Places a AutomationItem earlier in the automation
      *
-     * @param item
      */
     public void moveItemUp(AutomationItem item) {
         int sequenceId = item.getSequenceId();
@@ -478,7 +474,6 @@ public class Automation implements java.beans.PropertyChangeListener {
     /**
      * Places a AutomationItem later in the automation
      *
-     * @param item
      */
     public void moveItemDown(AutomationItem item) {
         int sequenceId = item.getSequenceId();

--- a/java/src/jmri/jmrit/operations/automation/AutomationItem.java
+++ b/java/src/jmri/jmrit/operations/automation/AutomationItem.java
@@ -78,7 +78,6 @@ public class AutomationItem implements java.beans.PropertyChangeListener {
 
     /**
      *
-     * @param id
      */
     public AutomationItem(String id) {
         log.debug("New automation item id: {}", id);
@@ -195,8 +194,7 @@ public class AutomationItem implements java.beans.PropertyChangeListener {
 
     /**
      * The automation for actions, not the automation associated with this item.
-     * 
-     * @param automation
+     *
      */
     public void setAutomationToRun(Automation automation) {
         Automation old = AutomationManager.instance().getAutomationById(_automationIdToRun);
@@ -223,8 +221,7 @@ public class AutomationItem implements java.beans.PropertyChangeListener {
 
     /**
      * The automation for action GOTO, not this automation item.
-     * 
-     * @param automationItem
+     *
      */
     public void setGotoAutomationItem(AutomationItem automationItem) {
         AutomationItem oldItem = null;

--- a/java/src/jmri/jmrit/operations/automation/AutomationManager.java
+++ b/java/src/jmri/jmrit/operations/automation/AutomationManager.java
@@ -87,7 +87,6 @@ public class AutomationManager implements java.beans.PropertyChangeListener {
      * Finds an existing automation or creates a new automation if needed
      * requires automation's name creates a unique id for this automation
      *
-     * @param name
      *
      * @return new automation or existing automation
      */

--- a/java/src/jmri/jmrit/operations/automation/AutomationTableModel.java
+++ b/java/src/jmri/jmrit/operations/automation/AutomationTableModel.java
@@ -363,8 +363,7 @@ public class AutomationTableModel extends javax.swing.table.AbstractTableModel i
     /**
      * Returns either a comboBox loaded with Automations, or a goto list of
      * AutomationItems, or TrainSchedules.
-     * 
-     * @param item
+     *
      * @return comboBox loaded with automations or a goto automationIem list
      */
     private JComboBox<?> getAutomationComboBox(AutomationItem item) {

--- a/java/src/jmri/jmrit/operations/automation/actions/Action.java
+++ b/java/src/jmri/jmrit/operations/automation/actions/Action.java
@@ -42,8 +42,7 @@ public abstract class Action {
 
     /**
      * Mask off menu bits.
-     * 
-     * @param code
+     *
      * @return code {@literal &} ActionCodes.CODE_MASK
      */
     protected int getCode(int code) {
@@ -192,8 +191,7 @@ public abstract class Action {
      * <p>
      * action name, train name, route location name, automation name, goto item id,
      * train schedule day.
-     * 
-     * @param message
+     *
      * @return formated message
      */
     public String getFormatedMessage(String message) {

--- a/java/src/jmri/jmrit/operations/automation/actions/WaitTrainAction.java
+++ b/java/src/jmri/jmrit/operations/automation/actions/WaitTrainAction.java
@@ -43,8 +43,7 @@ public class WaitTrainAction extends Action implements PropertyChangeListener {
     /**
      * Wait for train to build and no location, or train to arrive at location,
      * or train build to be deselected.
-     * 
-     * @param evt
+     *
      */
     private void trainUpdate(PropertyChangeEvent evt) {
         if (getAutomationItem() != null) {

--- a/java/src/jmri/jmrit/operations/automation/actions/WaitTrainTerminatedAction.java
+++ b/java/src/jmri/jmrit/operations/automation/actions/WaitTrainTerminatedAction.java
@@ -42,8 +42,7 @@ public class WaitTrainTerminatedAction extends Action implements PropertyChangeL
     /**
      * Wait for train to terminate or if user deselects the train build
      * checkbox.
-     * 
-     * @param evt
+     *
      */
     private void trainUpdate(PropertyChangeEvent evt) {
         if (getAutomationItem() != null) {

--- a/java/src/jmri/jmrit/operations/locations/Location.java
+++ b/java/src/jmri/jmrit/operations/locations/Location.java
@@ -1087,7 +1087,6 @@ public class Location implements java.beans.PropertyChangeListener {
     
     /**
      * True if this location has a track with pick up or set out restrictions.
-     * @return
      */
     public boolean hasServiceRestrictions() {
         Track track;

--- a/java/src/jmri/jmrit/operations/locations/Location.java
+++ b/java/src/jmri/jmrit/operations/locations/Location.java
@@ -118,7 +118,6 @@ public class Location implements java.beans.PropertyChangeListener {
     /**
      * Sets the location's name.
      *
-     * @param name
      */
     public void setName(String name) {
         String old = _name;
@@ -190,7 +189,6 @@ public class Location implements java.beans.PropertyChangeListener {
     /**
      * Set total length of all tracks for this location
      *
-     * @param length
      */
     public void setLength(int length) {
         int old = _length;
@@ -283,7 +281,6 @@ public class Location implements java.beans.PropertyChangeListener {
 
     /**
      *
-     * @param trackType
      * @return True if location has the track type specified Track.INTERCHANGE
      *         Track.YARD Track.SPUR Track.Staging
      */
@@ -331,7 +328,6 @@ public class Location implements java.beans.PropertyChangeListener {
     /**
      * Sets the number of cars and or engines on for this location
      *
-     * @param number
      */
     public void setNumberRS(int number) {
         int old = _numberRS;
@@ -353,7 +349,6 @@ public class Location implements java.beans.PropertyChangeListener {
     /**
      * Sets the number of cars at this location
      *
-     * @param number
      */
     private void setNumberCars(int number) {
         int old = _numberCars;
@@ -375,7 +370,6 @@ public class Location implements java.beans.PropertyChangeListener {
     /**
      * Sets the number of engines at this location
      *
-     * @param number
      */
     private void setNumberEngines(int number) {
         int old = _numberEngines;
@@ -398,7 +392,6 @@ public class Location implements java.beans.PropertyChangeListener {
      * When true, a switchlist is desired for this location. Used for preview
      * and printing a manifest for a single location
      *
-     * @param switchList
      */
     public void setSwitchListEnabled(boolean switchList) {
         boolean old = _switchList;
@@ -521,7 +514,6 @@ public class Location implements java.beans.PropertyChangeListener {
     /**
      * Adds rolling stock to a specific location.
      *
-     * @param rs
      */
     public void addRS(RollingStock rs) {
         setNumberRS(getNumberRS() + 1);

--- a/java/src/jmri/jmrit/operations/locations/LocationManager.java
+++ b/java/src/jmri/jmrit/operations/locations/LocationManager.java
@@ -108,7 +108,6 @@ public class LocationManager implements java.beans.PropertyChangeListener {
      * Finds an existing location or creates a new location if needed requires
      * location's name creates a unique id for this location
      *
-     * @param name
      *
      * @return new location or existing location
      */

--- a/java/src/jmri/jmrit/operations/locations/Schedule.java
+++ b/java/src/jmri/jmrit/operations/locations/Schedule.java
@@ -86,7 +86,6 @@ public class Schedule implements java.beans.PropertyChangeListener {
     /**
      * Adds a car type to the end of this schedule
      *
-     * @param type
      * @return ScheduleItem created for the car type added
      */
     public ScheduleItem addItem(String type) {
@@ -110,8 +109,6 @@ public class Schedule implements java.beans.PropertyChangeListener {
      * Allowable sequence numbers are 0 to max size of schedule. 0 = start of
      * list.
      *
-     * @param item
-     * @param sequence
      * @return schedule item
      */
     public ScheduleItem addItem(String item, int sequence) {
@@ -150,7 +147,6 @@ public class Schedule implements java.beans.PropertyChangeListener {
     /**
      * Delete a ScheduleItem
      *
-     * @param si
      */
     public void deleteItem(ScheduleItem si) {
         if (si != null) {
@@ -179,7 +175,6 @@ public class Schedule implements java.beans.PropertyChangeListener {
     /**
      * Get item by car type (gets last schedule item with this type)
      *
-     * @param type
      * @return schedule item
      */
     public ScheduleItem getItemByType(String type) {
@@ -198,7 +193,6 @@ public class Schedule implements java.beans.PropertyChangeListener {
     /**
      * Get a ScheduleItem by id
      *
-     * @param id
      * @return schedule item
      */
     public ScheduleItem getItemById(String id) {
@@ -248,7 +242,6 @@ public class Schedule implements java.beans.PropertyChangeListener {
     /**
      * Places a ScheduleItem earlier in the schedule
      *
-     * @param si
      */
     public void moveItemUp(ScheduleItem si) {
         int sequenceId = si.getSequenceId();
@@ -271,7 +264,6 @@ public class Schedule implements java.beans.PropertyChangeListener {
     /**
      * Places a ScheduleItem later in the schedule
      *
-     * @param si
      */
     public void moveItemDown(ScheduleItem si) {
         int sequenceId = si.getSequenceId();

--- a/java/src/jmri/jmrit/operations/locations/ScheduleItem.java
+++ b/java/src/jmri/jmrit/operations/locations/ScheduleItem.java
@@ -43,7 +43,6 @@ public class ScheduleItem implements java.beans.PropertyChangeListener {
 
     /**
      *
-     * @param id
      * @param type car type for schedule
      */
     public ScheduleItem(String id, String type) {

--- a/java/src/jmri/jmrit/operations/locations/ScheduleManager.java
+++ b/java/src/jmri/jmrit/operations/locations/ScheduleManager.java
@@ -86,7 +86,6 @@ public class ScheduleManager implements java.beans.PropertyChangeListener {
      * Finds an existing schedule or creates a new schedule if needed requires
      * schedule's name creates a unique id for this schedule
      *
-     * @param name
      *
      * @return new schedule or existing schedule
      */

--- a/java/src/jmri/jmrit/operations/locations/Track.java
+++ b/java/src/jmri/jmrit/operations/locations/Track.java
@@ -538,7 +538,6 @@ public class Track {
     /**
      * Sets the number of rolling stock (cars and or engines) on this track
      *
-     * @param number
      */
     private void setNumberRS(int number) {
         int old = _numberRS;
@@ -552,7 +551,6 @@ public class Track {
     /**
      * Sets the number of cars on this track
      *
-     * @param number
      */
     private void setNumberCars(int number) {
         int old = _numberCars;
@@ -566,7 +564,6 @@ public class Track {
     /**
      * Sets the number of engines on this track
      *
-     * @param number
      */
     private void setNumberEngines(int number) {
         int old = _numberEngines;
@@ -604,7 +601,6 @@ public class Track {
     /**
      * Adds rolling stock to a specific track.
      *
-     * @param rs
      */
     public void addRS(RollingStock rs) {
         setNumberRS(getNumberRS() + 1);
@@ -1203,7 +1199,6 @@ public class Track {
      * Determine if train can set out cars to this track. Based on the train's
      * id or train's route id. See setDropOption(option).
      *
-     * @param train
      * @return true if the train can set out cars to this track.
      */
     public boolean acceptsDropTrain(Train train) {
@@ -1264,7 +1259,6 @@ public class Track {
     /**
      * Add train or route id to this track.
      *
-     * @param id
      */
     public void addPickupId(String id) {
         if (_pickupList.contains(id)) {
@@ -1285,7 +1279,6 @@ public class Track {
      * Determine if train can pick up cars from this track. Based on the train's
      * id or train's route id. See setPickupOption(option).
      *
-     * @param train
      * @return true if the train can pick up cars from this track.
      */
     public boolean acceptsPickupTrain(Train train) {
@@ -1427,7 +1420,6 @@ public class Track {
 
     /**
      *
-     * @param length
      * @return true if the program should ignore some percentage of the car's
      *         length currently consuming track space.
      */
@@ -1750,7 +1742,6 @@ public class Track {
      * Checks to see if car can be placed on this spur using this schedule.
      * Returns OKAY if the schedule can service the car.
      *
-     * @param car
      * @return Track.OKAY track.CUSTOM track.SCHEDULE
      */
     public String checkSchedule(Car car) {
@@ -1867,7 +1858,6 @@ public class Track {
      * item in the list. Load the car with the next schedule load if one exists,
      * and set the car's final destination if there's one in the schedule.
      *
-     * @param car
      * @return Track.OKAY or Track.SCHEDULE
      */
     public String scheduleNext(Car car) {
@@ -1961,8 +1951,6 @@ public class Track {
      * the schedule item. Also sets the next load and wait count that will kick
      * in when the car arrives at the spur with this schedule.
      *
-     * @param scheduleItem
-     * @param car
      */
     private void loadNext(ScheduleItem scheduleItem, Car car) {
         if (scheduleItem == null) {
@@ -2169,7 +2157,6 @@ public class Track {
     /**
      * Returns true if destination is valid from this track.
      *
-     * @param destination
      * @return true if track services the destination
      */
     public boolean acceptsDestination(Location destination) {

--- a/java/src/jmri/jmrit/operations/rollingstock/RollingStock.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/RollingStock.java
@@ -111,7 +111,6 @@ public class RollingStock implements java.beans.PropertyChangeListener {
     /**
      * Set the rolling stock identification or road number
      *
-     * @param number
      */
     public void setNumber(String number) {
         String old = _number;
@@ -172,8 +171,7 @@ public class RollingStock implements java.beans.PropertyChangeListener {
 
     /*
      * Sets the length of the rolling stock.
-     * 
-     * @param length
+     *
      */
     public void setLength(String length) {
         String old = _length;
@@ -296,7 +294,6 @@ public class RollingStock implements java.beans.PropertyChangeListener {
      * two years if the rolling stock was built in the 1900s. Use MM-YYYY for
      * units build after 1999.
      *
-     * @param built
      */
     public void setBuilt(String built) {
         String old = _built;
@@ -392,7 +389,6 @@ public class RollingStock implements java.beans.PropertyChangeListener {
     /**
      * Sets rolling stock location on the layout
      *
-     * @param location
      * @param track (yard, spur, staging, or interchange track)
      *
      * @return "okay" if successful, "type" if the rolling stock's type isn't
@@ -405,7 +401,6 @@ public class RollingStock implements java.beans.PropertyChangeListener {
     /**
      * Sets rolling stock location on the layout
      *
-     * @param location
      * @param track    (yard, spur, staging, or interchange track)
      * @param force    when true place rolling stock ignore track length, type,
      *                 {@literal &} road
@@ -481,7 +476,6 @@ public class RollingStock implements java.beans.PropertyChangeListener {
     /**
      * Sets rolling stock destination on the layout
      *
-     * @param destination
      * @param track (yard, spur, staging, or interchange track)
      * @return "okay" if successful, "type" if the rolling stock's type isn't
      *         acceptable, or "length" if the rolling stock length didn't fit.
@@ -493,7 +487,6 @@ public class RollingStock implements java.beans.PropertyChangeListener {
     /**
      * Sets rolling stock destination on the layout
      *
-     * @param destination
      * @param track       (yard, spur, staging, or interchange track)
      * @param force       when true ignore track length, type, {@literal &} road
      *                    when setting destination
@@ -564,8 +557,6 @@ public class RollingStock implements java.beans.PropertyChangeListener {
     /**
      * Used to check destination track to see if it will accept rolling stock
      *
-     * @param destination
-     * @param track
      * @return status OKAY, TYPE, ROAD, LENGTH, ERROR_TRACK
      */
     public String testDestination(Location destination, Track track) {
@@ -620,7 +611,6 @@ public class RollingStock implements java.beans.PropertyChangeListener {
      * space or drop count. Used by car router to test destinations. Does not
      * fire a property change. Use setDestination(Location, Track) instead.
      *
-     * @param track
      */
     public void setDestinationTrack(Track track) {
         if (track != null) {
@@ -677,7 +667,6 @@ public class RollingStock implements java.beans.PropertyChangeListener {
     /**
      * Sets the train that will service this rolling stock.
      *
-     * @param train
      */
     public void setTrain(Train train) {
         Train old = _train;
@@ -900,7 +889,6 @@ public class RollingStock implements java.beans.PropertyChangeListener {
      * Sets the last date when this rolling stock was moved, or was reset from a
      * built train.
      *
-     * @param date
      */
     public void setLastDate(Date date) {
         Date old = _lastDate;

--- a/java/src/jmri/jmrit/operations/rollingstock/RollingStockAttribute.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/RollingStockAttribute.java
@@ -68,7 +68,6 @@ public class RollingStockAttribute {
     /**
      * Performs number sort before adding to list
      *
-     * @param lengths
      */
     public void setValues(String[] lengths) {
         if (lengths.length == 0) {

--- a/java/src/jmri/jmrit/operations/rollingstock/RollingStockLogger.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/RollingStockLogger.java
@@ -265,7 +265,6 @@ public class RollingStockLogger extends XmlFile implements java.beans.PropertyCh
      * Individual files for each rolling stock stored in a directory called
      * "rollingStock" inside the "logger" directory.
      *
-     * @return
      */
     public String getFullLoggerFileName(RollingStock rs) {
         if (!OperationsXml.checkFileName(rs.toString())) { // NOI18N
@@ -284,8 +283,7 @@ public class RollingStockLogger extends XmlFile implements java.beans.PropertyCh
     /**
      * Return the date and time in an MS Excel friendly format yyyy/MM/dd
      * HH:mm:ss
-     * 
-     * @return
+     *
      */
     private String getTime() {
         String time = Calendar.getInstance().getTime().toString();

--- a/java/src/jmri/jmrit/operations/rollingstock/RollingStockLogger.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/RollingStockLogger.java
@@ -264,8 +264,7 @@ public class RollingStockLogger extends XmlFile implements java.beans.PropertyCh
     /**
      * Individual files for each rolling stock stored in a directory called
      * "rollingStock" inside the "logger" directory.
-     * 
-     * @param rs
+     *
      * @return
      */
     public String getFullLoggerFileName(RollingStock rs) {

--- a/java/src/jmri/jmrit/operations/rollingstock/RollingStockManager.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/RollingStockManager.java
@@ -525,7 +525,6 @@ public class RollingStockManager {
     /**
      * Get a list of rolling stocks assigned to a train ordered by location
      *
-     * @param train
      * @return List of RollingStock assigned to the train ordered by location
      */
     public List<RollingStock> getByTrainList(Train train) {

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/Car.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/Car.java
@@ -204,7 +204,6 @@ public class Car extends RollingStock {
     /**
      * Used to keep track of which item in a schedule was used for this car.
      *
-     * @param id
      */
     public void setScheduleItemId(String id) {
         log.debug("Set schedule item id ({}) for car ({})", id, toString());
@@ -504,7 +503,6 @@ public class Car extends RollingStock {
     /**
      * A kernel is a group of cars that are switched as a unit.
      *
-     * @param kernel
      */
     public void setKernel(Kernel kernel) {
         if (_kernel == kernel) {
@@ -581,7 +579,6 @@ public class Car extends RollingStock {
     /**
      * Sets the car's destination on the layout
      *
-     * @param destination
      * @param track       (yard, spur, staging, or interchange track)
      * @return "okay" if successful, "type" if the rolling stock's type isn't
      *         acceptable, or "length" if the rolling stock length didn't fit,
@@ -598,7 +595,6 @@ public class Car extends RollingStock {
     /**
      * Sets the car's destination on the layout
      *
-     * @param destination
      * @param track       (yard, spur, staging, or interchange track)
      * @param force       when true ignore track length, type, {@literal &} road
      *                    when setting destination

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/CarLoads.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/CarLoads.java
@@ -86,7 +86,6 @@ public class CarLoads extends RollingStockAttribute {
     /**
      * Gets the appropriate car loads for the car's type.
      *
-     * @param type
      * @return JComboBox with car loads starting with empty string.
      */
     public JComboBox<String> getSelectComboBox(String type) {
@@ -101,7 +100,6 @@ public class CarLoads extends RollingStockAttribute {
     /**
      * Gets the appropriate car loads for the car's type.
      *
-     * @param type
      * @return JComboBox with car loads.
      */
     public JComboBox<String> getComboBox(String type) {

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/CarManager.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/CarManager.java
@@ -109,7 +109,6 @@ public class CarManager extends RollingStockManager {
     /**
      * Create a new Kernel
      *
-     * @param name
      * @return Kernel
      */
     public Kernel newKernel(String name) {
@@ -127,7 +126,6 @@ public class CarManager extends RollingStockManager {
     /**
      * Delete a Kernel by name
      *
-     * @param name
      */
     public void deleteKernel(String name) {
         Kernel kernel = getKernelByName(name);
@@ -143,7 +141,6 @@ public class CarManager extends RollingStockManager {
     /**
      * Get a Kernel by name
      *
-     * @param name
      * @return named Kernel
      */
     public Kernel getKernelByName(String name) {
@@ -314,7 +311,6 @@ public class CarManager extends RollingStockManager {
      * to this train) on a route, cars are ordered least recently moved to most
      * recently moved.
      *
-     * @param train
      * @return List of cars with no assigned train on a route
      */
     public List<Car> getAvailableTrainList(Train train) {
@@ -411,7 +407,6 @@ public class CarManager extends RollingStockManager {
      * If the train is to be blocked by track blocking order, all of the tracks
      * at that location need a blocking number greater than 0.
      *
-     * @param train
      * @return Ordered list of cars assigned to the train
      */
     public List<Car> getByTrainDestinationList(Train train) {

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/CarsTableModel.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/CarsTableModel.java
@@ -105,8 +105,7 @@ public class CarsTableModel extends javax.swing.table.AbstractTableModel impleme
      * <p>
      * Moves, Built, Owner, Value, RFID, Wait, Pickup, and Last are grouped
      * together.
-     * 
-     * @param sort
+     *
      */
     public void setSort(int sort) {
         _sort = sort;
@@ -217,7 +216,6 @@ public class CarsTableModel extends javax.swing.table.AbstractTableModel impleme
     /**
      * Search for car by road number
      *
-     * @param roadNumber
      * @return -1 if not found, table row number if found
      */
     public int findCarByRoadNumber(String roadNumber) {

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/Engine.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/Engine.java
@@ -35,7 +35,6 @@ public class Engine extends RollingStock {
      * Set the locomotive's model. Note a model has only one length, type, and
      * horsepower rating.
      *
-     * @param model
      */
     public void setModel(String model) {
         String old = _model;
@@ -214,7 +213,6 @@ public class Engine extends RollingStock {
     /**
      * Place locomotive in a consist
      *
-     * @param consist
      */
     public void setConsist(Consist consist) {
         if (_consist == consist) {

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/EngineManager.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/EngineManager.java
@@ -71,8 +71,6 @@ public class EngineManager extends RollingStockManager {
      * Finds an existing engine or creates a new engine if needed requires
      * engine's road and number
      *
-     * @param engineRoad
-     * @param engineNumber
      * @return new engine or existing engine
      */
     public Engine newEngine(String engineRoad, String engineNumber) {
@@ -222,7 +220,6 @@ public class EngineManager extends RollingStockManager {
      * return a list available engines (no assigned train) engines are ordered
      * least recently moved to most recently moved.
      *
-     * @param train
      * @return Ordered list of engines not assigned to a train
      */
     public List<Engine> getAvailableTrainList(Train train) {

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/EnginesTableModel.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/EnginesTableModel.java
@@ -119,7 +119,6 @@ public class EnginesTableModel extends javax.swing.table.AbstractTableModel impl
     /**
      * Search for engine by road number
      *
-     * @param roadNumber
      * @return -1 if not found, table row number if found
      */
     public int findEngineByRoadNumber(String roadNumber) {

--- a/java/src/jmri/jmrit/operations/router/Router.java
+++ b/java/src/jmri/jmrit/operations/router/Router.java
@@ -229,8 +229,6 @@ public class Router extends TrainCommon {
      * Checks to see if a single train can transport car to its final
      * destination.
      *
-     * @param car
-     * @param clone
      * @return true if single train can transport car to its final destination.
      */
     private boolean checkForSingleTrain(Car car, Car clone) {
@@ -272,9 +270,6 @@ public class Router extends TrainCommon {
      * the needs to go the alternate track or yard track if the car's final
      * destination track is full. Returns false if car is stuck in staging.
      *
-     * @param testTrain
-     * @param car
-     * @param clone
      * @return true for all cases except if car is departing staging and is
      *         stuck there.
      */

--- a/java/src/jmri/jmrit/operations/routes/Route.java
+++ b/java/src/jmri/jmrit/operations/routes/Route.java
@@ -92,7 +92,6 @@ public class Route implements java.beans.PropertyChangeListener {
     /**
      * Adds a location to the end of this route
      *
-     * @param location
      * @return RouteLocation created for the location added
      */
     public RouteLocation addLocation(Location location) {
@@ -115,8 +114,6 @@ public class Route implements java.beans.PropertyChangeListener {
      * Add a route location at a specific place (sequence) in the route
      * Allowable sequence numbers are 0 to max size of route;
      *
-     * @param location
-     * @param sequence
      * @return route location
      */
     public RouteLocation addLocation(Location location, int sequence) {
@@ -155,7 +152,6 @@ public class Route implements java.beans.PropertyChangeListener {
     /**
      * Delete a RouteLocation
      *
-     * @param rl
      */
     public void deleteLocation(RouteLocation rl) {
         if (rl != null) {
@@ -231,7 +227,6 @@ public class Route implements java.beans.PropertyChangeListener {
     /**
      * Get location by name (gets last route location with name)
      *
-     * @param name
      * @return route location
      */
     public RouteLocation getLastLocationByName(String name) {
@@ -250,7 +245,6 @@ public class Route implements java.beans.PropertyChangeListener {
     /**
      * Get a RouteLocation by id
      *
-     * @param id
      * @return route location
      */
     public RouteLocation getLocationById(String id) {
@@ -291,7 +285,6 @@ public class Route implements java.beans.PropertyChangeListener {
     /**
      * Places a RouteLocation earlier in the route.
      *
-     * @param rl
      */
     public void moveLocationUp(RouteLocation rl) {
         int sequenceId = rl.getSequenceId();
@@ -314,7 +307,6 @@ public class Route implements java.beans.PropertyChangeListener {
     /**
      * Moves a RouteLocation later in the route.
      *
-     * @param rl
      */
     public void moveLocationDown(RouteLocation rl) {
         int sequenceId = rl.getSequenceId();

--- a/java/src/jmri/jmrit/operations/routes/RouteLocation.java
+++ b/java/src/jmri/jmrit/operations/routes/RouteLocation.java
@@ -167,7 +167,6 @@ public class RouteLocation implements java.beans.PropertyChangeListener {
     /**
      * Set the train length departing this location when building a train
      *
-     * @param length
      */
     public void setTrainLength(int length) {
         int old = _trainLength;
@@ -184,7 +183,6 @@ public class RouteLocation implements java.beans.PropertyChangeListener {
     /**
      * Set the train weight departing this location when building a train
      *
-     * @param weight
      */
     public void setTrainWeight(int weight) {
         int old = _trainWeight;
@@ -264,7 +262,6 @@ public class RouteLocation implements java.beans.PropertyChangeListener {
     /**
      * Set the number of moves that this location has when building a train
      *
-     * @param moves
      */
     public void setCarMoves(int moves) {
         int old = _carMoves;

--- a/java/src/jmri/jmrit/operations/routes/RouteManager.java
+++ b/java/src/jmri/jmrit/operations/routes/RouteManager.java
@@ -81,7 +81,6 @@ public class RouteManager {
      * Finds an existing route or creates a new route if needed requires route's
      * name creates a unique id for this route
      *
-     * @param name
      *
      * @return new route or existing route
      */

--- a/java/src/jmri/jmrit/operations/setup/BackupBase.java
+++ b/java/src/jmri/jmrit/operations/setup/BackupBase.java
@@ -430,7 +430,6 @@ public abstract class BackupBase {
          * @param sourceFileName
          * @param destFileName
          * @param overwrite
-         * @throws IOException
          */
         @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "OBL_UNSATISFIED_OBLIGATION")
         public static void copy(String sourceFileName, String destFileName,

--- a/java/src/jmri/jmrit/operations/setup/BackupBase.java
+++ b/java/src/jmri/jmrit/operations/setup/BackupBase.java
@@ -161,7 +161,6 @@ public abstract class BackupBase {
     /**
      * Check to see if the given backup set already exists in the backup store.
      *
-     * @param setName
      * @return true if it exists
      */
     public boolean checkIfBackupSetExists(String setName) {
@@ -183,7 +182,6 @@ public abstract class BackupBase {
     /**
      * Restores a Backup Set with the given name from the backup store.
      *
-     * @param setName
      * @throws java.io.IOException
      */
     public void restoreFilesFromSetName(String setName) throws IOException {
@@ -193,7 +191,6 @@ public abstract class BackupBase {
     /**
      * Restores a Backup Set from the given directory.
      *
-     * @param directory
      * @throws java.io.IOException
      */
     public void restoreFilesFromDirectory(File directory) throws IOException {
@@ -209,8 +206,6 @@ public abstract class BackupBase {
      *
      * Only copies files that are included in the list of Operations files.
      *
-     * @param sourceDir
-     * @param destDir
      * @throws java.io.IOException
      */
     public void copyBackupSet(File sourceDir, File destDir) throws IOException {
@@ -427,9 +422,6 @@ public abstract class BackupBase {
          * Copies an existing file to a new file. Overwriting a file of the same
          * name is allowed. The destination directory must exist.
          *
-         * @param sourceFileName
-         * @param destFileName
-         * @param overwrite
          */
         @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "OBL_UNSATISFIED_OBLIGATION")
         public static void copy(String sourceFileName, String destFileName,

--- a/java/src/jmri/jmrit/operations/setup/Setup.java
+++ b/java/src/jmri/jmrit/operations/setup/Setup.java
@@ -3076,7 +3076,6 @@ public class Setup {
     /**
      * Converts the xml key to the proper locale text
      *
-     * @param keys
      */
     private static void keyToStringConversion(String[] keys) {
         for (int i = 0; i < keys.length; i++) {
@@ -3098,7 +3097,6 @@ public class Setup {
     /**
      * Converts the strings into English tags for xml storage
      *
-     * @param strings
      */
     private static void stringToKeyConversion(String[] strings) {
         Locale locale = Locale.ROOT;

--- a/java/src/jmri/jmrit/operations/trains/Train.java
+++ b/java/src/jmri/jmrit/operations/trains/Train.java
@@ -821,7 +821,6 @@ public class Train implements java.beans.PropertyChangeListener {
     /**
      * Get train's status in the specified locale.
      *
-     * @param locale
      * @return Human-readable status
      */
     public String getStatus(Locale locale) {
@@ -831,7 +830,6 @@ public class Train implements java.beans.PropertyChangeListener {
     /**
      * Get the human-readable status for the requested status code.
      *
-     * @param locale
      * @param code requested status
      * @return Human-readable status
      */
@@ -1455,7 +1453,6 @@ public class Train implements java.beans.PropertyChangeListener {
     /**
      * Only rolling stock built in or after this year will be used.
      *
-     * @param year
      */
     public void setBuiltStartYear(String year) {
         String old = _builtStartYear;
@@ -1472,7 +1469,6 @@ public class Train implements java.beans.PropertyChangeListener {
     /**
      * Only rolling stock built in or before this year will be used.
      *
-     * @param year
      */
     public void setBuiltEndYear(String year) {
         String old = _builtEndYear;
@@ -1489,7 +1485,6 @@ public class Train implements java.beans.PropertyChangeListener {
     /**
      * Determine if train will service rolling stock by built date.
      *
-     * @param date
      * @return true is built date is in the acceptable range.
      */
     public boolean acceptsBuiltDate(String date) {
@@ -2764,8 +2759,7 @@ public class Train implements java.beans.PropertyChangeListener {
      * adding or removing a car from a train, or changing the manifest format.
      * Once the manifest has been regenerated (modified == false), the old
      * status for the train is restored.
-     * 
-     * @param modified
+     *
      */
     public void setModified(boolean modified) {
         log.debug("Set modified {}", modified);

--- a/java/src/jmri/jmrit/operations/trains/TrainBuilder.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainBuilder.java
@@ -1799,7 +1799,6 @@ public class TrainBuilder extends TrainCommon {
      * checks to see if the kernel has a lead car and the lead car is in
      * service.
      *
-     * @param car
      */
     private void checkKernel(Car car) throws BuildFailedException {
         boolean foundLeadCar = false;
@@ -2389,7 +2388,6 @@ public class TrainBuilder extends TrainCommon {
 
     /**
      *
-     * @param engine
      * @param rl where in the train's route to pick up the engine
      * @param rld where in the train's route to set out the engine
      * @param track destination track for this engine
@@ -3636,7 +3634,6 @@ public class TrainBuilder extends TrainCommon {
      * wasn't given a destination, shifts the car's order earlier in the car
      * list so it won't be evaluated again.
      *
-     * @param car
      */
     private void checkCarOrder(Car car) {
         // is car sitting on a FIFO or LIFO track?
@@ -3666,7 +3663,6 @@ public class TrainBuilder extends TrainCommon {
     /**
      * Checks to see if car has a destination and tries to add car to train
      *
-     * @param car
      * @param rl the car's route location
      * @param routeIndex where in the route the car pick up is
      * @return true if car has a destination.
@@ -4430,7 +4426,6 @@ public class TrainBuilder extends TrainCommon {
      * pulled by this train, but cars were sent to the alternate because the
      * spur was full at the time it was tested.
      *
-     * @param rl
      * @return true if one or more cars were redirected
      */
     private boolean redirectCarsFromAlternateTrack() {

--- a/java/src/jmri/jmrit/operations/trains/TrainBuilder.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainBuilder.java
@@ -842,7 +842,6 @@ public class TrainBuilder extends TrainCommon {
      * (departStageTrack != null) engines must come from that track.
      *
      * @return true if correct number of engines found.
-     * @throws BuildFailedException
      */
     private boolean getEngines(int numberOfEngines, String model, String road, RouteLocation rl, RouteLocation rld,
             boolean useBunit) throws BuildFailedException {
@@ -1424,7 +1423,6 @@ public class TrainBuilder extends TrainCommon {
      * Removes the remaining cabooses and cars with FRED from consideration.
      * Also saves a car's final destination in case of train reset.
      *
-     * @throws BuildFailedException
      */
     private void removeCaboosesAndCarsWithFredAndSaveFinalDestination() throws BuildFailedException {
         addLine(_buildReport, SEVEN, BLANK_LINE); // add line when in very detailed report mode
@@ -1802,7 +1800,6 @@ public class TrainBuilder extends TrainCommon {
      * service.
      *
      * @param car
-     * @throws BuildFailedException
      */
     private void checkKernel(Car car) throws BuildFailedException {
         boolean foundLeadCar = false;
@@ -1832,7 +1829,6 @@ public class TrainBuilder extends TrainCommon {
      * correct number of set outs. The destination must accept all cars in the
      * pick up block.
      *
-     * @throws BuildFailedException
      */
     private void blockCarsFromStaging() throws BuildFailedException {
         if (_departStageTrack == null || !_departStageTrack.isBlockCarsEnabled()) {
@@ -1997,7 +1993,6 @@ public class TrainBuilder extends TrainCommon {
      *
      * @param percent How much of the available moves should be used in this pass.
      * @param firstPass True if first pass, ignore cars in staging.
-     * @throws BuildFailedException
      */
     private void placeCars(int percent, boolean firstPass) throws BuildFailedException {
         addLine(_buildReport, THREE, BLANK_LINE); // add line when in normal report mode
@@ -2154,7 +2149,6 @@ public class TrainBuilder extends TrainCommon {
      * @param routeIndex Where in the route to add cars to this train.
      * @param isSecondPass When true this is the second time we've looked at
      *            these cars. Used to perform local moves.
-     * @throws BuildFailedException
      */
     private void findDestinationsForCarsFromLocation(RouteLocation rl, int routeIndex, boolean isSecondPass)
             throws BuildFailedException {
@@ -3072,7 +3066,6 @@ public class TrainBuilder extends TrainCommon {
      * @param car the car with the load
      * @return true if there's a schedule that can be routed to for this car and
      *         load
-     * @throws BuildFailedException
      */
     private boolean findFinalDestinationForCarLoad(Car car) throws BuildFailedException {
         boolean routeToSpurFound = false;
@@ -3275,7 +3268,6 @@ public class TrainBuilder extends TrainCommon {
      * schedule and load car if possible.
      *
      * @param car the car
-     * @throws BuildFailedException
      */
     private boolean generateCarLoadFromStaging(Car car) throws BuildFailedException {
         if (car.getTrack() == null || !car.getTrack().getTrackType().equals(Track.STAGING)
@@ -3387,7 +3379,6 @@ public class TrainBuilder extends TrainCommon {
      * load.
      *
      * @param car the car
-     * @throws BuildFailedException
      */
     private boolean generateCarLoadStagingToStaging(Car car) throws BuildFailedException {
         if (car.getTrack() == null || !car.getTrack().getTrackType().equals(Track.STAGING)
@@ -3470,7 +3461,6 @@ public class TrainBuilder extends TrainCommon {
      * @param car the car.
      * @param track the car's destination track that has the schedule.
      * @return ScheduleItem si if match found, null otherwise.
-     * @throws BuildFailedException
      */
     private ScheduleItem getScheduleItem(Car car, Track track) throws BuildFailedException {
         if (track.getSchedule() == null) {
@@ -3902,7 +3892,6 @@ public class TrainBuilder extends TrainCommon {
      * @param rl The car's route location
      * @param rld The car's route destination
      * @return true if successful.
-     * @throws BuildFailedException
      */
     private boolean findDestinationAndTrack(Car car, RouteLocation rl, RouteLocation rld) throws BuildFailedException {
         int index;
@@ -3927,7 +3916,6 @@ public class TrainBuilder extends TrainCommon {
      *            destination for this car.
      * @param routeEnd Where to stop looking for a destination.
      * @return true if successful, car has destination, track and a train.
-     * @throws BuildFailedException
      */
     private boolean findDestinationAndTrack(Car car, RouteLocation rl, int routeIndex, int routeEnd)
             throws BuildFailedException {
@@ -4649,7 +4637,6 @@ public class TrainBuilder extends TrainCommon {
      * MPH. The formula HPT x 12 / % Grade = Speed, is used to determine the
      * horsepower needed. For example a 1% grade requires a minimum of 3 HPT.
      *
-     * @throws BuildFailedException
      */
     private void checkNumnberOfEnginesNeeded() throws BuildFailedException {
         if (_reqNumEngines == 0 || !_train.isBuildConsistEnabled() || Setup.getHorsePowerPerTon() == 0) {

--- a/java/src/jmri/jmrit/operations/trains/TrainCommon.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainCommon.java
@@ -72,11 +72,7 @@ public class TrainCommon {
 
     /**
      * Used to generate "Two Column" format for engines.
-     * 
-     * @param file
-     * @param engineList
-     * @param rl
-     * @param isManifest
+     *
      */
     protected void blockLocosTwoColumn(PrintWriter file, List<Engine> engineList, RouteLocation rl,
             boolean isManifest) {
@@ -103,10 +99,6 @@ public class TrainCommon {
      * Adds a list of locomotive pick ups for the route location to the output
      * file. Used to generate "Standard" format.
      *
-     * @param file
-     * @param engineList
-     * @param rl
-     * @param isManifest
      */
     protected void pickupEngines(PrintWriter file, List<Engine> engineList, RouteLocation rl, boolean isManifest) {
         boolean printHeader = Setup.isPrintHeadersEnabled();
@@ -140,10 +132,6 @@ public class TrainCommon {
      * Adds a list of locomotive drops for the route location to the output
      * file. Used to generate "Standard" format.
      *
-     * @param file
-     * @param engineList
-     * @param rl
-     * @param isManifest
      */
     protected void dropEngines(PrintWriter file, List<Engine> engineList, RouteLocation rl, boolean isManifest) {
         boolean printHeader = Setup.isPrintHeadersEnabled();
@@ -177,7 +165,6 @@ public class TrainCommon {
      * Returns the pick up string for a loco. Useful for frames like the train
      * conductor and yardmaster.
      *
-     * @param engine
      * @return engine pick up string
      */
     public String pickupEngine(Engine engine) {
@@ -192,7 +179,6 @@ public class TrainCommon {
      * Returns the drop string for a loco. Useful for frames like the train
      * conductor and yardmaster.
      *
-     * @param engine
      * @return engine drop string
      */
     public String dropEngine(Engine engine) {
@@ -630,8 +616,6 @@ public class TrainCommon {
      * Adds the car's pick up string to the output file using the truncated
      * manifest format
      *
-     * @param file
-     * @param car
      */
     protected void pickUpCarTruncated(PrintWriter file, Car car, boolean isManifest) {
         pickUpCar(file, car,
@@ -643,8 +627,6 @@ public class TrainCommon {
      * Adds the car's pick up string to the output file using the manifest or
      * switch list format
      *
-     * @param file
-     * @param car
      */
     protected void pickUpCar(PrintWriter file, Car car, boolean isManifest) {
         if (isManifest) {
@@ -682,7 +664,6 @@ public class TrainCommon {
      *
      * @param isManifest when true use manifest format, when false use switch
      *            list format
-     * @param car
      * @return pick up car string
      */
     public String pickupCar(Car car, boolean isManifest, boolean isTwoColumnTrack) {
@@ -709,8 +690,6 @@ public class TrainCommon {
      * manifest format. Does not print out local moves. Local moves are only
      * shown on the switch list for that location.
      *
-     * @param file
-     * @param car
      */
     protected void truncatedDropCar(PrintWriter file, Car car, boolean isManifest) {
         // local move?
@@ -725,9 +704,6 @@ public class TrainCommon {
      * Adds the car's set out string to the output file using the manifest or
      * switch list format
      *
-     * @param file
-     * @param car
-     * @param isManifest
      */
     protected void dropCar(PrintWriter file, Car car, boolean isManifest) {
         if (isManifest) {
@@ -774,7 +750,6 @@ public class TrainCommon {
      * Returns the drop car string. Useful for frames like train conductor and
      * yardmaster.
      *
-     * @param car
      * @param isManifest when true use manifest format, when false use switch
      *            list format
      * @return drop car string
@@ -812,7 +787,6 @@ public class TrainCommon {
      *
      * @param isManifest when true use manifest format, when false use switch
      *            list format
-     * @param car
      * @return move car string
      */
     public String localMoveCar(Car car, boolean isManifest) {
@@ -837,10 +811,6 @@ public class TrainCommon {
      * Add a list of utility cars scheduled for pick up from the route location
      * to the output file. The cars are blocked by destination.
      *
-     * @param file
-     * @param carList
-     * @param car
-     * @param isManifest
      */
     protected void pickupUtilityCars(PrintWriter file, List<Car> carList, Car car, boolean isManifest) {
         // list utility cars by type, track, length, and load
@@ -864,10 +834,6 @@ public class TrainCommon {
      * Add a list of utility cars scheduled for drop at the route location to
      * the output file.
      *
-     * @param file
-     * @param carList
-     * @param car
-     * @param isManifest
      */
     protected void setoutUtilityCars(PrintWriter file, List<Car> carList, Car car, boolean isManifest) {
         boolean isLocal = isLocalMove(car);
@@ -993,10 +959,6 @@ public class TrainCommon {
      * car provided. Returns 0 if this car type has already been processed,
      * otherwise the number of cars with the same attribute.
      *
-     * @param format
-     * @param carList
-     * @param car
-     * @param isPickup
      * @return 0 if the car type has already been processed
      */
     protected int countUtilityCars(String[] format, List<Car> carList, Car car, boolean isPickup) {
@@ -1146,7 +1108,6 @@ public class TrainCommon {
     /**
      * Used to determine if car is a local move
      *
-     * @param car
      * @return true if the move is at the same location
      */
     protected boolean isLocalMove(Car car) {
@@ -1192,8 +1153,6 @@ public class TrainCommon {
     /**
      * Writes string to file. No line length wrap or protection.
      *
-     * @param file
-     * @param string
      */
     protected void addLine(PrintWriter file, String string) {
         if (log.isDebugEnabled()) {
@@ -1208,8 +1167,6 @@ public class TrainCommon {
      * Writes a string to a file. Checks for string length, and will
      * automatically wrap lines.
      *
-     * @param file
-     * @param string
      * @param isManifest set true for manifest page orientation, false for
      *            switch list orientation
      */
@@ -1237,7 +1194,6 @@ public class TrainCommon {
     /**
      * Adds a blank line to the file.
      *
-     * @param file
      */
     protected void newLine(PrintWriter file) {
         file.println(BLANK_LINE);
@@ -1248,7 +1204,6 @@ public class TrainCommon {
      * is an integer or if the first character after the hyphen is a left
      * parenthesis "(".
      *
-     * @param name
      * @return First half of the string.
      */
     public static String splitString(String name) {
@@ -1267,8 +1222,7 @@ public class TrainCommon {
 
     /**
      * Splits a string if there's a hyphen followed by a left parenthesis "-(".
-     * 
-     * @param name
+     *
      * @return First half of the string.
      */
     private static String splitStringLeftParenthesis(String name) {
@@ -1301,8 +1255,6 @@ public class TrainCommon {
     /**
      * returns true if the train has work at the location
      *
-     * @param train
-     * @param location
      * @return true if the train has work at the location
      */
     public static boolean isThereWorkAtLocation(Train train, Location location) {
@@ -1569,8 +1521,6 @@ public class TrainCommon {
     /**
      * Two column header format. Left side pick ups, right side set outs
      *
-     * @param file
-     * @param isManifest
      */
     public void printEngineHeader(PrintWriter file, boolean isManifest) {
         int lineLength = getLineLength(isManifest);
@@ -1606,8 +1556,6 @@ public class TrainCommon {
      * Prints the two column header for cars. Left side pick ups, right side set
      * outs.
      *
-     * @param file
-     * @param isManifest
      */
     public void printCarHeader(PrintWriter file, boolean isManifest, boolean isTwoColumnTrack) {
         int lineLength = getLineLength(isManifest);
@@ -1827,7 +1775,6 @@ public class TrainCommon {
     /**
      * Prints a line across the entire page.
      *
-     * @param file
      */
     public void printHorizontalLine(PrintWriter file, boolean isManifest) {
         printHorizontalLine(file, 0, getLineLength(isManifest));
@@ -1884,7 +1831,6 @@ public class TrainCommon {
      * Returns a double in minutes representing the string date. Date string has
      * to be in the order: Month / day / year hour:minute AM_PM
      *
-     * @param date
      * @return double in minutes @deprecated. Use date object comparisons
      *         instead.
      */
@@ -1925,8 +1871,6 @@ public class TrainCommon {
      * remove characters from the end of the string if the string exceeds the
      * field size.
      *
-     * @param s
-     * @param fieldSize
      * @return A String the specified length
      */
     public static String padAndTruncateString(String s, int fieldSize) {
@@ -1948,8 +1892,6 @@ public class TrainCommon {
      * Adjusts string to be a certain number of characters by adding spaces to
      * the end of the string.
      *
-     * @param s
-     * @param fieldSize
      * @return A String the specified length
      */
     public static String padString(String s, int fieldSize) {
@@ -1963,8 +1905,6 @@ public class TrainCommon {
     /**
      * Adds the requested number of spaces to the start of the string.
      *
-     * @param s
-     * @param tabSize
      * @return A String the specified length
      */
     public static String tabString(String s, int tabSize) {
@@ -2011,10 +1951,6 @@ public class TrainCommon {
     /**
      * Checks to see if the the string fits on the page.
      *
-     * @param string
-     * @param orientation
-     * @param fontName
-     * @param fontSize
      * @return false if string length is longer than page width.
      */
     private boolean checkStringLength(String string, String orientation, String fontName, int fontSize) {
@@ -2046,7 +1982,6 @@ public class TrainCommon {
      * Produces a string using commas and spaces between the strings provided in
      * the array. Does not check for embedded commas in the string array.
      *
-     * @param array
      * @return formated string using commas and spaces
      */
     public static String formatStringToCommaSeparated(String[] array) {

--- a/java/src/jmri/jmrit/operations/trains/TrainCsvSwitchLists.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainCsvSwitchLists.java
@@ -34,7 +34,6 @@ public class TrainCsvSwitchLists extends TrainCsvCommon {
     /**
      * builds a csv file containing the switch list for a location
      *
-     * @param location
      * @return File
      */
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "CarManager only provides Car Objects")

--- a/java/src/jmri/jmrit/operations/trains/TrainLogger.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainLogger.java
@@ -220,7 +220,6 @@ public class TrainLogger extends XmlFile implements java.beans.PropertyChangeLis
     /**
      * Return the date and time in an MS Excel friendly format
      * yyyy/MM/dd HH:mm:ss
-     * @return
      */
     private String getTime() {
         String time = Calendar.getInstance().getTime().toString();

--- a/java/src/jmri/jmrit/operations/trains/TrainManager.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainManager.java
@@ -330,7 +330,6 @@ public class TrainManager implements java.beans.PropertyChangeListener {
      * Finds an existing train or creates a new train if needed requires train's
      * name creates a unique id for this train
      *
-     * @param name
      *
      * @return new train or existing train
      */
@@ -428,7 +427,6 @@ public class TrainManager implements java.beans.PropertyChangeListener {
 
     /**
      *
-     * @param car
      * @return Train that can service car from its current location to the its
      * destination.
      */
@@ -438,9 +436,7 @@ public class TrainManager implements java.beans.PropertyChangeListener {
 
     /**
      *
-     * @param car
      * @param excludeTrain The only train not to try.
-     * @param buildReport
      * @return Train that can service car from its current location to the its
      * destination.
      */

--- a/java/src/jmri/jmrit/operations/trains/TrainManagerXml.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainManagerXml.java
@@ -276,7 +276,6 @@ public class TrainManagerXml extends OperationsXml {
     /**
      * Save previous manifest file in a separate directory called manifestBackups.
      * Each train manifest is saved in a unique directory using the train's name.
-     * @param name
      */
     private void savePreviousManifestFile(String name) {
         if (Setup.isSaveTrainManifestsEnabled()) {

--- a/java/src/jmri/jmrit/operations/trains/TrainsTableModel.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainsTableModel.java
@@ -606,7 +606,6 @@ public class TrainsTableModel extends javax.swing.table.AbstractTableModel imple
         /**
          * Dark colors need white lettering
          *
-         * @param row
          * @return
          */
         private Color getForegroundColor(Color background) {

--- a/java/src/jmri/jmrit/operations/trains/TrainsTableModel.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainsTableModel.java
@@ -606,7 +606,6 @@ public class TrainsTableModel extends javax.swing.table.AbstractTableModel imple
         /**
          * Dark colors need white lettering
          *
-         * @return
          */
         private Color getForegroundColor(Color background) {
             if (background == null) {

--- a/java/src/jmri/jmrit/operations/trains/excel/SetupExcelProgramFrame.java
+++ b/java/src/jmri/jmrit/operations/trains/excel/SetupExcelProgramFrame.java
@@ -84,7 +84,6 @@ public class SetupExcelProgramFrame extends OperationsFrame {
      * Opens a dialog window in either the csvManifest or csvSwitchLists
      * directory
      *
-     * @param directoryName
      * @return
      */
     protected File selectFile(String directoryName) {

--- a/java/src/jmri/jmrit/operations/trains/excel/SetupExcelProgramFrame.java
+++ b/java/src/jmri/jmrit/operations/trains/excel/SetupExcelProgramFrame.java
@@ -84,7 +84,6 @@ public class SetupExcelProgramFrame extends OperationsFrame {
      * Opens a dialog window in either the csvManifest or csvSwitchLists
      * directory
      *
-     * @return
      */
     protected File selectFile(String directoryName) {
         JFileChooser fc = jmri.jmrit.XmlFile.userFileChooser(Bundle.getMessage("ExcelProgramFiles"), "xls", "xlsm"); // NOI18N

--- a/java/src/jmri/jmrit/operations/trains/excel/TrainCustomManifest.java
+++ b/java/src/jmri/jmrit/operations/trains/excel/TrainCustomManifest.java
@@ -53,7 +53,6 @@ public class TrainCustomManifest {
     /**
      * Adds one CSV file path to the collection of files to be processed.
      *
-     * @param csvFile
      */
     public static void addCVSFile(File csvFile) {
         // Ignore null files...

--- a/java/src/jmri/jmrit/operations/trains/excel/TrainCustomSwitchList.java
+++ b/java/src/jmri/jmrit/operations/trains/excel/TrainCustomSwitchList.java
@@ -57,7 +57,6 @@ public class TrainCustomSwitchList {
     /**
      * Adds one CSV file path to the collection of files to be processed.
      *
-     * @param csvFile
      */
     public static void addCVSFile(File csvFile) {
         // Ignore null files...

--- a/java/src/jmri/jmrit/operations/trains/timetable/TrainScheduleManager.java
+++ b/java/src/jmri/jmrit/operations/trains/timetable/TrainScheduleManager.java
@@ -94,7 +94,6 @@ public class TrainScheduleManager implements java.beans.PropertyChangeListener {
      * Finds an existing schedule or creates a new schedule if needed requires
      * schedule's name creates a unique id for this schedule
      *
-     * @param name
      *
      * @return new TrainSchedule or existing TrainSchedule
      */


### PR DESCRIPTION
This removes:
- empty @return
- @param with just a variable name, no description
- @throws with just an exception name, no description

from the jmrit.operations packages.  Done as a separate PR to avoid conflicts with ongoing work by @DanielBoudreau. Dan, when this is OK could you comment or merge?  Thanks. 