### PR TITLE
Remove FindBugs problem

### DIFF
--- a/java/src/jmri/jmrix/dccpp/dccppovertcp/ClientRxHandler.java
+++ b/java/src/jmri/jmrix/dccpp/dccppovertcp/ClientRxHandler.java
@@ -162,12 +162,6 @@ public final class ClientRxHandler extends Thread implements DCCppListener {
 			outBuf.append(">");
                         log.debug("ClientTxHandler: Send: " + outBuf.toString());
                         outBuf.append("\r\n");
-                        // See if we are waiting for an echo of a sent message
-                        // and if it is append the Ack to the client
-                        if ((lastSentMessage != null) && lastSentMessage.equals(msg)) {
-                            lastSentMessage = null;
-                            outBuf.append("SENT OK\r\n");
-                        }
                         outStream.write(outBuf.toString().getBytes());
                         outStream.flush();
                     }

--- a/java/src/jmri/jmrix/dccpp/dccppovertcp/DCCppOverTcpPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/dccppovertcp/DCCppOverTcpPacketizer.java
@@ -15,9 +15,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Converts Stream-based I/O to/from LocoNet messages. The "LocoNetInterface"
- * side sends/receives LocoNetMessage objects. The connection to a
- * LnPortnetworkController is via a pair of *Streams, which then carry sequences
+ * Converts Stream-based I/O to/from DCC++ messages. The "DCCppInterface"
+ * side sends/receives DCCppMessage objects. The connection to a
+ * DCCppPortnetworkController is via a pair of *Streams, which then carry sequences
  * of characters for transmission.
  * <P>
  * Messages come to this via the main GUI thread, and are forwarded back to
@@ -30,11 +30,6 @@ import org.slf4j.LoggerFactory;
  * <LI> (everything else)
  * </UL>
  * <P>
- * Some of the message formats used in this class are Copyright Digitrax, Inc.
- * and used with permission as part of the JMRI project. That permission does
- * not extend to uses in other software products. If you wish to use this code,
- * algorithm or these message formats outside of JMRI, please contact Digitrax
- * Inc for separate permission.
  *
  * @author Bob Jacobsen Copyright (C) 2001
  * @author Alex Shepherd Copyright (C) 2003, 2006
@@ -133,7 +128,7 @@ public class DCCppOverTcpPacketizer extends DCCppPacketizer {
     }
 
     /**
-     * Forward a preformatted LocoNetMessage to the actual interface.
+     * Forward a preformatted DCCppMessage to the actual interface.
      *
      * Checksum is computed and overwritten here, then the message is converted
      * to a byte array and queue for transmission
@@ -317,7 +312,7 @@ public class DCCppOverTcpPacketizer extends DCCppPacketizer {
                     try {
                         if (ostream != null) {
                             //Commented out as the origianl LnPortnetworkController always returned true.
-                            //if (!networkController.okToSend()) log.warn("LocoNet port not ready to receive"); // TCP, not RS232, so message is a real warning
+                            //if (!networkController.okToSend()) log.warn(DCCpp port not ready to receive"); // TCP, not RS232, so message is a real warning
                             if (debug) {
                                 log.debug("start write to network stream");
                             }
@@ -335,10 +330,10 @@ public class DCCppOverTcpPacketizer extends DCCppPacketizer {
                             }
                         } else {
                             // no stream connected
-                            log.warn("sendLocoNetMessage: no connection established");
+                            log.warn("sendDCCppMessage: no connection established");
                         }
                     } catch (java.io.IOException e) {
-                        log.warn("sendLocoNetMessage: IOException: " + e.toString());
+                        log.warn("sendDCCppMessage: IOException: " + e.toString());
                     }
                 } catch (NoSuchElementException e) {
                     // message queue was empty, wait for input

--- a/java/src/jmri/jmrix/dccpp/dccppovertcp/DCCppTcpDriverAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/dccppovertcp/DCCppTcpDriverAdapter.java
@@ -10,10 +10,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Implements SerialPortAdapter for the LocoNetOverTcp system network
+ * Implements SerialPortAdapter for the DCCppOverTcp system network
  * connection.
  * <P>
- * This connects a Loconet via a telnet connection. Normally controlled by the
+ * This connects a DCC++ via a telnet connection. Normally controlled by the
  * DCCppTcpDriverFrame class.
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2002, 2003
@@ -35,7 +35,7 @@ public class DCCppTcpDriverAdapter extends DCCppNetworkPortController implements
     }
 
     /**
-     * set up all of the other objects to operate with a LocoNet connected via
+     * set up all of the other objects to operate with a DCC++ connected via
      * this class.
      */
     public void configure() {

--- a/java/src/jmri/jmrix/dccpp/dccppovertcp/Server.java
+++ b/java/src/jmri/jmrix/dccpp/dccppovertcp/Server.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Implementation of the LocoNetOverTcp LbServer Server Protocol
+ * Implementation of the DCCppOverTcp Server Protocol
  *
  * @author Alex Shepherd Copyright (C) 2006
  * @author Mark Underwood Copyright (C) 2015
@@ -96,7 +96,7 @@ public class Server {
         try {
             OutputStream outStream = new FileOutputStream(settingsFileName);
             PrintStream settingsStream = new PrintStream(outStream);
-            settingsStream.println("# LocoNetOverTcp Configuration Settings");
+            settingsStream.println("# DCCppOverTcp Configuration Settings");
             settingsStream.println(AUTO_START_KEY + " = " + (autoStart ? "1" : "0"));
             settingsStream.println(PORT_NUMBER_KEY + " = " + portNumber);
 

--- a/java/src/jmri/jmrix/dccpp/dccppovertcp/package.html
+++ b/java/src/jmri/jmrix/dccpp/dccppovertcp/package.html
@@ -14,24 +14,19 @@
     </head>
     <body bgcolor="white">
 
-        Defines classes for interfacing to an LocoNet
-        via a telnet connection to a LocoNetOverTcp driver.  
+        Defines classes for interfacing to a DCC++ Base Station
+        via a telnet connection to a DCCppOverTcp driver.  
 
         This package provides both client and server implementations 
         within JMRI.
 
         <h2>Related Documentation</h2>
 
-        For more information, please see:
-        <ul>
-            <li><a href="http://loconetovertcp.sourceforge.net/Client/index.html">LocoNet over TCP Client page</a>
-            <li><a href="http://loconetovertcp.sourceforge.net/Server/index.html">LocoNet over TCP Server page</a>
-        </ul>
 
-        @see jmri.jmrix.loconet.loconetovertcp.Server
-        @see jmri.jmrix.loconet.loconetovertcp.ClientRxHandler
+        @see jmri.jmrix.dccpp.dccppovertcp.Server
+        @see jmri.jmrix.dccpp.dccppovertcp.ClientRxHandler
 
-        @since 1.3.6
+        @since 4.1.7
 
     </body>
 </html>


### PR DESCRIPTION
* Remove an unused if() statement that was causing a FindBugs warning
in ClientRxHandler.java
* Clean up references to LocoNet in other DCCppOverTCP files.