### PR TITLE
Quick fix for #1674

### DIFF
--- a/java/src/jmri/jmrit/beantable/ListedTableFrame.java
+++ b/java/src/jmri/jmrit/beantable/ListedTableFrame.java
@@ -201,7 +201,9 @@ public class ListedTableFrame extends BeanTableFrame {
         }
     }
 
+    @Override
     public void dispose() {
+        pref.disallowSave();
         for (int x = 0; x < tabbedTableArray.size(); x++) {
             tabbedTableArray.get(x).dispose();
         }
@@ -209,6 +211,7 @@ public class ListedTableFrame extends BeanTableFrame {
             list.removeListSelectionListener(list.getListSelectionListeners()[0]);
         }
         super.dispose();
+        pref.allowSave();
     }
 
     void buildMenus(final TabbedTableItem item) {


### PR DESCRIPTION
The for loop in this method causes massive number of changes to UI
state to be saved when disposing the tabbed tables. By wrapping this
call in (dis)allowSave() methods, these calls can all be made without
causing disk IO. Once allowSave() is called, the UserPreferencesManager
will, assuming changes really were made, write all changes between the
(dis)allowSave() calls once.