### PR TITLE
Ensure .bat files are not normalized

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -55,6 +55,7 @@ TODO            text
 # These files are binary and should be left untouched
 # (binary is a macro for -text -diff)
 *.app           binary
+*.bat           binary
 *.class         binary
 *.dll           binary
 *.dylib         binary


### PR DESCRIPTION
They need the CRLF endings, and without this, a clean clone of the JMRI code on macOS immediately causes two .bat files to show up as changed.