### PR TITLE
Improve DEBUG running

### DIFF
--- a/java/test/jmri/util/JUnitAppender.java
+++ b/java/test/jmri/util/JUnitAppender.java
@@ -123,7 +123,7 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
         }
         int retval = 0;
         for (LoggingEvent event : list) {
-            if (event.getLevel().toInt() >= level.toInt()) retval++;  // higher number -> more severe, specific, limited
+            if (event != null && event.getLevel() != null && event.getLevel().toInt() >= level.toInt()) retval++;  // higher number -> more severe, specific, limited
             // with Log4J 2, this could have used isMoreSpecificThan(level)
         }
         list.clear();


### PR DESCRIPTION
1) Limit System Console window to 5000 lines (adjustable) to limit memory growth when running with debug on; log files not limited.

2) Protect against NPE during logging from failed tests