### PR TITLE
Adhere to contract

### DIFF
--- a/java/src/jmri/managers/WarningProgrammerManager.java
+++ b/java/src/jmri/managers/WarningProgrammerManager.java
@@ -98,7 +98,7 @@ public class WarningProgrammerManager implements ProgrammerManager {
         if (this.manager != null) {
             return this.manager.getUserName();
         }
-        return null;
+        return ""; // NOI18N returning empty string by contract
     }
 
     @Override


### PR DESCRIPTION
Method getUserName is non-null.
This fixes a FindBugs warning.