### PR TITLE
Replace use of JTableUtil.sortableDataModel()

### DIFF
--- a/java/src/jmri/jmrit/automat/monitor/AutomatTableFrame.java
+++ b/java/src/jmri/jmrit/automat/monitor/AutomatTableFrame.java
@@ -5,7 +5,8 @@ import javax.swing.BoxLayout;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
-import jmri.util.JTableUtil;
+import javax.swing.table.TableRowSorter;
+import jmri.swing.JmriTable;
 
 /**
  * Frame providing a table of Automat instances
@@ -25,7 +26,8 @@ public class AutomatTableFrame extends jmri.util.JmriJFrame {
         super();
         dataModel = model;
 
-        dataTable = JTableUtil.sortableDataModel(dataModel);
+        dataTable = new JmriTable(dataModel);
+        dataTable.setRowSorter(new TableRowSorter<>(dataModel));
         dataScroll = new JScrollPane(dataTable);
 
         // configure items for GUI

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
@@ -10,8 +10,9 @@ import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+import javax.swing.table.TableRowSorter;
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
-import jmri.util.JTableUtil;
+import jmri.swing.JmriTable;
 
 /**
  * Frame provinging a command station slot manager.
@@ -53,7 +54,8 @@ public class SlotMonPane extends jmri.jmrix.loconet.swing.LnPanel {
         super.initComponents(memo);
 
         slotModel = new SlotMonDataModel(128, 16, memo);
-        slotTable = JTableUtil.sortableDataModel(slotModel);
+        slotTable = new JmriTable(slotModel);
+        slotTable.setRowSorter(new TableRowSorter<>(slotModel));
         slotScroll = new JScrollPane(slotTable);
 
         // configure items for GUI

--- a/java/src/jmri/jmrix/openlcb/swing/tie/ConsumerTablePane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/tie/ConsumerTablePane.java
@@ -8,7 +8,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
-import javax.swing.table.TableModel;
+import javax.swing.table.TableRowSorter;
+import jmri.swing.JmriTable;
 
 /**
  * Pane for showing the consumer table
@@ -27,7 +28,7 @@ public class ConsumerTablePane extends JPanel {
     static ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.openlcb.swing.tie.TieBundle");
 
     protected JTable table = null;
-    protected TableModel tableModel = null;
+    protected ConsumerTableModel tableModel = null;
 
     public void initComponents() throws Exception {
 
@@ -36,7 +37,8 @@ public class ConsumerTablePane extends JPanel {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
         tableModel = new ConsumerTableModel();
-        table = jmri.util.JTableUtil.sortableDataModel(tableModel);
+        table = new JmriTable(tableModel);
+        table.setRowSorter(new TableRowSorter<>(tableModel));
         table.setRowSelectionAllowed(true);
         table.setPreferredScrollableViewportSize(new java.awt.Dimension(300, 350));
 

--- a/java/src/jmri/jmrix/openlcb/swing/tie/ProducerTablePane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/tie/ProducerTablePane.java
@@ -8,7 +8,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
-import javax.swing.table.TableModel;
+import javax.swing.table.TableRowSorter;
+import jmri.swing.JmriTable;
 
 /**
  * Pane for showing the producer table
@@ -27,7 +28,7 @@ public class ProducerTablePane extends JPanel {
     static ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.openlcb.swing.tie.TieBundle");
 
     protected JTable table = null;
-    protected TableModel tableModel = null;
+    protected ProducerTableModel tableModel = null;
 
     public void initComponents() throws Exception {
 
@@ -36,7 +37,8 @@ public class ProducerTablePane extends JPanel {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
         tableModel = new ProducerTableModel();
-        table = jmri.util.JTableUtil.sortableDataModel(tableModel);
+        table = new JmriTable(tableModel);
+        table.setRowSorter(new TableRowSorter<>(tableModel));
         table.setRowSelectionAllowed(true);
         table.setPreferredScrollableViewportSize(new java.awt.Dimension(300, 350));
 

--- a/java/src/jmri/jmrix/openlcb/swing/tie/TieTablePane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/tie/TieTablePane.java
@@ -8,7 +8,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
-import javax.swing.table.TableModel;
+import javax.swing.table.TableRowSorter;
+import jmri.swing.JmriTable;
 
 /**
  * Pane for showing the tie table
@@ -27,7 +28,7 @@ public class TieTablePane extends JPanel {
     static ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.openlcb.swing.tie.TieBundle");
 
     protected JTable table = null;
-    protected TableModel tableModel = null;
+    protected TieTableModel tableModel = null;
 
     public void initComponents() throws Exception {
 
@@ -36,7 +37,8 @@ public class TieTablePane extends JPanel {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
         tableModel = new TieTableModel();
-        table = jmri.util.JTableUtil.sortableDataModel(tableModel);
+        table = new JmriTable(tableModel);
+        table.setRowSorter(new TableRowSorter<>(tableModel));
         table.setRowSelectionAllowed(true);
         table.setPreferredScrollableViewportSize(new java.awt.Dimension(300, 350));
 

--- a/java/src/jmri/jmrix/pricom/pockettester/PacketTableFrame.java
+++ b/java/src/jmri/jmrix/pricom/pockettester/PacketTableFrame.java
@@ -6,7 +6,8 @@ import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
-import jmri.util.JTableUtil;
+import javax.swing.table.TableRowSorter;
+import jmri.swing.JmriTable;
 
 /**
  * Frame providing survey of DCC contents
@@ -29,7 +30,8 @@ public class PacketTableFrame extends jmri.util.JmriJFrame implements DataListen
 
     public void initComponents() {
 
-        table = JTableUtil.sortableDataModel(model);
+        table = new JmriTable(model);
+        table.setRowSorter(new TableRowSorter<>(model));
         scroll = new JScrollPane(table);
 
         model.configureTable(table);

--- a/java/src/jmri/jmrix/sprog/sprogslotmon/SprogSlotMonFrame.java
+++ b/java/src/jmri/jmrix/sprog/sprogslotmon/SprogSlotMonFrame.java
@@ -13,10 +13,10 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextArea;
-import jmri.jmrix.sprog.SprogCommandStation;
+import javax.swing.table.TableRowSorter;
 import jmri.jmrix.sprog.SprogConstants;
 import jmri.jmrix.sprog.SprogSystemConnectionMemo;
-import jmri.util.JTableUtil;
+import jmri.swing.JmriTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +49,8 @@ public class SprogSlotMonFrame extends jmri.util.JmriJFrame {
         _memo = memo;
         slotModel = new SprogSlotMonDataModel(SprogConstants.MAX_SLOTS, 8,_memo);
 
-        slotTable = JTableUtil.sortableDataModel(slotModel);
+        slotTable = new JmriTable(slotModel);
+        slotTable.setRowSorter(new TableRowSorter<>(slotModel));
         slotScroll = new JScrollPane(slotTable);
 
         // configure items for GUI

--- a/java/src/jmri/jmrix/tams/swing/locodatabase/LocoDataPane.java
+++ b/java/src/jmri/jmrix/tams/swing/locodatabase/LocoDataPane.java
@@ -13,14 +13,15 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+import javax.swing.table.TableRowSorter;
 import jmri.jmrix.tams.TamsMessage;
 import jmri.jmrix.tams.TamsSystemConnectionMemo;
-import jmri.util.JTableUtil;
+import jmri.swing.JmriTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Frame provinging access to the loco database on the Tams MC
+ * Frame providing access to the loco database on the Tams MC
  *
  * @author	Kevin Dickerson Copyright (C) 2012
  */
@@ -49,7 +50,8 @@ public class LocoDataPane extends jmri.jmrix.tams.swing.TamsPanel {
         super.initComponents(memo);
 
         locoModel = new LocoDataModel(128, 16, memo);
-        locoTable = JTableUtil.sortableDataModel(locoModel);
+        locoTable = new JmriTable(locoModel);
+        locoTable.setRowSorter(new TableRowSorter<>(locoModel));
         locoScroll = new JScrollPane(locoTable);
 
         locoModel.configureTable(locoTable);


### PR DESCRIPTION
Replace all use of JTableUtil.sortableDataModel() with the use of JmriTable instances with individual row sorters.