### PR TITLE
Set screen sizes to potentially saner defaults.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,10 @@ install:
   - mvn -version
 build: off
 
+before_test:
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/set-screenresolution.ps1'))
+- ps: Set-ScreenResolution 1280 768
+
 test_script:
 - ps: |
     mvn test -P appveyor --quiet --batch-mode


### PR DESCRIPTION
This size is the width of an older 4x3 VGA display (1280 x 1024) and the height of a new inexpensive Dell laptop display (1366 x 768), so window sizes retain some constraints.