### PR TITLE
Allow multiple ConnectionTypeLists to support single Manufacturer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ session.log
 /java/classes
 /java/tmp
 /java/doc
+/java/test-classes/
 *.class
 /temp
 .pydevproject

--- a/build.xml
+++ b/build.xml
@@ -134,6 +134,7 @@
     <property name="coveragetarget" value="${basedir}/coveragereport"/>
     <property name="source"       value="${javadir}/src"/>
     <property name="target"       value="${javadir}/classes"/>
+    <property name="testtarget"   value="${javadir}/test-classes"/>
     <property name="test"         value="${javadir}/test"/>
     <property name="templatedir"  value="${javadir}/template"/>
     <property name="tmptarget"    value="${javadir}/tmp"/>
@@ -230,7 +231,7 @@
         <pathelement path="${cp.prepend}"/>   <!-- prepended by user -->
         <pathelement location="${jartarget}"/>
         <path        refid="runtime.class.path"/>
-        <pathelement location="${target}/"/>  <!-- last to check for name collisions -->
+        <pathelement location="${target}/"/>  <!-- after declared jars to check for name collisions -->
         <pathelement path="${cp.append}"/>    <!-- appended by user -->
     </path>
 
@@ -238,7 +239,8 @@
     <path id="test.class.path">
         <pathelement location="${jartarget}"/>
         <path   refid="compile.class.path"/>
-        <pathelement location="${target}/"/>  <!-- last to check for name collisions -->
+        <pathelement location="${target}/"/>  <!-- after declared jars to check for name collisions -->
+        <pathelement location="${testtarget}"/> <!-- test resources in classpath that collide with stock resources -->
     </path>
 
     <macrodef name="quiet">
@@ -371,6 +373,7 @@
             <fileset file="${jartarget}/jmri.jar"/>
             <fileset dir="${doctarget}"/>
             <fileset dir="${target}"/>
+            <fileset dir="${testtarget}"/>
             <fileset dir="${dist}"/>
             <fileset dir="${genjavasrcdir}"/>
             <fileset file="${javadir}/manifest"/>
@@ -564,8 +567,11 @@
         <antcall target="-java-compile-internal">
             <param name="java.source.directory" value="${test}"/>
         </antcall>
-        <copy todir="${target}">
+        <!-- Copy resources into ${testtarget} so they coexist with identical
+             resources in ${target} (this is important for the Java ServiceLoader -->
+        <copy todir="${testtarget}">
             <fileset dir="${test}" includes="**/*.properties"/>
+            <fileset dir="${test}" includes="META-INF/**"/>
         </copy>
     </target>
 

--- a/java/src/jmri/jmrix/ConnectionConfigManager.java
+++ b/java/src/jmri/jmrix/ConnectionConfigManager.java
@@ -1,12 +1,15 @@
 package jmri.jmrix;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.TreeSet;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jmri.InstanceManager;
 import jmri.configurexml.ConfigXmlManager;
@@ -170,17 +173,40 @@ public class ConnectionConfigManager extends AbstractPreferencesManager implemen
         return false;
     }
 
-    public boolean remove(ConnectionConfig c) {
+    /**
+     * Remove a {@link jmri.jmrix.ConnectionConfig} following the rules
+     * specified in {@link java.util.Collection#add(java.lang.Object)}.
+     *
+     * @param c an existing ConnectionConfig
+     * @return true if c was removed, false otherwise
+     */
+    public boolean remove(@Nonnull ConnectionConfig c) {
         int i = connections.indexOf(c);
         boolean result = connections.remove(c);
-        fireIndexedPropertyChange(CONNECTIONS, i, c, null);
+        if (result) {
+            fireIndexedPropertyChange(CONNECTIONS, i, c, null);
+        }
         return result;
     }
 
+    /**
+     * Get an Array of {@link jmri.jmrix.ConnectionConfig} objects.
+     *
+     * @return an Array, possibly empty if there are no ConnectionConfig
+     *         objects.
+     */
+    @Nonnull
     public ConnectionConfig[] getConnections() {
         return connections.toArray(new ConnectionConfig[connections.size()]);
     }
 
+    /**
+     * Get the {@link jmri.jmrix.ConnectionConfig} at index following the rules
+     * specified in {@link java.util.Collection#add(java.lang.Object)}.
+     *
+     * @param index index of the ConnectionConfig to return
+     * @return the ConnectionConfig at the specified location
+     */
     public ConnectionConfig getConnections(int index) {
         return connections.get(index);
     }
@@ -190,18 +216,62 @@ public class ConnectionConfigManager extends AbstractPreferencesManager implemen
         return connections.iterator();
     }
 
-    public String[] getConnectionTypes(String manufacturer) {
-        if (InstanceManager.getOptionalDefault(ConnectionTypeManager.class) == null) {
-            InstanceManager.setDefault(ConnectionTypeManager.class, new ConnectionTypeManager());
-        }
-        return InstanceManager.getDefault(ConnectionTypeManager.class).getConnectionTypes(manufacturer);
+    /**
+     * Get the class names for classes supporting layout connections for the
+     * given manufacturer.
+     *
+     * @param manufacturer the name of the manufacturer
+     * @return An array of supporting class names; will return the list of
+     *         internal connection classes if manufacturer is not a known
+     *         manufacturer; the array may be empty if there are no supporting
+     *         classes for the given manufacturer.
+     */
+    @Nonnull
+    public String[] getConnectionTypes(@Nonnull String manufacturer) {
+        return this.getDefaultConnectionTypeManager().getConnectionTypes(manufacturer);
     }
 
+    /**
+     * Get the list of known manufacturers.
+     *
+     * @return An array of known manufacturers.
+     */
+    @Nonnull
     public String[] getConnectionManufacturers() {
+        return this.getDefaultConnectionTypeManager().getConnectionManufacturers();
+    }
+
+    /**
+     * Get the manufacturer that is supported by a connection type.
+     *
+     * @param connectionType the class name of a connection type.
+     * @return the supported manufacturer. If there are multiple manufacturers
+     *         supported by connectionType, returns only the first manufacturer.
+     *         Returns null if no manufacturer is associated with the
+     *         connectionType.
+     */
+    @CheckForNull
+    public String getConnectionManufacturer(@Nonnull String connectionType) {
+        for (String manufacturer : this.getConnectionManufacturers()) {
+            for (String manufacturerType : this.getConnectionTypes(manufacturer)) {
+                if (connectionType.equals(manufacturerType)) {
+                    return manufacturer;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the default {@link ConnectionTypeManager}, creating it if needed.
+     *
+     * @return the default ConnectionTypeManager
+     */
+    private ConnectionTypeManager getDefaultConnectionTypeManager() {
         if (InstanceManager.getOptionalDefault(ConnectionTypeManager.class) == null) {
             InstanceManager.setDefault(ConnectionTypeManager.class, new ConnectionTypeManager());
         }
-        return InstanceManager.getDefault(ConnectionTypeManager.class).getConnectionManufacturers();
+        return InstanceManager.getDefault(ConnectionTypeManager.class);
     }
 
     private static class ConnectionTypeManager {
@@ -214,10 +284,16 @@ public class ConnectionConfigManager extends AbstractPreferencesManager implemen
                     if (!connectionTypeLists.containsKey(manufacturer)) {
                         connectionTypeLists.put(manufacturer, ctl);
                     } else {
-                        log.error("Refusing to add ConnectionListType \"{}\" for manufacturer \"{}\"; existing class is \"{}\"",
-                                ctl.getClass().getName(),
-                                manufacturer,
-                                connectionTypeLists.get(manufacturer).getClass().getName());
+                        log.debug("Need a proxy for {} from {} in {}", manufacturer, ctl.getClass().getName(), this);
+                        ProxyConnectionTypeList proxy;
+                        ConnectionTypeList existing = connectionTypeLists.get(manufacturer);
+                        if (existing instanceof ProxyConnectionTypeList) {
+                            proxy = (ProxyConnectionTypeList) existing;
+                        } else {
+                            proxy = new ProxyConnectionTypeList(existing);
+                        }
+                        proxy.add(ctl);
+                        connectionTypeLists.put(manufacturer, proxy);
                     }
                 }
             }
@@ -237,6 +313,40 @@ public class ConnectionConfigManager extends AbstractPreferencesManager implemen
             a.sort(null);
             a.add(0, InternalConnectionTypeList.NONE);
             return a.toArray(new String[a.size()]);
+        }
+
+    }
+
+    private static class ProxyConnectionTypeList implements ConnectionTypeList {
+
+        private final ArrayList<ConnectionTypeList> connectionTypeLists = new ArrayList<>();
+
+        public ProxyConnectionTypeList(@Nonnull ConnectionTypeList connectionTypeList) {
+            log.debug("Creating proxy for {}", connectionTypeList.getManufacturers()[0]);
+            this.add(connectionTypeList);
+        }
+
+        public final void add(@Nonnull ConnectionTypeList connectionTypeList) {
+            log.debug("Adding {} to proxy", connectionTypeList.getClass().getName());
+            this.connectionTypeLists.add(connectionTypeList);
+        }
+
+        @Override
+        public String[] getAvailableProtocolClasses() {
+            TreeSet<String> classes = new TreeSet<>();
+            this.connectionTypeLists.stream().forEach((connectionTypeList) -> {
+                classes.addAll(Arrays.asList(connectionTypeList.getAvailableProtocolClasses()));
+            });
+            return classes.toArray(new String[classes.size()]);
+        }
+
+        @Override
+        public String[] getManufacturers() {
+            TreeSet<String> manufacturers = new TreeSet<>();
+            this.connectionTypeLists.stream().forEach((connectionTypeList) -> {
+                manufacturers.addAll(Arrays.asList(connectionTypeList.getManufacturers()));
+            });
+            return manufacturers.toArray(new String[manufacturers.size()]);
         }
 
     }

--- a/java/src/jmri/jmrix/ConnectionConfigManager.java
+++ b/java/src/jmri/jmrix/ConnectionConfigManager.java
@@ -242,13 +242,13 @@ public class ConnectionConfigManager extends AbstractPreferencesManager implemen
     }
 
     /**
-     * Get the manufacturer that is supported by a connection type.
+     * Get the manufacturer that is supported by a connection type. If there are
+     * multiple manufacturers supported by connectionType, returns only the
+     * first manufacturer.
      *
      * @param connectionType the class name of a connection type.
-     * @return the supported manufacturer. If there are multiple manufacturers
-     *         supported by connectionType, returns only the first manufacturer.
-     *         Returns null if no manufacturer is associated with the
-     *         connectionType.
+     * @return the supported manufacturer. Returns null if no manufacturer is
+     *         associated with the connectionType.
      */
     @CheckForNull
     public String getConnectionManufacturer(@Nonnull String connectionType) {
@@ -260,6 +260,27 @@ public class ConnectionConfigManager extends AbstractPreferencesManager implemen
             }
         }
         return null;
+    }
+
+    /**
+     * Get the list of all known manufacturers that a single connection type
+     * supports.
+     *
+     * @param connectionType the class name of a connection type.
+     * @return an Array of supported manufacturers. Returns an empty Array if no
+     *         manufacturer is associated with the connectionType.
+     */
+    @Nonnull
+    public String[] getConnectionManufacturers(@Nonnull String connectionType) {
+        ArrayList<String> manufacturers = new ArrayList<>();
+        for (String manufacturer : this.getConnectionManufacturers()) {
+            for (String manufacturerType : this.getConnectionTypes(manufacturer)) {
+                if (connectionType.equals(manufacturerType)) {
+                    manufacturers.add(manufacturer);
+                }
+            }
+        }
+        return manufacturers.toArray(new String[manufacturers.size()]);
     }
 
     /**

--- a/java/src/jmri/jmrix/ConnectionTypeList.java
+++ b/java/src/jmri/jmrix/ConnectionTypeList.java
@@ -1,5 +1,6 @@
 package jmri.jmrix;
 
+import javax.annotation.Nonnull;
 import jmri.spi.JmriServiceProviderInterface;
 
 /**
@@ -15,7 +16,21 @@ import jmri.spi.JmriServiceProviderInterface;
  */
 public interface ConnectionTypeList extends JmriServiceProviderInterface {
 
+    /**
+     * Get a list of classes that can configure a layout connection for the
+     * manufacturers specified in {@link #getManufacturers() }.
+     *
+     * @return an Array of classes or an empty Array if none
+     */
+    @Nonnull
     public String[] getAvailableProtocolClasses();
 
+    /**
+     * Get a list of manufacturer names supported by the classes specified in
+     * {@link #getAvailableProtocolClasses() }.
+     *
+     * @return an Array of manufacturers or an empty Array if none
+     */
+    @Nonnull
     public String[] getManufacturers();
 }

--- a/java/src/jmri/jmrix/DCCManufacturerList.java
+++ b/java/src/jmri/jmrix/DCCManufacturerList.java
@@ -6,7 +6,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Maintains lists equipment manufacturers that JMRI Supports.
- * <P>
+ * <p>
+ * Since JMRI 3.4.5, {@link jmri.jmrix.ConnectionTypeList} subclasses loadable
+ * by a {@link java.util.ServiceLoader} are used for this purpose.</p>
+ *
  * @author Bob Jacobsen Copyright (C) 2010
  * @author Kevin Dickerson Copyright (C) 2010
  * @deprecated Since 3.4.5 ensure the {@link jmri.jmrix.ConnectionTypeList} is
@@ -32,6 +35,7 @@ public class DCCManufacturerList {
     /**
      * Get a list of class names that handle the given system.
      *
+     * @param System the manufacturer name
      * @return The list of class names
      * @deprecated use
      * {@link jmri.jmrix.ConnectionConfigManager#getConnectionTypes(java.lang.String)}.
@@ -116,6 +120,8 @@ public class DCCManufacturerList {
      *
      * Note: No system should not be using a SystemConnectionMemo at this point.
      *
+     * @param a the system manufacturer
+     * @return a default system prefix
      * @deprecated Without replacement. Use
      * {@link jmri.util.ConnectionNameFromSystemName#getPrefixFromName(java.lang.String)}
      * for equivalent functionality.

--- a/java/test/META-INF/services/jmri.jmrix.ConnectionTypeList
+++ b/java/test/META-INF/services/jmri.jmrix.ConnectionTypeList
@@ -1,0 +1,6 @@
+# Providers of System Connections type lists for Unit Testing
+# These are fake system connection types with no real systems behind them
+# Order is Insignificant
+jmri.jmrix.connectionConfigManager.TestTypeList1A
+jmri.jmrix.connectionConfigManager.TestTypeList1B
+jmri.jmrix.connectionConfigManager.TestTypeList2

--- a/java/test/META-INF/services/jmri.jmrix.ConnectionTypeList
+++ b/java/test/META-INF/services/jmri.jmrix.ConnectionTypeList
@@ -4,3 +4,4 @@
 jmri.jmrix.connectionConfigManager.TestTypeList1A
 jmri.jmrix.connectionConfigManager.TestTypeList1B
 jmri.jmrix.connectionConfigManager.TestTypeList2
+jmri.jmrix.connectionConfigManager.TestTypeList3

--- a/java/test/jmri/jmrix/ConnectionConfigManagerTest.java
+++ b/java/test/jmri/jmrix/ConnectionConfigManagerTest.java
@@ -35,9 +35,11 @@ public class ConnectionConfigManagerTest {
     private Path workspace;
     public final static String MFG1 = "Mfg1";
     public final static String MFG2 = "Mfg2";
+    public final static String MFG3 = "Mfg3";
     public final static String TYPE_A = "TypeA";
     public final static String TYPE_B = "TypeB";
     public final static String TYPE_C = "TypeC";
+    public final static String TYPE_D = "TypeD";
     private final static Logger log = LoggerFactory.getLogger(ConnectionConfigManagerTest.class);
 
     @BeforeClass
@@ -75,20 +77,40 @@ public class ConnectionConfigManagerTest {
     }
 
     @Test
+    public void testGetConnectionManufacturers_String() {
+        ConnectionConfigManager instance = new ConnectionConfigManager();
+        String[] result = instance.getConnectionManufacturers(TYPE_A);
+        Assert.assertEquals(1, result.length);
+        Assert.assertEquals(MFG1, result[0]);
+        result = instance.getConnectionManufacturers(TYPE_D);
+        Assert.assertEquals(2, result.length);
+        List<String> types = Arrays.asList(result);
+        Assert.assertTrue(types.contains(MFG2));
+        Assert.assertTrue(types.contains(MFG3));
+        JUnitUtil.resetInstanceManager();
+    }
+
+    @Test
     public void testGetConnectionTypes() {
         ConnectionConfigManager instance = new ConnectionConfigManager();
         // Internal
         String[] result = instance.getConnectionTypes(InternalConnectionTypeList.NONE);
         Assert.assertEquals(1, result.length);
         Assert.assertEquals("jmri.jmrix.internal.ConnectionConfig", result[0]);
+        // MFG3
+        result = instance.getConnectionTypes(MFG3);
+        Assert.assertEquals(1, result.length);
+        Assert.assertEquals(TYPE_D, result[0]);
         // MFG2
         result = instance.getConnectionTypes(MFG2);
-        Assert.assertEquals(1, result.length);
+        Assert.assertEquals(2, result.length);
         Assert.assertEquals(TYPE_C, result[0]);
+        Assert.assertEquals(TYPE_D, result[1]);
         // MFG1
         result = instance.getConnectionTypes(MFG1);
         Assert.assertEquals(2, result.length);
         Assert.assertEquals(TYPE_A, result[0]);
+        Assert.assertEquals(TYPE_B, result[1]);
         JUnitUtil.resetInstanceManager();
     }
 

--- a/java/test/jmri/jmrix/ConnectionConfigManagerTest.java
+++ b/java/test/jmri/jmrix/ConnectionConfigManagerTest.java
@@ -5,8 +5,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import jmri.jmrix.internal.InternalConnectionTypeList;
 import jmri.profile.Profile;
@@ -14,54 +16,79 @@ import jmri.spi.PreferencesManager;
 import jmri.util.FileUtil;
 import jmri.util.JUnitUtil;
 import jmri.util.prefs.InitializationException;
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tests for ConnectionConfigManager.
  *
  * @author Randall Wood
  */
-public class ConnectionConfigManagerTest extends TestCase {
+public class ConnectionConfigManagerTest {
 
     private Path workspace;
+    public final static String MFG1 = "Mfg1";
+    public final static String MFG2 = "Mfg2";
+    public final static String TYPE_A = "TypeA";
+    public final static String TYPE_B = "TypeB";
+    public final static String TYPE_C = "TypeC";
+    private final static Logger log = LoggerFactory.getLogger(ConnectionConfigManagerTest.class);
 
-    // test suite from all defined tests
-    public static Test suite() {
-        return new TestSuite(ConnectionConfigManagerTest.class);
+    @BeforeClass
+    public static void setUpClass() throws Exception {
     }
 
-    @Override
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @Before
     public void setUp() throws Exception {
         Log4JFixture.setUp();
-        super.setUp();
-        this.workspace = Files.createTempDirectory(this.getName());
+        this.workspace = Files.createTempDirectory(this.getClass().getSimpleName());
         JUnitUtil.resetInstanceManager();
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+    @After
+    public void tearDown() throws Exception {
         Log4JFixture.tearDown();
         JUnitUtil.resetInstanceManager();
         FileUtil.delete(this.workspace.toFile());
     }
 
+    @Test
     public void testGetConnectionManufacturers() {
-        ConnectionConfigManager manager = new ConnectionConfigManager();
-        String[] result = manager.getConnectionManufacturers();
+        ConnectionConfigManager instance = new ConnectionConfigManager();
+        String[] result = instance.getConnectionManufacturers();
         Assert.assertTrue(result.length > 1);
         Assert.assertEquals(InternalConnectionTypeList.NONE, result[0]);
+        List<String> types = Arrays.asList(result);
+        Assert.assertTrue(types.contains(MFG1));
+        Assert.assertTrue(types.contains(MFG2));
         JUnitUtil.resetInstanceManager();
     }
 
+    @Test
     public void testGetConnectionTypes() {
-        ConnectionConfigManager manager = new ConnectionConfigManager();
-        String[] result = manager.getConnectionTypes(InternalConnectionTypeList.NONE);
+        ConnectionConfigManager instance = new ConnectionConfigManager();
+        // Internal
+        String[] result = instance.getConnectionTypes(InternalConnectionTypeList.NONE);
         Assert.assertEquals(1, result.length);
         Assert.assertEquals("jmri.jmrix.internal.ConnectionConfig", result[0]);
+        // MFG2
+        result = instance.getConnectionTypes(MFG2);
+        Assert.assertEquals(1, result.length);
+        Assert.assertEquals(TYPE_C, result[0]);
+        // MFG1
+        result = instance.getConnectionTypes(MFG1);
+        Assert.assertEquals(2, result.length);
+        Assert.assertEquals(TYPE_A, result[0]);
         JUnitUtil.resetInstanceManager();
     }
 
@@ -71,9 +98,10 @@ public class ConnectionConfigManagerTest extends TestCase {
      * @throws java.io.IOException if untested condition (most likely inability
      *                             to write to temp space) fails
      */
+    @Test
     public void testInitialize_EmptyProfile() throws IOException {
         String id = Long.toString((new Date()).getTime());
-        Profile profile = new Profile(this.getName(), id, new File(this.workspace.toFile(), id));
+        Profile profile = new Profile(this.getClass().getSimpleName(), id, new File(this.workspace.toFile(), id));
         ConnectionConfigManager instance = new ConnectionConfigManager();
         try {
             instance.initialize(profile);
@@ -85,6 +113,7 @@ public class ConnectionConfigManagerTest extends TestCase {
     /**
      * Test of getRequires method, of class ConnectionConfigManager.
      */
+    @Test
     public void testGetRequires() {
         ConnectionConfigManager instance = new ConnectionConfigManager();
         Set<Class<? extends PreferencesManager>> result = instance.getRequires();
@@ -94,6 +123,7 @@ public class ConnectionConfigManagerTest extends TestCase {
     /**
      * Test of add method, of class ConnectionConfigManager.
      */
+    @Test
     public void testAdd() {
         ConnectionConfig c = new TestConnectionConfig();
         ConnectionConfigManager instance = new ConnectionConfigManager();
@@ -115,6 +145,7 @@ public class ConnectionConfigManagerTest extends TestCase {
     /**
      * Test of remove method, of class ConnectionConfigManager.
      */
+    @Test
     public void testRemove() {
         ConnectionConfig c = new TestConnectionConfig();
         ConnectionConfigManager instance = new ConnectionConfigManager();
@@ -131,6 +162,7 @@ public class ConnectionConfigManagerTest extends TestCase {
     /**
      * Test of getConnections method, of class ConnectionConfigManager.
      */
+    @Test
     public void testGetConnections_0args() {
         ConnectionConfigManager instance = new ConnectionConfigManager();
         Assert.assertEquals(0, instance.getConnections().length);
@@ -141,6 +173,7 @@ public class ConnectionConfigManagerTest extends TestCase {
     /**
      * Test of getConnections method, of class ConnectionConfigManager.
      */
+    @Test
     public void testGetConnections_int() {
         ConnectionConfigManager instance = new ConnectionConfigManager();
         ConnectionConfig c = new TestConnectionConfig();
@@ -159,6 +192,7 @@ public class ConnectionConfigManagerTest extends TestCase {
     /**
      * Test of iterator method, of class ConnectionConfigManager.
      */
+    @Test
     public void testIterator() {
         ConnectionConfigManager instance = new ConnectionConfigManager();
         ConnectionConfig c = new TestConnectionConfig();
@@ -168,6 +202,25 @@ public class ConnectionConfigManagerTest extends TestCase {
         Assert.assertTrue(iterator.hasNext());
         Assert.assertEquals(c, iterator.next());
         Assert.assertFalse(iterator.hasNext());
+    }
+
+    /**
+     * Test of getConnectionManufacturer method, of class
+     * ConnectionConfigManager.
+     */
+    @Test
+    public void testGetConnectionManufacturer() {
+        ConnectionConfigManager instance = new ConnectionConfigManager();
+        String result = instance.getConnectionManufacturer(TYPE_A);
+        Assert.assertEquals(MFG1, result);
+        result = instance.getConnectionManufacturer(TYPE_B);
+        Assert.assertEquals(MFG1, result);
+        result = instance.getConnectionManufacturer(TYPE_C);
+        Assert.assertEquals(MFG2, result);
+        result = instance.getConnectionManufacturer("jmri.jmrix.internal.ConnectionConfig");
+        Assert.assertEquals(InternalConnectionTypeList.NONE, result);
+        result = instance.getConnectionManufacturer("not-a-connection-config-class");
+        Assert.assertNull(result);
     }
 
     private static class TestConnectionConfig extends AbstractSimulatorConnectionConfig {

--- a/java/test/jmri/jmrix/PackageTest.java
+++ b/java/test/jmri/jmrix/PackageTest.java
@@ -33,7 +33,7 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.jmrix.AbstractMRReplyTest.suite());
         suite.addTest(new TestSuite(jmri.jmrix.AbstractThrottleTest.class));
         suite.addTest(jmri.jmrix.BundleTest.suite());
-        suite.addTest(jmri.jmrix.ConnectionConfigManagerTest.suite());
+        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ConnectionConfigManagerTest.class));
 
         suite.addTest(jmri.jmrix.acela.PackageTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.bachrus.PackageTest.class));

--- a/java/test/jmri/jmrix/connectionConfigManager/TestTypeList1A.java
+++ b/java/test/jmri/jmrix/connectionConfigManager/TestTypeList1A.java
@@ -1,0 +1,25 @@
+package jmri.jmrix.connectionConfigManager;
+
+import static jmri.jmrix.ConnectionConfigManagerTest.MFG1;
+import static jmri.jmrix.ConnectionConfigManagerTest.TYPE_A;
+
+import jmri.jmrix.ConnectionTypeList;
+
+/**
+ * Test ConnectionTypeList
+ *
+ * @author Randall Wood (C) 2016
+ */
+public class TestTypeList1A implements ConnectionTypeList {
+
+    @Override
+    public String[] getAvailableProtocolClasses() {
+        return new String[]{TYPE_A};
+    }
+
+    @Override
+    public String[] getManufacturers() {
+        return new String[]{MFG1};
+    }
+
+}

--- a/java/test/jmri/jmrix/connectionConfigManager/TestTypeList1B.java
+++ b/java/test/jmri/jmrix/connectionConfigManager/TestTypeList1B.java
@@ -1,0 +1,25 @@
+package jmri.jmrix.connectionConfigManager;
+
+import static jmri.jmrix.ConnectionConfigManagerTest.MFG1;
+import static jmri.jmrix.ConnectionConfigManagerTest.TYPE_B;
+
+import jmri.jmrix.ConnectionTypeList;
+
+/**
+ * Test ConnectionTypeList
+ *
+ * @author Randall Wood (C) 2016
+ */
+public class TestTypeList1B implements ConnectionTypeList {
+
+    @Override
+    public String[] getAvailableProtocolClasses() {
+        return new String[]{TYPE_B};
+    }
+
+    @Override
+    public String[] getManufacturers() {
+        return new String[]{MFG1};
+    }
+
+}

--- a/java/test/jmri/jmrix/connectionConfigManager/TestTypeList2.java
+++ b/java/test/jmri/jmrix/connectionConfigManager/TestTypeList2.java
@@ -1,0 +1,25 @@
+package jmri.jmrix.connectionConfigManager;
+
+import static jmri.jmrix.ConnectionConfigManagerTest.MFG2;
+import static jmri.jmrix.ConnectionConfigManagerTest.TYPE_C;
+
+import jmri.jmrix.ConnectionTypeList;
+
+/**
+ * Test ConnectionTypeList
+ *
+ * @author Randall Wood (C) 2016
+ */
+public class TestTypeList2 implements ConnectionTypeList {
+
+    @Override
+    public String[] getAvailableProtocolClasses() {
+        return new String[]{TYPE_C};
+    }
+
+    @Override
+    public String[] getManufacturers() {
+        return new String[]{MFG2};
+    }
+
+}

--- a/java/test/jmri/jmrix/connectionConfigManager/TestTypeList3.java
+++ b/java/test/jmri/jmrix/connectionConfigManager/TestTypeList3.java
@@ -1,7 +1,6 @@
 package jmri.jmrix.connectionConfigManager;
 
-import static jmri.jmrix.ConnectionConfigManagerTest.MFG2;
-import static jmri.jmrix.ConnectionConfigManagerTest.TYPE_C;
+import static jmri.jmrix.ConnectionConfigManagerTest.MFG3;
 import static jmri.jmrix.ConnectionConfigManagerTest.TYPE_D;
 
 import jmri.jmrix.ConnectionTypeList;
@@ -11,16 +10,16 @@ import jmri.jmrix.ConnectionTypeList;
  *
  * @author Randall Wood (C) 2016
  */
-public class TestTypeList2 implements ConnectionTypeList {
+public class TestTypeList3 implements ConnectionTypeList {
 
     @Override
     public String[] getAvailableProtocolClasses() {
-        return new String[]{TYPE_C, TYPE_D};
+        return new String[]{TYPE_D};
     }
 
     @Override
     public String[] getManufacturers() {
-        return new String[]{MFG2};
+        return new String[]{MFG3};
     }
 
 }


### PR DESCRIPTION
This allows more than one ```jmri.jmrix.ConnectionTypeList``` to specify classes that support a single manufacturer (for example "MERG"). Internally to JMRI, this would allow ConnectionTypeLists that list classes in adjacent packages to be split up (see ```jmri.jmrix.merg.MergConnectionTypeList``` as an example case). Externally to JMRI, this could allow experimental new connection types to be used by adding a JAR containing the connectionTypeList to the JMRI class path (documentation still needs to be hashed out for this).

A side effect of the unit tests for this is that test resources in the CLASSPATH are no longer mingled with the compiled classes, but are kept separate.