### PR TITLE
Fix decoder identification in certain circumstances.

### DIFF
--- a/java/src/jmri/jmrit/decoderdefn/DecoderIndexFile.java
+++ b/java/src/jmri/jmrit/decoderdefn/DecoderIndexFile.java
@@ -63,8 +63,8 @@ public class DecoderIndexFile extends XmlFile {
     /**
      * Get a List of decoders matching some information
      */
-    public List<DecoderFile> matchingDecoderList(String mfg, String family, 
-            String decoderMfgID, String decoderVersionID, String decoderProductID, 
+    public List<DecoderFile> matchingDecoderList(String mfg, String family,
+            String decoderMfgID, String decoderVersionID, String decoderProductID,
             String model) {
         return (matchingDecoderList(mfg, family, decoderMfgID, decoderVersionID, decoderProductID, model, null));
     }
@@ -72,8 +72,8 @@ public class DecoderIndexFile extends XmlFile {
     /**
      * Get a List of decoders matching some information
      */
-    public List<DecoderFile> matchingDecoderList(String mfg, String family, 
-            String decoderMfgID, String decoderVersionID, 
+    public List<DecoderFile> matchingDecoderList(String mfg, String family,
+            String decoderMfgID, String decoderVersionID,
             String decoderProductID, String model, String developerID) {
         List<DecoderFile> l = new ArrayList<DecoderFile>();
         for (int i = 0; i < numDecoders(); i++) {
@@ -133,8 +133,8 @@ public class DecoderIndexFile extends XmlFile {
      * Don't bother asking about the model number...
      *
      */
-    public boolean checkEntry(int i, String mfgName, String family, String mfgID, 
-            String decoderVersionID, String decoderProductID, String model, 
+    public boolean checkEntry(int i, String mfgName, String family, String mfgID,
+            String decoderVersionID, String decoderProductID, String model,
             String developerID) {
         DecoderFile r = decoderList.get(i);
         if (mfgName != null && !mfgName.equals(r.getMfg())) {
@@ -151,16 +151,14 @@ public class DecoderIndexFile extends XmlFile {
         }
         // check version ID - no match if a range specified and out of range
         if (decoderVersionID != null) {
-            int versionID = Integer.valueOf(decoderVersionID).intValue();
+            int versionID = Integer.parseInt(decoderVersionID);
             if (!r.isVersion(versionID)) {
                 return false;
             }
         }
         if (decoderProductID != null && !("," + r.getProductID()+ ",").contains("," + decoderProductID+ ",")) {
-            if ( !("," + r.getModelElement().getAttribute("productID") + ",").contains("," + decoderProductID +",") ) {
                 return false;
             }
-        }
         if (developerID != null && !developerID.equals(r.getDeveloperID())) {
             if ( !("," + r.getModelElement().getAttribute("developerID").getValue() + ",").contains("," + developerID +",") ) {
                 return false;
@@ -478,9 +476,9 @@ public class DecoderIndexFile extends XmlFile {
             String hiVersID = ((attr = decoder.getAttribute("highVersionID")) != null ? attr.getValue() : parentHighVersID);
             String replacementModelName = ((attr = decoder.getAttribute("replacementModel")) != null ? attr.getValue() : null);
             replacementFamilyName = ((attr = decoder.getAttribute("replacementFamily")) != null ? attr.getValue() : replacementFamilyName);
-            int numFns = ((attr = decoder.getAttribute("numFns")) != null ? Integer.valueOf(attr.getValue()).intValue() : -1);
-            int numOuts = ((attr = decoder.getAttribute("numOuts")) != null ? Integer.valueOf(attr.getValue()).intValue() : -1);
-            String devId = ((attr = decoder.getAttribute("developerId")) != null ? attr.getValue(): "-1");
+            int numFns = ((attr = decoder.getAttribute("numFns")) != null ? Integer.parseInt(attr.getValue()) : -1);
+            int numOuts = ((attr = decoder.getAttribute("numOuts")) != null ? Integer.parseInt(attr.getValue()) : -1);
+            String devId = ((attr = decoder.getAttribute("developerId")) != null ? attr.getValue() : "-1");
             DecoderFile df = new DecoderFile(mfg, mfgID,
                     ((attr = decoder.getAttribute("model")) != null ? attr.getValue() : null),
                     loVersID, hiVersID, familyName, filename, devId, numFns, numOuts, decoder,

--- a/java/src/jmri/jmrit/symbolicprog/CombinedLocoSelPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/CombinedLocoSelPane.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.List;
+import java.util.ListIterator;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -35,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * interested in.
  *
  * <P>
- * To overide this class to use a different decoder-selection GUI, replace
+ * To override this class to use a different decoder-selection GUI, replace
  * members:
  * <UL>
  * <LI>layoutDecoderSelection
@@ -46,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * <LI>isDecoderSelected
  * <LI>selectedDecoderName
  * </UL>
- * *
+ *
  * @author	Bob Jacobsen Copyright (C) 2001, 2002
  */
 public class CombinedLocoSelPane extends LocoSelPane implements PropertyChangeListener {
@@ -260,7 +261,9 @@ public class CombinedLocoSelPane extends LocoSelPane implements PropertyChangeLi
         // start identifying a loco
         final CombinedLocoSelPane me = this;
         Programmer p = null;
-        if (selector != null && selector.isSelected()) p = selector.getProgrammer();
+        if (selector != null && selector.isSelected()) {
+            p = selector.getProgrammer();
+        }
         if (p == null) {
             log.warn("Selector did not provide a programmer, use default");
             p = jmri.InstanceManager.getDefault(jmri.ProgrammerManager.class).getGlobalProgrammer();
@@ -295,7 +298,9 @@ public class CombinedLocoSelPane extends LocoSelPane implements PropertyChangeLi
         // start identifying a decoder
         final CombinedLocoSelPane me = this;
         Programmer p = null;
-        if (selector != null && selector.isSelected()) p = selector.getProgrammer();
+        if (selector != null && selector.isSelected()) {
+            p = selector.getProgrammer();
+        }
         if (p == null) {
             log.warn("Selector did not provide a programmer, use default");
             p = jmri.InstanceManager.getDefault(jmri.ProgrammerManager.class).getGlobalProgrammer();
@@ -375,7 +380,7 @@ public class CombinedLocoSelPane extends LocoSelPane implements PropertyChangeLi
         if (productID != -1) {
             String sz_productID = Integer.toString(productID);
             temp = DecoderIndexFile.instance().matchingDecoderList(null, null, Integer.toString(mfgID), Integer.toString(modelID), sz_productID, null);
-            if (temp.size() == 0) {
+            if (temp.isEmpty()) {
                 log.debug("selectDecoder found no items with product ID " + productID);
                 temp = null;
             } else {
@@ -389,6 +394,52 @@ public class CombinedLocoSelPane extends LocoSelPane implements PropertyChangeLi
             if (log.isDebugEnabled()) {
                 log.debug("selectDecoder without productID found " + temp.size() + " matches");
             }
+        }
+
+        // remove unwanted matches
+        int tempOriginalSize = temp.size(); // save size of unfiltered list
+        String theFamily = "";
+        String theModel = "";
+        String lastWasFamily = "";
+
+        ListIterator<DecoderFile> it = temp.listIterator();
+        while (it.hasNext()) {
+            log.debug("Match List size is currently {}, scanning for unwanted entries", temp.size());
+            DecoderFile t = it.next();
+            theFamily = t.getFamily();
+            theModel = t.getModel();
+            if (t.getFamily().equals(theModel)) {
+                log.debug("Match List index={} is family entry '{}'", it.previousIndex(), theFamily);
+                lastWasFamily = theFamily;
+            } else if (lastWasFamily.equals(theFamily)) {
+                log.debug("Match List index={} is first model '{}' in family '{}'", it.previousIndex(), theModel, theFamily);
+                log.debug("Removing family entry '{}'", theFamily);
+                t = it.previous();
+                t = it.previous();
+                it.remove();
+                lastWasFamily = "";
+            } else if ((t.getModelElement().getAttribute("show") != null)
+                    && (t.getModelElement().getAttribute("show").getValue().equals("no"))) {
+                log.debug("Match List index={} is legacy model '{}' in family '{}'", it.previousIndex(), theModel, theFamily);
+                log.debug("Removing legacy model '{}'", theModel);
+                t = it.previous();
+                it.remove();
+                lastWasFamily = "";
+            } else {
+                log.debug("Match List index={} is model '{}' in family '{}'", it.previousIndex(), theModel, theFamily);
+                lastWasFamily = "";
+            }
+        }
+
+        log.debug("Final Match List size is {}", temp.size());
+
+        // If we had match(es) previously but have lost them in filtering
+        // pretend we have no product ID so we get a coarse match
+        if (tempOriginalSize > 0 && temp.isEmpty()) {
+            log.debug("Filtering removed all matches so reverting to coarse match with mfgID='{}' & modelID='{}'",
+                    Integer.toString(mfgID), Integer.toString(modelID));
+            temp = DecoderIndexFile.instance().matchingDecoderList(null, null, Integer.toString(mfgID), Integer.toString(modelID), null, null);
+            log.debug("selectDecoder without productID found {} matches", temp.size());
         }
 
         // install all those in the JComboBox in place of the longer, original list
@@ -524,9 +575,11 @@ public class CombinedLocoSelPane extends LocoSelPane implements PropertyChangeLi
 
     /**
      * Start the desired type of programmer
-     * @param decoderFile defines the type of decoder installed; if null, check the RosterEntry re for that
-     * @param r Existing roster entry defining this locomotive
-     * @param progName name of the programmer (Layout connection) being used
+     *
+     * @param decoderFile defines the type of decoder installed; if null, check
+     *                    the RosterEntry re for that
+     * @param r           Existing roster entry defining this locomotive
+     * @param progName    name of the programmer (Layout connection) being used
      */
     // TODO: Fix inheritance.  This is both a base class (where startProgrammer really isn't part of the contract_
     //       and a first implementation (where this method is needed).  Because it's part of the contract, it can't be 


### PR DESCRIPTION
Read type from decoder reported unwanted multiple matches if:
- The match was to first model in the family.
- There was a match was to a show="no" model in the family. http://jmri.org/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml#update