### PR TITLE
Fix annotation on return type of generic method

### DIFF
--- a/java/src/jmri/util/StringUtil.java
+++ b/java/src/jmri/util/StringUtil.java
@@ -495,7 +495,7 @@ public class StringUtil {
      * value is displayed within square brackets and separated by commas.
      */
     @CheckReturnValue
-    static public <E> @Nonnull String arrayToString(@Nonnull E[] v) {
+    static public @Nonnull <E> String arrayToString(@Nonnull E[] v) {
         StringBuffer retval = new StringBuffer();
         boolean first = true;
         for (E e : v) {


### PR DESCRIPTION
The tagadab Jenkins Builds task is currently unhappy with an annotation:
````
    [javac] 33. ERROR in /var/lib/jenkins/jobs/Development/jobs/Builds/workspace/java/src/jmri/util/StringUtil.java (at line 498)
    [javac] 	static public <E> @Nonnull String arrayToString(@Nonnull E[] v) {
    [javac] 	                  ^^^^^^^^
    [javac] Annotation types that do not specify explicit target element types cannot be applied here
````

The situation is a bit confusing:
- That same line compiles fine on my computer (Mac OS X 10.11.5, java -version 1.8.0_25) and both Travis and AppVeyor. 
- Tagadab Jenkins seems to be using "JDK 8u72 (1.8.0_72)". 
- I updated my Java to 1.8.0_92, most recent, and the original line still compiles for me.

This PR (hopefully) fixes the line so it compiles all places, although I don't have

Particularly as we run more and more checks on the code, I expect we'll see more occurrences like this, where compilers aren't quite the same (this was an error, not a warning, but the general point still holds) 
