### PR TITLE
Fix threading issue in NXFrameTest

### DIFF
--- a/java/test/jmri/jmrit/logix/NXFrameTest.java
+++ b/java/test/jmri/jmrit/logix/NXFrameTest.java
@@ -112,6 +112,10 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
         });
         jmri.util.JUnitUtil.releaseThread(this);
 
+        JUnitUtil.waitFor(() -> {
+            return Bundle.getMessage("Halted", block.getDisplayName(), "0").equals(warrant.getRunningMessage());
+        }, "Warrant processed sensor change");
+
         Assert.assertEquals("Halted/Resume message", warrant.getRunningMessage(),
                 Bundle.getMessage("Halted", block.getDisplayName(), "0"));
 

--- a/java/test/jmri/jmrit/logix/NXFrameTest.java
+++ b/java/test/jmri/jmrit/logix/NXFrameTest.java
@@ -18,26 +18,25 @@ import junit.extensions.jfcunit.eventdata.MouseEventData;
 import junit.extensions.jfcunit.finder.AbstractButtonFinder;
 import junit.extensions.jfcunit.finder.ComponentFinder;
 import junit.extensions.jfcunit.finder.DialogFinder;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
- * Tests for the NXFrame class, and it's interactions with Warrants. 
+ * Tests for the NXFrame class, and it's interactions with Warrants.
  *
- * @author  Pete Cressman 2015
- * 
+ * @author Pete Cressman 2015
+ *
  * todo - test error conditions
  */
-public class NXFrameTest extends jmri.util.SwingTestCase {    
+public class NXFrameTest extends jmri.util.SwingTestCase {
 
     OBlockManager _OBlockMgr;
     PortalManager _portalMgr;
     SensorManager _sensorMgr;
     TurnoutManager _turnoutMgr;
 
-
-    public void testGetInstance(){
+    public void testGetInstance() {
         NXFrame nxFrame = NXFrame.getInstance();
         Assert.assertNotNull("NXFrame", nxFrame);
     }
@@ -68,10 +67,10 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
         nxFrame.init();
         nxFrame.setVisible(true);
         nxFrame._maxSpeedBox.setText("0.30");
-        
+
         nxFrame._origin.blockBox.setText("OB0");
         nxFrame._destination.blockBox.setText("OB10");
-        
+
         pressButton(nxFrame, Bundle.getMessage("ButtonRunNX"));
         confirmJOptionPane(null, Bundle.getMessage("WarningTitle"), Bundle.getMessage("NoLoco"), "OK");
         nxFrame.setAddress("666");
@@ -80,8 +79,8 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
         pressButton(nxFrame, Bundle.getMessage("ButtonRunNX"));
 
         DialogFinder finder = new DialogFinder(Bundle.getMessage("DialogTitle"));
-        java.awt.Container pickDia = (java.awt.Container)finder.find();
-        Assert.assertNotNull("PickRoute Dialog not found", pickDia);               
+        java.awt.Container pickDia = (java.awt.Container) finder.find();
+        Assert.assertNotNull("PickRoute Dialog not found", pickDia);
         pressButton(pickDia, Bundle.getMessage("ButtonReview"));
         confirmJOptionPane(null, Bundle.getMessage("WarningTitle"), Bundle.getMessage("SelectRoute"), "OK");
 
@@ -98,54 +97,56 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
         WarrantTableFrame tableFrame = WarrantTableFrame.getInstance();
         Warrant warrant = tableFrame.getModel().getWarrantAt(0);
         OBlock block = _OBlockMgr.getBySystemName("OB0");
-        Assert.assertEquals("Waiting message", warrant.getRunningMessage(), 
+        Assert.assertEquals("Waiting message", warrant.getRunningMessage(),
                 Bundle.getMessage("waitForDelayStart", warrant.getTrainName(), block.getDisplayName()));
-        
-        Sensor sensor0 = _sensorMgr.getBySystemName("IS0");
-        Assert.assertNotNull("Senor IS0 not found", sensor0); 
 
-        jmri.util.ThreadingUtil.runOnLayout( ()->{
+        Sensor sensor0 = _sensorMgr.getBySystemName("IS0");
+        Assert.assertNotNull("Senor IS0 not found", sensor0);
+
+        jmri.util.ThreadingUtil.runOnLayout(() -> {
             try {
                 sensor0.setState(Sensor.ACTIVE);
-            } catch (jmri.JmriException e) { Assert.fail("Unexpected Exception: "+e); }
+            } catch (jmri.JmriException e) {
+                Assert.fail("Unexpected Exception: " + e);
+            }
         });
         jmri.util.JUnitUtil.releaseThread(this);
 
-        Assert.assertEquals("Halted/Resume message", warrant.getRunningMessage(), 
+        Assert.assertEquals("Halted/Resume message", warrant.getRunningMessage(),
                 Bundle.getMessage("Halted", block.getDisplayName(), "0"));
 
-        jmri.util.ThreadingUtil.runOnGUI( ()->{
+        jmri.util.ThreadingUtil.runOnGUI(() -> {
             warrant.controlRunTrain(Warrant.RESUME);
         });
         String[] route = {"IS1", "IS2", "IS3", "IS7", "IS5", "IS10"};
         Sensor sensor10 = _sensorMgr.getBySystemName("IS10");
         Assert.assertEquals("Train in last block", sensor10, runtimes(sensor10, route));
-        
+
         flushAWT();
         flushAWT();   // let calm down before running abort
-                
-        jmri.util.ThreadingUtil.runOnGUI( ()->{
+
+        jmri.util.ThreadingUtil.runOnGUI(() -> {
             warrant.controlRunTrain(Warrant.ABORT);
         });
         flushAWT();
-        
+
         // passed test - cleanup.  Do it here so failure leaves traces.
         TestHelper.disposeWindow(tableFrame, this);
-        ControlPanelEditor panel = (ControlPanelEditor)jmri.util.JmriJFrame.getFrame("NXWarrantTest");
+        ControlPanelEditor panel = (ControlPanelEditor) jmri.util.JmriJFrame.getFrame("NXWarrantTest");
         TestHelper.disposeWindow(panel, this);
 
         // Dialog has popped up, so handle that. First, locate it.
         List<JDialog> dialogList = new DialogFinder(null).findAll(panel);
         TestHelper.disposeWindow(dialogList.get(0), this);
-        
+
         // confirm one message logged
         jmri.util.JUnitAppender.assertWarnMessage("RosterSpeedProfile not found. Using default ThrottleFactor 0.75");
     }
-    
+
     private javax.swing.AbstractButton pressButton(java.awt.Container frame, String text) {
         AbstractButtonFinder buttonFinder = new AbstractButtonFinder(text);
         javax.swing.AbstractButton button = (javax.swing.AbstractButton) buttonFinder.find(frame, 0);
-        Assert.assertNotNull(text+" Button not found", button);
+        Assert.assertNotNull(text + " Button not found", button);
         getHelper().enterClickAndLeave(new MouseEventData(this, button));
         return button;
     }
@@ -154,22 +155,22 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
     private void confirmJOptionPane(java.awt.Container frame, String title, String message, String buttonLabel) {
         ComponentFinder finder = new ComponentFinder(JOptionPane.class);
         JOptionPane pane;
-        if (frame==null) {
-            pane = (JOptionPane)finder.find();
-            Assert.assertNotNull(title+" JOptionPane not found", pane);            
+        if (frame == null) {
+            pane = (JOptionPane) finder.find();
+            Assert.assertNotNull(title + " JOptionPane not found", pane);
         } else {
             List<JOptionPane> list = finder.findAll(frame);
-            Assert.assertNotNull(title+" JOptionPane not found", list);
-            Assert.assertTrue(title+" JOptionPane not found", list.size()==1);
+            Assert.assertNotNull(title + " JOptionPane not found", list);
+            Assert.assertTrue(title + " JOptionPane not found", list.size() == 1);
 //          java.util.Iterator iter = list.iterator();
             pane = list.get(0);
         }
-        if (message!=null) {
-            Assert.assertEquals(title+" JOptionPane message", message, pane.getMessage());            
+        if (message != null) {
+            Assert.assertEquals(title + " JOptionPane message", message, pane.getMessage());
         }
         pressButton(pane, buttonLabel);
     }
-        
+
     @SuppressWarnings("unchecked") // For types from DialogFinder().findAll(..)
     private static List<JRadioButton> getRadioButtons(java.awt.Container frame) {
         ComponentFinder finder = new ComponentFinder(JRadioButton.class);
@@ -179,8 +180,9 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
     }
 
     /**
-     * works through a list of sensors, activating one, then the next, then 
+     * works through a list of sensors, activating one, then the next, then
      * inactivating the first and continuing. Leaves last ACTIVE.
+     *
      * @param sensor - active start sensor
      * @return - active end sensor
      * @throws Exception
@@ -188,11 +190,11 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
     private Sensor runtimes(Sensor sensor, String[] sensors) throws Exception {
         flushAWT();
         _sensorMgr.getSensor(sensors[0]).setState(Sensor.ACTIVE);
-        for (int i=1; i<sensors.length; i++) {
+        for (int i = 1; i < sensors.length; i++) {
             flushAWT();
             _sensorMgr.getSensor(sensors[i]).setState(Sensor.ACTIVE);
-            flushAWT();           
-            _sensorMgr.getSensor(sensors[i-i]).setState(Sensor.INACTIVE);
+            flushAWT();
+            _sensorMgr.getSensor(sensors[i - i]).setState(Sensor.INACTIVE);
         }
         return sensor;
     }
@@ -218,7 +220,7 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
     protected void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         super.setUp();
-         // set the locale to US English
+        // set the locale to US English
         Locale.setDefault(Locale.ENGLISH);
         JUnitUtil.resetInstanceManager();
         JUnitUtil.initConfigureManager();


### PR DESCRIPTION
This addresses the first of two issues in #2449, and may improve the reliability of existing tests.