### PR TITLE
IllegalArgumentException for invalid accessory address

### DIFF
--- a/java/src/jmri/NmraPacket.java
+++ b/java/src/jmri/NmraPacket.java
@@ -199,7 +199,8 @@ public class NmraPacket {
         // right hardware addresses
         if (addr < 1 || addr > 511) {
             log.error("invalid address " + addr);
-            return null;
+            //return null;
+            throw new IllegalArgumentException();
         }
         if (active < 0 || active > 1) {
             log.error("invalid active (C) bit " + addr);
@@ -235,7 +236,7 @@ public class NmraPacket {
 
         if (addr < 1 || addr > 511) {
             log.error("invalid address " + addr);
-            return null;
+            throw new IllegalArgumentException();
         }
         if (active < 0 || active > 1) {
             log.error("invalid active (C) bit " + addr);

--- a/java/test/jmri/NmraPacketTest.java
+++ b/java/test/jmri/NmraPacketTest.java
@@ -112,6 +112,22 @@ public class NmraPacketTest extends TestCase {
         Assert.assertEquals("third byte ", 0x38, ba[2] & 0xFF);
     }
 
+    public void testAccDecoderPacket13() {
+        // invalid address (0)
+        int addr = 0;
+        // expect this to throw exception
+        boolean threw = false;
+        try {
+            byte[] ba = NmraPacket.accDecoderPkt(addr, 0, 0);
+            Assert.fail("Expected IllegalArgumentException not thrown");
+        } catch (IllegalArgumentException ex) {
+            threw = true;
+        } finally {
+            jmri.util.JUnitAppender.assertErrorMessage("invalid address " + addr);
+        }
+        Assert.assertTrue("Expected exception", threw);
+    }
+
     public void testOpsModeLong() {
         // "typical packet" test
         byte[] ba = NmraPacket.opsCvWriteByte(2065, true, 21, 75);


### PR DESCRIPTION
Returning null causes turnout table to hang. Changed code to throw an exception instead if an illegal address is used to create an accessory packet.