### PR TITLE
TMCC throttle update

### DIFF
--- a/java/src/jmri/jmrix/acela/AcelaPortController.java
+++ b/java/src/jmri/jmrix/acela/AcelaPortController.java
@@ -1,4 +1,3 @@
-// AcelaPortController.java
 package jmri.jmrix.acela;
 
 import java.io.DataInputStream;
@@ -37,5 +36,3 @@ public abstract class AcelaPortController extends jmri.jmrix.AbstractSerialPortC
         return (AcelaSystemConnectionMemo) super.getSystemConnectionMemo();
     }
 }
-
-/* @(#)AcelaPortController.java */

--- a/java/src/jmri/jmrix/can/cbus/swing/CbusMenu.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/CbusMenu.java
@@ -1,4 +1,3 @@
-// CbusMenu.java
 package jmri.jmrix.can.cbus.swing;
 
 import java.util.ResourceBundle;
@@ -13,11 +12,6 @@ import jmri.jmrix.can.swing.CanNamedPaneAction;
  * @author Andrew Crosland 2008
  */
 public class CbusMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8901183972160758403L;
 
     public CbusMenu(CanSystemConnectionMemo memo) {
         super();

--- a/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolPane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolPane.java
@@ -49,10 +49,6 @@ public class ConfigToolPane extends jmri.jmrix.can.swing.CanPanel implements Can
 
         // add sensor
         makeSensor = new MakeNamedBean("LabelEventActive", "LabelEventInactive") {
-            /**
-             *
-             */
-            private static final long serialVersionUID = -7423601645608436305L;
 
             void create(String name) {
                 if (memo != null) {
@@ -278,11 +274,6 @@ public class ConfigToolPane extends jmri.jmrix.can.swing.CanPanel implements Can
      * Nested class to create one of these using old-style defaults
      */
     static public class Default extends jmri.jmrix.can.swing.CanNamedPaneAction {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 8264581016480363352L;
 
         public Default() {
             super("CBUS Event Capture Tool",

--- a/java/src/jmri/jmrix/can/cbus/swing/console/CbusConsolePane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/console/CbusConsolePane.java
@@ -1,4 +1,3 @@
-// CbusConsolePane.java
 package jmri.jmrix.can.cbus.swing.console;
 
 import java.awt.BorderLayout;
@@ -50,10 +49,6 @@ import org.slf4j.LoggerFactory;
  */
 public class CbusConsolePane extends jmri.jmrix.can.swing.CanPanel implements CanListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 7992772438444957125L;
     // member declarations
     protected JButton clearButton = new JButton();
     protected JToggleButton freezeButton = new JToggleButton();
@@ -1076,11 +1071,6 @@ public class CbusConsolePane extends jmri.jmrix.can.swing.CanPanel implements Ca
      * Nested class to create one of these using old-style defaults
      */
     static public class Default extends jmri.jmrix.can.swing.CanNamedPaneAction {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = -7861976003921031471L;
 
         public Default() {
             super("CBUS Console",

--- a/java/src/jmri/jmrix/can/cbus/swing/console/CbusEventFilterFrame.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/console/CbusEventFilterFrame.java
@@ -1,7 +1,3 @@
-/*
- * CbusEventFilterFrame.java
- *
- */
 package jmri.jmrix.can.cbus.swing.console;
 
 import java.awt.Color;
@@ -22,10 +18,6 @@ import org.slf4j.LoggerFactory;
  */
 public class CbusEventFilterFrame extends JmriJFrame {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -618391050120364272L;
     protected static final int FILTERS = 4;
     static final Color[] filterColors = {Color.RED, Color.GREEN, Color.CYAN, Color.YELLOW};
     protected CbusEventFilterPanel[] filterPanes = new CbusEventFilterPanel[FILTERS];

--- a/java/src/jmri/jmrix/can/cbus/swing/console/CbusEventFilterPanel.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/console/CbusEventFilterPanel.java
@@ -1,11 +1,3 @@
-/*
- * CbusEventFilterPanel.java
- *
- * Created on 16 August 2008, 15:15
- *
- * To change this template, choose Tools | Template Manager
- * and open the template in the editor.
- */
 package jmri.jmrix.can.cbus.swing.console;
 
 import javax.swing.BorderFactory;
@@ -25,10 +17,6 @@ import jmri.jmrix.can.cbus.CbusConstants;
  */
 public class CbusEventFilterPanel extends JPanel {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5291143894239237548L;
     protected JCheckBox nnEnButton = new JCheckBox();
     protected JTextField nnLowField = new JTextField("", 5);
     protected JTextField nnHighField = new JTextField("", 5);

--- a/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolPane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolPane.java
@@ -1,4 +1,3 @@
-// NodeConfigToolPane.java
 package jmri.jmrix.can.cbus.swing.nodeconfig;
 
 import java.util.ResourceBundle;
@@ -19,11 +18,6 @@ import jmri.jmrix.can.TrafficController;
   * @since 2.3.1
  */
 public class NodeConfigToolPane extends jmri.jmrix.can.swing.CanPanel implements CanListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5162692735562566371L;
 
     static ResourceBundle rb = ResourceBundle.getBundle("jmri.jmrix.can.cbus.swing.nodeconfig.NodeConfigToolBundle");
 
@@ -114,11 +108,6 @@ public class NodeConfigToolPane extends jmri.jmrix.can.swing.CanPanel implements
      * Nested class to create one of these using old-style defaults
      */
     static public class Default extends jmri.jmrix.can.swing.CanNamedPaneAction {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 7778206986212539509L;
 
         public Default() {
             super(ResourceBundle.getBundle("jmri.jmrix.can.cbus.swing.nodeconfig.NodeConfigToolBundle").getString("Title"),

--- a/java/src/jmri/jmrix/can/nmranet/swing/NmraNetMenu.java
+++ b/java/src/jmri/jmrix/can/nmranet/swing/NmraNetMenu.java
@@ -1,4 +1,3 @@
-// CbusMenu.java
 package jmri.jmrix.can.nmranet.swing;
 
 import java.util.ResourceBundle;
@@ -13,11 +12,6 @@ import jmri.jmrix.can.swing.CanNamedPaneAction;
  * @author Andrew Crosland 2008
  */
 public class NmraNetMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 6905626225063951958L;
 
     public NmraNetMenu(CanSystemConnectionMemo memo) {
         super();

--- a/java/src/jmri/jmrix/can/swing/CanMenu.java
+++ b/java/src/jmri/jmrix/can/swing/CanMenu.java
@@ -1,4 +1,3 @@
-// CbusMenu.java
 package jmri.jmrix.can.swing;
 
 import java.util.ResourceBundle;
@@ -12,11 +11,6 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
  * @author Andrew Crosland 2008
  */
 public class CanMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 892271699607148161L;
 
     public CanMenu(CanSystemConnectionMemo memo) {
         super();

--- a/java/src/jmri/jmrix/can/swing/CanNamedPaneAction.java
+++ b/java/src/jmri/jmrix/can/swing/CanNamedPaneAction.java
@@ -1,4 +1,3 @@
-// CbusNamedPaneAction.java
 package jmri.jmrix.can.swing;
 
 import javax.swing.Icon;
@@ -14,11 +13,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2012
  */
 public class CanNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5423896954824804035L;
 
     /**
      * Enhanced constructor for placing the pane in various GUIs
@@ -55,5 +49,3 @@ public class CanNamedPaneAction extends jmri.util.swing.JmriNamedPaneAction {
 
     private final static Logger log = LoggerFactory.getLogger(CanNamedPaneAction.class.getName());
 }
-
-/* @(#)CbusNamedPaneAction.java */

--- a/java/src/jmri/jmrix/can/swing/CanPanel.java
+++ b/java/src/jmri/jmrix/can/swing/CanPanel.java
@@ -1,4 +1,3 @@
-// CbusPanel.java
 package jmri.jmrix.can.swing;
 
 import jmri.jmrix.can.CanSystemConnectionMemo;
@@ -14,10 +13,6 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
  */
 abstract public class CanPanel extends jmri.util.swing.JmriPanel implements CanPanelInterface {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4619397055638527582L;
     /**
      * make "memo" object available as convenience
      */

--- a/java/src/jmri/jmrix/can/swing/monitor/MonitorPane.java
+++ b/java/src/jmri/jmrix/can/swing/monitor/MonitorPane.java
@@ -1,4 +1,3 @@
-// MonitorPane.java
 package jmri.jmrix.can.swing.monitor;
 
 import jmri.jmrix.can.CanListener;
@@ -15,11 +14,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2009
  */
 public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListener, CanPanelInterface {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4147929733083518618L;
 
     public MonitorPane() {
         super();
@@ -94,11 +88,6 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
      * Nested class to create one of these using old-style defaults
      */
     static public class Default extends jmri.jmrix.can.swing.CanNamedPaneAction {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = -2277527920171927509L;
 
         public Default() {
             super("CAN Monitor",

--- a/java/src/jmri/jmrix/can/swing/send/CanSendPane.java
+++ b/java/src/jmri/jmrix/can/swing/send/CanSendPane.java
@@ -1,4 +1,3 @@
-// CanSendPane.java
 package jmri.jmrix.can.swing.send;
 
 import java.awt.GridLayout;
@@ -33,10 +32,6 @@ import org.slf4j.LoggerFactory;
  */
 public class CanSendPane extends jmri.jmrix.can.swing.CanPanel implements CanListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 6281707873589937794L;
     // member declarations
     javax.swing.JLabel jLabel1 = new javax.swing.JLabel();
     javax.swing.JButton sendButton = new javax.swing.JButton();
@@ -294,11 +289,6 @@ public class CanSendPane extends jmri.jmrix.can.swing.CanPanel implements CanLis
      * Nested class to create one of these using old-style defaults
      */
     static public class Default extends jmri.jmrix.can.swing.CanNamedPaneAction {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 6513091592493774694L;
 
         public Default() {
             super("Send Can Frame",

--- a/java/src/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXml.java
@@ -102,6 +102,7 @@ abstract public class AbstractSerialConnectionConfigXml extends AbstractConnecti
                     null, null, null
             );
             // now force end to operation
+            log.debug("load failed");
             return false;
         }
 

--- a/java/src/jmri/jmrix/libusb/UsbViewAction.java
+++ b/java/src/jmri/jmrix/libusb/UsbViewAction.java
@@ -1,4 +1,3 @@
-// UsbViewAction.java
 package jmri.jmrix.libusb;
 
 import org.slf4j.Logger;
@@ -10,11 +9,6 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright 2008
   */
 public class UsbViewAction extends javax.swing.AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7957478904918565568L;
 
     public UsbViewAction(String s) {
         super(s);
@@ -36,5 +30,3 @@ public class UsbViewAction extends javax.swing.AbstractAction {
 
     private final static Logger log = LoggerFactory.getLogger(UsbViewAction.class.getName());
 }
-
-/* @(#)UsbViewAction.java */

--- a/java/src/jmri/jmrix/nce/NceSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/nce/NceSystemConnectionMemo.java
@@ -1,4 +1,3 @@
-// LocoNetSystemConnectionMemo.java
 package jmri.jmrix.nce;
 
 import java.util.ResourceBundle;
@@ -294,6 +293,3 @@ public class NceSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
     }
 
 }
-
-
-/* @(#)NceSystemConnectionMemo.java */

--- a/java/src/jmri/jmrix/nce/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/nce/serialdriver/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.nce.serialdriver;
 
 /**

--- a/java/src/jmri/jmrix/pricom/PricomMenu.java
+++ b/java/src/jmri/jmrix/pricom/PricomMenu.java
@@ -1,4 +1,3 @@
-// PricomMenu.java
 package jmri.jmrix.pricom;
 
 import javax.swing.JMenu;
@@ -9,11 +8,6 @@ import javax.swing.JMenu;
  * @author	Bob Jacobsen Copyright 2003, 2005
  */
 public class PricomMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4327120523599989299L;
 
     public PricomMenu(String name) {
         this();

--- a/java/src/jmri/jmrix/pricom/downloader/LoaderFrame.java
+++ b/java/src/jmri/jmrix/pricom/downloader/LoaderFrame.java
@@ -1,4 +1,3 @@
-// LoaderFrame.java
 package jmri.jmrix.pricom.downloader;
 
 import java.util.ResourceBundle;
@@ -13,10 +12,6 @@ import jmri.util.JmriJFrame;
  */
 public class LoaderFrame extends JmriJFrame {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -2659741505895230693L;
     // GUI member declarations
     LoaderPane pane = new LoaderPane();
 

--- a/java/src/jmri/jmrix/pricom/downloader/LoaderPanelAction.java
+++ b/java/src/jmri/jmrix/pricom/downloader/LoaderPanelAction.java
@@ -1,4 +1,3 @@
-// LoaderPanelAction.java
 package jmri.jmrix.pricom.downloader;
 
 import java.awt.event.ActionEvent;
@@ -12,10 +11,6 @@ import javax.swing.AbstractAction;
  */
 public class LoaderPanelAction extends AbstractAction {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3172906837130428976L;
     static ResourceBundle res = ResourceBundle.getBundle("jmri.jmrix.pricom.downloader.Loader");
 
     public LoaderPanelAction(String s) {
@@ -33,5 +28,3 @@ public class LoaderPanelAction extends AbstractAction {
         f.setVisible(true);
     }
 }
-
-/* @(#)LoaderPanelAction.java */

--- a/java/src/jmri/jmrix/pricom/pockettester/DataSourceAction.java
+++ b/java/src/jmri/jmrix/pricom/pockettester/DataSourceAction.java
@@ -1,4 +1,3 @@
-// pricom.pockettester.DataSourceAction.java
 package jmri.jmrix.pricom.pockettester;
 
 
@@ -11,11 +10,6 @@ package jmri.jmrix.pricom.pockettester;
  * @author	Bob Jacobsen Copyright (C) 2002,2005
   */
 public class DataSourceAction extends jmri.util.JmriJFrameAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3504361321427171189L;
 
     public DataSourceAction(String s) {
         super(s);
@@ -37,5 +31,3 @@ public class DataSourceAction extends jmri.util.JmriJFrameAction {
     }
 
 }
-
-/* @(#)DataSourceAction.java */

--- a/java/src/jmri/jmrix/pricom/pockettester/MonitorAction.java
+++ b/java/src/jmri/jmrix/pricom/pockettester/MonitorAction.java
@@ -1,4 +1,3 @@
-// pricom.pockettester.MonitorAction.java
 package jmri.jmrix.pricom.pockettester;
 
 import java.awt.event.ActionEvent;
@@ -15,11 +14,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2002,2004
   */
 public abstract class MonitorAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4061133241777429055L;
 
     public MonitorAction(String s) {
         super(s);
@@ -47,6 +41,3 @@ public abstract class MonitorAction extends AbstractAction {
     private final static Logger log = LoggerFactory.getLogger(MonitorAction.class.getName());
 
 }
-
-
-/* @(#)MonitorAction.java */

--- a/java/src/jmri/jmrix/pricom/pockettester/MonitorFrame.java
+++ b/java/src/jmri/jmrix/pricom/pockettester/MonitorFrame.java
@@ -1,4 +1,3 @@
-// pricom.pockettester.MonitorFrame.java
 package jmri.jmrix.pricom.pockettester;
 
 
@@ -11,10 +10,6 @@ package jmri.jmrix.pricom.pockettester;
   */
 public class MonitorFrame extends jmri.jmrix.AbstractMonFrame implements DataListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 7060223518481154741L;
     static java.util.ResourceBundle rb
             = java.util.ResourceBundle.getBundle("jmri.jmrix.pricom.pockettester.TesterBundle");
 

--- a/java/src/jmri/jmrix/pricom/pockettester/PacketDataModel.java
+++ b/java/src/jmri/jmrix/pricom/pockettester/PacketDataModel.java
@@ -1,4 +1,3 @@
-// PacketDataModel.java
 package jmri.jmrix.pricom.pockettester;
 
 import java.util.Vector;
@@ -20,10 +19,6 @@ import org.slf4j.LoggerFactory;
   */
 public class PacketDataModel extends javax.swing.table.AbstractTableModel {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8398725528235582417L;
     static java.util.ResourceBundle rb
             = java.util.ResourceBundle.getBundle("jmri.jmrix.pricom.pockettester.TesterBundle");
     static public final int ADDRESSCOLUMN = 0;

--- a/java/src/jmri/jmrix/pricom/pockettester/PacketTableAction.java
+++ b/java/src/jmri/jmrix/pricom/pockettester/PacketTableAction.java
@@ -1,4 +1,3 @@
-// PacketTableAction.java
 package jmri.jmrix.pricom.pockettester;
 
 import java.awt.event.ActionEvent;
@@ -10,11 +9,6 @@ import javax.swing.AbstractAction;
  * @author	Bob Jacobsen Copyright (C) 2005
  */
 public abstract class PacketTableAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -755408790466810109L;
 
     public PacketTableAction(String s) {
         super(s);
@@ -40,6 +34,3 @@ public abstract class PacketTableAction extends AbstractAction {
     abstract void connect(DataListener l);
 
 }
-
-
-/* @(#)PacketTableAction.java */

--- a/java/src/jmri/jmrix/pricom/pockettester/PacketTableFrame.java
+++ b/java/src/jmri/jmrix/pricom/pockettester/PacketTableFrame.java
@@ -1,4 +1,3 @@
-// PacketTableFrame.java
 package jmri.jmrix.pricom.pockettester;
 
 import javax.swing.BoxLayout;
@@ -15,10 +14,6 @@ import javax.swing.table.TableRowSorter;
   */
 public class PacketTableFrame extends jmri.util.JmriJFrame implements DataListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 219225062863225988L;
     PacketDataModel model = new PacketDataModel();
     JTable table;
     JScrollPane scroll;

--- a/java/src/jmri/jmrix/pricom/pockettester/PocketTesterMenu.java
+++ b/java/src/jmri/jmrix/pricom/pockettester/PocketTesterMenu.java
@@ -1,4 +1,3 @@
-// PocketTesterMenu.java
 package jmri.jmrix.pricom.pockettester;
 
 import java.util.ResourceBundle;
@@ -10,11 +9,6 @@ import javax.swing.JMenu;
  * @author	Bob Jacobsen Copyright 2005
  */
 public class PocketTesterMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5075945103413996675L;
 
     public PocketTesterMenu(String name) {
         this();

--- a/java/src/jmri/jmrix/pricom/pockettester/StatusAction.java
+++ b/java/src/jmri/jmrix/pricom/pockettester/StatusAction.java
@@ -1,4 +1,3 @@
-// pricom.pockettester.StatusAction.java
 package jmri.jmrix.pricom.pockettester;
 
 import java.awt.event.ActionEvent;
@@ -14,11 +13,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2002,2004, 2005
   */
 public abstract class StatusAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -2710088536076104047L;
 
     public StatusAction(String s) {
         super(s);
@@ -46,6 +40,3 @@ public abstract class StatusAction extends AbstractAction {
     private final static Logger log = LoggerFactory.getLogger(StatusAction.class.getName());
 
 }
-
-
-/* @(#)StatusAction.java */

--- a/java/src/jmri/jmrix/pricom/pockettester/StatusFrame.java
+++ b/java/src/jmri/jmrix/pricom/pockettester/StatusFrame.java
@@ -1,4 +1,3 @@
-// pricom.pockettester.StatusFrame.java
 package jmri.jmrix.pricom.pockettester;
 
 import java.util.Hashtable;
@@ -16,11 +15,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2005
   */
 public class StatusFrame extends jmri.util.JmriJFrame implements DataListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8215226616579760539L;
 
     static java.util.ResourceBundle rb
             = java.util.ResourceBundle.getBundle("jmri.jmrix.pricom.pockettester.TesterBundle");

--- a/java/src/jmri/jmrix/tams/TamsSensor.java
+++ b/java/src/jmri/jmrix/tams/TamsSensor.java
@@ -14,11 +14,6 @@ import jmri.implementation.AbstractSensor;
  * @author Kevin Dickerson (C) 2009
  */
 public class TamsSensor extends AbstractSensor {
-
-    /**
-     * 
-     */
-    private static final long serialVersionUID = 1L;
     
     public TamsSensor(String systemName, String userName) {
         super(systemName, userName);

--- a/java/src/jmri/jmrix/tams/swing/monitor/TamsMonPane.java
+++ b/java/src/jmri/jmrix/tams/swing/monitor/TamsMonPane.java
@@ -18,8 +18,6 @@ import jmri.jmrix.tams.swing.TamsPanelInterface;
  */
 public class TamsMonPane extends jmri.jmrix.AbstractMonPane implements TamsListener, TamsPanelInterface {
 
-    private static final long serialVersionUID = -504993705019695728L;
-
     private TamsMessage tm; //Keeping a local copy of the latest TamsMessage for helping with decoding
 
     public TamsMonPane() {
@@ -111,11 +109,6 @@ public class TamsMonPane extends jmri.jmrix.AbstractMonPane implements TamsListe
      * Nested class to create one of these using old-style defaults
      */
     static public class Default extends jmri.jmrix.tams.swing.TamsNamedPaneAction {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 1991332397617036846L;
 
         public Default() {
             super(ResourceBundle.getBundle("jmri.jmrix.tams.TamsBundle").getString("CommandMonitor"),

--- a/java/src/jmri/jmrix/tams/swing/packetgen/PacketGenPanel.java
+++ b/java/src/jmri/jmrix/tams/swing/packetgen/PacketGenPanel.java
@@ -17,8 +17,6 @@ import jmri.util.StringUtil;
  */
 public class PacketGenPanel extends jmri.jmrix.tams.swing.TamsPanel implements TamsListener {
 
-    private static final long serialVersionUID = 1L;
-    
     // member declarations
     javax.swing.JLabel jLabel1 = new javax.swing.JLabel();
     javax.swing.JButton sendButton = new javax.swing.JButton();

--- a/java/src/jmri/jmrix/tams/swing/statusframe/StatusPanel.java
+++ b/java/src/jmri/jmrix/tams/swing/statusframe/StatusPanel.java
@@ -100,11 +100,6 @@ public class StatusPanel extends jmri.jmrix.tams.swing.TamsPanel implements Tams
      */
     static public class Default extends jmri.jmrix.tams.swing.TamsNamedPaneAction {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = 2919382089865855790L;
-
         public Default() {
             super(ResourceBundle.getBundle("jmri.jmrix.tams.TamsBundle").getString("MenuItemInfo"),
                     new jmri.util.swing.sdi.JmriJFrameInterface(),

--- a/java/src/jmri/jmrix/tmcc/ActiveFlag.java
+++ b/java/src/jmri/jmrix/tmcc/ActiveFlag.java
@@ -1,4 +1,3 @@
-// ActiveFlag.java
 package jmri.jmrix.tmcc;
 
 /**
@@ -24,6 +23,3 @@ abstract public class ActiveFlag {
         return flag;
     }
 }
-
-
-/* @(#)AbstractMRReply.java */

--- a/java/src/jmri/jmrix/tmcc/SerialAddress.java
+++ b/java/src/jmri/jmrix/tmcc/SerialAddress.java
@@ -1,4 +1,3 @@
-// SerialAddress.java
 package jmri.jmrix.tmcc;
 
 import org.slf4j.Logger;
@@ -353,5 +352,3 @@ public class SerialAddress {
 
     private final static Logger log = LoggerFactory.getLogger(SerialAddress.class.getName());
 }
-
-/* @(#)SerialAddress.java */

--- a/java/src/jmri/jmrix/tmcc/SerialConnectionTypeList.java
+++ b/java/src/jmri/jmrix/tmcc/SerialConnectionTypeList.java
@@ -1,4 +1,3 @@
-// SerialConnectionTypeList.java
 package jmri.jmrix.tmcc;
 
 /**

--- a/java/src/jmri/jmrix/tmcc/SerialInterface.java
+++ b/java/src/jmri/jmrix/tmcc/SerialInterface.java
@@ -1,4 +1,3 @@
-// SerialInterface.java
 package jmri.jmrix.tmcc;
 
 /**
@@ -16,6 +15,3 @@ public interface SerialInterface {
 
     void sendSerialMessage(SerialMessage m, SerialListener l);  // 2nd arg gets the reply
 }
-
-
-/* @(#)SerialInterface.java */

--- a/java/src/jmri/jmrix/tmcc/SerialListener.java
+++ b/java/src/jmri/jmrix/tmcc/SerialListener.java
@@ -1,4 +1,3 @@
-// SerialListener.java
 package jmri.jmrix.tmcc;
 
 /**
@@ -12,5 +11,3 @@ public interface SerialListener extends jmri.jmrix.AbstractMRListener {
 
     public void reply(SerialReply m);
 }
-
-/* @(#)SerialListener.java */

--- a/java/src/jmri/jmrix/tmcc/SerialMessage.java
+++ b/java/src/jmri/jmrix/tmcc/SerialMessage.java
@@ -1,4 +1,3 @@
-// SerialMessage.java
 package jmri.jmrix.tmcc;
 
 
@@ -80,5 +79,3 @@ public class SerialMessage extends jmri.jmrix.AbstractMRMessage {
         return (getElement(1) & 0xFF) * 256 + (getElement(2) & 0xFF);
     }
 }
-
-/* @(#)SerialMessage.java */

--- a/java/src/jmri/jmrix/tmcc/SerialPortController.java
+++ b/java/src/jmri/jmrix/tmcc/SerialPortController.java
@@ -14,4 +14,8 @@ public abstract class SerialPortController extends jmri.jmrix.AbstractSerialPort
     protected SerialPortController(SystemConnectionMemo connectionMemo) {
         super(connectionMemo);
     }
+    @Override
+    public TMCCSystemConnectionMemo getSystemConnectionMemo() {
+        return (TMCCSystemConnectionMemo) super.getSystemConnectionMemo();
+    }
 }

--- a/java/src/jmri/jmrix/tmcc/SerialPortController.java
+++ b/java/src/jmri/jmrix/tmcc/SerialPortController.java
@@ -1,4 +1,3 @@
-// SerialPortController.java
 package jmri.jmrix.tmcc;
 
 import jmri.jmrix.SystemConnectionMemo;
@@ -16,6 +15,3 @@ public abstract class SerialPortController extends jmri.jmrix.AbstractSerialPort
         super(connectionMemo);
     }
 }
-
-
-/* @(#)SerialPortController.java */

--- a/java/src/jmri/jmrix/tmcc/SerialReply.java
+++ b/java/src/jmri/jmrix/tmcc/SerialReply.java
@@ -1,4 +1,3 @@
-// SerialReply.java
 package jmri.jmrix.tmcc;
 
 
@@ -47,5 +46,3 @@ public class SerialReply extends jmri.jmrix.AbstractMRReply {
     }
 
 }
-
-/* @(#)SerialReply.java */

--- a/java/src/jmri/jmrix/tmcc/SerialThrottleManager.java
+++ b/java/src/jmri/jmrix/tmcc/SerialThrottleManager.java
@@ -52,6 +52,18 @@ public class SerialThrottleManager extends AbstractThrottleManager {
         return false;
     }
 
+    /**
+     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
+     */
+    @Deprecated
+    static public SerialThrottleManager instance() {
+        if (_instance == null) {
+            _instance = new SerialThrottleManager();
+        }
+        return _instance;
+    }
+    static private SerialThrottleManager _instance;
+    
     private final static Logger log = LoggerFactory.getLogger(SerialThrottleManager.class.getName());
 
 }

--- a/java/src/jmri/jmrix/tmcc/TMCCSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/tmcc/TMCCSystemConnectionMemo.java
@@ -1,10 +1,16 @@
 package jmri.jmrix.tmcc;
 
 import java.util.ResourceBundle;
+
+import jmri.*;
 import jmri.jmrix.SystemConnectionMemo;
 
 /**
  * Provide the minimal required SystemConnectionMemo.
+ * 
+ * This is still single-system code, using the turnout and throttle
+ * instance() methods. To migrate to multiple systems, add a configureManagers()
+ * method that creates local objects and remove the instance() variables.
  *
  * @author Randall Wood randall.h.wood@alexandriasoftware.com
  */
@@ -12,11 +18,91 @@ public class TMCCSystemConnectionMemo extends SystemConnectionMemo {
 
     public TMCCSystemConnectionMemo() {
         super("T", "Lionel TMCC"); // Prefix from SerialTurnoutManager, UserName from SerialThrottleManager
+        register(); // registers general type
+        InstanceManager.store(this, TMCCSystemConnectionMemo.class); // also register as specific type
     }
 
     @Override
     protected ResourceBundle getActionModelResourceBundle() {
         return null;
     }
+
+    /**
+     * Provides access to the TrafficController for this particular connection.
+     */
+    public SerialTrafficController getTrafficController() {
+        return trafficController;
+    }
+    private SerialTrafficController trafficController;
+
+    public void setTrafficController(SerialTrafficController tc) {
+        trafficController = tc;
+    }
+
+    /**
+     * Configure the common managers for tmcc connections. This puts the common
+     * manager config in one place.
+     */
+    @SuppressWarnings("deprecation")
+    public void configureManagers() {
+        log.debug("configureManagers");
+        jmri.InstanceManager.setTurnoutManager(jmri.jmrix.tmcc.SerialTurnoutManager.instance());
+        jmri.InstanceManager.setThrottleManager(jmri.jmrix.tmcc.SerialThrottleManager.instance());
+    }
+    
+    /**
+     * Tells which managers this provides by class
+     */
+    @SuppressWarnings("deprecation")
+    public boolean provides(Class<?> type) {
+        if (getDisabled()) {
+            return false;
+        }
+
+        if (type.equals(jmri.ThrottleManager.class)) {
+            return true;
+        }
+
+        if (type.equals(jmri.TurnoutManager.class)) {
+            return true;
+        }
+
+        return false; // nothing, by default
+    }
+
+    /**
+     * Provide manager by class
+     */
+    @SuppressWarnings({"unchecked", "deprecation"})
+    public <T> T get(Class<?> T) {
+        if (getDisabled()) {
+            return null;
+        }
+
+        if (T.equals(jmri.ThrottleManager.class)) {
+            return (T) getThrottleManager();
+        }
+
+        if (T.equals(jmri.TurnoutManager.class)) {
+            return (T) getTurnoutManager();
+        }
+        return null; // nothing, by default
+    }
+
+    public TurnoutManager getTurnoutManager() {
+        return SerialTurnoutManager.instance();
+    }
+
+    public ThrottleManager getThrottleManager() {
+        return SerialThrottleManager.instance();
+    }
+
+    public void dispose() {
+        trafficController = null;
+        InstanceManager.deregister(this, TMCCSystemConnectionMemo.class);
+
+        super.dispose();
+    }
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TMCCSystemConnectionMemo.class.getName());
 
 }

--- a/java/src/jmri/jmrix/tmcc/serialdriver/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/tmcc/serialdriver/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.tmcc.serialdriver;
 
 /**

--- a/java/src/jmri/jmrix/tmcc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/tmcc/serialdriver/SerialDriverAdapter.java
@@ -175,8 +175,7 @@ public class SerialDriverAdapter extends SerialPortController implements jmri.jm
         // connect to the traffic controller
         SerialTrafficController.instance().connectPort(this);
 
-        jmri.InstanceManager.setTurnoutManager(jmri.jmrix.tmcc.SerialTurnoutManager.instance());
-        jmri.InstanceManager.setThrottleManager(new jmri.jmrix.tmcc.SerialThrottleManager());
+        this.getSystemConnectionMemo().configureManagers();
 
         jmri.jmrix.tmcc.ActiveFlag.setActive();
     }

--- a/java/src/jmri/managers/ManagerDefaultSelector.java
+++ b/java/src/jmri/managers/ManagerDefaultSelector.java
@@ -153,8 +153,8 @@ public class ManagerDefaultSelector extends AbstractPreferencesManager {
     @CheckForNull
     public InitializationException configure() {
         InitializationException error = null;
-        log.debug("configure defaults into InstanceManager");
         List<SystemConnectionMemo> connList = InstanceManager.getList(SystemConnectionMemo.class);
+        log.debug("configure defaults into InstanceManager from {} memos, {} defaults", connList.size(), defaults.keySet().size());
         for (Class<?> c : defaults.keySet()) {
             // 'c' is the class to load
             String connectionName = this.defaults.get(c);
@@ -175,6 +175,8 @@ public class ManagerDefaultSelector extends AbstractPreferencesManager {
                         log.warn("SystemConnectionMemo for {} ({}) provides a null {} instance", memo.getUserName(), memo.getClass(), c);
                     }
                     break;
+                } else {
+                    log.debug("   memo name didn't match: {} vs {}", testName, connectionName);
                 }
             }
             /*


### PR DESCRIPTION
For #2081

The TMCC ThrottleManager was not being registered because the system implementation had only partially been updated to multi-system form.

This is still not a complete implementation, as lots of code is still relying on "instance()" calls for various managers instead of referring to a SystemConnection.  But it does have the registration correct.

Note:  Existing preference profiles may need to reset their defaults to use the TMCC throttle. if the default startup preference has captured the "Internal" setting.  Newly configured profiles should be OK.