### PR TITLE
Update maven version in AppVeyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: '{build}'
 clone_depth: 50
 install:
-  - SET MAVEN_VERSION=3.3.3
+  - SET MAVEN_VERSION=3.3.9
   - SET MAVEN_HOME=C:\Users\appveyor\maven\apache-maven-%MAVEN_VERSION%
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem


### PR DESCRIPTION
Apparently the Apache mirror systems only maintain older versions of projects within the x.y.z versioning scheme for any given x.y for a limited time, so updating to the current 3.3.x version of maven, since older 3.3.x version were recently removed.