### PR TITLE
Remove Revision tag

### DIFF
--- a/help/en/JHelpDev.csh
+++ b/help/en/JHelpDev.csh
@@ -2,7 +2,5 @@
 #
 # csh script to launch JHelpDev with the current directory set
 #
-#($Revision$)
-#
 
 java -DHOMEDIR=${PWD} -Djava.io.tmpdir=/tmp -Xmx2000m -classpath ".:jhelpdev.jar:jars/jhall.jar:jars/xmlenc.jar" net.sourceforge.jhelpdev.JHelpDevFrame

--- a/help/en/build.xml
+++ b/help/en/build.xml
@@ -1,6 +1,5 @@
 <!-- an ANT build.xml file for JMRI XSLT -->
 <!-- Bob Jacobsen, Copyright 2002, 2003, 2004, 2005, 2008, 2010, 2015 -->
-<!-- Revision $Revision$ -->
 
 <!-- This file is part of JMRI.                                             -->
 <!--                                                                        -->

--- a/help/en/html/doc/Technical/GitFAQ.shtml
+++ b/help/en/html/doc/Technical/GitFAQ.shtml
@@ -1013,9 +1013,10 @@ your own.
 
         <dd>
           <p>When JMRI was originally using CVS, we used lines
-          like: <code># The next line is maintained by CVS, please
+          like: <br>
+          <code># The next line is maintained by CVS, please
           don't change it<br>
-          # $Revision$</code> as an additional way of tracking file
+          # $Revision$</code><br> as an additional way of tracking file
           versions. When we migrated to SVN, we kept those lines in
           certain files, like decoder XML, properties files, etc,
           that users are likely to edit and submit back for

--- a/help/en/indexheader
+++ b/help/en/indexheader
@@ -1,5 +1,5 @@
 <!-- indexheader - This file is included at the top of the page   -->
-<!-- when the web index is displayed online.   $Revision$   -->
+<!-- when the web index is displayed online.   -->
 <!-- Copyright 2008-2015 JMRI, Bob Jacobsen  See COPYING file for info -->
 
 <h1>JMRI&reg; Help: Index</h1>

--- a/help/en/tocheader
+++ b/help/en/tocheader
@@ -1,5 +1,5 @@
 <!-- indexheader - This file is included at the top of the page   -->
-<!-- when the web index is displayed online.   $Revision$   -->
+<!-- when the web index is displayed online.     -->
 <!-- Copyright 2008-2015 JMRI, Bob Jacobsen  See COPYING file for info -->
 
 <h1>JMRI&reg; Help: Table of Contents</h1>

--- a/help/fr/JHelpDev.csh
+++ b/help/fr/JHelpDev.csh
@@ -2,7 +2,5 @@
 #
 # csh script to launch JHelpDex with the current directory set
 #
-#($Revision: 1.3 $)
-#
 
 java -DHOMEDIR=${PWD} -Djava.io.tmpdir=/tmp -Xmx500m -classpath ".:jhelpdev.jar:lib/jhall.jar:lib/xmlenc.jar" net.sourceforge.jhelpdev.JHelpDevFrame

--- a/help/fr/build.xml
+++ b/help/fr/build.xml
@@ -1,6 +1,5 @@
 <!-- an ANT build.xml file for JMRI XSLT -->
 <!-- Bob Jacobsen, Copyright 2002, 2003, 2004, 2005, 2008, 2010, 2015 -->
-<!-- Revision $Revision: 17977 $ -->
 
 <!-- This file is part of JMRI.                                             -->
 <!--                                                                        -->

--- a/help/fr/indexheader
+++ b/help/fr/indexheader
@@ -1,5 +1,5 @@
 <!-- indexheader - This file is included at the top of the page   -->
-<!-- when the web index is displayed online.   $Revision: 1.4 $   -->
+<!-- when the web index is displayed online.    -->
 <!-- Copyright 2016 JMRI, Bob Jacobsen  See COPYING file for info -->
 <!-- Translated by Blorec Hervé le 2012-01-23 -->
 

--- a/help/fr/tocheader
+++ b/help/fr/tocheader
@@ -1,5 +1,5 @@
 <!-- tocheader - This file is included at the top of the page   -->
-<!-- when the web TOC is displayed online.   $Revision: 1.3 $   -->
+<!-- when the web TOC is displayed online.    -->
 <!-- Copyright 2016 JMRI, Bob Jacobsen  See COPYING file for info -->
 <!-- Translated by Blorec Herv&eacute; le 2012-01-23 -->
 

--- a/java/runtest.csh
+++ b/java/runtest.csh
@@ -29,8 +29,6 @@
 #
 # For more information, please see
 # http://jmri.org/install/ShellScripts.shtml
-#
-# $Revision$ (CVS maintains this line, do not edit please)
 
 # runs from usual program directory
 cd ..

--- a/java/src/apps/ActionListBundle.properties
+++ b/java/src/apps/ActionListBundle.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListBundle_ca.properties
+++ b/java/src/apps/ActionListBundle_ca.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListBundle_cs.properties
+++ b/java/src/apps/ActionListBundle_cs.properties
@@ -1,6 +1,6 @@
 # ActionListBundle_cs.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Czech (w/o diacritic) properties  listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListBundle_cs_CZ.properties
+++ b/java/src/apps/ActionListBundle_cs_CZ.properties
@@ -1,6 +1,6 @@
 # ActionListBundle_cs_CZ.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Override certain czech properties  listing names with CZ diacritic for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListBundle_da.properties
+++ b/java/src/apps/ActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # ActionListBundle_da.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListBundle_de.properties
+++ b/java/src/apps/ActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # ActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg, update Egbert Broerse
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/apps/ActionListBundle_es.properties
+++ b/java/src/apps/ActionListBundle_es.properties
@@ -1,6 +1,6 @@
 # ActionListBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListBundle_fr.properties
+++ b/java/src/apps/ActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListBundle_it.properties
+++ b/java/src/apps/ActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 # Properties listing names for "Action" classes that can appear

--- a/java/src/apps/ActionListBundle_ja.properties
+++ b/java/src/apps/ActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListBundle_ja_JP.properties
+++ b/java/src/apps/ActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListCoreBundle.properties
+++ b/java/src/apps/ActionListCoreBundle.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListCoreBundle_ca.properties
+++ b/java/src/apps/ActionListCoreBundle_ca.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListCoreBundle_cs.properties
+++ b/java/src/apps/ActionListCoreBundle_cs.properties
@@ -1,6 +1,6 @@
 # ActionListBundle_cs.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Czech (w/o diacritic) properties  listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListCoreBundle_cs_CZ.properties
+++ b/java/src/apps/ActionListCoreBundle_cs_CZ.properties
@@ -1,6 +1,6 @@
 # ActionListBundle_cs_CZ.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Override certain czech properties  listing names with CZ diacritic for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListCoreBundle_de.properties
+++ b/java/src/apps/ActionListCoreBundle_de.properties
@@ -1,6 +1,6 @@
 # ActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/apps/ActionListCoreBundle_es.properties
+++ b/java/src/apps/ActionListCoreBundle_es.properties
@@ -1,6 +1,6 @@
 # ActionListBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListCoreBundle_fr.properties
+++ b/java/src/apps/ActionListCoreBundle_fr.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListCoreBundle_it.properties
+++ b/java/src/apps/ActionListCoreBundle_it.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/apps/ActionListCoreBundle_ja.properties
+++ b/java/src/apps/ActionListCoreBundle_ja.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/ActionListCoreBundle_ja_JP.properties
+++ b/java/src/apps/ActionListCoreBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/AppsConfigBundle_ca.properties
+++ b/java/src/apps/AppsConfigBundle_ca.properties
@@ -1,6 +1,6 @@
 # AppsConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for configuration in the apps package of JMRI, including
 # the AppConfigPanel and PerformActionPanel classes

--- a/java/src/apps/AppsConfigBundle_cs.properties
+++ b/java/src/apps/AppsConfigBundle_cs.properties
@@ -1,6 +1,6 @@
 # AppsConfigBundle_cs.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Czech properties (w/o diacritic) for configuration in the apps package of JMRI, including
 # the AppConfigPanel and PerformActionPanel classes

--- a/java/src/apps/AppsConfigBundle_cs_CZ.properties
+++ b/java/src/apps/AppsConfigBundle_cs_CZ.properties
@@ -1,6 +1,6 @@
 # AppsConfigBundle_cs_CZ.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Override certain czech properties for configuration in the apps package of JMRI with CZ diacritic, including
 # the AppConfigPanel and PerformActionPanel classes

--- a/java/src/apps/AppsConfigBundle_da.properties
+++ b/java/src/apps/AppsConfigBundle_da.properties
@@ -1,6 +1,6 @@
 # AppsConfigBundle_da.properties
 #
-# Revision $Revision$
+#
 # Danish Translation by Sonny Hansen
 # Overrides some Default properties for configuration in the apps package of JMRI, including
 # the AppConfigPanel and PerformActionPanel classes

--- a/java/src/apps/AppsConfigBundle_en_GB.properties
+++ b/java/src/apps/AppsConfigBundle_en_GB.properties
@@ -1,6 +1,6 @@
 # AppsConfigBundle_en_GB.properties
 #
-# Revision $Revision$
+#
 #
 # en_GB properties for configuration in the apps package of JMRI, including
 # the AppConfigPanel and PerformActionPanel classes

--- a/java/src/apps/AppsConfigBundle_es.properties
+++ b/java/src/apps/AppsConfigBundle_es.properties
@@ -1,6 +1,6 @@
 # AppsConfigBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for configuration in the apps package of JMRI, including
 # the AppConfigPanel and PerformActionPanel classes

--- a/java/src/apps/AppsConfigBundle_fr.properties
+++ b/java/src/apps/AppsConfigBundle_fr.properties
@@ -1,6 +1,6 @@
 # AppsConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for configuration in the apps package of JMRI, including
 # the AppConfigPanel and PerformActionPanel classes

--- a/java/src/apps/AppsConfigBundle_it.properties
+++ b/java/src/apps/AppsConfigBundle_it.properties
@@ -1,6 +1,6 @@
 # AppsConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/apps/AppsConfigBundle_ja_JP.properties
+++ b/java/src/apps/AppsConfigBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # AppsConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for configuration in the apps package of JMRI, including
 # the AppConfigPanel and PerformActionPanel classes

--- a/java/src/apps/gui3/dp3/Bundle.properties
+++ b/java/src/apps/gui3/dp3/Bundle.properties
@@ -1,6 +1,6 @@
 # Bundle.properties
 #
-# Revision $Revision$
+#
 #
 
 FrameProgrammerSetup = Create New Loco

--- a/java/src/apps/gui3/dp3/Bundle_da.properties
+++ b/java/src/apps/gui3/dp3/Bundle_da.properties
@@ -1,7 +1,7 @@
 
 # Bundle_da.properties
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 
 FrameProgrammerSetup = Opret Nyt Loko

--- a/java/src/apps/gui3/dp3/Bundle_it.properties
+++ b/java/src/apps/gui3/dp3/Bundle_it.properties
@@ -1,6 +1,6 @@
 # Bundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/apps/gui3/dp3/DecoderPro3ActionListBundle_da.properties
+++ b/java/src/apps/gui3/dp3/DecoderPro3ActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/apps/gui3/dp3/DecoderPro3ActionListBundle_it.properties
+++ b/java/src/apps/gui3/dp3/DecoderPro3ActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/configurexml/SaveMenuBundle_ca.properties
+++ b/java/src/jmri/configurexml/SaveMenuBundle_ca.properties
@@ -1,6 +1,6 @@
 # SaveMenu.properties
 #
-# Revision $Revision$
+#
 #Translation Joan de Castro [joan276dca@yahoo.es] 20/09/2014
 # Default properties for the jmri.configurexml.SaveMenuItem
 

--- a/java/src/jmri/configurexml/SaveMenuBundle_da.properties
+++ b/java/src/jmri/configurexml/SaveMenuBundle_da.properties
@@ -1,6 +1,6 @@
 # SaveMenu_da.properties
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 # Overrides default properties for the jmri.configurexml.SaveMenuItem with danish
 

--- a/java/src/jmri/configurexml/SaveMenuBundle_es.properties
+++ b/java/src/jmri/configurexml/SaveMenuBundle_es.properties
@@ -1,6 +1,6 @@
 # SaveMenu.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.configurexml.SaveMenuItem
 

--- a/java/src/jmri/configurexml/SaveMenuBundle_fr.properties
+++ b/java/src/jmri/configurexml/SaveMenuBundle_fr.properties
@@ -1,6 +1,6 @@
 # SaveMenu_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.configurexml.SaveMenuItem
 #

--- a/java/src/jmri/configurexml/SaveMenuBundle_it.properties
+++ b/java/src/jmri/configurexml/SaveMenuBundle_it.properties
@@ -1,6 +1,6 @@
 # SaveMenu.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/configurexml/SaveMenuBundle_ja_JP.properties
+++ b/java/src/jmri/configurexml/SaveMenuBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # SaveMenu.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.configurexml.SaveMenuItem
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/implementation/swing/MessageBundle.properties
+++ b/java/src/jmri/implementation/swing/MessageBundle.properties
@@ -1,6 +1,6 @@
 # MessageBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for Swing implementations
 

--- a/java/src/jmri/implementation/swing/MessageBundle_ca.properties
+++ b/java/src/jmri/implementation/swing/MessageBundle_ca.properties
@@ -1,6 +1,6 @@
 # MessageBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Translation: Joan de Castro (joan276dca@yahoo.es) /  20-09-2014
 # Default properties for Swing implementations

--- a/java/src/jmri/implementation/swing/MessageBundle_da.properties
+++ b/java/src/jmri/implementation/swing/MessageBundle_da.properties
@@ -1,6 +1,6 @@
 # MessageBundle.properties
 #
-# Revision $Revision$
+#
 #Danish translation by Sonny Hansen
 ## Default properties for Swing implementations
 

--- a/java/src/jmri/implementation/swing/MessageBundle_de.properties
+++ b/java/src/jmri/implementation/swing/MessageBundle_de.properties
@@ -1,6 +1,6 @@
 # MessageBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for Swing implementations
 

--- a/java/src/jmri/implementation/swing/MessageBundle_fr.properties
+++ b/java/src/jmri/implementation/swing/MessageBundle_fr.properties
@@ -1,6 +1,6 @@
 # MessageBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for Swing implementations
 

--- a/java/src/jmri/implementation/swing/MessageBundle_it.properties
+++ b/java/src/jmri/implementation/swing/MessageBundle_it.properties
@@ -1,6 +1,6 @@
 # MessageBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/implementation/swing/MessageBundle_ja_JP.properties
+++ b/java/src/jmri/implementation/swing/MessageBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # MessageBundle.properties
 #
-# Revision $Revision$
+#
 #
 # japanese properties for Swing implementations
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmris/JmriServerBundle.properties
+++ b/java/src/jmri/jmris/JmriServerBundle.properties
@@ -1,6 +1,6 @@
 # JmriServerBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmris Server menu
 

--- a/java/src/jmri/jmris/JmriServerBundle_ca.properties
+++ b/java/src/jmri/jmris/JmriServerBundle_ca.properties
@@ -1,6 +1,6 @@
 # JmriServerBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Catalonian translation: Joan de Castro (joan276dca@yahoo.es)
 #

--- a/java/src/jmri/jmris/JmriServerBundle_da.properties
+++ b/java/src/jmri/jmris/JmriServerBundle_da.properties
@@ -1,6 +1,6 @@
 # JmriServerBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmris Server menu
 

--- a/java/src/jmri/jmris/JmriServerBundle_de.properties
+++ b/java/src/jmri/jmris/JmriServerBundle_de.properties
@@ -1,6 +1,6 @@
 # JmriServerBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg und Egbert Broerse
 # German properties for the jmri.jmris Server menu
 

--- a/java/src/jmri/jmris/JmriServerBundle_fr.properties
+++ b/java/src/jmri/jmris/JmriServerBundle_fr.properties
@@ -1,6 +1,6 @@
 # JmriServerBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmris Server menu
 

--- a/java/src/jmri/jmris/JmriServerBundle_it.properties
+++ b/java/src/jmri/jmris/JmriServerBundle_it.properties
@@ -1,6 +1,6 @@
 # JmriServerBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmris/simpleserver/SimpleServerBundle_ca.properties
+++ b/java/src/jmri/jmris/simpleserver/SimpleServerBundle_ca.properties
@@ -1,6 +1,6 @@
 # SimpleServerMenu.properties
 #
-# Revision $Revision$
+#
 #
 # catalan translation: Joan de Castro [joan276dca@yahoo.es]
 #

--- a/java/src/jmri/jmris/simpleserver/SimpleServerBundle_da.properties
+++ b/java/src/jmri/jmris/simpleserver/SimpleServerBundle_da.properties
@@ -1,6 +1,6 @@
 # SimpleServerMenu.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmris.simpleserver Server menu
 

--- a/java/src/jmri/jmris/simpleserver/SimpleServerBundle_fr.properties
+++ b/java/src/jmri/jmris/simpleserver/SimpleServerBundle_fr.properties
@@ -1,6 +1,6 @@
 # SimpleServerMenu.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmris.simpleserver Server menu
 # Updated by BLOREC Herv\u00e9 <bzh56420@yahoo.fr> 2016-01-08

--- a/java/src/jmri/jmris/simpleserver/SimpleServerBundle_it.properties
+++ b/java/src/jmri/jmris/simpleserver/SimpleServerBundle_it.properties
@@ -1,6 +1,6 @@
 # SimpleServerMenu.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmris/srcp/JmriSRCPServerBundle_ca.properties
+++ b/java/src/jmri/jmris/srcp/JmriSRCPServerBundle_ca.properties
@@ -1,6 +1,6 @@
 # JmriSRCPServerBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Catalan translation: Joan de Castro [joan276dca@yahoo.es] 17/08/2016
 #

--- a/java/src/jmri/jmris/srcp/JmriSRCPServerBundle_da.properties
+++ b/java/src/jmri/jmris/srcp/JmriSRCPServerBundle_da.properties
@@ -1,6 +1,6 @@
 # JmriSRCPServerBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmris Server menu
 

--- a/java/src/jmri/jmris/srcp/JmriSRCPServerBundle_fr.properties
+++ b/java/src/jmri/jmris/srcp/JmriSRCPServerBundle_fr.properties
@@ -1,6 +1,6 @@
 # JmriSRCPServerBundle.properties
 #
-# Revision $Revision$
+#
 # Updated by BLOREC Herv\u00e9 <bzh56420@yahoo.fr> 2016-01-08
 # Default properties for the jmri.jmris Server menu
 

--- a/java/src/jmri/jmris/srcp/JmriSRCPServerBundle_it.properties
+++ b/java/src/jmri/jmris/srcp/JmriSRCPServerBundle_it.properties
@@ -1,6 +1,6 @@
 # JmriSRCPServerBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/mailreport/ReportBundle.properties
+++ b/java/src/jmri/jmrit/mailreport/ReportBundle.properties
@@ -1,6 +1,6 @@
 # ReportBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmrit.mailreport package of jmri.
 #

--- a/java/src/jmri/jmrit/mailreport/ReportBundle_ca.properties
+++ b/java/src/jmri/jmrit/mailreport/ReportBundle_ca.properties
@@ -1,6 +1,6 @@
 # ReportBundle.properties
 #
-# Revision $Revision$
+#
 # Catalan Translation: Joan de Castro (joan276dca@yahoo.es) 18/08/2016
 # Default properties for the jmrit.mailreport package of jmri.
 #

--- a/java/src/jmri/jmrit/mailreport/ReportBundle_da.properties
+++ b/java/src/jmri/jmrit/mailreport/ReportBundle_da.properties
@@ -1,6 +1,6 @@
 # ReportBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmrit.mailreport package of jmri.
 #

--- a/java/src/jmri/jmrit/mailreport/ReportBundle_fr.properties
+++ b/java/src/jmri/jmrit/mailreport/ReportBundle_fr.properties
@@ -1,5 +1,5 @@
 # ReportBundle_fr.properties
-## Revision $Revision$
+##
 ## Default properties for the jmrit.mailreport package of jmri.
 ##
 # Translated by Herv\u00e9 BLOREC <bzh56420@yahoo.fr> le 2013-8-19

--- a/java/src/jmri/jmrit/mailreport/ReportBundle_it.properties
+++ b/java/src/jmri/jmrit/mailreport/ReportBundle_it.properties
@@ -1,6 +1,6 @@
 # ReportBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/mailreport/ReportBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/mailreport/ReportBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # ReportBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmrit.mailreport package of jmri.
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrit/operations/JmritOperationsBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/operations/JmritOperationsBundle_en_GB.properties
@@ -1,6 +1,6 @@
 # JmritOperationsBundle_en_GB.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit Operations menu
 

--- a/java/src/jmri/jmrit/operations/JmritOperationsBundle_fr.properties
+++ b/java/src/jmri/jmrit/operations/JmritOperationsBundle_fr.properties
@@ -1,6 +1,6 @@
 # JmritOperationsBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit Operations menu
 #

--- a/java/src/jmri/jmrit/operations/JmritOperationsBundle_it.properties
+++ b/java/src/jmri/jmrit/operations/JmritOperationsBundle_it.properties
@@ -1,6 +1,6 @@
 # JmritOperationsBundle_it.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/operations/JmritOperationsBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/operations/JmritOperationsBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # JmritOperationsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrit Operations menu
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrit/operations/automation/JmritOperationsAutomationBundle.properties
+++ b/java/src/jmri/jmrit/operations/automation/JmritOperationsAutomationBundle.properties
@@ -1,6 +1,6 @@
 # JmritOperationsAutomationBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for operations automation
 

--- a/java/src/jmri/jmrit/operations/automation/JmritOperationsAutomationBundle_ca.properties
+++ b/java/src/jmri/jmrit/operations/automation/JmritOperationsAutomationBundle_ca.properties
@@ -1,6 +1,6 @@
 # JmritOperationsAutomationBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for operations automation
 

--- a/java/src/jmri/jmrit/operations/automation/JmritOperationsAutomationBundle_da.properties
+++ b/java/src/jmri/jmrit/operations/automation/JmritOperationsAutomationBundle_da.properties
@@ -1,6 +1,6 @@
 # JmritOperationsAutomationBundle_da.properties
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 # Overides Default properties for operations automation
 

--- a/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_ca.properties
+++ b/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_ca.properties
@@ -1,6 +1,6 @@
 # JmritOperationsLocationsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.locations
 # Catalan Translation: Joan de Castro (joan276dca@yahoo.es) 18/08/2016

--- a/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_da.properties
+++ b/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_da.properties
@@ -1,6 +1,6 @@
 # JmritOperationsLocationsBundle_da.properties
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 # Overide some default properties for the jmri.jmrit.operations.locations
 

--- a/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_en_GB.properties
@@ -1,6 +1,6 @@
 # JmritOperationsLocationBundle_en_GB.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.locations
 

--- a/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_it.properties
+++ b/java/src/jmri/jmrit/operations/locations/JmritOperationsLocationsBundle_it.properties
@@ -1,6 +1,6 @@
 # JmritOperationsLocationsBundle_it.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/operations/rollingstock/JmritOperationsRollingStockBundle.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/JmritOperationsRollingStockBundle.properties
@@ -1,6 +1,6 @@
 # JmritOperationsCarsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.rollingstock
 #

--- a/java/src/jmri/jmrit/operations/rollingstock/JmritOperationsRollingStockBundle_ca.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/JmritOperationsRollingStockBundle_ca.properties
@@ -1,6 +1,6 @@
 # JmritOperationsCarsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.rollingstock
 #

--- a/java/src/jmri/jmrit/operations/rollingstock/JmritOperationsRollingStockBundle_da.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/JmritOperationsRollingStockBundle_da.properties
@@ -1,6 +1,6 @@
 # JmritOperationsCarsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.rollingstock
 #

--- a/java/src/jmri/jmrit/operations/rollingstock/JmritOperationsRollingStockBundle_fr.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/JmritOperationsRollingStockBundle_fr.properties
@@ -1,6 +1,6 @@
 # JmritOperationsCarsBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.rollingstock
 #

--- a/java/src/jmri/jmrit/operations/rollingstock/JmritOperationsRollingStockBundle_it.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/JmritOperationsRollingStockBundle_it.properties
@@ -1,6 +1,6 @@
 # JmritOperationsCarsBundle_it.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.rollingstock
 #

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle.properties
@@ -1,6 +1,6 @@
 # JmritOperationsCarsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.cars
 

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle_ca.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle_ca.properties
@@ -1,6 +1,6 @@
 # JmritOperationsCarsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.cars
 

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle_da.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle_da.properties
@@ -1,6 +1,6 @@
 # JmritOperationsCarsBundle_da.properties
 #
-# Revision $Revision$
+#
 #Danish translation by Sonny Hansen
 #Overrides some Default properties for the jmri.jmrit.operations.cars
 

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle_en_GB.properties
@@ -1,6 +1,6 @@
 # JmritOperationsCarsBundle_en_GB.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.cars
 

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle_fr.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle_fr.properties
@@ -1,5 +1,5 @@
 # JmritOperationsCarsBundle_fr.properties
-## Revision $Revision$
+##
 ## Default properties for the jmri.jmrit.operations.cars
 #
 # Updated by BLOREC Herv\u00e9 <bzh56420@yahoo.fr> 2016-01-11

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle_it.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle_it.properties
@@ -1,6 +1,6 @@
 # JmritOperationsCarsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/JmritOperationsCarsBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # JmritOperationsCarsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.cars
 

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle.properties
@@ -1,6 +1,6 @@
 # JmritOperationsEngineBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.engines
 

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_ca.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_ca.properties
@@ -1,6 +1,6 @@
 # JmritOperationsEngineBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.engines
 # Catalan Translation: Joan de Castro (joan276dca@yahoo.es) 18/08/2016

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_da.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_da.properties
@@ -1,6 +1,6 @@
 # JmritOperationsEngineBundle_da.properties
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 # Overide some Default properties for the jmri.jmrit.operations.engines
 

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_de.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_de.properties
@@ -1,6 +1,6 @@
 # JmritOperationsEngineBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.engines
 

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_en_GB.properties
@@ -1,6 +1,6 @@
 # JmritOperationsEngineBundle_en_GB.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.engines
 

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_fr.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_fr.properties
@@ -1,6 +1,6 @@
 # JmritOperationsEngineBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.engines
 #

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_it.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_it.properties
@@ -1,6 +1,6 @@
 # JmritOperationsEngineBundle_it.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/JmritOperationsEnginesBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # JmritOperationsEngineBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrit.operations.engines
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrit/operations/router/JmritOperationsRouterBundle.properties
+++ b/java/src/jmri/jmrit/operations/router/JmritOperationsRouterBundle.properties
@@ -1,6 +1,6 @@
 # JmritOperationsRouterBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.router
 

--- a/java/src/jmri/jmrit/operations/router/JmritOperationsRouterBundle_da.properties
+++ b/java/src/jmri/jmrit/operations/router/JmritOperationsRouterBundle_da.properties
@@ -1,6 +1,6 @@
 # JmritOperationsRouterBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.router
 

--- a/java/src/jmri/jmrit/operations/router/JmritOperationsRouterBundle_fr.properties
+++ b/java/src/jmri/jmrit/operations/router/JmritOperationsRouterBundle_fr.properties
@@ -1,5 +1,5 @@
 # JmritOperationsRouterBundle_fr.properties
-## Revision $Revision$
+##
 ## Default properties for the jmri.jmrit.operations.router
 ## Updated by BLOREC Herv\u00e9 <bzh56420@yahoo.fr> 2016-01-12
 

--- a/java/src/jmri/jmrit/operations/router/JmritOperationsRouterBundle_it.properties
+++ b/java/src/jmri/jmrit/operations/router/JmritOperationsRouterBundle_it.properties
@@ -1,6 +1,6 @@
 # JmritOperationsRouterBundle_it.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/operations/routes/JmritOperationsRoutesBundle.properties
+++ b/java/src/jmri/jmrit/operations/routes/JmritOperationsRoutesBundle.properties
@@ -1,6 +1,6 @@
 # JmritOperationsRoutesBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.routes
 

--- a/java/src/jmri/jmrit/operations/routes/JmritOperationsRoutesBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/operations/routes/JmritOperationsRoutesBundle_en_GB.properties
@@ -1,6 +1,6 @@
 # JmritOperationsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.routes
 

--- a/java/src/jmri/jmrit/operations/routes/JmritOperationsRoutesBundle_fr.properties
+++ b/java/src/jmri/jmrit/operations/routes/JmritOperationsRoutesBundle_fr.properties
@@ -1,6 +1,6 @@
 # JmritOperationsRoutesBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.routes
 #

--- a/java/src/jmri/jmrit/operations/routes/JmritOperationsRoutesBundle_it.properties
+++ b/java/src/jmri/jmrit/operations/routes/JmritOperationsRoutesBundle_it.properties
@@ -1,6 +1,6 @@
 # JmritOperationsRoutesBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/operations/routes/JmritOperationsRoutesBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/operations/routes/JmritOperationsRoutesBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # JmritOperationsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrit.operations.routes
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrit/operations/setup/JmritOperationsSetupBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/operations/setup/JmritOperationsSetupBundle_en_GB.properties
@@ -1,6 +1,6 @@
 # JmritOperationsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.setup
 

--- a/java/src/jmri/jmrit/operations/setup/JmritOperationsSetupBundle_fr.properties
+++ b/java/src/jmri/jmrit/operations/setup/JmritOperationsSetupBundle_fr.properties
@@ -1,6 +1,6 @@
 # JmritOperationsBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.setup
 #

--- a/java/src/jmri/jmrit/operations/setup/JmritOperationsSetupBundle_it.properties
+++ b/java/src/jmri/jmrit/operations/setup/JmritOperationsSetupBundle_it.properties
@@ -1,6 +1,6 @@
 # JmritOperationsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/operations/setup/JmritOperationsSetupBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/operations/setup/JmritOperationsSetupBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # JmritOperationsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrit.operations.setup
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrit/operations/trains/JmritOperationsTrainsBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/operations/trains/JmritOperationsTrainsBundle_en_GB.properties
@@ -1,6 +1,6 @@
 # JmritOperationsTrainsBundle_en_GB.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.operations.trains
 

--- a/java/src/jmri/jmrit/powerpanel/PowerPanelBundle.properties
+++ b/java/src/jmri/jmrit/powerpanel/PowerPanelBundle.properties
@@ -1,6 +1,6 @@
 # PowerPanelBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.powerpanel GUI elements
 

--- a/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_ca.properties
+++ b/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_ca.properties
@@ -1,6 +1,6 @@
 # PowerPanelBundle.properties
 #
-# Revision $Revision$
+#
 # Catalan Translation: Joan de Castro (joan276dca@yahoo.es) 218/08/2016
 # Default properties for the jmri.jmrit.powerpanel GUI eleme//ts
 

--- a/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_cs.properties
+++ b/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_cs.properties
@@ -1,6 +1,6 @@
 # PowerPanelBundle_cs.properties
 #
-# Revision $Revision$
+#
 #by Michal Basta
 # Czech properties (w/o diacritic) for the jmri.jmrit.powerpanel GUI elements
 #  

--- a/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_cs_CZ.properties
+++ b/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_cs_CZ.properties
@@ -1,6 +1,6 @@
 # PowerPanelBundle_cs_CZ.properties
 #
-# Revision $Revision$
+#
 #by Michal Basta
 # Override certain czech properties for the jmri.jmrit.powerpanel GUI elements with CZ diacritic
 #  

--- a/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_da.properties
+++ b/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_da.properties
@@ -1,6 +1,6 @@
 # PowerPanelBundle_da.properties
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 # Override certain properties for the jmri.jmrit.powerpanel GUI elements with danish
   

--- a/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_de.properties
+++ b/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_de.properties
@@ -1,6 +1,6 @@
 # PowerPanelBundlee_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrit.powerpanel GUI elements
 #   Made by JBuilder Mon Aug 11 23:13:04 PDT 2003

--- a/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_es.properties
+++ b/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_es.properties
@@ -1,6 +1,6 @@
 # PowerPanelBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.powerpanel GUI elements
 #   Made by JBuilder Mon Aug 11 23:13:04 PDT 2003

--- a/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_fr.properties
+++ b/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_fr.properties
@@ -1,6 +1,6 @@
 # PowerPanelBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.powerpanel GUI elements
 #   Made by JBuilder Mon Aug 11 23:13:04 PDT 2003

--- a/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_it.properties
+++ b/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_it.properties
@@ -1,6 +1,6 @@
 # PowerPanelBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/powerpanel/PowerPanelBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # PowerPanelBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrit.powerpanel GUI elements
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrit/progsupport/ProgSupportBundle_fr.properties
+++ b/java/src/jmri/jmrit/progsupport/ProgSupportBundle_fr.properties
@@ -1,6 +1,6 @@
 # ProgSupport_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties describing various programmer items
 #

--- a/java/src/jmri/jmrit/progsupport/ProgSupportBundle_it.properties
+++ b/java/src/jmri/jmrit/progsupport/ProgSupportBundle_it.properties
@@ -1,6 +1,6 @@
 # ProgSupport.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties describing various programmer items
 

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle_ca.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle_ca.properties
@@ -1,6 +1,6 @@
 # JmritRosterBundle.properties
 #
-# Revision $Revision$
+#
 
 # Catalan Translation: Joan de Castro (joan276dca@yahoo.es) 18/08/2016
 #

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle_cs.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle_cs.properties
@@ -1,6 +1,6 @@
 # JmritRosterBundle_cs.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Czech properties (w/o diacritic) for the jmri.jmrit.roster package
 

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle_cs_CZ.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle_cs_CZ.properties
@@ -1,6 +1,6 @@
 # JmritRosterBundle_cs_CZ.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Override certain czech jmri.jmrit.roster properties with CZ diacritic
 

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle_da.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle_da.properties
@@ -1,7 +1,7 @@
 # JmritRosterBundle_da.properties
 #
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 # Overides some Default properties for the jmri.jmrit.roster package
 

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle_de.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle_de.properties
@@ -1,6 +1,6 @@
 # JmritRosterBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg und Egbert Broerse 2016
 # German properties for the jmri.jmrit.roster package
 

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle_en_GB.properties
@@ -1,6 +1,6 @@
 # JmritRosterBundle_en_GB.properties
 #
-# Revision $Revision$
+#
 #
 # Override certain jmri.jmrit.roster properties for UK (GB) English
 

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle_es.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle_es.properties
@@ -1,6 +1,6 @@
 # JmritRosterBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Translated by Alfredo Sola <alfredos@users.sf.net> 20040826
 #

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle_fr.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle_fr.properties
@@ -1,5 +1,5 @@
 # JmritRosterBundle_fr.properties
-## Revision $Revision$
+##
 ## Default properties for the jmri.jmrit.roster package
 ## Updated by Herv\u00e9 BLOREC <bzh56420@yahoo.fr> le 2013-8-10
 ## Updated by Alain Le Marchand on 2016-05-05

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle_it.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle_it.properties
@@ -1,6 +1,6 @@
 # JmritRosterBundle_it.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # JmritRosterBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrit.roster package
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_da.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_da.properties
@@ -1,6 +1,6 @@
 # SimpleClockBundle_da.properties
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 # Danish properties for the jmri.jmrit.SimpleClockTable window
 

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_de.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_de.properties
@@ -1,6 +1,6 @@
 # SimpleClockBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrit.SimpleClockTable window
 

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_en_GB.properties
@@ -1,6 +1,6 @@
 # SimpleClockBundle.properties
 #
-# Revision $Revision$
+#
 # By Matthew Harris
 # English (United Kingdom) overriding properties for the jmri.jmrit.SimpleClockTable window
 

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_es.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_es.properties
@@ -1,6 +1,6 @@
 # SimpleClockBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.SimpleClockTable window
 #

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_fr.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_fr.properties
@@ -1,6 +1,6 @@
 # SimpleClockBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.SimpleClockTable window
 #

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_it.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_it.properties
@@ -1,6 +1,6 @@
 # SimpleClockBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # SimpleClockBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrit.SimpleClockTable window
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlBundle.properties
+++ b/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlBundle.properties
@@ -1,6 +1,6 @@
 # SimpleLightCtrlBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.simplelightctrl GUI elements
 

--- a/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlBundle_ca.properties
+++ b/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlBundle_ca.properties
@@ -1,6 +1,6 @@
 # SimpleLightCtrlBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Catalan translation: Joan de Castro Alemany [joan276dca@yahoo.es] 18/08/2016
 #

--- a/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlBundle_da.properties
+++ b/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlBundle_da.properties
@@ -1,6 +1,6 @@
 # SimpleLightCtrlBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.simplelightctrl GUI elements
 

--- a/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlBundle_fr.properties
+++ b/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlBundle_fr.properties
@@ -1,6 +1,6 @@
 # SimpleLightCtrlBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.simplelightctrl GUI elements
 

--- a/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlBundle_it.properties
+++ b/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlBundle_it.properties
@@ -1,6 +1,6 @@
 # SimpleLightCtrlBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/simplelightctrl/SimpleLightCtrlBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # SimpleLightCtrlBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrit.simplelightctrl GUI elements
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrit/speedometer/SpeedometerBundle.properties
+++ b/java/src/jmri/jmrit/speedometer/SpeedometerBundle.properties
@@ -1,6 +1,6 @@
 # SpeedometerBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.speedometer package
 

--- a/java/src/jmri/jmrit/speedometer/SpeedometerBundle_ca.properties
+++ b/java/src/jmri/jmrit/speedometer/SpeedometerBundle_ca.properties
@@ -1,6 +1,6 @@
 # SpeedometerBundle.properties
 #
-# Revision $Revision$
+#
 # Catalan translation: Joan de Castro Alemany (joan276dca@yahoo.es) 18/08/2016
 # Default properties for the jmri.jmrit.speedometer package
 

--- a/java/src/jmri/jmrit/speedometer/SpeedometerBundle_da.properties
+++ b/java/src/jmri/jmrit/speedometer/SpeedometerBundle_da.properties
@@ -1,6 +1,6 @@
 # SpeedometerBundle.properties
 #
-# Revision $Revision$
+#
 #Danish translation by Sonny Hansen
 #Overrides some Default properties for the jmri.jmrit.speedometer package
 

--- a/java/src/jmri/jmrit/speedometer/SpeedometerBundle_en_GB.properties
+++ b/java/src/jmri/jmrit/speedometer/SpeedometerBundle_en_GB.properties
@@ -1,6 +1,6 @@
 # SpeedometerBundle.properties
 #
-# Revision $Revision$
+#
 #
 # English (Great Britain) properties for the jmri.jmrit.speedometer package
 

--- a/java/src/jmri/jmrit/speedometer/SpeedometerBundle_fr.properties
+++ b/java/src/jmri/jmrit/speedometer/SpeedometerBundle_fr.properties
@@ -1,6 +1,6 @@
 # SpeedometerBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.speedometer package
 

--- a/java/src/jmri/jmrit/speedometer/SpeedometerBundle_it.properties
+++ b/java/src/jmri/jmrit/speedometer/SpeedometerBundle_it.properties
@@ -1,6 +1,6 @@
 # SpeedometerBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle_ca.properties
+++ b/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle_ca.properties
@@ -1,7 +1,7 @@
 #
 # jmri.jmrit.symbolicprog.SymbolicProgBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Copyright 2007 Bob Jacobsen, part of JMRI, 
 # see the COPYING file for license info

--- a/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle_da.properties
+++ b/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle_da.properties
@@ -1,7 +1,7 @@
 #
 # jmri.jmrit.symbolicprog.SymbolicProgBundle_da.properties
 #
-# Revision $Revision$
+#
 #
 # Copyright 2007 Bob Jacobsen, part of JMRI, 
 # see the COPYING file for license info

--- a/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle_es.properties
+++ b/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle_es.properties
@@ -1,7 +1,7 @@
 #
 # jmri.jmrit.symbolicprog.SymbolicProgBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Copyright 2007 Bob Jacobsen, part of JMRI, 
 # see the COPYING file for license info

--- a/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle_fr.properties
+++ b/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle_fr.properties
@@ -1,7 +1,7 @@
 #
 # jmri.jmrit.symbolicprog.SymbolicProgBundle.properties
 #
-# Revision $Revision$
+#
 ## Copyright 2007 Bob Jacobsen, part of JMRI,
 # see the COPYING file for license info
 ## Translated by Rodolphe Braud

--- a/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/symbolicprog/SymbolicProgBundle_ja_JP.properties
@@ -1,7 +1,7 @@
 #
 # jmri.jmrit.symbolicprog.SymbolicProgBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Copyright 2007 Bob Jacobsen, part of JMRI, 
 # see the COPYING file for license info

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle.properties
@@ -1,6 +1,6 @@
 # Throttle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.throttle GUI elements
 

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_ca.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_ca.properties
@@ -1,6 +1,6 @@
 # Throttle.properties
 #
-# Revision $Revision$
+#
 # Catalan Translation: Joan de Castro (joan276dca@yahoo.es) 20160818
 #
 # Default properties for the jmri.jmrit.throttle GUI elements

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_da.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_da.properties
@@ -1,6 +1,6 @@
 # Throttle_da.properties
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 # Overides some Default properties for the jmri.jmrit.throttle GUI elements
 

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_fr.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_fr.properties
@@ -1,6 +1,6 @@
 # Throttle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrit.throttle GUI elements
 

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_it.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_it.properties
@@ -1,6 +1,6 @@
 # Throttle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_ja_JP.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # Throttle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrit.throttle GUI elements
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle.properties
@@ -1,6 +1,6 @@
 # VSDecoder.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.VSDecoder GUI elements
 

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_ca.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_ca.properties
@@ -1,6 +1,6 @@
 # VSDecoder.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.VSDecoder GUI elements
 

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_da.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_da.properties
@@ -1,6 +1,6 @@
 # VSDecoder.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.VSDecoder GUI elements
 

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_fr.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_fr.properties
@@ -1,6 +1,6 @@
 # VSDecoder_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.VSDecoder GUI elements
 

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_it.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_it.properties
@@ -1,6 +1,6 @@
 # VSDecoder.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle.properties
@@ -1,6 +1,6 @@
 # VSDecoder.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.VSDecoder GUI elements
 

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_ca.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_ca.properties
@@ -1,6 +1,6 @@
 # VSDecoder.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.VSDecoder GUI elements
 

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_da.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_da.properties
@@ -1,6 +1,6 @@
 # VSDecoder.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.VSDecoder GUI elements
 

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_it.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_it.properties
@@ -1,6 +1,6 @@
 # VSDecoder.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.VSDecoder GUI elements
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )

--- a/java/src/jmri/jmrix/JmrixSystemsBundle.properties
+++ b/java/src/jmri/jmrix/JmrixSystemsBundle.properties
@@ -1,6 +1,6 @@
 # JmrixSystemsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix Systems menu
 

--- a/java/src/jmri/jmrix/JmrixSystemsBundle_ca.properties
+++ b/java/src/jmri/jmrix/JmrixSystemsBundle_ca.properties
@@ -1,6 +1,6 @@
 # JmrixSystemsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix Systems menu
 #

--- a/java/src/jmri/jmrix/JmrixSystemsBundle_cs.properties
+++ b/java/src/jmri/jmrix/JmrixSystemsBundle_cs.properties
@@ -1,6 +1,6 @@
 # JmrixSystemsBundle_cs.properties
 #
-# Revision $Revision$
+#
 #by Michal Basta
 # Czech properties (w/o diacritic) for the jmri.jmrix Systems menu
 

--- a/java/src/jmri/jmrix/JmrixSystemsBundle_cs_CZ.properties
+++ b/java/src/jmri/jmrix/JmrixSystemsBundle_cs_CZ.properties
@@ -1,6 +1,6 @@
 # JmrixSystemsBundle_cs_CZ.properties
 #
-# Revision $Revision$
+#
 #by Michal Basta
 # Override certain czech properties for the jmri.jmrix Systems menu with CZ diacritic
 

--- a/java/src/jmri/jmrix/JmrixSystemsBundle_da.properties
+++ b/java/src/jmri/jmrix/JmrixSystemsBundle_da.properties
@@ -1,6 +1,6 @@
 # JmrixSystemsBundle_da.properties
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen# Override certain properties for the jmri.jmrix Systems menu with danish
 
 MenuTools    = Systemer

--- a/java/src/jmri/jmrix/JmrixSystemsBundle_de.properties
+++ b/java/src/jmri/jmrix/JmrixSystemsBundle_de.properties
@@ -1,6 +1,6 @@
 # JmrixSystemsBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix Systems menu
 

--- a/java/src/jmri/jmrix/JmrixSystemsBundle_es.properties
+++ b/java/src/jmri/jmrix/JmrixSystemsBundle_es.properties
@@ -1,6 +1,6 @@
 # JmritSystemsBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix Systems menu
 #

--- a/java/src/jmri/jmrix/JmrixSystemsBundle_fr.properties
+++ b/java/src/jmri/jmrix/JmrixSystemsBundle_fr.properties
@@ -1,6 +1,6 @@
 # JmrixSystemsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix Systems menu
 

--- a/java/src/jmri/jmrix/JmrixSystemsBundle_it.properties
+++ b/java/src/jmri/jmrix/JmrixSystemsBundle_it.properties
@@ -1,6 +1,6 @@
 # JmrixSystemsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix Systems menu
 #

--- a/java/src/jmri/jmrix/JmrixSystemsBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/JmrixSystemsBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # JmrixSystemsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix Systems menu
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrix/acela/AcelaActionListBundle.properties
+++ b/java/src/jmri/jmrix/acela/AcelaActionListBundle.properties
@@ -1,6 +1,6 @@
 # AcelaActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/acela/AcelaActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/acela/AcelaActionListBundle_ca.properties
@@ -1,6 +1,6 @@
 # ActionListAcelaBundle_ca.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for Acela "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/acela/AcelaActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/acela/AcelaActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # AcelaActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/acela/AcelaActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/acela/AcelaActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # AcelaActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for Acela "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/acela/AcelaActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/acela/AcelaActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # AcelaActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/acela/AcelaActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/acela/AcelaActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # AcelaActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/acela/AcelaActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/acela/AcelaActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # AcelaActionListBundle_ja.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for Acela "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/acela/AcelaActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/acela/AcelaActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # AcelaActionListBundle_ja_JP.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for Acela "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/acela/nodeconfig/NodeConfigBundle.properties
+++ b/java/src/jmri/jmrix/acela/nodeconfig/NodeConfigBundle.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.acela.nodeconfig window
 

--- a/java/src/jmri/jmrix/acela/nodeconfig/NodeConfigBundle_da.properties
+++ b/java/src/jmri/jmrix/acela/nodeconfig/NodeConfigBundle_da.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.acela.nodeconfig window
 

--- a/java/src/jmri/jmrix/acela/nodeconfig/NodeConfigBundle_de.properties
+++ b/java/src/jmri/jmrix/acela/nodeconfig/NodeConfigBundle_de.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.acela.nodeconfig window
 

--- a/java/src/jmri/jmrix/acela/nodeconfig/NodeConfigBundle_fr.properties
+++ b/java/src/jmri/jmrix/acela/nodeconfig/NodeConfigBundle_fr.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.acela.nodeconfig window
 #

--- a/java/src/jmri/jmrix/acela/nodeconfig/NodeConfigBundle_it.properties
+++ b/java/src/jmri/jmrix/acela/nodeconfig/NodeConfigBundle_it.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/bachrus/BachrusBundle.properties
+++ b/java/src/jmri/jmrix/bachrus/BachrusBundle.properties
@@ -1,6 +1,6 @@
 # BachrusBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.bachrus interface
 

--- a/java/src/jmri/jmrix/bachrus/BachrusBundle_da.properties
+++ b/java/src/jmri/jmrix/bachrus/BachrusBundle_da.properties
@@ -1,6 +1,6 @@
 # BachrusBundle.properties
 #
-# Revision $Revision$
+#
 #Danish translation added by Sonny Hansen
 #Overrides some Default properties for the jmri.jmrix.bachrus interface
 

--- a/java/src/jmri/jmrix/bachrus/BachrusBundle_fr.properties
+++ b/java/src/jmri/jmrix/bachrus/BachrusBundle_fr.properties
@@ -1,6 +1,6 @@
 # BachrusBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.bachrus interface
 #

--- a/java/src/jmri/jmrix/bachrus/BachrusBundle_it.properties
+++ b/java/src/jmri/jmrix/bachrus/BachrusBundle_it.properties
@@ -1,6 +1,6 @@
 # BachrusBundle_it.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/can/CanActionListBundle.properties
+++ b/java/src/jmri/jmrix/can/CanActionListBundle.properties
@@ -1,6 +1,6 @@
 # CanActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/can/CanActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/can/CanActionListBundle_ca.properties
@@ -1,6 +1,6 @@
 # CanActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/can/CanActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/can/CanActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # CanActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/can/CanActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/can/CanActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # CanActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/jmri/jmrix/can/CanActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/can/CanActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # CanActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/can/CanActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/can/CanActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # CanActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/can/CanActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/can/CanActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # CanActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/can/CanActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/can/CanActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # CanActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/can/cbus/CbusBundle.properties
+++ b/java/src/jmri/jmrix/can/cbus/CbusBundle.properties
@@ -1,6 +1,6 @@
 # CbusBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix Systems menu
 

--- a/java/src/jmri/jmrix/can/cbus/CbusBundle_da.properties
+++ b/java/src/jmri/jmrix/can/cbus/CbusBundle_da.properties
@@ -1,6 +1,6 @@
 # CbusBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix Systems menu
 

--- a/java/src/jmri/jmrix/can/cbus/CbusBundle_fr.properties
+++ b/java/src/jmri/jmrix/can/cbus/CbusBundle_fr.properties
@@ -1,6 +1,6 @@
 # CbusBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix Systems menu
 #

--- a/java/src/jmri/jmrix/can/cbus/CbusBundle_it.properties
+++ b/java/src/jmri/jmrix/can/cbus/CbusBundle_it.properties
@@ -1,6 +1,6 @@
 # CbusBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolBundle.properties
+++ b/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolBundle.properties
@@ -1,6 +1,6 @@
 # ConfigToolBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.can.cbus.swing.configtool properties
 

--- a/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolBundle_da.properties
+++ b/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolBundle_da.properties
@@ -1,6 +1,6 @@
 # ConfigToolBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.can.cbus.swing.configtool properties
 

--- a/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolBundle_fr.properties
+++ b/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolBundle_fr.properties
@@ -1,6 +1,6 @@
 # ConfigToolBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.can.cbus.swing.configtool properties
 

--- a/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolBundle_it.properties
+++ b/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolBundle_it.properties
@@ -1,6 +1,6 @@
 # ConfigToolBundle_it.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # ConfigToolBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.can.cbus.swing.configtool properties
 

--- a/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolBundle.properties
+++ b/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolBundle.properties
@@ -1,6 +1,6 @@
 # NodeConfigToolBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.can.cbus.swing.nodeconfig properties
 

--- a/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolBundle_da.properties
+++ b/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolBundle_da.properties
@@ -1,6 +1,6 @@
 # NodeConfigToolBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.can.cbus.swing.nodeconfig properties
 

--- a/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolBundle_it.properties
+++ b/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolBundle_it.properties
@@ -1,6 +1,6 @@
 # NodeConfigToolBundle_it.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcActionListBundle.properties
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcActionListBundle.properties
@@ -1,6 +1,6 @@
 # LoconetActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # LoconetActionListBundle_da.properties
 #
-# Revision $Revision$
+#
 # Some danish translation added by Sonny Hansen
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcActionListBundle_it.properties
@@ -2,7 +2,7 @@
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcBundle.properties
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcBundle.properties
@@ -1,6 +1,6 @@
 # EcosBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.loconet menu
 

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcBundle_da.properties
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcBundle_da.properties
@@ -1,6 +1,6 @@
 # EcosBundle.properties
 #
-# Revision $Revision$
+#
 #Some danish translaton added by Sonny Hansen
 # Default properties for the jmri.jmrix.loconet menu
 

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcBundle_fr.properties
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcBundle_fr.properties
@@ -1,6 +1,6 @@
 # EcosBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.loconet menu
 

--- a/java/src/jmri/jmrix/dcc4pc/Dcc4PcBundle_it.properties
+++ b/java/src/jmri/jmrix/dcc4pc/Dcc4PcBundle_it.properties
@@ -1,6 +1,6 @@
 # EcosBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/dcc4pc/swing/boardlists/BoardListBundle.properties
+++ b/java/src/jmri/jmrix/dcc4pc/swing/boardlists/BoardListBundle.properties
@@ -1,6 +1,6 @@
 # EntryExitBundle.properties
 #
-# Revision $Revision$
+#
 # This file is part of JMRI.
 #
 # JMRI is free software; you can redistribute it and/or modify it under

--- a/java/src/jmri/jmrix/dcc4pc/swing/boardlists/BoardListBundle_da.properties
+++ b/java/src/jmri/jmrix/dcc4pc/swing/boardlists/BoardListBundle_da.properties
@@ -1,6 +1,6 @@
 # EntryExitBundle.properties
 #
-# Revision $Revision$
+#
 # This file is part of JMRI.
 #
 # JMRI is free software; you can redistribute it and/or modify it under

--- a/java/src/jmri/jmrix/dcc4pc/swing/boardlists/BoardListBundle_it.properties
+++ b/java/src/jmri/jmrix/dcc4pc/swing/boardlists/BoardListBundle_it.properties
@@ -1,6 +1,6 @@
 # EntryExitBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/dccpp/DCCppActionListBundle.properties
+++ b/java/src/jmri/jmrix/dccpp/DCCppActionListBundle.properties
@@ -1,6 +1,6 @@
 # DCCppActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/dccpp/DCCppBundle.properties
+++ b/java/src/jmri/jmrix/dccpp/DCCppBundle.properties
@@ -1,6 +1,6 @@
 # XNetBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.xpressnet menu
 

--- a/java/src/jmri/jmrix/dccpp/DCCppConfigurationBundle.properties
+++ b/java/src/jmri/jmrix/dccpp/DCCppConfigurationBundle.properties
@@ -1,6 +1,6 @@
 # DCCppConfiguration.properties
 #
-# Revision $Revision$
+#
 #
 # Default configuration properties for DCC++ connections.
 #

--- a/java/src/jmri/jmrix/dccpp/swing/DCCppSwingBundle.properties
+++ b/java/src/jmri/jmrix/dccpp/swing/DCCppSwingBundle.properties
@@ -1,6 +1,6 @@
 # DCCppSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.dccpp.swing package
 

--- a/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle.properties
+++ b/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle.properties
@@ -1,6 +1,6 @@
 # EasyDccActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_ca.properties
@@ -1,6 +1,6 @@
 # EasyDccActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_cs.properties
+++ b/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_cs.properties
@@ -1,6 +1,6 @@
 # EasyDccActionListBundle_cs.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Czech (w/o diacritic) properties  listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_cs_CZ.properties
+++ b/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_cs_CZ.properties
@@ -1,6 +1,6 @@
 # EasyDccActionListBundle_cs_CZ.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Override certain czech properties  listing names with CZ diacritic for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # EasyDccActionListBundle_da.properties
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # EasyDccActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_es.properties
+++ b/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_es.properties
@@ -1,6 +1,6 @@
 # EasyDccActionListBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # EasyDccActionListBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # EasyDccActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # EasyDccActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/easydcc/EasyDccActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # EasyDccActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/ecos/EcosActionListBundle.properties
+++ b/java/src/jmri/jmrix/ecos/EcosActionListBundle.properties
@@ -1,6 +1,6 @@
 # EcosActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/ecos/EcosActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/ecos/EcosActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # EcosActionListBundle_da.properties
 #
-# Revision $Revision$
+#
 
 #Danish translation added by Sonny Hansen# Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/ecos/EcosActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/ecos/EcosActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # EcosActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/ecos/EcosActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/ecos/EcosActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # EcosActionListBundle_fr.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/ecos/EcosActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/ecos/EcosActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # EcosActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/ecos/EcosActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/ecos/EcosActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # EcosActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/ecos/EcosActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/ecos/EcosActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # EcosActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/ecos/EcosBundle.properties
+++ b/java/src/jmri/jmrix/ecos/EcosBundle.properties
@@ -1,6 +1,6 @@
 # EcosBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.loconet menu
 

--- a/java/src/jmri/jmrix/ecos/EcosBundle_da.properties
+++ b/java/src/jmri/jmrix/ecos/EcosBundle_da.properties
@@ -1,6 +1,6 @@
 # EcosBundle.properties
 #
-# Revision $Revision$
+#
 # Danish translation added by Sonny Hansen 
 # Default properties for the jmri.jmrix.loconet menu
 

--- a/java/src/jmri/jmrix/ecos/EcosBundle_it.properties
+++ b/java/src/jmri/jmrix/ecos/EcosBundle_it.properties
@@ -1,6 +1,6 @@
 # EcosBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle.properties
@@ -1,6 +1,6 @@
 # GrapevineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_ca.properties
@@ -1,6 +1,6 @@
 # GrapevineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # GrapevineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # GrapevineActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # GrapevineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # GrapevineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # GrapevineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # GrapevineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/grapevine/GrapevineBundle.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineBundle.properties
@@ -1,6 +1,6 @@
 # GrapevineBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.grapevine menu
 

--- a/java/src/jmri/jmrix/grapevine/GrapevineBundle_da.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineBundle_da.properties
@@ -1,6 +1,6 @@
 # GrapevineBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.grapevine menu
 

--- a/java/src/jmri/jmrix/grapevine/GrapevineBundle_de.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineBundle_de.properties
@@ -1,6 +1,6 @@
 # GrapevineBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.grapevine menu
 

--- a/java/src/jmri/jmrix/grapevine/GrapevineBundle_it.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineBundle_it.properties
@@ -1,6 +1,6 @@
 # GrapevineBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/grapevine/GrapevineBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/grapevine/GrapevineBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # GrapevineBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.grapevine menu
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrix/grapevine/nodeconfig/NodeConfigBundle.properties
+++ b/java/src/jmri/jmrix/grapevine/nodeconfig/NodeConfigBundle.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.grapevine.nodeconfig window
 

--- a/java/src/jmri/jmrix/grapevine/nodeconfig/NodeConfigBundle_da.properties
+++ b/java/src/jmri/jmrix/grapevine/nodeconfig/NodeConfigBundle_da.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.grapevine.nodeconfig window
 

--- a/java/src/jmri/jmrix/grapevine/nodeconfig/NodeConfigBundle_de.properties
+++ b/java/src/jmri/jmrix/grapevine/nodeconfig/NodeConfigBundle_de.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.grapevine.nodeconfig window
 

--- a/java/src/jmri/jmrix/grapevine/nodeconfig/NodeConfigBundle_it.properties
+++ b/java/src/jmri/jmrix/grapevine/nodeconfig/NodeConfigBundle_it.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/grapevine/nodeconfig/NodeConfigBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/grapevine/nodeconfig/NodeConfigBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.grapevine.nodeconfig window
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrix/grapevine/nodetable/NodeTableBundle.properties
+++ b/java/src/jmri/jmrix/grapevine/nodetable/NodeTableBundle.properties
@@ -1,6 +1,6 @@
 # NodeTableBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.grapevine.nodetable package
 

--- a/java/src/jmri/jmrix/grapevine/nodetable/NodeTableBundle_da.properties
+++ b/java/src/jmri/jmrix/grapevine/nodetable/NodeTableBundle_da.properties
@@ -1,6 +1,6 @@
 # NodeTableBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.grapevine.nodetable package
 

--- a/java/src/jmri/jmrix/grapevine/nodetable/NodeTableBundle_it.properties
+++ b/java/src/jmri/jmrix/grapevine/nodetable/NodeTableBundle_it.properties
@@ -1,6 +1,6 @@
 # NodeTableBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/grapevine/nodetable/NodeTableBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/grapevine/nodetable/NodeTableBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # NodeTableBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.grapevine.nodetable package
 

--- a/java/src/jmri/jmrix/ieee802154/IEEE802154ActionListBundle.properties
+++ b/java/src/jmri/jmrix/ieee802154/IEEE802154ActionListBundle.properties
@@ -1,6 +1,6 @@
 #IEEE802154ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/ieee802154/IEEE802154ActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/ieee802154/IEEE802154ActionListBundle_da.properties
@@ -1,6 +1,6 @@
 #IEEE802154ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/ieee802154/IEEE802154ActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/ieee802154/IEEE802154ActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 #IEEE802154ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/ieee802154/IEEE802154ActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/ieee802154/IEEE802154ActionListBundle_it.properties
@@ -1,6 +1,6 @@
 #IEEE802154ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/ieee802154/swing/nodeconfig/NodeConfigBundle.properties
+++ b/java/src/jmri/jmrix/ieee802154/swing/nodeconfig/NodeConfigBundle.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.cmri.serial.nodeconfig window
 

--- a/java/src/jmri/jmrix/ieee802154/swing/nodeconfig/NodeConfigBundle_da.properties
+++ b/java/src/jmri/jmrix/ieee802154/swing/nodeconfig/NodeConfigBundle_da.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.cmri.serial.nodeconfig window
 

--- a/java/src/jmri/jmrix/ieee802154/swing/nodeconfig/NodeConfigBundle_it.properties
+++ b/java/src/jmri/jmrix/ieee802154/swing/nodeconfig/NodeConfigBundle_it.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle_it.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.cmri.serial.nodeconfig window
 

--- a/java/src/jmri/jmrix/ieee802154/xbee/swing/nodeconfig/NodeConfigBundle.properties
+++ b/java/src/jmri/jmrix/ieee802154/xbee/swing/nodeconfig/NodeConfigBundle.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.ieee802154.xbee.swing.nodeconfig window
 

--- a/java/src/jmri/jmrix/ieee802154/xbee/swing/nodeconfig/NodeConfigBundle_da.properties
+++ b/java/src/jmri/jmrix/ieee802154/xbee/swing/nodeconfig/NodeConfigBundle_da.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.cmri.serial.nodeconfig window
 

--- a/java/src/jmri/jmrix/ieee802154/xbee/swing/nodeconfig/NodeConfigBundle_it.properties
+++ b/java/src/jmri/jmrix/ieee802154/xbee/swing/nodeconfig/NodeConfigBundle_it.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.cmri.serial.nodeconfig window
 

--- a/java/src/jmri/jmrix/jinput/treecontrol/TreeBundle.properties
+++ b/java/src/jmri/jmrix/jinput/treecontrol/TreeBundle.properties
@@ -1,6 +1,6 @@
 # TreeBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.jinput.treecontrol window
 

--- a/java/src/jmri/jmrix/jinput/treecontrol/TreeBundle_da.properties
+++ b/java/src/jmri/jmrix/jinput/treecontrol/TreeBundle_da.properties
@@ -1,6 +1,6 @@
 # TreeBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.jinput.treecontrol window
 

--- a/java/src/jmri/jmrix/jinput/treecontrol/TreeBundle_de.properties
+++ b/java/src/jmri/jmrix/jinput/treecontrol/TreeBundle_de.properties
@@ -1,6 +1,6 @@
 # TreeBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.jinput.treecontrol window
 

--- a/java/src/jmri/jmrix/jinput/treecontrol/TreeBundle_fr.properties
+++ b/java/src/jmri/jmrix/jinput/treecontrol/TreeBundle_fr.properties
@@ -1,6 +1,6 @@
 # TreeBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.jinput.treecontrol window
 

--- a/java/src/jmri/jmrix/jinput/treecontrol/TreeBundle_it.properties
+++ b/java/src/jmri/jmrix/jinput/treecontrol/TreeBundle_it.properties
@@ -1,6 +1,6 @@
 # TreeBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/jinput/treecontrol/TreeBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/jinput/treecontrol/TreeBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # TreeBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.jinput.treecontrol window
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientConfigurationBundle.properties
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientConfigurationBundle.properties
@@ -1,6 +1,6 @@
 # JMRIClientConfiguration.properties
 #
-# Revision $Revision$
+#
 #
 # Default configuration properties for JMRIClient connections.
 #

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientConfigurationBundle_da.properties
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientConfigurationBundle_da.properties
@@ -1,6 +1,6 @@
 # JMRIClientConfiguration.properties
 #
-# Revision $Revision$
+#
 #
 # Default configuration properties for JMRIClient connections.
 #

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientConfigurationBundle_fr.properties
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientConfigurationBundle_fr.properties
@@ -1,6 +1,6 @@
 # JMRIClientConfiguration.properties
 #
-# Revision $Revision$
+#
 #
 # Default configuration properties for JMRIClient connections.
 #

--- a/java/src/jmri/jmrix/lenz/XNetActionListBundle.properties
+++ b/java/src/jmri/jmrix/lenz/XNetActionListBundle.properties
@@ -1,6 +1,6 @@
 # LenzActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/lenz/XNetActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/lenz/XNetActionListBundle_ca.properties
@@ -1,6 +1,6 @@
 # LenzActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/lenz/XNetActionListBundle_cs.properties
+++ b/java/src/jmri/jmrix/lenz/XNetActionListBundle_cs.properties
@@ -1,6 +1,6 @@
 # LenzActionListBundle_cs.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Czech (w/o diacritic) properties  listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/lenz/XNetActionListBundle_cs_CZ.properties
+++ b/java/src/jmri/jmrix/lenz/XNetActionListBundle_cs_CZ.properties
@@ -1,6 +1,6 @@
 # XNetActionListBundle_cs_CZ.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Override certain czech properties  listing names with CZ diacritic for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/lenz/XNetActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/lenz/XNetActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # LenzActionListBundle_da_DK.properties
 #
-# Revision $Revision$
+#
 #Danish translation by Sonny Hansen
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/lenz/XNetActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/lenz/XNetActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # LenzActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/jmri/jmrix/lenz/XNetActionListBundle_es.properties
+++ b/java/src/jmri/jmrix/lenz/XNetActionListBundle_es.properties
@@ -1,6 +1,6 @@
 # LenzActionListBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/lenz/XNetActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/lenz/XNetActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # LenzActionListBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/lenz/XNetActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/lenz/XNetActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # LenzActionListBundle.properties
 #
-# Revision $Revision$
+#
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #
 # Properties listing names for "Action" classes that can appear

--- a/java/src/jmri/jmrix/lenz/XNetActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/lenz/XNetActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # LenzActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/lenz/XNetActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/lenz/XNetActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # LenzActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/lenz/XNetBundle.properties
+++ b/java/src/jmri/jmrix/lenz/XNetBundle.properties
@@ -1,6 +1,6 @@
 # XNetBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.xpressnet menu
 

--- a/java/src/jmri/jmrix/lenz/XNetBundle_ca.properties
+++ b/java/src/jmri/jmrix/lenz/XNetBundle_ca.properties
@@ -1,6 +1,6 @@
 # XNetBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.xpressnet menu
 #

--- a/java/src/jmri/jmrix/lenz/XNetBundle_cs.properties
+++ b/java/src/jmri/jmrix/lenz/XNetBundle_cs.properties
@@ -1,6 +1,6 @@
 # XNetBundle_cs.properties
 #
-# Revision $Revision$
+#
 #by Michal Basta
 # Czech properties (w/o diacritic) for the jmri.jmrix.xpressnet menu
 

--- a/java/src/jmri/jmrix/lenz/XNetBundle_cs_CZ.properties
+++ b/java/src/jmri/jmrix/lenz/XNetBundle_cs_CZ.properties
@@ -1,6 +1,6 @@
 # XNetBundle_cs_CZ.properties
 #
-# Revision $Revision$
+#
 #by Michal Basta
 # Override certain czech properties for the jmri.jmrix.xpressnet menu with CZ diacritic
 

--- a/java/src/jmri/jmrix/lenz/XNetBundle_da.properties
+++ b/java/src/jmri/jmrix/lenz/XNetBundle_da.properties
@@ -1,6 +1,6 @@
 # XNetBundle_da_DK.properties
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 # 
 

--- a/java/src/jmri/jmrix/lenz/XNetBundle_de.properties
+++ b/java/src/jmri/jmrix/lenz/XNetBundle_de.properties
@@ -1,6 +1,6 @@
 # XNetBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.xpressnet menu
 

--- a/java/src/jmri/jmrix/lenz/XNetBundle_es.properties
+++ b/java/src/jmri/jmrix/lenz/XNetBundle_es.properties
@@ -1,6 +1,6 @@
 # XNetBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.xpressnet menu
 #

--- a/java/src/jmri/jmrix/lenz/XNetBundle_fr.properties
+++ b/java/src/jmri/jmrix/lenz/XNetBundle_fr.properties
@@ -1,6 +1,6 @@
 # XNetBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.xpressnet menu
 #

--- a/java/src/jmri/jmrix/lenz/XNetBundle_it.properties
+++ b/java/src/jmri/jmrix/lenz/XNetBundle_it.properties
@@ -1,6 +1,6 @@
 # XNetBundle.properties
 #
-# Revision $Revision$
+#
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #
 # Default properties for the jmri.jmrix.xpressnet menu

--- a/java/src/jmri/jmrix/lenz/XNetBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/lenz/XNetBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # XNetBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.xpressnet menu
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrix/lenz/XNetConfigurationBundle.properties
+++ b/java/src/jmri/jmrix/lenz/XNetConfigurationBundle.properties
@@ -1,6 +1,6 @@
 # XNetConfiguration.properties
 #
-# Revision $Revision$
+#
 #
 # Default configuration properties for XPressNet connections.
 #

--- a/java/src/jmri/jmrix/lenz/XNetConfigurationBundle_ca.properties
+++ b/java/src/jmri/jmrix/lenz/XNetConfigurationBundle_ca.properties
@@ -1,6 +1,6 @@
 # XNetConfiguration.properties
 #
-# Revision $Revision$
+#
 #
 # Default configuration properties for XPressNet connections.
 #

--- a/java/src/jmri/jmrix/lenz/XNetConfigurationBundle_da.properties
+++ b/java/src/jmri/jmrix/lenz/XNetConfigurationBundle_da.properties
@@ -1,6 +1,6 @@
 # XNetConfiguration.properties
 #
-# Revision $Revision$
+#
 #
 # Default configuration properties for XPressNet connections.
 #

--- a/java/src/jmri/jmrix/lenz/swing/XNetSwingBundle.properties
+++ b/java/src/jmri/jmrix/lenz/swing/XNetSwingBundle.properties
@@ -1,6 +1,6 @@
 # XNetSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.lenz.swing package
 

--- a/java/src/jmri/jmrix/lenz/swing/XNetSwingBundle_ca.properties
+++ b/java/src/jmri/jmrix/lenz/swing/XNetSwingBundle_ca.properties
@@ -1,6 +1,6 @@
 # XNetSwingBundle.properties
 #
-# Revision $Revision$
+#
 # Catalan translation: Joan de Castro Alemany (joan276dca@yahoo.es )
 #
 # Default properties for the jmri.jmrix.lenz.swing package

--- a/java/src/jmri/jmrix/lenz/swing/XNetSwingBundle_da.properties
+++ b/java/src/jmri/jmrix/lenz/swing/XNetSwingBundle_da.properties
@@ -1,6 +1,6 @@
 # XNetSwingBundle.properties
 #
-# Revision $Revision$
+#
 #Danish translation by Sonny Hansen
 # Default properties for the jmri.jmrix.lenz.swing package
 

--- a/java/src/jmri/jmrix/lenz/swing/XNetSwingBundle_it.properties
+++ b/java/src/jmri/jmrix/lenz/swing/XNetSwingBundle_it.properties
@@ -1,6 +1,6 @@
 # XNetSwingBundle.properties
 #
-# Revision $Revision$
+#
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #
 # Default properties for the jmri.jmrix.lenz.swing package

--- a/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle.properties
@@ -1,6 +1,6 @@
 # LV102Bundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.lenz.lv102 configuration utility
 

--- a/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_ca.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_ca.properties
@@ -1,6 +1,6 @@
 # LV102Bundle.properties
 #
-# Revision $Revision$
+#
 # Translated by Joan de Castro <joan276dca@yahoo.es> 20130613
 # Default properties for the jmri.jmrix.lenz.lv102 configuration utility
 

--- a/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_da.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_da.properties
@@ -1,6 +1,6 @@
 # LV102Bundle_da_DK.properties
 #
-# Revision $Revision$
+#
 #Danish translation by Sonny Hansen
 # Default properties for the jmri.jmrix.lenz.lv102 configuration utility
 

--- a/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_de.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_de.properties
@@ -1,6 +1,6 @@
 # LV102Bundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg und Egbert Broerse
 # German properties for the jmri.jmrix.lenz.lv102 configuration utility
 

--- a/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_es.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_es.properties
@@ -1,6 +1,6 @@
 # LV102Bundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.lenz.lv102 configuration utility
 #

--- a/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_fr.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_fr.properties
@@ -1,6 +1,6 @@
 # LV102Bundle.properties
 #
-# Revision $Revision$
+#
 #
 #Translated  by Blorec Herv\u00e9 bzh56420@yahoo.fr 2014-1-13
 #

--- a/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_it.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_it.properties
@@ -1,6 +1,6 @@
 # LV102Bundle.properties
 #
-# Revision $Revision$
+#
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #
 # Default properties for the jmri.jmrix.lenz.lv102 configuration utility

--- a/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lv102/LV102Bundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # LV102Bundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.lenz.lv102 configuration utility
 # Translated by Sakae Akanuma

--- a/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.lenz.lz100 configuration utility
 

--- a/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_ca.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_ca.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties
 #
-# Revision $Revision$
+#
 # Catal\u00e0 translation: Joan de Castro (joan276dca@yahoo.es )
 #
 # Default properties for the jmri.jmrix.lenz.lz100 configuration utility

--- a/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_da.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_da.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties_da_DK
 #
-# Revision $Revision$
+#
 # Danish translation by Sonny Hansen
 # Overrides some default properties with danish for the jmri.jmrix.lenz.lz100 configuration utility
 

--- a/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_de.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_de.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.lenz.lz100 configuration utility
 

--- a/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_es.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_es.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.lenz.lz100 configuration utility
 # Translated into Spanish by Alfredo 20050817

--- a/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_fr.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_fr.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties
 #
-# Revision $Revision$
+#
 #
 # Translated  by Blorec Herv\u00e9 bzh56420@yahoo.fr 2014-1-14
 #

--- a/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_it.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_it.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle_it.properties
 #
-# Revision $Revision$
+#
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #
 # Default properties for the jmri.jmrix.lenz.lz100 configuration utility

--- a/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lz100/LZ100Bundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.lenz.lz100 configuration utility
 

--- a/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.lenz.lz100 configuration utility
 

--- a/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle_ca.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle_ca.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties
 #
-# Revision $Revision$
+#
 # Catalonian translation: Joan de Castro (joan276dca@yahoo.es)
 #
 # Default properties for the jmri.jmrix.lenz.lz100 configuration utility

--- a/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle_da.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle_da.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties_da_DK
 #
-# Revision $Revision$
+#
 # by Klaus Kongsted
 # Overrides some default properties with danish for the jmri.jmrix.lenz.lz100 configuration utility
 

--- a/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle_de.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle_de.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.lenz.lz100 configuration utility
 

--- a/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle_es.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle_es.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.lenz.lz100 configuration utility
 # Translated by Alfredo 20050817

--- a/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle_it.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle_it.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle_it.properties
 #
-# Revision $Revision$
+#
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #
 # Default properties for the jmri.jmrix.lenz.lz100 configuration utility

--- a/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/lenz/swing/lzv100/LZV100Bundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # LZ100Bundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.lenz.lz100 configuration utility
 

--- a/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle.properties
+++ b/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle.properties
@@ -1,6 +1,6 @@
 # StackMonBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.lenz.stackmon stackbase tool
 

--- a/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle_ca.properties
+++ b/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle_ca.properties
@@ -1,6 +1,6 @@
 # StackMonBundle.properties
 #
-# Revision $Revision$
+#
 # Italian translation: Joan de Castro [joan276dca@yahoo.es]
 #
 # Default properties for the jmri.jmrix.lenz.stackmon stackbase tool

--- a/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle_da.properties
+++ b/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle_da.properties
@@ -1,6 +1,6 @@
 # StackMonBundle.properties_da_DK
 #
-# Revision $Revision$
+#
 #Danish translation by Sonny Hansen
 # Overrides some default properties with danish for the jmri.jmrix.lenz.stackmon stackbase tool
 

--- a/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle_de.properties
+++ b/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle_de.properties
@@ -1,6 +1,6 @@
 # StackMonBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.lenz.stackmon stackbase tool
 

--- a/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle_es.properties
+++ b/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle_es.properties
@@ -1,6 +1,6 @@
 # StackMonBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.lenz.stackmon stackbase tool
 

--- a/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle_it.properties
+++ b/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle_it.properties
@@ -1,6 +1,6 @@
 # StackMonBundle.properties
 #
-# Revision $Revision$
+#
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #
 # Default properties for the jmri.jmrix.lenz.stackmon stackbase tool

--- a/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/lenz/swing/stackmon/StackMonBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # StackMonBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.lenz.stackmon stackbase tool
 

--- a/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle.properties
+++ b/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle.properties
@@ -1,6 +1,6 @@
 # XnTcpBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.lenz.xntcp adapter
 

--- a/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_ca.properties
+++ b/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_ca.properties
@@ -1,6 +1,6 @@
 # XnTcpBundle.properties
 #
-# Revision $Revision$
+#
 # Catalan translation: Joan de Castro (joan276dca@yahoo.es )
 #
 # Default properties for the jmri.jmrix.lenz.xntcp adapter

--- a/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_da.properties
+++ b/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_da.properties
@@ -1,6 +1,6 @@
 # XnTcpBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.lenz.xntcp adapter
 

--- a/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_de.properties
+++ b/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_de.properties
@@ -1,6 +1,6 @@
 # XnTcpBundle.properties
 #
-# Revision $Revision$
+#
 #
 # German properties for the jmri.jmrix.lenz.xntcp adapter
 

--- a/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_es.properties
+++ b/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_es.properties
@@ -1,6 +1,6 @@
 # XnTcpBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Spanish properties for the jmri.jmrix.lenz.xntcp adapter
 

--- a/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_fr.properties
+++ b/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_fr.properties
@@ -1,6 +1,6 @@
 # XnTcpBundle.properties
 #
-# Revision $Revision$
+#
 #
 # French properties for the jmri.jmrix.lenz.xntcp adapter
 #

--- a/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_it.properties
+++ b/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_it.properties
@@ -1,6 +1,6 @@
 # XnTcpBundle.properties
 #
-# Revision $Revision$
+#
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #
 # Default properties for the jmri.jmrix.lenz.xntcp adapter

--- a/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/lenz/xntcp/XnTcpBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # XnTcpBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.lenz.xntcp adapter
 

--- a/java/src/jmri/jmrix/libusb/UsbViewActionBundle_de.properties
+++ b/java/src/jmri/jmrix/libusb/UsbViewActionBundle_de.properties
@@ -1,6 +1,6 @@
 # UsbViewActionBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.libusb menu
 

--- a/java/src/jmri/jmrix/maple/MapleBundle.properties
+++ b/java/src/jmri/jmrix/maple/MapleBundle.properties
@@ -1,6 +1,6 @@
 # MapleBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple menu
 

--- a/java/src/jmri/jmrix/maple/MapleBundle_da.properties
+++ b/java/src/jmri/jmrix/maple/MapleBundle_da.properties
@@ -1,6 +1,6 @@
 # CMRIBundle_da_DK.properties
 #
-# Revision $Revision$
+#
 # by Klaus Kongsted
 # Default properties for the jmri.jmrix.maple menu in danish
 

--- a/java/src/jmri/jmrix/maple/MapleBundle_de.properties
+++ b/java/src/jmri/jmrix/maple/MapleBundle_de.properties
@@ -1,6 +1,6 @@
 # CMRIBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.maple menu
 

--- a/java/src/jmri/jmrix/maple/MapleBundle_es.properties
+++ b/java/src/jmri/jmrix/maple/MapleBundle_es.properties
@@ -1,6 +1,6 @@
 # CMRIBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.cmri menu
 #

--- a/java/src/jmri/jmrix/maple/MapleBundle_fr.properties
+++ b/java/src/jmri/jmrix/maple/MapleBundle_fr.properties
@@ -1,6 +1,6 @@
 # MapleBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple menu
 #

--- a/java/src/jmri/jmrix/maple/MapleBundle_it.properties
+++ b/java/src/jmri/jmrix/maple/MapleBundle_it.properties
@@ -1,6 +1,6 @@
 # MapleBundle_it.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple menu
 

--- a/java/src/jmri/jmrix/maple/MapleBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/maple/MapleBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # MapleBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple menu
 

--- a/java/src/jmri/jmrix/maple/assignment/ListBundle.properties
+++ b/java/src/jmri/jmrix/maple/assignment/ListBundle.properties
@@ -1,6 +1,6 @@
 # ListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple.assignment window
 

--- a/java/src/jmri/jmrix/maple/assignment/ListBundle_da.properties
+++ b/java/src/jmri/jmrix/maple/assignment/ListBundle_da.properties
@@ -1,6 +1,6 @@
 # ListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple.assignment window
 

--- a/java/src/jmri/jmrix/maple/assignment/ListBundle_de.properties
+++ b/java/src/jmri/jmrix/maple/assignment/ListBundle_de.properties
@@ -1,6 +1,6 @@
 # ListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.maple.assignment window
 

--- a/java/src/jmri/jmrix/maple/assignment/ListBundle_es.properties
+++ b/java/src/jmri/jmrix/maple/assignment/ListBundle_es.properties
@@ -1,6 +1,6 @@
 # ListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple.assignment window
 

--- a/java/src/jmri/jmrix/maple/assignment/ListBundle_fr.properties
+++ b/java/src/jmri/jmrix/maple/assignment/ListBundle_fr.properties
@@ -1,6 +1,6 @@
 # ListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple.assignment window
 

--- a/java/src/jmri/jmrix/maple/assignment/ListBundle_it.properties
+++ b/java/src/jmri/jmrix/maple/assignment/ListBundle_it.properties
@@ -1,6 +1,6 @@
 # ListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple.assignment window
 #

--- a/java/src/jmri/jmrix/maple/assignment/ListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/maple/assignment/ListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # ListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.maple.assignment window
 # Translated by Sakae Akanum <akanuma@users.sourceforge.net mail>

--- a/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle.properties
+++ b/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple.nodeconfig window
 

--- a/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle_da.properties
+++ b/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle_da.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple.nodeconfig window
 

--- a/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle_de.properties
+++ b/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle_de.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.maple.nodeconfig window
 

--- a/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle_es.properties
+++ b/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle_es.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple.nodeconfig window
 #

--- a/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle_fr.properties
+++ b/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle_fr.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple.nodeconfig window
 #

--- a/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle_it.properties
+++ b/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle_it.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.maple.nodeconfig window
 #

--- a/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/maple/nodeconfig/NodeConfigBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.maple.nodeconfig window
 # Translated by Sakae Akanuma

--- a/java/src/jmri/jmrix/marklin/MarklinActionListBundle.properties
+++ b/java/src/jmri/jmrix/marklin/MarklinActionListBundle.properties
@@ -1,6 +1,6 @@
 # MarklinActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/marklin/MarklinActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/marklin/MarklinActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # MarklinActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/marklin/MarklinActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/marklin/MarklinActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # MarklinActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/marklin/MarklinActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/marklin/MarklinActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # MarklinActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/marklin/MarklinActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/marklin/MarklinActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # MarklinActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/marklin/MarklinActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/marklin/MarklinActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # MarklinActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/marklin/MarklinActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/marklin/MarklinActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # MarklinActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/marklin/MarklinBundle.properties
+++ b/java/src/jmri/jmrix/marklin/MarklinBundle.properties
@@ -1,6 +1,6 @@
 # MarklinBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.loconet menu
 

--- a/java/src/jmri/jmrix/marklin/MarklinBundle_da.properties
+++ b/java/src/jmri/jmrix/marklin/MarklinBundle_da.properties
@@ -1,6 +1,6 @@
 # MarklinBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.loconet menu
 

--- a/java/src/jmri/jmrix/marklin/MarklinBundle_it.properties
+++ b/java/src/jmri/jmrix/marklin/MarklinBundle_it.properties
@@ -1,6 +1,6 @@
 # MarklinBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.loconet menu
 #

--- a/java/src/jmri/jmrix/mrc/MrcBundle.properties
+++ b/java/src/jmri/jmrix/mrc/MrcBundle.properties
@@ -1,6 +1,6 @@
 # MrcBundle.properties
 #
-# Revision $Revision$
+#
 # @author kcameron Copyright (C) 2014
 #
 

--- a/java/src/jmri/jmrix/mrc/swing/MrcSwingBundle.properties
+++ b/java/src/jmri/jmrix/mrc/swing/MrcSwingBundle.properties
@@ -1,6 +1,6 @@
 # MrcSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Mrc Swing Modules
 #

--- a/java/src/jmri/jmrix/nce/NceActionListBundle.properties
+++ b/java/src/jmri/jmrix/nce/NceActionListBundle.properties
@@ -1,6 +1,6 @@
 # NceActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/nce/NceActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/nce/NceActionListBundle_ca.properties
@@ -1,6 +1,6 @@
 # NceActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/nce/NceActionListBundle_cs.properties
+++ b/java/src/jmri/jmrix/nce/NceActionListBundle_cs.properties
@@ -1,6 +1,6 @@
 # NceActionListBundle_cs.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Czech (w/o diacritic) properties  listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/nce/NceActionListBundle_cs_CZ.properties
+++ b/java/src/jmri/jmrix/nce/NceActionListBundle_cs_CZ.properties
@@ -1,6 +1,6 @@
 # ActionListBundle_cs_CZ.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Override certain czech properties  listing names with CZ diacritic for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/nce/NceActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/nce/NceActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # NceActionListBundle_da_DK.properties
 #
-# Revision $Revision$
+#
 # by Klaus Kongsted
 # Override certain properties listing names with danish, 
 # including special danish characters for "Action" classes that can appear

--- a/java/src/jmri/jmrix/nce/NceActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/nce/NceActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # ActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/jmri/jmrix/nce/NceActionListBundle_es.properties
+++ b/java/src/jmri/jmrix/nce/NceActionListBundle_es.properties
@@ -1,6 +1,6 @@
 # NceActionListBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/nce/NceActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/nce/NceActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # NceActionListBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/nce/NceActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/nce/NceActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # NceActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/nce/NceActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/nce/NceActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # NceActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/nce/NceActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/nce/NceActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # NceActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/nce/NceBundle.properties
+++ b/java/src/jmri/jmrix/nce/NceBundle.properties
@@ -1,6 +1,6 @@
 # NceBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.nce
 

--- a/java/src/jmri/jmrix/nce/NceBundle_da.properties
+++ b/java/src/jmri/jmrix/nce/NceBundle_da.properties
@@ -1,6 +1,6 @@
 # NceBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.nce
 

--- a/java/src/jmri/jmrix/nce/NceBundle_fr.properties
+++ b/java/src/jmri/jmrix/nce/NceBundle_fr.properties
@@ -1,6 +1,6 @@
 # NceBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.nce
 #

--- a/java/src/jmri/jmrix/nce/NceBundle_it.properties
+++ b/java/src/jmri/jmrix/nce/NceBundle_it.properties
@@ -1,6 +1,6 @@
 # NceBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.nce
 #

--- a/java/src/jmri/jmrix/nce/NceBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/nce/NceBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # NceBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.nce
 

--- a/java/src/jmri/jmrix/nce/NceClockControlBundle.properties
+++ b/java/src/jmri/jmrix/nce/NceClockControlBundle.properties
@@ -1,6 +1,6 @@
 # NceClockControlBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Clock Control
 #

--- a/java/src/jmri/jmrix/nce/NceClockControlBundle_da.properties
+++ b/java/src/jmri/jmrix/nce/NceClockControlBundle_da.properties
@@ -1,6 +1,6 @@
 # NceClockControlBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Clock Control
 #

--- a/java/src/jmri/jmrix/nce/NceClockControlBundle_de.properties
+++ b/java/src/jmri/jmrix/nce/NceClockControlBundle_de.properties
@@ -1,6 +1,6 @@
 # NceClockControlBundle.properties
 #
-# Revision $Revision$
+#
 # Translation by Simon Ginsburg
 # German properties for the Nce Clock Control
 #

--- a/java/src/jmri/jmrix/nce/NceClockControlBundle_fr.properties
+++ b/java/src/jmri/jmrix/nce/NceClockControlBundle_fr.properties
@@ -1,6 +1,6 @@
 # NceClockControlBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Clock Control
 #

--- a/java/src/jmri/jmrix/nce/NceClockControlBundle_it.properties
+++ b/java/src/jmri/jmrix/nce/NceClockControlBundle_it.properties
@@ -1,6 +1,6 @@
 # NceClockControlBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Clock Control
 #

--- a/java/src/jmri/jmrix/nce/NceClockControlBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/nce/NceClockControlBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # NceClockControlBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Clock Control
 #

--- a/java/src/jmri/jmrix/nce/boosterprog/BoosterProgBundle.properties
+++ b/java/src/jmri/jmrix/nce/boosterprog/BoosterProgBundle.properties
@@ -1,6 +1,6 @@
 # BoosterProgBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.nce.boosterprog GUI elements
 

--- a/java/src/jmri/jmrix/nce/boosterprog/BoosterProgBundle_da.properties
+++ b/java/src/jmri/jmrix/nce/boosterprog/BoosterProgBundle_da.properties
@@ -1,6 +1,6 @@
 # BoosterProgBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.nce.boosterprog GUI elements
 

--- a/java/src/jmri/jmrix/nce/boosterprog/BoosterProgBundle_de.properties
+++ b/java/src/jmri/jmrix/nce/boosterprog/BoosterProgBundle_de.properties
@@ -1,6 +1,6 @@
 # BoosterProgBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.nce.boosterprog GUI elements
 

--- a/java/src/jmri/jmrix/nce/boosterprog/BoosterProgBundle_fr.properties
+++ b/java/src/jmri/jmrix/nce/boosterprog/BoosterProgBundle_fr.properties
@@ -1,6 +1,6 @@
 # BoosterProgBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.nce.boosterprog GUI elements
 #

--- a/java/src/jmri/jmrix/nce/boosterprog/BoosterProgBundle_it.properties
+++ b/java/src/jmri/jmrix/nce/boosterprog/BoosterProgBundle_it.properties
@@ -1,6 +1,6 @@
 # BoosterProgBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.nce.boosterprog GUI elements
 #

--- a/java/src/jmri/jmrix/nce/boosterprog/BoosterProgBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/nce/boosterprog/BoosterProgBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # BoosterProgBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.nce.boosterprog GUI elements
 

--- a/java/src/jmri/jmrix/nce/cab/NceShowCabBundle.properties
+++ b/java/src/jmri/jmrix/nce/cab/NceShowCabBundle.properties
@@ -1,6 +1,6 @@
 # NceShowCabBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Show Cab Pane
 #

--- a/java/src/jmri/jmrix/nce/cab/NceShowCabBundle_da.properties
+++ b/java/src/jmri/jmrix/nce/cab/NceShowCabBundle_da.properties
@@ -1,6 +1,6 @@
 # NceShowCabBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Show Cab Pane
 #

--- a/java/src/jmri/jmrix/nce/cab/NceShowCabBundle_fr.properties
+++ b/java/src/jmri/jmrix/nce/cab/NceShowCabBundle_fr.properties
@@ -1,6 +1,6 @@
 # NceShowCabBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Show Cab Pane
 #

--- a/java/src/jmri/jmrix/nce/cab/NceShowCabBundle_it.properties
+++ b/java/src/jmri/jmrix/nce/cab/NceShowCabBundle_it.properties
@@ -1,6 +1,6 @@
 # NceShowCabBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Show Cab Pane
 #

--- a/java/src/jmri/jmrix/nce/clockmon/ClockMonBundle.properties
+++ b/java/src/jmri/jmrix/nce/clockmon/ClockMonBundle.properties
@@ -1,6 +1,6 @@
 # ClockMonBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Clock Monitor Pane
 #

--- a/java/src/jmri/jmrix/nce/clockmon/ClockMonBundle_da.properties
+++ b/java/src/jmri/jmrix/nce/clockmon/ClockMonBundle_da.properties
@@ -1,6 +1,6 @@
 # ClockMonBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Clock Monitor Pane
 #

--- a/java/src/jmri/jmrix/nce/clockmon/ClockMonBundle_de.properties
+++ b/java/src/jmri/jmrix/nce/clockmon/ClockMonBundle_de.properties
@@ -1,6 +1,6 @@
 # ClockMonBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the Nce Clock Monitor Pane
 #

--- a/java/src/jmri/jmrix/nce/clockmon/ClockMonBundle_fr.properties
+++ b/java/src/jmri/jmrix/nce/clockmon/ClockMonBundle_fr.properties
@@ -1,6 +1,6 @@
 # ClockMonBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Clock Monitor Pane
 #

--- a/java/src/jmri/jmrix/nce/clockmon/ClockMonBundle_it.properties
+++ b/java/src/jmri/jmrix/nce/clockmon/ClockMonBundle_it.properties
@@ -1,6 +1,6 @@
 # ClockMonBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Clock Monitor Pane
 #

--- a/java/src/jmri/jmrix/nce/clockmon/ClockMonBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/nce/clockmon/ClockMonBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # ClockMonBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Clock Monitor Pane
 #

--- a/java/src/jmri/jmrix/nce/macro/NceMacroBundle.properties
+++ b/java/src/jmri/jmrix/nce/macro/NceMacroBundle.properties
@@ -1,6 +1,6 @@
 # NceMacroBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the NceMacroEditPane
 #

--- a/java/src/jmri/jmrix/nce/macro/NceMacroBundle_da.properties
+++ b/java/src/jmri/jmrix/nce/macro/NceMacroBundle_da.properties
@@ -1,6 +1,6 @@
 # NceMacroBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the NceMacroEditPane
 #

--- a/java/src/jmri/jmrix/nce/macro/NceMacroBundle_fr.properties
+++ b/java/src/jmri/jmrix/nce/macro/NceMacroBundle_fr.properties
@@ -1,6 +1,6 @@
 # NceMacroBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the NceMacroEditPane
 #

--- a/java/src/jmri/jmrix/nce/macro/NceMacroBundle_it.properties
+++ b/java/src/jmri/jmrix/nce/macro/NceMacroBundle_it.properties
@@ -1,6 +1,6 @@
 # NceMacroBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the NceMacroEditPane
 #

--- a/java/src/jmri/jmrix/nce/macro/NceMonBinaryBundle_fr.properties
+++ b/java/src/jmri/jmrix/nce/macro/NceMonBinaryBundle_fr.properties
@@ -1,6 +1,6 @@
 # NceMonBinaryBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Translated by Herv\u00e9 BLOREC <bzh56420@yahoo.fr> le 2013-8-18
 

--- a/java/src/jmri/jmrix/nce/ncemon/NceMonBinaryBundle.properties
+++ b/java/src/jmri/jmrix/nce/ncemon/NceMonBinaryBundle.properties
@@ -1,6 +1,6 @@
 # NceMonBinaryBundle.properties
 #
-# Revision $Revision$
+#
 
 
 # Commands

--- a/java/src/jmri/jmrix/nce/ncemon/NceMonBinaryBundle_da.properties
+++ b/java/src/jmri/jmrix/nce/ncemon/NceMonBinaryBundle_da.properties
@@ -1,6 +1,6 @@
 # NceMonBinaryBundle.properties
 #
-# Revision $Revision$
+#
 
 
 # Commands

--- a/java/src/jmri/jmrix/nce/ncemon/NceMonBinaryBundle_fr.properties
+++ b/java/src/jmri/jmrix/nce/ncemon/NceMonBinaryBundle_fr.properties
@@ -1,6 +1,6 @@
 # NceMonBinaryBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Translated by Herv\u00e9 BLOREC <bzh56420@yahoo.fr> le 2013-8-18
 

--- a/java/src/jmri/jmrix/nce/ncemon/NceMonBinaryBundle_it.properties
+++ b/java/src/jmri/jmrix/nce/ncemon/NceMonBinaryBundle_it.properties
@@ -1,6 +1,6 @@
 # NceMonBinaryBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/nce/swing/NceSwingBundle.properties
+++ b/java/src/jmri/jmrix/nce/swing/NceSwingBundle.properties
@@ -1,6 +1,6 @@
 # NceSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Swing Modules
 #

--- a/java/src/jmri/jmrix/nce/swing/NceSwingBundle_da.properties
+++ b/java/src/jmri/jmrix/nce/swing/NceSwingBundle_da.properties
@@ -1,6 +1,6 @@
 # NceSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Swing Modules
 #

--- a/java/src/jmri/jmrix/nce/swing/NceSwingBundle_it.properties
+++ b/java/src/jmri/jmrix/nce/swing/NceSwingBundle_it.properties
@@ -1,6 +1,6 @@
 # NceSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Nce Swing Modules
 #

--- a/java/src/jmri/jmrix/oaktree/OakTreeBundle.properties
+++ b/java/src/jmri/jmrix/oaktree/OakTreeBundle.properties
@@ -1,6 +1,6 @@
 # OakTreeBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.tmcc menu
 

--- a/java/src/jmri/jmrix/oaktree/OakTreeBundle_da.properties
+++ b/java/src/jmri/jmrix/oaktree/OakTreeBundle_da.properties
@@ -1,6 +1,6 @@
 # OakTreeBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.tmcc menu
 

--- a/java/src/jmri/jmrix/oaktree/OakTreeBundle_de.properties
+++ b/java/src/jmri/jmrix/oaktree/OakTreeBundle_de.properties
@@ -1,6 +1,6 @@
 # OakTreeBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.tmcc menu
 

--- a/java/src/jmri/jmrix/oaktree/OakTreeBundle_fr.properties
+++ b/java/src/jmri/jmrix/oaktree/OakTreeBundle_fr.properties
@@ -1,6 +1,6 @@
 # OakTreeBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.tmcc menu
 

--- a/java/src/jmri/jmrix/oaktree/OakTreeBundle_it.properties
+++ b/java/src/jmri/jmrix/oaktree/OakTreeBundle_it.properties
@@ -1,6 +1,6 @@
 # OakTreeBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.tmcc menu
 #

--- a/java/src/jmri/jmrix/oaktree/OakTreeBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/oaktree/OakTreeBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # OakTreeBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.tmcc menu
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigBundle.properties
+++ b/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigBundle.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.oaktree.nodeconfig window
 

--- a/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigBundle_da.properties
+++ b/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigBundle_da.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.oaktree.nodeconfig window
 

--- a/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigBundle_de.properties
+++ b/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigBundle_de.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.oaktree.nodeconfig window
 

--- a/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigBundle_fr.properties
+++ b/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigBundle_fr.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.oaktree.nodeconfig window
 

--- a/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigBundle_it.properties
+++ b/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigBundle_it.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.oaktree.nodeconfig window
 #

--- a/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/oaktree/nodeconfig/NodeConfigBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.oaktree.nodeconfig window
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrix/openlcb/Bundle.properties
+++ b/java/src/jmri/jmrix/openlcb/Bundle.properties
@@ -1,6 +1,6 @@
 # Bundle.properties in jmrix.openlcb
 #
-# Revision $Revision$
+#
 #
 # Default properties for the openlcb package
 #

--- a/java/src/jmri/jmrix/openlcb/Bundle_da.properties
+++ b/java/src/jmri/jmrix/openlcb/Bundle_da.properties
@@ -1,6 +1,6 @@
 # Bundle.properties in jmrix.openlcb
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Clock Monitor Pane
 #

--- a/java/src/jmri/jmrix/openlcb/Bundle_fr.properties
+++ b/java/src/jmri/jmrix/openlcb/Bundle_fr.properties
@@ -1,6 +1,6 @@
 # Bundle.properties in jmrix.openlcb
 #
-# Revision $Revision$
+#
 #
 # Default properties for the openlcb package
 #

--- a/java/src/jmri/jmrix/openlcb/OlcbActionListBundle.properties
+++ b/java/src/jmri/jmrix/openlcb/OlcbActionListBundle.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/openlcb/OlcbActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/openlcb/OlcbActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/openlcb/OlcbActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/openlcb/OlcbActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # ActionListBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/openlcb/OlcbActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/openlcb/OlcbActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 # Properties listing names for "Action" classes that can appear

--- a/java/src/jmri/jmrix/openlcb/swing/Bundle.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/Bundle.properties
@@ -1,6 +1,6 @@
 # Bundle.properties in jmrix.openlcb
 #
-# Revision $Revision$
+#
 #
 # Default properties for the openlcb.swing package
 #

--- a/java/src/jmri/jmrix/openlcb/swing/Bundle_da.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/Bundle_da.properties
@@ -1,6 +1,6 @@
 # Bundle.properties in jmrix.openlcb
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Clock Monitor Pane
 #

--- a/java/src/jmri/jmrix/openlcb/swing/Bundle_fr.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/Bundle_fr.properties
@@ -1,6 +1,6 @@
 # Bundle.properties in jmrix.openlcb
 #
-# Revision $Revision$
+#
 #
 # Default properties for the openlcb.swing package
 #

--- a/java/src/jmri/jmrix/openlcb/swing/clockmon/Bundle.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/clockmon/Bundle.properties
@@ -1,6 +1,6 @@
 # Bundle.properties in jmrix.openlcb.swing.clockmon
 #
-# Revision $Revision$
+#
 #
 # Default properties for the openlcb.swing.clockmon package
 #

--- a/java/src/jmri/jmrix/openlcb/swing/clockmon/Bundle_da.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/clockmon/Bundle_da.properties
@@ -1,6 +1,6 @@
 # Bundle.properties in jmrix.openlcb
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Clock Monitor Pane
 #

--- a/java/src/jmri/jmrix/openlcb/swing/clockmon/Bundle_de.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/clockmon/Bundle_de.properties
@@ -1,6 +1,6 @@
 # Bundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the openlcb.swing.clockmon
 #

--- a/java/src/jmri/jmrix/openlcb/swing/clockmon/Bundle_fr.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/clockmon/Bundle_fr.properties
@@ -1,6 +1,6 @@
 # Bundle.properties in jmrix.openlcb.swing.clockmon
 #
-# Revision $Revision$
+#
 #
 # Default properties for the openlcb.swing.clockmon package
 #

--- a/java/src/jmri/jmrix/openlcb/swing/clockmon/Bundle_it.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/clockmon/Bundle_it.properties
@@ -1,6 +1,6 @@
 # Bundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the openlcb.swing.clockmon package
 #

--- a/java/src/jmri/jmrix/openlcb/swing/downloader/Bundle.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/downloader/Bundle.properties
@@ -1,6 +1,6 @@
 # Bundle.properties in jmrix.openlcb.swing.downloader
 #
-# Revision $Revision$
+#
 #
 # Default properties for the downloader
 #

--- a/java/src/jmri/jmrix/openlcb/swing/downloader/Bundle_fr.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/downloader/Bundle_fr.properties
@@ -1,6 +1,6 @@
 # Bundle.properties in jmrix.openlcb.swing.downloader
 #
-# Revision $Revision$
+#
 #
 # Default properties for the downloader
 #

--- a/java/src/jmri/jmrix/openlcb/swing/tie/TieBundle.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/tie/TieBundle.properties
@@ -1,6 +1,6 @@
 # TieBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.can.swing.tie Tie tools
 

--- a/java/src/jmri/jmrix/openlcb/swing/tie/TieBundle_da.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/tie/TieBundle_da.properties
@@ -1,6 +1,6 @@
 # TieBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.can.swing.tie Tie tools
 

--- a/java/src/jmri/jmrix/openlcb/swing/tie/TieBundle_fr.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/tie/TieBundle_fr.properties
@@ -1,6 +1,6 @@
 # TieBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.can.swing.tie Tie tools
 #

--- a/java/src/jmri/jmrix/openlcb/swing/tie/TieBundle_it.properties
+++ b/java/src/jmri/jmrix/openlcb/swing/tie/TieBundle_it.properties
@@ -1,6 +1,6 @@
 # TieBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.can.swing.tie Tie tools
 #

--- a/java/src/jmri/jmrix/pi/RaspberryPiActionListBundle.properties
+++ b/java/src/jmri/jmrix/pi/RaspberryPiActionListBundle.properties
@@ -1,6 +1,6 @@
 # RaspBerryPiActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/pi/RaspberryPiActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/pi/RaspberryPiActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # RaspBerryPiActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/powerline/PowerlineActionListBundle.properties
+++ b/java/src/jmri/jmrix/powerline/PowerlineActionListBundle.properties
@@ -1,6 +1,6 @@
 # PowerlineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_ca.properties
@@ -1,6 +1,6 @@
 # PowerlineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # PowerlineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # PowerlineActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # PowerlineActionListBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # PowerlineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # PowerlineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/powerline/PowerlineActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # PowerlineActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/powerline/SystemBundle.properties
+++ b/java/src/jmri/jmrix/powerline/SystemBundle.properties
@@ -1,6 +1,6 @@
 # powerline/SystemBundle.properties
 #
-# Revision $Revision$
+#
 #
 # From an earlier version by Bob Jacobsen, Copyright (C) 2008
 #

--- a/java/src/jmri/jmrix/powerline/SystemBundle_da.properties
+++ b/java/src/jmri/jmrix/powerline/SystemBundle_da.properties
@@ -1,6 +1,6 @@
 # powerline/SystemBundle.properties
 #
-# Revision $Revision$
+#
 #
 # From an earlier version by Bob Jacobsen, Copyright (C) 2008
 #

--- a/java/src/jmri/jmrix/powerline/SystemBundle_de.properties
+++ b/java/src/jmri/jmrix/powerline/SystemBundle_de.properties
@@ -1,6 +1,6 @@
 # powerline/SystemBundle.properties
 #
-# Revision $Revision$
+#
 # from earlier version by Simon Ginsburg Copyright (C) 2008
 # German properties for the jmri.jmrix.powerline menu
 

--- a/java/src/jmri/jmrix/powerline/SystemBundle_fr.properties
+++ b/java/src/jmri/jmrix/powerline/SystemBundle_fr.properties
@@ -1,6 +1,6 @@
 # powerline/SystemBundle.properties
 #
-# Revision $Revision$
+#
 #
 # From an earlier version by Bob Jacobsen, Copyright (C) 2008
 #

--- a/java/src/jmri/jmrix/powerline/SystemBundle_it.properties
+++ b/java/src/jmri/jmrix/powerline/SystemBundle_it.properties
@@ -1,6 +1,6 @@
 # powerline/SystemBundle.properties
 #
-# Revision $Revision$
+#
 #
 # From an earlier version by Bob Jacobsen, Copyright (C) 2008
 #

--- a/java/src/jmri/jmrix/powerline/SystemBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/powerline/SystemBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # powerline/SystemBundle.properties
 #
-# Revision $Revision$
+#
 #
 # From an earlier version by Bob Jacobsen, Copyright (C) 2008
 #

--- a/java/src/jmri/jmrix/powerline/swing/PowerlineSwingBundle.properties
+++ b/java/src/jmri/jmrix/powerline/swing/PowerlineSwingBundle.properties
@@ -1,6 +1,6 @@
 # PowerlineSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Powerline Swing Modules
 #

--- a/java/src/jmri/jmrix/powerline/swing/PowerlineSwingBundle_da.properties
+++ b/java/src/jmri/jmrix/powerline/swing/PowerlineSwingBundle_da.properties
@@ -1,6 +1,6 @@
 # PowerlineSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Powerline Swing Modules
 #

--- a/java/src/jmri/jmrix/powerline/swing/PowerlineSwingBundle_fr.properties
+++ b/java/src/jmri/jmrix/powerline/swing/PowerlineSwingBundle_fr.properties
@@ -1,6 +1,6 @@
 # PowerlineSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Powerline Swing Modules
 #

--- a/java/src/jmri/jmrix/powerline/swing/PowerlineSwingBundle_it.properties
+++ b/java/src/jmri/jmrix/powerline/swing/PowerlineSwingBundle_it.properties
@@ -1,6 +1,6 @@
 # PowerlineSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Powerline Swing Modules
 #

--- a/java/src/jmri/jmrix/powerline/swing/packetgen/SerialPacketGenBundle.properties
+++ b/java/src/jmri/jmrix/powerline/swing/packetgen/SerialPacketGenBundle.properties
@@ -1,6 +1,6 @@
 # SerialPacketGenBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Powerline Swing Modules
 #

--- a/java/src/jmri/jmrix/powerline/swing/packetgen/SerialPacketGenBundle_da.properties
+++ b/java/src/jmri/jmrix/powerline/swing/packetgen/SerialPacketGenBundle_da.properties
@@ -1,6 +1,6 @@
 # SerialPacketGenBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Powerline Swing Modules
 #

--- a/java/src/jmri/jmrix/powerline/swing/packetgen/SerialPacketGenBundle_it.properties
+++ b/java/src/jmri/jmrix/powerline/swing/packetgen/SerialPacketGenBundle_it.properties
@@ -1,6 +1,6 @@
 # SerialPacketGenBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Powerline Swing Modules
 #

--- a/java/src/jmri/jmrix/powerline/swing/serialmon/SerialMonBundle.properties
+++ b/java/src/jmri/jmrix/powerline/swing/serialmon/SerialMonBundle.properties
@@ -1,6 +1,6 @@
 # SerialPacketGenBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Powerline Swing Modules
 #

--- a/java/src/jmri/jmrix/powerline/swing/serialmon/SerialMonBundle_da.properties
+++ b/java/src/jmri/jmrix/powerline/swing/serialmon/SerialMonBundle_da.properties
@@ -1,6 +1,6 @@
 # SerialPacketGenBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Powerline Swing Modules
 #

--- a/java/src/jmri/jmrix/powerline/swing/serialmon/SerialMonBundle_it.properties
+++ b/java/src/jmri/jmrix/powerline/swing/serialmon/SerialMonBundle_it.properties
@@ -1,6 +1,6 @@
 # SerialPacketGenBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Powerline Swing Modules
 #

--- a/java/src/jmri/jmrix/pricom/downloader/Loader.properties
+++ b/java/src/jmri/jmrix/pricom/downloader/Loader.properties
@@ -1,6 +1,6 @@
 # Loader.properties
 #
-# Revision $Revision$
+#
 # Copyright 2005 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/pricom/downloader/Loader_da.properties
+++ b/java/src/jmri/jmrix/pricom/downloader/Loader_da.properties
@@ -1,6 +1,6 @@
 # Loader.properties
 #
-# Revision $Revision$
+#
 # Copyright 2005 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/pricom/downloader/Loader_de.properties
+++ b/java/src/jmri/jmrix/pricom/downloader/Loader_de.properties
@@ -1,6 +1,6 @@
 # Loader_de.properties
 #
-# Revision $Revision$
+#
 # Copyright 2005 Bob Jacobsen
 # Translation by Simon Ginsburg
 #

--- a/java/src/jmri/jmrix/pricom/downloader/Loader_fr.properties
+++ b/java/src/jmri/jmrix/pricom/downloader/Loader_fr.properties
@@ -1,6 +1,6 @@
 # Loader.properties
 #
-# Revision $Revision$
+#
 # Copyright 2005 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/pricom/downloader/Loader_it.properties
+++ b/java/src/jmri/jmrix/pricom/downloader/Loader_it.properties
@@ -1,6 +1,6 @@
 # Loader.properties
 #
-# Revision $Revision$
+#
 # Copyright 2005 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/pricom/downloader/Loader_ja_JP.properties
+++ b/java/src/jmri/jmrix/pricom/downloader/Loader_ja_JP.properties
@@ -1,6 +1,6 @@
 # Loader.properties
 #
-# Revision $Revision$
+#
 # Copyright 2005 Bob Jacobsen
 #
 #

--- a/java/src/jmri/jmrix/pricom/pockettester/TesterBundle.properties
+++ b/java/src/jmri/jmrix/pricom/pockettester/TesterBundle.properties
@@ -1,6 +1,6 @@
 # TesterBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the pricom.pockettester package
 

--- a/java/src/jmri/jmrix/pricom/pockettester/TesterBundle_da.properties
+++ b/java/src/jmri/jmrix/pricom/pockettester/TesterBundle_da.properties
@@ -1,6 +1,6 @@
 # TesterBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the pricom.pockettester package
 

--- a/java/src/jmri/jmrix/pricom/pockettester/TesterBundle_de.properties
+++ b/java/src/jmri/jmrix/pricom/pockettester/TesterBundle_de.properties
@@ -1,6 +1,6 @@
 # TesterBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the pricom.pockettester package
 

--- a/java/src/jmri/jmrix/pricom/pockettester/TesterBundle_fr.properties
+++ b/java/src/jmri/jmrix/pricom/pockettester/TesterBundle_fr.properties
@@ -1,6 +1,6 @@
 # TesterBundl_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the pricom.pockettester package
 #

--- a/java/src/jmri/jmrix/pricom/pockettester/TesterBundle_it.properties
+++ b/java/src/jmri/jmrix/pricom/pockettester/TesterBundle_it.properties
@@ -1,6 +1,6 @@
 # TesterBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the pricom.pockettester package
 #

--- a/java/src/jmri/jmrix/pricom/pockettester/TesterBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/pricom/pockettester/TesterBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # TesterBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the pricom.pockettester package
 

--- a/java/src/jmri/jmrix/qsi/QsiActionListBundle.properties
+++ b/java/src/jmri/jmrix/qsi/QsiActionListBundle.properties
@@ -1,6 +1,6 @@
 # QsiActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/qsi/QsiActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/qsi/QsiActionListBundle_ca.properties
@@ -1,6 +1,6 @@
 # QsiActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/qsi/QsiActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/qsi/QsiActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # QsiActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/qsi/QsiActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/qsi/QsiActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # QsiActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/jmri/jmrix/qsi/QsiActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/qsi/QsiActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # QsiActionListBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/qsi/QsiActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/qsi/QsiActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # QsiActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/qsi/QsiActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/qsi/QsiActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # QsiActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/qsi/QsiActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/qsi/QsiActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # QsiActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/roco/z21/z21ActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/roco/z21/z21ActionListBundle_da.properties
@@ -1,6 +1,6 @@
 #z21ActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/roco/z21/z21AdapterConfigurationBundle.properties
+++ b/java/src/jmri/jmrix/roco/z21/z21AdapterConfigurationBundle.properties
@@ -1,6 +1,6 @@
 # z21AdapterConfiguration.properties
 #
-# Revision $Revision$
+#
 #
 # Default configuration properties for z21/Z21 connections.
 #

--- a/java/src/jmri/jmrix/roco/z21/z21AdapterConfigurationBundle_da.properties
+++ b/java/src/jmri/jmrix/roco/z21/z21AdapterConfigurationBundle_da.properties
@@ -1,6 +1,6 @@
 # z21AdapterConfiguration.properties
 #
-# Revision $Revision$
+#
 #
 # Default configuration properties for z21/Z21 connections.
 #

--- a/java/src/jmri/jmrix/rps/RpsActionListBundle.properties
+++ b/java/src/jmri/jmrix/rps/RpsActionListBundle.properties
@@ -1,6 +1,6 @@
 # RpsActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/rps/RpsActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/rps/RpsActionListBundle_ca.properties
@@ -1,6 +1,6 @@
 # RpsActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/rps/RpsActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/rps/RpsActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # RpsActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/rps/RpsActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/rps/RpsActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # RpsActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/jmri/jmrix/rps/RpsActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/rps/RpsActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # RpsActionListBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/rps/RpsActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/rps/RpsActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # RpsActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/rps/RpsActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/rps/RpsActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # RpsActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/rps/RpsActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/rps/RpsActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # RpsActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/rps/RpsBundle.properties
+++ b/java/src/jmri/jmrix/rps/RpsBundle.properties
@@ -1,6 +1,6 @@
 # RpsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.rps package
 

--- a/java/src/jmri/jmrix/rps/RpsBundle_da.properties
+++ b/java/src/jmri/jmrix/rps/RpsBundle_da.properties
@@ -1,6 +1,6 @@
 # RpsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.rps package
 

--- a/java/src/jmri/jmrix/rps/RpsBundle_de.properties
+++ b/java/src/jmri/jmrix/rps/RpsBundle_de.properties
@@ -1,6 +1,6 @@
 # RpsBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.rps package
 

--- a/java/src/jmri/jmrix/rps/RpsBundle_fr.properties
+++ b/java/src/jmri/jmrix/rps/RpsBundle_fr.properties
@@ -1,6 +1,6 @@
 # RpsBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.rps package
 #

--- a/java/src/jmri/jmrix/rps/RpsBundle_it.properties
+++ b/java/src/jmri/jmrix/rps/RpsBundle_it.properties
@@ -1,6 +1,6 @@
 # RpsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/rps/RpsBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/rps/RpsBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # RpsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.rps package
 

--- a/java/src/jmri/jmrix/rps/aligntable/AlignTableBundle.properties
+++ b/java/src/jmri/jmrix/rps/aligntable/AlignTableBundle.properties
@@ -1,6 +1,6 @@
 # AlignTableBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.rps.aligntable package
 

--- a/java/src/jmri/jmrix/rps/aligntable/AlignTableBundle_da.properties
+++ b/java/src/jmri/jmrix/rps/aligntable/AlignTableBundle_da.properties
@@ -1,6 +1,6 @@
 # AlignTableBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.rps.aligntable package
 

--- a/java/src/jmri/jmrix/rps/aligntable/AlignTableBundle_it.properties
+++ b/java/src/jmri/jmrix/rps/aligntable/AlignTableBundle_it.properties
@@ -1,6 +1,6 @@
 # AlignTableBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/rps/aligntable/AlignTableBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/rps/aligntable/AlignTableBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # AlignTableBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.rps.aligntable package
 

--- a/java/src/jmri/jmrix/rps/swing/polling/PollingBundle.properties
+++ b/java/src/jmri/jmrix/rps/swing/polling/PollingBundle.properties
@@ -1,6 +1,6 @@
 # PollingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.rps.swing.polling package
 

--- a/java/src/jmri/jmrix/rps/swing/polling/PollingBundle_da.properties
+++ b/java/src/jmri/jmrix/rps/swing/polling/PollingBundle_da.properties
@@ -1,6 +1,6 @@
 # PollingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.rps.swing.polling package
 

--- a/java/src/jmri/jmrix/rps/swing/polling/PollingBundle_it.properties
+++ b/java/src/jmri/jmrix/rps/swing/polling/PollingBundle_it.properties
@@ -1,6 +1,6 @@
 # PollingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.rps.swing.polling package
 

--- a/java/src/jmri/jmrix/rps/swing/polling/PollingBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/rps/swing/polling/PollingBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # PollingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.rps.swing.polling package
 

--- a/java/src/jmri/jmrix/secsi/SecsiBundle.properties
+++ b/java/src/jmri/jmrix/secsi/SecsiBundle.properties
@@ -1,6 +1,6 @@
 # SecsiBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.secsi menu
 

--- a/java/src/jmri/jmrix/secsi/SecsiBundle_da.properties
+++ b/java/src/jmri/jmrix/secsi/SecsiBundle_da.properties
@@ -1,6 +1,6 @@
 # SecsiBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.secsi menu
 

--- a/java/src/jmri/jmrix/secsi/SecsiBundle_de.properties
+++ b/java/src/jmri/jmrix/secsi/SecsiBundle_de.properties
@@ -1,6 +1,6 @@
 # SecsiBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.secsci menu
 

--- a/java/src/jmri/jmrix/secsi/SecsiBundle_fr.properties
+++ b/java/src/jmri/jmrix/secsi/SecsiBundle_fr.properties
@@ -1,6 +1,6 @@
 # SecsiBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.secsi menu
 #

--- a/java/src/jmri/jmrix/secsi/SecsiBundle_it.properties
+++ b/java/src/jmri/jmrix/secsi/SecsiBundle_it.properties
@@ -1,6 +1,6 @@
 # SecsiBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.secsi menu
 #

--- a/java/src/jmri/jmrix/secsi/SecsiBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/secsi/SecsiBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # SecsiBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.secsi menu
 

--- a/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigBundle.properties
+++ b/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigBundle.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.secsi.nodeconfig window
 

--- a/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigBundle_da.properties
+++ b/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigBundle_da.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.secsi.nodeconfig window
 

--- a/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigBundle_de.properties
+++ b/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigBundle_de.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.secsi.nodeconfig window
 

--- a/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigBundle_fr.properties
+++ b/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigBundle_fr.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.secsi.nodeconfig window
 #

--- a/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigBundle_it.properties
+++ b/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigBundle_it.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/secsi/nodeconfig/NodeConfigBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # NodeConfigBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.secsi.nodeconfig window
 

--- a/java/src/jmri/jmrix/srcp/SrcpActionListBundle.properties
+++ b/java/src/jmri/jmrix/srcp/SrcpActionListBundle.properties
@@ -1,6 +1,6 @@
 # SrcpActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/srcp/SrcpActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/srcp/SrcpActionListBundle_ca.properties
@@ -1,6 +1,6 @@
 # SrcpActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/srcp/SrcpActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/srcp/SrcpActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # SrcpActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/srcp/SrcpActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/srcp/SrcpActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # SrcpActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/jmri/jmrix/srcp/SrcpActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/srcp/SrcpActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # SrcpActionListBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/srcp/SrcpActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/srcp/SrcpActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # SrcpActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )

--- a/java/src/jmri/jmrix/srcp/SrcpActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/srcp/SrcpActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # SrcpActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/srcp/SrcpActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/srcp/SrcpActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # SrcpActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/tams/TamsActionListBundle.properties
+++ b/java/src/jmri/jmrix/tams/TamsActionListBundle.properties
@@ -1,6 +1,6 @@
 # TamsActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/tams/TamsActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/tams/TamsActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # TamsActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/tams/TamsActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/tams/TamsActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # TamsActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/tams/TamsActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/tams/TamsActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # TamsActionListBundle_fr.properties
 #
-# Revision $Revision$#
+##
 # Translated by Herv\u00e9 BLOREC <bzh56420@yahoo.fr> le 2013-8-27
 
 # Properties listing names for "Action" classes that can appear

--- a/java/src/jmri/jmrix/tams/TamsActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/tams/TamsActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # TamsActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )

--- a/java/src/jmri/jmrix/tams/TamsActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/tams/TamsActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # TamsActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/tams/TamsActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/tams/TamsActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # TamsActionListBundle.properties
 #
-# Revision $Revision$
+#
 
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/tams/TamsBundle.properties
+++ b/java/src/jmri/jmrix/tams/TamsBundle.properties
@@ -1,6 +1,6 @@
 # TamsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.tams menu
 

--- a/java/src/jmri/jmrix/tams/TamsBundle_da.properties
+++ b/java/src/jmri/jmrix/tams/TamsBundle_da.properties
@@ -1,6 +1,6 @@
 # TamsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.tams menu
 

--- a/java/src/jmri/jmrix/tams/TamsBundle_fr.properties
+++ b/java/src/jmri/jmrix/tams/TamsBundle_fr.properties
@@ -1,6 +1,6 @@
 # TamsBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.tams menu
 #

--- a/java/src/jmri/jmrix/tams/TamsBundle_it.properties
+++ b/java/src/jmri/jmrix/tams/TamsBundle_it.properties
@@ -1,6 +1,6 @@
 # TamsBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/tams/swing/locodatabase/TamsLocoBundle.properties
+++ b/java/src/jmri/jmrix/tams/swing/locodatabase/TamsLocoBundle.properties
@@ -1,6 +1,6 @@
 # TamsLocoBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.tams.swing.locodatabase
 

--- a/java/src/jmri/jmrix/tams/swing/locodatabase/TamsLocoBundle_da.properties
+++ b/java/src/jmri/jmrix/tams/swing/locodatabase/TamsLocoBundle_da.properties
@@ -1,6 +1,6 @@
 # TamsLocoBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.tams.swing.locodatabase
 

--- a/java/src/jmri/jmrix/tams/swing/locodatabase/TamsLocoBundle_it.properties
+++ b/java/src/jmri/jmrix/tams/swing/locodatabase/TamsLocoBundle_it.properties
@@ -1,6 +1,6 @@
 # TamsLocoBundle.properties
 #
-# Revision $Revision$
+#
 #
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )

--- a/java/src/jmri/jmrix/tmcc/TMCCBundle.properties
+++ b/java/src/jmri/jmrix/tmcc/TMCCBundle.properties
@@ -1,6 +1,6 @@
 # TMCCBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.tmcc menu
 

--- a/java/src/jmri/jmrix/tmcc/TMCCBundle_da.properties
+++ b/java/src/jmri/jmrix/tmcc/TMCCBundle_da.properties
@@ -1,6 +1,6 @@
 # TMCCBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.tmcc menu
 

--- a/java/src/jmri/jmrix/tmcc/TMCCBundle_de.properties
+++ b/java/src/jmri/jmrix/tmcc/TMCCBundle_de.properties
@@ -1,6 +1,6 @@
 # TMCCBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the jmri.jmrix.tmcc menu
 

--- a/java/src/jmri/jmrix/tmcc/TMCCBundle_fr.properties
+++ b/java/src/jmri/jmrix/tmcc/TMCCBundle_fr.properties
@@ -1,6 +1,6 @@
 # TMCCBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.tmcc menu
 

--- a/java/src/jmri/jmrix/tmcc/TMCCBundle_it.properties
+++ b/java/src/jmri/jmrix/tmcc/TMCCBundle_it.properties
@@ -1,6 +1,6 @@
 # TMCCBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/tmcc/TMCCBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/tmcc/TMCCBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # TMCCBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Japanese properties for the jmri.jmrix.tmcc menu
 # Translated by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrix/xpa/XpaBundle.properties
+++ b/java/src/jmri/jmrix/xpa/XpaBundle.properties
@@ -1,6 +1,6 @@
 # XpaBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Xpa specific System Menu properties
 

--- a/java/src/jmri/jmrix/xpa/XpaBundle_da.properties
+++ b/java/src/jmri/jmrix/xpa/XpaBundle_da.properties
@@ -1,6 +1,6 @@
 # XpaBundle_da_DK.properties
 #
-# Revision $Revision$
+#
 # by Klaus Kongsted
 # Danish  overrides for Xpa specific System Menu properties
 

--- a/java/src/jmri/jmrix/xpa/XpaBundle_de.properties
+++ b/java/src/jmri/jmrix/xpa/XpaBundle_de.properties
@@ -1,6 +1,6 @@
 # XpaBundle.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German Xpa specific System Menu properties
 

--- a/java/src/jmri/jmrix/xpa/XpaBundle_es.properties
+++ b/java/src/jmri/jmrix/xpa/XpaBundle_es.properties
@@ -1,6 +1,6 @@
 # XpaBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Xpa specific System Menu properties
 #

--- a/java/src/jmri/jmrix/xpa/XpaBundle_fr.properties
+++ b/java/src/jmri/jmrix/xpa/XpaBundle_fr.properties
@@ -1,6 +1,6 @@
 # XpaBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Xpa specific System Menu properties
 #

--- a/java/src/jmri/jmrix/xpa/XpaBundle_it.properties
+++ b/java/src/jmri/jmrix/xpa/XpaBundle_it.properties
@@ -1,6 +1,6 @@
 # XpaBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #

--- a/java/src/jmri/jmrix/xpa/XpaBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/xpa/XpaBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # XpaBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Xpa specific System Menu properties
 # Japanese translation by Sakae Akanuma <sakaeakanuma@gmail.com>

--- a/java/src/jmri/jmrix/xpa/swing/XpaSwingBundle.properties
+++ b/java/src/jmri/jmrix/xpa/swing/XpaSwingBundle.properties
@@ -1,6 +1,6 @@
 # XpaSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri.jmrix.xpa.swing package
 

--- a/java/src/jmri/jmrix/zimo/ZimoActionListBundle.properties
+++ b/java/src/jmri/jmrix/zimo/ZimoActionListBundle.properties
@@ -1,6 +1,6 @@
 # ZimoActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/zimo/ZimoActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/zimo/ZimoActionListBundle_ca.properties
@@ -1,6 +1,6 @@
 # ZimoActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/zimo/ZimoActionListBundle_cs.properties
+++ b/java/src/jmri/jmrix/zimo/ZimoActionListBundle_cs.properties
@@ -1,6 +1,6 @@
 # ZimoActionListBundle_cs.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Czech (w/o diacritic) properties  listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/zimo/ZimoActionListBundle_cs_CZ.properties
+++ b/java/src/jmri/jmrix/zimo/ZimoActionListBundle_cs_CZ.properties
@@ -1,6 +1,6 @@
 # ZimoActionListBundle_cs_CZ.properties
 #
-# Revision $Revision$
+#
 # by Michal Basta
 # Override certain czech properties  listing names with CZ diacritic for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/zimo/ZimoActionListBundle_da.properties
+++ b/java/src/jmri/jmrix/zimo/ZimoActionListBundle_da.properties
@@ -1,6 +1,6 @@
 # ZimoActionListBundle_da_DK.properties
 #
-# Revision $Revision$
+#
 # by Klaus Kongsted
 # Override certain properties listing names with danish, 
 # including special danish characters for "Action" classes that can appear

--- a/java/src/jmri/jmrix/zimo/ZimoActionListBundle_de.properties
+++ b/java/src/jmri/jmrix/zimo/ZimoActionListBundle_de.properties
@@ -1,6 +1,6 @@
 # ZimoActionListBundle_de.properties
 #
-# Revision $Revision$
+#
 # by Simon Ginsburg
 # German properties for the apps package including Action List of jmri.
 #

--- a/java/src/jmri/jmrix/zimo/ZimoActionListBundle_es.properties
+++ b/java/src/jmri/jmrix/zimo/ZimoActionListBundle_es.properties
@@ -1,6 +1,6 @@
 # ZimoActionListBundle_es.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/zimo/ZimoActionListBundle_fr.properties
+++ b/java/src/jmri/jmrix/zimo/ZimoActionListBundle_fr.properties
@@ -1,6 +1,6 @@
 # ZimoActionListBundle_fr.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/zimo/ZimoActionListBundle_it.properties
+++ b/java/src/jmri/jmrix/zimo/ZimoActionListBundle_it.properties
@@ -1,6 +1,6 @@
 # ZimoActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Italian Translation Enzo Fortuna <babbo_enzo@yahoo.com>
 #

--- a/java/src/jmri/jmrix/zimo/ZimoActionListBundle_ja.properties
+++ b/java/src/jmri/jmrix/zimo/ZimoActionListBundle_ja.properties
@@ -1,6 +1,6 @@
 # ZimoActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/zimo/ZimoActionListBundle_ja_JP.properties
+++ b/java/src/jmri/jmrix/zimo/ZimoActionListBundle_ja_JP.properties
@@ -1,6 +1,6 @@
 # ZimoActionListBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences

--- a/java/src/jmri/jmrix/zimo/swing/Mx1SwingBundle.properties
+++ b/java/src/jmri/jmrix/zimo/swing/Mx1SwingBundle.properties
@@ -1,6 +1,6 @@
 # MrcSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Zimo Swing Modules
 #

--- a/java/src/jmri/jmrix/zimo/swing/Mx1SwingBundle_da.properties
+++ b/java/src/jmri/jmrix/zimo/swing/Mx1SwingBundle_da.properties
@@ -1,6 +1,6 @@
 # MrcSwingBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the Zimo Swing Modules
 #

--- a/java/src/jmri/managers/ManagersBundle.properties
+++ b/java/src/jmri/managers/ManagersBundle.properties
@@ -1,6 +1,6 @@
 # ManagersBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri package of JMRI
 #

--- a/java/src/jmri/managers/ManagersBundle_ca.properties
+++ b/java/src/jmri/managers/ManagersBundle_ca.properties
@@ -1,6 +1,6 @@
 # ManagersBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri package of JMRI
 #

--- a/java/src/jmri/managers/ManagersBundle_da.properties
+++ b/java/src/jmri/managers/ManagersBundle_da.properties
@@ -1,6 +1,6 @@
 # ManagersBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri package of JMRI
 #

--- a/java/src/jmri/managers/ManagersBundle_fr.properties
+++ b/java/src/jmri/managers/ManagersBundle_fr.properties
@@ -1,6 +1,6 @@
 # ManagersBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri package of JMRI
 #

--- a/java/src/jmri/managers/ManagersBundle_it.properties
+++ b/java/src/jmri/managers/ManagersBundle_it.properties
@@ -1,6 +1,6 @@
 # ManagersBundle.properties
 #
-# Revision $Revision$
+#
 #
 # Default properties for the jmri package of JMRI
 #

--- a/java/src/jmri/web/server/Services.properties
+++ b/java/src/jmri/web/server/Services.properties
@@ -10,7 +10,7 @@
 #
 # This file is not for Internationalization; do not translate!
 #
-# Revision $Revision$
+#
 #
 
 #

--- a/jython/InitLocoNetSensors.py
+++ b/jython/InitLocoNetSensors.py
@@ -2,7 +2,7 @@
 #
 #This script will issue the DS54 interrogate commands 
 #
-# $Revision$ revision of AutomatonExample distributed with JMRI
+# AutomatonExample distributed with JMRI
 #					 from which this script has been developed.
 # Created by Phil Klein
 

--- a/jython/NSelectorExample.py
+++ b/jython/NSelectorExample.py
@@ -10,9 +10,7 @@
 #
 # Author: Bob Jacobsen, copyright 2005
 # Part of the JMRI distribution
-#
-# The next line is maintained by CVS, please don't change it
-# $Revision$
+
 
 import jarray
 import jmri

--- a/jython/OpsProgExample.py
+++ b/jython/OpsProgExample.py
@@ -11,9 +11,6 @@
 
 # Author: Bob Jacobsen, copyright 2004, 2005
 # Part of the JMRI distribution
-#
-# The next line is maintained by CVS, please don't change it
-# $Revision$
 
 import jmri
 

--- a/jython/PollGrapevine.py
+++ b/jython/PollGrapevine.py
@@ -7,9 +7,6 @@
 #
 # Author: Bob Jacobsen, copyright 2008
 # JMRI
-#
-# The next line is maintained by CVS, please don't change it
-# $Revision$
     
 # Define Listener to make a note if an answer is received
 class NodeListener(jmri.jmrix.grapevine.SerialListener):

--- a/jython/RobotThrottle2.py
+++ b/jython/RobotThrottle2.py
@@ -4,9 +4,6 @@
 # Author: Ken Cameron, copyright 2009
 # Part of the JMRI distribution
 #
-# The next line is maintained by CVS, please don't change it
-# $Revision$
-#
 # The start button is inactive until data has been entered.
 #
 # The test button is to force re-evaluation of all block and signal values.

--- a/jython/RobotThrottle3.py
+++ b/jython/RobotThrottle3.py
@@ -4,9 +4,6 @@
 # Author: Ken Cameron, copyright 2009,2010
 # Part of the JMRI distribution
 #
-# The next line is maintained by CVS, please don't change it
-# $Revision$
-#
 # The start button is inactive until data has been entered.
 #
 # The test button is to force re-evaluation of all block and signal values.

--- a/jython/StepperDriver.py
+++ b/jython/StepperDriver.py
@@ -4,9 +4,6 @@
 # Author: Ken Cameron, copyright 2011
 # Part of the JMRI distribution
 #
-# The next line is maintained by CVS, please don't change it
-# $Revision$
-#
 # This class lets you create a light that is driven by a 4 pole
 #	stepper motor connected to a normal lamp dimmer. A novel solution
 #	to having your layout lighting tied to your fast clock.
@@ -15,7 +12,7 @@
 #	to the motor but it seems for a CMRI setup, this hasn't been
 #	an issue. The layout really using this is Jim Heidt's O&N
 #	in Central New York.
-##
+#
 
 import jmri
 

--- a/jython/javaone/blocksetup.py
+++ b/jython/javaone/blocksetup.py
@@ -2,9 +2,6 @@
 #
 # Author: Bob Jacobsen, copyright 2006
 # Part of the JMRI distribution
-#
-# The next line is maintained by CVS, please don't change it
-# $Revision$
 
 # create the blocks themselves
 IB150 = jmri.Block("IB150")

--- a/jython/jmri_defaults.py
+++ b/jython/jmri_defaults.py
@@ -9,9 +9,6 @@
 #
 # Author: Bob Jacobsen, copyright 2003, 2004
 # Part of the JMRI distribution
-#
-# The next line is maintained by CVS, please don't change it
-# $Revision$
 
 import jmri
 

--- a/jython/operations/OperationsAssignUnitsToFlatcars.py
+++ b/jython/operations/OperationsAssignUnitsToFlatcars.py
@@ -4,9 +4,6 @@
 # Author: Daniel Boudreau, copyright 2015
 # Part of the JMRI distribution
 #
-# The next line is maintained by CVS, please don't change it
-# $Revision$
-#
 # To use this script you must provide the type names for containers and trailers, and the type names for the flatcars to use. 
 # You must also enter the train name that will service them. The train doesn't have to service the flatcars, this script will
 # do the flatcar assignments based on the container or trailer destinations. Run this script after the train is built.

--- a/jython/operations/OperationsBuildAndTerminateTrain.py
+++ b/jython/operations/OperationsBuildAndTerminateTrain.py
@@ -2,9 +2,6 @@
 # 
 # Author: Daniel Boudreau, copyright 2010
 # Part of the JMRI distribution
-#
-# The next line is maintained by CVS, please don't change it
-# $Revision$
 
 import jmri
 

--- a/jython/operations/OperationsDeselectBuild.py
+++ b/jython/operations/OperationsDeselectBuild.py
@@ -3,9 +3,6 @@
 #
 # Author: Daniel Boudreau, copyright 2011
 # Part of the JMRI distribution
-#
-# The next line is maintained by CVS, please don't change it
-# $Revision$
 
 import jmri
 

--- a/jython/operations/OperationsListenersAllTrains.py
+++ b/jython/operations/OperationsListenersAllTrains.py
@@ -4,9 +4,6 @@
 # Author: Bob Jacobsen, copyright 2004
 # Author: Daniel Boudreau, copyright 2010, 2012
 # Part of the JMRI distribution
-#
-# The next line is maintained by CVS, please don't change it
-# $Revision$
 
 import java.beans.PropertyChangeListener as PropertyChangeListener
 import jmri

--- a/jython/operations/OperationsMoveTrain.py
+++ b/jython/operations/OperationsMoveTrain.py
@@ -5,8 +5,6 @@
 #
 # Author: Daniel Boudreau copyright 2010
 #
-# The next line is maintained by CVS, please don't change it
-# $Revision$
 
 import jmri
 

--- a/jython/operations/OperationsRemoveCarKernels.py
+++ b/jython/operations/OperationsRemoveCarKernels.py
@@ -3,8 +3,6 @@
 # Use this script after terminating a train that services kernels created by operation scripts.
 #
 # Author: Daniel Boudreau, copyright 2015
-# The next line is maintained by CVS, please don't change it
-# $Revision$
 #
 
 

--- a/jython/operations/OperationsReplaceCarLoads.py
+++ b/jython/operations/OperationsReplaceCarLoads.py
@@ -6,9 +6,6 @@
 # Author: Daniel Boudreau, copyright 2011
 # Part of the JMRI distribution
 #
-# The next line is maintained by CVS, please don't change it
-# $Revision$
-#
 # To use this script you must assign the location, tracks, car type
 # and car loads.
 #

--- a/jython/operations/OperationsTerminateTrains.py
+++ b/jython/operations/OperationsTerminateTrains.py
@@ -4,9 +4,6 @@
 #
 # Author: Daniel Boudreau, copyright 2010
 # Part of the JMRI distribution
-#
-# The next line is maintained by CVS, please don't change it
-# $Revision$
 
 import jmri
 

--- a/jython/operations/OperationsTrainWindow.py
+++ b/jython/operations/OperationsTrainWindow.py
@@ -3,9 +3,6 @@
 # Part of the JMRI distribution
 #
 # Author: Daniel Boudreau copyright 2010
-#
-# The next line is maintained by CVS, please don't change it
-# $Revision$
 
 import jmri
 

--- a/jython/operations/OperationsWaitCarsAfterBuildingTrain.py
+++ b/jython/operations/OperationsWaitCarsAfterBuildingTrain.py
@@ -7,8 +7,6 @@
 # Use this script after the train has been built.
 #
 # Author: Daniel Boudreau, copyright 2011, 2012
-# The next line is maintained by CVS, please don't change it
-# $Revision$
 #
 # To use this script you must assign the train that you want the cars waited, 
 # and the wait value.  

--- a/jython/xAPadapter.py
+++ b/jython/xAPadapter.py
@@ -20,7 +20,6 @@
 #			   
 #
 # The next line is maintained by CVS, please don't change it
-# $Revision$
 
 import jarray
 import jmri

--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -204,13 +204,13 @@ where the date at the end should be the date (and optionally time) of the last r
 - Put a comment in the release GitHub item saying the branch exists, and all future changes should be documented in the new release note
 
 ```
-The release-4.5.3 branch has been created. 
+The release-4.5.4 branch has been created. 
 
-From now on, please document your changes in the [jmri4.5.4.shtml](https://github.com/JMRI/website/blob/master/releasenotes/jmri4.5.4.shtml) release note file.
+From now on, please document your changes in the [jmri4.5.5.shtml](https://github.com/JMRI/website/blob/master/releasenotes/jmri4.5.5.shtml) release note file.
 
-Maintainers, please set the 4.5.4 milestone on pulls from now on, as that will be the next test release from the HEAD of the master branch.
+Maintainers, please set the 4.5.5 milestone on pulls from now on, as that will be the next test release from the HEAD of the master branch.
 
-Jenkins will be creating files shortly at the [new server](http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.5.3/)
+Jenkins will be creating files shortly at the [CI server](http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.5.4/)
 ````
 
 ================================================================================
@@ -283,9 +283,13 @@ If you're building locally:
 
 - Change the release note to point to the just-built files (in CI or where you put them), commit, wait (or force via ["Build Now"](http://jmri.tagadab.com/jenkins/job/Web%20Site/job/Website%20from%20JMRI%20GitHub%20website%20repository/) update). Confirm visible on web.
 
-- Announce the file set to jmri-developers with a download URL like:
+- Announce the file set via email to jmri-developers@lists.sf.net with a subject line "First 4.5.4 files available":
 
-    http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.5.2/
+First JMRI 4.5.4 files are available in the usual way at:
+
+http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.5.4
+
+Feedback appreciated. I would like to release this later today or tomorrow morning. 
 
 - *Wait for some replies* before proceeding
 
@@ -333,7 +337,7 @@ It still gets a bit tricky if there’s a difference (e.g. due to a conflict wit
 
  - (If you use a browser to download instead of curl, make sure the .tgz wasn't auto-expanded)
 
- - (The "./testrelease 4.5.2" local script on shell.sf.net does the following steps, except for the edit, of course)
+ - (The "./testrelease 4.5.4" local script on shell.sf.net does the following steps, except for the edit, of course)
 ```
     ssh user,jmri@shell.sf.net create
     ssh user,jmri@shell.sf.net
@@ -391,15 +395,15 @@ Note: Unlike releasing files to SourceForge, once a GitHub Release is created it
 ```
    - Description content (really need to automate this!):
 ```    
-[Release notes](http://jmri.org/releasenotes/jmri4.5.2.shtml)
+[Release notes](http://jmri.org/releasenotes/jmri4.5.4.shtml)
 
 Checksums:
 
 File | SHA256 checksum
 ---|---
-[JMRI.4.5.2-Rd144052.dmg](https://github.com/JMRI/JMRI/releases/download/v4.5.2/JMRI.4.5.2-Rd144052.dmg) | 346341bbb87d8c8530ae1ac923e2d1e61de3d97be5df364d85213d95d5f99702
-[JMRI.4.5.2-Rd144052.exe](https://github.com/JMRI/JMRI/releases/download/v4.5.2/JMRI.4.5.2-Rd144052.exe) | 4d8d86345adf2a06a2b60f3ddefbfa03751819bc34e894f5e947e98dcb36e294
-[JMRI.4.5.2-Rd144052.tgz](https://github.com/JMRI/JMRI/releases/download/v4.5.2/JMRI.4.5.2-Rd144052.tgz) | 0531e6ec7aebe13e75f82f4d9905431420f8a86e31f145470b0e3fe50d055c83
+[JMRI.4.5.4-Rb93cb4f.dmg](https://github.com/JMRI/JMRI/releases/download/v4.5.2/JMRI.4.5.4-Rb93cb4f.dmg) | f613c24cef0ba3e2aaa51575ba6566ef20ca57cb3f909ca4e3d8151f6f92693a
+[JMRI.4.5.4-Rb93cb4f.exe](https://github.com/JMRI/JMRI/releases/download/v4.5.2/JMRI.4.5.4-Rb93cb4f.exe) | 228b44a8bd3036f47be97492dcf51e37c64673bf322e417eefd849ab505ca5a6
+[JMRI.4.5.4-Rb93cb4f.tgz](https://github.com/JMRI/JMRI/releases/download/v4.5.2/JMRI.4.5.4-Rb93cb4f.tgz) | afe3d48bb6dc93f678dda3e6ce714c8683d225e80b7e884fe6c01e7aff038ba5
 ```
 
 - Attach files by dragging them in (you might have to have downloaded them above via e.g. a separate 

--- a/scripts/WinInstallFiles/InstallTest.bat
+++ b/scripts/WinInstallFiles/InstallTest.bat
@@ -1,4 +1,4 @@
-@REM Start the InstallTest program from JMRI ($Revision$)
+@REM Start the InstallTest program from JMRI
 @REM @author Ken Cameron
 @REM @author Matthew Harris
 

--- a/scripts/config-portable/build.xml
+++ b/scripts/config-portable/build.xml
@@ -1,6 +1,5 @@
 <!-- Ant build.xml file for JMRI development -->
 <!-- Bob Jacobsen, Copyright 2002, 2003, 2004 -->
-<!-- Revision $Revision$ -->
 
 <!-- This file is part of JMRI.                                             -->
 <!--                                                                        -->

--- a/scripts/config-portable/src/jmri/jmrit/roster/RosterConfigPane.java
+++ b/scripts/config-portable/src/jmri/jmrit/roster/RosterConfigPane.java
@@ -1,5 +1,3 @@
-// RosterConfigPane.java
-
 package jmri.jmrit.roster;
 
 import java.awt.FlowLayout;
@@ -15,7 +13,6 @@ import javax.swing.JTextField;
  *
  * @author      Bob Jacobsen   Copyright (C) 2001, 2003, 2007
  * @author      Matthew Harris  Copyright (C) 2008, 2010
- * @version	$Revision$
  */
 public class RosterConfigPane extends JPanel {
 

--- a/serialver.csh
+++ b/serialver.csh
@@ -30,7 +30,6 @@
 # For more information, please see
 # http://jmri.org/install/ShellScripts.shtml
 #
-# $Revision$ (CVS maintains this line, do not edit please)
 
 
 SYSLIBPATH=

--- a/xml/DTD/decoder-config.dtd
+++ b/xml/DTD/decoder-config.dtd
@@ -1,6 +1,5 @@
 <!-- Defines XML documenting a type or types of DCC decoder as  -->
 <!-- a component, esp. information on how to program it. -->
-<!-- $Revision$ -->
 
 <!-- This DTD is part of JMRI. Copyright 2001-2007.                         -->
 <!--                                                                        -->

--- a/xml/DTD/decoderIndex-config.dtd
+++ b/xml/DTD/decoderIndex-config.dtd
@@ -1,5 +1,4 @@
 <!-- Defines XML documenting the list of available decoder definitions -->
-<!-- $Revision$ -->
 
 <!-- This DTD is part of JMRI. Copyright 2001-2007.                         -->
 <!--                                                                        -->

--- a/xml/DTD/names-config.dtd
+++ b/xml/DTD/names-config.dtd
@@ -1,5 +1,4 @@
 <!-- Defines XML documenting standard names and aliases -->
-<!-- $Revision$ -->
 
 <!-- This DTD is part of JMRI. Copyright 2001-2007.                         -->
 <!--                                                                        -->

--- a/xml/DTD/programmer-config.dtd
+++ b/xml/DTD/programmer-config.dtd
@@ -1,5 +1,4 @@
 <!-- Defines XML for a programmer layout for the JMRI tabbed programmer    -->
-<!-- $Revision$ -->
 
 <!-- This DTD is part of JMRI. Copyright 2001-2009.                         -->
 <!--                                                                        -->

--- a/xml/XSLT/build.xml
+++ b/xml/XSLT/build.xml
@@ -1,6 +1,5 @@
 <!-- an ANT build.xml file for JMRI XSLT -->
 <!-- Bob Jacobsen, Copyright 2002, 2003, 2004, 2005 -->
-<!-- Revision $Revision$ -->
 
 <!-- This file is part of JMRI.                                             -->
 <!--                                                                        -->

--- a/xml/decoders/CT_Elektronik_DCX_old.xml
+++ b/xml/decoders/CT_Elektronik_DCX_old.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
 <!-- Copyright (C) JMRI 2004, 2007 All rights reserved -->
-<!-- $Revision$ -->
-<!--                                                                        -->
+
 <!-- JMRI is free software; you can redistribute it and/or modify it under  -->
 <!-- the terms of version 2 of the GNU General Public License as published  -->
 <!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->

--- a/xml/decoders/Zimo_MX66-2000-11.xml
+++ b/xml/decoders/Zimo_MX66-2000-11.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
 <!-- Copyright (C) JMRI 2007 All rights reserved -->
-<!-- $Revision$ -->
+
 <!--                                                                        -->
 <!-- JMRI is free software; you can redistribute it and/or modify it under  -->
 <!-- the terms of version 2 of the GNU General Public License as published  -->

--- a/xml/schema/node-identity-config.xsd
+++ b/xml/schema/node-identity-config.xsd
@@ -3,8 +3,6 @@
 
 <!-- Schema for JMRI profile support.          -->
 
-<!-- $Revision: $ -->
-
 <!-- This schema is part of JMRI. Copyright 2013.                           -->
 <!--                                                                        -->
 <!-- JMRI is free software; you can redistribute it and/or modify it under  -->

--- a/xml/schema/profile.xsd
+++ b/xml/schema/profile.xsd
@@ -3,8 +3,6 @@
 
 <!-- Schema for JMRI profile support.          -->
 
-<!-- $Revision: $ -->
-
 <!-- This schema is part of JMRI. Copyright 2013.                           -->
 <!--                                                                        -->
 <!-- JMRI is free software; you can redistribute it and/or modify it under  -->


### PR DESCRIPTION
Removes `$Revision` tag:
- from .properties files
- from XML, schema and DTD files
- from sample scripts
- from help files
- and a few other places

AFAIK, this completes the removal from this repository )not yet from the website repository)