### PR TITLE
Improve tidy test of HTML

### DIFF
--- a/scripts/tidy-scan.sh
+++ b/scripts/tidy-scan.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 # scan the English help files for HMTL errors, used in Jenkins
 
-find help/en/ -name \*html -exec echo Filename: {} \; -exec tidy -e {} \; 2>&1 | awk -f scripts/tidy.awk
+find help/en/*/ -name \*html -exec echo Filename: {} \; -exec tidy -e -access 0 {} \; 2>&1 | tr '<' '&lt;' | tr '>' '&gt;' | awk -f scripts/tidy.awk


### PR DESCRIPTION
- skip scan of auto-gen files in help/en itself
- convert to &gt; and &lt; in the output so that they appear in report

This is an update to the script used for the [Jenkins HTML check](http://jmri.tagadab.com/jenkins/job/Development/job/HTML%20Scan/) job.
