### PR TITLE
Increase delay before LocoNet Power Manager queries track power

### DIFF
--- a/java/src/jmri/jmrix/loconet/LnPowerManager.java
+++ b/java/src/jmri/jmrix/loconet/LnPowerManager.java
@@ -152,7 +152,7 @@ public class LnPowerManager
             // wait a little bit to allow power manager to be initialized
             try {
                 // Delay 200 mSec to allow init of traffic controller, listeners.
-                Thread.sleep(200);
+                Thread.sleep(500);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt(); // retain if needed later
             }

--- a/java/src/jmri/jmrix/loconet/LnPowerManager.java
+++ b/java/src/jmri/jmrix/loconet/LnPowerManager.java
@@ -151,7 +151,7 @@ public class LnPowerManager
         public void run() {
             // wait a little bit to allow power manager to be initialized
             try {
-                // Delay 200 mSec to allow init of traffic controller, listeners.
+                // Delay 500 mSec to allow init of traffic controller, listeners.
                 Thread.sleep(500);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt(); // retain if needed later


### PR DESCRIPTION
Intended to address problem from #2080 .  Adds more delay between LnPowerManager constructor execution and the slot 0 read request it causes.
