### PR TITLE
Build on JDK8 and run on JDK9 on macOS

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -396,7 +396,7 @@
             <fileset dir="${resourcedir}" includes="*.gif"/>
         </copy>
         <copy todir="${target}">
-            <fileset dir="${source}" includes="**/*.properties"/>
+            <fileset dir="${source}" includes="**/*.properties,**/*.js"/>
             <fileset dir="${source}" includes="META-INF/**"/>
         </copy>
     </target>

--- a/help/en/html/tools/scripting/AppleScript.shtml
+++ b/help/en/html/tools/scripting/AppleScript.shtml
@@ -1,131 +1,71 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
-"http://www.w3.org/TR/html4/strict.dtd">
+    "http://www.w3.org/TR/html4/strict.dtd">
 
 <html lang="en">
-<head>
-  <meta name="generator" content=
-  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
-  <!-- Copyright Bob Jacobsen 2008 -->
+    <head>
+        <meta name="generator" content=
+              "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
+        <!-- Copyright Bob Jacobsen 2008 -->
 
-  <title>JMRI: AppleScript</title><!-- Style -->
-  <meta http-equiv="Content-Type" content=
-  "text/html; charset=us-ascii">
-  <link rel="stylesheet" type="text/css" href="/css/default.css"
-  media="screen">
-  <link rel="stylesheet" type="text/css" href="/css/print.css"
-  media="print">
-  <link rel="icon" href="/images/jmri.ico" type="image/png">
-  <link rel="home" title="Home" href="/"><!-- /Style -->
-</head>
+        <title>JMRI: Open Scripting Architecture</title><!-- Style -->
+        <meta http-equiv="Content-Type" content=
+              "text/html; charset=us-ascii">
+        <link rel="stylesheet" type="text/css" href="/css/default.css"
+              media="screen">
+        <link rel="stylesheet" type="text/css" href="/css/print.css"
+              media="print">
+        <link rel="icon" href="/images/jmri.ico" type="image/png">
+        <link rel="home" title="Home" href="/"><!-- /Style -->
+    </head>
 
-<body>
-  <!--#include virtual="/Header" -->
+    <body>
+        <!--#include virtual="/Header" -->
 
-  <div id="mBody">
-    <!--#include virtual="Sidebar" -->
+        <div id="mBody">
+            <!--#include virtual="Sidebar" -->
 
-    <div id="mainContent">
-      <h1>JMRI: AppleScript</h1>On Mac OS X, you can use
-      AppleScript to with JMRI. There are two ways to do this:
+            <div id="mainContent">
+                <h1>JMRI: Open Scripting Architecture</h1>
 
-      <ul>
-        <li>A JMRI script can use AppleScript to ask Mac OS X to do
-        things.</li>
+                <p>On macOS, you can use the Open Scripting Architecture (OSA)
+                    with JMRI to send instructions to OS X or other
+                    applications.</p>
 
-        <li>AppleScripts running outside of JMRI can ask a JMRI
-        application to do things.</li>
-      </ul>Together, these simplify the connection between JMRI and
-      the rest of your Mac, so that they can work together easily.
-
-      <h2>Operating Your Mac from JMRI via an AppleScript</h2>You
-      can write AppleScript commands and programs (scripts) within
-      JMRI jython scripts, and then invoke them to have your Mac
-      perform functions outside JMRI. An example of this is in the
-      <a href=
-      "http://jmri.org/jython/AppleScript.py">AppleScript.py</a>
-      sample script distributed with JMRI. It executes a very
-      simple AppleScript:
-      <pre style="font-family: monospace;">
+                <p>You can embed or call OSA scripts within JMRI scripts, invoking
+                    them to have your Mac perform functions outside JMRI. An example
+                    of this is in the <a href="http://jmri.org/jython/AppleScript.py">AppleScript.py</a>
+                    sample script distributed with JMRI. It executes a simple
+                    AppleScript:
+                <pre style="font-family: monospace;">
   tell application "Finder"
     make new folder at desktop
   end tell
-</pre>To do this, it has to
+                </pre></p>
 
-      <ul>
-        <li>Import some libraries to get access to AppleScript</li>
+                <p>The sample script shows how to do this, and can easily
+                    form the basis for running your own OSA scripts from within
+                    JMRI.</p>
 
-        <li>Create a string that holds the script itself</li>
+                <h2>AppleScript Information</h2>
 
-        <li>Create some objects to interpet the script and handle
-        errors</li>
+                <p>For more information on AppleScript, please see:</p>
 
-        <li>Then execute the script</li>
-      </ul>The sample script shows how to do this, and can easily
-      form the basis for running your own AppleScripts from within
-      JMRI.
+                <ul>
+                    <li><a href="http://help.apple.com/applescript/mac/10.9/">AppleScript Help</a>
+                        at <a href="http://www.apple.com/">Apple</a>.</li>
 
-      <h2>Controlling JMRI via an AppleScript</h2>This section
-      needs a lot of work; in the meantime, try
-      <pre style="font-family: monospace;">
-osascript -e 'tell application "DecoderPro" to get its |user.name|'
-</pre>and look at the <a href=
-"http://developer.apple.com/documentation/AppleScript/Conceptual/AppleScriptX/Concepts/work_with_as.html">
-      Apple doc page</a>.
+                    <li>The <a href="http://en.wikipedia.org/wiki/AppleScript">Wikipedia
+                            AppleScript article</a> has some interesting background
+                        info.</li>
 
-      <p>Also, search for "AppleScript" and "System Events" on
-      <a href=
-      "http://developer.apple.com/documentation/Java/Conceptual/Java14Development/07-NativePlatformIntegration/NativePlatformIntegration.html#//apple_ref/doc/uid/TP40001909">
-      this page</a>.</p>
+                    <li><a href="http://developer.apple.com/applescript">AppleScript
+                            Overview</a> at <a href="http://developer.apple.com/">Apple</a>.</li>
 
-      <p>Note the need to set accessibility, mentioned on this
-      <a href=
-      "http://lists.apple.com/archives/java-dev/2005/Nov/msg00258.html">
-      page</a>. This is done on the Universal Access pane of System
-      Preferences (System row, near the bottom), represented by
-      this checkbox at the bottom:</p>
-      <pre>
-  [ ] Enable access for assistive devices
-</pre>
+                </ul>
 
-      <p>See the sample file
-      jython/applescript/sampleAppleScript.scpt</p>
-
-      <p>
-      http://lists.apple.com/archives/java-dev/2005/May/msg00170.html</p>
-
-      <h2>AppleScript Information</h2>For more information on
-      AppleScripts, including how to write and debug them, please
-      see:
-
-      <ul>
-        <li>The <a href=
-        "http://www.apple.com/applescript/">AppleScript page</a> on
-        the <a href="http://www.apple.com/">Apple web site</a>. The
-        "<a href=
-        "http://www.apple.com/applescript/learn.html">Learn</a>"
-        section has useful examples.</li>
-
-        <li>The <a href=
-        "http://en.wikipedia.org/wiki/AppleScript">WikiPedia
-        AppleScript entry</a> has some interesting background
-        info.</li>
-
-        <li>There's an <a href=
-        "http://developer.apple.com/documentation/AppleScript/Conceptual/AppleScriptLangGuide/introduction/ASLR_intro.html">
-        AppleScript language guide</a> on the Apple <a href=
-        "http://developer.apple.com/applescript/">developer
-        AppleScript site</a>.</li>
-
-        <li>There's a very good <a href=
-        "http://www.oreilly.com/pub/a/mac/2003/02/25/apple_scripting.html">
-        O'Reilly article</a> on combining AppleScript and Java,
-        i.e. JMRI. It covers the technical aspects of running your
-        Mac from within JMRI.</li>
-      </ul>And, of course, a <a href=
-      "http://www.google.com/search?client=safari&amp;rls=en-us&amp;q=applescript&amp;ie=UTF-8&amp;oe=UTF-8">
-      Google search</a> will turn up lots of interesting resources.
-      <!--#include virtual="/Footer" -->
-    </div><!-- closes #mainContent-->
-  </div><!-- closes #mBody-->
-</body>
+                <p>A <a href="http://www.google.com/search?q=applescript">Google search</a> will turn up lots of interesting resources.</p>
+                <!--#include virtual="/Footer" -->
+            </div><!-- closes #mainContent-->
+        </div><!-- closes #mBody-->
+    </body> 
 </html>

--- a/java/src/META-INF/services/javax.script.ScriptEngineFactory
+++ b/java/src/META-INF/services/javax.script.ScriptEngineFactory
@@ -1,1 +1,0 @@
-apple.applescript.AppleScriptEngineFactory

--- a/java/src/jmri/package-info.java
+++ b/java/src/jmri/package-info.java
@@ -1,6 +1,3 @@
-// This is the template file for package-info.java files.
-// Update the following, including the package statement, 
-// and remove these three lines.
 /**
  * Provides basic interfaces and certain core implementations for the JMRI
  * layout management concepts.

--- a/java/src/jmri/plaf/macosx/AboutHandler.js
+++ b/java/src/jmri/plaf/macosx/AboutHandler.js
@@ -1,0 +1,11 @@
+/*
+ * Set the Java Desktop aboutHandler to handler (passed in script context)
+ */
+
+var aboutHandler = new java.awt.desktop.AboutHandler() {
+    handleAbout: function(e) {
+        handler.handleAbout(e);
+    }
+};
+
+java.awt.Desktop.getDesktop().setAboutHandler(aboutHandler);

--- a/java/src/jmri/plaf/macosx/Application.java
+++ b/java/src/jmri/plaf/macosx/Application.java
@@ -1,9 +1,6 @@
 package jmri.plaf.macosx;
 
-import com.apple.eawt.AppEvent.AboutEvent;
-import com.apple.eawt.AppEvent.PreferencesEvent;
-import com.apple.eawt.AppEvent.QuitEvent;
-import com.apple.eawt.QuitResponse;
+import java.awt.Desktop;
 import jmri.util.SystemType;
 
 /**
@@ -12,7 +9,8 @@ import jmri.util.SystemType;
  * <p>
  * <b>NOTE</b> All use of this class must be wrapped in a conditional test that
  * ensures that JMRI is not running on Mac OS X or in Try-Catch blocks. The
- * easiest test is:  <pre><code>
+ * easiest test is:
+ * <pre><code>
  * if (SystemType.isMacOSX()) {
  *     ...
  * }
@@ -24,117 +22,40 @@ import jmri.util.SystemType;
  * {@link com.apple.eawt.Application} class, as it only provides support for
  * those integration aspects that were implemented in JMRI 3.1.
  *
- * @author rhwood
- * @see com.apple.eawt.Application
+ * @author Randall Wood (c) 2011, 2016
+ * @see EawtApplication
+ * @see Jdk9Application
  */
-public class Application {
+abstract public class Application {
 
     private static volatile Application sharedApplication = null;
-    private com.apple.eawt.Application application = null;
 
     public static Application getApplication() {
         if (!SystemType.isMacOSX()) {
             return null;
         }
         if (sharedApplication == null) {
-            sharedApplication = new Application();
+            try {
+                // test that Desktop supports AboutHandlers
+                if (Desktop.getDesktop().isSupported(Desktop.Action.valueOf("APP_ABOUT"))) { // NOI18N
+                    sharedApplication = new Jdk9Application();
+                }
+            } catch (IllegalArgumentException ex) {
+                // if Desktop.Action does not include AboutHandlers, its not
+                // recognized to be (un)supported, so assume the Eawt is available 
+                sharedApplication = new EawtApplication();
+            }
         }
         return sharedApplication;
     }
 
-    private Application() {
-        application = com.apple.eawt.Application.getApplication();
+    Application() {
+        // do nothing but require that subclass constructors are package private
     }
 
-    public void setAboutHandler(final AboutHandler handler) {
-        try {
-            if (handler != null) {
-                application.setAboutHandler(new com.apple.eawt.AboutHandler() {
-                    @Override
-                    public void handleAbout(AboutEvent ae) {
-                        handler.handleAbout(ae);
-                    }
-                });
-            } else {
-                application.setAboutHandler(null);
-            }
-        } catch (java.lang.NoClassDefFoundError ex) {
-            // this simply means that the OS X version is too old to implement this
-            // so we ignore it
-        }
-    }
+    abstract public void setAboutHandler(final AboutHandler handler);
 
-    public void setPreferencesHandler(final PreferencesHandler handler) {
-        try {
-            if (handler != null) {
-                application.setPreferencesHandler(new com.apple.eawt.PreferencesHandler() {
-                    @Override
-                    public void handlePreferences(PreferencesEvent pe) {
-                        handler.handlePreferences(pe);
-                    }
-                });
-            } else {
-                application.setPreferencesHandler(null);
-            }
-        } catch (java.lang.NoClassDefFoundError ex) {
-            // this simply means that the OS X version is too old to implement this
-            // so we ignore it
-        }
-    }
-    /*
-     public static void setWindowCanFullScreen(Window window, boolean state) {
-     if (SystemType.isMacOSX()) {
-     try {
-     FullScreenUtilities.setWindowCanFullScreen(window, state);
-     } catch (java.lang.NoClassDefFoundError ex) {
-     // this simply means that the OS X version is too old to implement this
-     // so we ignore it
-     }
-     }
-     }
+    abstract public void setPreferencesHandler(final PreferencesHandler handler);
 
-     public static void addFullScreenListenerTo(Window window, FullScreenListener listener) {
-     if (SystemType.isMacOSX()) {
-     try {
-     FullScreenUtilities.addFullScreenListenerTo(window, listener);
-     } catch (java.lang.NoClassDefFoundError ex) {
-     // this simply means that the OS X version is too old to implement this
-     // so we ignore it
-     }
-     }
-     }
-
-     public static void removeFullScreenListenerFrom(Window window, FullScreenListener listener) {
-     if (SystemType.isMacOSX()) {
-     try {
-     FullScreenUtilities.removeFullScreenListenerFrom(window, listener);
-     } catch (java.lang.NoClassDefFoundError ex) {
-     // this simply means that the OS X version is too old to implement this
-     // so we ignore it
-     }
-     }
-     }
-     */
-
-    public void setQuitHandler(final QuitHandler handler) {
-        try {
-            if (handler != null) {
-                application.setQuitHandler(new com.apple.eawt.QuitHandler() {
-                    @Override
-                    public void handleQuitRequestWith(QuitEvent qe, QuitResponse qr) {
-                        if (handler.handleQuitRequest(qe)) {
-                            qr.performQuit();
-                        } else {
-                            qr.cancelQuit();
-                        }
-                    }
-                });
-            } else {
-                application.setQuitHandler(null);
-            }
-        } catch (java.lang.NoClassDefFoundError ex) {
-            // this simply means that the OS X version is too old to implement this
-            // so we ignore it
-        }
-    }
+    abstract public void setQuitHandler(final QuitHandler handler);
 }

--- a/java/src/jmri/plaf/macosx/EawtApplication.java
+++ b/java/src/jmri/plaf/macosx/EawtApplication.java
@@ -1,0 +1,88 @@
+package jmri.plaf.macosx;
+
+import com.apple.eawt.AppEvent.AboutEvent;
+import com.apple.eawt.AppEvent.PreferencesEvent;
+import com.apple.eawt.AppEvent.QuitEvent;
+import com.apple.eawt.QuitResponse;
+
+/**
+ * Wrapper for Apple provided extensions to Java that allow Java apps to feel
+ * more "Mac-like" on Mac OS X using JDK 8.
+ * <p>
+ * <b>NOTE</b> All use of this class must be wrapped in a conditional test that
+ * ensures that JMRI is not running on Mac OS X or in Try-Catch blocks. The
+ * easiest test is:  <pre><code>
+ * if (SystemType.isMacOSX()) {
+ *     ...
+ * }
+ * </code></pre> A Try-Catch block will need to catch
+ * {@link java.lang.NoClassDefFoundError} Failure to use one of these methods
+ * will result in crashes.
+ * <p>
+ * This wrapper currently provides incomplete support for the Apple
+ * {@link com.apple.eawt.Application} class, as it only provides support for
+ * those integration aspects that were implemented in JMRI 3.1.
+ *
+ * @author Randall Wood (c) 2016
+ * @see com.apple.eawt.Application
+ */
+class EawtApplication extends Application {
+
+    private com.apple.eawt.Application application = null;
+
+    EawtApplication() {
+        application = com.apple.eawt.Application.getApplication();
+    }
+
+    @Override
+    public void setAboutHandler(final AboutHandler handler) {
+        try {
+            if (handler != null) {
+                application.setAboutHandler((AboutEvent ae) -> {
+                    handler.handleAbout(ae);
+                });
+            } else {
+                application.setAboutHandler(null);
+            }
+        } catch (java.lang.NoClassDefFoundError ex) {
+            // this simply means that the OS X version is too old to implement this
+            // so we ignore it
+        }
+    }
+
+    @Override
+    public void setPreferencesHandler(final PreferencesHandler handler) {
+        try {
+            if (handler != null) {
+                application.setPreferencesHandler((PreferencesEvent pe) -> {
+                    handler.handlePreferences(pe);
+                });
+            } else {
+                application.setPreferencesHandler(null);
+            }
+        } catch (java.lang.NoClassDefFoundError ex) {
+            // this simply means that the OS X version is too old to implement this
+            // so we ignore it
+        }
+    }
+
+    @Override
+    public void setQuitHandler(final QuitHandler handler) {
+        try {
+            if (handler != null) {
+                application.setQuitHandler((QuitEvent qe, QuitResponse qr) -> {
+                    if (handler.handleQuitRequest(qe)) {
+                        qr.performQuit();
+                    } else {
+                        qr.cancelQuit();
+                    }
+                });
+            } else {
+                application.setQuitHandler(null);
+            }
+        } catch (java.lang.NoClassDefFoundError ex) {
+            // this simply means that the OS X version is too old to implement this
+            // so we ignore it
+        }
+    }
+}

--- a/java/src/jmri/plaf/macosx/Jdk9Application.java
+++ b/java/src/jmri/plaf/macosx/Jdk9Application.java
@@ -1,0 +1,110 @@
+package jmri.plaf.macosx;
+
+import java.awt.Desktop;
+import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+import javax.script.SimpleBindings;
+import javax.script.SimpleScriptContext;
+import jmri.script.JmriScriptEngineManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Wrapper for Apple provided extensions to Java that allow Java apps to feel
+ * more "Mac-like" on Mac OS X for JDK 9.
+ * <p>
+ * <b>NOTE</b> All use of this class must be wrapped in a conditional test that
+ * ensures that JMRI is not running on Mac OS X or in Try-Catch blocks. The
+ * easiest test is:
+ * <pre><code>
+ * if (SystemType.isMacOSX()) {
+ *     ...
+ * }
+ * </code></pre> A Try-Catch block will need to catch
+ * {@link java.lang.NoClassDefFoundError} Failure to use one of these methods
+ * will result in crashes.
+ * <p>
+ * This wrapper currently provides incomplete support for the Apple
+ * {@link com.apple.eawt.Application} class, as it only provides support for
+ * those integration aspects that were implemented in JMRI 3.1.
+ *
+ * @author Randall Wood (c) 2016
+ * @see Application
+ */
+class Jdk9Application extends Application {
+
+    private final static Logger log = LoggerFactory.getLogger(Jdk9Application.class);
+
+    Jdk9Application() {
+    }
+
+    private void setHandler(String methodName, String handlerType, Object handler) {
+        try {
+            Class parameterType = Class.forName(handlerType);
+            Class parameterTypes[] = {parameterType};
+            Method method = java.awt.Desktop.class.getDeclaredMethod(methodName, parameterTypes);
+            Object parameters[] = {handler};
+            method.invoke(Desktop.getDesktop(), parameters);
+        } catch (NoClassDefFoundError | ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+            log.debug("Exception calling {} with {}", methodName, handlerType, ex);
+        }
+    }
+
+    @Override
+    public void setAboutHandler(final AboutHandler handler) {
+        if (handler != null) {
+            try {
+                InputStreamReader reader = new InputStreamReader(Jdk9Application.class.getResourceAsStream("AboutHandler.js")); // NOI18N
+                ScriptEngine engine = JmriScriptEngineManager.getDefault().getEngineByMimeType("js"); // NOI18N
+                JmriScriptEngineManager.getDefault().eval(reader, engine, this.getContext(handler));
+            } catch (ScriptException ex) {
+                log.error("Unable to execute script AboutHandler.js", ex);
+            }
+        } else {
+            this.setHandler("setAboutHandler", "java.awt.desktop.AboutHandler", this.getContext(handler)); // NOI18N
+        }
+    }
+
+    @Override
+    public void setPreferencesHandler(final PreferencesHandler handler) {
+        if (handler != null) {
+            try {
+                InputStreamReader reader = new InputStreamReader(Jdk9Application.class.getResourceAsStream("PreferencesHandler.js")); // NOI18N
+                ScriptEngine engine = JmriScriptEngineManager.getDefault().getEngineByMimeType("js"); // NOI18N
+                JmriScriptEngineManager.getDefault().eval(reader, engine, this.getContext(handler));
+            } catch (ScriptException ex) {
+                log.error("Unable to execute script PreferencesHandler.js", ex);
+            }
+        } else {
+            this.setHandler("setPreferencesHandler", "java.awt.desktop.PreferencesHandler", handler); // NOI18N
+        }
+    }
+
+    @Override
+    public void setQuitHandler(final QuitHandler handler) {
+        if (handler != null) {
+            try {
+                InputStreamReader reader = new InputStreamReader(Jdk9Application.class.getResourceAsStream("QuitHandler.js")); // NOI18N
+                ScriptEngine engine = JmriScriptEngineManager.getDefault().getEngineByMimeType("js"); // NOI18N
+                JmriScriptEngineManager.getDefault().eval(reader, engine, this.getContext(handler));
+            } catch (ScriptException ex) {
+                log.error("Unable to execute script QuitHandler.js", ex);
+            }
+        } else {
+            this.setHandler("setQuitHandler", "java.awt.desktop.QuitHandler", handler); // NOI18N
+        }
+    }
+
+    private ScriptContext getContext(Object handler) {
+        Bindings bindings = new SimpleBindings();
+        bindings.put("handler", handler); // NOI18N
+        ScriptContext context = new SimpleScriptContext();
+        context.setBindings(bindings, ScriptContext.ENGINE_SCOPE);
+        return context;
+    }
+}

--- a/java/src/jmri/plaf/macosx/PreferencesHandler.js
+++ b/java/src/jmri/plaf/macosx/PreferencesHandler.js
@@ -1,0 +1,11 @@
+/*
+ * Set the Java Desktop preferencesHandler to handler (passed in script context)
+ */
+
+var preferencesHandler = new java.awt.desktop.PreferencesHandler() {
+    handlePreferences: function(e) {
+        handler.handlePreferences(e);
+    }
+};
+
+java.awt.Desktop.getDesktop().setPreferencesHandler(preferencesHandler);

--- a/java/src/jmri/plaf/macosx/QuitHandler.js
+++ b/java/src/jmri/plaf/macosx/QuitHandler.js
@@ -1,0 +1,15 @@
+/*
+ * Set the Java Desktop quitHandler to handler (passed in script context)
+ */
+
+var quitHandler = new java.awt.desktop.QuitHandler() {
+    handleQuitRequestWith: function(qe, qr) {
+        if (handler.handleQuitRequest(qe)) {
+            qr.performQuit();
+        } else {
+            qr.cancelQuit();
+        }
+    }
+};
+
+java.awt.Desktop.getDesktop().setQuitHandler(quitHandler);

--- a/java/src/jmri/plaf/macosx/package-info.java
+++ b/java/src/jmri/plaf/macosx/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * This package provides OS X Desktop compatibility with the Aqua user interface.
+ * <p>
+ * <strong>NOTE</strong> This package will be deprecated once JMRI requires JDK
+ * 9 or newer, and replaced with the direct use of {@link java.awt.Desktop},
+ * which is expanded in JDK 9 to support OS X integration that once depended
+ * upon the com.apple.eawt package.
+ */
+package jmri.plaf.macosx;

--- a/java/src/jmri/script/JmriScriptEngineManager.java
+++ b/java/src/jmri/script/JmriScriptEngineManager.java
@@ -177,6 +177,7 @@ public final class JmriScriptEngineManager {
      * Given a file extension, get the ScriptEngine registered to handle that
      * extension.
      *
+     * @param extension a file extension
      * @return a ScriptEngine or null
      */
     public ScriptEngine getEngineByExtension(String extension) {
@@ -191,6 +192,7 @@ public final class JmriScriptEngineManager {
      * Given a mime type, get the ScriptEngine registered to handle that mime
      * type.
      *
+     * @param mimeType a mimeType for a script
      * @return a ScriptEngine or null
      */
     public ScriptEngine getEngineByMimeType(String mimeType) {
@@ -204,6 +206,7 @@ public final class JmriScriptEngineManager {
     /**
      * Given a short name, get the ScriptEngine registered by that name.
      *
+     * @param shortName the short name for the ScriptEngine
      * @return a ScriptEngine or null
      */
     public ScriptEngine getEngineByName(String shortName) {
@@ -217,6 +220,7 @@ public final class JmriScriptEngineManager {
     /**
      * Get a ScriptEngine by it's name.
      *
+     * @param engineName the complete name for the ScriptEngine
      * @return a ScriptEngine or null
      */
     public ScriptEngine getEngine(String engineName) {
@@ -237,6 +241,10 @@ public final class JmriScriptEngineManager {
     /**
      * Evaluate a script using the given ScriptEngine.
      *
+     * @param script The script.
+     * @param engine The script engine.
+     * @return The results of evaluating the script.
+     * @throws javax.script.ScriptException if there is an error in the script.
      */
     public Object eval(String script, ScriptEngine engine) throws ScriptException {
         if (PYTHON.equals(engine.getFactory().getEngineName()) && this.jython != null) {
@@ -249,6 +257,10 @@ public final class JmriScriptEngineManager {
     /**
      * Evaluate a script using the given ScriptEngine.
      *
+     * @param reader The script.
+     * @param engine The script engine.
+     * @return The results of evaluating the script.
+     * @throws javax.script.ScriptException if there is an error in the script.
      */
     public Object eval(Reader reader, ScriptEngine engine) throws ScriptException {
         return engine.eval(reader);
@@ -261,16 +273,35 @@ public final class JmriScriptEngineManager {
      * @param engine   The script engine.
      * @param bindings Bindings passed to the script.
      * @return The results of evaluating the script.
-     * @throws ScriptException if there is an error in the script.
+     * @throws javax.script.ScriptException if there is an error in the script.
      */
     public Object eval(Reader reader, ScriptEngine engine, Bindings bindings) throws ScriptException {
         return engine.eval(reader, bindings);
     }
 
     /**
+     * Evaluate a script using the given ScriptEngine and Bindings.
+     *
+     * @param reader  The script.
+     * @param engine  The script engine.
+     * @param context Context for the script.
+     * @return The results of evaluating the script.
+     * @throws javax.script.ScriptException if there is an error in the script.
+     */
+    public Object eval(Reader reader, ScriptEngine engine, ScriptContext context) throws ScriptException {
+        return engine.eval(reader, context);
+    }
+
+    /**
      * Evaluate a script contained in a file. Uses the extension of the file to
      * determine which ScriptEngine to use.
      *
+     * @param file the script file to evaluate.
+     * @return the results of the evaluation.
+     * @throws javax.script.ScriptException  if there is an error evaluating the
+     *                                       script.
+     * @throws java.io.FileNotFoundException if the script file cannot be found.
+     * @throws java.io.IOException           if the script file cannot be read.
      */
     public Object eval(File file) throws ScriptException, FileNotFoundException, IOException {
         ScriptEngine engine = this.getEngineByExtension(FilenameUtils.getExtension(file.getName()));
@@ -290,8 +321,15 @@ public final class JmriScriptEngineManager {
      * {@link javax.script.Bindings} to add to the script's context. Uses the
      * extension of the file to determine which ScriptEngine to use.
      *
+     * @param file     the script file to evaluate.
+     * @param bindings script bindings to evaluate against.
+     * @return the results of the evaluation.
+     * @throws javax.script.ScriptException  if there is an error evaluating the
+     *                                       script.
+     * @throws java.io.FileNotFoundException if the script file cannot be found.
+     * @throws java.io.IOException           if the script file cannot be read.
      */
-    public Object eval(File file, Bindings n) throws ScriptException, FileNotFoundException, IOException {
+    public Object eval(File file, Bindings bindings) throws ScriptException, FileNotFoundException, IOException {
         ScriptEngine engine = this.getEngineByExtension(FilenameUtils.getExtension(file.getName()));
         if (PYTHON.equals(engine.getFactory().getEngineName()) && this.jython != null) {
             try (FileInputStream fi = new FileInputStream(file)) {
@@ -300,7 +338,7 @@ public final class JmriScriptEngineManager {
             return null;
         }
         try (FileReader fr = new FileReader(file)) {
-            return engine.eval(fr, n);
+            return engine.eval(fr, bindings);
         }
     }
 
@@ -309,6 +347,13 @@ public final class JmriScriptEngineManager {
      * script. Uses the extension of the file to determine which ScriptEngine to
      * use.
      *
+     * @param file    the script file to evaluate.
+     * @param context script context to evaluate within.
+     * @return the results of the evaluation.
+     * @throws javax.script.ScriptException  if there is an error evaluating the
+     *                                       script.
+     * @throws java.io.FileNotFoundException if the script file cannot be found.
+     * @throws java.io.IOException           if the script file cannot be read.
      */
     public Object eval(File file, ScriptContext context) throws ScriptException, FileNotFoundException, IOException {
         ScriptEngine engine = this.getEngineByExtension(FilenameUtils.getExtension(file.getName()));
@@ -366,6 +411,7 @@ public final class JmriScriptEngineManager {
      * Given a file extension, get the ScriptEngineFactory registered to handle
      * that extension.
      *
+     * @param extension a file extension
      * @return a ScriptEngineFactory or null
      */
     public ScriptEngineFactory getFactoryByExtension(String extension) {
@@ -380,6 +426,7 @@ public final class JmriScriptEngineManager {
      * Given a mime type, get the ScriptEngineFactory registered to handle that
      * mime type.
      *
+     * @param mimeType the script mimeType
      * @return a ScriptEngineFactory or null
      */
     public ScriptEngineFactory getFactoryByMimeType(String mimeType) {
@@ -393,6 +440,7 @@ public final class JmriScriptEngineManager {
     /**
      * Given a short name, get the ScriptEngineFactory registered by that name.
      *
+     * @param shortName the short name for the factory
      * @return a ScriptEngineFactory or null
      */
     public ScriptEngineFactory getFactoryByName(String shortName) {
@@ -406,6 +454,7 @@ public final class JmriScriptEngineManager {
     /**
      * Get a ScriptEngineFactory by it's name.
      *
+     * @param factoryName the complete name for a factory
      * @return a ScriptEngineFactory or null
      */
     public ScriptEngineFactory getFactory(String factoryName) {

--- a/java/src/jmri/script/JmriScriptEngineManager.java
+++ b/java/src/jmri/script/JmriScriptEngineManager.java
@@ -255,6 +255,19 @@ public final class JmriScriptEngineManager {
     }
 
     /**
+     * Evaluate a script using the given ScriptEngine and Bindings.
+     *
+     * @param reader   The script.
+     * @param engine   The script engine.
+     * @param bindings Bindings passed to the script.
+     * @return The results of evaluating the script.
+     * @throws ScriptException if there is an error in the script.
+     */
+    public Object eval(Reader reader, ScriptEngine engine, Bindings bindings) throws ScriptException {
+        return engine.eval(reader, bindings);
+    }
+
+    /**
      * Evaluate a script contained in a file. Uses the extension of the file to
      * determine which ScriptEngine to use.
      *

--- a/jython/AppleScript.py
+++ b/jython/AppleScript.py
@@ -1,26 +1,32 @@
-# Invoke an AppleScript from
-# JMRI on Mac OS X.
+# Demonstration of invoking osascript (using AppleScript) from JMRI on Mac OS X.
 #
 # Author: Bob Jacobsen, Copyright 2008, 2016
 # Part of the JMRI distribution
-#
 
 import jmri
 
+# osascript is an external command, so we need to use Popen to call it and PIPE
+# to get its input and output
 from subprocess import Popen, PIPE
 
-# define a method for running an Applescript 
-def run_this_scpt(scpt, args=[]):
-     p = Popen(['osascript', '-'] + args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-     stdout, stderr = p.communicate(scpt)
-     return stdout
+# define a method for running osascript
+# takes two arguments:
+#   a script (required)
+#   an array of arguments to pass to the script (optional)
+def osascript(scpt, args=[]):
+    # create an osascript process
+    p = Popen(['osascript', '-'] + args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    # execute the script
+    stdout, stderr = p.communicate(scpt)
+    # return its output
+    return stdout
 
-# a sample - note that a lot of quoting \ characters are needed to get lines right
+# sample - note extensive use of quoting and \ characters to get lines right
 script = \
-"tell application \"Finder\"\n"+ \
-"  make new folder at desktop\n"+ \
+"tell application \"Finder\"\n" + \
+"  make new folder at desktop\n" + \
 "end tell\n"
 
 # Execute the sample
-run_this_scpt(script)
+osascript(script)
 

--- a/jython/AppleScript.py
+++ b/jython/AppleScript.py
@@ -4,10 +4,6 @@
 # Author: Bob Jacobsen, Copyright 2008, 2016
 # Part of the JMRI distribution
 #
-# Note: Modern JMRI versions can directly run Applescript, without
-# having to start with the Python interpreter. See the 
-# jython/Console.applescript file for an example.
-#
 
 import jmri
 

--- a/jython/Console.applescript
+++ b/jython/Console.applescript
@@ -1,8 +1,0 @@
--- Open the current JMRI session log in the OS X Console.app
-
--- This can be invoked within JMRI on OS X using any method used to invoke
--- Python scripts or can be invoked from the OS X Script Editor
-tell application "Finder"
-	set JMRI to folder "JMRI" in folder "Preferences" in folder "Library" in home
-	open file "session.log" in folder "log" in JMRI
-end tell

--- a/jython/applescript/sampleAppleScript.scpt
+++ b/jython/applescript/sampleAppleScript.scpt
@@ -1,1 +1,0 @@
-# List all the UI elements of a windowtell application "System Events"  tell application process "DecoderPro"    tell window "DecoderPro"      get UI elements    end tell  end tellend tell# (To open the pane needed to authorize this)#  tell app "System Preferences"#    set current pane to pane id "com.apple.preference.universalaccess"#  end tell


### PR DESCRIPTION
- Drop AppleScript support. Scripting JMRI (and Java apps) requires Java SE 6, and using AppleScript directly is removed in JDK 9.
- Implement Desktop support introduced in JDK9 to replace Apple-provided Desktop support dropped in JDK9.
- Use JavaScript for JDK9 only Desktop features so JMRI can be built on JDK8.
- Update AppleScript page to reflect that support is limited to using the ```osascript``` command from Python or JavaScript within the JMRI scripting support.
