### PR TITLE
Migrate headless checks from suite to test

### DIFF
--- a/java/test/jmri/jmrit/PackageTest.java
+++ b/java/test/jmri/jmrit/PackageTest.java
@@ -42,7 +42,7 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.jmrit.dispatcher.PackageTest.suite());
         suite.addTest(jmri.jmrit.display.PackageTest.suite());
         suite.addTest(jmri.jmrit.jython.PackageTest.suite());
-        suite.addTest(jmri.jmrit.log.PackageTest.suite());
+        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.log.PackageTest.class));
         suite.addTest(jmri.jmrit.logix.PackageTest.suite());
         suite.addTest(jmri.jmrit.operations.PackageTest.suite());
         suite.addTest(jmri.jmrit.progsupport.PackageTest.suite());

--- a/java/test/jmri/jmrit/ampmeter/PackageTest.java
+++ b/java/test/jmri/jmrit/ampmeter/PackageTest.java
@@ -28,9 +28,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/analogclock/PackageTest.java
+++ b/java/test/jmri/jmrit/analogclock/PackageTest.java
@@ -28,9 +28,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/audio/PackageTest.java
+++ b/java/test/jmri/jmrit/audio/PackageTest.java
@@ -29,8 +29,6 @@ public class PackageTest extends TestCase {
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
         suite.addTest(jmri.jmrit.audio.swing.PackageTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.audio.configurexml.PackageTest.class));
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
 
         return suite;
     }

--- a/java/test/jmri/jmrit/audio/swing/PackageTest.java
+++ b/java/test/jmri/jmrit/audio/swing/PackageTest.java
@@ -28,9 +28,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/dispatcher/DispatcherFrameTest.java
+++ b/java/test/jmri/jmrit/dispatcher/DispatcherFrameTest.java
@@ -1,11 +1,12 @@
 package jmri.jmrit.dispatcher;
 
+import java.awt.GraphicsEnvironment;
 import jmri.Scale;
 import jmri.util.JmriJFrame;
 import junit.extensions.jfcunit.TestHelper;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Swing jfcUnit tests for dispatcher options
@@ -15,8 +16,9 @@ import junit.framework.TestSuite;
 public class DispatcherFrameTest extends jmri.util.SwingTestCase {
 
     public void testShowAndClose() throws Exception {
-        new jmri.configurexml.ConfigXmlManager() {
-        }; // replace manager
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
 
         OptionsFile.setDefaultFileName("java/test/jmri/jmrit/dispatcher/dispatcheroptions.xml");  // exist?
 
@@ -88,12 +90,14 @@ public class DispatcherFrameTest extends jmri.util.SwingTestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() throws Exception {
         super.setUp();
         apps.tests.Log4JFixture.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
     }
 
+    @Override
     protected void tearDown() throws Exception {
         apps.tests.Log4JFixture.tearDown();
         super.tearDown();

--- a/java/test/jmri/jmrit/dispatcher/PackageTest.java
+++ b/java/test/jmri/jmrit/dispatcher/PackageTest.java
@@ -28,10 +28,7 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.jmrit.dispatcher.DispatcherTrainInfoTest.suite());
         suite.addTest(jmri.jmrit.dispatcher.DispatcherTrainInfoFileTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(jmri.jmrit.dispatcher.DispatcherFrameTest.suite());
-        }
+        suite.addTest(jmri.jmrit.dispatcher.DispatcherFrameTest.suite());
         return suite;
     }
 

--- a/java/test/jmri/jmrit/display/controlPanelEditor/PackageTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/PackageTest.java
@@ -27,9 +27,6 @@ public class PackageTest extends TestCase {
     public static Test suite() {
         TestSuite suite = new TestSuite("jmri.jmrit.display.controlPanelEditor");   // no tests in this class itself
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         suite.addTest(jmri.jmrit.display.controlPanelEditor.shape.PackageTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.display.controlPanelEditor.configurexml.PackageTest.class));

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/PackageTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/PackageTest.java
@@ -27,9 +27,6 @@ public class PackageTest extends TestCase {
     public static Test suite() {
         TestSuite suite = new TestSuite("jmri.jmrit.display.controlPanelEditor.shape");   // no tests in this class itself
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.display.controlPanelEditor.shape.configurexml.PackageTest.class));
 

--- a/java/test/jmri/jmrit/display/panelEditor/PackageTest.java
+++ b/java/test/jmri/jmrit/display/panelEditor/PackageTest.java
@@ -27,11 +27,6 @@ public class PackageTest extends TestCase {
     public static Test suite() {
         TestSuite suite = new TestSuite("jmri.jmrit.display.panelEditor");   // no tests in this class itself
 
-
-
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.display.panelEditor.configurexml.PackageTest.class));
 

--- a/java/test/jmri/jmrit/dualdecoder/PackageTest.java
+++ b/java/test/jmri/jmrit/dualdecoder/PackageTest.java
@@ -28,9 +28,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/jython/JythonWindowsTest.java
+++ b/java/test/jmri/jmrit/jython/JythonWindowsTest.java
@@ -1,10 +1,13 @@
 package jmri.jmrit.jython;
 
+import java.awt.GraphicsEnvironment;
 import javax.swing.JFrame;
+import org.junit.After;
 import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.netbeans.jemmy.operators.JFrameOperator;
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.jython tree
@@ -13,10 +16,12 @@ import junit.framework.TestSuite;
  *
  * @author	Bob Jacobsen Copyright 2009, 2016
  */
-public class JythonWindowsTest extends TestCase {
+public class JythonWindowsTest {
 
     // Really a check of Jython init, including the defaults file
+    @Test
     public void testExec() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         jmri.util.JUnitAppender.clearBacklog();
         // open output window
         JythonWindow outputWindow;  // actually an Action class
@@ -36,10 +41,10 @@ public class JythonWindowsTest extends TestCase {
         } catch (Exception e) {
             Assert.fail("exception during execution: " + e);
         }
-        
+
         // find, close output window
-        JFrame f = jmri.util.JmriJFrame.getFrame("Script Output");
-        Assert.assertTrue("found output frame", f != null);
+        JFrame f = JFrameOperator.waitJFrame("Script Output", true, true);
+        Assert.assertNotNull("found output frame", f);
         f.dispose();
 
         // error messages are a fail
@@ -48,42 +53,25 @@ public class JythonWindowsTest extends TestCase {
         }
     }
 
+    @Test
     public void testInput() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         new InputWindowAction().actionPerformed(null);
-        JFrame f = jmri.util.JmriJFrame.getFrame("Script Entry");
-        Assert.assertTrue("found input frame", f != null);
+        JFrame f = JFrameOperator.findJFrame("Script Entry", true, true);
+        Assert.assertNotNull("found input frame", f);
         f.dispose();
     }
 
-    // from here down is testing infrastructure
-    public JythonWindowsTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", JythonWindowsTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(JythonWindowsTest.class);
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    protected void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
-
-        super.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
     }
 
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         jmri.util.JUnitUtil.resetInstanceManager();
-        super.tearDown();
         apps.tests.Log4JFixture.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/jython/PackageTest.java
+++ b/java/test/jmri/jmrit/jython/PackageTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.jython;
 
+import junit.framework.JUnit4TestAdapter;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -26,21 +27,21 @@ public class PackageTest extends TestCase {
     public static Test suite() {
         TestSuite suite = new TestSuite("jmri.jmrit.jython.PackageTest");   // no tests in this class itself
 
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
+        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(JythonWindowsTest.suite());
-        }
+        suite.addTest(new JUnit4TestAdapter(JythonWindowsTest.class));
 
         suite.addTest(SampleScriptTest.suite());
         return suite;
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
     }
 
+    @Override
     protected void tearDown() {
         apps.tests.Log4JFixture.tearDown();
     }

--- a/java/test/jmri/jmrit/lcdclock/PackageTest.java
+++ b/java/test/jmri/jmrit/lcdclock/PackageTest.java
@@ -28,9 +28,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/log/Log4JTreePaneTest.java
+++ b/java/test/jmri/jmrit/log/Log4JTreePaneTest.java
@@ -1,0 +1,46 @@
+package jmri.jmrit.log;
+
+import java.awt.GraphicsEnvironment;
+import javax.swing.JFrame;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.netbeans.jemmy.operators.JFrameOperator;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Invokes complete set of tests in the jmri.jmrit.log tree
+ *
+ * @author	Bob Jacobsen Copyright 2003, 2010
+ */
+public class Log4JTreePaneTest {
+
+    @Test
+    public void testShow() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        LoggerFactory.getLogger("jmri.jmrix");
+        LoggerFactory.getLogger("apps.foo");
+        LoggerFactory.getLogger("jmri.util");
+
+        new jmri.util.swing.JmriNamedPaneAction("Log4J Tree",
+                new jmri.util.swing.sdi.JmriJFrameInterface(),
+                "jmri.jmrit.log.Log4JTreePane").actionPerformed(null);
+        JFrame f = JFrameOperator.waitJFrame(Bundle.getMessage("MenuItemLogTreeAction"), true, true);
+        Assert.assertNotNull(f);
+        f.dispose();
+    }
+
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        apps.tests.Log4JFixture.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        apps.tests.Log4JFixture.tearDown();
+    }
+
+}

--- a/java/test/jmri/jmrit/log/PackageTest.java
+++ b/java/test/jmri/jmrit/log/PackageTest.java
@@ -1,58 +1,17 @@
 package jmri.jmrit.log;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.slf4j.LoggerFactory;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    BundleTest.class,
+    Log4JTreePaneTest.class
+})
 /**
  * Invokes complete set of tests in the jmri.jmrit.log tree
  *
  * @author	Bob Jacobsen Copyright 2003, 2010
  */
-public class PackageTest extends TestCase {
-
-    public void testShow() {
-        LoggerFactory.getLogger("jmri.jmrix");
-        LoggerFactory.getLogger("apps.foo");
-        LoggerFactory.getLogger("jmri.util");
-
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-
-            try {
-                new jmri.util.swing.JmriNamedPaneAction("Log4J Tree",
-                        new jmri.util.swing.sdi.JmriJFrameInterface(),
-                        "jmri.jmrit.log.Log4JTreePane").actionPerformed(null);
-            } catch (Exception e) {
-            }
-        }
-    }
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
-    }
-
-    protected void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
-    }
-
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/nixieclock/PackageTest.java
+++ b/java/test/jmri/jmrit/nixieclock/PackageTest.java
@@ -28,9 +28,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/operations/automation/actions/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/automation/actions/PackageTest.java
@@ -28,9 +28,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/operations/router/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/router/PackageTest.java
@@ -28,10 +28,6 @@ public class PackageTest extends TestCase {
         suite.addTest(OperationsCarRouterTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/operations/trains/excel/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/trains/excel/PackageTest.java
@@ -27,10 +27,6 @@ public class PackageTest extends TestCase {
         TestSuite suite = new TestSuite("jmri.jmrit.operations.trains.excel.PackageTest"); // no tests in class itself
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/picker/PackageTest.java
+++ b/java/test/jmri/jmrit/picker/PackageTest.java
@@ -28,9 +28,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/signalling/PackageTest.java
+++ b/java/test/jmri/jmrit/signalling/PackageTest.java
@@ -29,8 +29,6 @@ public class PackageTest extends TestCase {
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
         suite.addTest(jmri.jmrit.signalling.entryexit.PackageTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.signalling.configurexml.PackageTest.class));
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
 
         return suite;
     }

--- a/java/test/jmri/jmrit/signalling/entryexit/PackageTest.java
+++ b/java/test/jmri/jmrit/signalling/entryexit/PackageTest.java
@@ -28,9 +28,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/simpleprog/PackageTest.java
+++ b/java/test/jmri/jmrit/simpleprog/PackageTest.java
@@ -28,9 +28,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/speedometer/PackageTest.java
+++ b/java/test/jmri/jmrit/speedometer/PackageTest.java
@@ -28,9 +28,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PackageTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PackageTest.java
@@ -32,9 +32,6 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.jmrit.symbolicprog.tabbedframe.CheckProgrammerNames.suite());
         suite.addTest(jmri.jmrit.symbolicprog.tabbedframe.QualifiedVarTest.suite());
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/turnoutoperations/PackageTest.java
+++ b/java/test/jmri/jmrit/turnoutoperations/PackageTest.java
@@ -28,9 +28,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrit/withrottle/PackageTest.java
+++ b/java/test/jmri/jmrit/withrottle/PackageTest.java
@@ -45,22 +45,20 @@ public class PackageTest extends TestCase {
         suite.addTest(WiThrottlePreferencesTest.suite());
         suite.addTest(WiThrottlesListModelTest.suite());
         suite.addTest(new JUnit4TestAdapter(WiThrottlePrefsPanelTest.class));
-
-        // These tests do not need this protection against headless exceptions
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(new JUnit4TestAdapter(ControllerFilterActionTest.class));
-            suite.addTest(new JUnit4TestAdapter(ControllerFilterFrameTest.class));
-            suite.addTest(new JUnit4TestAdapter(UserInterfaceTest.class));
-        }
+        suite.addTest(new JUnit4TestAdapter(ControllerFilterActionTest.class));
+        suite.addTest(new JUnit4TestAdapter(ControllerFilterFrameTest.class));
+        suite.addTest(new JUnit4TestAdapter(UserInterfaceTest.class));
 
         return suite;
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
     }
 
+    @Override
     protected void tearDown() {
         apps.tests.Log4JFixture.tearDown();
     }

--- a/java/test/jmri/jmrix/dccpp/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/PackageTest.java
@@ -51,10 +51,6 @@ public class PackageTest extends TestCase {
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.dccpp.simulator.PackageTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.dccpp.serial.PackageTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.dccpp.configurexml.PackageTest.class));
-	/*
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-	*/
 
         return suite;
     }

--- a/java/test/jmri/jmrix/ecos/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/PackageTest.java
@@ -32,8 +32,6 @@ public class PackageTest extends TestCase {
         suite.addTest(new junit.framework.JUnit4TestAdapter(EcosPreferencesTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(EcosSystemConnectionMemoTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ecos.utilities.PackageTest.class));
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
 
         return suite;
     }

--- a/java/test/jmri/jmrix/ecos/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/swing/PackageTest.java
@@ -33,9 +33,6 @@ public class PackageTest extends TestCase {
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ecos.swing.preferences.PackageTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ecos.swing.statusframe.PackageTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrix/ecos/swing/locodatabase/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/swing/locodatabase/PackageTest.java
@@ -27,9 +27,6 @@ public class PackageTest extends TestCase {
         TestSuite suite = new TestSuite("jmri.jmrix.ecos.swing.locodatabase.PackageTest");  // no tests in this class itself
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrix/lenz/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/PackageTest.java
@@ -66,9 +66,6 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.jmrix.lenz.swing.SwingTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.lenz.configurexml.PackageTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrix/loconet/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/PackageTest.java
@@ -82,9 +82,6 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.jmrix.loconet.locoio.PackageTest.suite());
         suite.addTest(jmri.jmrix.loconet.locogen.PackageTest.suite());
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrix/mrc/PackageTest.java
+++ b/java/test/jmri/jmrix/mrc/PackageTest.java
@@ -30,8 +30,6 @@ public class PackageTest extends TestCase {
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.mrc.simulator.PackageTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.mrc.serialdriver.PackageTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.mrc.configurexml.PackageTest.class));
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
 
         return suite;
     }

--- a/java/test/jmri/jmrix/mrc/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/mrc/swing/PackageTest.java
@@ -29,9 +29,6 @@ public class PackageTest extends TestCase {
 
         suite.addTest(jmri.jmrix.mrc.swing.packetgen.PackageTest.suite());
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrix/mrc/swing/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/mrc/swing/packetgen/PackageTest.java
@@ -27,9 +27,6 @@ public class PackageTest extends TestCase {
         TestSuite suite = new TestSuite("jmri.jmrix.mrc.swing.packetgen.PackageTest");  // no tests in this class itself
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrix/zimo/PackageTest.java
+++ b/java/test/jmri/jmrix/zimo/PackageTest.java
@@ -29,8 +29,6 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.jmrix.zimo.swing.PackageTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.zimo.mx1.PackageTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.zimo.mxulf.PackageTest.class));
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
 
         return suite;
     }

--- a/java/test/jmri/jmrix/zimo/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/zimo/swing/PackageTest.java
@@ -30,9 +30,6 @@ public class PackageTest extends TestCase {
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.zimo.swing.monitor.PackageTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 

--- a/java/test/jmri/jmrix/zimo/swing/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/zimo/swing/packetgen/PackageTest.java
@@ -29,9 +29,6 @@ public class PackageTest extends TestCase {
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1PacketGenPanelTest.class));
 
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-        }
-
         return suite;
     }
 


### PR DESCRIPTION
Additional migrations of headless checks from suite to test. Includes some conversion of test classes from TestCases to JUnit4 tests.