### PR TITLE
Fix logic error in JRE detection on OS X

### DIFF
--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -284,7 +284,7 @@ if [ -z "${JAVA_HOME}" ] ; then
         if [ -x "${JAVA_HOME}/bin/java" ] ; then
             JAVACMD="${JAVA_HOME}/bin/java"
             # Test if java is present and version 1.8 or 1.9
-            if [[ -x "${JAVACMD}" && "$( "${JAVACMD}" -version 2>&1 )" =~ 1.[89] ]] ; then
+            if [[ ! "$( "${JAVACMD}" -version 2>&1 )" =~ 1.[89] ]] ; then
                 JAVA_HOME=""
             fi
         fi

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -120,7 +120,7 @@ function parse_args() {
 # - with an absolute minimum of 192MB
 function heap_size() {
     # get Java heap size
-    heap=$( java -XX:+PrintFlagsFinal -version 2>/dev/null | grep MaxHeapSize | awk '{print $4}' )
+    heap=$( "${JAVACMD}" -XX:+PrintFlagsFinal -version 2>/dev/null | grep MaxHeapSize | awk '{print $4}' )
     heap=$( expr ${heap} / 1048576 ) # bytes to MB
     # Java heap defaults to 1/4 total memory size
     # if <= 768MB (1/4 of 3MB), set it ourselves

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -244,16 +244,6 @@ parse_args "$default_options"
 parse_args $JMRI_OPTIONS # support JMRI_OPTIONS if someone is using it
 parse_args $@
 
-# set if -J-Xmx=... is not in options or arguments
-if [ -z "${jmri_xmx:-}" ] ; then
-    jmri_xmx="-Xmx$( heap_size )m"
-fi
-# set if -J-Xms=... is not in options or arguments
-if [ -z "${jmri_xms:-}" ] ; then
-    # initial heap size = default for 6 GB RAM (default = 1/64 installed RAM)
-    jmri_xms="-Xms96m"
-fi
-
 # define JAVA_HOME if needed
 if [ -z "${JAVA_HOME}" ] ; then
     #
@@ -327,6 +317,16 @@ else
 fi
 # make JAVA_HOME available to spawned processes
 export JAVA_HOME
+
+# set if -J-Xmx=... is not in options or arguments
+if [ -z "${jmri_xmx:-}" ] ; then
+    jmri_xmx="-Xmx$( heap_size )m"
+fi
+# set if -J-Xms=... is not in options or arguments
+if [ -z "${jmri_xms:-}" ] ; then
+    # initial heap size = default for 6 GB RAM (default = 1/64 installed RAM)
+    jmri_xms="-Xms96m"
+fi
 
 # define JMRI_HOME if it is not defined
 if [ -z "${JMRI_HOME}" ] ; then


### PR DESCRIPTION
Unlike the error in 4.5.1, this error correctly detected the right version of java, but acted as if it did not. This change causes us not to unset JAVA_HOME after confirming that JAVA_HOME has the right version of java.
Also remove redundant check that JAVA_HOME/bin/java is executable.