### PR TITLE
Fix layout editor properties file (Issue 2510)

### DIFF
--- a/java/src/jmri/jmrit/display/DisplayBundle.properties
+++ b/java/src/jmri/jmrit/display/DisplayBundle.properties
@@ -37,6 +37,7 @@ SelectLoco      = Select Loco
 EnterLocoMarker = Enter Loco Marker
 EnterLocoID     = Enter Loco ID (6 characters max)
 LocoID          = Loco ID
+OK             = OK
 setDockingLocation=Set Location for Docking
 dockIcon        = Dock
 

--- a/java/src/jmri/jmrit/display/DisplayBundle_cs.properties
+++ b/java/src/jmri/jmrit/display/DisplayBundle_cs.properties
@@ -41,7 +41,6 @@ SelectLoco      = Vybrat lokomotivu
 EnterLocoMarker = Zadat zna\u010dku lokomotivy
 EnterLocoID     = Zadat ID lokomotivy (max 6 znak\u016f)
 LocoID         = ID lokomotivy
-OK             = OK
 setDockingLocation=Nastavit um\u00edst\u011bn\u00ed pro st\u00e1n\u00ed
 dockIcon		= St\u00e1n\u00ed
 


### PR DESCRIPTION
Adds the "OK" string to the base properties file, removing it from the _cs file, to fix #2510.