### PR TITLE
Update handling of IllegalArgumentException from Manager.provideFoo(..) calls

### DIFF
--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -230,12 +230,12 @@ the custom appender is told when a test is beginning and ending.
 <CODE><PRE>
     // The minimal setup for log4J<br/>
     protected void setUp() throws Exception { <br/>
-        apps.tests.Log4JFixture.setUp(); <br/>
         super.setUp();<br/>
+        apps.tests.Log4JFixture.setUp(); <br/>
     }<br/>
     protected void tearDown() throws Exception { <br/>
-        super.tearDown();<br/>
         apps.tests.Log4JFixture.tearDown(); <br/>
+        super.tearDown();<br/>
     }<br/>
 </PRE></code>
 <LI>When a test is deliberately invoking a message, it should then
@@ -276,6 +276,7 @@ clear and reset it to ensure you get reproducible results.
 Depending on what managers your code uses, your <code>setUp()</code> implementation should start with:
 <p><CODE><PRE>
     super.setUp();<br/>
+    apps.tests.Log4JFixture.setUp(); <br/>
     jmri.util.JUnitUtil.resetInstanceManager();<br/>
     jmri.util.JUnitUtil.initInternalTurnoutManager();<br/>
     jmri.util.JUnitUtil.initInternalLightManager();<br/>
@@ -290,7 +291,8 @@ Your <code>tearDown()</code> should end with:
 <p>
 <CODE><PRE>
     jmri.util.JUnitUtil.resetInstanceManager();<br/>
-    super.tearDown();
+    apps.tests.Log4JFixture.tearDown(); <br/>
+    super.tearDown();<br/>
 </PRE></code>
 
 <h3><a name="RunningListeners">Working with Listeners</a></h3>

--- a/help/fr/html/doc/Technical/JUnit.shtml
+++ b/help/fr/html/doc/Technical/JUnit.shtml
@@ -142,11 +142,13 @@ tests JUnit puissent les regarder avant de les transmettre dans le rapport. Il y
 faire en sorte que log4j soit bien initialis&#233;, et que l'appender personnalis&#233; dialogue quand un test commence et se termine.
 <CODE> <PRE>
      // La configuration minimale pour log4j
-    protected void  setUp() throws Exception {
-         apps.tests.Log4JFixture.setUp ();
+     @Override
+     protected void  setUp() throws Exception {
          super.setUp ();
+         apps.tests.Log4JFixture.setUp ();
      }
-      protected void tearDown () throws Exception {
+     @Override
+     protected void tearDown () throws Exception {
          super.tearDown ();
          apps.tests.Log4JFixture.tearDown ();
      }

--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -141,11 +141,11 @@ public class Block extends jmri.implementation.AbstractNamedBean implements Phys
             return false;
         }
         if (InstanceManager.sensorManagerInstance() != null) {
-            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(pName);
-            if (sensor != null) {
+            try {
+                Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(pName);
                 setNamedSensor(jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(pName, sensor));
                 return true;
-            } else {
+            } catch (IllegalArgumentException ex) {
                 setNamedSensor(null);
                 log.error("Sensor '" + pName + "' not available");
             }

--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -75,12 +75,13 @@ public class BlockManager extends AbstractManager
     }
 
     /**
-     * Method to create a new Block if it does not exist 
+     * Method to create a new Block only if it does not exist 
      * @return null if a Block
      * with the same systemName or userName already exists, or if there is
      * trouble creating a new Block.
      */
-    public @CheckForNull Block createNewBlock(@Nonnull String systemName, @CheckForNull String userName) {
+    public @CheckForNull Block createNewBlock(@Nonnull String systemName, @CheckForNull String userName) 
+                throws IllegalArgumentException {
         // Check that Block does not already exist
         Block r;
         if (userName != null && !userName.equals("")) {
@@ -119,7 +120,14 @@ public class BlockManager extends AbstractManager
         return r;
     }
 
-    public @Nonnull Block createNewBlock(@Nonnull String userName) {
+    /**
+     * Method to create a new Block using an automatically incrementing
+     * system name.
+     * @return null if a Block
+     * with the same systemName or userName already exists, or if there is
+     * trouble creating a new Block.
+     */
+    public @CheckForNull Block createNewBlock(@Nonnull String userName) {
         int nextAutoBlockRef = lastAutoBlockRef + 1;
         StringBuilder b = new StringBuilder("IB:AUTO:");
         String nextNumber = paddedNumber.format(nextAutoBlockRef);
@@ -127,16 +135,24 @@ public class BlockManager extends AbstractManager
         return createNewBlock(b.toString(), userName);
     }
 
-    public @Nonnull Block provideBlock(@Nonnull String name) {
+    /**
+     * If the Block exists, return it, otherwise create a new one and return it.
+     * If the argument starts with the system prefix and type letter, usually "IB",
+     * then the argument is considered a system name, otherwise it's considered
+     * a user name and a system name is automatically created.
+     * @returns never null
+     */
+    public @Nonnull Block provideBlock(@Nonnull String name)  {
         Block b = getBlock(name);
         if (b != null) {
             return b;
         }
         if (name.startsWith(getSystemPrefix() + typeLetter())) {
-            return createNewBlock(name, null);
+            b = createNewBlock(name, null);
         } else {
-            return createNewBlock(makeSystemName(name), null);
+            b = createNewBlock(makeSystemName(name), null);
         }
+        return b;
     }
 
     DecimalFormat paddedNumber = new DecimalFormat("0000");

--- a/java/src/jmri/MemoryManager.java
+++ b/java/src/jmri/MemoryManager.java
@@ -59,7 +59,7 @@ public interface MemoryManager extends Manager {
      *                                  e.g. an illegal name or name that can't
      *                                  be parsed.
      */
-    public @Nonnull Memory provideMemory(@Nonnull String name);
+    public @Nonnull Memory provideMemory(@Nonnull String name) throws IllegalArgumentException;
 
     /**
      * Locate via user name, then system name if needed. If that fails, return

--- a/java/src/jmri/RailComManager.java
+++ b/java/src/jmri/RailComManager.java
@@ -31,7 +31,7 @@ public interface RailComManager extends IdTagManager {
      *                                  be parsed.
      */
     @Override
-    public @Nonnull RailCom provideIdTag(@Nonnull String name);
+    public @Nonnull RailCom provideIdTag(@Nonnull String name) throws IllegalArgumentException;
 
     @Override
     public @CheckForNull RailCom getIdTag(@Nonnull String name);

--- a/java/src/jmri/configurexml/BlockManagerXml.java
+++ b/java/src/jmri/configurexml/BlockManagerXml.java
@@ -328,9 +328,13 @@ public class BlockManagerXml extends jmri.managers.configurexml.AbstractMemoryMa
         if (reporters.size() == 1) {
             // Reporter
             String name = reporters.get(0).getAttribute("systemName").getValue();
-            Reporter reporter = InstanceManager.reporterManagerInstance().provideReporter(name);
-            block.setReporter(reporter);
-            block.setReportingCurrent(reporters.get(0).getAttribute("useCurrent").getValue().equals("yes"));
+            try {
+                Reporter reporter = InstanceManager.reporterManagerInstance().provideReporter(name);
+                block.setReporter(reporter);
+                block.setReportingCurrent(reporters.get(0).getAttribute("useCurrent").getValue().equals("yes"));
+            } catch (IllegalArgumentException ex) {
+                log.warn("failed to create Reporter \"{}\" during Block load", name);
+            }
         }
 
         // load paths if present
@@ -415,10 +419,14 @@ public class BlockManagerXml extends jmri.managers.configurexml.AbstractMemoryMa
             log.error("invalid number of turnout element children");
         }
         String name = turnouts.get(0).getAttribute("systemName").getValue();
-        Turnout t = InstanceManager.turnoutManagerInstance().provideTurnout(name);
+        try {
+            Turnout t = InstanceManager.turnoutManagerInstance().provideTurnout(name);
+            BeanSetting bs = new BeanSetting(t, name, setting);
+            path.addSetting(bs);
+        } catch (IllegalArgumentException ex) {
+            log.warn("failed to create Turnout \"{}\" during Block load", name);
+        }
 
-        BeanSetting bs = new BeanSetting(t, name, setting);
-        path.addSetting(bs);
     }
 
     public int loadOrder() {

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -580,7 +580,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
     private NamedBeanHandle<Sensor> _secondNamedSensor;
 
     @Override
-    public void provideFirstFeedbackSensor(String pName) throws jmri.JmriException {
+    public void provideFirstFeedbackSensor(String pName) throws jmri.JmriException, IllegalArgumentException {
         if (InstanceManager.sensorManagerInstance() != null) {
             if (pName == null || pName.equals("")) {
                 provideFirstFeedbackNamedSensor(null);
@@ -622,7 +622,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
     }
 
     @Override
-    public void provideSecondFeedbackSensor(String pName) throws jmri.JmriException {
+    public void provideSecondFeedbackSensor(String pName) throws jmri.JmriException, IllegalArgumentException {
         if (InstanceManager.sensorManagerInstance() != null) {
             if (pName == null || pName.equals("")) {
                 provideSecondFeedbackNamedSensor(null);

--- a/java/src/jmri/implementation/DefaultConditionalAction.java
+++ b/java/src/jmri/implementation/DefaultConditionalAction.java
@@ -147,6 +147,7 @@ public class DefaultConditionalAction implements ConditionalAction {
                     try {
                         bean = InstanceManager.sensorManagerInstance().provideSensor(devName);
                     } catch (IllegalArgumentException e) {
+                        bean = null;
                         log.error("invalid sensor name= \"" + _deviceName + "\" in conditional action");
                     }
                     break;
@@ -154,49 +155,64 @@ public class DefaultConditionalAction implements ConditionalAction {
                     try {
                         bean = InstanceManager.turnoutManagerInstance().provideTurnout(devName);
                     } catch (IllegalArgumentException e) {
+                        bean = null;
                         log.error("invalid turnout name= \"" + _deviceName + "\" in conditional action");
                     }
                     break;
                 case Conditional.ITEM_TYPE_MEMORY:
-                    bean = InstanceManager.memoryManagerInstance().provideMemory(devName);
-                    if (bean == null) {
+                    try {
+                        bean = InstanceManager.memoryManagerInstance().provideMemory(devName);
+                    } catch (IllegalArgumentException e) {
+                        bean = null;
                         log.error("invalid memory name= \"" + _deviceName + "\" in conditional action");
                     }
                     break;
                 case Conditional.ITEM_TYPE_LIGHT:
-                    bean = InstanceManager.lightManagerInstance().getLight(devName);
-                    if (bean == null) {
+                    try {
+                        bean = InstanceManager.lightManagerInstance().getLight(devName);
+                    } catch (IllegalArgumentException e) {
+                        bean = null;
                         log.error("invalid light name= \"" + _deviceName + "\" in conditional action");
                     }
                     break;
                 case Conditional.ITEM_TYPE_SIGNALMAST:
-                    bean = InstanceManager.signalMastManagerInstance().provideSignalMast(devName);
-                    if (bean == null) {
+                    try {
+                        bean = InstanceManager.signalMastManagerInstance().provideSignalMast(devName);
+                    } catch (IllegalArgumentException e) {
+                        bean = null;
                         log.error("invalid signal mast name= \"" + _deviceName + "\" in conditional action");
                     }
                     break;
                 case Conditional.ITEM_TYPE_SIGNALHEAD:
-                    bean = InstanceManager.signalHeadManagerInstance().getSignalHead(devName);
-                    if (bean == null) {
+                    try {
+                        bean = InstanceManager.signalHeadManagerInstance().getSignalHead(devName);
+                    } catch (IllegalArgumentException e) {
+                        bean = null;
                         log.error("invalid signal head name= \"" + _deviceName + "\" in conditional action");
                     }
                     break;
                 case Conditional.ITEM_TYPE_WARRANT:
-                    bean = InstanceManager.getDefault(WarrantManager.class).getWarrant(devName);
-                    if (bean == null) {
+                    try {
+                        bean = InstanceManager.getDefault(WarrantManager.class).getWarrant(devName);
+                    } catch (IllegalArgumentException e) {
+                        bean = null;
                         log.error("invalid Warrant name= \"" + _deviceName + "\" in conditional action");
                     }
                     break;
                 case Conditional.ITEM_TYPE_OBLOCK:
-                    bean = InstanceManager.getDefault(OBlockManager.class).getOBlock(devName);
-                    if (bean == null) {
+                    try {
+                        bean = InstanceManager.getDefault(OBlockManager.class).getOBlock(devName);
+                    } catch (IllegalArgumentException e) {
+                        bean = null;
                         log.error("invalid OBlock name= \"" + _deviceName + "\" in conditional action");
                     }
                     break;
                 default:
                     if (getType() == Conditional.ACTION_TRIGGER_ROUTE) {
-                        bean = InstanceManager.getDefault(RouteManager.class).getRoute(devName);
-                        if (bean == null) {
+                        try {
+                            bean = InstanceManager.getDefault(RouteManager.class).getRoute(devName);
+                        } catch (IllegalArgumentException e) {
+                            bean = null;
                             log.error("invalid Route name= \"" + _deviceName + "\" in conditional action");
                         }
                     }

--- a/java/src/jmri/implementation/DefaultIdTag.java
+++ b/java/src/jmri/implementation/DefaultIdTag.java
@@ -115,10 +115,14 @@ public class DefaultIdTag extends AbstractIdTag {
                 this.setComment(e.getChild("comment").getText()); //NOI18N
             }
             if (e.getChild("whereLastSeen") != null) { //NOI18N
-                this.setWhereLastSeen(
-                        InstanceManager.reporterManagerInstance().provideReporter(
-                                e.getChild("whereLastSeen").getText())); //NOI18N
-                this.whenLastSeen = null;
+                try {
+                    Reporter r = InstanceManager.reporterManagerInstance()
+                                    .provideReporter(e.getChild("whereLastSeen").getText()); //NOI18N
+                    this.setWhereLastSeen(r);
+                    this.whenLastSeen = null;
+                } catch (IllegalArgumentException ex) {
+                    log.warn("Failed to provide Turnout \"{}\" in load", e.getChild("whereLastSeen").getText());
+                }
             }
             if (e.getChild("whenLastSeen") != null) { //NOI18N
                 log.debug("When Last Seen: " + e.getChild("whenLastSeen").getText());

--- a/java/src/jmri/implementation/DefaultLogix.java
+++ b/java/src/jmri/implementation/DefaultLogix.java
@@ -476,18 +476,19 @@ public class DefaultLogix extends AbstractNamedBean
                                 variable.getDataString());
                         if (positionOfListener == -1) {
                             String name = variable.getDataString();
-                            Memory my = InstanceManager.memoryManagerInstance().provideMemory(name);
-                            if (my == null) {
+                            try {
+                                Memory my = InstanceManager.memoryManagerInstance().provideMemory(name);
+                                NamedBeanHandle<?> nb = jmri.InstanceManager.getDefault(
+                                        jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, my);
+
+                                listener = new JmriTwoStatePropertyListener("value", LISTENER_TYPE_MEMORY,
+                                        nb, varType,
+                                        conditional);
+                                _listeners.add(listener);
+                            } catch (IllegalArgumentException ex) {
                                 log.error("invalid memory name= \"" + name + "\" in state variable");
                                 break;
-                            }
-                            NamedBeanHandle<?> nb = jmri.InstanceManager.getDefault(
-                                    jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, my);
-
-                            listener = new JmriTwoStatePropertyListener("value", LISTENER_TYPE_MEMORY,
-                                    nb, varType,
-                                    conditional);
-                            _listeners.add(listener);
+                            }                        
                         } else {
                             listener = _listeners.get(positionOfListener);
                             listener.addConditional(conditional);

--- a/java/src/jmri/implementation/DefaultRoute.java
+++ b/java/src/jmri/implementation/DefaultRoute.java
@@ -70,7 +70,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
         NamedBeanHandle<Sensor> _sensor;
         int _state = Sensor.ACTIVE;
 
-        OutputSensor(String name) {
+        OutputSensor(String name) throws IllegalArgumentException {
             Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(name);
             _sensor = nbhm.getNamedBeanHandle(name, sensor);
         }
@@ -153,7 +153,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
         NamedBeanHandle<Turnout> _turnout;
         int _state;
 
-        OutputTurnout(String name) {
+        OutputTurnout(String name) throws IllegalArgumentException {
             Turnout turnout = InstanceManager.turnoutManagerInstance().provideTurnout(name);
             _turnout = nbhm.getNamedBeanHandle(name, turnout);
 
@@ -308,7 +308,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
      * might be user or system names
      */
     @Override
-    public boolean isOutputTurnoutIncluded(String turnoutName) {
+    public boolean isOutputTurnoutIncluded(String turnoutName) throws IllegalArgumentException {
         Turnout t1 = InstanceManager.turnoutManagerInstance().provideTurnout(turnoutName);
         return isOutputTurnoutIncluded(t1);
     }
@@ -345,7 +345,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
      * @return -1 if there are less than 'k' Turnouts defined
      */
     @Override
-    public int getOutputTurnoutSetState(String name) {
+    public int getOutputTurnoutSetState(String name) throws IllegalArgumentException {
         Turnout t1 = InstanceManager.turnoutManagerInstance().provideTurnout(name);
         for (int i = 0; i < _outputTurnoutList.size(); i++) {
             if (_outputTurnoutList.get(i).getTurnout() == t1) {
@@ -431,7 +431,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
      * Method to inquire if a Sensor is included in this Route
      */
     @Override
-    public boolean isOutputSensorIncluded(String sensorName) {
+    public boolean isOutputSensorIncluded(String sensorName) throws IllegalArgumentException {
         Sensor s1 = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
         return isOutputSensorIncluded(s1);
     }
@@ -453,7 +453,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
      * Both the input or internal names can be either system or user names
      */
     @Override
-    public int getOutputSensorSetState(String name) {
+    public int getOutputSensorSetState(String name) throws IllegalArgumentException {
         Sensor s1 = InstanceManager.sensorManagerInstance().provideSensor(name);
         for (int i = 0; i < _outputSensorList.size(); i++) {
             if (_outputSensorList.get(i).getSensor() == s1) {
@@ -540,7 +540,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
      * Method to set turnouts aligned sensor
      */
     @Override
-    public void setTurnoutsAlignedSensor(String sensorName) {
+    public void setTurnoutsAlignedSensor(String sensorName) throws IllegalArgumentException {
         log.debug("setTurnoutsAlignedSensor {} {}", getSystemName(), sensorName);
 
         mTurnoutsAlignedSensor = sensorName;
@@ -565,7 +565,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
 
     @Override
     @CheckForNull
-    public Sensor getTurnoutsAlgdSensor() {
+    public Sensor getTurnoutsAlgdSensor() throws IllegalArgumentException {
         if (mTurnoutsAlignedNamedSensor != null) {
             return mTurnoutsAlignedNamedSensor.getBean();
         } else if (mTurnoutsAlignedSensor != null && !mTurnoutsAlignedSensor.isEmpty()) {
@@ -701,7 +701,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
      * Method to set the Name of a control Turnout for this Route
      */
     @Override
-    public void setControlTurnout(String turnoutName) {
+    public void setControlTurnout(String turnoutName) throws IllegalArgumentException {
         mControlTurnout = turnoutName;
         if (mControlTurnout == null || mControlTurnout.isEmpty()) {
             mControlNamedTurnout = null;
@@ -724,7 +724,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
 
     @Override
     @CheckForNull
-    public Turnout getCtlTurnout() {
+    public Turnout getCtlTurnout() throws IllegalArgumentException {
         if (mControlNamedTurnout != null) {
             return mControlNamedTurnout.getBean();
         } else if (mControlTurnout != null && !mControlTurnout.isEmpty()) {
@@ -741,7 +741,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
      * @param turnoutName the turnout name
      */
     @Override
-    public void setLockControlTurnout(@Nullable String turnoutName) {
+    public void setLockControlTurnout(@Nullable String turnoutName) throws IllegalArgumentException {
         mLockControlTurnout = turnoutName;
         if (mLockControlTurnout == null || mLockControlTurnout.isEmpty()) {
             mLockControlNamedTurnout = null;
@@ -764,7 +764,7 @@ public class DefaultRoute extends AbstractNamedBean implements Route, java.beans
 
     @Override
     @CheckForNull
-    public Turnout getLockCtlTurnout() {
+    public Turnout getLockCtlTurnout() throws IllegalArgumentException {
         if (mLockControlNamedTurnout != null) {
             return mLockControlNamedTurnout.getBean();
         } else if (mLockControlTurnout != null && !mLockControlTurnout.isEmpty()) {

--- a/java/src/jmri/implementation/SE8cSignalHead.java
+++ b/java/src/jmri/implementation/SE8cSignalHead.java
@@ -129,7 +129,7 @@ public class SE8cSignalHead extends DefaultSignalHead {
      * Create a handle from a raw number. Static, so can be referenced before
      * ctor complete.
      */
-    static NamedBeanHandle<Turnout> makeHandle(int i) {
+    static NamedBeanHandle<Turnout> makeHandle(int i) throws IllegalArgumentException {
         String number = "" + i;
         return jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(
                 number,

--- a/java/src/jmri/implementation/configurexml/DoubleTurnoutSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/DoubleTurnoutSignalHeadXml.java
@@ -110,8 +110,13 @@ public class DoubleTurnoutSignalHeadXml extends jmri.managers.configurexml.Abstr
             return jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, t);
         } else {
             String name = e.getText();
-            Turnout t = InstanceManager.turnoutManagerInstance().provideTurnout(name);
-            return jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, t);
+            try {
+                Turnout t = InstanceManager.turnoutManagerInstance().provideTurnout(name);
+                return jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, t);
+            } catch (IllegalArgumentException ex) {
+                log.warn("Failed to provide Turnout \"{}\" in sendStatus", name);
+                return null;
+            }            
         }
     }
 

--- a/java/src/jmri/implementation/configurexml/MergSD2SignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/MergSD2SignalHeadXml.java
@@ -1,4 +1,3 @@
-// MergSD2SignalHeadXml.java
 package jmri.implementation.configurexml;
 
 import java.util.List;
@@ -26,7 +25,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2003, 2008
  * @author Kevin Dickerson Copyright: Copyright (c) 2009
- * @version $Revision$
  */
 public class MergSD2SignalHeadXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
 
@@ -193,8 +191,13 @@ public class MergSD2SignalHeadXml extends jmri.managers.configurexml.AbstractNam
             return jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, t);
         } else {
             String name = e.getText();
-            Turnout t = InstanceManager.turnoutManagerInstance().provideTurnout(name);
-            return jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, t);
+            try {
+                Turnout t = InstanceManager.turnoutManagerInstance().provideTurnout(name);
+                return jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, t);
+            } catch (IllegalArgumentException ex) {
+                log.warn("Failed to provide Turnout \"{}\" in loadTurnout", name);
+                return null;
+            }
         }
     }
 

--- a/java/src/jmri/implementation/configurexml/SE8cSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/SE8cSignalHeadXml.java
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory;
  * Handle XML configuration for SE8cSignalHead objects.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2004, 2008, 2010
- * @version $Revision$
  */
 public class SE8cSignalHeadXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
 
@@ -109,8 +108,13 @@ public class SE8cSignalHeadXml extends jmri.managers.configurexml.AbstractNamedB
             return jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, t);
         } else {
             String name = e.getText();
-            Turnout t = InstanceManager.turnoutManagerInstance().provideTurnout(name);
-            return jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, t);
+            try {
+                Turnout t = InstanceManager.turnoutManagerInstance().provideTurnout(name);
+                return jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, t);
+            } catch (IllegalArgumentException ex) {
+                log.warn("Failed to provide Turnout \"{}\" in loadTurnout", name);
+                return null;
+            }
         }
     }
 

--- a/java/src/jmri/implementation/configurexml/SingleTurnoutSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/SingleTurnoutSignalHeadXml.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
  * DoubleTurnoutSignalHeadXML by Bob Jacobsen
  *
  * @author Kevin Dickerson: Copyright (c) 2010
- * @version $Revision$
  */
 public class SingleTurnoutSignalHeadXml extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
 
@@ -132,8 +131,13 @@ public class SingleTurnoutSignalHeadXml extends jmri.managers.configurexml.Abstr
         Element e = (Element) o;
 
         String name = e.getText();
-        Turnout t = InstanceManager.turnoutManagerInstance().provideTurnout(name);
-        return jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, t);
+        try {
+            Turnout t = InstanceManager.turnoutManagerInstance().provideTurnout(name);
+            return jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(name, t);
+        } catch (IllegalArgumentException ex) {
+            log.warn("Failed to provide Turnout \"{}\" in loadTurnout", name);
+            return null;
+        }
     }
 
     public void load(Element element, Object o) {

--- a/java/src/jmri/jmris/AbstractLightServer.java
+++ b/java/src/jmri/jmris/AbstractLightServer.java
@@ -1,4 +1,3 @@
-//AbstractLightServer.java
 package jmri.jmris;
 
 import java.beans.PropertyChangeEvent;
@@ -17,7 +16,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author Paul Bender Copyright (C) 2010
  * @author Randall Wood Copyright (C) 2013, 2014
- * @version $Revision$
  */
 abstract public class AbstractLightServer {
 
@@ -51,10 +49,10 @@ abstract public class AbstractLightServer {
         }
     }
 
-    public Light initLight(String lightName) {
+    public Light initLight(String lightName)  throws IllegalArgumentException {
         Light light = InstanceManager.lightManagerInstance().provideLight(lightName);
         this.addLightToList(lightName);
-        return light;
+        return light;        
     }
 
     public void lightOff(String lightName) {

--- a/java/src/jmri/jmris/AbstractMemoryServer.java
+++ b/java/src/jmri/jmris/AbstractMemoryServer.java
@@ -1,4 +1,3 @@
-//AbstractMemoryServer.java
 package jmri.jmris;
 
 import java.beans.PropertyChangeEvent;
@@ -17,7 +16,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author mstevetodd Copyright (C) 2012 (copied from AbstractSensorServer)
  * @author Randall Wood Copyright (C) 2013, 2014
- * @version $Revision: $
  */
 abstract public class AbstractMemoryServer {
 
@@ -51,7 +49,7 @@ abstract public class AbstractMemoryServer {
         }
     }
 
-    public Memory initMemory(String memoryName) {
+    public Memory initMemory(String memoryName) throws IllegalArgumentException {
         Memory memory = InstanceManager.memoryManagerInstance().provideMemory(memoryName);
         this.addMemoryToList(memoryName);
         return memory;

--- a/java/src/jmri/jmris/AbstractReporterServer.java
+++ b/java/src/jmri/jmris/AbstractReporterServer.java
@@ -1,4 +1,3 @@
-//AbstractReporterServer.java
 package jmri.jmris;
 
 import java.beans.PropertyChangeEvent;
@@ -17,7 +16,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author Paul Bender Copyright (C) 2010
  * @author Randall Wood Copyright (C) 2013
- * @version $Revision$
  */
 abstract public class AbstractReporterServer {
 
@@ -51,7 +49,7 @@ abstract public class AbstractReporterServer {
         }
     }
 
-    public Reporter initReporter(String reporterName) {
+    public Reporter initReporter(String reporterName) throws IllegalArgumentException {
         Reporter reporter = InstanceManager.reporterManagerInstance().provideReporter(reporterName);
         this.addReporterToList(reporterName);
         return reporter;

--- a/java/src/jmri/jmris/AbstractSensorServer.java
+++ b/java/src/jmri/jmris/AbstractSensorServer.java
@@ -1,4 +1,3 @@
-//AbstractSensorServer.java
 package jmri.jmris;
 
 import java.beans.PropertyChangeEvent;
@@ -16,7 +15,6 @@ import org.slf4j.LoggerFactory;
  * Abstract interface between the a JMRI sensor and a network connection
  *
  * @author Paul Bender Copyright (C) 2010
- * @version $Revision$
  */
 abstract public class AbstractSensorServer {
 
@@ -50,7 +48,7 @@ abstract public class AbstractSensorServer {
         }
     }
 
-    public Sensor initSensor(String sensorName) {
+    public Sensor initSensor(String sensorName) throws IllegalArgumentException {
         Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
         this.addSensorToList(sensorName);
         return sensor;

--- a/java/src/jmri/jmris/AbstractTurnoutServer.java
+++ b/java/src/jmri/jmris/AbstractTurnoutServer.java
@@ -1,4 +1,3 @@
-//AbstractTurnoutServer.java
 package jmri.jmris;
 
 import java.beans.PropertyChangeEvent;
@@ -17,7 +16,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author Paul Bender Copyright (C) 2010-2013
  * @author Randall Wood Copyright (C) 2013
- * @version $Revision$
  */
 abstract public class AbstractTurnoutServer {
 
@@ -51,7 +49,7 @@ abstract public class AbstractTurnoutServer {
         }
     }
 
-    public Turnout initTurnout(String turnoutName) {
+    public Turnout initTurnout(String turnoutName) throws IllegalArgumentException {
         Turnout turnout = InstanceManager.turnoutManagerInstance().provideTurnout(turnoutName);
         this.addTurnoutToList(turnoutName);
         return turnout;

--- a/java/src/jmri/jmris/simpleserver/SimpleReporterServer.java
+++ b/java/src/jmri/jmris/simpleserver/SimpleReporterServer.java
@@ -66,9 +66,13 @@ public class SimpleReporterServer extends AbstractReporterServer {
             // setReporterReport ALSO triggers sending the status report, so 
             // no further action is required to echo the status to the client.
         } else {
-           // send the current status if the report
-           Reporter reporter = InstanceManager.reporterManagerInstance().provideReporter(reporterName);
-           sendReport(reporterName, reporter.getCurrentReport());
+            // send the current status if the report
+            try {
+               Reporter reporter = InstanceManager.reporterManagerInstance().provideReporter(reporterName);
+               sendReport(reporterName, reporter.getCurrentReport());
+            } catch (IllegalArgumentException ex) {
+                log.warn("Failed to provide Reporter \"{}\" in parseStatus", reporterName);
+            }
         }
     }
 
@@ -79,4 +83,6 @@ public class SimpleReporterServer extends AbstractReporterServer {
             this.connection.sendMessage(message);
         }
     }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SimpleReporterServer.class.getName());
 }

--- a/java/src/jmri/jmris/simpleserver/SimpleSensorServer.java
+++ b/java/src/jmri/jmris/simpleserver/SimpleSensorServer.java
@@ -77,9 +77,12 @@ public class SimpleSensorServer extends AbstractSensorServer {
                 // remove anything following the space.
                 sensorName = sensorName.substring(0,sensorName.indexOf(" "));
             }
-            Sensor sensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-            sendStatus(sensorName, sensor.getKnownState());
-
+            try {
+                Sensor sensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(sensorName);
+                sendStatus(sensorName, sensor.getKnownState());
+            } catch (IllegalArgumentException ex) {
+                log.warn("Failed to provide Sensor \"{}\" in sendStatus", sensorName);
+            }
         }
     }
 

--- a/java/src/jmri/jmris/simpleserver/SimpleTurnoutServer.java
+++ b/java/src/jmri/jmris/simpleserver/SimpleTurnoutServer.java
@@ -75,8 +75,12 @@ public class SimpleTurnoutServer extends AbstractTurnoutServer {
             closeTurnout(statusString.substring(index, statusString.indexOf(" ", index + 1)).toUpperCase());
         } else {
             // default case, return status for this turnout
-            sendStatus(statusString.substring(index),
+            try {
+                sendStatus(statusString.substring(index),
                     InstanceManager.turnoutManagerInstance().provideTurnout(statusString.substring(index).toUpperCase()).getKnownState());
+            } catch (IllegalArgumentException ex) {
+                log.warn("Failed to provide Turnout \"{}\" in parseStatus", statusString.substring(index).toUpperCase());
+            }
         }
     }
 

--- a/java/src/jmri/jmris/srcp/JmriSRCPSensorServer.java
+++ b/java/src/jmri/jmris/srcp/JmriSRCPSensorServer.java
@@ -1,4 +1,3 @@
-//JmriSRCPSensorServer.java
 package jmri.jmris.srcp;
 
 import java.io.DataInputStream;
@@ -8,15 +7,12 @@ import jmri.InstanceManager;
 import jmri.Sensor;
 import jmri.jmris.AbstractSensorServer;
 import jmri.jmrix.SystemConnectionMemo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * SRCP Server interface between the JMRI Sensor manager and a network
  * connection
  *
  * @author Paul Bender Copyright (C) 2011
- * @version $Revision$
  */
 public class JmriSRCPSensorServer extends AbstractSensorServer {
 
@@ -76,14 +72,18 @@ public class JmriSRCPSensorServer extends AbstractSensorServer {
         }
         String sensorName = memo.getSystemPrefix()
                 + "S" + address;
-        int Status = InstanceManager.sensorManagerInstance().provideSensor(sensorName).getKnownState();
-        if (Status == Sensor.ACTIVE) {
-            TimeStampedOutput.writeTimestamp(output, "100 INFO " + bus + " FB " + address + " 1\n\r");
-        } else if (Status == Sensor.INACTIVE) {
-            TimeStampedOutput.writeTimestamp(output, "100 INFO " + bus + " FB " + address + " 0\n\r");
-        } else {
-            //  unknown state
-            TimeStampedOutput.writeTimestamp(output, "411 ERROR unknown value\n\r");
+        try {
+            int Status = InstanceManager.sensorManagerInstance().provideSensor(sensorName).getKnownState();
+            if (Status == Sensor.ACTIVE) {
+                TimeStampedOutput.writeTimestamp(output, "100 INFO " + bus + " FB " + address + " 1\n\r");
+            } else if (Status == Sensor.INACTIVE) {
+                TimeStampedOutput.writeTimestamp(output, "100 INFO " + bus + " FB " + address + " 0\n\r");
+            } else {
+                //  unknown state
+                TimeStampedOutput.writeTimestamp(output, "411 ERROR unknown value\n\r");
+            }
+        } catch (IllegalArgumentException ex) {
+            log.warn("Failed to provide Sensor \"{}\" in sendStatus", sensorName);
         }
     }
 
@@ -152,5 +152,5 @@ public class JmriSRCPSensorServer extends AbstractSensorServer {
             }
         }
     }
-    private final static Logger log = LoggerFactory.getLogger(JmriSRCPSensorServer.class.getName());
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(JmriSRCPSensorServer.class.getName());
 }

--- a/java/src/jmri/jmris/srcp/JmriSRCPTurnoutServer.java
+++ b/java/src/jmri/jmris/srcp/JmriSRCPTurnoutServer.java
@@ -55,17 +55,21 @@ public class JmriSRCPTurnoutServer extends AbstractTurnoutServer {
         }
         String turnoutName = memo.getSystemPrefix()
                 + "T" + address;
-        // busy loop, wait for turnout to settle before continuing.
-        while (InstanceManager.turnoutManagerInstance().provideTurnout(turnoutName).getKnownState() != InstanceManager.turnoutManagerInstance().provideTurnout(turnoutName).getCommandedState()) {
-        }
-        int Status = InstanceManager.turnoutManagerInstance().provideTurnout(turnoutName).getKnownState();
-        if (Status == Turnout.THROWN) {
-            TimeStampedOutput.writeTimestamp(output, "100 INFO " + bus + " GA " + address + " 1 0\n\r");
-        } else if (Status == Turnout.CLOSED) {
-            TimeStampedOutput.writeTimestamp(output, "100 INFO " + bus + " GA " + address + " 0 0\n\r");
-        } else {
-            //  unknown state
-            TimeStampedOutput.writeTimestamp(output, "411 ERROR unknown value\n\r");
+        try {
+            // busy loop, wait for turnout to settle before continuing.
+            while (InstanceManager.turnoutManagerInstance().provideTurnout(turnoutName).getKnownState() != InstanceManager.turnoutManagerInstance().provideTurnout(turnoutName).getCommandedState()) {
+            }
+            int Status = InstanceManager.turnoutManagerInstance().provideTurnout(turnoutName).getKnownState();
+            if (Status == Turnout.THROWN) {
+                TimeStampedOutput.writeTimestamp(output, "100 INFO " + bus + " GA " + address + " 1 0\n\r");
+            } else if (Status == Turnout.CLOSED) {
+                TimeStampedOutput.writeTimestamp(output, "100 INFO " + bus + " GA " + address + " 0 0\n\r");
+            } else {
+                //  unknown state
+                TimeStampedOutput.writeTimestamp(output, "411 ERROR unknown value\n\r");
+            }
+        } catch (IllegalArgumentException ex) {
+            log.warn("Failed to provide Turnout \"{}\" in sendStatus", turnoutName);
         }
     }
 

--- a/java/src/jmri/jmrit/audio/swing/AudioBufferFrame.java
+++ b/java/src/jmri/jmrit/audio/swing/AudioBufferFrame.java
@@ -263,8 +263,9 @@ public class AudioBufferFrame extends AbstractAudioFrame {
         AudioBuffer b;
         try {
             AudioManager am = InstanceManager.audioManagerInstance();
-            b = (AudioBuffer) am.provideAudio(sName);
-            if (b == null) {
+            try {
+                b = (AudioBuffer) am.provideAudio(sName);
+            } catch (IllegalArgumentException ex) {
                 throw new AudioException("Problem creating buffer");
             }
             if (newBuffer && am.getByUserName(user) != null) {

--- a/java/src/jmri/jmrit/audio/swing/AudioListenerFrame.java
+++ b/java/src/jmri/jmrit/audio/swing/AudioListenerFrame.java
@@ -151,7 +151,7 @@ public class AudioListenerFrame extends AbstractAudioFrame {
 
             // Notify changes
             model.fireTableDataChanged();
-        } catch (AudioException ex) {
+        } catch (AudioException | IllegalArgumentException ex) {
             JOptionPane.showMessageDialog(null, ex.getMessage(), Bundle.getMessage("AudioCreateErrorTitle"), JOptionPane.ERROR_MESSAGE);
         }
     }

--- a/java/src/jmri/jmrit/audio/swing/AudioSourceFrame.java
+++ b/java/src/jmri/jmrit/audio/swing/AudioSourceFrame.java
@@ -354,8 +354,9 @@ public class AudioSourceFrame extends AbstractAudioFrame {
         AudioSource s;
         try {
             AudioManager am = InstanceManager.audioManagerInstance();
-            s = (AudioSource) am.provideAudio(sName);
-            if (s == null) {
+            try {
+                s = (AudioSource) am.provideAudio(sName);
+            } catch (IllegalArgumentException ex) {
                 throw new AudioException("Problem creating source");
             }
             if (newSource && am.getByUserName(user) != null) {

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -4621,7 +4621,11 @@ public class LogixTableAction extends AbstractTableAction {
                     return name;
                 }
             }
-            h = InstanceManager.signalMastManagerInstance().provideSignalMast(name);
+            try {
+                h = InstanceManager.signalMastManagerInstance().provideSignalMast(name);
+            } catch (IllegalArgumentException ex) {
+                h = null; // tested below
+            }
         }
         if (h == null) {
             messageInvalidActionItemName(name, "SignalMast"); //NOI18N

--- a/java/src/jmri/jmrit/beantable/RouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableAction.java
@@ -960,7 +960,11 @@ public class RouteTableAction extends AbstractTableAction {
                 status1.setText(Bundle.getMessage("RouteAddStatusEnter"));
                 return null;
             }
-            g = jmri.InstanceManager.routeManagerInstance().provideRoute(sName, uName);
+            try {
+                g = jmri.InstanceManager.routeManagerInstance().provideRoute(sName, uName);
+            } catch (IllegalArgumentException ex) {
+                g = null; // for later check
+            }
         }
         if (g == null) {
             // should never get here

--- a/java/src/jmri/jmrit/beantable/SectionTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SectionTableAction.java
@@ -760,32 +760,32 @@ public class SectionTableAction extends AbstractTableAction {
         if ((txt == null) || (txt.equals(""))) {
             fSensor = null;
         } else {
-            fSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(txt);
-            if (fSensor == null) {
+            try {
+                fSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(txt);
+                if (!txt.equals(fSensor.getUserName())) {
+                    forwardSensorField.setText(fSensor.getSystemName());
+                }
+            } catch (IllegalArgumentException ex) {
                 javax.swing.JOptionPane.showMessageDialog(addFrame, rbx
                         .getString("Message7"), Bundle.getMessage("ErrorTitle"),
                         javax.swing.JOptionPane.ERROR_MESSAGE);
                 return false;
-            } else {
-                if (!txt.equals(fSensor.getUserName())) {
-                    forwardSensorField.setText(fSensor.getSystemName());
-                }
             }
         }
         txt = reverseSensorField.getText();
         if ((txt == null) || (txt.equals(""))) {
             rSensor = null;
         } else {
-            rSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(txt);
-            if (rSensor == null) {
+            try { 
+                rSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(txt);
+                if (!txt.equals(rSensor.getUserName())) {
+                    reverseSensorField.setText(rSensor.getSystemName());
+                }
+            } catch (IllegalArgumentException ex) {
                 javax.swing.JOptionPane.showMessageDialog(addFrame, rbx
                         .getString("Message8"), Bundle.getMessage("ErrorTitle"),
                         javax.swing.JOptionPane.ERROR_MESSAGE);
                 return false;
-            } else {
-                if (!txt.equals(rSensor.getUserName())) {
-                    reverseSensorField.setText(rSensor.getSystemName());
-                }
             }
         }
         if ((fSensor != null) && (fSensor == rSensor)) {
@@ -799,32 +799,32 @@ public class SectionTableAction extends AbstractTableAction {
         if ((txt == null) || (txt.equals(""))) {
             fStopSensor = null;
         } else {
-            fStopSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(txt);
-            if (fStopSensor == null) {
+            try {
+                fStopSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(txt);
+                if (!txt.equals(fStopSensor.getUserName())) {
+                    forwardStopSensorField.setText(fStopSensor.getSystemName());
+                }
+            } catch (IllegalArgumentException ex) {
                 javax.swing.JOptionPane.showMessageDialog(addFrame, rbx
                         .getString("Message7"), Bundle.getMessage("ErrorTitle"),
                         javax.swing.JOptionPane.ERROR_MESSAGE);
                 return false;
-            } else {
-                if (!txt.equals(fStopSensor.getUserName())) {
-                    forwardStopSensorField.setText(fStopSensor.getSystemName());
-                }
             }
         }
         txt = reverseStopSensorField.getText();
         if ((txt == null) || (txt.equals(""))) {
             rStopSensor = null;
         } else {
-            rStopSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(txt);
-            if (rStopSensor == null) {
+            try {
+                rStopSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor(txt);
+                if (!txt.equals(rStopSensor.getUserName())) {
+                    reverseStopSensorField.setText(rStopSensor.getSystemName());
+                }
+            } catch (IllegalArgumentException ex) {
                 javax.swing.JOptionPane.showMessageDialog(addFrame, rbx
                         .getString("Message8"), Bundle.getMessage("ErrorTitle"),
                         javax.swing.JOptionPane.ERROR_MESSAGE);
                 return false;
-            } else {
-                if (!txt.equals(rStopSensor.getUserName())) {
-                    reverseStopSensorField.setText(rStopSensor.getSystemName());
-                }
             }
         }
         return true;

--- a/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
@@ -724,12 +724,14 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
             javax.swing.JOptionPane.showMessageDialog(null, "Please enter a System Name and User Name.", "Error", javax.swing.JOptionPane.WARNING_MESSAGE);
             return null;
         }
-        SignalGroup g = jmri.InstanceManager.signalGroupManagerInstance().provideSignalGroup(sName, uName);
-        if (g == null) {
+        try {
+            SignalGroup g = jmri.InstanceManager.signalGroupManagerInstance().provideSignalGroup(sName, uName);
+            return g;
+        } catch (IllegalArgumentException ex) {
             // should never get here
             log.error("Unknown failure to create SignalGroup with System Name: " + sName);
-        }
-        return g;
+            throw ex;
+        }   
     }
 
     int setSignalInformation(SignalGroup g) {

--- a/java/src/jmri/jmrit/beantable/oblock/BlockPathTableModel.java
+++ b/java/src/jmri/jmrit/beantable/oblock/BlockPathTableModel.java
@@ -18,7 +18,6 @@ package jmri.jmrit.beantable.oblock;
  * <P>
  *
  * @author	Pete Cressman (C) 2010
- * @version $Revision$
  */
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -39,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 public class BlockPathTableModel extends AbstractTableModel implements PropertyChangeListener {
 
-    private static final long serialVersionUID = -2472819814795605641L;
     public static final int FROM_PORTAL_COLUMN = 0;
     public static final int NAME_COLUMN = 1;
     public static final int TO_PORTAL_COLUMN = 2;

--- a/java/src/jmri/jmrit/beantable/sensor/AddSensorPanel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/AddSensorPanel.java
@@ -1,4 +1,3 @@
-// AddSensorPanel.java
 package jmri.jmrit.beantable.sensor;
 
 import java.awt.event.ActionEvent;
@@ -21,17 +20,11 @@ import org.slf4j.LoggerFactory;
  * JPanel to create a new Sensor
  *
  * @author	Bob Jacobsen Copyright (C) 2009
- * @version $Revision$
  * @deprecated Replaced by
  * {@link jmri.jmrit.beantable.AddNewHardwareDevicePanel}
  */
 @Deprecated
 public class AddSensorPanel extends jmri.util.swing.JmriPanel {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4498057881822875833L;
 
     public AddSensorPanel() {
         p = jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class);
@@ -158,18 +151,6 @@ public class AddSensorPanel extends jmri.util.swing.JmriPanel {
         //p = null;
     }
 
-    /*void okPressed(ActionEvent e) {
-     String user = userName.getText();
-     Sensor s = null;
-     try {
-     s = InstanceManager.sensorManagerInstance().provideSensor(sysName.getText());
-     } catch (IllegalArgumentException ex) {
-     // user input no good
-     handleCreateException(sysName.getText());
-     return; // without creating       
-     }
-     if (user!= null && !user.equals("")) s.setUserName(user);
-     }*/
     void okPressed(ActionEvent e) {
         /*String user = userName.getText();
          if (user.equals("")) user=null;*/

--- a/java/src/jmri/jmrit/blockboss/BlockBossLogic.java
+++ b/java/src/jmri/jmrit/blockboss/BlockBossLogic.java
@@ -179,8 +179,9 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             watchSensor1 = null;
             return;
         }
-        watchSensor1 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
-        if (watchSensor1.getBean() == null) {
+        try {
+            watchSensor1 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
+        } catch (IllegalArgumentException ex) {
             log.warn(rb.getString("Sensor1_") + name + rb.getString("_was_not_found!"));
         }
     }
@@ -190,8 +191,9 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             watchSensor2 = null;
             return;
         }
-        watchSensor2 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
-        if (watchSensor2.getBean() == null) {
+        try {
+            watchSensor2 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
+        } catch (IllegalArgumentException ex) {
             log.warn(rb.getString("Sensor2_") + name + rb.getString("_was_not_found!"));
         }
     }
@@ -201,8 +203,9 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             watchSensor3 = null;
             return;
         }
-        watchSensor3 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
-        if (watchSensor3.getBean() == null) {
+        try {
+            watchSensor3 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
+        } catch (IllegalArgumentException ex) {
             log.warn(rb.getString("Sensor3_") + name + rb.getString("_was_not_found!"));
         }
     }
@@ -212,8 +215,9 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             watchSensor4 = null;
             return;
         }
-        watchSensor4 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
-        if (watchSensor4.getBean() == null) {
+        try {
+            watchSensor4 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
+        } catch (IllegalArgumentException ex) {
             log.warn(rb.getString("Sensor4_") + name + rb.getString("_was_not_found!"));
         }
     }
@@ -223,8 +227,9 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             watchSensor5 = null;
             return;
         }
-        watchSensor5 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
-        if (watchSensor5.getBean() == null) {
+        try {
+            watchSensor5 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
+        } catch (IllegalArgumentException ex) {
             log.warn(rb.getString("Sensor5_") + name + rb.getString("_was_not_found!"));
         }
     }
@@ -274,8 +279,9 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             watchTurnout = null;
             return;
         }
-        watchTurnout = nbhm.getNamedBeanHandle(name, InstanceManager.turnoutManagerInstance().provideTurnout(name));
-        if (watchTurnout.getBean() == null) {
+        try {
+            watchTurnout = nbhm.getNamedBeanHandle(name, InstanceManager.turnoutManagerInstance().provideTurnout(name));
+        } catch (IllegalArgumentException ex) {
             log.warn(rb.getString("Turnout_") + name + rb.getString("_was_not_found!"));
         }
     }
@@ -410,8 +416,9 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             watchedSensor1 = null;
             return;
         }
-        watchedSensor1 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
-        if (watchedSensor1.getBean() == null) {
+        try {
+            watchedSensor1 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
+        } catch (IllegalArgumentException ex) {
             log.warn(rb.getString("Sensor1_") + name + rb.getString("_was_not_found!"));
         }
 
@@ -434,8 +441,9 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             watchedSensor1Alt = null;
             return;
         }
-        watchedSensor1Alt = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
-        if (watchedSensor1Alt.getBean() == null) {
+        try {
+            watchedSensor1Alt = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
+        } catch (IllegalArgumentException ex) {
             log.warn(rb.getString("Sensor1Alt_") + name + rb.getString("_was_not_found!"));
         }
 
@@ -458,8 +466,9 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             watchedSensor2 = null;
             return;
         }
-        watchedSensor2 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
-        if (watchedSensor2.getBean() == null) {
+        try {
+            watchedSensor2 = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
+        } catch (IllegalArgumentException ex) {
             log.warn(rb.getString("Sensor2_") + name + rb.getString("_was_not_found!"));
         }
 
@@ -482,8 +491,9 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             watchedSensor2Alt = null;
             return;
         }
-        watchedSensor2Alt = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
-        if (watchedSensor2Alt.getBean() == null) {
+        try {
+            watchedSensor2Alt = nbhm.getNamedBeanHandle(name, InstanceManager.sensorManagerInstance().provideSensor(name));
+        } catch (IllegalArgumentException ex) {
             log.warn(rb.getString("Sensor2Alt_") + name + rb.getString("_was_not_found!"));
         }
 

--- a/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
@@ -1,4 +1,3 @@
-// DispatcherFrame.java
 package jmri.jmrit.dispatcher;
 
 import java.awt.BorderLayout;
@@ -69,14 +68,8 @@ import org.slf4j.LoggerFactory;
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
  * @author	Dave Duchamp Copyright (C) 2008-2011
- * @version	$Revision$
  */
 public class DispatcherFrame extends jmri.util.JmriJFrame {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8419164039506787803L;
 
     /**
      * Get a DispatcherFrame through the instance() method

--- a/java/src/jmri/jmrit/display/IndicatorTrackIcon.java
+++ b/java/src/jmri/jmrit/display/IndicatorTrackIcon.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 public class IndicatorTrackIcon extends PositionableIcon
         implements java.beans.PropertyChangeListener, IndicatorTrack {
 
-    private static final long serialVersionUID = 3651878897031870004L;
     private NamedBeanHandle<Sensor> namedOccSensor = null;
     private NamedBeanHandle<OBlock> namedOccBlock = null;
 
@@ -81,10 +80,10 @@ public class IndicatorTrackIcon extends PositionableIcon
             return;
         }
         if (InstanceManager.sensorManagerInstance() != null) {
-            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(pName);
-            if (sensor != null) {
+            try {
+                Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(pName);
                 setOccSensorHandle(jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(pName, sensor));
-            } else {
+            } catch (IllegalArgumentException ex) {
                 log.error("Occupancy Sensor '" + pName + "' not available, icon won't see changes");
             }
         } else {

--- a/java/src/jmri/jmrit/display/IndicatorTurnoutIcon.java
+++ b/java/src/jmri/jmrit/display/IndicatorTurnoutIcon.java
@@ -116,10 +116,10 @@ public class IndicatorTurnoutIcon extends TurnoutIcon implements IndicatorTrack 
             return;
         }
         if (InstanceManager.sensorManagerInstance() != null) {
-            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(pName);
-            if (sensor != null) {
+            try {
+                Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(pName);
                 setOccSensorHandle(jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(pName, sensor));
-            } else {
+            } catch (IllegalArgumentException ex) {
                 log.error("Occupancy Sensor '" + pName + "' not available, icon won't see changes");
             }
         } else {

--- a/java/src/jmri/jmrit/display/MultiSensorIcon.java
+++ b/java/src/jmri/jmrit/display/MultiSensorIcon.java
@@ -93,7 +93,8 @@ public class MultiSensorIcon extends PositionableLabel implements java.beans.Pro
     public void addEntry(String pName, NamedIcon icon) {
         NamedBeanHandle<Sensor> sensor;
         if (InstanceManager.sensorManagerInstance() != null) {
-            sensor = jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(pName, InstanceManager.sensorManagerInstance().provideSensor(pName));
+            sensor = jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class)
+                        .getNamedBeanHandle(pName, InstanceManager.sensorManagerInstance().provideSensor(pName));
             addEntry(sensor, icon);
         } else {
             log.error("No SensorManager for this protocol, icon won't see changes");

--- a/java/src/jmri/jmrit/display/SensorIcon.java
+++ b/java/src/jmri/jmrit/display/SensorIcon.java
@@ -33,10 +33,6 @@ import org.slf4j.LoggerFactory;
  */
 public class SensorIcon extends PositionableIcon implements java.beans.PropertyChangeListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6172183103608993048L;
     static final public int UNKOWN_FONT_COLOR = 0x03;
     static final public int UNKOWN_BACKGROUND_COLOR = 0x04;
     static final public int ACTIVE_FONT_COLOR = 0x05;
@@ -114,10 +110,10 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
      */
     public void setSensor(String pName) {
         if (InstanceManager.sensorManagerInstance() != null) {
-            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(pName);
-            if (sensor != null) {
+            try {
+                Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(pName);
                 setSensor(jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(pName, sensor));
-            } else {
+            } catch (IllegalArgumentException ex) {
                 log.error("Sensor '" + pName + "' not available, icon won't see changes");
             }
         } else {

--- a/java/src/jmri/jmrit/display/TurnoutIcon.java
+++ b/java/src/jmri/jmrit/display/TurnoutIcon.java
@@ -78,10 +78,10 @@ public class TurnoutIcon extends PositionableIcon implements java.beans.Property
      */
     public void setTurnout(String pName) {
         if (InstanceManager.turnoutManagerInstance() != null) {
-            Turnout turnout = InstanceManager.turnoutManagerInstance().provideTurnout(pName);
-            if (turnout != null) {
+            try {
+                Turnout turnout = InstanceManager.turnoutManagerInstance().provideTurnout(pName);
                 setTurnout(jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(pName, turnout));
-            } else {
+            } catch (IllegalArgumentException ex) {
                 log.error("Turnout '" + pName + "' not available, icon won't see changes");
             }
         } else {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -2186,21 +2186,21 @@ public class LayoutBlockManager extends AbstractManager implements jmri.Instance
      */
     public void setStabilisedSensor(String pName) throws jmri.JmriException {
         if (InstanceManager.sensorManagerInstance() != null) {
-            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(pName);
-            if (sensor != null) {
+            try {
+                Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(pName);
                 namedStabilisedIndicator = jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(pName, sensor);
-            } else {
+                try {
+                    if (stabilised) {
+                        sensor.setState(Sensor.ACTIVE);
+                    } else {
+                        sensor.setState(Sensor.INACTIVE);
+                    }
+                } catch (jmri.JmriException ex) {
+                    log.error("Error setting stablilty indicator sensor");
+                }
+            } catch (IllegalArgumentException ex) {
                 log.error("Sensor '" + pName + "' not available");
                 throw new jmri.JmriException("Sensor '" + pName + "' not available");
-            }
-            try {
-                if (stabilised) {
-                    sensor.setState(Sensor.ACTIVE);
-                } else {
-                    sensor.setState(Sensor.INACTIVE);
-                }
-            } catch (jmri.JmriException ex) {
-                log.error("Error setting stablilty indicator sensor");
             }
         } else {
             log.error("No SensorManager for this protocol");

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorFindItems.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorFindItems.java
@@ -197,7 +197,7 @@ public class LayoutEditorFindItems {
 
     }
 
-    public LayoutTurnout findLayoutTurnoutBySignalMast(String signalMastName) {
+    public LayoutTurnout findLayoutTurnoutBySignalMast(String signalMastName) throws IllegalArgumentException {
         return findLayoutTurnoutByBean(jmri.InstanceManager.signalMastManagerInstance().provideSignalMast(signalMastName));
     }
 
@@ -271,15 +271,15 @@ public class LayoutEditorFindItems {
         return null;
     }
 
-    public LayoutTurnout findLayoutTurnoutBySensor(String sensorName) {
+    public LayoutTurnout findLayoutTurnoutBySensor(String sensorName) throws IllegalArgumentException {
         return findLayoutTurnoutByBean(jmri.InstanceManager.sensorManagerInstance().provideSensor(sensorName));
     }
 
-    public LevelXing findLevelXingBySignalMast(String signalMastName) {
+    public LevelXing findLevelXingBySignalMast(String signalMastName) throws IllegalArgumentException {
         return findLevelXingByBean(jmri.InstanceManager.signalMastManagerInstance().provideSignalMast(signalMastName));
     }
 
-    public LevelXing findLevelXingBySensor(String sensorName) {
+    public LevelXing findLevelXingBySensor(String sensorName) throws IllegalArgumentException {
         return findLevelXingByBean(jmri.InstanceManager.sensorManagerInstance().provideSensor(sensorName));
     }
 
@@ -394,11 +394,11 @@ public class LayoutEditorFindItems {
         return null;
     }
 
-    public LayoutSlip findLayoutSlipBySignalMast(String signalMastName) {
+    public LayoutSlip findLayoutSlipBySignalMast(String signalMastName) throws IllegalArgumentException {
         return findLayoutSlipByBean(jmri.InstanceManager.signalMastManagerInstance().provideSignalMast(signalMastName));
     }
 
-    public LayoutSlip findLayoutSlipBySensor(String sensorName) {
+    public LayoutSlip findLayoutSlipBySensor(String sensorName) throws IllegalArgumentException {
         return findLayoutSlipByBean(jmri.InstanceManager.sensorManagerInstance().provideSensor(sensorName));
     }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
@@ -5897,8 +5897,9 @@ public class LayoutEditorTools {
         }
         String sensorName = "IS" + namer;
         String logixName = "IX" + namer;
-        Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-        if (sensor == null) {
+        try {
+            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
+        } catch (IllegalArgumentException ex) {
             log.error("Trouble creating sensor " + sensorName + " while setting up Logix.");
             return "";
         }
@@ -13225,8 +13226,9 @@ public class LayoutEditorTools {
 
         String logixName = "SYS_LAYOUTSLIP:" + slip.ident;
         String sensorName = "IS:" + logixName + "C" + number;
-        Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-        if (sensor == null) {
+        try {
+            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
+        } catch (IllegalArgumentException ex) {
             log.error("Trouble creating sensor " + sensorName + " while setting up Logix.");
             return "";
         }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
@@ -57,7 +57,6 @@ import org.slf4j.LoggerFactory;
  * are placed here by Set Signals at Level Crossing in Tools menu.
  *
  * @author Dave Duchamp Copyright (c) 2004-2007
- * @version $Revision: 19729 $
  */
 public class LayoutSlip extends LayoutTurnout {
 
@@ -1063,18 +1062,14 @@ public class LayoutSlip extends LayoutTurnout {
             }
             // get new block, or null if block has been removed
             blockName = blockNameField.getText().trim();
-            //if ( (blockName!=null) && (blockName.length()>0)) {
-            block = layoutEditor.provideLayoutBlock(blockName);
 
-            if (block == null) {
+            try { 
+                block = layoutEditor.provideLayoutBlock(blockName);
+
+            } catch (IllegalArgumentException ex) {
                 blockName = "";
                 blockNameField.setText("");
             }
-            //}
-            //else {
-            //	block = null;
-            //	blockName = "";
-            //}
             needRedraw = true;
             layoutEditor.auxTools.setBlockConnectivityChanged();
             needsBlockUpdate = true;

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
@@ -99,7 +99,6 @@ import org.slf4j.LoggerFactory;
  * required to be able to correctly interpret the use of signal heads.
  *
  * @author Dave Duchamp Copyright (c) 2004-2007
- * @version $Revision$
  */
 public class LayoutTurnout {
 
@@ -846,10 +845,10 @@ public class LayoutTurnout {
             return;
         }
 
-        Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-        if (sensor != null) {
+        try {
+            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
             sensorANamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(sensorName, sensor);
-        } else {
+        } catch (IllegalArgumentException ex)  {
             sensorANamed = null;
         }
     }
@@ -874,10 +873,10 @@ public class LayoutTurnout {
             return;
         }
 
-        Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-        if (sensor != null) {
+        try {
+            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
             sensorBNamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(sensorName, sensor);
-        } else {
+        } catch (IllegalArgumentException ex)  {
             sensorBNamed = null;
         }
     }
@@ -902,10 +901,10 @@ public class LayoutTurnout {
             return;
         }
 
-        Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-        if (sensor != null) {
+        try {
+            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
             sensorCNamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(sensorName, sensor);
-        } else {
+        } catch (IllegalArgumentException ex)  {
             sensorCNamed = null;
         }
     }
@@ -930,10 +929,10 @@ public class LayoutTurnout {
             return;
         }
 
-        Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-        if (sensor != null) {
+        try {
+            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
             sensorDNamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(sensorName, sensor);
-        } else {
+        } catch (IllegalArgumentException ex)  {
             sensorDNamed = null;
         }
     }
@@ -2640,8 +2639,9 @@ public class LayoutTurnout {
             }
             // get new block, or null if block has been removed
             blockName = blockNameField.getText().trim();
-            block = layoutEditor.provideLayoutBlock(blockName);
-            if (block == null) {
+            try {
+                block = layoutEditor.provideLayoutBlock(blockName);
+            } catch (IllegalArgumentException ex) {
                 blockName = "";
             }
             // decrement use if block was already counted
@@ -2674,8 +2674,9 @@ public class LayoutTurnout {
             }
             // get new block, or null if block has been removed
             blockBName = blockBNameField.getText().trim();
-            blockB = layoutEditor.provideLayoutBlock(blockBName);
-            if (blockB == null) {
+            try {
+                blockB = layoutEditor.provideLayoutBlock(blockBName);
+            } catch (IllegalArgumentException ex) {
                 blockBName = "";
             }
             // decrement use if block was already counted
@@ -2708,8 +2709,9 @@ public class LayoutTurnout {
             }
             // get new block, or null if block has been removed
             blockCName = blockCNameField.getText().trim();
-            blockC = layoutEditor.provideLayoutBlock(blockCName);
-            if (blockC == null) {
+            try {
+                blockC = layoutEditor.provideLayoutBlock(blockCName);
+            } catch (IllegalArgumentException ex) {
                 blockCName = "";
             }
             // decrement use if block was already counted
@@ -2742,8 +2744,9 @@ public class LayoutTurnout {
             }
             // get new block, or null if block has been removed
             blockDName = blockDNameField.getText().trim();
-            blockD = layoutEditor.provideLayoutBlock(blockDName);
-            if (blockD == null) {
+            try {
+                blockD = layoutEditor.provideLayoutBlock(blockDName);
+            } catch (IllegalArgumentException ex) {
                 blockDName = "";
             }
             // decrement use if block was already counted
@@ -2820,8 +2823,9 @@ public class LayoutTurnout {
             }
             // get new block, or null if block has been removed
             blockName = blockNameField.getText().trim();
-            block = layoutEditor.provideLayoutBlock(blockName);
-            if (block == null) {
+            try {
+                block = layoutEditor.provideLayoutBlock(blockName);
+            } catch (IllegalArgumentException ex) {
                 blockName = "";
             }
             // decrement use if block was already counted
@@ -2842,8 +2846,9 @@ public class LayoutTurnout {
                 }
                 // get new block, or null if block has been removed
                 blockBName = blockBNameField.getText().trim();
-                blockB = layoutEditor.provideLayoutBlock(blockBName);
-                if (blockB == null) {
+                try {
+                    blockB = layoutEditor.provideLayoutBlock(blockBName);
+                } catch (IllegalArgumentException ex) {
                     blockBName = "";
                 }
                 // decrement use if block was already counted
@@ -2863,8 +2868,9 @@ public class LayoutTurnout {
                 }
                 // get new block, or null if block has been removed
                 blockCName = blockCNameField.getText().trim();
-                blockC = layoutEditor.provideLayoutBlock(blockCName);
-                if (blockC == null) {
+                try {
+                    blockC = layoutEditor.provideLayoutBlock(blockCName);
+                } catch (IllegalArgumentException ex) {
                     blockCName = "";
                 }
 
@@ -2885,8 +2891,9 @@ public class LayoutTurnout {
                 }
                 // get new block, or null if block has been removed
                 blockDName = blockDNameField.getText().trim();
-                blockD = layoutEditor.provideLayoutBlock(blockDName);
-                if (blockD == null) {
+                try {
+                    blockD = layoutEditor.provideLayoutBlock(blockDName);
+                } catch (IllegalArgumentException ex) {
                     blockDName = "";
                 }
                 // decrement use if block was already counted

--- a/java/src/jmri/jmrit/display/layoutEditor/LevelXing.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LevelXing.java
@@ -54,7 +54,6 @@ import org.slf4j.LoggerFactory;
  * placed here by Set Signals at Level Crossing in Tools menu.
  *
  * @author Dave Duchamp Copyright (c) 2004-2007
- * @version $Revision$
  */
 public class LevelXing {
 
@@ -356,10 +355,10 @@ public class LevelXing {
             return;
         }
 
-        SignalMast mast = InstanceManager.signalMastManagerInstance().provideSignalMast(signalMast);
-        if (mast != null) {
+        try {
+            SignalMast mast = InstanceManager.signalMastManagerInstance().provideSignalMast(signalMast);
             signalAMastNamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(signalMast, mast);
-        } else {
+        } catch (IllegalArgumentException ex) {
             signalAMastNamed = null;
         }
     }
@@ -384,10 +383,10 @@ public class LevelXing {
             return;
         }
 
-        SignalMast mast = InstanceManager.signalMastManagerInstance().provideSignalMast(signalMast);
-        if (mast != null) {
+        try {
+            SignalMast mast = InstanceManager.signalMastManagerInstance().provideSignalMast(signalMast);
             signalBMastNamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(signalMast, mast);
-        } else {
+        } catch (IllegalArgumentException ex) {
             signalBMastNamed = null;
         }
     }
@@ -412,10 +411,10 @@ public class LevelXing {
             return;
         }
 
-        SignalMast mast = InstanceManager.signalMastManagerInstance().provideSignalMast(signalMast);
-        if (mast != null) {
+        try {
+            SignalMast mast = InstanceManager.signalMastManagerInstance().provideSignalMast(signalMast);
             signalCMastNamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(signalMast, mast);
-        } else {
+        } catch (IllegalArgumentException ex) {
             signalCMastNamed = null;
         }
     }
@@ -440,10 +439,10 @@ public class LevelXing {
             return;
         }
 
-        SignalMast mast = InstanceManager.signalMastManagerInstance().provideSignalMast(signalMast);
-        if (mast != null) {
+        try {
+            SignalMast mast = InstanceManager.signalMastManagerInstance().provideSignalMast(signalMast);
             signalDMastNamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(signalMast, mast);
-        } else {
+        } catch (IllegalArgumentException ex) {
             signalDMastNamed = null;
         }
     }
@@ -468,10 +467,10 @@ public class LevelXing {
             return;
         }
 
-        Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-        if (sensor != null) {
+        try {
+            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
             sensorANamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(sensorName, sensor);
-        } else {
+        } catch (IllegalArgumentException ex) {
             sensorANamed = null;
         }
     }
@@ -496,10 +495,10 @@ public class LevelXing {
             return;
         }
 
-        Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-        if (sensor != null) {
+        try {
+            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
             sensorBNamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(sensorName, sensor);
-        } else {
+        } catch (IllegalArgumentException ex) {
             sensorBNamed = null;
         }
     }
@@ -524,10 +523,10 @@ public class LevelXing {
             return;
         }
 
-        Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-        if (sensor != null) {
+        try {
+            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
             sensorCNamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(sensorName, sensor);
-        } else {
+        } catch (IllegalArgumentException ex) {
             sensorCNamed = null;
         }
     }
@@ -552,10 +551,10 @@ public class LevelXing {
             return;
         }
 
-        Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-        if (sensor != null) {
+        try {
+            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
             sensorDNamed = InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(sensorName, sensor);
-        } else {
+        } catch (IllegalArgumentException ex) {
             sensorDNamed = null;
         }
     }
@@ -1259,13 +1258,13 @@ public class LevelXing {
             // get new block, or null if block has been removed
             blockNameAC = block1Name.getText().trim();
             if ((blockNameAC != null) && (blockNameAC.length() > 0)) {
-                blockAC = layoutEditor.provideLayoutBlock(blockNameAC);
-                if (blockAC != null) {
+                try {
+                    blockAC = layoutEditor.provideLayoutBlock(blockNameAC);
                     // decrement use if block was previously counted
                     if ((blockAC != null) && (blockAC == blockBD)) {
                         blockAC.decrementUse();
                     }
-                } else {
+                } catch (IllegalArgumentException ex) {
                     blockNameAC = "";
                     block1Name.setText("");
                 }
@@ -1298,13 +1297,13 @@ public class LevelXing {
             // get new block, or null if block has been removed
             blockNameBD = block2Name.getText().trim();
             if ((blockNameBD != null) && (blockNameBD.length() > 0)) {
-                blockBD = layoutEditor.provideLayoutBlock(blockNameBD);
-                if (blockBD != null) {
+                try {
+                    blockBD = layoutEditor.provideLayoutBlock(blockNameBD);
                     // decrement use if block was previously counted
                     if ((blockBD != null) && (blockAC == blockBD)) {
                         blockBD.decrementUse();
                     }
-                } else {
+                } catch (IllegalArgumentException ex) {
                     blockNameBD = "";
                     block2Name.setText("");
                 }
@@ -1337,13 +1336,13 @@ public class LevelXing {
             // get new block, or null if block has been removed
             blockNameAC = block1Name.getText().trim();
             if ((blockNameAC != null) && (blockNameAC.length() > 0)) {
-                blockAC = layoutEditor.provideLayoutBlock(blockNameAC);
-                if (blockAC != null) {
+                try {
+                    blockAC = layoutEditor.provideLayoutBlock(blockNameAC);
                     // decrement use if block was previously counted
                     if ((blockAC != null) && (blockAC == blockBD)) {
                         blockAC.decrementUse();
                     }
-                } else {
+                } catch (IllegalArgumentException ex) {
                     blockNameAC = "";
                     block1Name.setText("");
                 }
@@ -1363,13 +1362,13 @@ public class LevelXing {
             // get new block, or null if block has been removed
             blockNameBD = block2Name.getText().trim();
             if ((blockNameBD != null) && (blockNameBD.length() > 0)) {
-                blockBD = layoutEditor.provideLayoutBlock(blockNameBD);
-                if (blockBD != null) {
+                try {
+                    blockBD = layoutEditor.provideLayoutBlock(blockNameBD);
                     // decrement use if block was previously counted
                     if ((blockBD != null) && (blockAC == blockBD)) {
                         blockBD.decrementUse();
                     }
-                } else {
+                } catch (IllegalArgumentException ex) {
                     blockNameBD = "";
                     block2Name.setText("");
                 }

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -337,10 +337,10 @@ public class PositionablePoint {
             return;
         }
 
-        Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-        if (sensor != null) {
+        try {
+            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
             eastBoundSensorNamed = jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(sensorName, sensor);
-        } else {
+        } catch (IllegalArgumentException ex) {
             eastBoundSensorNamed = null;
         }
     }
@@ -364,10 +364,10 @@ public class PositionablePoint {
             westBoundSensorNamed = null;
             return;
         }
-        Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
-        if (sensor != null) {
+        try {
+            Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(sensorName);
             westBoundSensorNamed = jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class).getNamedBeanHandle(sensorName, sensor);
-        } else {
+        } catch (IllegalArgumentException ex) {
             westBoundSensorNamed = null;
         }
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -43,7 +43,6 @@ import org.slf4j.LoggerFactory;
  * TrackSegments may be hidden when the panel is not in EditMode.
  *
  * @author Dave Duchamp Copyright (c) 2004-2009
- * @version $Revision$
  */
 public class TrackSegment {
 
@@ -237,8 +236,6 @@ public class TrackSegment {
     public void trackRedrawn() {
         changed = false;
     }
-    //public int getRadius() {return radius;}
-    //public void setRadius(int x) {radius = x;} 
 
     public LayoutBlock getLayoutBlock() {
         if ((block == null) && (blockName != null) && (blockName != "")) {
@@ -682,8 +679,9 @@ public class TrackSegment {
             }
             // get new block, or null if block has been removed
             blockName = blockNameField.getText().trim();
-            block = layoutEditor.provideLayoutBlock(blockName);
-            if (block == null) {
+            try {
+                block = layoutEditor.provideLayoutBlock(blockName);
+            } catch (IllegalArgumentException ex) {
                 blockName = "";
             }
             needsRedraw = true;
@@ -743,8 +741,9 @@ public class TrackSegment {
             }
             // get new block, or null if block has been removed
             blockName = blockNameField.getText().trim();
-            block = layoutEditor.provideLayoutBlock(blockName);
-            if (block == null) {
+            try {
+                block = layoutEditor.provideLayoutBlock(blockName);
+            } catch (IllegalArgumentException ex) {
                 blockName = "";
             }
             needsRedraw = true;

--- a/java/src/jmri/jmrit/display/palette/SignalMastItemPanel.java
+++ b/java/src/jmri/jmrit/display/palette/SignalMastItemPanel.java
@@ -34,10 +34,6 @@ import org.slf4j.LoggerFactory;
 
 public class SignalMastItemPanel extends TableItemPanel implements ListSelectionListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7308622179668168349L;
     SignalMast _mast;
 
     public SignalMastItemPanel(JmriJFrame parentFrame, String type, String family, PickListModel model, Editor editor) {
@@ -156,8 +152,10 @@ public class SignalMastItemPanel extends TableItemPanel implements ListSelection
             _family = null;
             return;
         }
-        _mast = InstanceManager.signalMastManagerInstance().provideSignalMast(bean.getDisplayName());
-        if (_mast == null) {
+        
+        try {
+            _mast = InstanceManager.signalMastManagerInstance().provideSignalMast(bean.getDisplayName());
+        } catch (IllegalArgumentException ex) {
             log.error("getIconMap: No SignalMast called " + bean.getDisplayName());
             _currentIconMap = null;
             return;

--- a/java/src/jmri/jmrit/logix/OBlockManager.java
+++ b/java/src/jmri/jmrit/logix/OBlockManager.java
@@ -2,6 +2,10 @@ package jmri.jmrit.logix;
 
 import jmri.managers.AbstractManager;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.CheckReturnValue;
+
 /**
  * Basic Implementation of a OBlockManager.
  * <P>
@@ -38,7 +42,7 @@ public class OBlockManager extends AbstractManager
         return jmri.Manager.OBLOCKS;
     }
 
-    public String getSystemPrefix() {
+    public @Nonnull String getSystemPrefix() {
         return "O";
     }
 
@@ -106,13 +110,18 @@ public class OBlockManager extends AbstractManager
         return (OBlock) _tuser.get(key);
     }
 
-    public OBlock provideOBlock(String name) {
+    public @Nonnull OBlock provideOBlock(String name) throws IllegalArgumentException {
         if (name == null || name.length() == 0) {
-            return null;
+            throw new IllegalArgumentException("name \""+name+"\" invalid");
         }
         OBlock ob = getByUserName(name);
         if (ob == null) {
             ob = getBySystemName(name);
+        }
+        if (ob == null) {
+            ob = createNewOBlock(name, null);
+            if (ob == null) throw new IllegalArgumentException("could not create OBlock \""+name+"\"");
+            register(ob);
         }
         return ob;
     }

--- a/java/src/jmri/jmrit/logix/configurexml/OBlockManagerXml.java
+++ b/java/src/jmri/jmrit/logix/configurexml/OBlockManagerXml.java
@@ -209,15 +209,14 @@ public class OBlockManagerXml // extends XmlFile
     OBlock getBlock(String sysName) {
         OBlock block = _blockMap.get(sysName);
         if (block == null) {
-            block = _manager.provideOBlock(sysName);
-            if (block == null) {
+            try {
+                block = _manager.provideOBlock(sysName);
+                log.debug("found OBlock: ({}) {}", sysName, block);
+            } catch (IllegalArgumentException ex) {
                 block = _manager.createNewOBlock(sysName, null);
-                if (log.isDebugEnabled()) {
-                    log.debug("create OBlock: (" + sysName + ")");
-                }
-            } else {
-                _blockMap.put(sysName, block);
+                log.debug("create OBlock: ({})", sysName);
             }
+            _blockMap.put(sysName, block);
         }
         return block;
     }
@@ -320,14 +319,12 @@ public class OBlockManagerXml // extends XmlFile
         if (errSensor != null) {
             // sensor
             String name = errSensor.getAttribute("systemName").getValue();
-            //Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(name);
             block.setErrorSensor(name);
         }
         Element reporter = elem.getChild("reporter");
         if (reporter != null) {
             // sensor
             String name = reporter.getAttribute("systemName").getValue();
-            //Sensor sensor = InstanceManager.sensorManagerInstance().provideSensor(name);
             try {
                 Reporter rep = InstanceManager.reporterManagerInstance().getReporter(name);
                 if (rep != null) {

--- a/java/src/jmri/jmrit/logix/configurexml/WarrantManagerXml.java
+++ b/java/src/jmri/jmrit/logix/configurexml/WarrantManagerXml.java
@@ -311,8 +311,9 @@ public class WarrantManagerXml //extends XmlFile
         if (blocks.size()>0) {
             // sensor
             String name = blocks.get(0).getAttribute("systemName").getValue();
-            block = InstanceManager.getDefault(jmri.jmrit.logix.OBlockManager.class).provideOBlock(name);
-            if (block==null) {
+            try {
+                block = InstanceManager.getDefault(jmri.jmrit.logix.OBlockManager.class).provideOBlock(name);
+            } catch (IllegalArgumentException ex) {
                 log.error("Unknown Block \""+name+"\" is null in BlockOrder.");
                 return null;
             }

--- a/java/src/jmri/jmrit/operations/locations/Location.java
+++ b/java/src/jmri/jmrit/operations/locations/Location.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
  * Represents a location on the layout
  *
  * @author Daniel Boudreau Copyright (C) 2008, 2012, 2013
- * @version $Revision$
  */
 public class Location implements java.beans.PropertyChangeListener {
 

--- a/java/src/jmri/jmrit/picker/PickListModel.java
+++ b/java/src/jmri/jmrit/picker/PickListModel.java
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Abstract class to make pick lists for NamedBeans.
+ * Abstract class to make pick lists for NamedBeans; Table model for pick lists in IconAdder
  * <P>
  * Concrete pick list class for many beans are include at the end of this file.
  * This class also has instantiation methods serve as a factory for those
@@ -56,17 +56,9 @@ import org.slf4j.LoggerFactory;
  * <P>
  *
  * @author Pete Cressman Copyright (C) 2009, 2010
- * @version
- */
-/**
- * Table model for pick lists in IconAdder
  */
 public abstract class PickListModel extends jmri.jmrit.beantable.BeanTableDataModel implements PropertyChangeListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4174669657476555432L;
     protected ArrayList<NamedBean> _pickList;
     protected String _name;
     private JTable _table;       // table using this model
@@ -488,7 +480,7 @@ public abstract class PickListModel extends jmri.jmrit.beantable.BeanTableDataMo
             return manager;
         }
 
-        public NamedBean addBean(String name) {
+        public NamedBean addBean(String name) throws IllegalArgumentException {
             return manager.provideTurnout(name);
         }
 
@@ -518,7 +510,7 @@ public abstract class PickListModel extends jmri.jmrit.beantable.BeanTableDataMo
             return manager;
         }
 
-        public NamedBean addBean(String name) {
+        public NamedBean addBean(String name) throws IllegalArgumentException {
             return manager.provideSensor(name);
         }
 
@@ -608,11 +600,11 @@ public abstract class PickListModel extends jmri.jmrit.beantable.BeanTableDataMo
             return manager;
         }
 
-        public NamedBean addBean(String name) {
+        public NamedBean addBean(String name) throws IllegalArgumentException {
             return manager.provideSignalMast(name);
         }
 
-        public NamedBean addBean(String sysName, String userName) {
+        public NamedBean addBean(String sysName, String userName) throws IllegalArgumentException {
             SignalMast sm = manager.getSignalMast(userName);
             if (sm == null) {
                 sm = manager.provideSignalMast(sysName);
@@ -642,7 +634,7 @@ public abstract class PickListModel extends jmri.jmrit.beantable.BeanTableDataMo
             return manager;
         }
 
-        public NamedBean addBean(String name) {
+        public NamedBean addBean(String name) throws IllegalArgumentException {
             return manager.provideMemory(name);
         }
 
@@ -672,7 +664,7 @@ public abstract class PickListModel extends jmri.jmrit.beantable.BeanTableDataMo
             return manager;
         }
 
-        public NamedBean addBean(String name) {
+        public NamedBean addBean(String name) throws IllegalArgumentException {
             return manager.provideBlock(name);
         }
 
@@ -702,7 +694,7 @@ public abstract class PickListModel extends jmri.jmrit.beantable.BeanTableDataMo
             return manager;
         }
 
-        public NamedBean addBean(String name) {
+        public NamedBean addBean(String name) throws IllegalArgumentException {
             return manager.provideReporter(name);
         }
 
@@ -732,7 +724,7 @@ public abstract class PickListModel extends jmri.jmrit.beantable.BeanTableDataMo
             return manager;
         }
 
-        public NamedBean addBean(String name) {
+        public NamedBean addBean(String name) throws IllegalArgumentException {
             return manager.provideLight(name);
         }
 
@@ -762,7 +754,7 @@ public abstract class PickListModel extends jmri.jmrit.beantable.BeanTableDataMo
             return manager;
         }
 
-        public NamedBean addBean(String name) {
+        public NamedBean addBean(String name) throws IllegalArgumentException {
             return manager.provideOBlock(name);
         }
 
@@ -792,7 +784,7 @@ public abstract class PickListModel extends jmri.jmrit.beantable.BeanTableDataMo
             return manager;
         }
 
-        public NamedBean addBean(String name) {
+        public NamedBean addBean(String name) throws IllegalArgumentException {
             return manager.provideWarrant(name);
         }
 

--- a/java/src/jmri/jmrit/sensorgroup/SensorTableModel.java
+++ b/java/src/jmri/jmrit/sensorgroup/SensorTableModel.java
@@ -1,4 +1,3 @@
-// SensorTableModel.java
 package jmri.jmrit.sensorgroup;
 
 import java.beans.PropertyChangeListener;
@@ -13,14 +12,9 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2007
  * @author Pete Cressman Copyright (C) 2009
  *
- * @version $Revision$
  */
 public class SensorTableModel extends BeanTableModel implements PropertyChangeListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3536564177611715912L;
     String[] _sysNameList;
     Boolean[] _includedSensors;
 
@@ -90,4 +84,3 @@ public class SensorTableModel extends BeanTableModel implements PropertyChangeLi
     private final static Logger log = LoggerFactory.getLogger(SensorTableModel.class.getName());
 
 }
-/* @(#)SensorTableModel.java */

--- a/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
@@ -1,4 +1,3 @@
-// Timebase.java
 package jmri.jmrit.simpleclock;
 
 import java.beans.PropertyChangeEvent;
@@ -30,48 +29,42 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright (C) 2004, 2007 Dave Duchamp - 2007
  * additions/revisions for handling one hardware clock
- * @version	$Revision$
  */
 public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implements Timebase {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5893225952525687431L;
 
     public SimpleTimebase() {
         super("SIMPLECLOCK");
         // initialize time-containing memory
-        clockMemory = jmri.InstanceManager.memoryManagerInstance().provideMemory("IMCURRENTTIME");
-        if (clockMemory == null) {
-            log.warn("Unable to create IMCURRENTTIME time memory variable");
-        } else {
+        try {
+            clockMemory = jmri.InstanceManager.memoryManagerInstance().provideMemory("IMCURRENTTIME");
             clockMemory.setValue("--");
+        } catch (IllegalArgumentException ex) {
+            log.warn("Unable to create IMCURRENTTIME time memory variable");
         }
         // set to start counting from now
         setTime(new Date());
         pauseTime = null;
         // initialize start/stop sensor for time running
-        clockSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor("ISCLOCKRUNNING");
         try {
+            clockSensor = jmri.InstanceManager.sensorManagerInstance().provideSensor("ISCLOCKRUNNING");
             clockSensor.setKnownState(Sensor.ACTIVE);
-        } catch (jmri.JmriException e) {
-            log.warn("Exception setting ISCLOCKRUNNING sensor ACTIVE: " + e);
-        }
-        clockSensor.addPropertyChangeListener(
+            clockSensor.addPropertyChangeListener(
                     new PropertyChangeListener() {
                         public void propertyChange(PropertyChangeEvent e) {
                             clockSensorChanged();
                         }
                     });
+        } catch (jmri.JmriException e) {
+            log.warn("Exception setting ISCLOCKRUNNING sensor ACTIVE: " + e);
+        }
         // initialize rate factor-containing memory
         if (jmri.InstanceManager.memoryManagerInstance() != null) {
             // only try to create memory if memories are supported
-            factorMemory = jmri.InstanceManager.memoryManagerInstance().provideMemory("IMRATEFACTOR");
-            if (factorMemory == null) {
-                log.warn("Unable to create IMRATEFACTOR time memory variable");
-            } else {
+            try {
+                factorMemory = jmri.InstanceManager.memoryManagerInstance().provideMemory("IMRATEFACTOR");
                 factorMemory.setValue(userGetRate());
+            } catch (IllegalArgumentException ex) {
+                log.warn("Unable to create IMRATEFACTOR time memory variable");
             }
         }
     }

--- a/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlFrame.java
+++ b/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlFrame.java
@@ -1,4 +1,3 @@
-// SimpleLightCtrlFrame.java
 package jmri.jmrit.simplelightctrl;
 
 import java.awt.Dimension;
@@ -18,14 +17,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Ken Cameron Copyright (C) 2008
  * @author	Bob Jacobsen Copyright (C) 2001, 2008
- * @version $Revision$
  */
 public class SimpleLightCtrlFrame extends jmri.util.JmriJFrame implements java.beans.PropertyChangeListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 7837647126381592983L;
     ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrit.simplelightctrl.SimpleLightCtrlBundle");
     static final ResourceBundle rbean = ResourceBundle.getBundle("jmri.NamedBeanBundle");
 
@@ -239,19 +233,20 @@ public class SimpleLightCtrlFrame extends jmri.util.JmriJFrame implements java.b
                 // we're changing the light we're watching
                 light.removePropertyChangeListener(this);
             }
-            light = InstanceManager.lightManagerInstance().provideLight(
+            try {
+                light = InstanceManager.lightManagerInstance().provideLight(
                     adrTextField.getText());
 
-            if (light == null) {
+            } catch (IllegalArgumentException ex) {
                 log.error(rb.getString("LightErrorButtonNameBad") + adrTextField.getText());
-            } else {
-                light.addPropertyChangeListener(this);
-                if (log.isDebugEnabled()) {
-                    log.debug("about to command CLOSED");
-                }
-                // and set commanded state to CLOSED
-                light.setState(Light.OFF);
             }
+            light.addPropertyChangeListener(this);
+            if (log.isDebugEnabled()) {
+                log.debug("about to command CLOSED");
+            }
+            // and set commanded state to CLOSED
+            light.setState(Light.OFF);
+
         } catch (Exception ex) {
             log.error(rb.getString("LightErrorOffButtonException") + ex.toString());
             nowStateTextField.setText("ERROR");
@@ -265,19 +260,19 @@ public class SimpleLightCtrlFrame extends jmri.util.JmriJFrame implements java.b
                 // we're changing the light we're watching
                 light.removePropertyChangeListener(this);
             }
-            light = InstanceManager.lightManagerInstance().provideLight(
+            try {
+                light = InstanceManager.lightManagerInstance().provideLight(
                     adrTextField.getText());
 
-            if (light == null) {
+            } catch (IllegalArgumentException ex) {
                 log.error(rb.getString("LightErrorButtonNameBad") + adrTextField.getText());
-            } else {
-                light.addPropertyChangeListener(this);
-                if (log.isDebugEnabled()) {
-                    log.debug("about to command ON");
-                }
-                // and set commanded state to ON
-                light.setState(Light.ON);
+            } 
+            light.addPropertyChangeListener(this);
+            if (log.isDebugEnabled()) {
+                log.debug("about to command ON");
             }
+            // and set commanded state to ON
+            light.setState(Light.ON);
         } catch (Exception ex) {
             log.error(rb.getString("LightErrorOnButtonException") + ex.toString());
             nowStateTextField.setText("ERROR");
@@ -291,19 +286,20 @@ public class SimpleLightCtrlFrame extends jmri.util.JmriJFrame implements java.b
                 // we're changing the light we're watching
                 light.removePropertyChangeListener(this);
             }
-            light = InstanceManager.lightManagerInstance().provideLight(
+            try {
+                light = InstanceManager.lightManagerInstance().provideLight(
                     adrTextField.getText());
 
-            if (light == null) {
+            } catch (IllegalArgumentException ex) {
                 log.error(rb.getString("LightErrorButtonNameBad") + adrTextField.getText());
-            } else {
-                light.addPropertyChangeListener(this);
-                if (log.isDebugEnabled()) {
-                    log.debug("about to command DIM");
-                }
-                // and set commanded state to DIM
-                light.setTargetIntensity(Double.parseDouble(intensityTextField.getText().trim()) / 100);
             }
+            light.addPropertyChangeListener(this);
+            if (log.isDebugEnabled()) {
+                log.debug("about to command DIM");
+            }
+            // and set commanded state to DIM
+            light.setTargetIntensity(Double.parseDouble(intensityTextField.getText().trim()) / 100);
+
         } catch (Exception ex) {
             log.error(rb.getString("LightErrorIntensityButtonException") + ex.toString());
             nowStateTextField.setText("ERROR");
@@ -320,22 +316,24 @@ public class SimpleLightCtrlFrame extends jmri.util.JmriJFrame implements java.b
                 // we're changing the light we're watching
                 light.removePropertyChangeListener(this);
             }
-            light = InstanceManager.lightManagerInstance().provideLight(adrTextField.getText());
+            try {
+                light = InstanceManager.lightManagerInstance().provideLight(adrTextField.getText());
 
-            if (light == null) {
+            } catch (IllegalArgumentException ex) {
                 nowStateTextField.setText(rb.getString("LightErrorButtonNameBad") + adrTextField.getText());
-            } else {
-                double min = Double.parseDouble(intensityMinTextField.getText()) / 100.;
-                double max = Double.parseDouble(intensityMaxTextField.getText()) / 100.;
-                double time = Double.parseDouble(transitionTimeTextField.getText());
-                if (log.isDebugEnabled()) {
-                    log.debug("setting min: " + min + " max: " + max + " transition: " + time);
-                }
-                light.setMinIntensity(min);
-                light.setMaxIntensity(max);
-                light.setTransitionTime(time);
-                updateLightStatusFields(false);
             }
+            
+            double min = Double.parseDouble(intensityMinTextField.getText()) / 100.;
+            double max = Double.parseDouble(intensityMaxTextField.getText()) / 100.;
+            double time = Double.parseDouble(transitionTimeTextField.getText());
+            if (log.isDebugEnabled()) {
+                log.debug("setting min: " + min + " max: " + max + " transition: " + time);
+            }
+            light.setMinIntensity(min);
+            light.setMaxIntensity(max);
+            light.setTransitionTime(time);
+            updateLightStatusFields(false);
+
         } catch (Exception ex) {
             log.error(rb.getString("LightErrorApplyButtonException") + ex.toString());
             nowStateTextField.setText("ERROR");
@@ -353,61 +351,22 @@ public class SimpleLightCtrlFrame extends jmri.util.JmriJFrame implements java.b
                 // we're changing the light we're watching
                 light.removePropertyChangeListener(this);
             }
-            light = InstanceManager.lightManagerInstance().provideLight(adrTextField.getText());
+            
+            try {
+                light = InstanceManager.lightManagerInstance().provideLight(adrTextField.getText());
 
-            if (light == null) {
+            } catch (IllegalArgumentException ex) {
                 nowStateTextField.setText(rb.getString("LightErrorButtonNameBad") + adrTextField.getText());
-            } else {
-                updateLightStatusFields(true);
-            }
+            } 
+            
+            updateLightStatusFields(true);
+
         } catch (Exception ex) {
             log.error(rb.getString("LightErrorStatusButtonException") + ex.toString());
             nowStateTextField.setText("ERROR");
         }
     }
 
-//	public void lockButtonActionPerformed(java.awt.event.ActionEvent e) {
-//		// load address from switchAddrTextField
-//		try {
-//			if (light != null)
-//				light.removePropertyChangeListener(this);
-//			light = InstanceManager.lightManagerInstance().provideLight(
-//					adrTextField.getText());
-//
-//			if (light == null) {
-//				log.error("Light " + adrTextField.getText()
-//						+ " is not available");
-//			} else {
-//				light.addPropertyChangeListener(this);
-//
-//			}
-//		} catch (Exception ex) {
-//			log.error("LockButtonActionPerformed, exception: "
-//							+ ex.toString());
-//			nowStateTextField.setText("ERROR");
-//		}
-//	}
-//	public void lockPushButtonActionPerformed(java.awt.event.ActionEvent e) {
-//		// load address from switchAddrTextField
-//		try {
-//			if (light != null)
-//				light.removePropertyChangeListener(this);
-//			light = InstanceManager.lightManagerInstance().provideLight(
-//					adrTextField.getText());
-//
-//			if (light == null) {
-//				log.error("Light " + adrTextField.getText()
-//						+ " is not available");
-//			} else {
-//				light.addPropertyChangeListener(this);
-//				
-//			}
-//		} catch (Exception ex) {
-//			log.error("LockPushButtonActionPerformed, exception: "
-//							+ ex.toString());
-//			nowStateTextField.setText("ERROR");
-//		}
-//	}
     // update state field in GUI as state of light changes
     public void propertyChange(java.beans.PropertyChangeEvent e) {
         if (log.isDebugEnabled()) {

--- a/java/src/jmri/jmrit/tracker/MemoryTracker.java
+++ b/java/src/jmri/jmrit/tracker/MemoryTracker.java
@@ -10,14 +10,13 @@ import org.slf4j.LoggerFactory;
  * Tracks train into memory object
  *
  * @author	Bob Jacobsen Copyright (C) 2006
- * @version	$Revision$
  */
 public class MemoryTracker {
 
     /**
      * Create a Tracker object, providing a list of blocks to watch
      */
-    public MemoryTracker(Block b, String namePrefix) {
+    public MemoryTracker(Block b, String namePrefix) throws IllegalArgumentException {
         block = b;
 
         // make sure Memory objects exist & remember it

--- a/java/src/jmri/jmrit/vsdecoder/AudioUtil.java
+++ b/java/src/jmri/jmrit/vsdecoder/AudioUtil.java
@@ -139,7 +139,7 @@ public class AudioUtil {
                 }
 
                 rlist.add(buf);
-            } catch (AudioException e) {
+            } catch (AudioException | IllegalArgumentException e) {
                 log.warn("Error on provideAudio! " + e.toString());
                 if (log.isDebugEnabled()) {
                     jmri.InstanceManager.audioManagerInstance().getSystemNameList(Audio.BUFFER).stream().forEach((s) -> {

--- a/java/src/jmri/jmrit/vsdecoder/Diesel3Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Diesel3Sound.java
@@ -529,7 +529,7 @@ class Diesel3Sound extends EngineSound {
                         return (null);
                     }
                 }
-            } catch (AudioException ex) {
+            } catch (AudioException | IllegalArgumentException ex) {
                 log.error("Problem creating SoundBite: " + ex);
                 return (null);
             }

--- a/java/src/jmri/jmrit/vsdecoder/SoundBite.java
+++ b/java/src/jmri/jmrit/vsdecoder/SoundBite.java
@@ -16,7 +16,6 @@ package jmri.jmrit.vsdecoder;
  * <P>
  *
  * @author			Mark Underwood Copyright (C) 2011
- * @version			$Revision$
  */
 import java.util.ArrayList;
 import jmri.AudioException;
@@ -113,7 +112,7 @@ class SoundBite extends VSDSound {
                     sound_src.setAssignedBuffer(sound_buf);
                     setLength();
                 }
-            } catch (AudioException ex) {
+            } catch (AudioException | IllegalArgumentException ex) {
                 log.warn("Problem creating SoundBite: " + ex);
             }
         }

--- a/java/src/jmri/jmrit/vsdecoder/listener/VSDListener.java
+++ b/java/src/jmri/jmrit/vsdecoder/listener/VSDListener.java
@@ -30,8 +30,8 @@ public class VSDListener {
         try {
             _listener = (AudioListener) am.provideAudio(ListenerSysNamePrefix + _sysname);
             log.debug("Listener Created: " + _listener);
-        } catch (AudioException ae) {
-            log.debug("AudioException creating Listener: " + ae);
+        } catch (AudioException | IllegalArgumentException ae) {
+            log.warn("Exception creating Listener: " + ae);
             // Do nothing?
         }
     }

--- a/java/src/jmri/jmrit/withrottle/RouteController.java
+++ b/java/src/jmri/jmrit/withrottle/RouteController.java
@@ -123,9 +123,11 @@ public class RouteController extends AbstractController implements PropertyChang
             list.append("}|{");
             String turnoutsAlignedSensor = r.getTurnoutsAlignedSensor();
             if (!turnoutsAlignedSensor.equals("")) {  //only set if found
-                Sensor routeAligned = InstanceManager.sensorManagerInstance().provideSensor(turnoutsAlignedSensor);
-                if (routeAligned != null) {
+                try {
+                    Sensor routeAligned = InstanceManager.sensorManagerInstance().provideSensor(turnoutsAlignedSensor);
                     list.append(routeAligned.getKnownState());
+                } catch (IllegalArgumentException ex) {
+                    log.warn("Failed to provide turnoutsAlignedSensor \"{}\" in sendList", turnoutsAlignedSensor);
                 }
             }
 

--- a/java/src/jmri/jmrix/ecos/EcosSensorManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosSensorManager.java
@@ -1,4 +1,3 @@
-// EcosSensorManager.java
 package jmri.jmrix.ecos;
 
 import java.util.Hashtable;
@@ -14,7 +13,6 @@ import org.slf4j.LoggerFactory;
  * s88 Bus Module and yy is the port on that module.
  *
  * @author	Kevin Dickerson Copyright (C) 2009
- * @version	$Revision$
  */
 public class EcosSensorManager extends jmri.managers.AbstractSensorManager
         implements EcosListener {
@@ -91,9 +89,11 @@ public class EcosSensorManager extends jmri.managers.AbstractSensorManager
                                 sb.append("0");
                             }
                             sb.append(j);
-                            EcosReporter rp = (EcosReporter) memo.getReporterManager().provideReporter(sb.toString());
-                            if (rp != null) {
+                            try {
+                                EcosReporter rp = (EcosReporter) memo.getReporterManager().provideReporter(sb.toString());
                                 rp.decodeDetails(lines[i]);
+                            } catch (IllegalArgumentException ex) {
+                                log.warn("Failed to provide Reporter \"{}\" in reply", sb.toString());
                             }
                         }
 
@@ -144,12 +144,14 @@ public class EcosSensorManager extends jmri.managers.AbstractSensorManager
                                                     sb.append("0");
                                                 }
                                                 sb.append(j);
-                                                EcosReporter rp = (EcosReporter) memo.getReporterManager().provideReporter(sb.toString());
-                                                if (rp != null) {
+                                                try {
+                                                    EcosReporter rp = (EcosReporter) memo.getReporterManager().provideReporter(sb.toString());
                                                     rp.setObjectPort(object, (j - 1));
                                                     es.setReporter(rp);
                                                     EcosMessage em = new EcosMessage("get(" + object + ", railcom[" + (j - 1) + "])");
                                                     tc.sendEcosMessage(em, this);
+                                                } catch (IllegalArgumentException ex) {
+                                                    log.warn("Failed to provide Reporter \"{}\"", sb.toString());
                                                 }
                                             }
                                         }

--- a/java/src/jmri/jmrix/grapevine/SerialNode.java
+++ b/java/src/jmri/jmrix/grapevine/SerialNode.java
@@ -1,4 +1,3 @@
-// SerialNode.java
 package jmri.jmrix.grapevine;
 
 import jmri.JmriException;
@@ -23,7 +22,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright (C) 2003, 2006, 2007, 2008
  * @author Bob Jacobsen, Dave Duchamp, multiNode extensions, 2004
- * @version	$Revision$
  */
 public class SerialNode extends AbstractNode {
 

--- a/java/src/jmri/jmrix/jinput/UsbNode.java
+++ b/java/src/jmri/jmrix/jinput/UsbNode.java
@@ -1,4 +1,3 @@
-// UsbNode.java
 package jmri.jmrix.jinput;
 
 import java.util.HashMap;
@@ -18,14 +17,9 @@ import org.slf4j.LoggerFactory;
  * Can be connected to a JMRI Sensor or Memory.
  *
  * @author	Bob Jacobsen Copyright 2008
- * @version	$Revision$
  */
 public class UsbNode extends DefaultMutableTreeNode {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8201606725792217137L;
     String name;
     Controller controller;
     Component component;

--- a/java/src/jmri/jmrix/loconet/pr3/PR3SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/pr3/PR3SystemConnectionMemo.java
@@ -1,4 +1,3 @@
-// PR3SystemConnectionMemo.java
 package jmri.jmrix.loconet.pr3;
 
 import jmri.InstanceManager;
@@ -15,7 +14,6 @@ import org.slf4j.LoggerFactory;
  * Lightweight class to denote that a PR3 is active
  *
  * @author	Bob Jacobsen Copyright (C) 2010
- * @version $Revision$
  */
 public class PR3SystemConnectionMemo extends LocoNetSystemConnectionMemo {
 

--- a/java/src/jmri/jmrix/serialsensor/SerialSensorAdapter.java
+++ b/java/src/jmri/jmrix/serialsensor/SerialSensorAdapter.java
@@ -219,7 +219,7 @@ public class SerialSensorAdapter extends AbstractSerialPortController
             try {
                 InstanceManager.sensorManagerInstance().provideSensor(mSensor)
                         .setKnownState(value);
-            } catch (JmriException e) {
+            } catch (JmriException | IllegalArgumentException e) {
                 log.error("Exception setting state: " + e);
             }
         }

--- a/java/src/jmri/jmrix/srcp/parser/SRCPClientVisitor.java
+++ b/java/src/jmri/jmrix/srcp/parser/SRCPClientVisitor.java
@@ -1,4 +1,3 @@
-//SRCPClientVisitor.java
 package jmri.jmrix.srcp.parser;
 
 import jmri.jmrix.srcp.SRCPBusConnectionMemo;
@@ -9,7 +8,6 @@ import org.slf4j.LoggerFactory;
 /* This class provides an interface between the JavaTree/JavaCC 
  * parser for the SRCP protocol and the JMRI front end.
  * @author Paul Bender Copyright (C) 2011
- * @version $Revision$
  */
 public class SRCPClientVisitor implements jmri.jmrix.srcp.parser.SRCPClientParserVisitor {
 

--- a/java/src/jmri/managers/AbstractLightManager.java
+++ b/java/src/jmri/managers/AbstractLightManager.java
@@ -46,8 +46,10 @@ public abstract class AbstractLightManager extends AbstractManager
         }
         if (name.startsWith(getSystemPrefix() + typeLetter())) {
             return newLight(name, null);
-        } else {
+        } else if (name.length() > 0) {
             return newLight(makeSystemName(name), null);
+        } else {
+            throw new IllegalArgumentException("Name must have non-full length");
         }
     }
 

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -123,7 +123,7 @@ abstract public class AbstractProxyManager implements Manager {
      *
      * @return Never null under normal circumstances
      */
-    protected NamedBean provideNamedBean(String name) {
+    protected NamedBean provideNamedBean(String name) throws IllegalArgumentException {
         // make sure internal present
         initInternal();
 

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -15,9 +15,6 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractSensorManager extends AbstractManager implements SensorManager {
 
-    /*public AbstractSensorManager(){
-     super(Manager.SENSORS);
-     }*/
     public int getXMLOrder() {
         return Manager.SENSORS;
     }
@@ -31,10 +28,13 @@ public abstract class AbstractSensorManager extends AbstractManager implements S
         if (t != null) {
             return t;
         }
+        log.debug("check \"{}\" get {}", name, isNumber(name));
         if (isNumber(name)) {
             return newSensor(makeSystemName(name), null);
-        } else {
+        } else if (name.length() > 0) {
             return newSensor(name, null);
+        } else {
+            throw new IllegalArgumentException("Name must have non-full length");
         }
     }
 
@@ -80,7 +80,8 @@ public abstract class AbstractSensorManager extends AbstractManager implements S
         return sysName;
     }
 
-    public Sensor newSensor(String sysName, String userName) {
+    public Sensor newSensor(String sysName, String userName) throws IllegalArgumentException {
+        log.debug(" newSensor(\"{}\", \"{}\"", sysName, userName);
         String systemName = normalizeSystemName(sysName);
         if (log.isDebugEnabled()) {
             log.debug("newSensor:"
@@ -93,8 +94,9 @@ public abstract class AbstractSensorManager extends AbstractManager implements S
             throw new IllegalArgumentException("systemName null in newSensor");
         }
         // is system name in correct format?
-        if (!systemName.startsWith(getSystemPrefix() + typeLetter())) {
-            log.error("Invalid system name for sensor: " + systemName
+        if (!systemName.startsWith(getSystemPrefix() + typeLetter()) 
+                || !(systemName.length() > (getSystemPrefix() + typeLetter()).length())) {
+            log.warn("Invalid system name for sensor: " + systemName
                     + " needed " + getSystemPrefix() + typeLetter());
             throw new IllegalArgumentException("systemName \""+systemName+"\" bad format in newSensor");
         }

--- a/java/src/jmri/managers/AbstractTurnoutManager.java
+++ b/java/src/jmri/managers/AbstractTurnoutManager.java
@@ -67,7 +67,8 @@ public abstract class AbstractTurnoutManager extends AbstractManager
                     + ";" + ((userName == null) ? "null" : userName));
         }
         // is system name in correct format?
-        if (!systemName.startsWith(getSystemPrefix() + typeLetter())) {
+        if (!systemName.startsWith(getSystemPrefix() + typeLetter()) 
+                || !(systemName.length() > (getSystemPrefix() + typeLetter()).length())) {
             log.error("Invalid system name for turnout: " + systemName
                     + " needed " + getSystemPrefix() + typeLetter());
             throw new IllegalArgumentException("Invalid system name for turnout: " + systemName

--- a/java/src/jmri/managers/DefaultIdTagManager.java
+++ b/java/src/jmri/managers/DefaultIdTagManager.java
@@ -102,7 +102,7 @@ public class DefaultIdTagManager extends AbstractManager
     }
 
     @Override
-    public IdTag provideIdTag(String name) {
+    public IdTag provideIdTag(String name) throws IllegalArgumentException {
         if (!initialised && !loading) {
             init();
         }
@@ -436,7 +436,7 @@ public class DefaultIdTagManager extends AbstractManager
             writeXML(file, doc);
         }
 
-        private void readFile(String fileName) throws org.jdom2.JDOMException, java.io.IOException {
+        private void readFile(String fileName) throws org.jdom2.JDOMException, java.io.IOException, IllegalArgumentException {
             // Check file exists
             if (findFile(fileName) == null) {
                 log.debug(fileName + " file could not be found");

--- a/java/src/jmri/managers/DefaultSignalMastLogicManager.java
+++ b/java/src/jmri/managers/DefaultSignalMastLogicManager.java
@@ -481,14 +481,18 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
                             }
                         } else {
                             sec.setSectionType(Section.SIGNALMASTLOGIC);
-                            //Auto running requires forward/reverse sensors, but at this stage SML does not support that, so just create dummy internal ones for now.
-                            Sensor sen = InstanceManager.sensorManagerInstance().provideSensor("IS:" + sec.getSystemName() + ":forward");
-                            sen.setUserName(sec.getSystemName() + ":forward");
+                            try {
+                                //Auto running requires forward/reverse sensors, but at this stage SML does not support that, so just create dummy internal ones for now.
+                                Sensor sen = InstanceManager.sensorManagerInstance().provideSensor("IS:" + sec.getSystemName() + ":forward");
+                                sen.setUserName(sec.getSystemName() + ":forward");
 
-                            sen = InstanceManager.sensorManagerInstance().provideSensor("IS:" + sec.getSystemName() + ":reverse");
-                            sen.setUserName(sec.getSystemName() + ":reverse");
-                            sec.setForwardBlockingSensorName(sec.getSystemName() + ":forward");
-                            sec.setReverseBlockingSensorName(sec.getSystemName() + ":reverse");
+                                sen = InstanceManager.sensorManagerInstance().provideSensor("IS:" + sec.getSystemName() + ":reverse");
+                                sen.setUserName(sec.getSystemName() + ":reverse");
+                                sec.setForwardBlockingSensorName(sec.getSystemName() + ":forward");
+                                sec.setReverseBlockingSensorName(sec.getSystemName() + ":reverse");
+                            } catch (IllegalArgumentException ex) {
+                                log.warn("Failed to provide Sensor in generateSection");
+                            }
                         }
                         sml.setAssociatedSection(sec, destMast);
                         sec.setProperty("forwardMast", destMast.getDisplayName());

--- a/java/src/jmri/managers/ProxyLightManager.java
+++ b/java/src/jmri/managers/ProxyLightManager.java
@@ -47,7 +47,7 @@ public class ProxyLightManager extends AbstractProxyManager
      *
      * @return Never null under normal circumstances
      */
-    public Light provideLight(String name) {
+    public Light provideLight(String name) throws IllegalArgumentException {
         return (Light) super.provideNamedBean(name);
     }
 

--- a/java/src/jmri/managers/ProxyReporterManager.java
+++ b/java/src/jmri/managers/ProxyReporterManager.java
@@ -37,7 +37,7 @@ public class ProxyReporterManager extends AbstractProxyManager implements Report
         return ((ReporterManager) getMgr(i)).newReporter(systemName, userName);
     }
 
-    public Reporter provideReporter(String sName) {
+    public Reporter provideReporter(String sName) throws IllegalArgumentException {
         return (Reporter) super.provideNamedBean(sName);
     }
 

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -31,11 +31,12 @@ public class ProxySensorManager extends AbstractProxyManager
         return (Sensor) super.getNamedBean(name);
     }
 
-    protected Sensor makeBean(int i, String systemName, String userName) {
+    protected Sensor makeBean(int i, String systemName, String userName) throws IllegalArgumentException {
+        log.debug("makeBean({}, \"{}\", \"{}\"", i, systemName, userName);
         return ((SensorManager) getMgr(i)).newSensor(systemName, userName);
     }
 
-    public Sensor provideSensor(String sName) {
+    public Sensor provideSensor(String sName) throws IllegalArgumentException {
         return (Sensor) super.provideNamedBean(sName);
     }
 

--- a/java/src/jmri/managers/ProxyTurnoutManager.java
+++ b/java/src/jmri/managers/ProxyTurnoutManager.java
@@ -49,7 +49,7 @@ public class ProxyTurnoutManager extends AbstractProxyManager implements Turnout
         return ((TurnoutManager) getMgr(i)).newTurnout(systemName, userName);
     }
 
-    public Turnout provideTurnout(String name) {
+    public Turnout provideTurnout(String name) throws IllegalArgumentException {
         return (Turnout) super.provideNamedBean(name);
     }
 

--- a/java/src/jmri/managers/configurexml/DefaultRouteManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultRouteManagerXml.java
@@ -283,203 +283,205 @@ public class DefaultRouteManagerXml extends jmri.managers.configurexml.AbstractN
                 log.debug("create route: (" + sysName + ")("
                         + (userName == null ? "<null>" : userName) + ")");
             }
-            Route r = tm.provideRoute(sysName, userName);
+            
+            Route r;
+            try {
+                r = tm.provideRoute(sysName, userName);
+            } catch (IllegalArgumentException ex) {
+                log.error("failed to create Route: " + sysName);
+                return;
+            }
 
             // load common parts
             loadCommon(r, routeList.get(i));
 
-            if (r != null) {
-                // add control turnout if there is one
-                if (cTurnout != null) {
-                    r.setControlTurnout(cTurnout);
-                    if (cTurnoutState != null) {
-                        if (cTurnoutState.equals("THROWN")) {
-                            r.setControlTurnoutState(Route.ONTHROWN);
-                        } else if (cTurnoutState.equals("CHANGE")) {
-                            r.setControlTurnoutState(Route.ONCHANGE);
-                        } else if (cTurnoutState.equals("VETOCLOSED")) {
-                            r.setControlTurnoutState(Route.VETOCLOSED);
-                        } else if (cTurnoutState.equals("VETOTHROWN")) {
-                            r.setControlTurnoutState(Route.VETOTHROWN);
-                        } else {
-                            r.setControlTurnoutState(Route.ONCLOSED);
-                        }
+            // add control turnout if there is one
+            if (cTurnout != null) {
+                r.setControlTurnout(cTurnout);
+                if (cTurnoutState != null) {
+                    if (cTurnoutState.equals("THROWN")) {
+                        r.setControlTurnoutState(Route.ONTHROWN);
+                    } else if (cTurnoutState.equals("CHANGE")) {
+                        r.setControlTurnoutState(Route.ONCHANGE);
+                    } else if (cTurnoutState.equals("VETOCLOSED")) {
+                        r.setControlTurnoutState(Route.VETOCLOSED);
+                    } else if (cTurnoutState.equals("VETOTHROWN")) {
+                        r.setControlTurnoutState(Route.VETOTHROWN);
                     } else {
-                        log.error("cTurnoutState was null!");
+                        r.setControlTurnoutState(Route.ONCLOSED);
                     }
+                } else {
+                    log.error("cTurnoutState was null!");
                 }
-                // set added delay
-                r.setRouteCommandDelay(addedDelay);
+            }
+            // set added delay
+            r.setRouteCommandDelay(addedDelay);
 
-                // determine if route locked
-                if (routeLockedTxt != null && routeLockedTxt.equals("True")) {
-                    r.setLocked(true);
-                }
+            // determine if route locked
+            if (routeLockedTxt != null && routeLockedTxt.equals("True")) {
+                r.setLocked(true);
+            }
 
-                //add lock control turout if there is one
-                if (cLockTurnout != null) {
-                    r.setLockControlTurnout(cLockTurnout);
-                    if (cLockTurnoutState != null) {
-                        if (cLockTurnoutState.equals("THROWN")) {
-                            r.setLockControlTurnoutState(Route.ONTHROWN);
-                        } else if (cLockTurnoutState.equals("CHANGE")) {
-                            r.setLockControlTurnoutState(Route.ONCHANGE);
-                        } else {
-                            r.setLockControlTurnoutState(Route.ONCLOSED);
-                        }
+            //add lock control turout if there is one
+            if (cLockTurnout != null) {
+                r.setLockControlTurnout(cLockTurnout);
+                if (cLockTurnoutState != null) {
+                    if (cLockTurnoutState.equals("THROWN")) {
+                        r.setLockControlTurnoutState(Route.ONTHROWN);
+                    } else if (cLockTurnoutState.equals("CHANGE")) {
+                        r.setLockControlTurnoutState(Route.ONCHANGE);
                     } else {
-                        log.error("cLockTurnoutState was null!");
+                        r.setLockControlTurnoutState(Route.ONCLOSED);
                     }
+                } else {
+                    log.error("cLockTurnoutState was null!");
                 }
+            }
 
-                // load output turnouts if there are any - old format first (1.7.6 and before)
-                List<Element> routeTurnoutList = routeList.get(i).getChildren("routeTurnout");
-                if (routeTurnoutList.size() > 0) {
-                    // This route has turnouts
-                    for (int k = 0; k < routeTurnoutList.size(); k++) {
-                        if (((routeTurnoutList.get(k))).getAttribute("systemName") == null) {
-                            log.warn("unexpected null in systemName " + ((routeTurnoutList.get(k)))
-                                    + " " + ((routeTurnoutList.get(k))).getAttributes());
-                            break;
-                        }
-                        String tSysName = ((routeTurnoutList.get(k)))
-                                .getAttribute("systemName").getValue();
-                        String rState = ((routeTurnoutList.get(k)))
-                                .getAttribute("state").getValue();
-                        int tSetState = Turnout.CLOSED;
-                        if (rState.equals("THROWN")) {
-                            tSetState = Turnout.THROWN;
-                        } else if (rState.equals("TOGGLE")) {
-                            tSetState = Route.TOGGLE;
-                        }
+            // load output turnouts if there are any - old format first (1.7.6 and before)
+            List<Element> routeTurnoutList = routeList.get(i).getChildren("routeTurnout");
+            if (routeTurnoutList.size() > 0) {
+                // This route has turnouts
+                for (int k = 0; k < routeTurnoutList.size(); k++) {
+                    if (((routeTurnoutList.get(k))).getAttribute("systemName") == null) {
+                        log.warn("unexpected null in systemName " + ((routeTurnoutList.get(k)))
+                                + " " + ((routeTurnoutList.get(k))).getAttributes());
+                        break;
+                    }
+                    String tSysName = ((routeTurnoutList.get(k)))
+                            .getAttribute("systemName").getValue();
+                    String rState = ((routeTurnoutList.get(k)))
+                            .getAttribute("state").getValue();
+                    int tSetState = Turnout.CLOSED;
+                    if (rState.equals("THROWN")) {
+                        tSetState = Turnout.THROWN;
+                    } else if (rState.equals("TOGGLE")) {
+                        tSetState = Route.TOGGLE;
+                    }
+                    // Add turnout to route
+                    r.addOutputTurnout(tSysName, tSetState);
+                }
+            }
+            // load output turnouts if there are any - new format
+            routeTurnoutList = routeList.get(i).getChildren("routeOutputTurnout");
+            if (routeTurnoutList.size() > 0) {
+                // This route has turnouts
+                for (int k = 0; k < routeTurnoutList.size(); k++) {
+                    if (routeTurnoutList.get(k).getAttribute("systemName") == null) {
+                        log.warn("unexpected null in systemName " + routeTurnoutList.get(k)
+                                + " " + routeTurnoutList.get(k).getAttributes());
+                        break;
+                    }
+                    String tSysName = routeTurnoutList.get(k)
+                            .getAttribute("systemName").getValue();
+                    String rState = routeTurnoutList.get(k)
+                            .getAttribute("state").getValue();
+                    int tSetState = Turnout.CLOSED;
+                    if (rState.equals("THROWN")) {
+                        tSetState = Turnout.THROWN;
+                    } else if (rState.equals("TOGGLE")) {
+                        tSetState = Route.TOGGLE;
+                    }
+                    // If the Turnout has already been added to the route and is the same as that loaded, 
+                    // we will not re add the turnout.
+                    if (!r.isOutputTurnoutIncluded(tSysName)) {
+
                         // Add turnout to route
                         r.addOutputTurnout(tSysName, tSetState);
-                    }
-                }
-                // load output turnouts if there are any - new format
-                routeTurnoutList = routeList.get(i).getChildren("routeOutputTurnout");
-                if (routeTurnoutList.size() > 0) {
-                    // This route has turnouts
-                    for (int k = 0; k < routeTurnoutList.size(); k++) {
-                        if (routeTurnoutList.get(k).getAttribute("systemName") == null) {
-                            log.warn("unexpected null in systemName " + routeTurnoutList.get(k)
-                                    + " " + routeTurnoutList.get(k).getAttributes());
-                            break;
-                        }
-                        String tSysName = routeTurnoutList.get(k)
-                                .getAttribute("systemName").getValue();
-                        String rState = routeTurnoutList.get(k)
-                                .getAttribute("state").getValue();
-                        int tSetState = Turnout.CLOSED;
-                        if (rState.equals("THROWN")) {
-                            tSetState = Turnout.THROWN;
-                        } else if (rState.equals("TOGGLE")) {
-                            tSetState = Route.TOGGLE;
-                        }
-                        // If the Turnout has already been added to the route and is the same as that loaded, 
-                        // we will not re add the turnout.
-                        if (!r.isOutputTurnoutIncluded(tSysName)) {
 
-                            // Add turnout to route
-                            r.addOutputTurnout(tSysName, tSetState);
-
-                            // determine if turnout should be locked
-                            Turnout t = r.getOutputTurnout(k);
-                            if (r.getLocked()) {
-                                t.setLocked(Turnout.CABLOCKOUT + Turnout.PUSHBUTTONLOCKOUT, true);
-                            }
+                        // determine if turnout should be locked
+                        Turnout t = r.getOutputTurnout(k);
+                        if (r.getLocked()) {
+                            t.setLocked(Turnout.CABLOCKOUT + Turnout.PUSHBUTTONLOCKOUT, true);
                         }
                     }
                 }
-                // load output sensors if there are any - new format
-                routeTurnoutList = routeList.get(i).getChildren("routeOutputSensor");
-                if (routeTurnoutList.size() > 0) {
-                    // This route has turnouts
-                    for (int k = 0; k < routeTurnoutList.size(); k++) {
-                        if (routeTurnoutList.get(k).getAttribute("systemName") == null) {
-                            log.warn("unexpected null in systemName " + routeTurnoutList.get(k)
-                                    + " " + routeTurnoutList.get(k).getAttributes());
-                            break;
-                        }
-                        String tSysName = routeTurnoutList.get(k)
-                                .getAttribute("systemName").getValue();
-                        String rState = routeTurnoutList.get(k)
-                                .getAttribute("state").getValue();
-                        int tSetState = Sensor.INACTIVE;
-                        if (rState.equals("ACTIVE")) {
-                            tSetState = Sensor.ACTIVE;
-                        } else if (rState.equals("TOGGLE")) {
-                            tSetState = Route.TOGGLE;
-                        }
-                        // If the Turnout has already been added to the route and is the same as that loaded, 
-                        // we will not re add the turnout.                        
-                        if (r.isOutputSensorIncluded(tSysName)) {
-                            break;
-                        }
-                        // Add turnout to route
-                        r.addOutputSensor(tSysName, tSetState);
-                    }
-                }
-                // load sound, script files if present
-                Element fileElement = routeList.get(i).getChild("routeSoundFile");
-                if (fileElement != null) {
-                    // convert to absolute path name
-                    r.setOutputSoundName(
-                            jmri.util.FileUtil.getExternalFilename(fileElement.getAttribute("name").getValue())
-                    );
-                }
-                fileElement = routeList.get(i).getChild("routeScriptFile");
-                if (fileElement != null) {
-                    r.setOutputScriptName(
-                            jmri.util.FileUtil.getExternalFilename(fileElement.getAttribute("name").getValue())
-                    );
-                }
-                // load turnouts aligned sensor if there is one
-                fileElement = routeList.get(i).getChild("turnoutsAlignedSensor");
-                if (fileElement != null) {
-                    r.setTurnoutsAlignedSensor(fileElement.getAttribute("name").getValue());
-                }
-
-                // load route control sensors, if there are any
-                List<Element> routeSensorList = routeList.get(i).getChildren("routeSensor");
-                if (routeSensorList.size() > 0) {
-                    // This route has sensors
-                    for (int k = 0; k < routeSensorList.size(); k++) {
-                        if (routeSensorList.get(k).getAttribute("systemName") == null) {
-                            log.warn("unexpected null in systemName " + routeSensorList.get(k)
-                                    + " " + routeSensorList.get(k).getAttributes());
-                            break;
-                        }
-                        int mode = Route.ONACTIVE;  // default mode
-                        if (routeSensorList.get(k).getAttribute("mode") != null) {
-                            String sm = routeSensorList.get(k).getAttribute("mode").getValue();
-                            if (sm.equals("onActive")) {
-                                mode = Route.ONACTIVE;
-                            } else if (sm.equals("onInactive")) {
-                                mode = Route.ONINACTIVE;
-                            } else if (sm.equals("onChange")) {
-                                mode = Route.ONCHANGE;
-                            } else if (sm.equals("vetoActive")) {
-                                mode = Route.VETOACTIVE;
-                            } else if (sm.equals("vetoInactive")) {
-                                mode = Route.VETOINACTIVE;
-                            } else {
-                                log.warn("unexpected sensor mode in route " + sysName + " was " + sm);
-                            }
-                        }
-
-                        // Add Sensor to route
-                        r.addSensorToRoute(routeSensorList.get(k)
-                                .getAttribute("systemName").getValue(), mode);
-                    }
-                }
-
-                // and start it working
-                r.activateRoute();
-
-            } else {
-                log.error("failed to create Route: " + sysName);
             }
+            // load output sensors if there are any - new format
+            routeTurnoutList = routeList.get(i).getChildren("routeOutputSensor");
+            if (routeTurnoutList.size() > 0) {
+                // This route has turnouts
+                for (int k = 0; k < routeTurnoutList.size(); k++) {
+                    if (routeTurnoutList.get(k).getAttribute("systemName") == null) {
+                        log.warn("unexpected null in systemName " + routeTurnoutList.get(k)
+                                + " " + routeTurnoutList.get(k).getAttributes());
+                        break;
+                    }
+                    String tSysName = routeTurnoutList.get(k)
+                            .getAttribute("systemName").getValue();
+                    String rState = routeTurnoutList.get(k)
+                            .getAttribute("state").getValue();
+                    int tSetState = Sensor.INACTIVE;
+                    if (rState.equals("ACTIVE")) {
+                        tSetState = Sensor.ACTIVE;
+                    } else if (rState.equals("TOGGLE")) {
+                        tSetState = Route.TOGGLE;
+                    }
+                    // If the Turnout has already been added to the route and is the same as that loaded, 
+                    // we will not re add the turnout.                        
+                    if (r.isOutputSensorIncluded(tSysName)) {
+                        break;
+                    }
+                    // Add turnout to route
+                    r.addOutputSensor(tSysName, tSetState);
+                }
+            }
+            // load sound, script files if present
+            Element fileElement = routeList.get(i).getChild("routeSoundFile");
+            if (fileElement != null) {
+                // convert to absolute path name
+                r.setOutputSoundName(
+                        jmri.util.FileUtil.getExternalFilename(fileElement.getAttribute("name").getValue())
+                );
+            }
+            fileElement = routeList.get(i).getChild("routeScriptFile");
+            if (fileElement != null) {
+                r.setOutputScriptName(
+                        jmri.util.FileUtil.getExternalFilename(fileElement.getAttribute("name").getValue())
+                );
+            }
+            // load turnouts aligned sensor if there is one
+            fileElement = routeList.get(i).getChild("turnoutsAlignedSensor");
+            if (fileElement != null) {
+                r.setTurnoutsAlignedSensor(fileElement.getAttribute("name").getValue());
+            }
+
+            // load route control sensors, if there are any
+            List<Element> routeSensorList = routeList.get(i).getChildren("routeSensor");
+            if (routeSensorList.size() > 0) {
+                // This route has sensors
+                for (int k = 0; k < routeSensorList.size(); k++) {
+                    if (routeSensorList.get(k).getAttribute("systemName") == null) {
+                        log.warn("unexpected null in systemName " + routeSensorList.get(k)
+                                + " " + routeSensorList.get(k).getAttributes());
+                        break;
+                    }
+                    int mode = Route.ONACTIVE;  // default mode
+                    if (routeSensorList.get(k).getAttribute("mode") != null) {
+                        String sm = routeSensorList.get(k).getAttribute("mode").getValue();
+                        if (sm.equals("onActive")) {
+                            mode = Route.ONACTIVE;
+                        } else if (sm.equals("onInactive")) {
+                            mode = Route.ONINACTIVE;
+                        } else if (sm.equals("onChange")) {
+                            mode = Route.ONCHANGE;
+                        } else if (sm.equals("vetoActive")) {
+                            mode = Route.VETOACTIVE;
+                        } else if (sm.equals("vetoInactive")) {
+                            mode = Route.VETOINACTIVE;
+                        } else {
+                            log.warn("unexpected sensor mode in route " + sysName + " was " + sm);
+                        }
+                    }
+
+                    // Add Sensor to route
+                    r.addSensorToRoute(routeSensorList.get(k)
+                            .getAttribute("systemName").getValue(), mode);
+                }
+            }
+
+            // and start it working
+            r.activateRoute();
         }
     }
 

--- a/java/src/jmri/managers/configurexml/DefaultSignalMastManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultSignalMastManagerXml.java
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory;
  * Handle XML configuration for a DefaultSignalMastManager objects.
  *
  * @author Bob Jacobsen Copyright: Copyright (c) 2009
- * @version $Revision$
  */
 public class DefaultSignalMastManagerXml
         extends jmri.managers.configurexml.AbstractNamedBeanManagerConfigXML {
@@ -97,14 +96,18 @@ public class DefaultSignalMastManagerXml
             if (e.getAttribute("class") == null) {
                 SignalMast m;
                 String sys = getSystemName(e);
-                m = InstanceManager.signalMastManagerInstance()
-                        .provideSignalMast(sys);
+                try {
+                    m = InstanceManager.signalMastManagerInstance()
+                            .provideSignalMast(sys);
 
-                if (getUserName(e) != null) {
-                    m.setUserName(getUserName(e));
+                    if (getUserName(e) != null) {
+                        m.setUserName(getUserName(e));
+                    }
+
+                    loadCommon(m, e);
+                } catch (IllegalArgumentException ex) {
+                    log.warn("Failed to provide SignalMast \"{}\" in load", sys);
                 }
-
-                loadCommon(m, e);
             } else {
                 String adapterName = e.getAttribute("class").getValue();
                 log.debug("load via " + adapterName);

--- a/java/test/jmri/BlockManagerTest.java
+++ b/java/test/jmri/BlockManagerTest.java
@@ -58,6 +58,13 @@ public class BlockManagerTest extends TestCase {
         Assert.assertEquals("user name 1", "", b1.getUserName());
     }
 
+    public void testProvideWorksTwice() {
+        // original create with no systemname and an empty username
+        Block b1 = InstanceManager.blockManagerInstance().provideBlock("IB12");
+        b1 = InstanceManager.blockManagerInstance().provideBlock("!!");
+        Assert.assertNotNull(b1);
+    }
+    
     public void testGet1() {
         // original create with no systemname and a username
         Block b1 = InstanceManager.blockManagerInstance().createNewBlock("UserName4");

--- a/java/test/jmri/configurexml/load/LoadMultipleSystems.xml
+++ b/java/test/jmri/configurexml/load/LoadMultipleSystems.xml
@@ -11,8 +11,8 @@
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
     </operations>
-    <turnout systemName="IT" feedback="DIRECT" inverted="false" automate="Default">
-      <systemName>IT</systemName>
+    <turnout systemName="IT0" feedback="DIRECT" inverted="false" automate="Default">
+      <systemName>IT0</systemName>
     </turnout>
     <turnout systemName="IT1" feedback="DIRECT" inverted="false" automate="Default">
       <systemName>IT1</systemName>
@@ -83,13 +83,13 @@
     <signalhead class="jmri.implementation.configurexml.LsDecSignalHeadXml" systemName="IH2" userName="LDT">
       <systemName>IH2</systemName>
       <userName>LDT</userName>
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml" systemName="IH20" userName="upper">
       <systemName>IH20</systemName>
@@ -106,20 +106,20 @@
     <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH3" aspects="2" userName="Merg">
       <systemName>IH3</systemName>
       <userName>Merg</userName>
-      <turnoutname defines="input1">IT</turnoutname>
+      <turnoutname defines="input1">IT0</turnoutname>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH4" aspects="3" userName="Merg3">
       <systemName>IH4</systemName>
       <userName>Merg3</userName>
-      <turnoutname defines="input1">IT</turnoutname>
-      <turnoutname defines="input2">IT</turnoutname>
+      <turnoutname defines="input1">IT0</turnoutname>
+      <turnoutname defines="input2">IT0</turnoutname>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH5" aspects="4" userName="Merg4">
       <systemName>IH5</systemName>
       <userName>Merg4</userName>
-      <turnoutname defines="input1">IT</turnoutname>
-      <turnoutname defines="input2">IT</turnoutname>
-      <turnoutname defines="input3">IT</turnoutname>
+      <turnoutname defines="input1">IT0</turnoutname>
+      <turnoutname defines="input2">IT0</turnoutname>
+      <turnoutname defines="input3">IT0</turnoutname>
     </signalhead> 
     <signalhead class="jmri.implementation.configurexml.QuadOutputSignalHeadXml" systemName="IH6" userName="Quad">
       <systemName>IH6</systemName>

--- a/java/test/jmri/configurexml/loadref/LoadMultipleSystems.xml
+++ b/java/test/jmri/configurexml/loadref/LoadMultipleSystems.xml
@@ -36,8 +36,8 @@
     </operations>
     <defaultclosedspeed>Normal</defaultclosedspeed>
     <defaultthrownspeed>Restricted</defaultthrownspeed>
-    <turnout systemName="IT" feedback="DIRECT" inverted="false" automate="Default">
-      <systemName>IT</systemName>
+    <turnout systemName="IT0" feedback="DIRECT" inverted="false" automate="Default">
+      <systemName>IT0</systemName>
     </turnout>
     <turnout systemName="IT1" feedback="DIRECT" inverted="false" automate="Default">
       <systemName>IT1</systemName>
@@ -139,13 +139,13 @@
     <signalhead class="jmri.implementation.configurexml.LsDecSignalHeadXml" systemName="IH2" userName="LDT">
       <systemName>IH2</systemName>
       <userName>LDT</userName>
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml" systemName="IH20" userName="upper">
       <systemName>IH20</systemName>
@@ -162,20 +162,20 @@
     <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH3" aspects="2" userName="Merg">
       <systemName>IH3</systemName>
       <userName>Merg</userName>
-      <turnoutname defines="input1">IT</turnoutname>
+      <turnoutname defines="input1">IT0</turnoutname>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH4" aspects="3" userName="Merg3">
       <systemName>IH4</systemName>
       <userName>Merg3</userName>
-      <turnoutname defines="input1">IT</turnoutname>
-      <turnoutname defines="input2">IT</turnoutname>
+      <turnoutname defines="input1">IT0</turnoutname>
+      <turnoutname defines="input2">IT0</turnoutname>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH5" aspects="4" userName="Merg4">
       <systemName>IH5</systemName>
       <userName>Merg4</userName>
-      <turnoutname defines="input1">IT</turnoutname>
-      <turnoutname defines="input2">IT</turnoutname>
-      <turnoutname defines="input3">IT</turnoutname>
+      <turnoutname defines="input1">IT0</turnoutname>
+      <turnoutname defines="input2">IT0</turnoutname>
+      <turnoutname defines="input3">IT0</turnoutname>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.QuadOutputSignalHeadXml" systemName="IH6" userName="Quad">
       <systemName>IH6</systemName>

--- a/java/test/jmri/jmrit/display/configurexml/load/OneOfEach.3.3.3.xml
+++ b/java/test/jmri/jmrit/display/configurexml/load/OneOfEach.3.3.3.xml
@@ -33,9 +33,6 @@
     </operations>
     <defaultclosedspeed>Normal</defaultclosedspeed>
     <defaultthrownspeed>Restricted</defaultthrownspeed>
-    <turnout systemName="IT" feedback="DIRECT" inverted="false" automate="Default">
-      <systemName>IT</systemName>
-    </turnout>
     <turnout systemName="IT0" feedback="DIRECT" inverted="false" automate="Default">
       <systemName>IT0</systemName>
     </turnout>
@@ -68,6 +65,9 @@
     </turnout>
     <turnout systemName="IT9" feedback="DIRECT" inverted="false" automate="Default">
       <systemName>IT9</systemName>
+    </turnout>
+    <turnout systemName="IT99" feedback="DIRECT" inverted="false" automate="Default">
+      <systemName>IT99</systemName>
     </turnout>
   </turnouts>
   <lights class="jmri.managers.configurexml.InternalLightManagerXml">

--- a/java/test/jmri/jmrit/display/configurexml/load/OneOfEach.xml
+++ b/java/test/jmri/jmrit/display/configurexml/load/OneOfEach.xml
@@ -11,8 +11,8 @@
     <operations automate="false">
       <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
     </operations>
-    <turnout systemName="IT" feedback="DIRECT" inverted="false" automate="Default">
-      <systemName>IT</systemName>
+    <turnout systemName="IT0" feedback="DIRECT" inverted="false" automate="Default">
+      <systemName>IT0</systemName>
     </turnout>
     <turnout systemName="IT1" feedback="DIRECT" inverted="false" automate="Default">
       <systemName>IT1</systemName>
@@ -83,13 +83,13 @@
     <signalhead class="jmri.implementation.configurexml.LsDecSignalHeadXml" systemName="IH2" userName="LDT">
       <systemName>IH2</systemName>
       <userName>LDT</userName>
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml" systemName="IH20" userName="upper">
       <systemName>IH20</systemName>
@@ -106,20 +106,20 @@
     <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH3" aspects="2" userName="Merg">
       <systemName>IH3</systemName>
       <userName>Merg</userName>
-      <turnoutname defines="input1">IT</turnoutname>
+      <turnoutname defines="input1">IT0</turnoutname>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH4" aspects="3" userName="Merg3">
       <systemName>IH4</systemName>
       <userName>Merg3</userName>
-      <turnoutname defines="input1">IT</turnoutname>
-      <turnoutname defines="input2">IT</turnoutname>
+      <turnoutname defines="input1">IT0</turnoutname>
+      <turnoutname defines="input2">IT0</turnoutname>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH5" aspects="4" userName="Merg4">
       <systemName>IH5</systemName>
       <userName>Merg4</userName>
-      <turnoutname defines="input1">IT</turnoutname>
-      <turnoutname defines="input2">IT</turnoutname>
-      <turnoutname defines="input3">IT</turnoutname>
+      <turnoutname defines="input1">IT0</turnoutname>
+      <turnoutname defines="input2">IT0</turnoutname>
+      <turnoutname defines="input3">IT0</turnoutname>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.QuadOutputSignalHeadXml" systemName="IH6" userName="Quad">
       <systemName>IH6</systemName>

--- a/java/test/jmri/jmrit/display/configurexml/loadref/OneOfEach.3.3.3.xml
+++ b/java/test/jmri/jmrit/display/configurexml/loadref/OneOfEach.3.3.3.xml
@@ -36,9 +36,6 @@
     </operations>
     <defaultclosedspeed>Normal</defaultclosedspeed>
     <defaultthrownspeed>Restricted</defaultthrownspeed>
-    <turnout systemName="IT" feedback="DIRECT" inverted="false" automate="Default">
-      <systemName>IT</systemName>
-    </turnout>
     <turnout systemName="IT0" feedback="DIRECT" inverted="false" automate="Default">
       <systemName>IT0</systemName>
     </turnout>
@@ -71,6 +68,9 @@
     </turnout>
     <turnout systemName="IT9" feedback="DIRECT" inverted="false" automate="Default">
       <systemName>IT9</systemName>
+    </turnout>
+    <turnout systemName="IT99" feedback="DIRECT" inverted="false" automate="Default">
+      <systemName>IT99</systemName>
     </turnout>
   </turnouts>
   <lights class="jmri.jmrix.internal.configurexml.InternalLightManagerXml">

--- a/java/test/jmri/jmrit/display/configurexml/loadref/OneOfEach.xml
+++ b/java/test/jmri/jmrit/display/configurexml/loadref/OneOfEach.xml
@@ -36,8 +36,8 @@
     </operations>
     <defaultclosedspeed>Normal</defaultclosedspeed>
     <defaultthrownspeed>Restricted</defaultthrownspeed>
-    <turnout systemName="IT" feedback="DIRECT" inverted="false" automate="Default">
-      <systemName>IT</systemName>
+    <turnout systemName="IT0" feedback="DIRECT" inverted="false" automate="Default">
+      <systemName>IT0</systemName>
     </turnout>
     <turnout systemName="IT1" feedback="DIRECT" inverted="false" automate="Default">
       <systemName>IT1</systemName>
@@ -139,13 +139,13 @@
     <signalhead class="jmri.implementation.configurexml.LsDecSignalHeadXml" systemName="IH2" userName="LDT">
       <systemName>IH2</systemName>
       <userName>LDT</userName>
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
-      <turnout systemName="IT" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
+      <turnout systemName="IT0" state="CLOSED" />
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml" systemName="IH20" userName="upper">
       <systemName>IH20</systemName>
@@ -162,20 +162,20 @@
     <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH3" aspects="2" userName="Merg">
       <systemName>IH3</systemName>
       <userName>Merg</userName>
-      <turnoutname defines="input1">IT</turnoutname>
+      <turnoutname defines="input1">IT0</turnoutname>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH4" aspects="3" userName="Merg3">
       <systemName>IH4</systemName>
       <userName>Merg3</userName>
-      <turnoutname defines="input1">IT</turnoutname>
-      <turnoutname defines="input2">IT</turnoutname>
+      <turnoutname defines="input1">IT0</turnoutname>
+      <turnoutname defines="input2">IT0</turnoutname>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH5" aspects="4" userName="Merg4">
       <systemName>IH5</systemName>
       <userName>Merg4</userName>
-      <turnoutname defines="input1">IT</turnoutname>
-      <turnoutname defines="input2">IT</turnoutname>
-      <turnoutname defines="input3">IT</turnoutname>
+      <turnoutname defines="input1">IT0</turnoutname>
+      <turnoutname defines="input2">IT0</turnoutname>
+      <turnoutname defines="input3">IT0</turnoutname>
     </signalhead>
     <signalhead class="jmri.implementation.configurexml.QuadOutputSignalHeadXml" systemName="IH6" userName="Quad">
       <systemName>IH6</systemName>

--- a/java/test/jmri/jmrit/display/configurexml/verify/OneOfEach.3.3.3.xml
+++ b/java/test/jmri/jmrit/display/configurexml/verify/OneOfEach.3.3.3.xml
@@ -33,9 +33,6 @@
         </operations>
         <defaultclosedspeed>Normal</defaultclosedspeed>
         <defaultthrownspeed>Restricted</defaultthrownspeed>
-        <turnout systemName="IT" feedback="DIRECT" inverted="false" automate="Default">
-            <systemName>IT</systemName>
-        </turnout>
         <turnout systemName="IT0" feedback="DIRECT" inverted="false" automate="Default">
             <systemName>IT0</systemName>
         </turnout>
@@ -68,6 +65,9 @@
         </turnout>
         <turnout systemName="IT9" feedback="DIRECT" inverted="false" automate="Default">
             <systemName>IT9</systemName>
+        </turnout>
+        <turnout systemName="IT99" feedback="DIRECT" inverted="false" automate="Default">
+            <systemName>IT99</systemName>
         </turnout>
     </turnouts>
     <lights class="jmri.managers.configurexml.InternalLightManagerXml">

--- a/java/test/jmri/jmrit/display/configurexml/verify/OneOfEach.xml
+++ b/java/test/jmri/jmrit/display/configurexml/verify/OneOfEach.xml
@@ -11,8 +11,8 @@
         <operations automate="false">
             <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
         </operations>
-        <turnout systemName="IT" feedback="DIRECT" inverted="false" automate="Default">
-            <systemName>IT</systemName>
+        <turnout systemName="IT0" feedback="DIRECT" inverted="false" automate="Default">
+            <systemName>IT0</systemName>
         </turnout>
         <turnout systemName="IT1" feedback="DIRECT" inverted="false" automate="Default">
             <systemName>IT1</systemName>
@@ -83,13 +83,13 @@
         <signalhead class="jmri.implementation.configurexml.LsDecSignalHeadXml" systemName="IH2" userName="LDT">
             <systemName>IH2</systemName>
             <userName>LDT</userName>
-            <turnout systemName="IT" state="CLOSED" />
-            <turnout systemName="IT" state="CLOSED" />
-            <turnout systemName="IT" state="CLOSED" />
-            <turnout systemName="IT" state="CLOSED" />
-            <turnout systemName="IT" state="CLOSED" />
-            <turnout systemName="IT" state="CLOSED" />
-            <turnout systemName="IT" state="CLOSED" />
+            <turnout systemName="IT0" state="CLOSED" />
+            <turnout systemName="IT0" state="CLOSED" />
+            <turnout systemName="IT0" state="CLOSED" />
+            <turnout systemName="IT0" state="CLOSED" />
+            <turnout systemName="IT0" state="CLOSED" />
+            <turnout systemName="IT0" state="CLOSED" />
+            <turnout systemName="IT0" state="CLOSED" />
         </signalhead>
         <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml" systemName="IH20" userName="upper">
             <systemName>IH20</systemName>
@@ -106,20 +106,20 @@
         <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH3" aspects="2" userName="Merg">
             <systemName>IH3</systemName>
             <userName>Merg</userName>
-            <turnoutname defines="input1">IT</turnoutname>
+            <turnoutname defines="input1">IT0</turnoutname>
         </signalhead>
         <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH4" aspects="3" userName="Merg3">
             <systemName>IH4</systemName>
             <userName>Merg3</userName>
-            <turnoutname defines="input1">IT</turnoutname>
-            <turnoutname defines="input2">IT</turnoutname>
+            <turnoutname defines="input1">IT0</turnoutname>
+            <turnoutname defines="input2">IT0</turnoutname>
         </signalhead>
         <signalhead class="jmri.implementation.configurexml.MergSD2SignalHeadXml" systemName="IH5" aspects="4" userName="Merg4">
             <systemName>IH5</systemName>
             <userName>Merg4</userName>
-            <turnoutname defines="input1">IT</turnoutname>
-            <turnoutname defines="input2">IT</turnoutname>
-            <turnoutname defines="input3">IT</turnoutname>
+            <turnoutname defines="input1">IT0</turnoutname>
+            <turnoutname defines="input2">IT0</turnoutname>
+            <turnoutname defines="input3">IT0</turnoutname>
         </signalhead>
         <signalhead class="jmri.implementation.configurexml.QuadOutputSignalHeadXml" systemName="IH6" userName="Quad">
             <systemName>IH6</systemName>

--- a/java/test/jmri/jmrit/logix/OBlockManagerTest.java
+++ b/java/test/jmri/jmrit/logix/OBlockManagerTest.java
@@ -1,0 +1,77 @@
+package jmri.jmrit.logix;
+
+import jmri.*;
+
+import junit.framework.Assert;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Tests for the OBlockManager class
+ * <P>
+ * @author Bob Coleman Copyright 2012
+ * @author Bob Jacobsen Copyright 2014
+ */
+public class OBlockManagerTest extends TestCase {
+
+    OBlockManager l;
+    
+    public void testProvide() {
+        // original create with systemname
+        OBlock b1 = l.provideOBlock("OB101");
+        Assert.assertNotNull(b1);
+        Assert.assertEquals("system name", "OB101", b1.getSystemName());
+    }
+
+    public void testProvideWorksTwice() {
+        Block b1 = l.provideOBlock("OB102");
+        Block b2 = l.provideOBlock("OB102");
+        Assert.assertNotNull(b1);
+        Assert.assertNotNull(b2);
+        Assert.assertEquals(b1, b2);
+    }
+
+    public void testProvideFailure() {
+        boolean correct = false;
+        try {
+            OBlock t = l.provideOBlock("");
+            Assert.fail("didn't throw");
+        } catch (IllegalArgumentException ex) {
+            correct = true;
+        }
+        Assert.assertTrue("Exception thrown properly", correct);
+        
+    }
+
+    // from here down is testing infrastructure
+    public OBlockManagerTest(String s) {
+        super(s);
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {OBlockManagerTest.class.getName()};
+        junit.textui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        TestSuite suite = new TestSuite(OBlockManagerTest.class);
+        return suite;
+    }
+
+    // The minimal setup for log4J
+    @Override
+    protected void setUp() throws Exception {
+        apps.tests.Log4JFixture.setUp();
+        super.setUp();
+        jmri.util.JUnitUtil.resetInstanceManager();
+        l = new OBlockManager();
+    }
+
+    @Override
+    protected void tearDown() {
+        apps.tests.Log4JFixture.tearDown();
+    }
+}

--- a/java/test/jmri/jmrit/logix/PackageTest.java
+++ b/java/test/jmri/jmrit/logix/PackageTest.java
@@ -30,6 +30,7 @@ public class PackageTest extends TestCase {
 //		Something wrong in the xsd files?  maybe using -2-9-6 version?
         suite.addTest(SchemaTest.suite());
         suite.addTest(OBlockTest.suite());
+        suite.addTest(OBlockManagerTest.suite());
         suite.addTest(OPathTest.suite());
         suite.addTest(WarrantTest.suite());
         suite.addTest(LogixActionTest.suite());

--- a/java/test/jmri/jmrix/acela/AcelaTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/acela/AcelaTurnoutManagerTest.java
@@ -66,8 +66,15 @@ public class AcelaTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTes
 
     AcelaNode a0, a1, a2, a3;
 
-    // The minimal setup for log4J
-    protected void setUp() {
+    @Override
+    protected void tearDown() throws Exception {
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         apps.tests.Log4JFixture.setUp();
 
         // We need to delete the nodes so we can re-allocate them
@@ -104,11 +111,6 @@ public class AcelaTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTes
         // create and register the manager object
         l = new AcelaTurnoutManager();
         jmri.InstanceManager.setTurnoutManager(l);
-    }
-
-    @Override
-    protected void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
     }
 
     private final static Logger log = LoggerFactory.getLogger(AcelaTurnoutManagerTest.class.getName());

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutManagerTest.java
@@ -15,8 +15,15 @@ import org.slf4j.LoggerFactory;
  */
 public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
 
+    protected void tearDown() throws Exception {
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
     @Override
-    public void setUp() {
+    public void setUp() throws Exception {
+        super.setUp();
+        apps.tests.Log4JFixture.setUp();
         // replace the SerialTrafficController
         SerialTrafficController t = new SerialTrafficController() {
             SerialTrafficController test() {

--- a/java/test/jmri/jmrix/dcc/DccTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/dcc/DccTurnoutManagerTest.java
@@ -16,7 +16,16 @@ import org.slf4j.LoggerFactory;
 
 public class DccTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
 
-    public void setUp() {
+    @Override
+    protected void tearDown() throws Exception {
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        apps.tests.Log4JFixture.setUp();
         // create and register the manager object
         l = new DccTurnoutManager();
         jmri.InstanceManager.setTurnoutManager(l);

--- a/java/test/jmri/jmrix/easydcc/EasyDccTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccTurnoutManagerTest.java
@@ -16,7 +16,16 @@ import org.slf4j.LoggerFactory;
 
 public class EasyDccTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
 
-    public void setUp() {
+    @Override
+    protected void tearDown() throws Exception {
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        apps.tests.Log4JFixture.setUp();
         // create and register the manager object
         l = new EasyDccTurnoutManager();
         jmri.InstanceManager.setTurnoutManager(l);

--- a/java/test/jmri/jmrix/lenz/XNetTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetTurnoutManagerTest.java
@@ -111,8 +111,16 @@ public class XNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         return suite;
     }
 
-    // The minimal setup for log4J
-    protected void setUp() {
+    @Override
+    protected void tearDown() throws Exception {
+        jmri.util.JUnitUtil.resetInstanceManager();
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         apps.tests.Log4JFixture.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         // prepare an interface, register
@@ -120,11 +128,6 @@ public class XNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         // create and register the manager object
         l = new XNetTurnoutManager(lnis, "X");
         jmri.InstanceManager.setTurnoutManager(l);
-    }
-
-    protected void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
-        jmri.util.JUnitUtil.resetInstanceManager();
     }
 
     private final static Logger log = LoggerFactory.getLogger(XNetTurnoutManagerTest.class.getName());

--- a/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetTurnoutManagerTest.java
@@ -112,18 +112,21 @@ public class EliteXNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutMg
         return suite;
     }
 
-    // The minimal setup for log4J
-    protected void setUp() {
+    @Override
+    protected void tearDown() throws Exception {
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         apps.tests.Log4JFixture.setUp();
         // prepare an interface, register
         lnis = new XNetInterfaceScaffold(new HornbyEliteCommandStation());
         // create and register the manager object
         l = new EliteXNetTurnoutManager(lnis, "X");
         jmri.InstanceManager.setTurnoutManager(l);
-    }
-
-    protected void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
     }
 
     private final static Logger log = LoggerFactory.getLogger(EliteXNetTurnoutManagerTest.class.getName());

--- a/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
@@ -24,7 +24,16 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
 
     LocoNetInterfaceScaffold lnis;
 
-    public void setUp() {
+    @Override
+    protected void tearDown() throws Exception {
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        apps.tests.Log4JFixture.setUp();
         // prepare an interface, register
         lnis = new LocoNetInterfaceScaffold();
         // create and register the manager object

--- a/java/test/jmri/jmrix/maple/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/maple/SerialTurnoutManagerTest.java
@@ -15,7 +15,15 @@ import org.slf4j.LoggerFactory;
  */
 public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
 
-    public void setUp() {
+    protected void tearDown() throws Exception {
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        apps.tests.Log4JFixture.setUp();
         // replace the SerialTrafficController
         SerialTrafficController t = new SerialTrafficController() {
             SerialTrafficController test() {

--- a/java/test/jmri/jmrix/nce/NceTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/nce/NceTurnoutManagerTest.java
@@ -17,7 +17,16 @@ public class NceTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest 
 
     private NceInterfaceScaffold nis = null;
 
-    public void setUp() {
+    @Override
+    protected void tearDown() throws Exception {
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        apps.tests.Log4JFixture.setUp();
         // prepare an interface, register
         nis = new NceInterfaceScaffold();
         // create and register the manager object

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetTurnoutManagerTest.java
@@ -113,18 +113,22 @@ public class Z21XNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrT
         return suite;
     }
 
-    // The minimal setup for log4J
-    protected void setUp() {
+    @Override
+    protected void tearDown() throws Exception {
+        jmri.util.JUnitUtil.resetInstanceManager();
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         apps.tests.Log4JFixture.setUp();
         // prepare an interface, register
         lnis = new XNetInterfaceScaffold(new RocoZ21CommandStation());
         // create and register the manager object
         l = new Z21XNetTurnoutManager(lnis, "X");
         jmri.InstanceManager.setTurnoutManager(l);
-    }
-
-    protected void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
     }
 
     private final static Logger log = LoggerFactory.getLogger(Z21XNetTurnoutManagerTest.class.getName());

--- a/java/test/jmri/jmrix/tmcc/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/tmcc/SerialTurnoutManagerTest.java
@@ -15,7 +15,15 @@ import org.slf4j.LoggerFactory;
  */
 public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
 
-    public void setUp() {
+    protected void tearDown() throws Exception {
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        apps.tests.Log4JFixture.setUp();
         // create and register the manager object
         l = new SerialTurnoutManager();
         jmri.InstanceManager.setTurnoutManager(l);

--- a/java/test/jmri/managers/AbstractLightMgrTest.java
+++ b/java/test/jmri/managers/AbstractLightMgrTest.java
@@ -68,6 +68,17 @@ public abstract class AbstractLightMgrTest extends TestCase {
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
+    public void testProvideFailure() {
+        boolean correct = false;
+        try {
+            Light t = l.provideLight("");
+            Assert.fail("didn't throw");
+        } catch (IllegalArgumentException ex) {
+            correct = true;
+        }
+        Assert.assertTrue("Exception thrown properly", correct);        
+    }
+    
     public void testSingleObject() {
         // test that you always get the same representation
         Light t1 = l.newLight(getSystemName(getNumToTest1()), "mine");

--- a/java/test/jmri/managers/AbstractReporterMgrTest.java
+++ b/java/test/jmri/managers/AbstractReporterMgrTest.java
@@ -64,6 +64,17 @@ public abstract class AbstractReporterMgrTest extends TestCase {
         Assert.assertTrue("provided same object ", t == t2);
     }
 
+    public void testProvideFailure() {
+        boolean correct = false;
+        try {
+            Reporter t = l.provideReporter("..");
+            Assert.fail("didn't throw");
+        } catch (IllegalArgumentException ex) {
+            correct = true;
+        }
+        Assert.assertTrue("Exception thrown properly", correct);        
+    }
+
     public void testReporterGetBySystemName() {
         // Try a successful one -- the one that was added in testReporterProvideReporter()
         Reporter t = l.getBySystemName(getSystemName(getNumToTest1()));

--- a/java/test/jmri/managers/AbstractSensorMgrTest.java
+++ b/java/test/jmri/managers/AbstractSensorMgrTest.java
@@ -68,6 +68,18 @@ public abstract class AbstractSensorMgrTest extends TestCase {
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
+    public void testProvideFailure() {
+        boolean correct = false;
+        try {
+            Sensor t = l.provideSensor("");
+            Assert.fail("didn't throw");
+        } catch (IllegalArgumentException ex) {
+            correct = true;
+        }
+        Assert.assertTrue("Exception thrown properly", correct);  
+        jmri.util.JUnitAppender.assertWarnMessage("Invalid system name for sensor: IS needed IS");      
+    }
+
     public void testSingleObject() {
         // test that you always get the same representation
         Sensor t1 = l.newSensor(getSystemName(getNumToTest1()), "mine");

--- a/java/test/jmri/managers/AbstractTurnoutMgrTest.java
+++ b/java/test/jmri/managers/AbstractTurnoutMgrTest.java
@@ -1,17 +1,3 @@
-/**
- * AbstractTurnoutMgrTest.java
- *
- * Description:	AbsBaseClass for TurnoutManager tests in specific jmrix.
- * packages
- *
- * @author	Bob Jacobsen
- * @version
- */
-/**
- * This is not itself a test class, e.g. should not be added to a suite.
- * Instead, this forms the base for test classes, including providing some
- * common tests
- */
 package jmri.managers;
 
 import java.beans.PropertyChangeListener;
@@ -20,13 +6,25 @@ import jmri.TurnoutManager;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 
+/**
+ * Base for TurnoutManager tests in specific jmrix.packages
+ * <p>
+ * This is not itself a test class, e.g. should not be added to a suite.
+ * Instead, this forms the base for test classes, including providing some
+ * common tests
+ *
+ * @author	Bob Jacobsen
+ */
 public abstract class AbstractTurnoutMgrTest extends TestCase {
 
-    // implementing classes must provide these abstract members:
-    //
-    abstract protected void setUp();    	// load t with actual object; create scaffolds as needed
-
+    // implementing classes must implement to convert integer (count) to a system name
     abstract public String getSystemName(int i);
+
+    /**
+     * Overload to load t with actual object; create scaffolds as needed
+     */
+    @javax.annotation.OverridingMethodsMustInvokeSuper
+    protected void setUp() throws Exception { super.setUp(); }    	
 
     public AbstractTurnoutMgrTest(String s) {
         super(s);
@@ -54,6 +52,18 @@ public abstract class AbstractTurnoutMgrTest extends TestCase {
         }
     }
 
+    public void testProvideFailure() {
+        boolean correct = false;
+        try {
+            Turnout t = l.provideTurnout("");
+            Assert.fail("didn't throw");
+        } catch (IllegalArgumentException ex) {
+            correct = true;
+        }
+        Assert.assertTrue("Exception thrown properly", correct);
+        jmri.util.JUnitAppender.assertErrorMessage("Invalid system name for turnout: "+l.getSystemPrefix()+l.typeLetter()+" needed "+l.getSystemPrefix()+l.typeLetter());
+    }
+    
     public void testTurnoutPutGet() {
         // create
         Turnout t = l.newTurnout(getSystemName(getNumToTest1()), "mine");

--- a/java/test/jmri/managers/InternalLightManagerTest.java
+++ b/java/test/jmri/managers/InternalLightManagerTest.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Tests for the jmri.managers.InternalTurnoutManager class.
+ * Tests for the jmri.managers.InternalLightManager class.
  *
  * @author	Bob Jacobsen Copyright 2009
  */

--- a/java/test/jmri/managers/InternalSensorManagerTest.java
+++ b/java/test/jmri/managers/InternalSensorManagerTest.java
@@ -23,7 +23,7 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
 
         // ask for a Sensor, and check type
         SensorManager lm = jmri.InstanceManager.sensorManagerInstance();
-
+        
         Sensor tl = lm.newSensor("IS21", "my name");
 
         if (log.isDebugEnabled()) {

--- a/java/test/jmri/managers/ProxyLightManagerTest.java
+++ b/java/test/jmri/managers/ProxyLightManagerTest.java
@@ -53,6 +53,18 @@ public class ProxyLightManagerTest extends TestCase {
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
+    public void testProvideFailure() {
+        boolean correct = false;
+        try {
+            Light t = l.provideLight("");
+            Assert.fail("didn't throw");
+        } catch (IllegalArgumentException ex) {
+            correct = true;
+        }
+        Assert.assertTrue("Exception thrown properly", correct);
+        
+    }
+
     public void testSingleObject() {
         // test that you always get the same representation
         Light t1 = l.newLight(getSystemName(getNumToTest1()), "mine");

--- a/java/test/jmri/managers/ProxyReporterManagerTest.java
+++ b/java/test/jmri/managers/ProxyReporterManagerTest.java
@@ -56,6 +56,18 @@ public class ProxyReporterManagerTest extends TestCase {
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest3())));
     }
 
+    public void testProvideFailure() {
+        boolean correct = false;
+        try {
+            Reporter t = l.provideReporter("");
+            Assert.fail("didn't throw");
+        } catch (IllegalArgumentException ex) {
+            correct = true;
+        }
+        Assert.assertTrue("Exception thrown properly", correct);
+        
+    }
+
     public void testSingleObject() {
         // test that you always get the same representation
         Reporter t1 = l.newReporter(getSystemName(getNumToTest1()), "mine");

--- a/java/test/jmri/managers/ProxySensorManagerTest.java
+++ b/java/test/jmri/managers/ProxySensorManagerTest.java
@@ -53,6 +53,17 @@ public class ProxySensorManagerTest extends TestCase {
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
+    public void testProvideFailure() {
+        boolean correct = false;
+        try {
+            Sensor t = l.provideSensor("");
+            Assert.fail("didn't throw");
+        } catch (IllegalArgumentException ex) {
+            correct = true;
+        }
+        Assert.assertTrue("Exception thrown properly", correct);
+        
+    }
     public void testSingleObject() {
         // test that you always get the same representation
         Sensor t1 = l.newSensor(getSystemName(getNumToTest1()), "mine");

--- a/java/test/jmri/managers/ProxyTurnoutManagerTest.java
+++ b/java/test/jmri/managers/ProxyTurnoutManagerTest.java
@@ -53,6 +53,18 @@ public class ProxyTurnoutManagerTest extends TestCase {
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
+    public void testProvideFailure() {
+        boolean correct = false;
+        try {
+            Turnout t = l.provideTurnout("");
+            Assert.fail("didn't throw");
+        } catch (IllegalArgumentException ex) {
+            correct = true;
+        }
+        Assert.assertTrue("Exception thrown properly", correct);
+        jmri.util.JUnitAppender.assertErrorMessage("Invalid system name for turnout: JT needed JT");
+    }
+
     public void testSingleObject() {
         // test that you always get the same representation
         Turnout t1 = l.newTurnout(getSystemName(getNumToTest1()), "mine");


### PR DESCRIPTION
(Note: This is a continuation of PR #1554)

Systematically go through the code that references the `provideFoo` method in each `FooManager`, converting all tests for `null` returns (which no longer happen) into try/catch for IllegalArgumentException.

After this, the next step is to use FindBugs and CheckerFramework to find places additional places where the return isn't being properly handled.

This runs JUnit tests fine, but it's possible that something subtle was broken, particularly in the large classes in `jmrit.logix` and `display.layoutEditor`. If you do have trouble reading an existing file, please open a new issue and upload the file.  Thanks.
