### PR TITLE
POSIX Launcher passes Java properties incorrectly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,8 @@ session.log
 /nbproject/private
 /.idea/workspace.xml
 local.properties
-local.conf
+/test
+/test/jmri.conf
 *.original~
 .metadata
 RemoteSystemsTempFiles

--- a/build.xml
+++ b/build.xml
@@ -381,6 +381,7 @@
             <fileset file="jmri-fb.html"/>
             <fileset file="jacoco.exec"/>
             <fileset file=".run.sh"/>
+            <fileset file="test"/>
         </delete>
         <ant dir="xml/XSLT" target="clean" inheritAll="false"  />
     </target>

--- a/help/en/html/doc/Technical/StartUpScripts.shtml
+++ b/help/en/html/doc/Technical/StartUpScripts.shtml
@@ -107,6 +107,11 @@
         itself to the console. On OS X, this is always on, and
         debugging output is available through the Console.app.</dd>
 
+        <dt><code>-D<em>PROPERTY</em></code></dt>
+
+        <dd>Pass a Java System Property to the Java Virtual
+        Machine. This will be available to the JMRI application while running.</dd>
+
         <dt><code>-J<em>OPTION</em></code></dt>
 
         <dd>Pass a complete Java option to the Java Virtual
@@ -146,6 +151,10 @@
             <dd><code>${HOME}/Library/Preferences/JMRI</code></dd>
           </dl>
         </dd>
+        
+        <dt><code>--help</code></dt>
+        
+        <dd>Print a consise list of all options the launcher handles.</dd>
       </dl>
 
       <p>If you need to set one or more of these parameters

--- a/runtest.csh
+++ b/runtest.csh
@@ -50,7 +50,7 @@
 # xprop -root -remove _MOTIF_DEFAULT_BINDINGS
 #
 # For more information, please see
-# http://jmri.org/install/ShellScripts.shtml
+# http://jmri.org/help/en/html/doc/Technical/StartUpScripts.shtml
 
 dirname="$( dirname $0 )"
 # assume ant is in the path, and silence output

--- a/runtest.csh
+++ b/runtest.csh
@@ -19,12 +19,12 @@
 #
 # By default this script sets the JMRI settings: dir to the directory "temp" in
 # the directory its run from. Pass the option --settingsdir="" to use the JMRI
-# default location. local.conf in the directory this script is run from is
-# copied to jmri.conf in the settings: dir if the settings: dir is not "" and
-# local.conf is newer than jmri.conf.
+# default location. test/jmri.conf in the directory this script is run from is
+# used to pull any persistent settings unless --settingsdir=... is specified.
 #
 # Note that this script may mangle arguments with unescaped spaces. This can be
-# avoided by writing spaces in arguments as "\ ".
+# avoided by writing spaces in arguments as "arg\ with\ spaces" or by wrapping
+# arguments with spaces in extra, escaped quotes like "\"arg with spaces\"".
 #
 # If you need to add any additional Java options or defines,
 # include them in the JMRI_OPTIONS environment variable
@@ -60,14 +60,17 @@ if [ $result -ne 0 ] ; then
     exit $result
 fi
 
+testdir="$( dirname 0 )/test"
 # set the default settings dir to $( dirname 0 )/temp, but allow it to be
 # overridden
-settingsdir="$( dirname 0 )/temp"
+settingsdir="${testdir}"
+prefsdir="$( dirname 0 )/temp"
 found_settingsdir="no"
 for opt in "$@"; do
     if [ "${found_settingsdir}" = "yes" ]; then
         # --settingsdir /path/to/... part 2
         settingsdir="$opt"
+        prefsdir="$settingsdir"
         break
     elif [ "$opt" = "--settingsdir" ]; then
         # --settingsdir /path/to/... part 1
@@ -75,21 +78,18 @@ for opt in "$@"; do
     elif [[ "$opt" =~ "--settingsdir=" ]]; then
         # --settingsdir=/path/to/...
         settingsdir="${opt#*=}"
+        prefsdir="$settingsdir"
         break;
     fi
 done
-
-# if settingsdir is not empty (using JMRI default), and local.conf is newer than
-# jmri.conf, copy local.conf to jmri.conf
-if [ ! -z "${settingsdir}" -a "$( dirname $0 )/local.conf" -nt "${settingsdir}/jmri.conf" ] ; then
-    mkdir -p "${settingsdir}"
-    cp "$( dirname $0 )/local.conf" "${settingsdir}/jmri.conf"
-fi
 
 # if --settingsdir="" was passed, allow run.sh to use JMRI default, otherwise
 # prepend the option token to ensure run.sh sets the settings dir correctly
 if [ -n "$settingsdir" ] ; then
     settingsdir="--settingsdir=${settingsdir}"
 fi
+if [ -n "$prefsdir" ] ; then
+    prefsdir="-Dorg.jmri.Apps.configFilename=${prefsdir}"
+fi
 
-$( dirname $0 )/.run.sh "$settingsdir" $@
+"$( dirname $0 )/.run.sh" "$settingsdir" "$prefsdir" $@

--- a/runtest.csh
+++ b/runtest.csh
@@ -52,19 +52,20 @@
 # For more information, please see
 # http://jmri.org/install/ShellScripts.shtml
 
+dirname="$( dirname $0 )"
 # assume ant is in the path, and silence output
-ant run-sh 1>/dev/null
-result=$?
-if [ $result -ne 0 ] ; then
-    echo "ant run-sh failed."
-    exit $result
+if [ "${dirname}/scripts/AppScriptTemplate" -nt "${dirname}/.run.sh" ] ; then
+    ant run-sh
+    result=$?
+    if [ $result -ne 0 ] ; then
+        exit $result
+    fi
 fi
 
-testdir="$( dirname 0 )/test"
-# set the default settings dir to $( dirname 0 )/temp, but allow it to be
+# set the default settings dir to ${dirname}/temp, but allow it to be
 # overridden
-settingsdir="${testdir}"
-prefsdir="$( dirname 0 )/temp"
+settingsdir="${dirname}/test"
+prefsdir="${dirname}/temp"
 found_settingsdir="no"
 for opt in "$@"; do
     if [ "${found_settingsdir}" = "yes" ]; then
@@ -92,4 +93,4 @@ if [ -n "$prefsdir" ] ; then
     prefsdir="-Dorg.jmri.Apps.configFilename=${prefsdir}"
 fi
 
-"$( dirname $0 )/.run.sh" "$settingsdir" "$prefsdir" $@
+"${dirname}/.run.sh" "$settingsdir" "$prefsdir" $@

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -55,7 +55,7 @@ Usage: $( basename $0 ) [--help] [OPTIONS] [--] [ARGUMENTS]
   --cp:p=CLASSPATH               Prepend specified JARs to the classpath
                                  Multiple JARs are separated with colons (:)
   -d, --debug                    Add verbose output to this script
-  -DOPTION                       Set the Java System property OPTION
+  -DPROPERTY                     Set the Java System property PROPERTY
   -JOPTION                       Pass the option OPTION to the JVM
   -m MAIN, --main=MAIN           Use main() method in class MAIN to start JMRI
   -p PROFILE, --profile=PROFILE  Start JMRI with the profile PROFILE

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -55,6 +55,7 @@ Usage: $( basename $0 ) [--help] [OPTIONS] [--] [ARGUMENTS]
   --cp:p=CLASSPATH               Prepend specified JARs to the classpath
                                  Multiple JARs are separated with colons (:)
   -d, --debug                    Add verbose output to this script
+  -DOPTION                       Set the Java System property OPTION
   -JOPTION                       Pass the option OPTION to the JVM
   -m MAIN, --main=MAIN           Use main() method in class MAIN to start JMRI
   -p PROFILE, --profile=PROFILE  Start JMRI with the profile PROFILE
@@ -79,6 +80,8 @@ function parse_args() {
             # use named configuration
             -c|--config) CONFIGNAME="$2" ; shift ;;
             --config=*) CONFIGNAME="${1#*=}" ;;
+            # Java system properties
+            -D*) jmri_options="${jmri_options} ${1}" ;;
             # debugging
             -d|--debug) DEBUG="yes" ;;
             # help


### PR DESCRIPTION
Also simpler use of jmri.conf in runtest.csh.