### PR TITLE
when a ConnectionConfigXml object is created without an adapter, make…

### DIFF
--- a/java/src/jmri/jmrix/cmri/serial/networkdriver/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/cmri/serial/networkdriver/configurexml/ConnectionConfigXml.java
@@ -30,7 +30,10 @@ public class ConnectionConfigXml extends AbstractNetworkConnectionConfigXml {
     }
 
     protected void getInstance() {
-        adapter = new NetworkDriverAdapter();
+        if(adapter == null) {
+           adapter = new NetworkDriverAdapter();
+           adapter.configure(); // sets the memo and traffic controller.
+        }
     }
 
     protected void getInstance(Object object) {

--- a/java/src/jmri/jmrix/cmri/serial/serialdriver/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/cmri/serial/serialdriver/configurexml/ConnectionConfigXml.java
@@ -74,8 +74,12 @@ public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
         return p;
     }
 
+    @Override
     protected void getInstance() {
-        adapter = SerialDriverAdapter.instance();
+        if(adapter == null) {
+           adapter = new SerialDriverAdapter();
+           adapter.configure(); // sets the memo and traffic controller.
+        } 
     }
 
     @Override

--- a/java/src/jmri/jmrix/cmri/serial/sim/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/cmri/serial/sim/configurexml/ConnectionConfigXml.java
@@ -24,8 +24,12 @@ public class ConnectionConfigXml extends jmri.jmrix.cmri.serial.serialdriver.con
         super();
     }
 
+    @Override
     protected void getInstance() {
-        adapter = SimDriverAdapter.instance();
+        if(adapter == null) {
+           adapter = new SimDriverAdapter();
+           adapter.configure(); // sets the memo and traffic controller.
+        }
     }
 
     @Override

--- a/java/src/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXml.java
@@ -30,7 +30,7 @@ abstract public class AbstractSerialConnectionConfigXml extends AbstractConnecti
      * Default implementation for storing the static contents of the serial port
      * implementation
      *
-     * @param object Object to store, of type PositionableLabel
+     * @param object Object to store, of type AbstractSerialConnectionConfig 
      * @return Element containing the complete info
      */
     public Element store(Object object) {


### PR DESCRIPTION
… sure the created adapter has both a traffic controller and a memo (which are required to store nodes on C/MRI).