### PR TITLE
Protect against null managers.

### DIFF
--- a/java/src/jmri/managers/Bundle.java
+++ b/java/src/jmri/managers/Bundle.java
@@ -1,6 +1,7 @@
 package jmri.managers;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Locale;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -22,13 +23,13 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = "jmri.managers.ManagersBundle"; // no local resources
+    private final static String name = "jmri.managers.ManagersBundle";
 
     //
     // below here is boilerplate to be copied exactly
     //
     /**
-     * Provides access to a string for a given key from the package resource
+     * Provides a translated string for a given key from the package resource
      * bundle or parent.
      * <p>
      * Note that this is intentionally package-local access.
@@ -41,17 +42,52 @@ public class Bundle extends jmri.Bundle {
     }
 
     /**
-     * Merges user data with a string for a given key from the package resource
-     * bundle or parent.
+     * Provides a translated string for a given key in a given locale from the
+     * package resource bundle or parent.
      * <p>
      * Note that this is intentionally package-local access.
      *
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key) {
+        return b.handleGetMessage(locale, key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
      * @param key  Bundle key to be translated
      * @param subs One or more objects to be inserted into the message
      * @return Internationalized text
      */
     static String getMessage(String key, Object... subs) {
         return b.handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return b.handleGetMessage(locale, key, subs);
     }
 
     private final static Bundle b = new Bundle();

--- a/java/src/jmri/managers/ManagerDefaultSelector.java
+++ b/java/src/jmri/managers/ManagerDefaultSelector.java
@@ -169,10 +169,10 @@ public class ManagerDefaultSelector extends AbstractPreferencesManager {
                         log.debug("   setting default for \"{}\" to \"{}\" in configure", c, memo.get(c));
                         InstanceManager.setDefault(c, memo.get(c));
                     } catch (NullPointerException ex) {
-                        String englishMsg = Bundle.getMessage(Locale.ENGLISH, "ErrorNullDefault", memo.getUserName(), memo.getClass(), c); // NOI18N
-                        String localizedMsg = Bundle.getMessage("ErrorNullDefault", memo.getUserName(), memo.getClass(), c); // NOI18N
+                        String englishMsg = Bundle.getMessage(Locale.ENGLISH, "ErrorNullDefault", memo.getUserName(), c); // NOI18N
+                        String localizedMsg = Bundle.getMessage("ErrorNullDefault", memo.getUserName(), c); // NOI18N
                         error = new InitializationException(englishMsg, localizedMsg);
-                        log.warn(englishMsg);
+                        log.warn("SystemConnectionMemo for {} ({}) provides a null {} instance", memo.getUserName(), memo.getClass(), c);
                     }
                     break;
                 }

--- a/java/src/jmri/managers/ManagersBundle.properties
+++ b/java/src/jmri/managers/ManagersBundle.properties
@@ -36,4 +36,4 @@ SkipMessageFuture   = Skip message in future?
 Reminder            = Reminder
 ReminderLine        = You can re-display this message from 'Edit|Preferences|Message' Menu.
 
-ErrorNullDefault = System connection {0} ({1}) provides a null {2}
+ErrorNullDefault = System connection {0} provides a null manager for {1}

--- a/java/src/jmri/managers/ManagersBundle.properties
+++ b/java/src/jmri/managers/ManagersBundle.properties
@@ -35,3 +35,5 @@ SkipMessageSession  = Skip message for this session only?
 SkipMessageFuture   = Skip message in future?
 Reminder            = Reminder
 ReminderLine        = You can re-display this message from 'Edit|Preferences|Message' Menu.
+
+ErrorNullDefault = System connection {0} ({1}) provides a null {2}


### PR DESCRIPTION
Protects the running application against NPEs from SystemConnectionMemos that provide a null manager. Note that this may leave the application in an unusable state, so besides logging the null manager, it should also cause an error message to be displayed to the user if triggered through ```ManagerDefaultSelector.initialize(Profile)```.