### PR TITLE
Do not log recurring external error.

### DIFF
--- a/java/src/jmri/server/json/JsonWebSocket.java
+++ b/java/src/jmri/server/json/JsonWebSocket.java
@@ -7,6 +7,7 @@ import jmri.implementation.QuietShutDownTask;
 import jmri.jmris.json.JSON;
 import jmri.jmris.json.JsonServerPreferences;
 import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.StatusCode;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
@@ -64,7 +65,7 @@ public class JsonWebSocket {
     @OnWebSocketError
     public void onError(Throwable thrwbl) {
         if (thrwbl instanceof SocketTimeoutException) {
-            log.error(thrwbl.getMessage());
+            this.connection.getSession().close(StatusCode.NO_CLOSE, thrwbl.getMessage());
         } else {
             log.error(thrwbl.getMessage(), thrwbl);
         }


### PR DESCRIPTION
The error in this case is the client stopped responding, but maintains
the connection, spamming the logs.
I haven’t figured out the cause and real fix in the JavaScript code,
but don’t need to spam anyone’s logs about this either.
(The debug statement in the onClose method does correctly report why
its closing as a result of this change, so we don’t need two logging
statements either).