### PR TITLE
Updates OlcbConfigurationManager to use the OlcbInterface class.

### DIFF
--- a/java/src/jmri/jmrix/openlcb/OlcbConfigurationManager.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbConfigurationManager.java
@@ -22,6 +22,7 @@ import org.openlcb.NodeID;
 import org.openlcb.OlcbInterface;
 import org.openlcb.SimpleNodeIdentInfoReplyMessage;
 import org.openlcb.SimpleNodeIdentInfoRequestMessage;
+import org.openlcb.Version;
 import org.openlcb.can.AliasMap;
 import org.openlcb.can.CanFrame;
 import org.openlcb.can.CanFrameListener;
@@ -318,7 +319,10 @@ public class OlcbConfigurationManager extends jmri.jmrix.can.ConfigurationManage
         public void handleSimpleNodeIdentInfoRequest(SimpleNodeIdentInfoRequestMessage msg,
                                                      Connection sender) {
             if (msg.getDestNodeID().equals(nodeID)) {
-                getInterface().getOutputConnection().put(new SimpleNodeIdentInfoReplyMessage(nodeID, msg.getSourceNodeID(), content), this);
+                // Sending a SNIP reply to the bus crashes the library up to 0.7.7.
+                if (msg.getSourceNodeID().equals(nodeID) || (Version.major > 0 || Version.minor > 7 || Version.libMod > 7)) {
+                    getInterface().getOutputConnection().put(new SimpleNodeIdentInfoReplyMessage(nodeID, msg.getSourceNodeID(), content), this);
+                }
             }
         }
     }


### PR DESCRIPTION
This removes a lot of redundant code around initialization and message routing between openlcb.jar and jmri.jar.
Fixes problems such as JMRI not responding to VerifyNodeId and SimpleNodeInfo messages.
Fixes major problems around packet routing in case the OpenLCB Hub is used, e.g. https://github.com/openlcb/OpenLCB_Java/issues/7