### PR TITLE
Unit test updates

### DIFF
--- a/java/test/jmri/jmrit/display/palette/ItemPaletteTest.java
+++ b/java/test/jmri/jmrit/display/palette/ItemPaletteTest.java
@@ -1,0 +1,56 @@
+package jmri.jmrit.display.palette;
+
+import java.beans.PropertyChangeEvent;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import junit.framework.Assert;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+/**
+ *
+ * @author	Bob Jacobsen
+ */
+public class ItemPaletteTest extends jmri.util.SwingTestCase {
+
+    ItemPalette ip;
+    
+    public void testShow() {
+        jmri.util.ThreadingUtil.runOnGUI(() -> {
+            ip = new ItemPalette("Test ItemPalette", null);
+            ip.pack();
+        });
+        ip.setVisible(true);
+    }
+
+
+    // from here down is testing infrastructure
+    public ItemPaletteTest(String s) {
+        super(s);
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {"-noloading", ItemPaletteTest.class.getName()};
+        junit.textui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        TestSuite suite = new TestSuite(ItemPaletteTest.class);
+        return suite;
+    }
+
+    // The minimal setup for log4J
+    protected void setUp() {
+        apps.tests.Log4JFixture.setUp();
+    
+        jmri.util.JUnitUtil.resetInstanceManager();
+    }
+
+    protected void tearDown() {
+        apps.tests.Log4JFixture.tearDown();
+    }
+
+	// static private Logger log = LoggerFactory.getLogger(ItemPaletteTest.class.getName());
+}

--- a/java/test/jmri/jmrit/display/palette/PackageTest.java
+++ b/java/test/jmri/jmrit/display/palette/PackageTest.java
@@ -30,6 +30,7 @@ public class PackageTest extends TestCase {
 
 
         if (!System.getProperty("jmri.headlesstest", "false").equals("true")) {
+            suite.addTest(ItemPaletteTest.suite());
         }
 
         suite.addTest(BundleTest.suite());

--- a/java/test/jmri/util/junit/TestClassMainMethod.java
+++ b/java/test/jmri/util/junit/TestClassMainMethod.java
@@ -11,7 +11,9 @@ public class TestClassMainMethod {
 
     // Main entry point
     static public void main(String[] args) {
-        String className = args[0];        
+        String className = args[0];
+        // as a convenience, allow e.g. jmri/BundleTest in addition to jmri.BundleTest
+        className = className.replace('/','.');    
         try {
             // first try to find a main in the class
             Class<?> cl = Class.forName(className);


### PR DESCRIPTION
- Add unit test for ItemPalette NPE #1721 #1722
- Update the ./runtest launcher to take class name in both jmri.Foo and jmri/Foo form, as the old one did.
