### PR TITLE
fix link from removed page in help

### DIFF
--- a/help/en/html/doc/Technical/I8N.shtml
+++ b/help/en/html/doc/Technical/I8N.shtml
@@ -184,7 +184,7 @@ Please see the
 for more info on how to include those characters in your .properties files, particularly the
 question on "How do I specify non-ASCII strings in a properties file?".
 <p>An example is the 
-<a href="https://github.com/JMRI/JMRI/blob/master/java/src/apps/AppsBundle_cs_CZ.properties">java/src/apps/AppsBundle_cs_CZ.properties</a> 
+<a href="https://github.com/JMRI/JMRI/blob/master/java/src/apps/AppsBundle_cs.properties">java/src/apps/AppsBundle_cs.properties</a> 
 file, which contains diacritical letters for the Czech translation. 
 <p>The "<a href="http://docs.oracle.com/javase/7/docs/technotes/tools/index.html#intl">native2ascii</a>" tool can help with this
 by converting special characters to the right sequences, but you must run your files through it before submitting them to JMRI.


### PR DESCRIPTION
In 4.5.6 was removed language _cs_CZ. Link to this property file is redirected to _cs.properties file.