### PR TITLE
Finish deprecation of Programmer#confirmCV(int ..)

### DIFF
--- a/help/en/html/apps/DecoderPro/Programmer.shtml
+++ b/help/en/html/apps/DecoderPro/Programmer.shtml
@@ -238,7 +238,7 @@ list is remade each time you open a new programmer window.
 </dl>
 
 <a name="id">
-<h3>How variables in a decoder file match up with the programmer file</h3></a>
+</a><h3>How variables in a decoder file match up with the programmer file</h3>
 
 Each decoder file defines 
 <a href="CreateDecoder.shtml#variable">variables</a> that describe specific controls within the

--- a/java/src/jmri/implementation/AddressedHighCvProgrammerFacade.java
+++ b/java/src/jmri/implementation/AddressedHighCvProgrammerFacade.java
@@ -76,11 +76,6 @@ public class AddressedHighCvProgrammerFacade extends AbstractProgrammerFacade im
     }
 
     @Override
-    public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
-        confirmCV("" + CV, val, p);
-    }
-
-    @Override
     public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }

--- a/java/src/jmri/implementation/OffsetHighCvProgrammerFacade.java
+++ b/java/src/jmri/implementation/OffsetHighCvProgrammerFacade.java
@@ -77,11 +77,6 @@ public class OffsetHighCvProgrammerFacade extends AbstractProgrammerFacade imple
     }
 
     @Override
-    public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
-        confirmCV("" + CV, val, p);
-    }
-
-    @Override
     public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }

--- a/java/src/jmri/implementation/ResettingOffsetHighCvProgrammerFacade.java
+++ b/java/src/jmri/implementation/ResettingOffsetHighCvProgrammerFacade.java
@@ -83,11 +83,6 @@ public class ResettingOffsetHighCvProgrammerFacade extends AbstractProgrammerFac
     }
 
     @Override
-    public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
-        confirmCV("" + CV, val, p);
-    }
-
-    @Override
     public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }

--- a/java/src/jmri/jmrix/AbstractProgrammer.java
+++ b/java/src/jmri/jmrix/AbstractProgrammer.java
@@ -101,8 +101,10 @@ public abstract class AbstractProgrammer implements Programmer {
         readCV(Integer.parseInt(CV), p);
     }
 
-    public void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
-        confirmCV(Integer.parseInt(CV), val, p);
+    @Override
+    @SuppressWarnings("deprecation") // parent Programmer method deprecated, will remove at same time
+    public final void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+        confirmCV(""+CV, val, p);
     }
 
     /**

--- a/java/src/jmri/jmrix/AbstractProgrammerFacade.java
+++ b/java/src/jmri/jmrix/AbstractProgrammerFacade.java
@@ -57,8 +57,9 @@ public abstract class AbstractProgrammerFacade implements Programmer {
     }
 
     @Override
-    public void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
-        prog.confirmCV(CV, val, p);
+    @SuppressWarnings("deprecation") // parent Programmer method deprecated, will remove at same time
+    public final void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+        confirmCV("" + CV, val, p);
     }
 
     @Override

--- a/java/src/jmri/jmrix/can/cbus/CbusDccOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusDccOpsModeProgrammer.java
@@ -35,6 +35,7 @@ public class CbusDccOpsModeProgrammer extends CbusDccProgrammer implements Addre
     /**
      * Forward a write request to an ops-mode write operation
      */
+    @Override
     synchronized public void writeCV(int CV, int val, ProgListener p) throws ProgrammerException {
         log.debug("ops mode write CV=" + CV + " val=" + val);
 
@@ -50,6 +51,7 @@ public class CbusDccOpsModeProgrammer extends CbusDccProgrammer implements Addre
         notifyProgListenerEnd(_val, jmri.ProgListener.OK);
     }
 
+    @Override
     synchronized public void readCV(int CV, ProgListener p) throws ProgrammerException {
         if (log.isDebugEnabled()) {
             log.debug("read CV=" + CV);
@@ -58,7 +60,8 @@ public class CbusDccOpsModeProgrammer extends CbusDccProgrammer implements Addre
         throw new ProgrammerException();
     }
 
-    synchronized public void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+    @Override
+    synchronized public void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
         if (log.isDebugEnabled()) {
             log.debug("confirm CV=" + CV);
         }

--- a/java/src/jmri/jmrix/can/cbus/CbusDccProgrammer.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusDccProgrammer.java
@@ -74,7 +74,7 @@ public class CbusDccProgrammer extends AbstractProgrammer implements CanListener
     }
 
     @Override
-    synchronized public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    synchronized public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 

--- a/java/src/jmri/jmrix/can/cbus/CbusProgrammer.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusProgrammer.java
@@ -57,6 +57,7 @@ public class CbusProgrammer extends AbstractProgrammer implements CanListener, A
     int operationVariableNumber; // remember the variable number being read/written
 
     // programming interface
+    @Override
     synchronized public void writeCV(int varnum, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         if (log.isDebugEnabled()) {
             log.debug("write " + varnum + " listens " + p);
@@ -78,10 +79,12 @@ public class CbusProgrammer extends AbstractProgrammer implements CanListener, A
         notifyProgListenerEnd(operationValue, jmri.ProgListener.OK);
     }
 
-    synchronized public void confirmCV(int varnum, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    @Override
+    synchronized public void confirmCV(String varnum, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(varnum, p);
     }
 
+    @Override
     synchronized public void readCV(int varnum, jmri.ProgListener p) throws jmri.ProgrammerException {
         if (log.isDebugEnabled()) {
             log.debug("readCV " + varnum + " listens " + p);

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcOpsModeProgrammer.java
@@ -1,4 +1,3 @@
-/* Dcc4PcOpsModeProgrammer.java */
 package jmri.jmrix.dcc4pc;
 
 import java.beans.PropertyChangeListener;
@@ -18,7 +17,6 @@ import org.slf4j.LoggerFactory;
  *
  * @see jmri.Programmer
  * @author Kevin Dickerson Copyright (C) 2012
- * @version $Revision: 17977 $
  */
 public class Dcc4PcOpsModeProgrammer extends jmri.jmrix.AbstractProgrammer implements PropertyChangeListener, AddressedProgrammer {
 
@@ -46,14 +44,15 @@ public class Dcc4PcOpsModeProgrammer extends jmri.jmrix.AbstractProgrammer imple
     /**
      * Send an ops-mode write request to the XPressnet.
      */
+    @Override
     synchronized public void writeCV(int CV, int val, ProgListener p) throws ProgrammerException {
         rcTag.setExpectedCv(cv);
         progListener = p;
         defaultProgrammer.writeCV(CV, val, new ProxyProgList());
     }
 
+    @Override
     synchronized public void readCV(int cv, ProgListener p) throws ProgrammerException {
-
         rcTag.addPropertyChangeListener(this);
         rcTag.setExpectedCv(cv);
         progListener = p;
@@ -76,14 +75,16 @@ public class Dcc4PcOpsModeProgrammer extends jmri.jmrix.AbstractProgrammer imple
         }
     }
 
-    public void confirmCV(int cv, int val, ProgListener p) throws ProgrammerException {
+    @Override
+    public void confirmCV(String cvName, int val, ProgListener p) throws ProgrammerException {
+        int cv = Integer.parseInt(cvName);
         rcTag.addPropertyChangeListener(this);
         rcTag.setExpectedCv(cv);
         synchronized (this) {
             progListener = p;
         }
         this.cv = cv;
-        defaultProgrammer.confirmCV(cv, val, new ProxyProgList());
+        defaultProgrammer.confirmCV(cvName, val, new ProxyProgList());
     }
 
     /**
@@ -136,5 +137,3 @@ public class Dcc4PcOpsModeProgrammer extends jmri.jmrix.AbstractProgrammer imple
     private final static Logger log = LoggerFactory.getLogger(Dcc4PcOpsModeProgrammer.class.getName());
 
 }
-
-/* @(#)XnetOpsModeProgrammer.java */

--- a/java/src/jmri/jmrix/dccpp/DCCppOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppOpsModeProgrammer.java
@@ -1,4 +1,3 @@
-/* DCCppOpsModeProgrammer.java */
 package jmri.jmrix.dccpp;
 
 import java.util.ArrayList;
@@ -19,7 +18,6 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2003-2010
  * @author Girgio Terdina Copyright (C) 2007
  * @author Mark Underwood Copyright (C) 2015
- * @version $Revision$
  *
  * Based on XNetOpsModeProgrammer by Paul Bender and Girgio Terdina
  */
@@ -72,7 +70,8 @@ public class DCCppOpsModeProgrammer extends jmri.jmrix.AbstractProgrammer implem
         p.programmingOpReply(CV, jmri.ProgListener.NotImplemented);
     }
 
-    public void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+    @Override
+    public void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
         //DCCppMessage msg = DCCppMessage.getVerifyOpsModeCVMsg(mAddressHigh, mAddressLow, CV, val);
         //tc.sendDCCppMessage(msg, this);
         /* We can trigger a read to an LRC120, but the information is not
@@ -166,5 +165,3 @@ public class DCCppOpsModeProgrammer extends jmri.jmrix.AbstractProgrammer implem
     private final static Logger log = LoggerFactory.getLogger(DCCppOpsModeProgrammer.class.getName());
 
 }
-
-/* @(#)DCCppOpsModeProgrammer.java */

--- a/java/src/jmri/jmrix/dccpp/DCCppProgrammer.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppProgrammer.java
@@ -1,7 +1,3 @@
-/**
- * XNetProgrammer.java
- */
- // Convert the jmri.Programmer interface into commands for the Lenz XpressNet
 package jmri.jmrix.dccpp;
 
 import java.util.ArrayList;
@@ -25,7 +21,6 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (c) 2002, 2007
  * @author Paul Bender Copyright (c) 2003-2010
  * @author Giorgio Terdina Copyright (c) 2007
- * @version $Revision$
  */
 public class DCCppProgrammer extends AbstractProgrammer implements DCCppListener {
 
@@ -150,7 +145,8 @@ public class DCCppProgrammer extends AbstractProgrammer implements DCCppListener
 	    //}
     }
 
-    synchronized public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    @Override
+    synchronized public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 
@@ -284,6 +280,3 @@ public class DCCppProgrammer extends AbstractProgrammer implements DCCppListener
     private final static Logger log = LoggerFactory.getLogger(DCCppProgrammer.class.getName());
 
 }
-
-
-/* @(#)DCCppProgrammer.java */

--- a/java/src/jmri/jmrix/easydcc/EasyDccOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccOpsModeProgrammer.java
@@ -1,4 +1,3 @@
-/* EasyDccOpsModeProgrammer.java */
 package jmri.jmrix.easydcc;
 
 import java.util.ArrayList;
@@ -20,7 +19,6 @@ import org.slf4j.LoggerFactory;
  *
  * @see jmri.Programmer
  * @author	Bob Jacobsen Copyright (C) 2002
- * @version	$Revision$
  */
 public class EasyDccOpsModeProgrammer extends EasyDccProgrammer implements AddressedProgrammer {
 
@@ -76,7 +74,8 @@ public class EasyDccOpsModeProgrammer extends EasyDccProgrammer implements Addre
         throw new ProgrammerException();
     }
 
-    public synchronized void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+    @Override
+    public synchronized void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
         if (log.isDebugEnabled()) {
             log.debug("confirm CV=" + CV);
         }
@@ -130,5 +129,3 @@ public class EasyDccOpsModeProgrammer extends EasyDccProgrammer implements Addre
     private final static Logger log = LoggerFactory.getLogger(EasyDccOpsModeProgrammer.class.getName());
 
 }
-
-/* @(#)EasyDccOpsModeProgrammer.java */

--- a/java/src/jmri/jmrix/easydcc/EasyDccProgrammer.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccProgrammer.java
@@ -1,4 +1,3 @@
-//EasyDccProgrammer.java
 package jmri.jmrix.easydcc;
 
 import java.util.ArrayList;
@@ -14,7 +13,6 @@ import org.slf4j.LoggerFactory;
  * powerstation
  *
  * @author	Bob Jacobsen Copyright (C) 2001
- * @version	$Revision$
  */
 public class EasyDccProgrammer extends AbstractProgrammer implements EasyDccListener {
 
@@ -66,7 +64,8 @@ public class EasyDccProgrammer extends AbstractProgrammer implements EasyDccList
         }
     }
 
-    public synchronized void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    @Override
+    public synchronized void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 
@@ -217,6 +216,3 @@ public class EasyDccProgrammer extends AbstractProgrammer implements EasyDccList
     private final static Logger log = LoggerFactory.getLogger(EasyDccProgrammer.class.getName());
 
 }
-
-
-/* @(#)EasyDccProgrammer.java */

--- a/java/src/jmri/jmrix/ecos/EcosProgrammer.java
+++ b/java/src/jmri/jmrix/ecos/EcosProgrammer.java
@@ -1,4 +1,3 @@
-// EcosProgrammer.java
 package jmri.jmrix.ecos;
 
 import java.util.ArrayList;
@@ -15,7 +14,6 @@ import org.slf4j.LoggerFactory;
  * programmer. This provides a service mode programmer.
  *
  * @author Karl Johan Lisby Copyright (C) 2015
- * @version	$Revision$
  */
 public class EcosProgrammer extends AbstractProgrammer implements EcosListener {
 
@@ -66,7 +64,8 @@ public class EcosProgrammer extends AbstractProgrammer implements EcosListener {
         tc.sendEcosMessage(m, this);
     }
 
-    synchronized public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    @Override
+    synchronized public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 

--- a/java/src/jmri/jmrix/lenz/XNetOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/lenz/XNetOpsModeProgrammer.java
@@ -1,4 +1,3 @@
-/* XNetOpsModeProgrammer.java */
 package jmri.jmrix.lenz;
 
 import java.util.ArrayList;
@@ -18,7 +17,6 @@ import org.slf4j.LoggerFactory;
  * @see jmri.Programmer
  * @author Paul Bender Copyright (C) 2003-2010
  * @author Girgio Terdina Copyright (C) 2007
- * @version $Revision$
  */
 public class XNetOpsModeProgrammer extends jmri.jmrix.AbstractProgrammer implements XNetListener, AddressedProgrammer {
 
@@ -49,6 +47,7 @@ public class XNetOpsModeProgrammer extends jmri.jmrix.AbstractProgrammer impleme
     /**
      * Send an ops-mode write request to the XPressnet.
      */
+    @Override
     synchronized public void writeCV(int CV, int val, ProgListener p) throws ProgrammerException {
         XNetMessage msg = XNetMessage.getWriteOpsModeCVMsg(mAddressHigh, mAddressLow, CV, val);
         tc.sendXNetMessage(msg, this);
@@ -61,6 +60,7 @@ public class XNetOpsModeProgrammer extends jmri.jmrix.AbstractProgrammer impleme
         restartTimer(msg.getTimeout());
     }
 
+    @Override
     synchronized public void readCV(int CV, ProgListener p) throws ProgrammerException {
         XNetMessage msg = XNetMessage.getVerifyOpsModeCVMsg(mAddressHigh, mAddressLow, CV, value);
         tc.sendXNetMessage(msg, this);
@@ -69,7 +69,9 @@ public class XNetOpsModeProgrammer extends jmri.jmrix.AbstractProgrammer impleme
         p.programmingOpReply(CV, jmri.ProgListener.NotImplemented);
     }
 
-    public void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+    @Override
+    public void confirmCV(String CVname, int val, ProgListener p) throws ProgrammerException {
+        int CV = Integer.parseInt(CVname);
         XNetMessage msg = XNetMessage.getVerifyOpsModeCVMsg(mAddressHigh, mAddressLow, CV, val);
         tc.sendXNetMessage(msg, this);
         /* We can trigger a read to an LRC120, but the information is not
@@ -169,5 +171,3 @@ public class XNetOpsModeProgrammer extends jmri.jmrix.AbstractProgrammer impleme
     private final static Logger log = LoggerFactory.getLogger(XNetOpsModeProgrammer.class.getName());
 
 }
-
-/* @(#)XnetOpsModeProgrammer.java */

--- a/java/src/jmri/jmrix/lenz/XNetProgrammer.java
+++ b/java/src/jmri/jmrix/lenz/XNetProgrammer.java
@@ -220,7 +220,7 @@ public class XNetProgrammer extends AbstractProgrammer implements XNetListener {
         }
     }
 
-    synchronized public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    synchronized public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 

--- a/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetProgrammer.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetProgrammer.java
@@ -1,7 +1,3 @@
-/*
- * EliteXNetProgrammer.java
- */
- // Convert the jmri.Programmer interface into commands for the Lenz XpressNet
 package jmri.jmrix.lenz.hornbyelite;
 
 import jmri.jmrix.lenz.XNetConstants;
@@ -30,7 +26,6 @@ import org.slf4j.LoggerFactory;
  * </UL>
  *
  * @author Paul Bender Copyright (c) 2008
- * @version $Revision$
  */
 public class EliteXNetProgrammer extends XNetProgrammer implements XNetListener {
 
@@ -94,7 +89,7 @@ public class EliteXNetProgrammer extends XNetProgrammer implements XNetListener 
         controller().sendXNetMessage(resultMsg, this);
     }
 
-    synchronized public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    synchronized public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 
@@ -356,6 +351,3 @@ public class EliteXNetProgrammer extends XNetProgrammer implements XNetListener 
     private final static Logger log = LoggerFactory.getLogger(EliteXNetProgrammer.class.getName());
 
 }
-
-
-/* @(#)XNetProgrammer.java */

--- a/java/src/jmri/jmrix/lenz/li100/LI100XNetProgrammer.java
+++ b/java/src/jmri/jmrix/lenz/li100/LI100XNetProgrammer.java
@@ -1,7 +1,3 @@
-/**
- * LI100XNetProgrammer.java
- */
- // Convert the jmri.Programmer interface into commands for the Lenz XpressNet
 package jmri.jmrix.lenz.li100;
 
 import jmri.jmrix.lenz.XNetConstants;
@@ -30,7 +26,6 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (c) 2002, 2007
  * @author Paul Bender Copyright (c) 2003, 2004, 2005, 2009
  * @author Giorgio Terdina Copyright (c) 2007
- * @version $Revision$
  */
 public class LI100XNetProgrammer extends XNetProgrammer implements XNetListener {
 
@@ -85,7 +80,7 @@ public class LI100XNetProgrammer extends XNetProgrammer implements XNetListener 
         }
     }
 
-    synchronized public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    synchronized public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 
@@ -420,6 +415,3 @@ public class LI100XNetProgrammer extends XNetProgrammer implements XNetListener 
     private final static Logger log = LoggerFactory.getLogger(LI100XNetProgrammer.class.getName());
 
 }
-
-
-/* @(#)XNetProgrammer.java */

--- a/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
@@ -1,4 +1,3 @@
-/* LnOpsModeProgrammer.java */
 package jmri.jmrix.loconet;
 
 import java.beans.PropertyChangeListener;
@@ -19,7 +18,6 @@ import org.slf4j.LoggerFactory;
  *
  * @see jmri.Programmer
  * @author	Bob Jacobsen Copyright (C) 2002
- * @version	$Revision$
  */
 public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener {
 
@@ -45,18 +43,17 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
     /**
      * Forward a write request to an ops-mode write operation
      */
+    @Override
     public void writeCV(int CV, int val, ProgListener p) throws ProgrammerException {
         mSlotMgr.writeCVOpsMode(CV, val, p, mAddress, mLongAddr);
     }
 
+    @Override
     public void readCV(int CV, ProgListener p) throws ProgrammerException {
         mSlotMgr.readCVOpsMode(CV, p, mAddress, mLongAddr);
     }
 
-    public void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
-        mSlotMgr.confirmCVOpsMode(CV, val, p, mAddress, mLongAddr);
-    }
-
+    @Override
     public void writeCV(String CV, int val, ProgListener p) throws ProgrammerException {
         this.p = null;
         // Check mode
@@ -91,6 +88,7 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
         }
     }
 
+    @Override
     public void readCV(String CV, ProgListener p) throws ProgrammerException {
         this.p = null;
         // Check mode
@@ -125,6 +123,13 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
         }
     }
 
+    @Override
+    @SuppressWarnings("deprecation") // parent Programmer method deprecated, will remove at same time
+    public final void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+        confirmCV(""+CV, val, p);
+    }
+
+    @Override
     public void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
         this.p = null;
         // Check mode
@@ -347,5 +352,3 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
     private final static Logger log = LoggerFactory.getLogger(LnOpsModeProgrammer.class.getName());
 
 }
-
-/* @(#)LnOpsModeProgrammer.java */

--- a/java/src/jmri/jmrix/loconet/LocoNetActionListBundle.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetActionListBundle.properties
@@ -1,6 +1,5 @@
 # LoconetActionListBundle.properties
 #
-# Revision $Revision$
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_ca.properties
@@ -1,6 +1,5 @@
 # LoconetActionListBundle.properties
 #
-# Revision $Revision$
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_cs.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_cs.properties
@@ -1,6 +1,5 @@
 # LoconetActionListBundle_cs.properties
 #
-# Revision $Revision$
 # by Michal Basta
 # Czech (w/o diacritic) properties  listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_cs_CZ.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_cs_CZ.properties
@@ -1,6 +1,5 @@
 # LocoNetActionListBundle_cs_CZ.properties
 #
-# Revision $Revision$
 # by Michal Basta
 # Override certain czech properties  listing names with CZ diacritic for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_da.properties
@@ -1,6 +1,5 @@
 # LoconetActionListBundle_da_DK.properties
 #
-# Revision $Revision$
 #Danish translation by Sonny Hansen# Overrides Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences
 

--- a/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_de.properties
@@ -1,6 +1,5 @@
 # LoconetActionListBundle_de.properties
 #
-# Revision $Revision$
 # by Simon Ginsburg
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_es.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_es.properties
@@ -1,6 +1,5 @@
 # LoconetActionListBundle_es.properties
 #
-# Revision $Revision$
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_fr.properties
@@ -1,6 +1,5 @@
 # LoconetActionListBundle.properties
 #
-# Revision $Revision$
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_it.properties
@@ -1,6 +1,5 @@
 # LoconetActionListBundle.properties
 #
-# Revision $Revision$
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_ja.properties
@@ -1,6 +1,5 @@
 # LoconetActionListBundle.properties
 #
-# Revision $Revision$
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetActionListBundle_ja_JP.properties
@@ -1,6 +1,5 @@
 # LoconetActionListBundle.properties
 #
-# Revision $Revision$
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle.properties
@@ -1,6 +1,5 @@
 # LocoNetBundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet menu
 

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_cs.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_cs.properties
@@ -1,6 +1,5 @@
 # LocoNetBundle_cs.properties
 #
-# Revision $Revision$
 #by Michal Basta
 # Czech properties (w/o diacritic) for the jmri.jmrix.loconet menu
 

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_cs_CZ.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_cs_CZ.properties
@@ -1,6 +1,5 @@
 # LocoNetBundle_cs_CZ.properties
 #
-# Revision $Revision$
 #by Michal Basta
 # Override certain czech properties for the jmri.jmrix.loconet menu with CZ diacritic
 

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_da.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_da.properties
@@ -1,6 +1,5 @@
 # LocoNetBundle_da_DK.properties
 #
-# Revision $Revision$
 # Danish translation by Sonny Hansen
 # Overrides some 
 # Default properties for the jmri.jmrix.loconet menu

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_de.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_de.properties
@@ -1,6 +1,5 @@
 # LocoNetBundle_de.properties
 #
-# Revision $Revision$
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.loconet menu
 

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_es.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_es.properties
@@ -1,6 +1,5 @@
 # LocoNetBundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet menu
 #

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_fr.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_fr.properties
@@ -1,6 +1,5 @@
 # LocoNetBundle_fr.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet menu
 #

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_it.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_it.properties
@@ -1,6 +1,5 @@
 # LocoNetBundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet menu
 #

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle_ja_JP.properties
@@ -1,6 +1,5 @@
 # LocoNetBundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet menu
 

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -769,6 +769,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
         doWrite(CV, val, p, 0x67);  // ops mode byte write, with feedback
     }
 
+    @Override
     public void writeCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         lopsa = 0;
         hopsa = 0;
@@ -806,15 +807,18 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
         tc.sendLocoNetMessage(progTaskStart(pcmd, val, CV, true));
     }
 
-    public void confirmCVOpsMode(int CV, int val, jmri.ProgListener p,
+    public void confirmCVOpsMode(String CVname, int val, jmri.ProgListener p,
             int addr, boolean longAddr) throws jmri.ProgrammerException {
+        int CV = Integer.parseInt(CVname);
         lopsa = addr & 0x7f;
         hopsa = (addr / 128) & 0x7f;
         mServiceMode = false;
         doConfirm(CV, val, p, 0x2F);  // although LPE implies 0x2C, 0x2F is observed
     }
 
-    public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    @Override
+    public void confirmCV(String CVname, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+        int CV = Integer.parseInt(CVname);
         lopsa = 0;
         hopsa = 0;
         mServiceMode = true;
@@ -872,6 +876,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
         doRead(CV, p, 0x2F);  // although LPE implies 0x2C, 0x2F is observed
     }
 
+    @Override
     public void readCV(int CV, jmri.ProgListener p) throws jmri.ProgrammerException {
         lopsa = 0;
         hopsa = 0;

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options.properties
@@ -1,6 +1,5 @@
 # DB150options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DB150 (Empire Builder)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options_da.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options_da.properties
@@ -1,6 +1,5 @@
 # DB150options.properties
 #
-# Revision $Revision$
 #Danish translation by Sonny Hansen
 #Overides some Default command station options for the DB150 (Empire Builder)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options_de.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options_de.properties
@@ -1,6 +1,5 @@
 # DB150options.properties
 #
-# Revision $Revision$
 # by Simon Ginsburg
 # German command station options for the DB150 (Empire Builder)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options_es.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options_es.properties
@@ -1,6 +1,5 @@
 # DB150options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DB150 (Empire Builder)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options_fr.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options_fr.properties
@@ -1,6 +1,5 @@
 # DB150options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DB150 (Empire Builder)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options_it.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options_it.properties
@@ -1,6 +1,5 @@
 # DB150options.properties
 #
-# Revision $Revision$
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DB150options_ja_JP.properties
@@ -1,6 +1,5 @@
 # DB150options.properties
 #
-# Revision $Revision$
 #
 # Japanese command station options for the DB150 (Empire Builder)
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS100options.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS100options.properties
@@ -1,6 +1,5 @@
 # DCS100options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DCS100 (Chief)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS100options_da.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS100options_da.properties
@@ -1,6 +1,5 @@
 # DCS100options.properties
 #
-# Revision $Revision$
 #
  Danish translation by Sonny Hansen#Overrides Default command station options for the DCS100 (Chief)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS100options_de.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS100options_de.properties
@@ -1,6 +1,5 @@
 # DCS100options.properties
 #
-# Revision $Revision$
 # by Simon Ginsburg
 # German command station options for the DCS100 (Chief)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS100options_it.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS100options_it.properties
@@ -1,6 +1,5 @@
 # DCS100options.properties
 #
-# Revision $Revision$
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS100options_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS100options_ja_JP.properties
@@ -1,6 +1,5 @@
 # DCS100options.properties
 #
-# Revision $Revision$
 #
 # Japanese command station options for the DCS100 (Chief)
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS200options.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS200options.properties
@@ -1,6 +1,5 @@
 # DCS200options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DCS200
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS200options_da.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS200options_da.properties
@@ -1,6 +1,5 @@
 # DCS200options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DCS200
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS200options_fr.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS200options_fr.properties
@@ -1,6 +1,5 @@
 # DCS200options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DCS200
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS200options_it.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS200options_it.properties
@@ -1,6 +1,5 @@
 # DCS200options.properties
 #
-# Revision $Revision$
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS200options_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS200options_ja_JP.properties
@@ -1,6 +1,5 @@
 # DCS200options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DCS200
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS50options.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS50options.properties
@@ -1,6 +1,5 @@
 # DCS50options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DCS50 (Zephyr)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS50options_da.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS50options_da.properties
@@ -1,6 +1,5 @@
 # DCS50options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DCS50 (Zephyr)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS50options_de.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS50options_de.properties
@@ -1,6 +1,5 @@
 # DCS50options.properties
 #
-# Revision $Revision$
 # by Simon Ginsburg
 # German command station options for the DCS50 (Zephyr)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS50options_fr.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS50options_fr.properties
@@ -1,6 +1,5 @@
 # DCS50options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DCS50 (Zephyr)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS50options_it.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS50options_it.properties
@@ -1,6 +1,5 @@
 # DCS50options.properties
 #
-# Revision $Revision$
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS50options_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS50options_ja_JP.properties
@@ -1,6 +1,5 @@
 # DCS50options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DCS50 (Zephyr)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS51options.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS51options.properties
@@ -1,6 +1,5 @@
 # DCS51options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DCS51 (Zephyr)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS51options_da.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS51options_da.properties
@@ -1,6 +1,5 @@
 # DCS51options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DCS51 (Zephyr)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS51options_fr.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS51options_fr.properties
@@ -1,6 +1,5 @@
 # DCS51options.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the DCS51 (Zephyr)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS51options_it.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/DCS51options_it.properties
@@ -1,6 +1,5 @@
 # DCS51options.properties
 #
-# Revision $Revision$
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Defaultoptions.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Defaultoptions.properties
@@ -1,6 +1,5 @@
 # Defaultoptions.properties
 #
-# Revision $Revision$
 #
 # Default command station options for when the command
 # station isn't recognized.  These are the same as the Chief (DCS100)

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Defaultoptions_da.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Defaultoptions_da.properties
@@ -1,6 +1,5 @@
 # Defaultoptions.properties
 #
-# Revision $Revision$
 #
 # Default command station options for when the command
 # station isn't recognized.  These are the same as the Chief (DCS100)

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Defaultoptions_de.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Defaultoptions_de.properties
@@ -1,6 +1,5 @@
 # Defaultoptions.properties
 #
-# Revision $Revision$
 # by Simon Ginsburg
 # German command station options for when the command
 # station isn't recognized.  These are the same as the Chief (DCS100)

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Defaultoptions_fr.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Defaultoptions_fr.properties
@@ -1,6 +1,5 @@
 # Defaultoptions.properties
 #
-# Revision $Revision$
 #
 # Default command station options for when the command
 # station isn't recognized.  These are the same as the Chief (DCS100)

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Defaultoptions_it.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Defaultoptions_it.properties
@@ -1,6 +1,5 @@
 # Defaultoptions.properties
 #
-# Revision $Revision$
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Defaultoptions_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Defaultoptions_ja_JP.properties
@@ -1,6 +1,5 @@
 # Defaultoptions.properties
 #
-# Revision $Revision$
 #
 # Default command station options for when the command
 # station isn't recognized.  These are the same as the Chief (DCS100)

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Intelliboxoptions.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Intelliboxoptions.properties
@@ -1,6 +1,5 @@
 # Intelliboxoptions.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the Intellibox.
 # These were actually taken from the DCS100, and it's

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Intelliboxoptions_da.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Intelliboxoptions_da.properties
@@ -1,6 +1,5 @@
 # Intelliboxoptions.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the Intellibox.
 # These were actually taken from the DCS100, and it's

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Intelliboxoptions_de.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Intelliboxoptions_de.properties
@@ -1,6 +1,5 @@
 # Intelliboxoptions.properties
 #
-# Revision $Revision$
 # by Simon Ginsburg
 # German command station options for the Intellibox.
 # These were actually taken from the DCS100, and it's

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Intelliboxoptions_fr.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Intelliboxoptions_fr.properties
@@ -1,6 +1,5 @@
 # Intelliboxoptions.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the Intellibox.
 # These were actually taken from the DCS100, and it's

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Intelliboxoptions_it.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Intelliboxoptions_it.properties
@@ -1,6 +1,5 @@
 # Intelliboxoptions.properties
 #
-# Revision $Revision$
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Intelliboxoptions_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Intelliboxoptions_ja_JP.properties
@@ -1,6 +1,5 @@
 # Intelliboxoptions.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the Intellibox.
 # These were actually taken from the DCS100, and it's

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/LocoBufferoptions.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/LocoBufferoptions.properties
@@ -1,6 +1,5 @@
 # LocoBufferoptions.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the LocoBuffer-PS (Programming Station)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/LocoBufferoptions_da.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/LocoBufferoptions_da.properties
@@ -1,6 +1,5 @@
 # LocoBufferoptions.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the LocoBuffer-PS (Programming Station)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/LocoBufferoptions_de.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/LocoBufferoptions_de.properties
@@ -1,6 +1,5 @@
 # LocoBufferoptions_de.properties
 #
-# Revision $Revision$
 # by Simon Ginsburg
 # German command station options for the DB150 (Empire Builder)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/LocoBufferoptions_fr.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/LocoBufferoptions_fr.properties
@@ -1,6 +1,5 @@
 # LocoBufferoptions.properties
 #
-# Revision $Revision$
 #
 # Default command station options for the LocoBuffer-PS (Programming Station)
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/LocoBufferoptions_it.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/LocoBufferoptions_it.properties
@@ -1,6 +1,5 @@
 # LocoBufferoptions.properties
 #
-# Revision $Revision$
 #
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/LocoBufferoptions_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/LocoBufferoptions_ja_JP.properties
@@ -1,6 +1,5 @@
 # LocoBufferoptions.properties
 #
-# Revision $Revision$
 #
 # Japanese command station options for the LocoBuffer-PS (Programming Station)
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Mix-Masteroptions.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Mix-Masteroptions.properties
@@ -1,6 +1,5 @@
 # Mix-Masteroptions.properties
 #
-# Revision $Revision$
 # by Dick Bronson
 # Default command station options for the Mix-Master
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Mix-Masteroptions_da.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Mix-Masteroptions_da.properties
@@ -1,6 +1,5 @@
 # Mix-Masteroptions_da.properties
 #
-# Revision $Revision$
 # by Dick Bronson
 # Danish translation by Sonny Hansen# Overrides some Default command station options for the Mix-Master
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Mix-Masteroptions_fr.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Mix-Masteroptions_fr.properties
@@ -1,6 +1,5 @@
 # Mix-Masteroptions.properties
 #
-# Revision $Revision$
 # by Dick Bronson
 # Default command station options for the Mix-Master
 

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Mix-Masteroptions_it.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Mix-Masteroptions_it.properties
@@ -1,6 +1,5 @@
 # Mix-Masteroptions.properties
 #
-# Revision $Revision$
 # by Dick Bronson
 # Default command station options for the Mix-Master
 #

--- a/java/src/jmri/jmrix/loconet/downloader/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/downloader/Bundle.properties
@@ -1,6 +1,5 @@
 # Bundle.properties
 #
-# Revision $Revision$
 # Copyright 2005 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/downloader/Bundle_da.properties
+++ b/java/src/jmri/jmrix/loconet/downloader/Bundle_da.properties
@@ -1,6 +1,5 @@
 # Bundle.properties
 #
-# Revision $Revision$
 # Copyright 2005 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/downloader/Bundle_de.properties
+++ b/java/src/jmri/jmrix/loconet/downloader/Bundle_de.properties
@@ -1,6 +1,5 @@
 # Bundle_de.properties
 #
-# Revision $Revision$
 # Copyright 2005 Bob Jacobsen
 # Translation by Simon Ginsburg
 #

--- a/java/src/jmri/jmrix/loconet/downloader/Bundle_fr.properties
+++ b/java/src/jmri/jmrix/loconet/downloader/Bundle_fr.properties
@@ -1,6 +1,5 @@
 # Bundle_fr.properties
 #
-# Revision $Revision$
 # Copyright 2005 Bob Jacobsen
 #
 # Translated  by Blorec Herv\u00e9 bzh56420@yahoo.fr le2014-1-13

--- a/java/src/jmri/jmrix/loconet/downloader/Bundle_it.properties
+++ b/java/src/jmri/jmrix/loconet/downloader/Bundle_it.properties
@@ -1,6 +1,5 @@
 # Bundle_it.properties
 #
-# Revision $Revision$
 # Copyright 2005 Bob Jacobsen
 #
 # Default properties for the jmri.jmrix.loconet.downloader GUI elements

--- a/java/src/jmri/jmrix/loconet/downloader/Bundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/downloader/Bundle_ja_JP.properties
@@ -1,6 +1,5 @@
 # Bundle_ja_JP.properties
 #
-# Revision $Revision$
 # Copyright 2005 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle.properties
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle.properties
@@ -1,6 +1,5 @@
 # HexFileBundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.hexfile.
 

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_da.properties
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_da.properties
@@ -1,6 +1,5 @@
 # HexFileBundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.hexfile.
 

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_fr.properties
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_fr.properties
@@ -1,6 +1,5 @@
 # HexFileBundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.hexfile.
 

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_it.properties
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileBundle_it.properties
@@ -1,6 +1,5 @@
 # HexFileBundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.hexfile.
 

--- a/java/src/jmri/jmrix/loconet/locoid/LocoId.properties
+++ b/java/src/jmri/jmrix/loconet/locoid/LocoId.properties
@@ -1,6 +1,5 @@
 # LocoId.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.locoid package
 

--- a/java/src/jmri/jmrix/loconet/locoid/LocoId_da.properties
+++ b/java/src/jmri/jmrix/loconet/locoid/LocoId_da.properties
@@ -1,6 +1,5 @@
 # LocoId.properties
 #
-# Revision $Revision$
 #Danish translation by Sonny Hansen
 # Default properties for the jmri.jmrix.loconet.locoid package
 

--- a/java/src/jmri/jmrix/loconet/locoid/LocoId_de.properties
+++ b/java/src/jmri/jmrix/loconet/locoid/LocoId_de.properties
@@ -1,6 +1,5 @@
 # LocoId_de.properties
 #
-# Revision $Revision$
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.loconet.locoid package
 

--- a/java/src/jmri/jmrix/loconet/locoid/LocoId_fr.properties
+++ b/java/src/jmri/jmrix/loconet/locoid/LocoId_fr.properties
@@ -1,6 +1,5 @@
 # LocoId.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.locoid package
 

--- a/java/src/jmri/jmrix/loconet/locoid/LocoId_it.properties
+++ b/java/src/jmri/jmrix/loconet/locoid/LocoId_it.properties
@@ -1,6 +1,5 @@
 # LocoId.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.locoid package
 #

--- a/java/src/jmri/jmrix/loconet/locoid/LocoId_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/locoid/LocoId_ja_JP.properties
@@ -1,6 +1,5 @@
 # LocoId.properties
 #
-# Revision $Revision$
 #
 # Japanese properties for the jmri.jmrix.loconet.locoid package
 

--- a/java/src/jmri/jmrix/loconet/locostats/LocoStatsBundle.properties
+++ b/java/src/jmri/jmrix/loconet/locostats/LocoStatsBundle.properties
@@ -1,6 +1,5 @@
 # LocoStatsBundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.locostats menu
 

--- a/java/src/jmri/jmrix/loconet/locostats/LocoStatsBundle_da.properties
+++ b/java/src/jmri/jmrix/loconet/locostats/LocoStatsBundle_da.properties
@@ -1,6 +1,5 @@
 # Danish Translation added by Sonny Hansen# LocoStatsBundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.locostats menu
 

--- a/java/src/jmri/jmrix/loconet/locostats/LocoStatsBundle_de.properties
+++ b/java/src/jmri/jmrix/loconet/locostats/LocoStatsBundle_de.properties
@@ -1,6 +1,5 @@
 # LocoStatsBundle_de.properties
 #
-# Revision $Revision$
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.loconet.locostats menu
 

--- a/java/src/jmri/jmrix/loconet/locostats/LocoStatsBundle_fr.properties
+++ b/java/src/jmri/jmrix/loconet/locostats/LocoStatsBundle_fr.properties
@@ -1,6 +1,5 @@
 # LocoStatsBundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.locostats menu
 

--- a/java/src/jmri/jmrix/loconet/locostats/LocoStatsBundle_it.properties
+++ b/java/src/jmri/jmrix/loconet/locostats/LocoStatsBundle_it.properties
@@ -1,6 +1,5 @@
 # LocoStatsBundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.locostats menu
 #

--- a/java/src/jmri/jmrix/loconet/locostats/LocoStatsBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/locostats/LocoStatsBundle_ja_JP.properties
@@ -1,6 +1,5 @@
 # LocoStatsBundle.properties
 #
-# Revision $Revision$
 #
 # Japanese properties for the jmri.jmrix.loconet.locostats menu
 

--- a/java/src/jmri/jmrix/loconet/pr3/Pr3Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/pr3/Pr3Bundle.properties
@@ -1,6 +1,5 @@
 # Pr3Bundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.pr3 resources
 #

--- a/java/src/jmri/jmrix/loconet/pr3/Pr3Bundle_da.properties
+++ b/java/src/jmri/jmrix/loconet/pr3/Pr3Bundle_da.properties
@@ -1,6 +1,5 @@
 # Pr3Bundle.properties
 #
-# Revision $Revision$
 #Danish translation by Sonny Hansen
 # Default properties for the jmri.jmrix.loconet.pr3 resources
 #

--- a/java/src/jmri/jmrix/loconet/pr3/Pr3Bundle_de.properties
+++ b/java/src/jmri/jmrix/loconet/pr3/Pr3Bundle_de.properties
@@ -1,6 +1,5 @@
 # Pr3Bundle_de.properties
 #
-# Revision $Revision$
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.loconet.pr3 resources
 #

--- a/java/src/jmri/jmrix/loconet/pr3/Pr3Bundle_fr.properties
+++ b/java/src/jmri/jmrix/loconet/pr3/Pr3Bundle_fr.properties
@@ -1,6 +1,5 @@
 # Pr3Bundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.pr3 resources
 #

--- a/java/src/jmri/jmrix/loconet/pr3/Pr3Bundle_it.properties
+++ b/java/src/jmri/jmrix/loconet/pr3/Pr3Bundle_it.properties
@@ -1,6 +1,5 @@
 # Pr3Bundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.pr3 resources
 #

--- a/java/src/jmri/jmrix/loconet/pr3/Pr3Bundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/pr3/Pr3Bundle_ja_JP.properties
@@ -1,6 +1,5 @@
 # Pr3Bundle.properties
 #
-# Revision $Revision$
 #
 # Default properties for the jmri.jmrix.loconet.pr3 resources
 #

--- a/java/src/jmri/jmrix/loconet/sdfeditor/Editor.properties
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/Editor.properties
@@ -1,6 +1,5 @@
 # Editor.properties
 #
-# Revision $Revision$
 # Copyright 2007 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/sdfeditor/Editor_da.properties
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/Editor_da.properties
@@ -1,6 +1,5 @@
 # Editor.properties
 #
-# Revision $Revision$
 # Copyright 2007 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/sdfeditor/Editor_de.properties
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/Editor_de.properties
@@ -1,6 +1,5 @@
 # Editor_de.properties
 #
-# Revision $Revision$
 # Copyright 2007 Bob Jacobsen
 # Translation by Simon Ginsburg
 #

--- a/java/src/jmri/jmrix/loconet/sdfeditor/Editor_fr.properties
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/Editor_fr.properties
@@ -1,6 +1,5 @@
 # Editor.properties
 #
-# Revision $Revision$
 # Copyright 2007 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/sdfeditor/Editor_it.properties
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/Editor_it.properties
@@ -1,6 +1,5 @@
 # Editor.properties
 #
-# Revision $Revision$
 # Copyright 2007 Bob Jacobsen
 #
 # Default properties for the jmri.jmrix.loconet.sdfeditor.Editor GUI elements

--- a/java/src/jmri/jmrix/loconet/sdfeditor/Editor_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/Editor_ja_JP.properties
@@ -1,6 +1,5 @@
 # Editor.properties
 #
-# Revision $Revision$
 # Copyright 2007 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/sdfeditor/Explanations_de.properties
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/Explanations_de.properties
@@ -1,6 +1,5 @@
 # Explanations_de.properties
 #
-# Revision $Revision$
 # Copyright 2007 Bob Jacobsen
 # Translation by Simon Ginsburg
 #

--- a/java/src/jmri/jmrix/loconet/soundloader/Editor.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Editor.properties
@@ -1,6 +1,5 @@
 # Editor.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/soundloader/Editor_da.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Editor_da.properties
@@ -1,6 +1,5 @@
 # Editor.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/soundloader/Editor_de.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Editor_de.properties
@@ -1,6 +1,5 @@
 # Editor_de.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 # by Simon Ginsburg

--- a/java/src/jmri/jmrix/loconet/soundloader/Editor_fr.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Editor_fr.properties
@@ -1,6 +1,5 @@
 # Editor.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/soundloader/Editor_it.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Editor_it.properties
@@ -1,6 +1,5 @@
 # Editor.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 # Default properties for the jmri.jmrix.loconet.soundloader.Editor GUI elements

--- a/java/src/jmri/jmrix/loconet/soundloader/Editor_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Editor_ja_JP.properties
@@ -1,6 +1,5 @@
 # Editor.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/soundloader/Loader.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Loader.properties
@@ -1,6 +1,5 @@
 # Loader.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/soundloader/Loader_da.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Loader_da.properties
@@ -1,6 +1,5 @@
 # Loader.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/soundloader/Loader_de.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Loader_de.properties
@@ -1,6 +1,5 @@
 # Loader_de.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 # by Simon Ginsburg

--- a/java/src/jmri/jmrix/loconet/soundloader/Loader_en_GB.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Loader_en_GB.properties
@@ -1,6 +1,5 @@
 # Loader.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 # by Matthew Harris

--- a/java/src/jmri/jmrix/loconet/soundloader/Loader_fr.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Loader_fr.properties
@@ -1,6 +1,5 @@
 # Loader.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/soundloader/Loader_it.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Loader_it.properties
@@ -1,6 +1,5 @@
 # Loader.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/loconet/soundloader/Loader_ja_JP.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Loader_ja_JP.properties
@@ -1,6 +1,5 @@
 # Loader.properties
 #
-# Revision $Revision$
 # Copyright 2005, 2006 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/mrc/MrcOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/mrc/MrcOpsModeProgrammer.java
@@ -1,4 +1,3 @@
-/* MrcOpsModeProgrammer.java */
 package jmri.jmrix.mrc;
 
 import java.util.ArrayList;
@@ -20,7 +19,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2002
  * @author	Ken Cameron Copyright (C) 2014
  * @author Kevin Dickerson Copyright (C) 2014
- * @version	$Revision: 24270 $
  */
 public class MrcOpsModeProgrammer extends MrcProgrammer implements jmri.AddressedProgrammer {
 
@@ -67,7 +65,7 @@ public class MrcOpsModeProgrammer extends MrcProgrammer implements jmri.Addresse
         throw new ProgrammerException();
     }
 
-    public synchronized void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+    public synchronized void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
         log.debug("confirm CV={}", CV);
         log.error(MrcOpsModeBundle.getMessage("LogMrcOpsModeProgrammerConfirmCvModeError")); //IN18N
         throw new ProgrammerException();
@@ -130,5 +128,3 @@ public class MrcOpsModeProgrammer extends MrcProgrammer implements jmri.Addresse
     private final static Logger log = LoggerFactory.getLogger(MrcOpsModeProgrammer.class.getName());
 
 }
-
-/* @(#)MrcOpsModeProgrammer.java */

--- a/java/src/jmri/jmrix/mrc/MrcProgrammer.java
+++ b/java/src/jmri/jmrix/mrc/MrcProgrammer.java
@@ -1,4 +1,3 @@
-// MrcProgrammer.java
 package jmri.jmrix.mrc;
 
 import java.util.ArrayList;
@@ -19,7 +18,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2002
  * @author	Ken Cameron Copyright (C) 2014
  * @author Kevin Dickerson Copyright (C) 2014
- * @version $Revision: 24290 $
  */
 public class MrcProgrammer extends AbstractProgrammer implements MrcTrafficListener {
 
@@ -98,7 +96,8 @@ public class MrcProgrammer extends AbstractProgrammer implements MrcTrafficListe
         }
     }
 
-    public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    @Override
+    public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 
@@ -230,4 +229,3 @@ public class MrcProgrammer extends AbstractProgrammer implements MrcTrafficListe
 
     private final static Logger log = LoggerFactory.getLogger(MrcProgrammer.class.getName());
 }
-/* @(#)MrcProgrammer.java */

--- a/java/src/jmri/jmrix/nce/NceOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/nce/NceOpsModeProgrammer.java
@@ -1,4 +1,3 @@
-/* NceOpsModeProgrammer.java */
 package jmri.jmrix.nce;
 
 import java.util.ArrayList;
@@ -21,7 +20,6 @@ import org.slf4j.LoggerFactory;
  * @see jmri.Programmer
  * @author	Bob Jacobsen Copyright (C) 2002, 2014
  * @author kcameron Copyright (C) 2014
- * @version	$Revision$
  */
 public class NceOpsModeProgrammer extends NceProgrammer implements AddressedProgrammer {
 
@@ -88,9 +86,9 @@ public class NceOpsModeProgrammer extends NceProgrammer implements AddressedProg
         throw new ProgrammerException();
     }
 
-    public synchronized void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+    public synchronized void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
         if (log.isDebugEnabled()) {
-            log.debug("confirm CV=" + CV);
+            log.debug("confirm CV={}", CV);
         }
         log.error("confirmCV not available in this protocol");
         throw new ProgrammerException();
@@ -155,5 +153,3 @@ public class NceOpsModeProgrammer extends NceProgrammer implements AddressedProg
     private final static Logger log = LoggerFactory.getLogger(NceOpsModeProgrammer.class.getName());
 
 }
-
-/* @(#)NceOpsModeProgrammer.java */

--- a/java/src/jmri/jmrix/nce/NceProgrammer.java
+++ b/java/src/jmri/jmrix/nce/NceProgrammer.java
@@ -122,7 +122,8 @@ public class NceProgrammer extends AbstractProgrammer implements NceListener {
         }
     }
 
-    public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    @Override
+    public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 

--- a/java/src/jmri/jmrix/openlcb/OlcbProgrammer.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbProgrammer.java
@@ -1,4 +1,3 @@
-/* OlcbProgrammer.java */
 package jmri.jmrix.openlcb;
 
 import java.util.ArrayList;
@@ -78,11 +77,6 @@ public class OlcbProgrammer extends jmri.jmrix.AbstractProgrammer implements jmr
     }
 
     @Override
-    @Deprecated
-    public void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
-    }
-
-    @Override
     public void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
     }
     
@@ -93,6 +87,3 @@ public class OlcbProgrammer extends jmri.jmrix.AbstractProgrammer implements jmr
     public String getAddress() { return "";}
 
 }
-
-
-/* @(#)OlcbProgrammer.java */

--- a/java/src/jmri/jmrix/qsi/QsiProgrammer.java
+++ b/java/src/jmri/jmrix/qsi/QsiProgrammer.java
@@ -70,7 +70,8 @@ public class QsiProgrammer extends AbstractProgrammer implements QsiListener {
         controller().sendQsiMessage(QsiMessage.getWriteCV(CV, val, getMode()), this);
     }
 
-    public synchronized void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    @Override
+    public synchronized void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 

--- a/java/src/jmri/jmrix/sprog/SprogOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/sprog/SprogOpsModeProgrammer.java
@@ -1,4 +1,3 @@
-/* SprogOpsModeProgrammer.java */
 package jmri.jmrix.sprog;
 
 import java.util.ArrayList;
@@ -19,7 +18,6 @@ import org.slf4j.LoggerFactory;
  *
  * @see jmri.Programmer
  * @author	Andrew Crosland Copyright (C) 2006
- * @version	$Revision$
  */
 public class SprogOpsModeProgrammer extends SprogProgrammer implements AddressedProgrammer {
 
@@ -66,9 +64,9 @@ public class SprogOpsModeProgrammer extends SprogProgrammer implements Addressed
         throw new ProgrammerException();
     }
 
-    synchronized public void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+    synchronized public void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
         if (log.isDebugEnabled()) {
-            log.debug("confirm CV=" + CV);
+            log.debug("confirm CV={}", CV);
         }
         log.error("confirmCV not available in this protocol");
         throw new ProgrammerException();
@@ -124,5 +122,3 @@ public class SprogOpsModeProgrammer extends SprogProgrammer implements Addressed
     private final static Logger log = LoggerFactory.getLogger(SprogOpsModeProgrammer.class.getName());
 
 }
-
-/* @(#)SprogOpsModeProgrammer.java */

--- a/java/src/jmri/jmrix/sprog/SprogProgrammer.java
+++ b/java/src/jmri/jmrix/sprog/SprogProgrammer.java
@@ -73,7 +73,8 @@ public class SprogProgrammer extends AbstractProgrammer implements SprogListener
         controller().sendSprogMessage(SprogMessage.getProgMode(), this);
     }
 
-    synchronized public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    @Override
+    synchronized public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 

--- a/java/src/jmri/jmrix/srcp/SRCPProgrammer.java
+++ b/java/src/jmri/jmrix/srcp/SRCPProgrammer.java
@@ -48,6 +48,7 @@ public class SRCPProgrammer extends AbstractProgrammer implements SRCPListener {
     int _cv;	// remember the cv being read/written
 
     // programming interface
+    @Override
     synchronized public void writeCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         if (log.isDebugEnabled()) {
             log.debug("writeCV " + CV + " listens " + p);
@@ -79,7 +80,9 @@ public class SRCPProgrammer extends AbstractProgrammer implements SRCPListener {
         }
     }
 
-    synchronized public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    @Override
+    synchronized public void confirmCV(String CVname, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+        int CV = Integer.parseInt(CVname);
         if (log.isDebugEnabled()) {
             log.debug("confirmCV " + CV + " val " + val + " listens " + p);
         }
@@ -112,6 +115,7 @@ public class SRCPProgrammer extends AbstractProgrammer implements SRCPListener {
         //readCV(CV, p);
     }
 
+    @Override
     synchronized public void readCV(int CV, jmri.ProgListener p) throws jmri.ProgrammerException {
         if (log.isDebugEnabled()) {
             log.debug("readCV " + CV + " listens " + p);

--- a/java/src/jmri/jmrix/tams/TamsOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/tams/TamsOpsModeProgrammer.java
@@ -1,4 +1,3 @@
-/* TamsOpsModeProgrammer.java */
 package jmri.jmrix.tams;
 
 import java.util.ArrayList;
@@ -19,7 +18,6 @@ import org.slf4j.LoggerFactory;
  *
  * @see jmri.Programmer Based on work by Bob Jacobsen
  * @author	Kevin Dickerson Copyright (C) 2012
- * @version	$Revision: 19990 $
  */
 public class TamsOpsModeProgrammer extends TamsProgrammer implements AddressedProgrammer {
 
@@ -62,7 +60,7 @@ public class TamsOpsModeProgrammer extends TamsProgrammer implements AddressedPr
         throw new ProgrammerException();
     }
 
-    public synchronized void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+    public synchronized void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
         if (log.isDebugEnabled()) {
             log.debug("confirm CV=" + CV);
         }
@@ -129,5 +127,3 @@ public class TamsOpsModeProgrammer extends TamsProgrammer implements AddressedPr
     private final static Logger log = LoggerFactory.getLogger(TamsOpsModeProgrammer.class.getName());
 
 }
-
-/* @(#)TamsOpsModeProgrammer.java */

--- a/java/src/jmri/jmrix/tams/TamsProgrammer.java
+++ b/java/src/jmri/jmrix/tams/TamsProgrammer.java
@@ -1,4 +1,3 @@
-// TamsProgrammer.java
 package jmri.jmrix.tams;
 
 import java.util.ArrayList;
@@ -17,7 +16,6 @@ import org.slf4j.LoggerFactory;
  * work by Bob Jacobsen
  *
  * @author	Kevin Dickerson Copyright (C) 2012
- * @version $Revision: 17977 $
  */
 public class TamsProgrammer extends AbstractProgrammer implements TamsListener {
 
@@ -75,7 +73,8 @@ public class TamsProgrammer extends AbstractProgrammer implements TamsListener {
         }
     }
 
-    public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    @Override
+    public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 
@@ -256,6 +255,3 @@ public class TamsProgrammer extends AbstractProgrammer implements TamsListener {
     private final static Logger log = LoggerFactory.getLogger(TamsProgrammer.class.getName());
 
 }
-
-
-/* @(#)TamsProgrammer.java */

--- a/java/src/jmri/jmrix/zimo/Mx1Programmer.java
+++ b/java/src/jmri/jmrix/zimo/Mx1Programmer.java
@@ -84,7 +84,7 @@ public class Mx1Programmer extends AbstractProgrammer implements Mx1Listener {
         }
     }
 
-    public void confirmCV(int CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+    public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
         readCV(CV, p);
     }
 

--- a/java/src/jmri/progdebugger/ProgDebugger.java
+++ b/java/src/jmri/progdebugger/ProgDebugger.java
@@ -1,4 +1,3 @@
-// ProgDebugger.java
 package jmri.progdebugger;
 
 import java.beans.PropertyChangeListener;
@@ -23,7 +22,6 @@ import org.slf4j.LoggerFactory;
  * Only supports the DCC single-number address space.
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2007, 2013
- * @version $Revision$
  */
 public class ProgDebugger implements AddressedProgrammer {
 
@@ -143,11 +141,15 @@ public class ProgDebugger implements AddressedProgrammer {
 
     boolean confirmOK;  // cached result of last compare
 
-    public void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
-        confirmCV(Integer.parseInt(CV), val, p);
+    @Override
+    @SuppressWarnings("deprecation") // parent Programmer method deprecated, will remove at same time
+    public final void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+        confirmCV("" + CV, val, p);
     }
 
-    public void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+    @Override
+    public void confirmCV(String CVname, int val, ProgListener p) throws ProgrammerException {
+        int CV = Integer.parseInt(CVname);
         final ProgListener m = p;
 
         nOperations++;
@@ -364,5 +366,3 @@ public class ProgDebugger implements AddressedProgrammer {
 
     private final static Logger log = LoggerFactory.getLogger(ProgDebugger.class.getName());
 }
-
-/* @(#)ProgDebugger.java */

--- a/java/test/jmri/jmrix/AbstractProgrammerTest.java
+++ b/java/test/jmri/jmrix/AbstractProgrammerTest.java
@@ -42,7 +42,7 @@ public class AbstractProgrammerTest extends TestCase {
             public ProgrammingMode getBestMode() { return DefaultProgrammerManager.REGISTERMODE; }
             
             public void writeCV(int i, int j, ProgListener l) {}
-            public void confirmCV(int i, int j, ProgListener l) {}
+            public void confirmCV(String i, int j, ProgListener l) {}
             public void readCV(int i, ProgListener l) {}
             public void timeout() {}
             public boolean getCanRead() { return true;}
@@ -135,7 +135,7 @@ public class AbstractProgrammerTest extends TestCase {
             }
 
             public void writeCV(int i, int j, ProgListener l) {}
-            public void confirmCV(int i, int j, ProgListener l) {}
+            public void confirmCV(String i, int j, ProgListener l) {}
             public void readCV(int i, ProgListener l) {}
             public void timeout() {}
             public boolean getCanRead() { return true;}


### PR DESCRIPTION
The Programmer#confirmCV(int ..) method and four base implementations are still there, so there will be a few deprecation warnings until it's finally removed or somebody figures out how to suppress them.

Also includes removal of $Release from LocoNet properties files.