### PR TITLE
Change olcb turnout default feedback mode to MONITORING

### DIFF
--- a/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
@@ -22,9 +22,10 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout
     private static final long serialVersionUID = -2709042631708878196L;
     OlcbAddress addrThrown;   // go to thrown state
     OlcbAddress addrClosed;   // go to closed state
-    private static final String[] validFeedbackNames = {"MONITORING", "ONESENSOR", "TWOSENSOR"};
-    private static final int[] validFeedbackModes = {MONITORING, ONESENSOR, TWOSENSOR};
-    private static final int validFeedbackTypes = MONITORING | ONESENSOR | TWOSENSOR;
+    private static final String[] validFeedbackNames = {"MONITORING", "ONESENSOR", "TWOSENSOR",
+            "DIRECT"};
+    private static final int[] validFeedbackModes = {MONITORING, ONESENSOR, TWOSENSOR, DIRECT};
+    private static final int validFeedbackTypes = MONITORING | ONESENSOR | TWOSENSOR | DIRECT;
     private static final int defaultFeedbackType = MONITORING;
 
     protected OlcbTurnout(String prefix, String address, TrafficController tc) {
@@ -106,13 +107,13 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout
 
     public void message(CanMessage f) {
         if (addrThrown.match(f)) {
-            newCommandedState(THROWN);
             if (_activeFeedbackType == MONITORING) {
+                newCommandedState(THROWN);
                 newKnownState(THROWN);
             }
         } else if (addrClosed.match(f)) {
-            newCommandedState(CLOSED);
             if (_activeFeedbackType == MONITORING) {
+                newCommandedState(CLOSED);
                 newKnownState(CLOSED);
             }
         }
@@ -120,13 +121,13 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout
 
     public void reply(CanReply f) {
         if (addrThrown.match(f)) {
-            newCommandedState(THROWN);
             if (_activeFeedbackType == MONITORING) {
+                newCommandedState(THROWN);
                 newKnownState(THROWN);
             }
         } else if (addrClosed.match(f)) {
-            newCommandedState(CLOSED);
             if (_activeFeedbackType == MONITORING) {
+                newCommandedState(CLOSED);
                 newKnownState(CLOSED);
             }
         }

--- a/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
@@ -22,10 +22,16 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout
     private static final long serialVersionUID = -2709042631708878196L;
     OlcbAddress addrThrown;   // go to thrown state
     OlcbAddress addrClosed;   // go to closed state
+    private static final String[] validFeedbackNames = {"MONITORING", "ONESENSOR", "TWOSENSOR"};
+    private static final int validFeedbackTypes = MONITORING | ONESENSOR | TWOSENSOR;
+    private static final int defaultFeedbackType = MONITORING;
 
     protected OlcbTurnout(String prefix, String address, TrafficController tc) {
         super(prefix + "T" + address);
         this.tc = tc;
+        this._validFeedbackNames = validFeedbackNames;
+        this._validFeedbackTypes = validFeedbackTypes;
+        this._activeFeedbackType = defaultFeedbackType;
         init(address);
     }
 
@@ -89,16 +95,28 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout
     public void message(CanMessage f) {
         if (addrThrown.match(f)) {
             newCommandedState(THROWN);
+            if (_activeFeedbackType == MONITORING) {
+                newKnownState(THROWN);
+            }
         } else if (addrClosed.match(f)) {
             newCommandedState(CLOSED);
+            if (_activeFeedbackType == MONITORING) {
+                newKnownState(CLOSED);
+            }
         }
     }
 
     public void reply(CanReply f) {
         if (addrThrown.match(f)) {
             newCommandedState(THROWN);
+            if (_activeFeedbackType == MONITORING) {
+                newKnownState(THROWN);
+            }
         } else if (addrClosed.match(f)) {
             newCommandedState(CLOSED);
+            if (_activeFeedbackType == MONITORING) {
+                newKnownState(CLOSED);
+            }
         }
     }
 

--- a/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
@@ -88,9 +88,19 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout
         if (s == Turnout.THROWN) {
             m = addrThrown.makeMessage();
             tc.sendCanMessage(m, this);
+            // TC will not give us back the message we sent to the port, so short-circuit the
+            // monitoring feedback here
+            if (_activeFeedbackType == MONITORING) {
+                newKnownState(THROWN);
+            }
         } else if (s == Turnout.CLOSED) {
             m = addrClosed.makeMessage();
             tc.sendCanMessage(m, this);
+            // TC will not give us back the message we sent to the port, so short-circuit the
+            // monitoring feedback here
+            if (_activeFeedbackType == MONITORING) {
+                newKnownState(CLOSED);
+            }
         }
     }
 

--- a/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
@@ -23,6 +23,7 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout
     OlcbAddress addrThrown;   // go to thrown state
     OlcbAddress addrClosed;   // go to closed state
     private static final String[] validFeedbackNames = {"MONITORING", "ONESENSOR", "TWOSENSOR"};
+    private static final int[] validFeedbackModes = {MONITORING, ONESENSOR, TWOSENSOR};
     private static final int validFeedbackTypes = MONITORING | ONESENSOR | TWOSENSOR;
     private static final int defaultFeedbackType = MONITORING;
 
@@ -30,6 +31,7 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout
         super(prefix + "T" + address);
         this.tc = tc;
         this._validFeedbackNames = validFeedbackNames;
+        this._validFeedbackModes = validFeedbackModes;
         this._validFeedbackTypes = validFeedbackTypes;
         this._activeFeedbackType = defaultFeedbackType;
         init(address);


### PR DESCRIPTION
An LCC user reported the following problem: when the physical panel is used to throw a turnout, the JMRI panels (layout editor) do not update the state of the turnout. Surprisingly, the turnout table did update the value shown. Similarly throwing a turnout form one JMRI computer does not update the panel on another JMRI computer connected to the same CAN network.

This pull request implements the feedback mode MONITORING for OlcbTurnout. We also change the default feedback mode to MONITORING; this is consistent with the default behavior of Turnout objects in other p2p buses (like LocoNet).

Note: 
this change removes DIRECT feedback option from OlcbTurnout. Existing saved XML files will update their turnout objects from DIRECT to MONITORING feedback, so that users will not automatically get this bugfix and not have to have to perform manual action. Any turnouts that have explicit feedback configured will not be touched of course.

Tested:
Added unit tests to OlcbTurnoutTest that check that the known state property change is fired when receiving messages. Added unit test for having two turnouts communicate with each other via CAN-bus messages, which reasonably closely approximates two JMRI computers talking to each other.