### PR TITLE
Utf-8 fix

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1131,7 +1131,7 @@
     <!-- end of file-checking targets -->
 
     <target name="fixlineends" description="convert specific files to LF line ends">
-        <fixcrlf eol="unix" srcdir="." includes="
+        <fixcrlf eol="unix" srcdir="." encoding="UTF-8" includes="
             **/*.csh
             **/*.css
             **/*.df

--- a/xml/config/parts/WindowsMenu.xml
+++ b/xml/config/parts/WindowsMenu.xml
@@ -18,20 +18,20 @@
         <name xml:lang="it">Attive</name>
         <name xml:lang="de">Aktiv</name>
 		<name xml:lang="ca">Activa</name>
-        <name xml:lang="cs">AktivnÌ</name>
+        <name xml:lang="cs">Aktivn√≠</name>
         <node>
             <name>Sample Window 1</name>
             <name xml:lang="it">Finestra Esempio 1</name>
             <name xml:lang="de">Vorbildfenster 1</name>
 			<name xml:lang="ca">Finestra d'exemple 1</name>
-            <name xml:lang="cs">Uk·zkovÈ okno 1</name>
+            <name xml:lang="cs">Uk√°zkov√© okno 1</name>
         </node>
         <node>
             <name>Sample Window 2</name>
             <name xml:lang="it">Finestra Esempio 2</name>
             <name xml:lang="de">Vorbildfenster 2</name>
 			<name xml:lang="ca">Finestra d'exemple 2</name>
-            <name xml:lang="cs">Uk·zkovÈ okno 2</name>
+            <name xml:lang="cs">Uk√°zkov√© okno 2</name>
         </node>
     </node>
     <node
@@ -39,7 +39,7 @@
         <name xml:lang="it">Nuova Finestra PanelPro</name>
         <name xml:lang="de">Neues PanelPro Fenster</name>
 		<name xml:lang="ca">Nova Finestra del PanelPro</name>
-        <name xml:lang="cs">NovÈ okno PanelPro</name>
+        <name xml:lang="cs">Nov√© okno PanelPro</name>
         <adapter>apps.gui3.paned.PanelProAction</adapter>
     </node>
 </node>


### PR DESCRIPTION
Fix for failing file noted in #2511.

Update ant build file to force UTF-8 encoding in `fixlineends` task.