### PR TITLE
Prevent preventable NPE

### DIFF
--- a/java/src/jmri/jmrit/catalog/CatalogTreeModel.java
+++ b/java/src/jmri/jmrit/catalog/CatalogTreeModel.java
@@ -71,11 +71,12 @@ public class CatalogTreeModel extends DefaultTreeModel {
             
             if (sp == null) {
                 log.warn("unexpected null list() in insertResourceNodes from \"{}\"", pPath);
+                return;
             }
             
-            for (int i = 0; i < sp.length; i++) {
-                log.trace("Descend into resource: {}", sp[i]);
-                insertResourceNodes(sp[i], pPath + "/" + sp[i], newElement);
+            for (String item : sp) {
+                log.trace("Descend into resource: {}", item);
+                insertResourceNodes(item, pPath + "/" + item, newElement);
             }
         }
     }


### PR DESCRIPTION
Exit void method after warning against null object instead attempting to use object.

This was flagged in [Jenkins](http://jmri.tagadab.com/jenkins/job/Development/job/Findbugs/636/findbugsResult/HIGH/file.-468992277/source.-8809842731789589463/#66)