### PR TITLE
Tidy script and squash test

### DIFF
--- a/scripts/tidy-scan.sh
+++ b/scripts/tidy-scan.sh
@@ -1,3 +1,4 @@
 #! /bin/bash
-#
+# scan the English help files for HMTL errors, used in Jenkins
+
 find help/en/ -name \*html -exec echo Filename: {} \; -exec tidy -e {} \; 2>&1 | awk -f scripts/tidy.awk

--- a/scripts/tidy-scan.sh
+++ b/scripts/tidy-scan.sh
@@ -1,1 +1,3 @@
+#! /bin/bash
+#
 find help/en/ -name \*html -exec echo Filename: {} \; -exec tidy -e {} \; 2>&1 | awk -f scripts/tidy.awk

--- a/scripts/tidy-scan.sh
+++ b/scripts/tidy-scan.sh
@@ -1,0 +1,1 @@
+find help/en/ -name \*html -exec echo Filename: {} \; -exec tidy -e {} \; 2>&1 | awk -f scripts/tidy.awk

--- a/scripts/tidy.awk
+++ b/scripts/tidy.awk
@@ -1,0 +1,2 @@
+$1 == "Filename:" {file = $2}
+$6 == "Warning:" {print file " " $0}


### PR DESCRIPTION
Add a script and Awk file to scan the help/en files for HTML errors. Will eventually give us a Jenkins dashboard to slowly clean up the HTML help. No effect on JMRI compile-time or run-time behavior.

Done in three commits to see what happens to `git blame` with a squash commit.