### PR TITLE
Fix some minor errors in the launcher

### DIFF
--- a/jmri.conf
+++ b/jmri.conf
@@ -28,11 +28,11 @@
 #
 # Examples:
 # - Set the maximum memory JMRI is allowed to use to 2 GB (2048 MB):
-#   default_options="-J-Xmx=2048m"
+#   default_options="-J-Xmx2048m"
 # - Set the serial ports to /dev/loconet and /dev/cmri:
 #   default_options="--serial-ports=/dev/loconet,/dev/cmri"
 # - Combine the two examples above:
-#   default_options="-J-Xmx=2-48m --serial-ports=/dev/loconet,/dev/cmri"
+#   default_options="-J-Xmx2048m --serial-ports=/dev/loconet,/dev/cmri"
 #
 # See jmri.org/help/en/html/doc/Technical/StartUpScripts.shtml for more details.
 default_options=""

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -238,7 +238,7 @@ done
 if [ -f "${settingsdir}/jmri.conf" ] ; then
     default_options=""
     source "${settingsdir}/jmri.conf"
-    parse_args "${default_options}"
+    parse_args ${default_options}
 fi
 
 # process environment and command line arguments


### PR DESCRIPTION
- Typos in jmri.conf samples
- Unquote an erroneously quoted variable