### PR TITLE
CI builds on OS X in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,20 @@ addons:
     packages:
     - graphviz
 
+before_install:
+  # set Linux to use JDK 8, accept defaults on OS X
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] ; then jdk_switcher use "oraclejdk8" ; fi
+
 # prevent travis default mvn install behavior
 install: true
-
+    
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
+  # setup a display on linux ( the sleep gives xvfb some time to start )
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] ; then export DISPLAY=:99.0 ; sh -e /etc/init.d/xvfb start ; sleep 3 ; fi
 
 script:
   - export MAVEN_OPTS=-Xmx1536M
   - travis_wait 30 mvn test -U -P travis --batch-mode
-
-jdk:
-  - oraclejdk8
 
 cache:
   directories:
@@ -26,4 +26,4 @@ cache:
 
 os:
   - linux
-#  - osx # Travis OS X support does not include Java
+  - osx

--- a/build.xml
+++ b/build.xml
@@ -122,6 +122,12 @@
             <isset property="cp.prepend"/>
         </not>
     </condition>
+    <condition property="os.linux" value="true">
+        <and>
+            <os family="unix"/>
+            <equals arg1="${os.name}" arg2="Linux"/>
+        </and>
+    </condition>
 
     <!-- set global properties for this build -->
     <property name="dist"         value="${basedir}/dist"/>
@@ -1091,7 +1097,7 @@
 
     <!-- check for non-ASCII characters in properties files -->
 
-    <target name="checknonascii" description="check for non-ASCII characters in properties files (Linux only)">
+    <target name="checknonascii" description="check for non-ASCII characters in properties files (Linux only)" if="os.linux">
         <exec executable="sh" outputproperty="checknonascii.files">
             <arg value="-c" />
             <arg value="grep -rIn -P '[^\x00-\x7f]' --include=*.properties java/src" />

--- a/java/test/jmri/jmrit/display/PositionableLabelTest.java
+++ b/java/test/jmri/jmrit/display/PositionableLabelTest.java
@@ -222,7 +222,7 @@ public class PositionableLabelTest extends jmri.util.SwingTestCase {
         if (!System.getProperty("jmri.headlesstest","false").equals("false")) { return; }
 
         if (System.getProperty("jmri.migrationtests", "false").equals("false")) { // skip test for migration, but warn about it
-            log.warn("skipping testDisplayAnimatedRGBrotated45degrees because jmri.migrationtests not set true");
+            log.warn("skipping testDisplayAnimatedRGB because jmri.migrationtests not set true");
             return;
         }
 

--- a/java/test/jmri/jmrit/display/PositionableLabelTest.java
+++ b/java/test/jmri/jmrit/display/PositionableLabelTest.java
@@ -221,6 +221,11 @@ public class PositionableLabelTest extends jmri.util.SwingTestCase {
     public void testDisplayAnimatedRGB() throws IOException {
         if (!System.getProperty("jmri.headlesstest","false").equals("false")) { return; }
 
+        if (System.getProperty("jmri.migrationtests", "false").equals("false")) { // skip test for migration, but warn about it
+            log.warn("skipping testDisplayAnimatedRGBrotated45degrees because jmri.migrationtests not set true");
+            return;
+        }
+
         JFrame f = new JFrame();
         f.getContentPane().setBackground(Color.blue);
         f.setUndecorated(true); // skip frame decoration, which can force a min size.


### PR DESCRIPTION
Contrary to the comment previously in place, Travis does support Java builds on OS X, with the following caveats:
- Can only use default JDK
- Only if maven is used to bootstrap rest of Java build chain (maven is installed and reasonably current on Travis's OS X)
