### PR TITLE
Update deprecated jmri.jmris.json.JsonException

### DIFF
--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -531,13 +531,13 @@ simple tests for those to ensure they keep working.
 
 <h3><a id="sampleJythonScriptTesting" name="sampleJythonScriptTesting"></a>Testing Jython sample scripts</h3>
 
-Test scripts can be placed in <code>jython</code> and invoked by 
+Test scripts can be placed in <code>jython/test</code> are automatically invoked by
 <code><a href="https://github.com/JMRI/JMRI/blob/master/java/test/jmri/jmrit/jython/SampleScriptTest.java">java/test/jmri/jmrit/jython/SampleScriptTest.java</a></code>.
 <p>
 See the <code><a href="https://github.com/JMRI/JMRI/blob/master/jython/test/jmri_bindings_test.py">jmri_bindings_test.py</a></code> 
-sample for syntax.
+sample for syntax, including examples of how to signal test failures.
 <p>
-The <code>SampleScriptTest</code> class is a placeholder, and should (eventually) be extended to pick up files automatically, 
+In the future, this could be extended to pick up files automatically, 
 to support xUnit testing, etc.
 <p>
 

--- a/java/src/jmri/jmris/AbstractSignalHeadServer.java
+++ b/java/src/jmri/jmris/AbstractSignalHeadServer.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.SignalHead;
-import jmri.jmris.json.JsonException;
+import jmri.server.json.JsonException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/java/src/jmri/jmris/AbstractSignalMastServer.java
+++ b/java/src/jmri/jmris/AbstractSignalMastServer.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.SignalMast;
-import jmri.jmris.json.JsonException;
+import jmri.server.json.JsonException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/java/src/jmri/jmris/json/JsonConsistServer.java
+++ b/java/src/jmri/jmris/json/JsonConsistServer.java
@@ -1,4 +1,3 @@
-// JsonConsistServer.java
 package jmri.jmris.json;
 
 import static jmri.jmris.json.JSON.ADDRESS;
@@ -24,12 +23,12 @@ import jmri.DccLocoAddress;
 import jmri.InstanceManager;
 import jmri.jmris.JmriConnection;
 import jmri.jmrit.consisttool.ConsistFile;
+import jmri.server.json.JsonException;
 import org.jdom2.JDOMException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- *
  * @author rhwood
  */
 public class JsonConsistServer {

--- a/java/src/jmri/jmris/json/JsonException.java
+++ b/java/src/jmri/jmris/json/JsonException.java
@@ -7,7 +7,6 @@ package jmri.jmris.json;
  * @deprecated Use {@link jmri.server.json.JsonException}
  */
 @Deprecated
-@SuppressWarnings("serial")
 public class JsonException extends jmri.server.json.JsonException {
 
     public JsonException(int i, String s, Throwable t) {

--- a/java/src/jmri/jmris/json/JsonLightServer.java
+++ b/java/src/jmri/jmris/json/JsonLightServer.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import jmri.JmriException;
 import jmri.jmris.AbstractLightServer;
 import jmri.jmris.JmriConnection;
+import jmri.server.json.JsonException;
 import static jmri.jmris.json.JSON.LIGHT;
 import static jmri.jmris.json.JSON.METHOD;
 import static jmri.jmris.json.JSON.NAME;

--- a/java/src/jmri/jmris/json/JsonMemoryServer.java
+++ b/java/src/jmri/jmris/json/JsonMemoryServer.java
@@ -1,4 +1,3 @@
-//JsonMemoryServer.java
 package jmri.jmris.json;
 
 import static jmri.jmris.json.JSON.MEMORY;
@@ -13,6 +12,7 @@ import java.util.Locale;
 import jmri.JmriException;
 import jmri.jmris.AbstractMemoryServer;
 import jmri.jmris.JmriConnection;
+import jmri.server.json.JsonException;
 
 /**
  * JSON server interface between the JMRI Memory manager and a network
@@ -25,7 +25,6 @@ import jmri.jmris.JmriConnection;
  *
  * @author mstevetodd Copyright (C) 2012 (copied from JsonSensorServer)
  * @author Randall Wood Copyright (C) 2013
- * @version $Revision: $
  */
 public class JsonMemoryServer extends AbstractMemoryServer {
 

--- a/java/src/jmri/jmris/json/JsonOperationsServer.java
+++ b/java/src/jmri/jmris/json/JsonOperationsServer.java
@@ -19,6 +19,7 @@ import jmri.JmriException;
 import jmri.jmris.AbstractOperationsServer;
 import jmri.jmris.JmriConnection;
 import jmri.jmrit.operations.trains.Train;
+import jmri.server.json.JsonException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/java/src/jmri/jmris/json/JsonPowerServer.java
+++ b/java/src/jmri/jmris/json/JsonPowerServer.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import jmri.JmriException;
 import jmri.jmris.AbstractPowerServer;
 import jmri.jmris.JmriConnection;
+import jmri.server.json.JsonException;
 
 /**
  * Send power status over WebSockets as a JSON String

--- a/java/src/jmri/jmris/json/JsonReporterServer.java
+++ b/java/src/jmri/jmris/json/JsonReporterServer.java
@@ -1,4 +1,3 @@
-//JsonReporterServer.java
 package jmri.jmris.json;
 
 import static jmri.jmris.json.JSON.DATA;
@@ -17,6 +16,7 @@ import java.util.Locale;
 import jmri.JmriException;
 import jmri.jmris.AbstractReporterServer;
 import jmri.jmris.JmriConnection;
+import jmri.server.json.JsonException;
 
 /**
  * JSON Server interface between the JMRI reporter manager and a network
@@ -29,7 +29,6 @@ import jmri.jmris.JmriConnection;
  *
  * @author Paul Bender Copyright (C) 2011
  * @author Randall Wood Copyright (C) 2013
- * @version $Revision: 21313 $
  */
 public class JsonReporterServer extends AbstractReporterServer {
 

--- a/java/src/jmri/jmris/json/JsonRosterServer.java
+++ b/java/src/jmri/jmris/json/JsonRosterServer.java
@@ -17,6 +17,7 @@ import java.util.Locale;
 import jmri.jmris.JmriConnection;
 import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
+import jmri.server.json.JsonException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/java/src/jmri/jmris/json/JsonRouteServer.java
+++ b/java/src/jmri/jmris/json/JsonRouteServer.java
@@ -1,4 +1,3 @@
-//SimpleSensorServer.java
 package jmri.jmris.json;
 
 import static jmri.jmris.json.JSON.NAME;
@@ -11,13 +10,13 @@ import java.util.Locale;
 import jmri.JmriException;
 import jmri.jmris.AbstractRouteServer;
 import jmri.jmris.JmriConnection;
+import jmri.server.json.JsonException;
 
 /**
  * JSON Web Socket interface between the JMRI Sensor manager and a network
  * connection
  *
  * @author Paul Bender Copyright (C) 2010
- * @version $Revision: 21313 $
  */
 public class JsonRouteServer extends AbstractRouteServer {
 

--- a/java/src/jmri/jmris/json/JsonSensorServer.java
+++ b/java/src/jmri/jmris/json/JsonSensorServer.java
@@ -12,6 +12,7 @@ import java.util.Locale;
 import jmri.JmriException;
 import jmri.jmris.AbstractSensorServer;
 import jmri.jmris.JmriConnection;
+import jmri.server.json.JsonException;
 
 /**
  * JSON Web Socket interface between the JMRI Sensor manager and a network

--- a/java/src/jmri/jmris/json/JsonSignalHeadServer.java
+++ b/java/src/jmri/jmris/json/JsonSignalHeadServer.java
@@ -1,4 +1,3 @@
-//JsonSignalHeadServer.java
 package jmri.jmris.json;
 
 import static jmri.jmris.json.JSON.CODE;
@@ -20,6 +19,7 @@ import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.jmris.AbstractSignalHeadServer;
 import jmri.jmris.JmriConnection;
+import jmri.server.json.JsonException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
  * connection
  *
  * @author Paul Bender Copyright (C) 2010
- * @version $Revision: 21313 $
  */
 public class JsonSignalHeadServer extends AbstractSignalHeadServer {
 

--- a/java/src/jmri/jmris/json/JsonSignalMastServer.java
+++ b/java/src/jmri/jmris/json/JsonSignalMastServer.java
@@ -1,4 +1,3 @@
-//JsonSignalMastServer.java
 package jmri.jmris.json;
 
 import static jmri.jmris.json.JSON.ASPECT_DARK;
@@ -23,6 +22,7 @@ import jmri.JmriException;
 import jmri.SignalMast;
 import jmri.jmris.AbstractSignalMastServer;
 import jmri.jmris.JmriConnection;
+import jmri.server.json.JsonException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
  * connection
  *
  * @author Paul Bender Copyright (C) 2010
- * @version $Revision: 21313 $
  */
 public class JsonSignalMastServer extends AbstractSignalMastServer {
 

--- a/java/src/jmri/jmris/json/JsonTimeServer.java
+++ b/java/src/jmri/jmris/json/JsonTimeServer.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import jmri.JmriException;
 import jmri.jmris.AbstractTimeServer;
 import jmri.jmris.JmriConnection;
+import jmri.server.json.JsonException;
 
 @Deprecated
 public class JsonTimeServer extends AbstractTimeServer {

--- a/java/src/jmri/jmris/json/JsonTurnoutServer.java
+++ b/java/src/jmri/jmris/json/JsonTurnoutServer.java
@@ -1,4 +1,3 @@
-//JsonTurnoutServer.java
 package jmri.jmris.json;
 
 import static jmri.jmris.json.JSON.METHOD;
@@ -13,6 +12,7 @@ import java.util.Locale;
 import jmri.JmriException;
 import jmri.jmris.AbstractTurnoutServer;
 import jmri.jmris.JmriConnection;
+import jmri.server.json.JsonException;
 
 /**
  * JSON Server interface between the JMRI turnout manager and a network
@@ -25,7 +25,6 @@ import jmri.jmris.JmriConnection;
  *
  * @author Paul Bender Copyright (C) 2010
  * @author Randall Wood Copyright (C) 2012, 2013
- * @version $Revision: 21327 $
  * @deprecated 4.3.4
  */
 @Deprecated

--- a/java/src/jmri/jmris/json/JsonUtil.java
+++ b/java/src/jmri/jmris/json/JsonUtil.java
@@ -1,4 +1,3 @@
-// JsonUtil.java
 package jmri.jmris.json;
 
 import static jmri.jmris.json.JSON.*;
@@ -54,6 +53,7 @@ import jmri.jmrix.ConnectionConfig;
 import jmri.jmrix.ConnectionConfigManager;
 import jmri.jmrix.SystemConnectionMemo;
 import jmri.profile.ProfileManager;
+import jmri.server.json.JsonException;
 import jmri.util.ConnectionNameFromSystemName;
 import jmri.util.JmriJFrame;
 import jmri.util.node.NodeIdentity;

--- a/java/src/jmri/web/servlet/operations/OperationsServlet.java
+++ b/java/src/jmri/web/servlet/operations/OperationsServlet.java
@@ -18,7 +18,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import jmri.jmris.json.JSON;
-import jmri.jmris.json.JsonException;
+import jmri.server.json.JsonException;
 import jmri.jmris.json.JsonUtil;
 import jmri.jmrit.operations.OperationsManager;
 import jmri.jmrit.operations.rollingstock.cars.CarManager;


### PR DESCRIPTION
change JsonException references from deprecated jmri.jmris.json.JsonException to jmri.server.json.JsonException

(Also serves as a end-to-end test of new Jenkins task showing deprecations)