### PR TITLE
NPE from call to getOccupancySensor().

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -567,6 +567,8 @@ public class LayoutBlock extends AbstractNamedBean implements java.beans.Propert
             }
         }
 
+        if (getOccupancySensor() == null)
+            return (UNKNOWN);
         if (getOccupancySensor().getKnownState() != occupiedSense) {
             return (EMPTY);
         } else if (getOccupancySensor().getKnownState() == occupiedSense) {


### PR DESCRIPTION
Added protection to return UNKNOWN if it is null.

If you edit a LE panel that has blocks, but not all of the blocks have sensors yet, you get a bunch of these NPE's.