### PR TITLE
Better handling of user-specified settings: dir.

### DIFF
--- a/java/src/jmri/util/FileUtil.java
+++ b/java/src/jmri/util/FileUtil.java
@@ -49,7 +49,7 @@ public final class FileUtil {
      * Replaced with {@link #PROGRAM}.
      *
      * @see #PROGRAM
-     * @deprecated
+     * @deprecated since 2.13.1
      */
     @Deprecated
     static public final String RESOURCE = "resource:"; // NOI18N
@@ -57,7 +57,7 @@ public final class FileUtil {
      * Replaced with {@link #PREFERENCES}.
      *
      * @see #PREFERENCES
-     * @deprecated
+     * @deprecated since 2.13.1
      */
     @Deprecated
     static public final String FILE = "file:"; // NOI18N

--- a/java/src/jmri/util/FileUtil.java
+++ b/java/src/jmri/util/FileUtil.java
@@ -8,8 +8,6 @@ import java.net.URI;
 import java.net.URL;
 import java.util.jar.JarFile;
 import javax.annotation.Nonnull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Common utility methods for working with Files.
@@ -67,8 +65,6 @@ public final class FileUtil {
      * The portable file path component separator.
      */
     static public final char SEPARATOR = '/'; // NOI18N
-    // initialize logging
-    private static final Logger log = LoggerFactory.getLogger(FileUtil.class);
 
     /**
      * The types of locations to use when falling back on default locations in {@link #findURL(java.lang.String, java.lang.String...)
@@ -85,7 +81,9 @@ public final class FileUtil {
      * of returning null (as File would). Use {@link #getURI(java.lang.String) }
      * or {@link #getURL(java.lang.String) } instead of this method if possible.
      *
+     * @param path the path to find
      * @return {@link java.io.File} at path
+     * @throws java.io.FileNotFoundException if path cannot be found
      * @see #getURI(java.lang.String)
      * @see #getURL(java.lang.String)
      */
@@ -98,7 +96,9 @@ public final class FileUtil {
      * {@link java.io.FileNotFoundException} if the file cannot be found instead
      * of returning null (as File would).
      *
+     * @param path the path to find
      * @return {@link java.io.File} at path
+     * @throws java.io.FileNotFoundException if path cannot be found
      * @see #getFile(java.lang.String)
      * @see #getURL(java.lang.String)
      */
@@ -111,7 +111,9 @@ public final class FileUtil {
      * {@link java.io.FileNotFoundException} if the URL cannot be found instead
      * of returning null.
      *
+     * @param path the path to find
      * @return {@link java.net.URL} at path
+     * @throws java.io.FileNotFoundException if path cannot be found
      * @see #getFile(java.lang.String)
      * @see #getURI(java.lang.String)
      */
@@ -171,6 +173,7 @@ public final class FileUtil {
     /**
      * Convert a portable filename into an absolute filename.
      *
+     * @param path the portable filename
      * @return An absolute filename
      */
     static public String getAbsoluteFilename(String path) {
@@ -268,6 +271,7 @@ public final class FileUtil {
      * Note that this method may return a false positive if the filename is a
      * file: URL.
      *
+     * @param filename the name to test
      * @return true if filename is portable
      */
     static public boolean isPortableFilename(String filename) {
@@ -362,6 +366,7 @@ public final class FileUtil {
      * Convenience method that calls
      * {@link FileUtil#setProgramPath(java.io.File)} with the passed in path.
      *
+     * @param path the path to the JMRI installation
      */
     static public void setProgramPath(String path) {
         FileUtilSupport.getDefault().setProgramPath(new File(path));
@@ -375,6 +380,7 @@ public final class FileUtil {
      * loading JMRI (prior to loading any other JMRI code) to be meaningfully
      * used.
      *
+     * @param path the path to the JMRI installation
      */
     static public void setProgramPath(File path) {
         FileUtilSupport.getDefault().setProgramPath(path);
@@ -384,6 +390,7 @@ public final class FileUtil {
      * Get the URL of a portable filename if it can be located using
      * {@link #findURL(java.lang.String)}
      *
+     * @param path the path to find
      * @return URL of portable or absolute path
      */
     static public URI findExternalFilename(String path) {
@@ -654,6 +661,7 @@ public final class FileUtil {
     /**
      * Return the {@link java.net.URI} for a given URL
      *
+     * @param url the URL
      * @return a URI or null if the conversion would have caused a
      *         {@link java.net.URISyntaxException}
      */
@@ -715,6 +723,7 @@ public final class FileUtil {
      *
      * @param file The text file.
      * @return The contents of the file.
+     * @throws java.io.IOException if the file cannot be read
      */
     public static String readFile(File file) throws IOException {
         return FileUtil.readURL(FileUtil.fileToURL(file));
@@ -726,6 +735,7 @@ public final class FileUtil {
      *
      * @param url The text URL.
      * @return The contents of the file.
+     * @throws java.io.IOException if the URL cannot be read
      */
     public static String readURL(URL url) throws IOException {
         return FileUtilSupport.getDefault().readURL(url);
@@ -745,6 +755,7 @@ public final class FileUtil {
      * Create a directory if required. Any parent directories will also be
      * created.
      *
+     * @param path directory to create
      */
     public static void createDirectory(String path) {
         FileUtilSupport.getDefault().createDirectory(path);
@@ -754,6 +765,7 @@ public final class FileUtil {
      * Create a directory if required. Any parent directories will also be
      * created.
      *
+     * @param dir directory to create
      */
     public static void createDirectory(File dir) {
         FileUtilSupport.getDefault().createDirectory(dir);
@@ -764,6 +776,7 @@ public final class FileUtil {
      * {@link java.nio.file.Files#delete(java.nio.file.Path)} or
      * {@link java.nio.file.Files#deleteIfExists(java.nio.file.Path)} for files.
      *
+     * @param path path to delete
      * @return true if path was deleted, false otherwise
      */
     public static boolean delete(File path) {
@@ -775,7 +788,9 @@ public final class FileUtil {
      * {@link java.nio.file.Files#copy(java.nio.file.Path, java.io.OutputStream)}
      * for files.
      *
-     * @param dest must be the file, not the destination directory.
+     * @param source the file or directory to copy
+     * @param dest   must be the file or directory, not the containing directory
+     * @throws java.io.IOException if file cannot be copied
      */
     public static void copy(File source, File dest) throws IOException {
         FileUtilSupport.getDefault().copy(source, dest);
@@ -794,8 +809,13 @@ public final class FileUtil {
     }
 
     /**
-     * Backup a file.
+     * Backup a file. The backup is in the same location as the original file,
+     * has the extension <code>.bak</code> appended to the file name, and up to
+     * four revisions are retained. The lowest numbered revision is the most
+     * recent.
      *
+     * @param file the file to backup
+     * @throws java.io.IOException if a backup cannot be created
      * @see jmri.util.FileUtilSupport#backup(java.io.File)
      */
     public static void backup(File file) throws IOException {
@@ -803,11 +823,18 @@ public final class FileUtil {
     }
 
     /**
-     * Rotate a file
+     * Rotate a file and its backups, retaining only a set number of backups.
      *
+     * @param file      the file to rotate
+     * @param max       maximum number of backups to retain
+     * @param extension The extension to use for the rotations. If null or an
+     *                  empty string, the rotation number is used as the
+     *                  extension.
+     * @throws java.io.IOException if a backup cannot be created
+     * @throws IllegalArgumentException if max is less than one
      * @see jmri.util.FileUtilSupport#rotate(java.io.File, int,
      * java.lang.String)
-     * @see backup
+     * @see jmri.util.FileUtilSupport#backup(java.io.File) 
      */
     public static void rotate(File file, int max, String extension) throws IOException {
         FileUtilSupport.getDefault().rotate(file, max, extension);

--- a/java/src/jmri/util/FileUtilSupport.java
+++ b/java/src/jmri/util/FileUtilSupport.java
@@ -347,6 +347,7 @@ public class FileUtilSupport extends Bean {
      * @param filename the name to test
      * @return true if filename is portable
      */
+    @SuppressWarnings("deprecation")
     public boolean isPortableFilename(String filename) {
         return (filename.startsWith(PROGRAM)
                 || filename.startsWith(HOME)
@@ -577,6 +578,7 @@ public class FileUtilSupport extends Bean {
      * @param path the path to find
      * @return URL of portable or absolute path
      */
+    @SuppressWarnings("deprecation")
     public URI findExternalFilename(String path) {
         log.debug("Finding external path {}", path);
         if (this.isPortableFilename(path)) {
@@ -1239,6 +1241,7 @@ public class FileUtilSupport extends Bean {
      * @return Canonical path to use, or null if one cannot be found.
      * @since 2.7.2
      */
+    @SuppressWarnings("deprecation")
     private String pathFromPortablePath(@Nonnull String path) {
         if (path.startsWith(PROGRAM)) {
             if (new File(path.substring(PROGRAM.length())).isAbsolute()) {

--- a/java/src/jmri/util/FileUtilSupport.java
+++ b/java/src/jmri/util/FileUtilSupport.java
@@ -443,8 +443,17 @@ public class FileUtilSupport extends Bean {
     public String getPreferencesPath() {
         // return jmri.prefsdir property if present
         String jmriPrefsDir = System.getProperty("jmri.prefsdir", ""); // NOI18N
-        if (!jmriPrefsDir.isEmpty() && !jmriPrefsDir.endsWith(File.separator)) {
-            return jmriPrefsDir + File.separator;
+        if (!jmriPrefsDir.isEmpty()) {
+            try {
+                return new File(jmriPrefsDir).getCanonicalPath() + File.separator;
+            } catch (IOException ex) {
+                // use System.err because logging at this point will fail
+                // since this method is called to setup logging
+                System.err.println("Unable to locate settings dir \"" + jmriPrefsDir + "\"");
+                if (!jmriPrefsDir.endsWith(File.separator)) {
+                    return jmriPrefsDir + File.separator;
+                }
+            }
         }
         String result;
         switch (SystemType.getType()) {

--- a/java/test/jmri/util/FileUtilTest.java
+++ b/java/test/jmri/util/FileUtilTest.java
@@ -12,12 +12,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Scanner;
 import java.util.UUID;
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests for the jmri.util.FileUtil class.
@@ -28,19 +26,21 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright 2003, 2009
  */
-public class FileUtilTest extends TestCase {
+public class FileUtilTest {
 
     private File programTestFile;
     private File preferencesTestFile;
 
     // tests of internal to external mapping
     // relative file with no prefix: Leave relative in system-specific form
+    @Test
     public void testGEFRel() {
         String name = FileUtil.getExternalFilename("resources/non-existant-file-foo");
-        Assert.assertEquals("resources" + File.separator + "non-existant-file-foo", name); 
+        Assert.assertEquals("resources" + File.separator + "non-existant-file-foo", name);
     }
 
     // relative file with no prefix: Leave relative in system-specific form
+    @Test
     public void testGEFAbs() {
         File f = new File("resources/non-existant-file-foo");
         String name = FileUtil.getExternalFilename(f.getAbsolutePath());
@@ -48,12 +48,14 @@ public class FileUtilTest extends TestCase {
     }
 
     // resource: prefix with relative path, convert to relative in system-specific form
+    @Test
     public void testGEFResourceRel() {
         String name = FileUtil.getExternalFilename("resource:resources/non-existant-file-foo");
         Assert.assertEquals(new File("resources/non-existant-file-foo").getAbsolutePath(), name);
     }
 
     // resource: prefix with absolute path, convert to absolute in system-specific form
+    @Test
     public void testGEFResourceAbs() {
         File f = new File("resources/non-existant-file-foo");
         String name = FileUtil.getExternalFilename("resource:" + f.getAbsolutePath());
@@ -61,12 +63,14 @@ public class FileUtilTest extends TestCase {
     }
 
     // program: prefix with relative path, convert to relative in system-specific form
+    @Test
     public void testGEFProgramRel() {
         String name = FileUtil.getExternalFilename("program:jython");
         Assert.assertEquals(new File("jython").getAbsolutePath(), name);
     }
 
     // program: prefix with absolute path, convert to absolute in system-specific form
+    @Test
     public void testGEFProgramAbs() {
         File f = new File("resources/non-existant-file-foo");
         String name = FileUtil.getExternalFilename("program:" + f.getAbsolutePath());
@@ -74,12 +78,14 @@ public class FileUtilTest extends TestCase {
     }
 
     // preference: prefix with relative path, convert to absolute in system-specific form
+    @Test
     public void testGEFPrefRel() {
         String name = FileUtil.getExternalFilename("preference:non-existant-file-foo");
         Assert.assertEquals(FileUtil.getUserFilesPath() + "non-existant-file-foo", name);
     }
 
     // preference: prefix with absolute path, convert to absolute in system-specific form
+    @Test
     public void testGEFPrefAbs() {
         File f = new File("resources/non-existant-file-foo");
         String name = FileUtil.getExternalFilename("preference:" + f.getAbsolutePath());
@@ -87,12 +93,14 @@ public class FileUtilTest extends TestCase {
     }
 
     // file: prefix with relative path, convert to absolute in system-specific form
+    @Test
     public void testGEFFileRel() {
         String name = FileUtil.getExternalFilename("file:non-existant-file-foo");
         Assert.assertEquals(new File(FileUtil.getUserFilesPath() + "resources" + File.separator + "non-existant-file-foo").getAbsolutePath(), name);
     }
 
     // file: prefix with absolute path, convert to absolute in system-specific form
+    @Test
     public void testGEFFileAbs() {
         File f = new File("resources/non-existant-file-foo");
         String name = FileUtil.getExternalFilename("file:" + f.getAbsolutePath());
@@ -100,12 +108,14 @@ public class FileUtilTest extends TestCase {
     }
 
     // home: prefix with relative path, convert to absolute in system-specific form
+    @Test
     public void testGEFHomeRel() {
         String name = FileUtil.getExternalFilename("home:non-existant-file-foo");
         Assert.assertEquals(System.getProperty("user.home") + File.separator + "non-existant-file-foo", name);
     }
 
     // home: prefix with absolute path, convert to absolute in system-specific form
+    @Test
     public void testGEFHomeAbs() {
         File f = new File("resources/non-existant-file-foo");
         String name = FileUtil.getExternalFilename("home:" + f.getAbsolutePath());
@@ -114,43 +124,48 @@ public class FileUtilTest extends TestCase {
 
     // tests of external to internal mapping
     @SuppressWarnings("unused")
+    @Test
     public void testGetpfPreferenceF() throws IOException {
         File f = new File(FileUtil.getUserFilesPath() + "non-existant-file-foo");
         String name = FileUtil.getPortableFilename(f);
         Assert.assertEquals("preference:non-existant-file-foo", name);
     }
 
+    @Test
     public void testGetpfPreferenceS() {
         String name = FileUtil.getPortableFilename("preference:non-existant-file-foo");
         Assert.assertEquals("preference:non-existant-file-foo", name);
     }
 
     @SuppressWarnings("unused")
+    @Test
     public void testGetpfResourceF() throws IOException {
         File f = new File(FileUtil.getUserFilesPath() + "resources" + File.separator + "non-existant-file-foo");
         String name = FileUtil.getPortableFilename(f);
         Assert.assertEquals("preference:resources/non-existant-file-foo", name);
     }
 
+    @Test
     public void testGetpfResourceS() {
         String name = FileUtil.getPortableFilename("resource:resources/non-existant-file-foo");
         Assert.assertEquals("program:resources/non-existant-file-foo", name);
     }
 
-    @SuppressWarnings("unused")
+    @Test
     public void testGetpfPrefF() throws IOException {
         File f = new File(FileUtil.getUserFilesPath() + "resources" + File.separator + "non-existant-file-foo");
         String name = FileUtil.getPortableFilename(f);
         Assert.assertEquals("preference:resources/non-existant-file-foo", name);
     }
 
-    @SuppressWarnings("unused")
+    @Test
     public void testGetpfProgramF() throws IOException {
         File f = new File("resources" + File.separator + "non-existant-file-foo");
         String name = FileUtil.getPortableFilename(f);
         Assert.assertEquals("program:resources/non-existant-file-foo", name);
     }
 
+    @Test
     public void testGetpfProgramS() {
         String name = FileUtil.getPortableFilename("program:resources/non-existant-file-foo");
         Assert.assertEquals("program:resources/non-existant-file-foo", name);
@@ -159,27 +174,32 @@ public class FileUtilTest extends TestCase {
     /*
      * Test a real directory. It should end with a separator.
      */
+    @Test
     public void testGetpfProgramDirS() {
         String name = FileUtil.getPortableFilename("program:resources/icons");
         Assert.assertEquals("program:resources/icons/", name);
     }
 
+    @Test
     public void testGetpfFileS() {
         String name = FileUtil.getPortableFilename("file:non-existant-file-foo");
         Assert.assertEquals("preference:resources/non-existant-file-foo", name);
     }
 
+    @Test
     public void testGetpfFileS2() {
         String name = FileUtil.getPortableFilename("resource:resources/non-existant-file-foo");
         Assert.assertEquals("program:resources/non-existant-file-foo", name);
     }
 
+    @Test
     public void testGetpfHomeS() {
         String name = FileUtil.getPortableFilename("home:non-existant-file-foo");
         Assert.assertEquals("home:non-existant-file-foo", name);
     }
 
     @SuppressWarnings("unused")
+    @Test
     public void testGetpfHomeF() throws IOException {
         File f = new File(System.getProperty("user.home") + File.separator + "resources" + File.separator + "non-existant-file-foo");
         String name = FileUtil.getPortableFilename(f);
@@ -194,12 +214,14 @@ public class FileUtilTest extends TestCase {
      * other prefixes.
      */
     // relative file with no prefix: Should become null
+    @Test
     public void testGAFRel() {
         String name = FileUtil.getAbsoluteFilename("resources/non-existant-file-foo");
         Assert.assertEquals(null, name);
     }
 
     // absolute file: Should become canonical path
+    @Test
     public void testGAFAbs() throws IOException {
         File f = new File("resources/non-existant-file-foo");
         String name = FileUtil.getAbsoluteFilename(f.getAbsolutePath());
@@ -207,12 +229,14 @@ public class FileUtilTest extends TestCase {
     }
 
     // program: prefix with relative path, convert to relative in system-specific form
+    @Test
     public void testGAFProgRel() throws IOException {
         String name = FileUtil.getAbsoluteFilename(FileUtil.PROGRAM + "jython");
         Assert.assertEquals(new File("jython").getCanonicalPath(), name);
     }
 
     // program: prefix with absolute path, convert to absolute in system-specific form
+    @Test
     public void testGAFProgAbs() throws IOException {
         File f = new File("resources/non-existant-file-foo");
         String name = FileUtil.getAbsoluteFilename(FileUtil.PROGRAM + f.getAbsolutePath());
@@ -220,12 +244,14 @@ public class FileUtilTest extends TestCase {
     }
 
     // preference: prefix with relative path, convert to absolute in system-specific form
+    @Test
     public void testGAFPrefRel() throws IOException {
         String name = FileUtil.getAbsoluteFilename(FileUtil.PREFERENCES + "non-existant-file-foo");
         Assert.assertEquals(new File(FileUtil.getUserFilesPath() + "non-existant-file-foo").getCanonicalPath(), name);
     }
 
     // preference: prefix with absolute path, convert to absolute in system-specific form
+    @Test
     public void testGAFPrefAbs() throws IOException {
         File f = new File("resources/non-existant-file-foo");
         String name = FileUtil.getAbsoluteFilename(FileUtil.PREFERENCES + f.getAbsolutePath());
@@ -233,18 +259,21 @@ public class FileUtilTest extends TestCase {
     }
 
     // home: prefix with relative path, convert to absolute in system-specific form
+    @Test
     public void testGAFHomeRel() throws IOException {
         String name = FileUtil.getAbsoluteFilename(FileUtil.HOME + "non-existant-file-foo");
         Assert.assertEquals(new File(System.getProperty("user.home") + File.separator + "non-existant-file-foo").getCanonicalPath(), name);
     }
 
     // home: prefix with absolute path, convert to absolute in system-specific form
+    @Test
     public void testGAFHomeAbs() throws IOException {
         File f = new File("resources/non-existant-file-foo");
         String name = FileUtil.getAbsoluteFilename(FileUtil.HOME + f.getAbsolutePath());
         Assert.assertEquals(f.getCanonicalPath(), name);
     }
 
+    @Test
     public void testCopyFile() throws FileNotFoundException {
         File src = FileUtil.getFile(FileUtil.getAbsoluteFilename("program:default.lcf"));
         File dest = new File(FileUtil.getAbsoluteFilename("program:fileUtilTest.lcf"));
@@ -263,12 +292,14 @@ public class FileUtilTest extends TestCase {
             }
             s.close();
         } catch (IOException ex) {
-            log.error("Unable to copy");
+            FileUtil.delete(dest);
+            Assert.fail("Unable to copy");
         }
         FileUtil.delete(dest);
         Assert.assertTrue(sl.equals(dl));
     }
 
+    @Test
     public void testCopyDirectoryToExistingDirectory() throws FileNotFoundException, IOException {
         File src = FileUtil.getFile(FileUtil.getAbsoluteFilename("program:web/fonts"));
         File dest = Files.createTempDirectory("FileUtilTest").toFile();
@@ -281,6 +312,7 @@ public class FileUtilTest extends TestCase {
         Assert.assertTrue(Arrays.equals(srcFiles, destFiles));
     }
 
+    @Test
     public void testDeleteFile() throws IOException {
         File file = File.createTempFile("FileUtilTest", null);
         FileUtil.copy(FileUtil.getFile(FileUtil.getAbsoluteFilename("program:default.lcf")), file);
@@ -288,6 +320,7 @@ public class FileUtilTest extends TestCase {
         Assert.assertFalse(file.exists());
     }
 
+    @Test
     public void testAppendTextToFile() throws IOException {
         File file = File.createTempFile("FileUtilTest", null);
         String text = "jmri.util.FileUtil#appendTextToFile";
@@ -296,6 +329,7 @@ public class FileUtilTest extends TestCase {
         Assert.assertEquals(text, lines.get(0));
     }
 
+    @Test
     public void testFindURIPath() {
         URI uri = this.programTestFile.toURI();
         Assert.assertNotNull(uri);
@@ -309,6 +343,7 @@ public class FileUtilTest extends TestCase {
         Assert.assertNull(FileUtil.findURI(FileUtil.PROGRAM + this.preferencesTestFile.getName()));
     }
 
+    @Test
     public void testFindURIPathLocation() {
         URI uri = this.programTestFile.toURI();
         Assert.assertNotNull(uri);
@@ -322,6 +357,7 @@ public class FileUtilTest extends TestCase {
         Assert.assertNull(FileUtil.findURI(this.preferencesTestFile.getName(), FileUtil.Location.INSTALLED));
     }
 
+    @Test
     public void testFindURIPathSearchPaths() {
         URI uri = this.programTestFile.toURI();
         Assert.assertNotNull(uri);
@@ -335,6 +371,7 @@ public class FileUtilTest extends TestCase {
         Assert.assertEquals(uri, FileUtil.findURI(this.preferencesTestFile.getName(), new String[]{FileUtil.getProgramPath()}));
     }
 
+    @Test
     public void testFindExternalFilename() {
         URI uri = this.programTestFile.toURI();
         Assert.assertNotNull(uri);
@@ -348,36 +385,17 @@ public class FileUtilTest extends TestCase {
         Assert.assertNull(FileUtil.findExternalFilename(FileUtil.PROGRAM + this.preferencesTestFile.getName()));
     }
 
-    @Override
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         this.programTestFile = new File(UUID.randomUUID().toString());
         this.programTestFile.createNewFile();
         this.preferencesTestFile = new File(FileUtil.getProfilePath() + UUID.randomUUID().toString());
         this.preferencesTestFile.createNewFile();
     }
 
-    @Override
-    protected void tearDown() {
+    @After
+    public void tearDown() {
         this.programTestFile.delete();
         this.preferencesTestFile.delete();
     }
-
-    // from here down is testing infrastructure
-    public FileUtilTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", FileUtilTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(FileUtilTest.class);
-        return suite;
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(FileUtilTest.class.getName());
 }

--- a/java/test/jmri/util/PackageTest.java
+++ b/java/test/jmri/util/PackageTest.java
@@ -27,7 +27,7 @@ public class PackageTest extends TestCase {
         TestSuite suite = new TestSuite("jmri.util.PackageTest");   // no tests in this class itself
 
         suite.addTest(BundleTest.suite());
-        suite.addTest(FileUtilTest.suite());
+        suite.addTest(new junit.framework.JUnit4TestAdapter(FileUtilTest.class));
         suite.addTest(JUnitAppenderTest.suite());
         suite.addTest(IntlUtilitiesTest.suite());
         suite.addTest(Log4JUtilTest.suite());
@@ -63,10 +63,12 @@ public class PackageTest extends TestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
     }
 
+    @Override
     protected void tearDown() {
         apps.tests.Log4JFixture.tearDown();
     }


### PR DESCRIPTION
We previously took the user-specified settings: dir, set in the System
property jmri.prefsdir, blindly, which could lead to a situation where
portable paths would be incorrectly generated as the settings: dir
would be mistakenly treated as a subdirectory of one of the other
portable paths. This change returns the canonical path from jmri.prefsdir if set.