### PR TITLE
JTablePersistenceManager improvements

### DIFF
--- a/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
@@ -172,7 +172,7 @@ abstract public class AbstractTableTabAction extends AbstractTableAction {
                 tableAction.setManager(manager);
             }
             dataModel = tableAction.getTableDataModel();
-            TableRowSorter<BeanTableDataModel> sorter = new TableRowSorter(dataModel);
+            TableRowSorter<BeanTableDataModel> sorter = new TableRowSorter<>(dataModel);
             dataTable = dataModel.makeJTable(dataModel.getMasterClassName() + ":" + getItemString(), dataModel, sorter);
             dataScroll = new JScrollPane(dataTable);
 

--- a/java/src/jmri/jmrit/beantable/AudioTablePanel.java
+++ b/java/src/jmri/jmrit/beantable/AudioTablePanel.java
@@ -65,7 +65,7 @@ public class AudioTablePanel extends JPanel {
 
         super();
         listenerDataModel = listenerModel;
-        TableRowSorter sorter = new TableRowSorter<>(listenerDataModel);
+        TableRowSorter<AudioTableDataModel> sorter = new TableRowSorter<>(listenerDataModel);
         sorter.setComparator(AudioTableDataModel.SYSNAMECOL, new SystemNameComparator());
         RowSorterUtil.setSortOrder(sorter, AudioTableDataModel.SYSNAMECOL, SortOrder.ASCENDING);
         listenerDataTable = listenerDataModel.makeJTable(listenerDataModel.getMasterClassName(), listenerDataModel, sorter);

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -469,14 +469,14 @@ abstract public class BeanTableDataModel extends AbstractTableModel implements P
         for (int i = 0; i < this.getRowCount(); i++) {
             for (int j = 0; j < this.getColumnCount(); j++) {
                 //check for special, non string contents
-                if (this.getValueAt(i, j) == null) {
+                Object value = this.getValueAt(i, j);
+                if (value == null) {
                     columnStrings[j] = spaces.toString();
-                } else if (this.getValueAt(i, j) instanceof JComboBox) {
-                    columnStrings[j] = (String) ((JComboBox<String>) this.getValueAt(i, j)).getSelectedItem();
-                } else if (this.getValueAt(i, j) instanceof Boolean) {
-                    columnStrings[j] = (this.getValueAt(i, j)).toString();
+                } else if (value instanceof JComboBox) {
+                    columnStrings[j] = (String) ((JComboBox<String>) value).getSelectedItem();
                 } else {
-                    columnStrings[j] = (String) this.getValueAt(i, j);
+                    // Boolean or String
+                    columnStrings[j] = value.toString();
                 }
             }
             printColumns(w, columnStrings, columnSize);
@@ -590,7 +590,6 @@ abstract public class BeanTableDataModel extends AbstractTableModel implements P
 
     protected void showPopup(MouseEvent e) {
         JTable source = (JTable) e.getSource();
-        TableModel tmodel = source.getModel();
         int row = source.rowAtPoint(e.getPoint());
         int column = source.columnAtPoint(e.getPoint());
         if (!source.isRowSelected(row)) {

--- a/java/src/jmri/jmrit/beantable/ListedTableFrame.java
+++ b/java/src/jmri/jmrit/beantable/ListedTableFrame.java
@@ -373,7 +373,7 @@ public class ListedTableFrame extends BeanTableFrame {
 
         void createDataModel() {
             dataModel = tableAction.getTableDataModel();
-            TableRowSorter<BeanTableDataModel> sorter = new TableRowSorter(dataModel);
+            TableRowSorter<BeanTableDataModel> sorter = new TableRowSorter<>(dataModel);
             dataTable = dataModel.makeJTable(dataModel.getMasterClassName() + ":" + getItemString(), dataModel, sorter);
             dataScroll = new JScrollPane(dataTable);
 

--- a/java/src/jmri/jmrit/beantable/RouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableAction.java
@@ -549,7 +549,7 @@ public class RouteTableAction extends AbstractTableAction {
             p2xt.add(p21t);
             _routeTurnoutModel = new RouteTurnoutModel();
             JTable routeTurnoutTable = new JmriTable(_routeTurnoutModel);
-            TableRowSorter rtSorter = new TableRowSorter(_routeTurnoutModel);
+            TableRowSorter<RouteTurnoutModel> rtSorter = new TableRowSorter<>(_routeTurnoutModel);
             rtSorter.setComparator(RouteTurnoutModel.SNAME_COLUMN, new SystemNameComparator());
             RowSorterUtil.setSortOrder(rtSorter, RouteTurnoutModel.SNAME_COLUMN, SortOrder.ASCENDING);
             routeTurnoutTable.setRowSorter(rtSorter);
@@ -601,7 +601,7 @@ public class RouteTableAction extends AbstractTableAction {
             p2xs.add(p21s);
             _routeSensorModel = new RouteSensorModel();
             JTable routeSensorTable = new JmriTable(_routeSensorModel);
-            TableRowSorter rsSorter = new TableRowSorter(_routeSensorModel);
+            TableRowSorter<RouteSensorModel> rsSorter = new TableRowSorter<>(_routeSensorModel);
             rsSorter.setComparator(RouteSensorModel.SNAME_COLUMN, new SystemNameComparator());
             RowSorterUtil.setSortOrder(rsSorter, RouteSensorModel.SNAME_COLUMN, SortOrder.ASCENDING);
             routeSensorTable.setRowSorter(rsSorter);

--- a/java/src/jmri/swing/JTablePersistenceManager.java
+++ b/java/src/jmri/swing/JTablePersistenceManager.java
@@ -41,10 +41,10 @@ public interface JTablePersistenceManager {
      *
      * @param table the table to persist
      * @throws IllegalArgumentException if another table instance is already
-     *                                  persisted by the same name or if the
-     *                                  table name is null
+     *                                  persisted by the same name
+     * @throws NullPointerException     if the table name is null
      */
-    public void persist(@Nonnull JTable table) throws IllegalArgumentException;
+    public void persist(@Nonnull JTable table) throws IllegalArgumentException, NullPointerException;
 
     /**
      * Stop persisting the table. This does not clear the persistence state, but

--- a/java/src/jmri/swing/RowSorterUtil.java
+++ b/java/src/jmri/swing/RowSorterUtil.java
@@ -33,7 +33,7 @@ public final class RowSorterUtil {
      */
     @Nonnull
     public static SortOrder getSortOrder(@Nonnull RowSorter<? extends TableModel> rowSorter, int column) {
-        for (RowSorter.SortKey key : rowSorter.getSortKeys()) {
+        for (SortKey key : rowSorter.getSortKeys()) {
             if (key.getColumn() == column) {
                 return key.getSortOrder();
             }
@@ -53,7 +53,7 @@ public final class RowSorterUtil {
      * @param sortOrder the sort order
      */
     public static void setSortOrder(@Nonnull RowSorter<? extends TableModel> rowSorter, int column, @Nonnull SortOrder sortOrder) {
-        List<RowSorter.SortKey> keys = new ArrayList<>();
+        List<SortKey> keys = new ArrayList<>();
         if (!sortOrder.equals(SortOrder.UNSORTED)) {
             keys.add(new RowSorter.SortKey(column, sortOrder));
         }
@@ -71,12 +71,12 @@ public final class RowSorterUtil {
     public static RowSorterListener addSingleSortableColumnListener(@Nonnull RowSorter<? extends TableModel> rowSorter) {
         Objects.requireNonNull(rowSorter, "rowSorter must be nonnull.");
         RowSorterListener listener = new RowSorterListener() {
-            List<SortKey> priorSortKeys = new ArrayList<>();
+            List<? extends SortKey> priorSortKeys = new ArrayList<>();
 
             @Override
             public void sorterChanged(RowSorterEvent e) {
                 if (e.getType().equals(RowSorterEvent.Type.SORT_ORDER_CHANGED)) {
-                    List<RowSorter.SortKey> newSortKeys = new ArrayList<>(e.getSource().getSortKeys());
+                    List<? extends SortKey> newSortKeys = new ArrayList<>(e.getSource().getSortKeys());
                     newSortKeys.removeAll(priorSortKeys);
                     if (!newSortKeys.isEmpty()) {
                         priorSortKeys = newSortKeys;

--- a/java/test/jmri/swing/JmriJTablePersistenceManagerTest.java
+++ b/java/test/jmri/swing/JmriJTablePersistenceManagerTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import apps.tests.Log4JFixture;
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.HashSet;
 import java.util.Set;
@@ -338,14 +337,23 @@ public class JmriJTablePersistenceManagerTest {
      * Test of propertyChange method, of class JmriJTablePersistenceManager.
      */
     @Test
-    @Ignore
     public void testPropertyChange() {
-        System.out.println("propertyChange");
-        PropertyChangeEvent evt = null;
-        JmriJTablePersistenceManager instance = new JmriJTablePersistenceManager();
-        instance.propertyChange(evt);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
+        JmriJTablePersistenceManagerSpy instance = new JmriJTablePersistenceManagerSpy();
+        JTable table = new JTable();
+        String name1 = "test name";
+        String name2 = "name test";
+        table.setName(name1);
+        try {
+            instance.persist(table);
+            // passes
+        } catch (NullPointerException ex) {
+            Assert.fail("threw unexpected NPE");
+        }
+        Assert.assertNotNull(instance.getListener(name1));
+        Assert.assertNull(instance.getListener(name2));
+        table.setName(name2);
+        Assert.assertNull(instance.getListener(name1));
+        Assert.assertNotNull(instance.getListener(name2));
     }
 
     private final static class JmriJTablePersistenceManagerSpy extends JmriJTablePersistenceManager {
@@ -354,6 +362,10 @@ public class JmriJTablePersistenceManagerTest {
         JTableListener getListener(JTable table) {
             return this.listeners.get(table.getName());
         }
-
+        
+        //default access
+        JTableListener getListener(String name) {
+            return this.listeners.get(name);
+        }
     }
 }

--- a/java/test/jmri/swing/JmriJTablePersistenceManagerTest.java
+++ b/java/test/jmri/swing/JmriJTablePersistenceManagerTest.java
@@ -3,11 +3,14 @@ package jmri.swing;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import apps.tests.Log4JFixture;
 import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.HashSet;
 import java.util.Set;
 import javax.swing.JTable;
 import javax.swing.SortOrder;
+import javax.swing.table.TableRowSorter;
 import jmri.profile.Profile;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -18,42 +21,127 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 /**
+ * Tests the {@link jmri.swing.JmriJTablePersistenceManager}. Some tests use a
+ * {@link jmri.swing.JmriJTablePersistenceManagerTest.JmriJTablePersistenceManagerSpy}
+ * class that exposes some protected properties for testing purposes.
  *
- * @author rhwood
+ * @author Randall Wood (C) 2016
  */
 public class JmriJTablePersistenceManagerTest {
-    
+
     public JmriJTablePersistenceManagerTest() {
     }
-    
+
     @BeforeClass
     public static void setUpClass() {
+        Log4JFixture.setUp();
     }
-    
+
     @AfterClass
     public static void tearDownClass() {
+        Log4JFixture.tearDown();
     }
-    
+
     @Before
     public void setUp() {
     }
-    
+
     @After
     public void tearDown() {
     }
 
     /**
-     * Test of persist method, of class JmriJTablePersistenceManager.
+     * Test of persist method, of class JmriJTablePersistenceManager. This tests
+     * persistence by verifying that tables get the expected listeners attached.
      */
     @Test
-    @Ignore
     public void testPersist() {
-        System.out.println("persist");
+        JmriJTablePersistenceManagerSpy instance = new JmriJTablePersistenceManagerSpy();
+        // null table
         JTable table = null;
-        JmriJTablePersistenceManager instance = new JmriJTablePersistenceManager();
-        instance.persist(table);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
+        try {
+            instance.persist(table);
+            Assert.fail("did not throw NPE on null table");
+        } catch (NullPointerException ex) {
+            // passes
+        }
+        // null table name
+        table = new JTable();
+        try {
+            instance.persist(table);
+            Assert.fail("did not throw NPE on table with null name");
+        } catch (NullPointerException ex) {
+            // passes
+        }
+        // correct table
+        table.setName("test name");
+        try {
+            instance.persist(table);
+            // passes
+        } catch (NullPointerException ex) {
+            Assert.fail("threw unexpected NPE");
+        }
+        int managers = 0;
+        int listeners = 0;
+        for (PropertyChangeListener listener : table.getPropertyChangeListeners()) {
+            if (listener.equals(instance)) {
+                managers++;
+            }
+            if (listener.equals(instance.getListener(table))) {
+                listeners++;
+            }
+        }
+        Assert.assertEquals(1, managers);
+        Assert.assertEquals(1, listeners);
+        // allow table twice
+        try {
+            instance.persist(table);
+            // passes
+        } catch (IllegalArgumentException ex) {
+            Assert.fail("threw unexpected IllegalArgumentException");
+        }
+        managers = 0;
+        listeners = 0;
+        for (PropertyChangeListener listener : table.getPropertyChangeListeners()) {
+            if (listener.equals(instance)) {
+                managers++;
+            }
+            if (listener.equals(instance.getListener(table))) {
+                listeners++;
+            }
+        }
+        Assert.assertEquals(1, managers);
+        Assert.assertEquals(1, listeners);
+        // duplicate table name
+        JTable table2 = new JTable();
+        table2.setRowSorter(new TableRowSorter<>(table2.getModel()));
+        table2.setName("test name");
+        try {
+            instance.persist(table2);
+            Assert.fail("Accepted duplicate name");
+        } catch (IllegalArgumentException ex) {
+            // passes
+        }
+        // a second table
+        table2.setName("test name 2");
+        try {
+            instance.persist(table);
+            // passes
+        } catch (IllegalArgumentException ex) {
+            Assert.fail("threw unexpected IllegalArgumentException");
+        }
+        managers = 0;
+        listeners = 0;
+        for (PropertyChangeListener listener : table.getPropertyChangeListeners()) {
+            if (listener.equals(instance)) {
+                managers++;
+            }
+            if (listener.equals(instance.getListener(table))) {
+                listeners++;
+            }
+        }
+        Assert.assertEquals(1, managers);
+        Assert.assertEquals(1, listeners);
     }
 
     /**
@@ -227,5 +315,13 @@ public class JmriJTablePersistenceManagerTest {
         // TODO review the generated test code and remove the default call to fail.
         fail("The test case is a prototype.");
     }
-    
+
+    private final static class JmriJTablePersistenceManagerSpy extends JmriJTablePersistenceManager {
+
+        //default access
+        JTableListener getListener(JTable table) {
+            return this.listeners.get(table.getName());
+        }
+
+    }
 }

--- a/java/test/jmri/swing/JmriJTablePersistenceManagerTest.java
+++ b/java/test/jmri/swing/JmriJTablePersistenceManagerTest.java
@@ -148,14 +148,46 @@ public class JmriJTablePersistenceManagerTest {
      * Test of stopPersisting method, of class JmriJTablePersistenceManager.
      */
     @Test
-    @Ignore
     public void testStopPersisting() {
-        System.out.println("stopPersisting");
-        JTable table = null;
-        JmriJTablePersistenceManager instance = new JmriJTablePersistenceManager();
-        instance.stopPersisting(table);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
+        JmriJTablePersistenceManagerSpy instance = new JmriJTablePersistenceManagerSpy();
+        JTable table = new JTable();
+        table.setName("test name");
+        try {
+            instance.persist(table);
+            // passes
+        } catch (NullPointerException ex) {
+            Assert.fail("threw unexpected NPE");
+        }
+        int managers = 0;
+        int listeners = 0;
+        for (PropertyChangeListener listener : table.getPropertyChangeListeners()) {
+            if (listener.equals(instance)) {
+                managers++;
+            }
+            if (listener.equals(instance.getListener(table))) {
+                listeners++;
+            }
+        }
+        Assert.assertEquals(1, managers);
+        Assert.assertEquals(1, listeners);
+        try {
+            instance.stopPersisting(table);
+            // passes
+        } catch (NullPointerException ex) {
+            Assert.fail("threw unexpected NPE");
+        }
+        managers = 0;
+        listeners = 0;
+        for (PropertyChangeListener listener : table.getPropertyChangeListeners()) {
+            if (listener.equals(instance)) {
+                managers++;
+            }
+            if (listener.equals(instance.getListener(table))) {
+                listeners++;
+            }
+        }
+        Assert.assertEquals(0, managers);
+        Assert.assertEquals(0, listeners);
     }
 
     /**


### PR DESCRIPTION
- Throw NPE for null table names consistently.
- Fix an error causing too many PropertyChangeListeners to be added to tables.
- Documentation improvements.
- Real persistence tests.