### PR TITLE
Stop using deprecated method sendHello()

### DIFF
--- a/java/src/jmri/jmris/json/JsonServer.java
+++ b/java/src/jmri/jmris/json/JsonServer.java
@@ -90,7 +90,7 @@ public class JsonServer extends JmriServer {
         JsonClientHandler handler = new JsonClientHandler(new JsonConnection(outStream));
 
         // Start by sending a welcome message
-        handler.sendHello(this.timeout);
+        handler.onMessage(JsonClientHandler.HELLO_MSG);
 
         while (true) {
             try {

--- a/java/src/jmri/server/json/JsonClientHandler.java
+++ b/java/src/jmri/server/json/JsonClientHandler.java
@@ -48,6 +48,12 @@ import org.slf4j.LoggerFactory;
 
 public class JsonClientHandler {
 
+    /**
+     * When used as a parameter to
+     * {@link #onMessage(java.lang.String)}, will cause a
+     * {@value jmri.server.json.JSON#HELLO} message to be sent to the client.
+     */
+    public static final String HELLO_MSG = "{\"" + JSON.TYPE + "\":\"" + JSON.HELLO + "\"}";
     private final JsonConsistServer consistServer;
     private final JsonOperationsServer operationsServer;
     private final JsonProgrammerServer programmerServer;
@@ -258,13 +264,14 @@ public class JsonClientHandler {
     /**
      *
      * @param heartbeat seconds until heartbeat must be received before breaking
-     *                  connection to client.
+     *                  connection to client; currently ignored
      * @throws IOException if communications broken with client
-     * @deprecated since 4.5.2 without direct replacement
+     * @deprecated since 4.5.2; use {@link #onMessage(java.lang.String)} with
+     * the parameter {@link #HELLO_MSG} instead
      */
     @Deprecated
     public void sendHello(int heartbeat) throws IOException {
-        this.connection.sendMessage(JsonUtil.getHello(this.connection.getLocale(), heartbeat));
+        this.onMessage(HELLO_MSG);
     }
 
     private void sendErrorMessage(int code, String message) throws IOException {

--- a/java/src/jmri/server/json/JsonWebSocket.java
+++ b/java/src/jmri/server/json/JsonWebSocket.java
@@ -46,7 +46,7 @@ public class JsonWebSocket {
                 }
             };
             log.debug("Sending hello");
-            this.handler.sendHello(JsonServerPreferences.getDefault().getHeartbeatInterval());
+            this.handler.onMessage(JsonClientHandler.HELLO_MSG);
         } catch (IOException e) {
             log.warn("Error opening WebSocket:\n{}", e.getMessage());
             sn.close();


### PR DESCRIPTION
This removes use of a deprecated call to a non-modular method of
sending the initial hello message. The modular response to an initial hello message is more complete than the non-modular response, since two modular servers respond to it. (The current power state is sent as a second message in a modular response to a hello message.)