### PR TITLE
runtest.csh uses POSIX launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ RemoteSystemsTempFiles
 [Tt]humbs.db
 *.DS_Store
 /jmri-fb.html
+
+.run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -29,11 +29,13 @@ session.log
 /xml/XSLT/properties
 /xml/XSLT/xml
 /xml/XSLT/pages
+.run.sh
 
 # private / per-user configuration files
 /nbproject/private
 /.idea/workspace.xml
 local.properties
+local.conf
 *.original~
 .metadata
 RemoteSystemsTempFiles
@@ -45,5 +47,3 @@ RemoteSystemsTempFiles
 [Tt]humbs.db
 *.DS_Store
 /jmri-fb.html
-
-.run.sh

--- a/build.xml
+++ b/build.xml
@@ -830,9 +830,9 @@
     </target>
 
     <target name="run-sh" description="Create run.sh in SCM root">
-        <make-startup-script script.name="run.sh"
+        <make-startup-script script.name=".run.sh"
                              script.class="jmri.util.junit.TestClassMainMethod"
-                             dest="${basedir}/run.sh"/>
+                             dest="${basedir}/.run.sh"/>
     </target>
 
     <!-- This is a set of targets used to start up the various JMRI applications

--- a/build.xml
+++ b/build.xml
@@ -380,6 +380,7 @@
             <fileset file="junit-results.xml"/>
             <fileset file="jmri-fb.html"/>
             <fileset file="jacoco.exec"/>
+            <fileset file=".run.sh"/>
         </delete>
         <ant dir="xml/XSLT" target="clean" inheritAll="false"  />
     </target>

--- a/build.xml
+++ b/build.xml
@@ -829,6 +829,12 @@
         </java>
     </target>
 
+    <target name="run-sh" description="Create run.sh in SCM root">
+        <make-startup-script script.name="run.sh"
+                             script.class="jmri.util.junit.TestClassMainMethod"
+                             dest="${basedir}/run.sh"/>
+    </target>
+
     <!-- This is a set of targets used to start up the various JMRI applications
                They all use the same back-end target run-jmri-application to do the work,
                with the only differences among them being the value of the initial classname

--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -856,11 +856,11 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         pane2.add(new JLabel(line1()));
         pane2.add(new JLabel(line2()));
         pane2.add(new JLabel(line3()));
-        
-        if (ProfileManager.getDefault()!=null && ProfileManager.getDefault().getActiveProfile() != null) {
+
+        if (ProfileManager.getDefault() != null && ProfileManager.getDefault().getActiveProfile() != null) {
             pane2.add(new JLabel(Bundle.getMessage("ActiveProfile", ProfileManager.getDefault().getActiveProfile().getName())));
         } else {
-            pane2.add(new JLabel(Bundle.getMessage("FailedProfile")));            
+            pane2.add(new JLabel(Bundle.getMessage("FailedProfile")));
         }
         // add listener for Com port updates
         ConnectionStatus.instance().addPropertyChangeListener(this);
@@ -953,7 +953,7 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
     static JComponent _buttonSpace = null;
     static SplashWindow sp = null;
     static AWTEventListener debugListener = null;
-    
+
     // TODO: Remove the "static" nature of much of the initialization someday.
     //       It exits to allow splash() to be called first-thing in main(), see e.g.
     //       apps.DecoderPro.DecoderPro.main(...) 
@@ -973,7 +973,8 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
      * Left as a deprecated method because other code, e.g. CATS is still using
      * in in JMRI 3.7 and perhaps 3.8
      *
-     * @deprecated Since 3.7.2, use @{link jmri.util.Log4JUtil#initLogging} directly.
+     * @deprecated Since 3.7.2, use @{link jmri.util.Log4JUtil#initLogging}
+     * directly.
      */
     @Deprecated
     static protected void initLog4J() {
@@ -995,7 +996,7 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
                                  and the if the debugFired hasn't been set, this allows us to ensure that we don't
                                  miss the user pressing F8, while we are checking*/
                         debugmsg = true;
-                        if (e.getID() == KeyEvent.KEY_PRESSED && e instanceof KeyEvent && ((KeyEvent)e).getKeyCode() == 119) {
+                        if (e.getID() == KeyEvent.KEY_PRESSED && e instanceof KeyEvent && ((KeyEvent) e).getKeyCode() == 119) {
                             startupDebug();
                         } else {
                             debugmsg = false;
@@ -1086,6 +1087,10 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
      * @param args Argument array from the main routine
      */
     static protected void setConfigFilename(String def, String[] args) {
+        // skip if org.jmri.Apps.configFilename is set
+        if (System.getProperty("org.jmri.Apps.configFilename") != null) {
+            return;
+        }
         // save the configuration filename if present on the command line
         if (args.length >= 1 && args[0] != null && !args[0].contains("=")) {
             def = args[0];
@@ -1140,7 +1145,7 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         }
 
     }
-    static String configFilename = "jmriconfig2.xml";  // usually overridden, this is default
+    static String configFilename = System.getProperty("org.jmri.Apps.configFilename", "jmriconfig2.xml");  // usually overridden, this is default
     // The following MUST be protected for 3rd party applications 
     // (such as CATS) which are derived from this class.
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "MS_PKGPROTECT",

--- a/java/src/apps/AppsLaunchPane.java
+++ b/java/src/apps/AppsLaunchPane.java
@@ -294,6 +294,10 @@ public abstract class AppsLaunchPane extends JPanel implements PropertyChangeLis
      * @param args Argument array from the main routine
      */
     static protected void setConfigFilename(String def, String[] args) {
+        // if the property org.jmri.Apps.configFilename was set, skip
+        if (System.getProperty("org.jmri.Apps.configFilename") != null) {
+            return;
+        }
         // save the configuration filename if present on the command line
         if (args.length >= 1 && args[0] != null && !args[0].contains("=")) {
             def = args[0];

--- a/runtest.csh
+++ b/runtest.csh
@@ -14,7 +14,7 @@
 # org.junit.runner.JUnitCore runner is asked to try to run the
 # class as JUnit4 tests. 
 #
-# This works by calling run.sh, which is generated from the JMRI POSIX launcher
+# This works by calling .run.sh, which is generated from the JMRI POSIX launcher
 # by running 'ant run-sh'
 #
 # By default this script sets the JMRI settings: dir to the directory "temp" in
@@ -82,6 +82,7 @@ done
 # if settingsdir is not empty (using JMRI default), and local.conf is newer than
 # jmri.conf, copy local.conf to jmri.conf
 if [ ! -z "${settingsdir}" -a "$( dirname $0 )/local.conf" -nt "${settingsdir}/jmri.conf" ] ; then
+    mkdir -p "${settingsdir}"
     cp "$( dirname $0 )/local.conf" "${settingsdir}/jmri.conf"
 fi
 

--- a/runtest.csh
+++ b/runtest.csh
@@ -82,4 +82,4 @@ if [ -n "$settingsdir" ] ; then
     settingsdir="--settingsdir=${settingsdir}"
 fi
 
-$( dirname $0 )/run.sh "$settingsdir" $@
+$( dirname $0 )/.run.sh "$settingsdir" $@

--- a/runtest.csh
+++ b/runtest.csh
@@ -19,7 +19,9 @@
 #
 # By default this script sets the JMRI settings: dir to the directory "temp" in
 # the directory its run from. Pass the option --settingsdir="" to use the JMRI
-# default location.
+# default location. local.conf in the directory this script is run from is
+# copied to jmri.conf in the settings: dir if the settings: dir is not "" and
+# local.conf is newer than jmri.conf.
 #
 # Note that this script may mangle arguments with unescaped spaces. This can be
 # avoided by writing spaces in arguments as "\ ".
@@ -76,6 +78,13 @@ for opt in "$@"; do
         break;
     fi
 done
+
+# if settingsdir is not empty (using JMRI default), and local.conf is newer than
+# jmri.conf, copy local.conf to jmri.conf
+if [ ! -z "${settingsdir}" -a "$( dirname $0 )/local.conf" -nt "${settingsdir}/jmri.conf" ] ; then
+    cp "$( dirname $0 )/local.conf" "${settingsdir}/jmri.conf"
+fi
+
 # if --settingsdir="" was passed, allow run.sh to use JMRI default, otherwise
 # prepend the option token to ensure run.sh sets the settings dir correctly
 if [ -n "$settingsdir" ] ; then

--- a/runtest.csh
+++ b/runtest.csh
@@ -11,19 +11,12 @@
 # If there is no main() method found in the named class, an
 # org.junit.runner.JUnitCore runner is asked to try to run the
 # class as JUnit4 tests. 
-# 
-# All this is done by using a script similar to (originally
-# identical to) the JMRI POSIX launcher, which invokes a
-# bespoke jmri.util.junit.TestClassMainMethod class.
 #
-# Note that, unlike running JUnit tests from Ant, 
-# this currently doesn't set the jmri.prefsdir system property
-# to "temp". Running tests in Ant does that, which causes
-# them to use a custom preferences directory.  You can
-# do that manually via (or similar)
-#  setenv JMRI_OPTIONS "-Djmri.prefsdir=${PWD}/temp ${JMRI_OPTIONS}"
+# This works by calling run.sh, which is generated from the JMRI POSIX launcher
+# by running 'ant run-sh'
 #
-# Made from the DecoderPro script, January 2010
+# Note that this script may mangle arguments with unescaped spaces. This can be
+# avoided by writing spaces in arguments as "\ ".
 #
 # If you need to add any additional Java options or defines,
 # include them in the JMRI_OPTIONS environment variable
@@ -50,130 +43,13 @@
 #
 # For more information, please see
 # http://jmri.org/install/ShellScripts.shtml
-#
 
-SYSLIBPATH=
-
-if [ -z "$OS" ]
-then
-    # start finding the architecture specific library directories
-    OS=`uname -s`
-
-    # normalize to match our standard names
-    if [ "$OS" = "Linux" ]
-    then
-      OS="linux"
-    fi
-
-    if [ "$OS" = "Darwin" ]
-    then
-      OS="macosx"
-    fi
+# assume ant is in the path, and silence output
+ant run-sh 2>/dev/null
+result=$?
+if [ $result -ne 0 ] ; then
+    echo "ant run-sh failed. please run independently to determine why."
+    exit $result
 fi
 
-if [ -d "lib/$OS" ]
-then
-  SYSLIBPATH="lib/$OS"
-fi
-
-# one or another of these commands should return a useful value, except that sometimes
-# it is spelled funny (e,g, amd64, not x86_64).  
-
-if [ -z "$ARCH" ]
-then
-    for cmd in "arch" "uname -i" "uname -p"
-    do
-      ARCH=`$cmd 2>/dev/null`
-      if [ -n "$ARCH" ]
-      then
-	    if [ "$ARCH" = "amd64" ]
-	    then
-	      ARCH="x86_64"
-	    fi
-
-	    if [ "$ARCH" = "i686" ]
-	    then
-	      ARCH="i386"
-	    fi
-
-	    if [ -d "lib/$OS/$ARCH" ]
-	    then
-	       SYSLIBPATH="lib/$OS/$ARCH:$SYSLIBPATH"
-
-	       # we're only interested in ONE of these values, so as soon as we find a supported
-	       # architecture directory, continue processing and start up the program
-	       break
-	    fi
-      fi
-    done
-fi
-
-
-# define the class to be invoked
-CLASSNAME=$1
-
-# set DEBUG to anything to see debugging output
-# DEBUG=yes
-
-# if JMRI_HOME is defined, go there, else
-# change directory to where the script is located
-if [ "${JMRI_HOME}" ]
-then
-    cd "${JMRI_HOME}"
-else 
-    cd `dirname $0`
-fi
-[ "${DEBUG}" ] && echo "PWD: '${PWD}'"
-
-# build classpath dynamically
-CP=".:classes:java/classes"
-# list of jar files in home, not counting jmri.jar
-LOCALJARFILES=`ls *.jar | grep -v jmri.jar | tr "\n" ":"`
-if [ ${LOCALJARFILES} ]
-then 
-  CP="${CP}:${LOCALJARFILES}"
-fi
-# add jmri.jar
-CP="${CP}:jmri.jar"
-# and contents of lib
-CP="${CP}:`ls -m lib/*.jar | tr -d ' \n' | tr ',' ':'`"
-# add a stand-in for ${ant.home}/lib/ant.jar
-CP="${CP}:/usr/share/ant/lib/ant.jar"
-
-[ "${DEBUG}" ] && echo "CLASSPATH: '${CP}'"
-
-# create the option string
-#
-# Add JVM and RMI options to user options, if any
-OPTIONS="${JMRI_OPTIONS} -noverify"
-OPTIONS="${OPTIONS} -Djava.security.policy=lib/security.policy"
-OPTIONS="${OPTIONS} -Djava.rmi.server.codebase=file:java/classes/"
-OPTIONS="${OPTIONS} -Djava.library.path=.:lib:$SYSLIBPATH"
-# ddraw is disabled to get around Swing performance problems in Java 1.5.0
-OPTIONS="${OPTIONS} -Dsun.java2d.noddraw"
-# memory start and max limits
-OPTIONS="${OPTIONS} -Xms30m"
-OPTIONS="${OPTIONS} -Xmx640m"
-
-# RXTX options (only works in some versions)
-OPTIONS="${OPTIONS} -Dgnu.io.rxtx.NoVersionOutput=true"
-[ "${DEBUG}" ] && echo "OPTIONS: '${OPTIONS}'"
-
-if [ -n "$JMRI_SERIAL_PORTS" ]
-then
-  JMRI_SERIAL_PORTS="$JMRI_SERIAL_PORTS,"
-fi
-
-# locate alternate serial ports
-ALTPORTS=`(echo $JMRI_SERIAL_PORTS; ls -fm /dev/ttyUSB* /dev/ttyACM* 2>/dev/null ) | tr -d " \n" | tr "," ":"`
-if [ "${ALTPORTS}" ]
-then
-  ALTPORTS=-Dgnu.io.rxtx.SerialPorts=${ALTPORTS}
-fi
-[ "${DEBUG}" ] && echo "ALTPORTS: '${ALTPORTS}'"
-
-[ "${DEBUG}" ] && echo java ${OPTIONS} "${ALTPORTS}" -cp "${CP}" "${CLASSNAME}" ${CONFIGFILE}
-java ${OPTIONS} ${ALTPORTS} -cp "${CP}" jmri.util.junit.TestClassMainMethod "${CLASSNAME}" $2 $3
-
-
-
+$( dirname $0 )/run.sh $@

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -101,7 +101,7 @@ function parse_args() {
             --settingsdir) shift ;;
             --settingsdir=*) ;;
             # everything after this is to be passed to JMRI
-            --) ARGS="${ARGS} $@" break ;;
+            --) ARGS="${ARGS} $@" ; break ;;
             # pass anything else on to JMRI
             *) ARGS="${ARGS} ${1}" ;;
         esac

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -97,6 +97,8 @@ function parse_args() {
             # serial ports
             --serial-ports) JMRI_SERIAL_PORTS="${2}" ;;
             --serial-ports=*) JMRI_SERIAL_PORTS="${1#*=}" ; shift ;;
+            # ignore and do not pass the settingsdir argument
+            --settingsdir=*) ;;
             # everything after this is to be passed to JMRI
             --) ARGS="${ARGS} $@" break ;;
             # pass anything else on to JMRI

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -98,6 +98,7 @@ function parse_args() {
             --serial-ports) JMRI_SERIAL_PORTS="${2}" ;;
             --serial-ports=*) JMRI_SERIAL_PORTS="${1#*=}" ; shift ;;
             # ignore and do not pass the settingsdir argument
+            --settingsdir) shift ;;
             --settingsdir=*) ;;
             # everything after this is to be passed to JMRI
             --) ARGS="${ARGS} $@" break ;;

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -1,11 +1,14 @@
 #! /bin/bash
 #
-# Script to start a JMRI @VERSION@ application
+# Script to start a JMRI @VERSION@ application.
 #
 # This script is used for both all POSIX operating systems including Linux
-# and macOS / OS X application bundles
+# and macOS / OS X application bundles.
 #
-# If you need to add any additional Java options or persistent command line
+# If you need to specify an option with spaces in it, escape the spaces with a
+# leading backslash like "\ ".
+#
+# If you need to add any persistent Java options or persistent command line
 # arguments, include them in the "default_options" statement in the file
 # jmri.conf in the settings directory.
 #
@@ -14,9 +17,9 @@
 # - all other: ${HOME}/.jmri
 #
 # The settings directory can be set to a non-standard location using the
-# "--settingsdir /path/to/my/settings" command line option (unlike all other
+# "--settingsdir=/path/to/my/settings" command line option (unlike all other
 # options, this one cannot be set in the jmri.conf file, since it determines
-# where the jmri.conf file will be read from).
+# from where the jmri.conf file is read).
 #
 # If your serial ports are not in the default list, include them in the
 # command line argument --serial-ports separated by commas:
@@ -45,7 +48,7 @@ set -u
 # display valid arguments
 function usage() {
     cat <<EOM
-Usage: $( basename $0 ) [--help] [OPTIONS]
+Usage: $( basename $0 ) [--help] [OPTIONS] [--] [ARGUMENTS]
   -c CONFIG, --config=CONFIG     Start JMRI with configuration CONFIG
   --cp:a=CLASSPATH               Append specified JARs to the classpath
                                  Multiple JARs are separated with colons (:)
@@ -53,9 +56,12 @@ Usage: $( basename $0 ) [--help] [OPTIONS]
                                  Multiple JARs are separated with colons (:)
   -d, --debug                    Add verbose output to this script
   -JOPTION                       Pass the option OPTION to the JVM
+  -m MAIN, --main=MAIN           Use main() method in class MAIN to start JMRI
   -p PROFILE, --profile=PROFILE  Start JMRI with the profile PROFILE
   --serial-ports=SERIAL_PORTS    Use the serial ports in SERIAL_PORTS
   --settingsdir=SETTINGS_DIR     Use SETTINGS_DIR as the settings directory
+  --                             Do not process anything following as an option,
+                                 even if it matches one of the above options
 EOM
 }
 
@@ -82,12 +88,19 @@ function parse_args() {
             -J-Xmx*) jmri_xmx="${1#-J}" ;;
             # JVM arguments other than max memory
             -J*) jmri_options="${jmri_options} ${1#-J}" ;;
+            # main class
+            -m|--main) CLASSNAME="$2" ; shift ;;
+            --main=*) CLASSNAME="${1#*=}" ;;
             # JMRI configuration profile
             -p|--profile) jmri_options="${jmri_options} -Dorg.jmri.profile=$2" ; shift ;;
             --profile=*) jmri_options="${jmri_options} -Dorg.jmri.profile=${1#*=}" ;;
             # serial ports
             --serial-ports) JMRI_SERIAL_PORTS="${2}" ;;
             --serial-ports=*) JMRI_SERIAL_PORTS="${1#*=}" ; shift ;;
+            # everything after this is to be passed to JMRI
+            --) ARGS="${ARGS} $@" break ;;
+            # pass anything else on to JMRI
+            *) ARGS="${ARGS} ${1}" ;;
         esac
         shift
     done
@@ -160,6 +173,10 @@ CONFIGFILE=""
 # Installation locations
 JAVA_HOME=${JAVA_HOME:-}
 JMRI_HOME=${JMRI_HOME:-}
+BUNDLEDIR=""
+
+# Set default arguments
+ARGS=
 
 # set DEBUG to any non-empty string to see debugging output
 DEBUG=${DEBUG:-}
@@ -168,7 +185,7 @@ DEBUG=${DEBUG:-}
 pre_classpath=""
 post_classpath=""
 
-# set the OS (can be overridden in enviroment for debugging and development)
+# set the OS (can be overridden in environment for debugging and development)
 # this value is used to find OS-specific libraries, so it gets normalized
 # in following case statement
 OS=${OS:-}
@@ -182,7 +199,6 @@ case "${OS}" in
     macosx|Darwin*)
         settingsdir="${HOME}/Library/Preferences/JMRI"
         OS="macosx"
-        DEBUG="yes" # default to on, so always available in Console.app
         ;;
     Linux*)
         settingsdir="${HOME}/.jmri"
@@ -308,12 +324,16 @@ export JAVA_HOME
 
 # define JMRI_HOME if it is not defined
 if [ -z "${JMRI_HOME}" ] ; then
+    JMRI_HOME="${SCRIPTDIR}"
     if [ "$OS" = "macosx" ] ; then
         # on OS X, the .app bundle is assumed to reside in the default JMRI_HOME
         BUNDLEDIR=$(cd "${SCRIPTDIR}/../.." && pwd)
-        JMRI_HOME=$(cd "${BUNDLEDIR}/.." && pwd)
-    else
-        JMRI_HOME="$SCRIPTDIR"
+        if [ -f "${BUNDLEDIR}/Contents/MacOS/StartJMRI" ] ; then
+            JMRI_HOME=$(cd "${BUNDLEDIR}/.." && pwd)
+            DEBUG="yes" # default to on, so always available in Console.app
+        else
+            BUNDLEDIR=""
+        fi
     fi
 fi
 
@@ -410,7 +430,7 @@ CP="${CP//\\ / }"
 
 # configuration file name is 1st argument.
 # If not provided, build config file name dynamically
-if [ "$OS" = "macosx" ] ; then
+if [ "$OS" = "macosx" -a -n "${BUNDLEDIR}" ] ; then
     # OS X can have spaces in the application name
     APPNAME=$( basename -s .app "${BUNDLEDIR}" )
 else
@@ -419,13 +439,14 @@ fi
 
 [ -n "${DEBUG}" ] && echo "APPNAME: '${APPNAME}'"
 
-# we only process a config file name when the application is
-# NOT the default one this script was built for.
-if [ "$APPNAME" != "$DEFAULT_APP_NAME" ] ; then
+# Process a config file name if passed as an option or when the application is
+# NOT the default one this script was built for and pass it as a Java property
+# so that scripts expecting another argument as the first one get that instead
+if [ "$APPNAME" != "$DEFAULT_APP_NAME" -o -n "${CONFIGNAME}" ] ; then
     if [ -z "${CONFIGNAME}" ] ; then
         CONFIGNAME=$( echo $APPNAME | tr -d '[:space:]' | tr -d '=' )
     fi
-    CONFIGFILE="config=${CONFIGNAME}Config.xml"
+    CONFIGFILE="-Dorg.jmri.Apps.configFilename=${CONFIGNAME}Config.xml"
     [ -n "${DEBUG}" ] && echo "CONFIGFILE: '${CONFIGFILE}'"
 fi
 
@@ -442,7 +463,7 @@ if [ "$OS" = "macosx" ] ; then
     if [ -f "${BUNDLEDIR}/Contents/Resources/@ICON@.icns" ] ; then
         APPICON="${BUNDLEDIR}/Contents/Resources/@ICON@.icns"
     else
-        APPICON=$( find "${BUNDLEDIR}" | grep -s -m 1 icns )
+        APPICON=$( find "${BUNDLEDIR}" 2>/dev/null | grep -s -m 1 icns )
     fi
 fi
 
@@ -486,9 +507,9 @@ EXIT_STATUS=${RESTART_CODE}
 while [ "${EXIT_STATUS}" -eq "${RESTART_CODE}" ] ; do
 
     if [ "$OS" = "macosx" ] ; then
-        "${JAVACMD}" "${DOCK_OPTIONS[@]}" ${OPTIONS} ${ALTPORTS} -cp "${CP}" "${CLASSNAME}" ${CONFIGFILE}
+        "${JAVACMD}" "${DOCK_OPTIONS[@]}" ${OPTIONS} ${ALTPORTS} ${CONFIGFILE} -cp "${CP}" "${CLASSNAME}" ${ARGS}
     else
-        "${JAVACMD}" ${OPTIONS} ${ALTPORTS} -cp "${CP}" "${CLASSNAME}" ${CONFIGFILE}
+        "${JAVACMD}" ${OPTIONS} ${ALTPORTS} ${CONFIGFILE} -cp "${CP}" "${CLASSNAME}" ${ARGS}
     fi
 
     EXIT_STATUS=$?


### PR DESCRIPTION
Make runtest.csh a wrapper around an ant process that will ensure the test class is run from a launcher built from the current AppScriptTemplate for POSIX launchers.