### PR TITLE
Missing profile properties (#1514)

### DIFF
--- a/java/src/jmri/profile/NullProfile.java
+++ b/java/src/jmri/profile/NullProfile.java
@@ -17,7 +17,7 @@ import javax.annotation.Nonnull;
  * that access the {@link #name} and {@link #id} fields to remove protections
  * and restrictions on those fields.
  *
- * @author rhwood Copyright (C) 2014
+ * @author Randall Wood Copyright (C) 2014
  * @see jmri.profile.ProfileManager#setActiveProfile(jmri.profile.Profile)
  */
 public class NullProfile extends Profile {

--- a/java/src/jmri/profile/Profile.java
+++ b/java/src/jmri/profile/Profile.java
@@ -37,6 +37,7 @@ public class Profile implements Comparable<Profile> {
      * in storage on the computer.
      *
      * @param path The Profile's directory
+     * @throws java.io.IOException If unable to read the Profile from path
      */
     public Profile(File path) throws IOException {
         this(path, true);
@@ -51,6 +52,12 @@ public class Profile implements Comparable<Profile> {
      * read-only property of the Profile. The {@link ProfileManager} will only
      * load a single profile with a given id.
      *
+     * @param name Name of the profile. Will not be used to enforce uniqueness
+     *             contraints.
+     * @param id   Id of the profile. Will be prepended to a random String to
+     *             enforce uniqueness constraints.
+     * @param path Location to store the profile
+     * @throws java.io.IOException If unable to create the profile at path
      */
     public Profile(String name, String id, File path) throws IOException, IllegalArgumentException {
         if (!path.getName().equals(id)) {
@@ -87,6 +94,10 @@ public class Profile implements Comparable<Profile> {
      * This method exists purely to support subclasses.
      *
      * @param path       The Profile's directory
+     * @param isReadable True if the profile has storage. See
+     *                   {@link jmri.profile.NullProfile} for a Profile subclass
+     *                   where this is not true.
+     * @throws java.io.IOException If the profile's preferences cannot be read.
      */
     protected Profile(File path, boolean isReadable) throws IOException {
         this.path = path;
@@ -130,7 +141,7 @@ public class Profile implements Comparable<Profile> {
     }
 
     private void readProfile() throws IOException {
-        ProfileProperties p = new ProfileProperties(this);
+        ProfileProperties p = new ProfileProperties(this.path);
         this.id = p.get(ID, true);
         this.name = p.get(NAME, true);
         if (this.id == null) {
@@ -139,8 +150,9 @@ public class Profile implements Comparable<Profile> {
         }
     }
 
-    /*
-     * Remove sometime after the new profiles get entrenched (JMRI 5.0, 6.0?)
+    /**
+     * @deprecated since 4.1.1; Remove sometime after the new profiles get
+     * entrenched (JMRI 5.0, 6.0?)
      */
     @Deprecated
     private void readProfileXml() throws IOException {
@@ -211,6 +223,7 @@ public class Profile implements Comparable<Profile> {
     /**
      * Test if the given path or subdirectories contains a Profile.
      *
+     * @param path Path to test.
      * @return true if path or subdirectories contains a Profile.
      * @since 3.9.4
      */
@@ -233,6 +246,7 @@ public class Profile implements Comparable<Profile> {
     /**
      * Test if the given path is within a directory that is a Profile.
      *
+     * @param path Path to test.
      * @return true if path or parent directories is a Profile.
      * @since 3.9.4
      */
@@ -249,6 +263,7 @@ public class Profile implements Comparable<Profile> {
     /**
      * Test if the given path is a Profile.
      *
+     * @param path Path to test.
      * @return true if path is a Profile.
      * @since 3.9.4
      */

--- a/java/src/jmri/profile/ProfileProperties.java
+++ b/java/src/jmri/profile/ProfileProperties.java
@@ -1,31 +1,47 @@
 package jmri.profile;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.prefs.BackingStoreException;
+import jmri.util.prefs.JmriPreferencesProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class ProfileProperties implements AuxiliaryProperties {
 
-    private final Profile project;
-    
+    private final File path;
+
     private final static Logger log = LoggerFactory.getLogger(ProfileProperties.class);
-    
+
     public ProfileProperties(Profile project) {
-        this.project = project;
+        this.path = project.getPath();
     }
-    
-    @Override
-    public String get(String key, boolean shared) {
-        return ProfileUtils.getPreferences(this.project, null, shared).node(Profile.PROFILE).get(key, null);
+
+    /**
+     * Package protected constructor used in
+     * {@link jmri.profile.Profile#Profile(java.io.File, boolean)}.
+     *
+     * @param path Path to a partially constructed Profile
+     */
+    ProfileProperties(File path) {
+        this.path = path;
     }
 
     @Override
+    @SuppressFBWarnings(value = "deprecation", justification = "Avoids errors passing partly constructed object.")
+    @SuppressWarnings("deprecation") // silence deprecation notice in IDEs
+    public String get(String key, boolean shared) {
+        return JmriPreferencesProvider.getPreferences(path, null, shared).node(Profile.PROFILE).get(key, null);
+    }
+
+    @Override
+    @SuppressFBWarnings(value = "deprecation", justification = "Avoids errors passing partly constructed object.")
+    @SuppressWarnings("deprecation")
     public Iterable<String> listKeys(boolean shared) {
         try {
-            String[] keys = ProfileUtils.getPreferences(this.project, null, shared).node(Profile.PROFILE).keys();
+            String[] keys = JmriPreferencesProvider.getPreferences(path, null, shared).node(Profile.PROFILE).keys();
             return new ArrayList<>(Arrays.asList(keys));
         } catch (BackingStoreException ex) {
             log.error("Unable to read properties.", ex);
@@ -34,8 +50,10 @@ public class ProfileProperties implements AuxiliaryProperties {
     }
 
     @Override
+    @SuppressFBWarnings(value = "deprecation", justification = "Avoids errors passing partly constructed object.")
+    @SuppressWarnings("deprecation")
     public void put(String key, String value, boolean shared) {
-        ProfileUtils.getPreferences(this.project, null, shared).node(Profile.PROFILE).put(key, value);
+        JmriPreferencesProvider.getPreferences(path, null, shared).node(Profile.PROFILE).put(key, value);
     }
-    
+
 }

--- a/java/test/jmri/profile/PackageTest.java
+++ b/java/test/jmri/profile/PackageTest.java
@@ -1,5 +1,6 @@
 package jmri.profile;
 
+import junit.framework.JUnit4TestAdapter;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -25,6 +26,7 @@ public class PackageTest extends TestCase {
     // test suite from all defined tests
     public static Test suite() {
         TestSuite suite = new TestSuite("jmri.profile.PackageTest");  // no tests in this class itself
+        suite.addTest(new JUnit4TestAdapter(ProfileTest.class));
         suite.addTest(new TestSuite(ProfileUtilsTest.class));
         suite.addTest(BundleTest.suite());
         return suite;

--- a/java/test/jmri/profile/ProfileTest.java
+++ b/java/test/jmri/profile/ProfileTest.java
@@ -1,0 +1,280 @@
+package jmri.profile;
+
+import apps.tests.Log4JFixture;
+import java.io.File;
+import java.io.IOException;
+import jmri.util.FileUtil;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author Randall Wood
+ */
+public class ProfileTest {
+
+    private final static Logger log = LoggerFactory.getLogger(ProfileTest.class);
+
+    public ProfileTest() {
+    }
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @BeforeClass
+    public static void setUpClass() {
+        Log4JFixture.setUp();
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        Log4JFixture.tearDown();
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of save method, of class Profile.
+     */
+    @Test
+    public void testSave() throws Exception {
+        File profileFolder = new File(folder.newFolder(Profile.PROFILE), "test");
+        Profile instance = new Profile("test", "test", profileFolder);
+        instance.setName("saved");
+        instance.save();
+        Assert.assertEquals("saved", (new ProfileProperties(profileFolder)).get(Profile.NAME, true));
+    }
+
+    /**
+     * Test of getName method, of class Profile.
+     */
+    @Test
+    public void testGetName() {
+        try {
+            File profileFolder = new File(folder.newFolder(Profile.PROFILE), "test");
+            Profile instance = new Profile("test", "test", profileFolder);
+            Assert.assertEquals("test", instance.getName());
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+    /**
+     * Test of setName method, of class Profile.
+     */
+    @Test
+    public void testSetName() {
+        try {
+            File profileFolder = new File(folder.newFolder(Profile.PROFILE), "test");
+            Profile instance = new Profile("test", "test", profileFolder);
+            instance.setName("changed");
+            Assert.assertEquals("changed", instance.getName());
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+    /**
+     * Test of getId method, of class Profile.
+     */
+    @Test
+    public void testGetId() {
+        try {
+            File profileFolder = new File(folder.newFolder(Profile.PROFILE), "test");
+            Profile instance = new Profile("test", "test", profileFolder);
+            String id = (new ProfileProperties(profileFolder)).get(Profile.ID, true);
+            Assert.assertEquals(id, instance.getId());
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+    /**
+     * Test of getPath method, of class Profile.
+     */
+    @Test
+    public void testGetPath() {
+        try {
+            File profileFolder = new File(folder.newFolder(Profile.PROFILE), "test");
+            Profile instance = new Profile("test", "test", profileFolder);
+            Assert.assertEquals(profileFolder, instance.getPath());
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+    /**
+     * Test of toString method, of class Profile.
+     */
+    @Test
+    public void testToString() {
+        try {
+            File profileFolder = new File(folder.newFolder(Profile.PROFILE), "test");
+            Profile instance = new Profile("test", "test", profileFolder);
+            Assert.assertEquals(instance.getName(), instance.toString());
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+    /**
+     * Test of hashCode method, of class Profile.
+     */
+    @Test
+    public void testHashCode() {
+        try {
+            File profileFolder = new File(folder.newFolder(Profile.PROFILE), "test");
+            Profile instance = new Profile("test", "test", profileFolder);
+            String id = (new ProfileProperties(profileFolder)).get(Profile.ID, true);
+            Assert.assertEquals(71 * 7 + id.hashCode(), instance.hashCode());
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+    /**
+     * Test of equals method, of class Profile.
+     */
+    @Test
+    public void testEquals() {
+        try {
+            File rootFolder = folder.newFolder(Profile.PROFILE);
+            File profileFolder = new File(rootFolder, "test");
+            File profileFolder2 = new File(rootFolder, "test2");
+            File profileFolder3 = new File(rootFolder, "test3");
+            Profile instance = new Profile("test", "test", profileFolder);
+            Profile instance2 = new Profile("test", "test2", profileFolder2);
+            FileUtil.copy(profileFolder, profileFolder3);
+            Profile instance3 = new Profile(profileFolder3);
+            Assert.assertFalse(instance.equals(null));
+            Assert.assertFalse(instance.equals(new String()));
+            Assert.assertFalse(instance.equals(instance2));
+            Assert.assertTrue(instance.equals(instance3));
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+    /**
+     * Test of isComplete method, of class Profile.
+     */
+    @Test
+    public void testIsComplete() {
+        try {
+            File profileFolder = new File(folder.newFolder(Profile.PROFILE), "test");
+            Profile instance = new Profile("test", "test", profileFolder);
+            Assert.assertTrue(instance.isComplete());
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+    /**
+     * Test of getUniqueId method, of class Profile.
+     */
+    @Test
+    public void testGetUniqueId() {
+        try {
+            File profileFolder = new File(folder.newFolder(Profile.PROFILE), "test");
+            Profile instance = new Profile("test", "test", profileFolder);
+            String id = (new ProfileProperties(profileFolder)).get(Profile.ID, true);
+            id = id.substring(id.lastIndexOf(".") + 1);
+            Assert.assertEquals(id, instance.getUniqueId());
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+    /**
+     * Test of containsProfile method, of class Profile.
+     */
+    @Test
+    public void testContainsProfile() {
+        try {
+            File rootFolder = folder.newFolder(Profile.PROFILE);
+            File profileFolder = new File(rootFolder, "test");
+            File rootFolder2 = folder.newFolder(Profile.PATH);
+            (new File(rootFolder2, "test2")).mkdirs();
+            new Profile("test", "test", profileFolder);
+            Assert.assertTrue(Profile.containsProfile(rootFolder));
+            Assert.assertFalse(Profile.containsProfile(rootFolder2));
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+    /**
+     * Test of inProfile method, of class Profile.
+     */
+    @Test
+    public void testInProfile() {
+        try {
+            File rootFolder = folder.newFolder(Profile.PROFILE);
+            File profileFolder = new File(rootFolder, "test");
+            File innerFolder = new File(profileFolder, "test");
+            innerFolder.mkdirs();
+            File rootFolder2 = folder.newFolder(Profile.PATH);
+            new Profile("test", "test", profileFolder);
+            Assert.assertTrue(Profile.inProfile(innerFolder));
+            Assert.assertFalse(Profile.inProfile(rootFolder2));
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+    /**
+     * Test of isProfile method, of class Profile.
+     */
+    @Test
+    public void testIsProfile() {
+        try {
+            File rootFolder = folder.newFolder(Profile.PROFILE);
+            File profileFolder = new File(rootFolder, "test");
+            new Profile("test", "test", profileFolder);
+            File innerFolder = new File(profileFolder, "test");
+            innerFolder.mkdirs();
+            Assert.assertTrue(Profile.isProfile(profileFolder));
+            Assert.assertFalse(Profile.isProfile(rootFolder));
+            Assert.assertFalse(Profile.isProfile(innerFolder));
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+    /**
+     * Test of compareTo method, of class Profile.
+     */
+    @Test
+    public void testCompareTo() {
+        try {
+            File rootFolder = folder.newFolder(Profile.PROFILE);
+            File profileFolder = new File(rootFolder, "test");
+            File profileFolder2 = new File(rootFolder, "test2");
+            File profileFolder3 = new File(rootFolder, "test3");
+            Profile instance = new Profile("test", "test", profileFolder);
+            Profile instance2 = new Profile("test", "test2", profileFolder2);
+            FileUtil.copy(profileFolder, profileFolder3);
+            Profile instance3 = new Profile(profileFolder3);
+            Assert.assertEquals(-1, instance.compareTo(instance2));
+            Assert.assertEquals(0, instance.compareTo(instance3));
+            Assert.assertEquals(1, instance2.compareTo(instance));
+        } catch (IOException | IllegalArgumentException ex) {
+            Assert.fail(ex.toString());
+        }
+    }
+
+}

--- a/java/test/jmri/util/prefs/JmriPreferencesProviderTest.java
+++ b/java/test/jmri/util/prefs/JmriPreferencesProviderTest.java
@@ -50,8 +50,8 @@ public class JmriPreferencesProviderTest extends TestCase {
     public void testFindProvider() throws IOException {
         String id = Long.toString((new Date()).getTime());
         Profile p = new Profile(this.getName(), id, new File(this.workspace.toFile(), id));
-        JmriPreferencesProvider shared = JmriPreferencesProvider.findProvider(p, true);
-        JmriPreferencesProvider privat = JmriPreferencesProvider.findProvider(p, false);
+        JmriPreferencesProvider shared = JmriPreferencesProvider.findProvider(p.getPath(), true);
+        JmriPreferencesProvider privat = JmriPreferencesProvider.findProvider(p.getPath(), false);
         assertNotNull(shared);
         assertNotNull(privat);
         assertNotSame(shared, privat);
@@ -91,7 +91,7 @@ public class JmriPreferencesProviderTest extends TestCase {
     public void testIsFirstUse() throws IOException {
         String id = Long.toString((new Date()).getTime());
         Profile project = new Profile(this.getName(), id, new File(this.workspace.toFile(), id));
-        JmriPreferencesProvider shared = JmriPreferencesProvider.findProvider(project, true);
+        JmriPreferencesProvider shared = JmriPreferencesProvider.findProvider(project.getPath(), true);
         assertEquals(shared.isFirstUse(), true);
         Preferences prefs = shared.getPreferences(this.getClass());
         prefs.put("test", "test");
@@ -100,7 +100,7 @@ public class JmriPreferencesProviderTest extends TestCase {
         } catch (BackingStoreException ex) {
             assertNull(ex);
         }
-        shared = new JmriPreferencesProvider(project, true);
+        shared = new JmriPreferencesProvider(project.getPath(), true);
         assertEquals(shared.isFirstUse(), false);
     }
 


### PR DESCRIPTION
Attempts to read a Profile’s preferences during Profile construction were failing on profiles created post 4.3.2 (as opposed to profiles created before 4.3.2). I did not completely understand or observe this behavior until after 4.3.7 was released. This was caused by passing an incompletely constructed Profile object to a JmriPreferencesProvider in an attempt to read the Profile’s preferences. The fix is to allow JmriPreferencesProvider objects to be accessed with just the path to the Profile instead of the complete Profile itself.