### PR TITLE
Use antcall instead of ant

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2050,13 +2050,13 @@
     <!-- CI Test runners -->
     <target name="travis-ci" description="Parallel execution of CI tasks on Travis CI">
         <parallel threadCount="4"> <!-- allow up to four tasks at once -->
-            <ant target="checklineends" />
-            <ant target="checknonascii" />
+            <antcall target="checklineends" />
+            <antcall target="checknonascii" />
             <sequential>
-                <ant target="compile-generated-source" />
+                <antcall target="compile-generated-source" />
                 <parallel>
-                    <ant target="javadoc" />
-                    <ant target="ci-test-travis" />
+                    <antcall target="javadoc" />
+                    <antcall target="ci-test-travis" />
                 </parallel>
             </sequential>
         </parallel>
@@ -2064,8 +2064,8 @@
     
     <target name="appveyor" description="Parallel execution of CI tasks on Appveyor">
         <parallel threadCount="4"> <!-- allow up to four tasks at once -->
-            <ant target="checkPropertiesFiles" />
-            <ant target="ci-test-appveyor" />
+            <antcall target="checkPropertiesFiles" />
+            <antcall target="ci-test-appveyor" />
         </parallel>
     </target>
 </project>


### PR DESCRIPTION
Although using macrodefs would be even better than antcall, antcall is
preferable (and hopefully faster) than ant when calling a target within
the same build.xml file.