### PR TITLE
Document why exception is thrown.

### DIFF
--- a/java/src/jmri/jmrit/operations/trains/excel/TrainCustomManifest.java
+++ b/java/src/jmri/jmrit/operations/trains/excel/TrainCustomManifest.java
@@ -157,7 +157,7 @@ public class TrainCustomManifest {
      * 
      * @return true if process completes without a timeout, false if there's a
      *         timeout.
-     * @throws InterruptedException
+     * @throws InterruptedException if process thread is interrupted
      */
     public static boolean waitForProcessToComplete() throws InterruptedException {
         boolean status;


### PR DESCRIPTION
Addresses Java and JavaDoc warnings in [Jenkins](http://jmri.tagadab.com/jenkins/job/Development/job/Builds/553/)