### PR TITLE
Save table column widths

### DIFF
--- a/java/src/jmri/managers/JmriUserPreferencesManager.java
+++ b/java/src/jmri/managers/JmriUserPreferencesManager.java
@@ -1264,6 +1264,10 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
         this.saveSimplePreferenceState();
         this.saveWindowDetails();
         this.resetChangeMade();
+        JmriJTablePersistenceManager manager = InstanceManager.getOptionalDefault(JmriJTablePersistenceManager.class);
+        if (manager != null) {
+            manager.savePreferences(ProfileManager.getDefault().getActiveProfile());
+        }
     }
 
     protected final static class ComboBoxLastSelection {

--- a/java/src/jmri/swing/JTablePersistenceManager.java
+++ b/java/src/jmri/swing/JTablePersistenceManager.java
@@ -24,7 +24,10 @@ import javax.swing.JTable;
  * Column attributes (order, visibility, and width) are persisted by listening
  * to changes in the {@link javax.swing.table.TableColumnModel} of the table.
  * Column visibility is persisted only if the TableColumnModel is assignable
- * from {@link jmri.util.swing.XTableColumnModel}.
+ * from {@link jmri.util.swing.XTableColumnModel}. Columns will be saved using
+ * the String representation of either
+ * {@link javax.swing.table.TableColumn#getIdentifier()} or
+ * {@link javax.swing.table.TableColumn#getHeaderValue()}.
  * <p>
  * <strong>Note:</strong> A JTable with UI state being persisted must have a
  * unique non-null name.

--- a/xml/schema/auxiliary-configuration/table-details-4-3-5.xsd
+++ b/xml/schema/auxiliary-configuration/table-details-4-3-5.xsd
@@ -56,7 +56,11 @@
                                         <xs:element name="column" minOccurs="0" maxOccurs="unbounded">
                                             <xs:complexType>
                                                 <xs:attribute name="name" type="xs:string" use="required" />
-                                                <xs:attribute name="order" type="xs:int" use="optional" /> 
+                                                <xs:attribute name="order" type="xs:int" use="optional">
+                                                    <xs:documentation>
+                                                        View index, not model index.
+                                                    </xs:documentation>
+                                                </xs:attribute>
                                                 <xs:attribute name="width" type="xs:int" use="optional" />
                                                 <xs:attribute name="hidden" type="xs:boolean" use="optional" />
                                             </xs:complexType>


### PR DESCRIPTION
- Save changes to a column’s preferred width.
- Improve performance by not saving state on every change, but by saving state after no changes have occurred for 1/2 second, and by not implicitly saving certain changes.
- Documentation improvements.
- Rely on the column’s identifier for column identity, setting it to the column’s headerValue if not set explicitly.