### PR TITLE
Fix a high priority FindBugs warning.

### DIFF
--- a/java/src/jmri/jmrit/beantable/signalmast/AddSignalMastPanel.java
+++ b/java/src/jmri/jmrit/beantable/signalmast/AddSignalMastPanel.java
@@ -2007,7 +2007,7 @@ public class AddSignalMastPanel extends JPanel {
          * @param panelBits char[] of up to 5 1's and 0's
          */
         MatrixAspectPanel(String aspect, char[] panelBits) {
-            if (panelBits == null || panelBits.equals("")) {
+            if (panelBits == null || panelBits.length == 0) {
                 return;
             }
             this.aspect = aspect;


### PR DESCRIPTION
A ```char[]``` can never equal an empty String, but can be 0 length. I think that was the intended test (parameter is neither null nor empty)