### PR TITLE
More headless tests

### DIFF
--- a/java/test/jmri/jmrit/display/IconEditorWindowTest.java
+++ b/java/test/jmri/jmrit/display/IconEditorWindowTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.display;
 
+import java.awt.GraphicsEnvironment;
 import javax.swing.JComponent;
 import jmri.InstanceManager;
 import jmri.Light;
@@ -13,9 +14,10 @@ import jmri.util.JUnitUtil;
 import junit.extensions.jfcunit.TestHelper;
 import junit.extensions.jfcunit.eventdata.EventDataConstants;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
+import org.netbeans.jemmy.operators.JFrameOperator;
 
 /**
  * Swing jfcUnit tests for the SensorIcon
@@ -24,11 +26,13 @@ import junit.framework.TestSuite;
  */
 public class IconEditorWindowTest extends jmri.util.SwingTestCase {
 
-    Editor _editor;
+    Editor _editor = null;
     JComponent _panel;
 
     public void testSensorEditor() throws Exception {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         _editor.addSensorEditor();
 
         Editor.JFrameItem iconEditorFrame = _editor.getIconFrame("Sensor");
@@ -46,7 +50,7 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
         int x = 50;
         int y = 20;
 
-        jmri.util.ThreadingUtil.runOnGUI(()->{
+        jmri.util.ThreadingUtil.runOnGUI(() -> {
             icon.setLocation(x, y);
             _panel.repaint();
         });
@@ -76,7 +80,9 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
     }
 
     public void testRightTOEditor() throws Exception {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         Editor.JFrameItem iconEditorFrame = _editor.getIconFrame("RightTurnout");
         IconAdder iconEditor = iconEditorFrame.getEditor();
         Assert.assertNotNull(iconEditor);
@@ -92,7 +98,7 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
         int x = 30;
         int y = 10;
 
-        jmri.util.ThreadingUtil.runOnGUI(()->{
+        jmri.util.ThreadingUtil.runOnGUI(() -> {
             icon.setLocation(x, y);
             _panel.repaint();
         });
@@ -122,7 +128,9 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
     }
 
     public void testLeftTOEditor() throws Exception {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         Editor.JFrameItem iconEditorFrame = _editor.getIconFrame("LeftTurnout");
         IconAdder iconEditor = iconEditorFrame.getEditor();
         Assert.assertNotNull(iconEditor);
@@ -138,7 +146,7 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
         int x = 30;
         int y = 10;
 
-        jmri.util.ThreadingUtil.runOnGUI(()->{
+        jmri.util.ThreadingUtil.runOnGUI(() -> {
             icon.setLocation(x, y);
             _panel.repaint();
         });
@@ -168,7 +176,9 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
     }
 
     public void testLightEditor() throws Exception {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         Editor.JFrameItem iconEditorFrame = _editor.getIconFrame("Light");
         IconAdder iconEditor = iconEditorFrame.getEditor();
         Assert.assertNotNull(iconEditor);
@@ -211,7 +221,9 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
     }
 
     public void testSignalHeadEditor() throws Exception {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         Editor.JFrameItem iconEditorFrame = _editor.getIconFrame("SignalHead");
         IconAdder iconEditor = iconEditorFrame.getEditor();
         Assert.assertNotNull(iconEditor);
@@ -257,7 +269,9 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
     }
 
     public void testMemoryEditor() throws Exception {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         Editor.JFrameItem iconEditorFrame = _editor.getIconFrame("Memory");
         IconAdder iconEditor = iconEditorFrame.getEditor();
         Assert.assertNotNull(iconEditor);
@@ -344,7 +358,9 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
     }
 
     public void testReporterEditor() throws Exception {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         Editor.JFrameItem iconEditorFrame = _editor.getIconFrame("Reporter");
         IconAdder iconEditor = iconEditorFrame.getEditor();
         Assert.assertNotNull(iconEditor);
@@ -378,9 +394,6 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
         TestHelper.disposeWindow(iconEditorFrame, this);
     }
 
-    /**
-     * ***********************************************************************************
-     */
     // from here down is testing infrastructure
     public IconEditorWindowTest(String s) {
         super(s);
@@ -399,6 +412,7 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() throws Exception {
         super.setUp();
         apps.tests.Log4JFixture.setUp();
@@ -410,12 +424,12 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
         JUnitUtil.initInternalSignalHeadManager();
         JUnitUtil.initShutDownManager();
 
-        jmri.util.ThreadingUtil.runOnGUI(()->{
+        if (!GraphicsEnvironment.isHeadless()) {
             _editor = new PanelEditor("IconEditorTestPanel");
-            Assert.assertNotNull(_editor);
+            Assert.assertNotNull(JFrameOperator.waitJFrame("IconEditorTestPanel", true, true));
             _panel = _editor.getTargetPanel();
             Assert.assertNotNull(_panel);
-        });
+        }
     }
 
     @Override
@@ -425,7 +439,9 @@ public class IconEditorWindowTest extends jmri.util.SwingTestCase {
         // directly instead of closing the window through a WindowClosing()
         // event - this is the method called to delete a panel if a user
         // selects that in the Hide/Delete dialog triggered by WindowClosing().
-        _editor.dispose(true);
+        if (_editor != null) {
+            _editor.dispose(true);
+        }
 
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();

--- a/java/test/jmri/jmrit/display/IndicatorTurnoutIconTest.java
+++ b/java/test/jmri/jmrit/display/IndicatorTurnoutIconTest.java
@@ -1,9 +1,11 @@
 package jmri.jmrit.display;
 
+import java.awt.GraphicsEnvironment;
+import java.awt.event.WindowListener;
 import javax.swing.JFrame;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * IndicatorTurnoutIconTest.java
@@ -12,42 +14,46 @@ import junit.framework.TestSuite;
  */
 public class IndicatorTurnoutIconTest extends jmri.util.SwingTestCase {
 
-    IndicatorTurnoutIcon to;
-    jmri.jmrit.display.panelEditor.PanelEditor panel;
+    jmri.jmrit.display.panelEditor.PanelEditor panel = null;
 
     public void testEquals() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         JFrame jf = new JFrame();
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
 
-        to = new IndicatorTurnoutIcon(panel);
+        IndicatorTurnoutIcon to = new IndicatorTurnoutIcon(panel);
         jmri.Turnout turnout = jmri.InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
-        to.setTurnout(new jmri.NamedBeanHandle<jmri.Turnout>("IT1", turnout));
+        to.setTurnout(new jmri.NamedBeanHandle<>("IT1", turnout));
 
         IndicatorTurnoutIcon to2 = new IndicatorTurnoutIcon(panel);
         turnout = jmri.InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
-        to2.setTurnout(new jmri.NamedBeanHandle<jmri.Turnout>("IT1", turnout));
+        to2.setTurnout(new jmri.NamedBeanHandle<>("IT1", turnout));
 
         Assert.assertTrue("identity", to.equals(to));
         Assert.assertFalse("object (not content) equality", to2.equals(to));
-        Assert.assertFalse("object (not content) equality commutes", to.equals(to2));        
+        Assert.assertFalse("object (not content) equality commutes", to.equals(to2));
     }
 
     public void testClone() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         JFrame jf = new JFrame();
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
 
-        to = new IndicatorTurnoutIcon(panel);
+        IndicatorTurnoutIcon to = new IndicatorTurnoutIcon(panel);
         jmri.Turnout turnout = jmri.InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
-        to.setTurnout(new jmri.NamedBeanHandle<jmri.Turnout>("IT1", turnout));
+        to.setTurnout(new jmri.NamedBeanHandle<>("IT1", turnout));
 
         IndicatorTurnoutIcon to2 = (IndicatorTurnoutIcon) to.deepClone();
 
         Assert.assertFalse("clone object (not content) equality", to2.equals(to));
-        
+
         Assert.assertTrue("class type equality", to2.getClass().equals(to.getClass()));
-        
+
     }
-    
 
     // from here down is testing infrastructure
     public IndicatorTurnoutIconTest(String s) {
@@ -67,23 +73,28 @@ public class IndicatorTurnoutIconTest extends jmri.util.SwingTestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
-    
+
         jmri.util.JUnitUtil.resetInstanceManager();
-        panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test IndicatorTurnoutIcon Panel");
-        to = null;
+        if (!GraphicsEnvironment.isHeadless()) {
+            panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test IndicatorTurnoutIcon Panel");
+        }
     }
 
+    @Override
     protected void tearDown() {
         // now close panel window
-        java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
-        for (int i = 0; i < listeners.length; i++) {
-            panel.getTargetFrame().removeWindowListener(listeners[i]);
+        if (panel != null) {
+            java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
+            for (WindowListener listener : listeners) {
+                panel.getTargetFrame().removeWindowListener(listener);
+            }
+            junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         }
-        junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         apps.tests.Log4JFixture.tearDown();
     }
 
-	// static private Logger log = LoggerFactory.getLogger(IndicatorTurnoutIconTest.class.getName());
+    // static private Logger log = LoggerFactory.getLogger(IndicatorTurnoutIconTest.class.getName());
 }

--- a/java/test/jmri/jmrit/display/LinkingLabelTest.java
+++ b/java/test/jmri/jmrit/display/LinkingLabelTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.display;
 
+import java.awt.GraphicsEnvironment;
+import java.awt.event.WindowListener;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -12,16 +14,18 @@ import junit.framework.TestSuite;
  * Description:
  *
  * @author	Bob Jacobsen
-  */
+ */
 public class LinkingLabelTest extends jmri.util.SwingTestCase {
 
     LinkingLabel to = null;
     jmri.jmrit.display.panelEditor.PanelEditor panel;
 
     public void testShow() {
-        panel
-            = new jmri.jmrit.display.panelEditor.PanelEditor("LinkingLabel Test Panel");
-            
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
+        panel = new jmri.jmrit.display.panelEditor.PanelEditor("LinkingLabel Test Panel");
+
         JFrame jf = new jmri.util.JmriJFrame("LinkingLabel Target Panel");
         JPanel p = new JPanel();
         jf.getContentPane().add(p);
@@ -73,23 +77,25 @@ public class LinkingLabelTest extends jmri.util.SwingTestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
     }
 
+    @Override
     protected void tearDown() {
         if (panel != null) {
             // now close panel window
             java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
-            for (int i = 0; i < listeners.length; i++) {
-                panel.getTargetFrame().removeWindowListener(listeners[i]);
+            for (WindowListener listener : listeners) {
+                panel.getTargetFrame().removeWindowListener(listener);
             }
             junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
-            apps.tests.Log4JFixture.tearDown();
-            
+
             panel = null;
         }
+        apps.tests.Log4JFixture.tearDown();
     }
 
-	// static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
+    // static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
 }

--- a/java/test/jmri/jmrit/display/MemoryIconTest.java
+++ b/java/test/jmri/jmrit/display/MemoryIconTest.java
@@ -2,7 +2,9 @@ package jmri.jmrit.display;
 
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.GraphicsEnvironment;
 import java.awt.Point;
+import java.awt.event.WindowListener;
 import java.awt.image.BufferedImage;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
@@ -10,9 +12,9 @@ import javax.swing.SwingUtilities;
 import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
 import junit.extensions.jfcunit.finder.ComponentFinder;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,20 +24,21 @@ import org.slf4j.LoggerFactory;
  * Description:
  *
  * @author	Bob Jacobsen Copyright 2007, 2015
-  */
+ */
 public class MemoryIconTest extends jmri.util.SwingTestCase {
 
-    MemoryIcon to = null;
-
-    jmri.jmrit.display.panelEditor.PanelEditor panel;
+    jmri.jmrit.display.panelEditor.PanelEditor panel = null;
 
     public void testShowContent() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         JFrame jf = new JmriJFrame();
         jf.setTitle("Expect \"Data Data\" as text");
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
         jf.getContentPane().setBackground(Color.white);
 
-        to = new MemoryIcon("MemoryTest1", panel);
+        MemoryIcon to = new MemoryIcon("MemoryTest1", panel);
         jf.getContentPane().add(to);
         to.getPopupUtility().setBackgroundColor(Color.white);
 
@@ -50,12 +53,12 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
         jf.setVisible(true);
         flushAWT();
 
-        int[] colors = getColor("Expect \"Data Data\" as text","| Expect \"Data Data\" as text",0,6,10);
-        int r = ((colors[1]>>16)&0xFF)+((colors[2]>>16)&0xFF)+((colors[3]>>16)&0xFF)+((colors[4]>>16)&0xFF);
-        int g = ((colors[1]>>8)&0xFF)+((colors[2]>>8)&0xFF)+((colors[3]>>8)&0xFF)+((colors[4]>>8)&0xFF);
-        int b = ((colors[1])&0xFF)+((colors[2])&0xFF)+((colors[3])&0xFF)+((colors[4])&0xFF);
-        Assert.assertTrue("Expect gray/black text", r==g & g==b); // gray pixels
-        Assert.assertTrue("Expect blacker than grey", r<4*0xee); // gray pixels
+        int[] colors = getColor("Expect \"Data Data\" as text", "| Expect \"Data Data\" as text", 0, 6, 10);
+        int r = ((colors[1] >> 16) & 0xFF) + ((colors[2] >> 16) & 0xFF) + ((colors[3] >> 16) & 0xFF) + ((colors[4] >> 16) & 0xFF);
+        int g = ((colors[1] >> 8) & 0xFF) + ((colors[2] >> 8) & 0xFF) + ((colors[3] >> 8) & 0xFF) + ((colors[4] >> 8) & 0xFF);
+        int b = ((colors[1]) & 0xFF) + ((colors[2]) & 0xFF) + ((colors[3]) & 0xFF) + ((colors[4]) & 0xFF);
+        Assert.assertTrue("Expect gray/black text", r == g & g == b); // gray pixels
+        Assert.assertTrue("Expect blacker than grey", r < 4 * 0xee); // gray pixels
 
         if (System.getProperty("jmri.demo", "false").equals("false")) {
             jf.setVisible(false);
@@ -64,13 +67,16 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
     }
 
     public void testShowBlank() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         log.debug("testShowBlank");
         JFrame jf = new JmriJFrame();
         jf.setTitle("Expect blank");
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
         jf.getContentPane().setBackground(Color.white);
 
-        to = new MemoryIcon("MemoryTest2", panel);
+        MemoryIcon to = new MemoryIcon("MemoryTest2", panel);
         jf.getContentPane().add(to);
         to.getPopupUtility().setBackgroundColor(Color.white);
 
@@ -84,9 +90,9 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
         jf.setVisible(true);
         flushAWT();
 
-        int[] colors = getColor("Expect blank","| Expect blank",0,6,10);
+        int[] colors = getColor("Expect blank", "| Expect blank", 0, 6, 10);
         //for (int i=0; i< 10; i++) System.out.println("   "+String.format("0x%8s", Integer.toHexString(colors[i])).replace(' ', '0'));
-        boolean white = (colors[3]==0xffffffff)&&(colors[4]==0xffffffff);
+        boolean white = (colors[3] == 0xffffffff) && (colors[4] == 0xffffffff);
         Assert.assertTrue("Expect white pixels", white);
 
         if (System.getProperty("jmri.demo", "false").equals("false")) {
@@ -97,12 +103,15 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
     }
 
     public void testShowEmpty() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         JFrame jf = new JmriJFrame();
         jf.setTitle("Expect empty");
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
         jf.getContentPane().setBackground(Color.white);
 
-        to = new MemoryIcon("MemoryTest3", panel);
+        MemoryIcon to = new MemoryIcon("MemoryTest3", panel);
         jf.getContentPane().add(to);
         to.getPopupUtility().setBackgroundColor(Color.white);
 
@@ -117,8 +126,8 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
         jf.setVisible(true);
         flushAWT();
 
-        int colors[] = getColor("Expect empty","| Expect empty",0,6,10);
-        Assert.assertTrue("Expect red X", (colors[3]==0xff800000)||(colors[4]==0xff800000)||(colors[5]==0xff800000));
+        int colors[] = getColor("Expect empty", "| Expect empty", 0, 6, 10);
+        Assert.assertTrue("Expect red X", (colors[3] == 0xff800000) || (colors[4] == 0xff800000) || (colors[5] == 0xff800000));
 
         if (System.getProperty("jmri.demo", "false").equals("false")) {
             jf.setVisible(false);
@@ -130,19 +139,19 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
     int[] getColor(String frameName, String label, int x, int y, int n) {
         // Find window by name
         JmriJFrame frame = JmriJFrame.getFrame(frameName);
-        Assert.assertNotNull("frame: "+frameName, frame);
+        Assert.assertNotNull("frame: " + frameName, frame);
 
         // find label within that
         ComponentFinder finder = new ComponentFinder(MemoryIcon.class);
         // FIXME: finder.findAll returns an untyped list, so we have issues with casting
         @SuppressWarnings("rawtypes")
         java.util.List list = finder.findAll(frame);
-        Assert.assertNotNull("list: "+frameName, list);
-        Assert.assertTrue("length: "+frameName+": "+list.size(), list.size()>0);
+        Assert.assertNotNull("list: " + frameName, list);
+        Assert.assertTrue("length: " + frameName + ": " + list.size(), list.size() > 0);
 
         // find a point in mid-center of memory icon - location choosen by
         // looking at v4.0.1 on Mac
-        Point p = SwingUtilities.convertPoint(((JComponent)list.get(0)),x,y,frame);
+        Point p = SwingUtilities.convertPoint(((JComponent) list.get(0)), x, y, frame);
 
         // check pixel color (from http://stackoverflow.com/questions/13307962/how-to-get-the-color-of-a-point-in-a-jpanel )
         BufferedImage image = new BufferedImage(400, 300, BufferedImage.TYPE_4BYTE_ABGR);
@@ -151,8 +160,8 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
 
         // display a sweep of color
         int[] colors = new int[n];
-        for (int i = 0; i<n; i++) {
-            int color = image.getRGB(p.x+i,p.y);
+        for (int i = 0; i < n; i++) {
+            int color = image.getRGB(p.x + i, p.y);
             //System.err.println(" "+i+" "+String.format("0x%8s", Integer.toHexString(color)).replace(' ', '0'));
             colors[i] = color;
         }
@@ -179,25 +188,31 @@ public class MemoryIconTest extends jmri.util.SwingTestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() throws Exception {
         super.setUp();
         apps.tests.Log4JFixture.setUp();
         JUnitUtil.resetInstanceManager();
         jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
-        panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test MemoryIcon Panel");
+        if (!GraphicsEnvironment.isHeadless()) {
+            panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test MemoryIcon Panel");
+        }
     }
 
+    @Override
     protected void tearDown() throws Exception {
         // now close panel window
-        java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
-        for (int i = 0; i < listeners.length; i++) {
-            panel.getTargetFrame().removeWindowListener(listeners[i]);
+        if (panel != null) {
+            java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
+            for (WindowListener listener : listeners) {
+                panel.getTargetFrame().removeWindowListener(listener);
+            }
+            junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         }
-        junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         super.tearDown();
         apps.tests.Log4JFixture.tearDown();
         JUnitUtil.resetInstanceManager();
     }
 
-	static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
+    static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
 }

--- a/java/test/jmri/jmrit/display/MemorySpinnerIconTest.java
+++ b/java/test/jmri/jmrit/display/MemorySpinnerIconTest.java
@@ -1,9 +1,11 @@
 package jmri.jmrit.display;
 
+import java.awt.GraphicsEnvironment;
+import java.awt.event.WindowListener;
 import jmri.util.JmriJFrame;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * MemorySpinnerIconTest.java
@@ -11,7 +13,7 @@ import junit.framework.TestSuite;
  * Description:
  *
  * @author	Bob Jacobsen Copyright 2009
-  */
+ */
 public class MemorySpinnerIconTest extends jmri.util.SwingTestCase {
 
     MemorySpinnerIcon tos1 = null;
@@ -21,9 +23,12 @@ public class MemorySpinnerIconTest extends jmri.util.SwingTestCase {
     MemorySpinnerIcon toi2 = null;
     MemorySpinnerIcon toi3 = null;
 
-    jmri.jmrit.display.panelEditor.PanelEditor panel;
+    jmri.jmrit.display.panelEditor.PanelEditor panel = null;
 
     public void testShow() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         JmriJFrame jf = new JmriJFrame();
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
 
@@ -44,7 +49,7 @@ public class MemorySpinnerIconTest extends jmri.util.SwingTestCase {
 
         toi1.setMemory("IM2");
         toi2.setMemory("IM2");
-        jmri.InstanceManager.memoryManagerInstance().getMemory("IM2").setValue(Integer.valueOf(10));
+        jmri.InstanceManager.memoryManagerInstance().getMemory("IM2").setValue(10);
 
         tos3 = new MemorySpinnerIcon(panel);
         jf.getContentPane().add(tos3);
@@ -52,8 +57,8 @@ public class MemorySpinnerIconTest extends jmri.util.SwingTestCase {
         jf.getContentPane().add(toi3);
         tos3.setMemory("IM1");
         toi3.setMemory("IM2");
-        jmri.InstanceManager.memoryManagerInstance().getMemory("IM1").setValue(new Float(11.58F));
-        jmri.InstanceManager.memoryManagerInstance().getMemory("IM2").setValue(new Double(0.89));
+        jmri.InstanceManager.memoryManagerInstance().getMemory("IM1").setValue(11.58F);
+        jmri.InstanceManager.memoryManagerInstance().getMemory("IM2").setValue(0.89);
         tos1.setMemory("IM1");
         Assert.assertEquals("Spinner 1", "12", tos1.getValue());
         tos2.setMemory("IM2");
@@ -61,7 +66,7 @@ public class MemorySpinnerIconTest extends jmri.util.SwingTestCase {
 
         jf.pack();
         jf.setVisible(true);
-        
+
         if (!System.getProperty("jmri.demo", "false").equals("false")) {
             jf.setVisible(false);
         }
@@ -86,21 +91,27 @@ public class MemorySpinnerIconTest extends jmri.util.SwingTestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
-        
-        panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test MemorySpinnerIcon Panel");
+
+        if (!GraphicsEnvironment.isHeadless()) {
+            panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test MemorySpinnerIcon Panel");
+        }
     }
 
+    @Override
     protected void tearDown() {
         // now close panel window
-        java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
-        for (int i = 0; i < listeners.length; i++) {
-            panel.getTargetFrame().removeWindowListener(listeners[i]);
+        if (panel != null) {
+            java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
+            for (WindowListener listener : listeners) {
+                panel.getTargetFrame().removeWindowListener(listener);
+            }
+            junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         }
-        junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         apps.tests.Log4JFixture.tearDown();
     }
 
-	// static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
+    // static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
 }

--- a/java/test/jmri/jmrit/display/PackageTest.java
+++ b/java/test/jmri/jmrit/display/PackageTest.java
@@ -27,33 +27,26 @@ public class PackageTest extends TestCase {
     // test suite from all defined tests
     public static Test suite() {
         TestSuite suite = new TestSuite("jmri.jmrit.display");   // no tests in this class itself
-
-        suite.addTest(jmri.jmrit.display.SchemaTest.suite());
-
-        suite.addTest(jmri.jmrit.display.PositionableLabelTest.suite());
-
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(jmri.jmrit.display.LinkingLabelTest.suite());
-            suite.addTest(jmri.jmrit.display.MemoryIconTest.suite());
-            suite.addTest(jmri.jmrit.display.MemorySpinnerIconTest.suite());
-            suite.addTest(jmri.jmrit.display.PanelEditorTest.suite());
-            suite.addTest(jmri.jmrit.display.ReporterIconTest.suite());
-            suite.addTest(jmri.jmrit.display.RpsPositionIconTest.suite());
-            suite.addTest(jmri.jmrit.display.SensorIconWindowTest.suite());
-            suite.addTest(jmri.jmrit.display.SignalMastIconTest.suite());
-            suite.addTest(jmri.jmrit.display.SignalSystemTest.suite());
-            suite.addTest(jmri.jmrit.display.TurnoutIconWindowTest.suite());
-            suite.addTest(jmri.jmrit.display.TurnoutIconTest.suite());
-            suite.addTest(jmri.jmrit.display.IndicatorTurnoutIconTest.suite());
-            suite.addTest(jmri.jmrit.display.IconEditorWindowTest.suite());
-        }
-
+        suite.addTest(SchemaTest.suite());
+        suite.addTest(PositionableLabelTest.suite());
+        suite.addTest(LinkingLabelTest.suite());
+        suite.addTest(MemoryIconTest.suite());
+        suite.addTest(MemorySpinnerIconTest.suite());
+        suite.addTest(new JUnit4TestAdapter(PanelEditorTest.class));
+        suite.addTest(ReporterIconTest.suite());
+        suite.addTest(RpsPositionIconTest.suite());
+        suite.addTest(SensorIconWindowTest.suite());
+        suite.addTest(SignalMastIconTest.suite());
+        suite.addTest(SignalSystemTest.suite());
+        suite.addTest(TurnoutIconWindowTest.suite());
+        suite.addTest(TurnoutIconTest.suite());
+        suite.addTest(IndicatorTurnoutIconTest.suite());
+        suite.addTest(IconEditorWindowTest.suite());
         suite.addTest(jmri.jmrit.display.configurexml.PackageTest.suite());
         suite.addTest(jmri.jmrit.display.layoutEditor.PackageTest.suite());
         suite.addTest(jmri.jmrit.display.panelEditor.PackageTest.suite());
         suite.addTest(new JUnit4TestAdapter(jmri.jmrit.display.palette.PackageTest.class));
         suite.addTest(jmri.jmrit.display.controlPanelEditor.PackageTest.suite());
-
         suite.addTest(new JUnit4TestAdapter(BundleTest.class));
         suite.addTest(new JUnit4TestAdapter(SensorTextEditTest.class));
         suite.addTest(new JUnit4TestAdapter(AnalogClock2DisplayTest.class));
@@ -75,15 +68,16 @@ public class PackageTest extends TestCase {
         suite.addTest(new JUnit4TestAdapter(SlipIconAdderTest.class));
         suite.addTest(new JUnit4TestAdapter(SlipTurnoutIconTest.class));
         suite.addTest(new JUnit4TestAdapter(SlipTurnoutTextEditTest.class));
-
         return suite;
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
     }
 
+    @Override
     protected void tearDown() {
         apps.tests.Log4JFixture.tearDown();
     }

--- a/java/test/jmri/jmrit/display/PanelEditorTest.java
+++ b/java/test/jmri/jmrit/display/PanelEditorTest.java
@@ -1,11 +1,13 @@
 package jmri.jmrit.display;
 
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import jmri.ConfigureManager;
 import jmri.InstanceManager;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * PanelEditorTest.java
@@ -13,54 +15,39 @@ import junit.framework.TestSuite;
  * Description:
  *
  * @author	Bob Jacobsen
-  */
-public class PanelEditorTest extends TestCase {
+ */
+public class PanelEditorTest {
 
-    TurnoutIcon to = null;
-
+    @Test
     public void testShow() throws Exception {
-
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // load and display
         File f = new File("java/test/jmri/jmrit/display/verify/PanelEditorTest1.xml");
         InstanceManager.getDefault(ConfigureManager.class).load(f);
 
     }
 
+    @Test
     public void testShow2() throws Exception {
-
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // load and display
         File f = new File("java/test/jmri/jmrit/display/configurexml/load/OneOfEach.xml");
         InstanceManager.getDefault(ConfigureManager.class).load(f);
 
     }
 
+    @Test
     public void testShow3() throws Exception {
-
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // load and display
         File f = new File("java/test/jmri/jmrit/display/configurexml/load/OneOfEach.3.3.3.xml");
         InstanceManager.getDefault(ConfigureManager.class).load(f);
 
     }
 
-    // from here down is testing infrastructure
-    public PanelEditorTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PanelEditorTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PanelEditorTest.class);
-        return suite;
-    }
-
     // The minimal setup for log4J
-    protected void setUp() {
+    @Before
+    public void setUp() {
         apps.tests.Log4JFixture.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();
@@ -68,9 +55,10 @@ public class PanelEditorTest extends TestCase {
         jmri.util.JUnitUtil.initConfigureManager();
     }
 
-    protected void tearDown() {
+    @After
+    public void tearDown() {
         apps.tests.Log4JFixture.tearDown();
     }
 
-	// static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
+    // static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
 }

--- a/java/test/jmri/jmrit/display/ReporterIconTest.java
+++ b/java/test/jmri/jmrit/display/ReporterIconTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.display;
 
+import java.awt.GraphicsEnvironment;
+import java.awt.event.WindowListener;
 import javax.swing.JFrame;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -13,13 +15,16 @@ import junit.framework.TestSuite;
  * Description:
  *
  * @author	Bob Jacobsen Copyright 2007
-  */
+ */
 public class ReporterIconTest extends jmri.util.SwingTestCase {
 
     ReporterIcon to = null;
     jmri.jmrit.display.panelEditor.PanelEditor panel;
 
     public void testShowSysName() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         JFrame jf = new JFrame();
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
 
@@ -45,6 +50,9 @@ public class ReporterIconTest extends jmri.util.SwingTestCase {
     }
 
     public void testShowNumericAddress() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         JFrame jf = new JFrame();
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
 
@@ -86,21 +94,26 @@ public class ReporterIconTest extends jmri.util.SwingTestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
-
-        panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test ReporterIcon Panel");
+        if (!GraphicsEnvironment.isHeadless()) {
+            panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test ReporterIcon Panel");
+        }
     }
 
+    @Override
     protected void tearDown() {
         // now close panel window
-        java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
-        for (int i = 0; i < listeners.length; i++) {
-            panel.getTargetFrame().removeWindowListener(listeners[i]);
+        if (panel != null) {
+            java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
+            for (WindowListener listener : listeners) {
+                panel.getTargetFrame().removeWindowListener(listener);
+            }
+            junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         }
-        junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         apps.tests.Log4JFixture.tearDown();
     }
 
-	// static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
+    // static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
 }

--- a/java/test/jmri/jmrit/display/RpsPositionIconTest.java
+++ b/java/test/jmri/jmrit/display/RpsPositionIconTest.java
@@ -1,71 +1,65 @@
 package jmri.jmrit.display;
 
+import java.awt.GraphicsEnvironment;
+import java.awt.event.WindowListener;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import jmri.jmrix.rps.Measurement;
 import jmri.jmrix.rps.Reading;
 import jmri.util.JmriJFrame;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the RpsIcon class.
  *
  * @author	Bob Jacobsen Copyright 2008
-  */
+ */
 public class RpsPositionIconTest extends jmri.util.SwingTestCase {
 
-    RpsPositionIcon rpsIcon;
-    jmri.jmrit.display.panelEditor.PanelEditor panel;
+    jmri.jmrit.display.panelEditor.PanelEditor panel = null;
 
     public void testShow() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         JmriJFrame jf = new JmriJFrame("RpsPositionIcon Test");
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
 
-        rpsIcon = new RpsPositionIcon(panel);
+        RpsPositionIcon rpsIcon = new RpsPositionIcon(panel);
         jf.getContentPane().add(rpsIcon);
 
         jmri.util.JUnitUtil.resetInstanceManager();
 
         // test buttons
         JButton originButton = new JButton("Set 0,0");
-        originButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                measButtonPushed(0., 0.);
-            }
+        originButton.addActionListener((java.awt.event.ActionEvent e) -> {
+            measButtonPushed(0., 0., rpsIcon);
         });
         jf.getContentPane().add(originButton);
 
         JButton tentenButton = new JButton("Set 10,10");
-        tentenButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                measButtonPushed(10., 10.);
-            }
+        tentenButton.addActionListener((java.awt.event.ActionEvent e) -> {
+            measButtonPushed(10., 10., rpsIcon);
         });
         jf.getContentPane().add(tentenButton);
 
         JButton fivetenButton = new JButton("Set 5,10");
-        fivetenButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                measButtonPushed(5., 10.);
-            }
+        fivetenButton.addActionListener((java.awt.event.ActionEvent e) -> {
+            measButtonPushed(5., 10., rpsIcon);
         });
         jf.getContentPane().add(fivetenButton);
 
         JButton loco21Button = new JButton("Loco 21");
-        loco21Button.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                locoButtonPushed("21");
-            }
+        loco21Button.addActionListener((java.awt.event.ActionEvent e) -> {
+            locoButtonPushed("21");
         });
         jf.getContentPane().add(loco21Button);
 
         JButton loco33Button = new JButton("Loco 33");
-        loco33Button.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                locoButtonPushed("33");
-            }
+        loco33Button.addActionListener((java.awt.event.ActionEvent e) -> {
+            locoButtonPushed("33");
         });
         jf.getContentPane().add(loco33Button);
 
@@ -81,7 +75,7 @@ public class RpsPositionIconTest extends jmri.util.SwingTestCase {
     String id = "20";
 
     // animate the visible frame
-    public void measButtonPushed(double x, double y) {
+    public void measButtonPushed(double x, double y, RpsPositionIcon rpsIcon) {
         Reading loco = new Reading(id, null);
         Measurement m = new Measurement(loco, x, y, 0.0, 0.133, 0, "source");
         rpsIcon.notify(m);
@@ -90,13 +84,6 @@ public class RpsPositionIconTest extends jmri.util.SwingTestCase {
     public void locoButtonPushed(String newID) {
         id = newID;
     }
-
-//    test order isn't guaranteed!
-//    public void testXFrameCreation() {
-//        JFrame f = jmri.util.JmriJFrame.getFrame("RpsPositionIcon Test");
-//        Assert.assertTrue("found frame", f != null);
-//        f.dispose();
-//    }
 
     // from here down is testing infrastructure
     public RpsPositionIconTest(String s) {
@@ -116,21 +103,26 @@ public class RpsPositionIconTest extends jmri.util.SwingTestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
-        
-        panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test RpsPositionIcon Panel");
+        if (!GraphicsEnvironment.isHeadless()) {
+            panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test RpsPositionIcon Panel");
+        }
     }
 
+    @Override
     protected void tearDown() {
         // now close panel window
-        java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
-        for (int i = 0; i < listeners.length; i++) {
-            panel.getTargetFrame().removeWindowListener(listeners[i]);
+        if (panel != null) {
+            java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
+            for (WindowListener listener : listeners) {
+                panel.getTargetFrame().removeWindowListener(listener);
+            }
+            junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         }
-        junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         apps.tests.Log4JFixture.tearDown();
     }
 
-	// static private Logger log = LoggerFactory.getLogger(RpsPositionIconTest.class.getName());
+    // static private Logger log = LoggerFactory.getLogger(RpsPositionIconTest.class.getName());
 }

--- a/java/test/jmri/jmrit/display/SensorIconWindowTest.java
+++ b/java/test/jmri/jmrit/display/SensorIconWindowTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.display;
 
+import java.awt.GraphicsEnvironment;
 import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -12,9 +13,9 @@ import junit.extensions.jfcunit.eventdata.EventDataConstants;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
 import junit.extensions.jfcunit.finder.AbstractButtonFinder;
 import junit.extensions.jfcunit.finder.DialogFinder;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Swing jfcUnit tests for the SensorIcon
@@ -25,7 +26,9 @@ public class SensorIconWindowTest extends jmri.util.SwingTestCase {
 
     @SuppressWarnings("unchecked") // DialogFinder not parameterized
     public void testPanelEditor() throws Exception {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         jmri.jmrit.display.panelEditor.PanelEditor panel
                 = new jmri.jmrit.display.panelEditor.PanelEditor("SensorIconWindowTest.testPanelEditor");
 
@@ -99,7 +102,9 @@ public class SensorIconWindowTest extends jmri.util.SwingTestCase {
 
     @SuppressWarnings("unchecked") // DialogFinder not parameterized
     public void testLayoutEditor() throws Exception {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         jmri.jmrit.display.layoutEditor.LayoutEditor panel
                 = new jmri.jmrit.display.layoutEditor.LayoutEditor("SensorIconWindowTest.testLayoutEditor");
 
@@ -191,6 +196,7 @@ public class SensorIconWindowTest extends jmri.util.SwingTestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() throws Exception {
         super.setUp();
         apps.tests.Log4JFixture.setUp();
@@ -200,6 +206,7 @@ public class SensorIconWindowTest extends jmri.util.SwingTestCase {
         JUnitUtil.initShutDownManager();
     }
 
+    @Override
     protected void tearDown() throws Exception {
         apps.tests.Log4JFixture.tearDown();
         super.tearDown();

--- a/java/test/jmri/jmrit/display/SignalMastIconTest.java
+++ b/java/test/jmri/jmrit/display/SignalMastIconTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.display;
 
+import java.awt.GraphicsEnvironment;
+import java.awt.event.WindowListener;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import jmri.InstanceManager;
@@ -14,19 +16,21 @@ import junit.framework.TestSuite;
  * Description:
  *
  * @author	Bob Jacobsen Copyright 2009
-  */
+ */
 public class SignalMastIconTest extends jmri.util.SwingTestCase {
 
-    SignalMastIcon to = null;
-    jmri.jmrit.display.panelEditor.PanelEditor panel;
+    jmri.jmrit.display.panelEditor.PanelEditor panel = null;
 
     public void testShowText() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         // this one is for Layout editor, which for now
         // is still in text form.
         JFrame jf = new JFrame("SignalMast Icon Text Test");
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
 
-        to = new SignalMastIcon(panel);
+        SignalMastIcon to = new SignalMastIcon(panel);
         to.setShowAutoText(true);
 
         jf.getContentPane().add(new JLabel("Should say Approach: "));
@@ -36,21 +40,24 @@ public class SignalMastIconTest extends jmri.util.SwingTestCase {
         jmri.util.JUnitUtil.resetInstanceManager();
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(
                 new DefaultSignalHead("IH1") {
-                    protected void updateOutput() {
-                    }
-                }
+            @Override
+            protected void updateOutput() {
+            }
+        }
         );
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(
                 new DefaultSignalHead("IH2") {
-                    protected void updateOutput() {
-                    }
-                }
+            @Override
+            protected void updateOutput() {
+            }
+        }
         );
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(
                 new DefaultSignalHead("IH3") {
-                    protected void updateOutput() {
-                    }
-                }
+            @Override
+            protected void updateOutput() {
+            }
+        }
         );
 
         SignalMast s = InstanceManager.getDefault(jmri.SignalMastManager.class)
@@ -70,10 +77,13 @@ public class SignalMastIconTest extends jmri.util.SwingTestCase {
     }
 
     public void testShowIcon() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         JFrame jf = new JFrame("SignalMastIcon Icon Test");
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
 
-        to = new SignalMastIcon(panel);
+        SignalMastIcon to = new SignalMastIcon(panel);
         to.setShowAutoText(false);
 
         jf.getContentPane().add(new JLabel("Should be yellow/red: "));
@@ -83,21 +93,24 @@ public class SignalMastIconTest extends jmri.util.SwingTestCase {
         jmri.util.JUnitUtil.resetInstanceManager();
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(
                 new DefaultSignalHead("IH1") {
-                    protected void updateOutput() {
-                    }
-                }
+            @Override
+            protected void updateOutput() {
+            }
+        }
         );
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(
                 new DefaultSignalHead("IH2") {
-                    protected void updateOutput() {
-                    }
-                }
+            @Override
+            protected void updateOutput() {
+            }
+        }
         );
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(
                 new DefaultSignalHead("IH3") {
-                    protected void updateOutput() {
-                    }
-                }
+            @Override
+            protected void updateOutput() {
+            }
+        }
         );
 
         SignalMast s = InstanceManager.getDefault(jmri.SignalMastManager.class)
@@ -135,20 +148,26 @@ public class SignalMastIconTest extends jmri.util.SwingTestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
-        panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test SignalMastIcon Panel");
+        if (!GraphicsEnvironment.isHeadless()) {
+            panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test SignalMastIcon Panel");
+        }
     }
 
+    @Override
     protected void tearDown() {
         // now close panel window
-        java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
-        for (int i = 0; i < listeners.length; i++) {
-            panel.getTargetFrame().removeWindowListener(listeners[i]);
+        if (panel != null) {
+            java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
+            for (WindowListener listener : listeners) {
+                panel.getTargetFrame().removeWindowListener(listener);
+            }
+            junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         }
-        junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         apps.tests.Log4JFixture.tearDown();
     }
 
-	// static private Logger log = LoggerFactory.getLogger(SignalMastIconTest.class.getName());
+    // static private Logger log = LoggerFactory.getLogger(SignalMastIconTest.class.getName());
 }

--- a/java/test/jmri/jmrit/display/TurnoutIconTest.java
+++ b/java/test/jmri/jmrit/display/TurnoutIconTest.java
@@ -1,11 +1,13 @@
 package jmri.jmrit.display;
 
+import java.awt.GraphicsEnvironment;
+import java.awt.event.WindowListener;
 import java.beans.PropertyChangeEvent;
 import javax.swing.JButton;
 import javax.swing.JFrame;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * TurnoutIconTest.java
@@ -14,79 +16,79 @@ import junit.framework.TestSuite;
  */
 public class TurnoutIconTest extends jmri.util.SwingTestCase {
 
-    TurnoutIcon to;
-    jmri.jmrit.display.panelEditor.PanelEditor panel;
+    jmri.jmrit.display.panelEditor.PanelEditor panel = null;
 
     public void testEquals() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         JFrame jf = new JFrame();
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
 
-        to = new TurnoutIcon(panel);
+        TurnoutIcon to = new TurnoutIcon(panel);
         jmri.Turnout turnout = jmri.InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
-        to.setTurnout(new jmri.NamedBeanHandle<jmri.Turnout>("IT1", turnout));
+        to.setTurnout(new jmri.NamedBeanHandle<>("IT1", turnout));
 
         TurnoutIcon to2 = new TurnoutIcon(panel);
         turnout = jmri.InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
-        to2.setTurnout(new jmri.NamedBeanHandle<jmri.Turnout>("IT1", turnout));
+        to2.setTurnout(new jmri.NamedBeanHandle<>("IT1", turnout));
 
         Assert.assertTrue("identity", to.equals(to));
         Assert.assertFalse("object (not content) equality", to2.equals(to));
-        Assert.assertFalse("object (not content) equality commutes", to.equals(to2));        
+        Assert.assertFalse("object (not content) equality commutes", to.equals(to2));
     }
 
     public void testClone() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         JFrame jf = new JFrame();
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
 
-        to = new TurnoutIcon(panel);
+        TurnoutIcon to = new TurnoutIcon(panel);
         jmri.Turnout turnout = jmri.InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
-        to.setTurnout(new jmri.NamedBeanHandle<jmri.Turnout>("IT1", turnout));
+        to.setTurnout(new jmri.NamedBeanHandle<>("IT1", turnout));
 
         TurnoutIcon to2 = (TurnoutIcon) to.deepClone();
 
         Assert.assertFalse("clone object (not content) equality", to2.equals(to));
-        
+
         Assert.assertTrue("class type equality", to2.getClass().equals(to.getClass()));
-        
+
     }
-    
+
     public void testShow() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         JFrame jf = new JFrame();
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
 
-        to = new TurnoutIcon(panel);
+        TurnoutIcon to = new TurnoutIcon(panel);
         jf.getContentPane().add(to);
 
         jmri.Turnout turnout = jmri.InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
-        to.setTurnout(new jmri.NamedBeanHandle<jmri.Turnout>("IT1", turnout));
+        to.setTurnout(new jmri.NamedBeanHandle<>("IT1", turnout));
 
         // test buttons
         JButton throwButton = new JButton("throw");
-        throwButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                throwButtonPushed();
-            }
+        throwButton.addActionListener((java.awt.event.ActionEvent e) -> {
+            throwButtonPushed();
         });
         jf.getContentPane().add(throwButton);
         JButton closeButton = new JButton("close");
-        closeButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                closeButtonPushed();
-            }
+        closeButton.addActionListener((java.awt.event.ActionEvent e) -> {
+            closeButtonPushed();
         });
         jf.getContentPane().add(closeButton);
         JButton unknownButton = new JButton("unknown");
-        unknownButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                unknownButtonPushed();
-            }
+        unknownButton.addActionListener((java.awt.event.ActionEvent e) -> {
+            unknownButtonPushed();
         });
         jf.getContentPane().add(unknownButton);
         JButton inconsistentButton = new JButton("inconsistent");
-        inconsistentButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                inconsistentButtonPushed();
-            }
+        inconsistentButton.addActionListener((java.awt.event.ActionEvent e) -> {
+            inconsistentButtonPushed();
         });
         jf.getContentPane().add(inconsistentButton);
 
@@ -97,26 +99,30 @@ public class TurnoutIconTest extends jmri.util.SwingTestCase {
 
     // animate the visible frame
     public void throwButtonPushed() {
+        TurnoutIcon to = new TurnoutIcon(panel);
         java.beans.PropertyChangeEvent e = new PropertyChangeEvent(this,
-                "KnownState", null, Integer.valueOf(jmri.Turnout.THROWN));
+                "KnownState", null, jmri.Turnout.THROWN);
         to.propertyChange(e);
     }
 
     public void closeButtonPushed() {
+        TurnoutIcon to = new TurnoutIcon(panel);
         java.beans.PropertyChangeEvent e = new PropertyChangeEvent(this,
-                "KnownState", null, Integer.valueOf(jmri.Turnout.CLOSED));
+                "KnownState", null, jmri.Turnout.CLOSED);
         to.propertyChange(e);
     }
 
     public void unknownButtonPushed() {
+        TurnoutIcon to = new TurnoutIcon(panel);
         java.beans.PropertyChangeEvent e = new PropertyChangeEvent(this,
-                "KnownState", null, Integer.valueOf(jmri.Turnout.UNKNOWN));
+                "KnownState", null, jmri.Turnout.UNKNOWN);
         to.propertyChange(e);
     }
 
     public void inconsistentButtonPushed() {
+        TurnoutIcon to = new TurnoutIcon(panel);
         java.beans.PropertyChangeEvent e = new PropertyChangeEvent(this,
-                "KnownState", null, Integer.valueOf(23));
+                "KnownState", null, 23);
         to.propertyChange(e);
     }
 
@@ -138,23 +144,28 @@ public class TurnoutIconTest extends jmri.util.SwingTestCase {
     }
 
     // The minimal setup for log4J
+    @Override
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
-    
+
         jmri.util.JUnitUtil.resetInstanceManager();
-        panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test TurnoutIcon Panel");
-        to = null;
+        if (!GraphicsEnvironment.isHeadless()) {
+            panel = new jmri.jmrit.display.panelEditor.PanelEditor("Test TurnoutIcon Panel");
+        }
     }
 
+    @Override
     protected void tearDown() {
         // now close panel window
-        java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
-        for (int i = 0; i < listeners.length; i++) {
-            panel.getTargetFrame().removeWindowListener(listeners[i]);
+        if (panel != null) {
+            java.awt.event.WindowListener[] listeners = panel.getTargetFrame().getWindowListeners();
+            for (WindowListener listener : listeners) {
+                panel.getTargetFrame().removeWindowListener(listener);
+            }
+            junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         }
-        junit.extensions.jfcunit.TestHelper.disposeWindow(panel.getTargetFrame(), this);
         apps.tests.Log4JFixture.tearDown();
     }
 
-	// static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
+    // static private Logger log = LoggerFactory.getLogger(TurnoutIconTest.class.getName());
 }

--- a/java/test/jmri/jmrit/display/TurnoutIconWindowTest.java
+++ b/java/test/jmri/jmrit/display/TurnoutIconWindowTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.display;
 
+import java.awt.GraphicsEnvironment;
 import java.util.List;
 import java.util.ResourceBundle;
 import javax.swing.JButton;
@@ -14,9 +15,9 @@ import junit.extensions.jfcunit.eventdata.EventDataConstants;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
 import junit.extensions.jfcunit.finder.AbstractButtonFinder;
 import junit.extensions.jfcunit.finder.DialogFinder;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Swing jfcUnit tests for the TurnoutIcon
@@ -29,7 +30,9 @@ public class TurnoutIconWindowTest extends jmri.util.SwingTestCase {
 
     @SuppressWarnings("unchecked")
     public void testPanelEditor() throws Exception {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         jmri.jmrit.display.panelEditor.PanelEditor panel
                 = new jmri.jmrit.display.panelEditor.PanelEditor("TurnoutIconWindowTest.testPanelEditor");
 
@@ -113,7 +116,9 @@ public class TurnoutIconWindowTest extends jmri.util.SwingTestCase {
 
     @SuppressWarnings("unchecked")
     public void testLayoutEditor() throws Exception {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't Assume in TestCase
+        }
         jmri.jmrit.display.layoutEditor.LayoutEditor panel
                 = new jmri.jmrit.display.layoutEditor.LayoutEditor("TurnoutIconWindowTest.testLayoutEditor");
 

--- a/java/test/jmri/jmrit/display/layoutEditor/BlockContentsIconTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/BlockContentsIconTest.java
@@ -1,57 +1,42 @@
 package jmri.jmrit.display.layoutEditor;
 
-import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import java.awt.GraphicsEnvironment;
 import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test simple functioning of BlockContentsIcon
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class BlockContentsIconTest extends TestCase {
+public class BlockContentsIconTest {
 
+    @Test
     public void testCtor() {
-        BlockContentsIcon  t = new BlockContentsIcon("test",new LayoutEditor());
-        Assert.assertNotNull("exists", t );
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        BlockContentsIcon t = new BlockContentsIcon("test", new LayoutEditor());
+        Assert.assertNotNull("exists", t);
     }
 
     // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         // reset the instance manager.
         JUnitUtil.resetInstanceManager();
     }
- 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
     }
-
-    public BlockContentsIconTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", BlockContentsIconTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(BlockContentsIconTest.class);
-        return suite;
-    }
-
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/ConnectivityUtilTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/ConnectivityUtilTest.java
@@ -1,57 +1,43 @@
 package jmri.jmrit.display.layoutEditor;
 
-import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import java.awt.GraphicsEnvironment;
 import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test simple functioning of ConnectivityUtil
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class ConnectivityUtilTest extends TestCase {
+public class ConnectivityUtilTest {
 
+    @Test
     public void testCtor() {
-        ConnectivityUtil  t = new ConnectivityUtil(new LayoutEditor());
-        Assert.assertNotNull("exists", t );
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        ConnectivityUtil t = new ConnectivityUtil(new LayoutEditor());
+        Assert.assertNotNull("exists", t);
     }
 
     // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         // reset the instance manager.
         JUnitUtil.resetInstanceManager();
     }
- 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
-    }
-
-    public ConnectivityUtilTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", ConnectivityUtilTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(ConnectivityUtilTest.class);
-        return suite;
     }
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LEConnectivityTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LEConnectivityTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.display.layoutEditor;
 
+import java.awt.GraphicsEnvironment;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JButton;
@@ -12,9 +13,9 @@ import junit.extensions.jfcunit.TestHelper;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
 import junit.extensions.jfcunit.finder.AbstractButtonFinder;
 import junit.extensions.jfcunit.finder.DialogFinder;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Swing jfcUnit tests for the LayoutEditor
@@ -25,6 +26,9 @@ public class LEConnectivityTest extends jmri.util.SwingTestCase {
 
     @SuppressWarnings("unchecked")
     public void testShowAndClose() throws Exception {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // Can't Assume in TestCase
+        }
         jmri.configurexml.ConfigXmlManager cm = new jmri.configurexml.ConfigXmlManager() {
         };
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorAuxToolsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorAuxToolsTest.java
@@ -1,57 +1,43 @@
 package jmri.jmrit.display.layoutEditor;
 
-import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import java.awt.GraphicsEnvironment;
 import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test simple functioning of LayoutEditorAuxTools
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class LayoutEditorAuxToolsTest extends TestCase {
+public class LayoutEditorAuxToolsTest {
 
+    @Test
     public void testCtor() {
-        LayoutEditorAuxTools  t = new LayoutEditorAuxTools(new LayoutEditor());
-        Assert.assertNotNull("exists", t );
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        LayoutEditorAuxTools t = new LayoutEditorAuxTools(new LayoutEditor());
+        Assert.assertNotNull("exists", t);
     }
 
     // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         // reset the instance manager.
         JUnitUtil.resetInstanceManager();
     }
- 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
-    }
-
-    public LayoutEditorAuxToolsTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", LayoutEditorAuxToolsTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(LayoutEditorAuxToolsTest.class);
-        return suite;
     }
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -1,35 +1,45 @@
 package jmri.jmrit.display.layoutEditor;
 
+import java.awt.GraphicsEnvironment;
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test simple functioning of LayoutEditor
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class LayoutEditorTest extends TestCase {
+public class LayoutEditorTest {
 
+    @Test
     public void testCtor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         Assert.assertNotNull("exists", e);
     }
 
+    @Test
     public void testStringCtor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor("Test Layout");
         Assert.assertNotNull("exists", e);
     }
 
+    @Test
     public void testGetFinder() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         LayoutEditorFindItems f = e.getFinder();
         Assert.assertNotNull("exists", f);
     }
 
+    @Test
     public void testSetSize() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         e.setSize(100, 100);
         java.awt.Dimension d = e.getSize();
@@ -39,40 +49,52 @@ public class LayoutEditorTest extends TestCase {
         Assert.assertEquals("Height Set", 100.0, d.getHeight(), 0.0);
     }
 
+    @Test
     public void testGetOpenDispatcherOnLoad() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to false.
         Assert.assertFalse("getOpenDispatcherOnLoad", e.getOpenDispatcherOnLoad());
     }
 
+    @Test
     public void testSetOpenDispatcherOnLoad() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to false, so set to true.
         e.setOpenDispatcherOnLoad(true);
         Assert.assertTrue("setOpenDispatcherOnLoad after set", e.getOpenDispatcherOnLoad());
     }
 
+    @Test
     public void testIsDirty() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to false.
         Assert.assertFalse("isDirty", e.isDirty());
     }
 
+    @Test
     public void testSetDirty() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to false, setDirty() sets it to true.
         e.setDirty();
         Assert.assertTrue("isDirty after set", e.isDirty());
     }
 
+    @Test
     public void testSetDirtyWithParameter() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to false, so set it to true.
         e.setDirty(true);
         Assert.assertTrue("isDirty after set", e.isDirty());
     }
 
+    @Test
     public void testResetDirty() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to false, so set it to true.
         e.setDirty(true);
@@ -81,56 +103,74 @@ public class LayoutEditorTest extends TestCase {
         Assert.assertFalse("isDirty after reset", e.isDirty());
     }
 
+    @Test
     public void testIsAnimating() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to true
         Assert.assertTrue("isAnimating", e.isAnimating());
     }
 
+    @Test
     public void testSetTurnoutAnimating() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to true, so set to false.
         e.setTurnoutAnimation(false);
         Assert.assertFalse("isAnimating after set", e.isAnimating());
     }
 
+    @Test
     public void testGetLayoutWidth() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 0
         Assert.assertEquals("layout width", 0, e.getLayoutWidth());
     }
 
+    @Test
     public void testGetLayoutHeight() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 0
         Assert.assertEquals("layout height", 0, e.getLayoutHeight());
     }
 
+    @Test
     public void testGetWindowWidth() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 0
         Assert.assertEquals("window width", 0, e.getWindowWidth());
     }
 
+    @Test
     public void testGetWindowHeight() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 0
         Assert.assertEquals("window height", 0, e.getWindowHeight());
     }
 
+    @Test
     public void testGetUpperLeftX() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 0
         Assert.assertEquals("upper left X", 0, e.getUpperLeftX());
     }
 
+    @Test
     public void testGetUpperLeftY() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 0
         Assert.assertEquals("upper left Y", 0, e.getUpperLeftY());
     }
 
+    @Test
     public void testSetLayoutDimensions() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set the panel dimensions to known values
         e.setLayoutDimensions(100, 100, 100, 100, 100, 100);
@@ -142,359 +182,473 @@ public class LayoutEditorTest extends TestCase {
         Assert.assertEquals("upper left Y after set", 100, e.getUpperLeftX());
     }
 
+    @Test
     public void testSetGrideSize() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         Assert.assertEquals("grid size after set", 100, e.setGridSize(100));
     }
 
+    @Test
     public void testGetGrideSize() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 10.
         Assert.assertEquals("grid size", 10, e.getGridSize());
     }
 
+    @Test
     public void testGetMainlineTrackWidth() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 4.
         Assert.assertEquals("mainline track width", 4, e.getMainlineTrackWidth());
     }
 
+    @Test
     public void testSetMainlineTrackWidth() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set to known value
         e.setMainlineTrackWidth(10);
         Assert.assertEquals("mainline track width after set", 10, e.getMainlineTrackWidth());
     }
 
+    @Test
     public void testGetSidelineTrackWidth() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 2.
         Assert.assertEquals("side track width", 2, e.getSideTrackWidth());
     }
 
+    @Test
     public void testSetSideTrackWidth() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set to known value
         e.setSideTrackWidth(10);
         Assert.assertEquals("Side track width after set", 10, e.getSideTrackWidth());
     }
 
+    @Test
     public void testGetXScale() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 1.
         Assert.assertEquals("XScale", 1.0, e.getXScale(), 0.0);
     }
 
+    @Test
     public void testSetXScale() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set to known value
         e.setXScale(2.0);
         Assert.assertEquals("XScale after set ", 2.0, e.getXScale(), 0.0);
     }
 
+    @Test
     public void testGetYScale() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 1.
         Assert.assertEquals("YScale", 1.0, e.getYScale(), 0.0);
     }
 
+    @Test
     public void testSetYScale() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set to known value
         e.setYScale(2.0);
         Assert.assertEquals("YScale after set ", 2.0, e.getYScale(), 0.0);
     }
 
+    @Test
     public void testGetDefaultTrackColor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         Assert.assertEquals("Default Track Color", "black", e.getDefaultTrackColor());
     }
 
+    @Test
     public void testSetDefaultTrackColor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         e.setDefaultTrackColor("pink");
         Assert.assertEquals("Default Track Color after Set", "pink", e.getDefaultTrackColor());
     }
 
+    @Test
     public void testGetDefaultOccupiedTrackColor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         Assert.assertEquals("Default Occupied Track Color", "red", e.getDefaultOccupiedTrackColor());
     }
 
+    @Test
     public void testSetDefaultOccupiedTrackColor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         e.setDefaultOccupiedTrackColor("pink");
         Assert.assertEquals("Default Occupied Track Color after Set", "pink", e.getDefaultOccupiedTrackColor());
     }
 
+    @Test
     public void testGetDefaultAlternativeTrackColor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         Assert.assertEquals("Default Alternative Track Color", "white", e.getDefaultAlternativeTrackColor());
     }
 
+    @Test
     public void testSetDefaultAlternativeTrackColor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         e.setDefaultAlternativeTrackColor("pink");
         Assert.assertEquals("Default Alternative Track Color after Set", "pink", e.getDefaultAlternativeTrackColor());
     }
 
+    @Test
     public void testGetDefaultTextColor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         Assert.assertEquals("Default Text Color", "black", e.getDefaultTextColor());
     }
 
+    @Test
     public void testSetDefaultTextColor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         e.setDefaultTextColor("pink");
         Assert.assertEquals("Default Text Color after Set", "pink", e.getDefaultTextColor());
     }
 
+    @Test
     public void testGetTurnoutCircleColor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         Assert.assertEquals("Turnout Circle Color", "black", e.getTurnoutCircleColor());
     }
 
+    @Test
     public void testSetTurnoutCircleColor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         e.setTurnoutCircleColor("pink");
         Assert.assertEquals("Turnout Circle after Set", "pink", e.getTurnoutCircleColor());
     }
 
+    @Test
     public void testGetTurnoutCircleSize() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 2.
         Assert.assertEquals("turnout circle size", 2, e.getTurnoutCircleSize());
     }
 
+    @Test
     public void testSetTurnoutCircleSize() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set to known value
         e.setTurnoutCircleSize(10);
         Assert.assertEquals("turnout circle size after set", 10, e.getTurnoutCircleSize());
     }
 
+    @Test
     public void testGetTurnoutDrawUnselectedLeg() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to true
         Assert.assertTrue("getTurnoutDrawUnselectedLeg", e.getTurnoutDrawUnselectedLeg());
     }
 
+    @Test
     public void testSetTurnoutDrawUnselectedLeg() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to true, so set to false.
         e.setTurnoutDrawUnselectedLeg(false);
         Assert.assertFalse("getTurnoutDrawUnselectedLeg after set", e.getTurnoutDrawUnselectedLeg());
     }
 
+    @Test
     public void testGetLayoutName() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default is "My Layout"
         Assert.assertEquals("getLayoutName", "My Layout", e.getLayoutName());
     }
 
+    @Test
     public void testSetLayoutName() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set to a known value
         e.setLayoutName("foo");
         Assert.assertEquals("getLayoutName after set", "foo", e.getLayoutName());
     }
 
+    @Test
     public void testGetShowHelpBar() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to true
         Assert.assertTrue("getShowHelpBar", e.getShowHelpBar());
     }
 
+    @Test
     public void testSetShowHelpBar() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to true, so set to false.
         e.setShowHelpBar(false);
         Assert.assertFalse("getShowHelpBar after set", e.getShowHelpBar());
     }
 
+    @Test
     public void testGetDrawGrid() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false 
         Assert.assertFalse("getDrawGrid", e.getDrawGrid());
     }
 
+    @Test
     public void testSetDrawGrid() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false, so set to true.
         e.setDrawGrid(true);
         Assert.assertTrue("getDrawGrid after set", e.getDrawGrid());
     }
 
+    @Test
     public void testGetSnapOnAdd() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false 
         Assert.assertFalse("getSnapOnAdd", e.getSnapOnAdd());
     }
 
+    @Test
     public void testSetSnapOnAdd() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false, so set to true.
         e.setSnapOnAdd(true);
         Assert.assertTrue("getSnapOnAdd after set", e.getSnapOnAdd());
     }
 
+    @Test
     public void testGetSnapOnMove() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false 
         Assert.assertFalse("getSnapOnMove", e.getSnapOnMove());
     }
 
+    @Test
     public void testSetSnapOnMove() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false, so set to true.
         e.setSnapOnMove(true);
         Assert.assertTrue("getSnapOnMove after set", e.getSnapOnMove());
     }
 
+    @Test
     public void testGetAntialiasingOn() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false 
         Assert.assertFalse("getAntialiasingOn", e.getAntialiasingOn());
     }
 
+    @Test
     public void testSetAntialiasingOn() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false, so set to true.
         e.setAntialiasingOn(true);
         Assert.assertTrue("getAntialiasingOn after set", e.getAntialiasingOn());
     }
 
+    @Test
     public void testGetTurnoutCircles() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false 
         Assert.assertFalse("getTurnoutCircles", e.getTurnoutCircles());
     }
 
+    @Test
     public void testSetTurnoutCircles() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false, so set to true.
         e.setTurnoutCircles(true);
         Assert.assertTrue("getSetTurnoutCircles after set", e.getTurnoutCircles());
     }
 
+    @Test
     public void testGetTooltipsNotEdit() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false 
         Assert.assertFalse("getTooltipsNotEdit", e.getTooltipsNotEdit());
     }
 
+    @Test
     public void testSetTooltipsNotEdit() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false, so set to true.
         e.setTooltipsNotEdit(true);
         Assert.assertTrue("getTooltipsNotEdit after set", e.getTooltipsNotEdit());
     }
 
+    @Test
     public void testGetTooltipsInEdit() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to true 
         Assert.assertTrue("getTooltipsInEdit", e.getTooltipsInEdit());
     }
 
+    @Test
     public void testSetTooltipsInEdit() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to true, so set to false.
         e.setTooltipsInEdit(false);
         Assert.assertFalse("getTooltipsInEdit after set", e.getTooltipsInEdit());
     }
 
+    @Test
     public void testGetAutoBlockAssignment() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false 
         Assert.assertFalse("getAutoBlockAssignment", e.getAutoBlockAssignment());
     }
 
+    @Test
     public void testSetAutoBlockAssignment() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false, so set to true.
         e.setAutoBlockAssignment(true);
         Assert.assertTrue("getAutoBlockAssignment after set", e.getAutoBlockAssignment());
     }
 
+    @Test
     public void testGetTurnoutBX() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 20. 
         Assert.assertEquals("getTurnoutBX", 20.0, e.getTurnoutBX(), 0.0);
     }
 
+    @Test
     public void testSetTurnoutBX() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set to known value
         e.setTurnoutBX(2.0);
         Assert.assertEquals("getTurnoutBX after set ", 2.0, e.getTurnoutBX(), 0.0);
     }
 
+    @Test
     public void testGetTurnoutCX() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 20.
         Assert.assertEquals("getTurnoutCX", 20.0, e.getTurnoutCX(), 0.0);
     }
 
+    @Test
     public void testSetTurnoutCX() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set to known value
         e.setTurnoutCX(2.0);
         Assert.assertEquals("getTurnoutCX after set ", 2.0, e.getTurnoutCX(), 0.0);
     }
 
+    @Test
     public void testGetTurnoutWid() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 10.
         Assert.assertEquals("getTurnoutWid", 10.0, e.getTurnoutWid(), 0.0);
     }
 
+    @Test
     public void testSetTurnoutWid() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set to known value
         e.setTurnoutWid(2.0);
         Assert.assertEquals("getTurnoutWid after set ", 2.0, e.getTurnoutWid(), 0.0);
     }
 
+    @Test
     public void testGetXOverLong() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 30.
         Assert.assertEquals("getXOverLong", 30.0, e.getXOverLong(), 0.0);
     }
 
+    @Test
     public void testSetXOverLong() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set to known value
         e.setXOverLong(2.0);
         Assert.assertEquals("getXOverLong after set ", 2.0, e.getXOverLong(), 0.0);
     }
 
+    @Test
     public void testGetXOverHWid() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 10.
         Assert.assertEquals("getXOverHWid", 10.0, e.getXOverHWid(), 0.0);
     }
 
+    @Test
     public void testSetXOverHWid() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set to known value
         e.setXOverHWid(2.0);
         Assert.assertEquals("getXOverWid after set ", 2.0, e.getXOverHWid(), 0.0);
     }
 
+    @Test
     public void testGetXOverShort() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // defaults to 10.
         Assert.assertEquals("getXOverShort", 10.0, e.getXOverShort(), 0.0);
     }
 
+    @Test
     public void testSetXOverShort() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set to known value
         e.setXOverShort(2.0);
         Assert.assertEquals("getXOverShort after set ", 2.0, e.getXOverShort(), 0.0);
     }
 
+    @Test
     public void testResetTurnoutSizes() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // set all dimensions to known value
         e.setTurnoutBX(2.0);
@@ -533,13 +687,17 @@ public class LayoutEditorTest extends TestCase {
         Assert.assertTrue("isDirty after resetTurnoutSize", e.isDirty());
     }
 
+    @Test
     public void testGetDirectTurnoutControl() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false 
         Assert.assertFalse("getDirectTurnoutControl", e.getDirectTurnoutControl());
     }
 
+    @Test
     public void testSetDirectTurnoutControl() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor e = new LayoutEditor();
         // default to false, so set to true.
         e.setDirectTurnoutControl(true);
@@ -547,9 +705,8 @@ public class LayoutEditorTest extends TestCase {
     }
 
     // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
@@ -557,29 +714,12 @@ public class LayoutEditorTest extends TestCase {
         JUnitUtil.resetInstanceManager();
     }
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
-    }
-
-    public LayoutEditorTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", LayoutEditorTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(LayoutEditorTest.class);
-        return suite;
     }
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorToolsTest.java
@@ -1,57 +1,43 @@
 package jmri.jmrit.display.layoutEditor;
 
-import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import java.awt.GraphicsEnvironment;
 import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test simple functioning of LayoutEditorTools
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class LayoutEditorToolsTest extends TestCase {
+public class LayoutEditorToolsTest {
 
+    @Test
     public void testCtor() {
-        LayoutEditorTools  t = new LayoutEditorTools(new LayoutEditor());
-        Assert.assertNotNull("exists", t );
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        LayoutEditorTools t = new LayoutEditorTools(new LayoutEditor());
+        Assert.assertNotNull("exists", t);
     }
 
     // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         // reset the instance manager.
         JUnitUtil.resetInstanceManager();
     }
- 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
-    }
-
-    public LayoutEditorToolsTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", LayoutEditorToolsTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(LayoutEditorToolsTest.class);
-        return suite;
     }
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorWindowTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorWindowTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.display.layoutEditor;
 
+import java.awt.GraphicsEnvironment;
 import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -8,9 +9,9 @@ import junit.extensions.jfcunit.TestHelper;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
 import junit.extensions.jfcunit.finder.AbstractButtonFinder;
 import junit.extensions.jfcunit.finder.DialogFinder;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Swing jfcUnit tests for the LayoutEditor
@@ -21,6 +22,9 @@ public class LayoutEditorWindowTest extends jmri.util.SwingTestCase {
 
     @SuppressWarnings("unchecked")
     public void testShowAndClose() throws Exception {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // Can't Assume in TestCase
+        }
         jmri.configurexml.ConfigXmlManager cm = new jmri.configurexml.ConfigXmlManager() {
         };
 

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutSlipTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutSlipTest.java
@@ -1,60 +1,44 @@
 package jmri.jmrit.display.layoutEditor;
 
+import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
-import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
 import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test simple functioning of LayoutSlip
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class LayoutSlipTest extends TestCase {
+public class LayoutSlipTest {
 
+    @Test
     public void testCtor() {
-        LayoutSlip  t = new LayoutSlip("test",new Point2D.Double(0.0,0.0),0.0,new LayoutEditor(),0);
-        Assert.assertNotNull("exists", t );
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        LayoutSlip t = new LayoutSlip("test", new Point2D.Double(0.0, 0.0), 0.0, new LayoutEditor(), 0);
+        Assert.assertNotNull("exists", t);
     }
 
     // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         // reset the instance manager.
         JUnitUtil.resetInstanceManager();
     }
- 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
-    }
-
-
-
-    public LayoutSlipTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", LayoutSlipTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(LayoutSlipTest.class);
-        return suite;
     }
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutTurntableTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutTurntableTest.java
@@ -1,60 +1,44 @@
 package jmri.jmrit.display.layoutEditor;
 
+import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
-import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
 import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test simple functioning of LayoutTurntable
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class LayoutTurntableTest extends TestCase {
+public class LayoutTurntableTest {
 
+    @Test
     public void testCtor() {
-        LayoutTurntable  t = new LayoutTurntable("test",new Point2D.Double(0.0,0.0),new LayoutEditor());
-        Assert.assertNotNull("exists", t );
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        LayoutTurntable t = new LayoutTurntable("test", new Point2D.Double(0.0, 0.0), new LayoutEditor());
+        Assert.assertNotNull("exists", t);
     }
 
     // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         // reset the instance manager.
         JUnitUtil.resetInstanceManager();
     }
- 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
-    }
-
-
-
-    public LayoutTurntableTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", LayoutTurntableTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(LayoutTurntableTest.class);
-        return suite;
     }
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LevelXingTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LevelXingTest.java
@@ -1,60 +1,43 @@
 package jmri.jmrit.display.layoutEditor;
 
+import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
-import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
 import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test simple functioning of LevelXing
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class LevelXingTest extends TestCase {
+public class LevelXingTest {
 
+    @Test
     public void testCtor() {
-        LevelXing  t = new LevelXing("test",new Point2D.Double(0.0,0.0),new LayoutEditor());
-        Assert.assertNotNull("exists", t );
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        LevelXing t = new LevelXing("test", new Point2D.Double(0.0, 0.0), new LayoutEditor());
+        Assert.assertNotNull("exists", t);
     }
 
     // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         // reset the instance manager.
         JUnitUtil.resetInstanceManager();
     }
- 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
     }
-
-
-
-    public LevelXingTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", LevelXingTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(LevelXingTest.class);
-        return suite;
-    }
-
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/MemoryIconTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/MemoryIconTest.java
@@ -1,59 +1,42 @@
 package jmri.jmrit.display.layoutEditor;
 
-import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import java.awt.GraphicsEnvironment;
 import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test simple functioning of MemoryIcon
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class MemoryIconTest extends TestCase {
+public class MemoryIconTest {
 
+    @Test
     public void testCtor() {
-        MemoryIcon  t = new MemoryIcon("test",new LayoutEditor());
-        Assert.assertNotNull("exists", t );
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        MemoryIcon t = new MemoryIcon("test", new LayoutEditor());
+        Assert.assertNotNull("exists", t);
     }
 
-    // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         // reset the instance manager.
         JUnitUtil.resetInstanceManager();
     }
- 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
-    }
-
-
-
-    public MemoryIconTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", MemoryIconTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(MemoryIconTest.class);
-        return suite;
     }
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/MultiSensorIconFrameTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/MultiSensorIconFrameTest.java
@@ -1,57 +1,43 @@
 package jmri.jmrit.display.layoutEditor;
 
-import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import java.awt.GraphicsEnvironment;
 import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test simple functioning of MultiSensorIconFrame
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class MultiSensorIconFrameTest extends TestCase {
+public class MultiSensorIconFrameTest {
 
+    @Test
     public void testCtor() {
-        MultiSensorIconFrame  t = new MultiSensorIconFrame(new LayoutEditor());
-        Assert.assertNotNull("exists", t );
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        MultiSensorIconFrame t = new MultiSensorIconFrame(new LayoutEditor());
+        Assert.assertNotNull("exists", t);
     }
 
     // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         // reset the instance manager.
         JUnitUtil.resetInstanceManager();
     }
- 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
-    }
-
-    public MultiSensorIconFrameTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", MultiSensorIconFrameTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(MultiSensorIconFrameTest.class);
-        return suite;
     }
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/PackageTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/PackageTest.java
@@ -1,6 +1,9 @@
 package jmri.jmrit.display.layoutEditor;
 
-import junit.framework.*;
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * Tests for the jmrit.display.layoutEditor package
@@ -17,7 +20,7 @@ public class PackageTest extends TestCase {
     // Main entry point
     static public void main(String[] args) {
         apps.tests.Log4JFixture.initLogging();
-        
+
         String[] testCaseName = {"-noloading", PackageTest.class.getName()};
         junit.textui.TestRunner.main(testCaseName);
     }
@@ -34,29 +37,26 @@ public class PackageTest extends TestCase {
         suite.addTest(LayoutTurnoutTest.suite());
         suite.addTest(LayoutConnectivityTest.suite());
 
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.display.layoutEditor.blockRoutingTable.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.display.layoutEditor.configurexml.PackageTest.class));
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(LayoutEditorActionTest.suite());
-            suite.addTest(LayoutEditorTest.suite());
-            suite.addTest(LayoutEditorToolsTest.suite());
-            suite.addTest(LayoutEditorAuxToolsTest.suite());
-            suite.addTest(ConnectivityUtilTest.suite());
-            suite.addTest(BlockContentsIconTest.suite());
-            suite.addTest(MultiIconEditorTest.suite());
-            suite.addTest(MultiSensorIconFrameTest.suite());
-            suite.addTest(LayoutTurntableTest.suite());
-            suite.addTest(LevelXingTest.suite());
-            suite.addTest(LayoutSlipTest.suite());
-            suite.addTest(MemoryIconTest.suite());
-            suite.addTest(PositionablePointTest.suite());
-            suite.addTest(TrackNodeTest.suite());
-            suite.addTest(TrackSegmentTest.suite());
-            suite.addTest(LayoutEditorWindowTest.suite());
-            suite.addTest(LEConnectivityTest.suite());
-        }
-
+        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
+        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.display.layoutEditor.blockRoutingTable.PackageTest.class));
+        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.display.layoutEditor.configurexml.PackageTest.class));
+        suite.addTest(LayoutEditorActionTest.suite());
+        suite.addTest(new JUnit4TestAdapter(LayoutEditorTest.class));
+        suite.addTest(new JUnit4TestAdapter(LayoutEditorToolsTest.class));
+        suite.addTest(new JUnit4TestAdapter(LayoutEditorAuxToolsTest.class));
+        suite.addTest(new JUnit4TestAdapter(ConnectivityUtilTest.class));
+        suite.addTest(new JUnit4TestAdapter(BlockContentsIconTest.class));
+        suite.addTest(MultiIconEditorTest.suite());
+        suite.addTest(new JUnit4TestAdapter(MultiSensorIconFrameTest.class));
+        suite.addTest(new JUnit4TestAdapter(LayoutTurntableTest.class));
+        suite.addTest(new JUnit4TestAdapter(LevelXingTest.class));
+        suite.addTest(new JUnit4TestAdapter(LayoutSlipTest.class));
+        suite.addTest(new JUnit4TestAdapter(MemoryIconTest.class));
+        suite.addTest(new JUnit4TestAdapter(PositionablePointTest.class));
+        suite.addTest(new JUnit4TestAdapter(TrackNodeTest.class));
+        suite.addTest(new JUnit4TestAdapter(TrackSegmentTest.class));
+        suite.addTest(LayoutEditorWindowTest.suite());
+        suite.addTest(LEConnectivityTest.suite());
         return suite;
     }
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/PositionablePointTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/PositionablePointTest.java
@@ -1,60 +1,44 @@
 package jmri.jmrit.display.layoutEditor;
 
+import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
-import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
 import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test simple functioning of PositionablePoint
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class PositionablePointTest extends TestCase {
+public class PositionablePointTest {
 
+    @Test
     public void testCtor() {
-        PositionablePoint  t = new PositionablePoint("test",PositionablePoint.ANCHOR,new Point2D.Double(0.0,0.0),new LayoutEditor());
-        Assert.assertNotNull("exists", t );
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        PositionablePoint t = new PositionablePoint("test", PositionablePoint.ANCHOR, new Point2D.Double(0.0, 0.0), new LayoutEditor());
+        Assert.assertNotNull("exists", t);
     }
 
     // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         // reset the instance manager.
         JUnitUtil.resetInstanceManager();
     }
- 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
-    }
-
-
-
-    public PositionablePointTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PositionablePointTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PositionablePointTest.class);
-        return suite;
     }
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/TrackNodeTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/TrackNodeTest.java
@@ -1,65 +1,49 @@
 package jmri.jmrit.display.layoutEditor;
 
-import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import jmri.util.JUnitUtil;
+import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
+import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
- * Test simple functioning of TrackNode 
+ * Test simple functioning of TrackNode
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class TrackNodeTest extends TestCase {
+public class TrackNodeTest {
 
+    @Test
     public void testCtor() {
-        LayoutTurnout  t = new LayoutTurnout();
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        LayoutTurnout t = new LayoutTurnout();
         LayoutEditor le = new LayoutEditor();
-        PositionablePoint p1 = new PositionablePoint("a",PositionablePoint.ANCHOR,new Point2D.Double(0.0,0.0),le);
-        PositionablePoint p2 = new PositionablePoint("b",PositionablePoint.ANCHOR,new Point2D.Double(1.0,1.0),le);
-        TrackSegment s = new TrackSegment("test",p1,LayoutEditor.POS_POINT,p2,LayoutEditor.POS_POINT,false,true,le);
-        TrackNode n = new TrackNode(t,LayoutEditor.TURNOUT_A,s,false,0);
-        Assert.assertNotNull("exists", n );
+        PositionablePoint p1 = new PositionablePoint("a", PositionablePoint.ANCHOR, new Point2D.Double(0.0, 0.0), le);
+        PositionablePoint p2 = new PositionablePoint("b", PositionablePoint.ANCHOR, new Point2D.Double(1.0, 1.0), le);
+        TrackSegment s = new TrackSegment("test", p1, LayoutEditor.POS_POINT, p2, LayoutEditor.POS_POINT, false, true, le);
+        TrackNode n = new TrackNode(t, LayoutEditor.TURNOUT_A, s, false, 0);
+        Assert.assertNotNull("exists", n);
     }
 
     // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         // reset the instance manager.
         JUnitUtil.resetInstanceManager();
     }
- 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
-    }
-
-
-
-    public TrackNodeTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", TrackNodeTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TrackNodeTest.class);
-        return suite;
     }
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/TrackSegmentTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/TrackSegmentTest.java
@@ -1,63 +1,47 @@
 package jmri.jmrit.display.layoutEditor;
 
-import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import jmri.util.JUnitUtil;
+import java.awt.GraphicsEnvironment;
 import java.awt.geom.Point2D;
+import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
- * Test simple functioning of TrackSegment 
+ * Test simple functioning of TrackSegment
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class TrackSegmentTest extends TestCase {
+public class TrackSegmentTest {
 
+    @Test
     public void testCtor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LayoutEditor le = new LayoutEditor();
-        PositionablePoint p1 = new PositionablePoint("a",PositionablePoint.ANCHOR,new Point2D.Double(0.0,0.0),le);
-        PositionablePoint p2 = new PositionablePoint("b",PositionablePoint.ANCHOR,new Point2D.Double(1.0,1.0),le);
-        TrackSegment s = new TrackSegment("test",p1,LayoutEditor.POS_POINT,p2,LayoutEditor.POS_POINT,false,true,le);
-        Assert.assertNotNull("exists", s );
+        PositionablePoint p1 = new PositionablePoint("a", PositionablePoint.ANCHOR, new Point2D.Double(0.0, 0.0), le);
+        PositionablePoint p2 = new PositionablePoint("b", PositionablePoint.ANCHOR, new Point2D.Double(1.0, 1.0), le);
+        TrackSegment s = new TrackSegment("test", p1, LayoutEditor.POS_POINT, p2, LayoutEditor.POS_POINT, false, true, le);
+        Assert.assertNotNull("exists", s);
     }
 
     // from here down is testing infrastructure
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         // reset the instance manager.
         JUnitUtil.resetInstanceManager();
     }
- 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
+
+    @After
+    public void tearDown() throws Exception {
         // dispose of the single PanelMenu instance
         jmri.jmrit.display.PanelMenu.dispose();
         JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
-    }
-
-
-
-    public TrackSegmentTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", TrackSegmentTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(TrackSegmentTest.class);
-        return suite;
     }
 
 }

--- a/java/test/jmri/jmrit/operations/automation/AutomationCopyFrameGuiTest.java
+++ b/java/test/jmri/jmrit/operations/automation/AutomationCopyFrameGuiTest.java
@@ -1,15 +1,19 @@
 package jmri.jmrit.operations.automation;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.util.JmriJFrame;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 public class AutomationCopyFrameGuiTest extends OperationsSwingTestCase {
 
     public void testFrameCreation() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         AutomationManager manager = AutomationManager.instance();
         Assert.assertEquals("Number of automations", 0, manager.getSize());
 
@@ -32,6 +36,9 @@ public class AutomationCopyFrameGuiTest extends OperationsSwingTestCase {
     }
     
     public void testFrameCreationWithAutomation() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         AutomationManager manager = AutomationManager.instance();
         Assert.assertEquals("Number of automations", 0, manager.getSize());
         

--- a/java/test/jmri/jmrit/operations/automation/AutomationTableFrameGuiTest.java
+++ b/java/test/jmri/jmrit/operations/automation/AutomationTableFrameGuiTest.java
@@ -1,14 +1,18 @@
 package jmri.jmrit.operations.automation;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 public class AutomationTableFrameGuiTest extends OperationsSwingTestCase {
 
     public void testNewFrameCreation() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         AutomationManager manager = AutomationManager.instance();
         Assert.assertEquals("Number of automations", 0, manager.getSize());
 
@@ -98,6 +102,9 @@ public class AutomationTableFrameGuiTest extends OperationsSwingTestCase {
     }
 
     public void testFrameCreation() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         Automation automation = AutomationManager.instance().newAutomation("Automation Table Frame Name");
         automation.setComment("Gui Test Automation Table Frame Comment");
 
@@ -168,6 +175,9 @@ public class AutomationTableFrameGuiTest extends OperationsSwingTestCase {
     }
 
     public void testFrameCreationWithAction() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         Automation automation = AutomationManager.instance().newAutomation("Automation Table Frame Name");
         automation.setComment("Gui Test Automation Table Frame Comment");
         automation.addItem();

--- a/java/test/jmri/jmrit/operations/automation/AutomationsTableFrameGuiTest.java
+++ b/java/test/jmri/jmrit/operations/automation/AutomationsTableFrameGuiTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.operations.automation;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.util.JmriJFrame;
 import junit.framework.Test;
@@ -9,6 +10,9 @@ import org.junit.Assert;
 public class AutomationsTableFrameGuiTest extends OperationsSwingTestCase {
 
     public void testFrameCreation() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         AutomationManager manager = AutomationManager.instance();
         Assert.assertEquals("Number of automations", 0, manager.getSize());
 

--- a/java/test/jmri/jmrit/operations/automation/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/automation/PackageTest.java
@@ -30,12 +30,9 @@ public class PackageTest extends TestCase {
         suite.addTest(AutomationItemTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
         suite.addTest(jmri.jmrit.operations.automation.actions.PackageTest.suite());
-
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(AutomationTableFrameGuiTest.suite());
-            suite.addTest(AutomationsTableFrameGuiTest.suite());
-            suite.addTest(AutomationCopyFrameGuiTest.suite());
-        }
+        suite.addTest(AutomationTableFrameGuiTest.suite());
+        suite.addTest(AutomationsTableFrameGuiTest.suite());
+        suite.addTest(AutomationCopyFrameGuiTest.suite());
 
         return suite;
     }

--- a/java/test/jmri/jmrit/operations/locations/InterchangeEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/locations/InterchangeEditFrameTest.java
@@ -1,12 +1,13 @@
 //InterchangeEditFrameTest.java
 package jmri.jmrit.operations.locations;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.rollingstock.cars.CarRoads;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations Locations GUI class
@@ -18,6 +19,9 @@ public class InterchangeEditFrameTest extends OperationsSwingTestCase {
     final static int ALL = Track.EAST + Track.WEST + Track.NORTH + Track.SOUTH;
 
     public void testInterchangeEditFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         // add UP road name
         CarRoads cr = CarRoads.instance();
         cr.addName("UP");

--- a/java/test/jmri/jmrit/operations/locations/LocationEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/locations/LocationEditFrameTest.java
@@ -1,6 +1,7 @@
 //LocationEditFrameTest.java
 package jmri.jmrit.operations.locations;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
 import junit.framework.Test;
@@ -17,6 +18,9 @@ public class LocationEditFrameTest extends OperationsSwingTestCase {
     final static int ALL = Track.EAST + Track.WEST + Track.NORTH + Track.SOUTH;
 
     public void testLocationEditFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         loadLocations();
         
         LocationEditFrame f = new LocationEditFrame(null);

--- a/java/test/jmri/jmrit/operations/locations/LocationTableFrameTest.java
+++ b/java/test/jmri/jmrit/operations/locations/LocationTableFrameTest.java
@@ -1,6 +1,7 @@
 //LocationTableFrameTest.java
 package jmri.jmrit.operations.locations;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.util.JmriJFrame;
 import junit.framework.Test;
@@ -17,6 +18,9 @@ public class LocationTableFrameTest extends OperationsSwingTestCase {
     final static int ALL = Track.EAST + Track.WEST + Track.NORTH + Track.SOUTH;
 
     public void testLocationsTableFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
 
         LocationsTableFrame f = new LocationsTableFrame();
 

--- a/java/test/jmri/jmrit/operations/locations/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/locations/PackageTest.java
@@ -33,15 +33,12 @@ public class PackageTest extends TestCase {
 
         suite.addTest(jmri.jmrit.operations.locations.tools.PackageTest.suite());
         suite.addTest(jmri.jmrit.operations.locations.schedules.PackageTest.suite());
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(InterchangeEditFrameTest.suite());
-            suite.addTest(LocationEditFrameTest.suite());
-            suite.addTest(LocationTableFrameTest.suite());
-            suite.addTest(SidingEditFrameTest.suite());
-            suite.addTest(StagingEditFrameTest.suite());
-            suite.addTest(YardEditFrameTest.suite());
-        }
+        suite.addTest(InterchangeEditFrameTest.suite());
+        suite.addTest(LocationEditFrameTest.suite());
+        suite.addTest(LocationTableFrameTest.suite());
+        suite.addTest(SidingEditFrameTest.suite());
+        suite.addTest(StagingEditFrameTest.suite());
+        suite.addTest(YardEditFrameTest.suite());
 
         return suite;
     }

--- a/java/test/jmri/jmrit/operations/locations/SidingEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/locations/SidingEditFrameTest.java
@@ -1,12 +1,13 @@
 //SidingEditFrameTest.java
 package jmri.jmrit.operations.locations;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.util.JmriJFrame;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations Locations GUI class
@@ -18,6 +19,9 @@ public class SidingEditFrameTest extends OperationsSwingTestCase {
     final static int ALL = Track.EAST + Track.WEST + Track.NORTH + Track.SOUTH;
 
     public void testSidingEditFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         LocationManager lManager = LocationManager.instance();
         Location l = lManager.getLocationByName("Test Loc C");
         SpurEditFrame f = new SpurEditFrame();

--- a/java/test/jmri/jmrit/operations/locations/StagingEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/locations/StagingEditFrameTest.java
@@ -1,11 +1,12 @@
 //StagingEditFrameTest.java
 package jmri.jmrit.operations.locations;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations Locations GUI class
@@ -23,6 +24,9 @@ public class StagingEditFrameTest extends OperationsSwingTestCase {
      * Staging tracks needs its own location
      */
     public void testAddOneStagingTrack() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         StagingEditFrame f = new StagingEditFrame();
         f.setTitle("Test Staging Add Frame");
         f.setLocation(0, 0);	// entire panel must be visible for tests to work properly
@@ -47,6 +51,9 @@ public class StagingEditFrameTest extends OperationsSwingTestCase {
      * Staging tracks needs its own location
      */
     public void testStagingEditFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         StagingEditFrame f = new StagingEditFrame();
         f.setTitle("Test Staging Add Frame");
         f.setLocation(0, 0);	// entire panel must be visible for tests to work properly

--- a/java/test/jmri/jmrit/operations/locations/YardEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/locations/YardEditFrameTest.java
@@ -1,11 +1,12 @@
 //YardEditFrameTest.java
 package jmri.jmrit.operations.locations;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations Locations GUI class
@@ -17,6 +18,9 @@ public class YardEditFrameTest extends OperationsSwingTestCase {
     final static int ALL = Track.EAST + Track.WEST + Track.NORTH + Track.SOUTH;
 
     public void testYardEditFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         LocationManager lManager = LocationManager.instance();
         Location l = lManager.getLocationByName("Test Loc C");
         YardEditFrame f = new YardEditFrame();

--- a/java/test/jmri/jmrit/operations/locations/schedules/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/locations/schedules/PackageTest.java
@@ -29,12 +29,8 @@ public class PackageTest extends TestCase {
         suite.addTest(ScheduleTest.suite());
         suite.addTest(ScheduleManagerTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(ScheduleEditFrameGuiTest.suite());
-            suite.addTest(ScheduleGuiTests.suite());
-        }
+        suite.addTest(ScheduleEditFrameGuiTest.suite());
+        suite.addTest(ScheduleGuiTests.suite());
 
         return suite;
     }

--- a/java/test/jmri/jmrit/operations/locations/schedules/ScheduleEditFrameGuiTest.java
+++ b/java/test/jmri/jmrit/operations/locations/schedules/ScheduleEditFrameGuiTest.java
@@ -1,21 +1,17 @@
 //ScheduleEditFrameTest.java
 package jmri.jmrit.operations.locations.schedules;
 
+import java.awt.GraphicsEnvironment;
 import java.util.List;
 import javax.swing.JComboBox;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.locations.Track;
-import jmri.jmrit.operations.locations.schedules.LocationTrackPair;
-import jmri.jmrit.operations.locations.schedules.Schedule;
-import jmri.jmrit.operations.locations.schedules.ScheduleEditFrame;
-import jmri.jmrit.operations.locations.schedules.ScheduleItem;
-import jmri.jmrit.operations.locations.schedules.ScheduleManager;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations Locations GUI class
@@ -27,6 +23,9 @@ public class ScheduleEditFrameGuiTest extends OperationsSwingTestCase {
     final static int ALL = Track.EAST + Track.WEST + Track.NORTH + Track.SOUTH;
 
     public void testScheduleEditFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         LocationManager lManager = LocationManager.instance();
         Location l2 = lManager.newLocation("Test Loc C");
         l2.setLength(1003);

--- a/java/test/jmri/jmrit/operations/locations/schedules/ScheduleGuiTests.java
+++ b/java/test/jmri/jmrit/operations/locations/schedules/ScheduleGuiTests.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.operations.locations.schedules;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.LocationManager;
@@ -16,6 +17,9 @@ import org.junit.Assert;
 public class ScheduleGuiTests extends OperationsSwingTestCase {
 
     public void testScheduleCopyFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         ScheduleCopyFrame f = new ScheduleCopyFrame();
         Assert.assertNotNull(f);
 
@@ -24,6 +28,9 @@ public class ScheduleGuiTests extends OperationsSwingTestCase {
     }
 
     public void testScheduleOptionsFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         LocationManager lManager = LocationManager.instance();
         Track track = lManager.getLocationByName("Test Loc E").getTrackByName("Test Track", null);
         ScheduleManager sManager = ScheduleManager.instance();
@@ -40,6 +47,9 @@ public class ScheduleGuiTests extends OperationsSwingTestCase {
     }
 
     public void testSchedulesByLoadFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         SchedulesByLoadFrame f = new SchedulesByLoadFrame();
         Assert.assertNotNull(f);
 
@@ -48,6 +58,9 @@ public class ScheduleGuiTests extends OperationsSwingTestCase {
     }
 
     public void testSchedulesTableFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         SchedulesTableFrame f = new SchedulesTableFrame();
         Assert.assertNotNull(f);
 

--- a/java/test/jmri/jmrit/operations/locations/tools/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/locations/tools/PackageTest.java
@@ -26,11 +26,7 @@ public class PackageTest extends TestCase {
     public static Test suite() {
         TestSuite suite = new TestSuite("jmri.jmrit.operations.locations.tools.PackageTest"); // no tests in class itself
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(PoolTrackGuiTest.suite());
-        }
+        suite.addTest(PoolTrackGuiTest.suite());
 
         return suite;
     }

--- a/java/test/jmri/jmrit/operations/locations/tools/PoolTrackGuiTest.java
+++ b/java/test/jmri/jmrit/operations/locations/tools/PoolTrackGuiTest.java
@@ -1,15 +1,15 @@
 package jmri.jmrit.operations.locations.tools;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.locations.Pool;
 import jmri.jmrit.operations.locations.Track;
-import jmri.jmrit.operations.locations.tools.PoolTrackFrame;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations PoolTrackFrame class
@@ -120,8 +120,11 @@ public class PoolTrackGuiTest extends OperationsSwingTestCase {
      * anything.
      */
     public void testPoolFrameCreate() throws Exception {
-		// Make sure the frame gets created OK and has
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
 
+        // Make sure the frame gets created OK and has
         //CreateTestLocations();
         // Maybe this should use the LocationManager instead????
         Location l = new Location("LOC1", "Location One");
@@ -131,7 +134,7 @@ public class PoolTrackGuiTest extends OperationsSwingTestCase {
 
         PoolTrackFrame f = new PoolTrackFrame(t);
         f.initComponents();
-		//f.setVisible(true);
+        //f.setVisible(true);
 
         // close windows
         f.dispose();
@@ -154,6 +157,9 @@ public class PoolTrackGuiTest extends OperationsSwingTestCase {
 //
 //	}
     public void testAddNewPoolName() throws Exception {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         // Enter a new Pool name and click Add, check that the Pool list count
         // is 1
         CreateTestLocations();
@@ -207,6 +213,9 @@ public class PoolTrackGuiTest extends OperationsSwingTestCase {
     }
 
     public void testSelectPoolAndSaveTrack() throws Exception {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         // This should change the pool track property of the Track under test.
         Location l = new Location("LOC1", "Location One");
         l.addPool("Pool 1");
@@ -237,6 +246,9 @@ public class PoolTrackGuiTest extends OperationsSwingTestCase {
     }
 
     public void testSetMinLengthAndSaveTrack() throws Exception {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
 // Enter a new minimum length, click save and check that the Track is updated.
         Location l = new Location("LOC1", "Location One");
 //		l.addPool("Pool 1");
@@ -319,7 +331,7 @@ public class PoolTrackGuiTest extends OperationsSwingTestCase {
         // Not sure if we need this one...
     }
 
-	// ***************************************************
+    // ***************************************************
     // OLD Locations stuff below here, just for reference.....
     // public void testLocationsTableFrame() {
     // // Make sure the frames gets created OK and have the list of current

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/CarAttributeEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/CarAttributeEditFrameTest.java
@@ -1,12 +1,13 @@
 //CarAttributeEditFrameTest.java
 package jmri.jmrit.operations.rollingstock.cars;
 
+import java.awt.GraphicsEnvironment;
 import java.util.List;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations CarAttributeEditFrame class
@@ -16,6 +17,9 @@ import junit.framework.TestSuite;
 public class CarAttributeEditFrameTest extends OperationsSwingTestCase {
 
     public void testCarAttributeEditFrameColor() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         CarAttributeEditFrame f = new CarAttributeEditFrame();
         f.initComponents(CarEditFrame.COLOR);
         f.addTextBox.setText("Pink");
@@ -41,6 +45,9 @@ public class CarAttributeEditFrameTest extends OperationsSwingTestCase {
     }
 
     public void testCarAttributeEditFrameKernel() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         // remove all kernels
         CarManager cm = CarManager.instance();
         List<String> kList = cm.getKernelNameList();
@@ -82,6 +89,9 @@ public class CarAttributeEditFrameTest extends OperationsSwingTestCase {
     }
 
     public void testCarAttributeEditFrame2() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         CarAttributeEditFrame f = new CarAttributeEditFrame();
         f.initComponents(CarEditFrame.LENGTH);
         f.dispose();

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/CarEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/CarEditFrameTest.java
@@ -1,6 +1,7 @@
 //CarEditFrameTest.java
 package jmri.jmrit.operations.rollingstock.cars;
 
+import java.awt.GraphicsEnvironment;
 import java.util.List;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
@@ -18,6 +19,9 @@ public class CarEditFrameTest extends OperationsSwingTestCase {
     List<String> tempCars;
 
     public void testCarEditFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         loadCars();		// load cars
         CarManager cManager = CarManager.instance();
         Assert.assertEquals("number of cars", 5, cManager.getNumEntries());
@@ -107,6 +111,9 @@ public class CarEditFrameTest extends OperationsSwingTestCase {
     }
 
     public void testCarEditFrameRead() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         loadCars();		// load cars
         CarManager cManager = CarManager.instance();
         // should have 5 cars now

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/CarLoadEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/CarLoadEditFrameTest.java
@@ -1,11 +1,12 @@
 //CarLoadEditFrameTest.java
 package jmri.jmrit.operations.rollingstock.cars;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations CarLoadEditFrame class
@@ -15,6 +16,9 @@ import junit.framework.TestSuite;
 public class CarLoadEditFrameTest extends OperationsSwingTestCase {
 
     public void testCarLoadEditFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         CarLoadEditFrame f = new CarLoadEditFrame();
         f.initComponents("Boxcar", "");
         f.addTextBox.setText("New Load");

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/CarSetFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/CarSetFrameTest.java
@@ -1,6 +1,7 @@
 //CarSetFrameTest.java
 package jmri.jmrit.operations.rollingstock.cars;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -13,6 +14,9 @@ import junit.framework.TestSuite;
 public class CarSetFrameTest extends OperationsSwingTestCase {
 
     public void testCarSetFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         loadCars();		// load cars
         CarSetFrame f = new CarSetFrame();
         f.setTitle("Test Car Set Frame");

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/CarsTableFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/CarsTableFrameTest.java
@@ -1,6 +1,7 @@
 //CarsTableFrameTest.java
 package jmri.jmrit.operations.rollingstock.cars;
 
+import java.awt.GraphicsEnvironment;
 import java.util.List;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.Location;
@@ -21,6 +22,9 @@ import org.junit.Assert;
 public class CarsTableFrameTest extends OperationsSwingTestCase {
 
     public void testCarsTableFrame() throws Exception {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         // remove previous cars
         CarManager.instance().dispose();
         CarRoads.instance().dispose();

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/PackageTest.java
@@ -36,15 +36,11 @@ public class PackageTest extends TestCase {
         suite.addTest(CarManagerTest.suite());
         suite.addTest(XmlTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(CarsTableFrameTest.suite());
-            suite.addTest(CarEditFrameTest.suite());
-            suite.addTest(CarAttributeEditFrameTest.suite());
-            suite.addTest(CarLoadEditFrameTest.suite());
-            suite.addTest(CarSetFrameTest.suite());
-        }
+        suite.addTest(CarsTableFrameTest.suite());
+        suite.addTest(CarEditFrameTest.suite());
+        suite.addTest(CarAttributeEditFrameTest.suite());
+        suite.addTest(CarLoadEditFrameTest.suite());
+        suite.addTest(CarSetFrameTest.suite());
 
         return suite;
     }

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/EngineAttributeEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/EngineAttributeEditFrameTest.java
@@ -1,6 +1,7 @@
 //EngineAttributeEditFrame.java
 package jmri.jmrit.operations.rollingstock.engines;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.LocationManager;
@@ -8,9 +9,9 @@ import jmri.jmrit.operations.locations.Track;
 import jmri.jmrit.operations.rollingstock.cars.CarOwners;
 import jmri.jmrit.operations.rollingstock.cars.CarRoads;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations Engines GUI class
@@ -21,6 +22,9 @@ import junit.framework.TestSuite;
 public class EngineAttributeEditFrameTest extends OperationsSwingTestCase {
 
     public void testEngineAttributeEditFrameModel() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         EngineAttributeEditFrame f = new EngineAttributeEditFrame();
         f.initComponents(EngineEditFrame.MODEL);
         // confirm that the right number of models were loaded
@@ -49,6 +53,9 @@ public class EngineAttributeEditFrameTest extends OperationsSwingTestCase {
     }
 
     public void testEngineAttributeEditFrame2() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         EngineAttributeEditFrame f = new EngineAttributeEditFrame();
         f.initComponents(EngineEditFrame.LENGTH);
         f.dispose();

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/EngineEditFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/EngineEditFrameTest.java
@@ -1,6 +1,7 @@
 //EngineEditFrameTest.java
 package jmri.jmrit.operations.rollingstock.engines;
 
+import java.awt.GraphicsEnvironment;
 import java.util.List;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.Location;
@@ -9,9 +10,9 @@ import jmri.jmrit.operations.locations.Track;
 import jmri.jmrit.operations.rollingstock.cars.CarOwners;
 import jmri.jmrit.operations.rollingstock.cars.CarRoads;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations EngineEditFrame class
@@ -24,7 +25,9 @@ public class EngineEditFrameTest  extends OperationsSwingTestCase {
     List<String> tempEngines;
 
     public void testEngineEditFrame() {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         EngineEditFrame f = new EngineEditFrame();
         f.initComponents();
         f.setTitle("Test Add Engine Frame");
@@ -60,6 +63,9 @@ public class EngineEditFrameTest  extends OperationsSwingTestCase {
     }
 
     public void testEngineEditFrameRead() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         EngineManager cManager = EngineManager.instance();
         Engine e1 = cManager.getByRoadAndNumber("NH", "1");
         EngineEditFrame f = new EngineEditFrame();

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/EngineSetFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/EngineSetFrameTest.java
@@ -1,15 +1,16 @@
 //EngineSetFrameTest.java
 package jmri.jmrit.operations.rollingstock.engines;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.locations.Track;
 import jmri.jmrit.operations.rollingstock.cars.CarOwners;
 import jmri.jmrit.operations.rollingstock.cars.CarRoads;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations EnginesSetFrame class
@@ -20,6 +21,9 @@ import junit.framework.TestSuite;
 public class EngineSetFrameTest extends OperationsSwingTestCase {
 
     public void testEngineSetFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         EngineSetFrame f = new EngineSetFrame();
         f.setTitle("Test Engine Set Frame");
         f.initComponents();

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/EnginesTableFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/EnginesTableFrameTest.java
@@ -1,6 +1,7 @@
 //EnginesTableFrameTest.java
 package jmri.jmrit.operations.rollingstock.engines;
 
+import java.awt.GraphicsEnvironment;
 import java.util.List;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.Location;
@@ -11,9 +12,9 @@ import jmri.jmrit.operations.rollingstock.cars.CarOwners;
 import jmri.jmrit.operations.rollingstock.cars.CarRoads;
 import jmri.jmrit.operations.setup.Setup;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations EnginesTableFrame class
@@ -24,7 +25,9 @@ import junit.framework.TestSuite;
 public class EnginesTableFrameTest extends OperationsSwingTestCase {
 
     public void testenginesTableFrame() throws Exception {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         // enable rfid field
         Setup.setRfidEnabled(true);
 

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/PackageTest.java
@@ -33,14 +33,10 @@ public class PackageTest extends TestCase {
         suite.addTest(EngineManagerTest.suite());
         suite.addTest(XmlTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(EnginesTableFrameTest.suite());
-            suite.addTest(EngineEditFrameTest.suite());
-            suite.addTest(EngineAttributeEditFrameTest.suite());
-            suite.addTest(EngineSetFrameTest.suite());
-        }
+        suite.addTest(EnginesTableFrameTest.suite());
+        suite.addTest(EngineEditFrameTest.suite());
+        suite.addTest(EngineAttributeEditFrameTest.suite());
+        suite.addTest(EngineSetFrameTest.suite());
 
         return suite;
     }

--- a/java/test/jmri/jmrit/operations/routes/OperationsRoutesGuiTest.java
+++ b/java/test/jmri/jmrit/operations/routes/OperationsRoutesGuiTest.java
@@ -1,6 +1,7 @@
 //OperationsRoutesGuiTest.java
 package jmri.jmrit.operations.routes;
 
+import java.awt.GraphicsEnvironment;
 import java.util.List;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.Location;
@@ -19,6 +20,9 @@ import org.junit.Assert;
 public class OperationsRoutesGuiTest extends OperationsSwingTestCase {
 
     public void testRoutesTableFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         loadRoutes();
 
         RoutesTableFrame f = new RoutesTableFrame();
@@ -48,6 +52,9 @@ public class OperationsRoutesGuiTest extends OperationsSwingTestCase {
     }
 
     public void testRouteEditFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         RouteEditFrame f = new RouteEditFrame();
         f.setTitle("Test Add Route Frame");
         f.initComponents(null);
@@ -114,6 +121,9 @@ public class OperationsRoutesGuiTest extends OperationsSwingTestCase {
     }
 
     public void testRouteEditFrameRead() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         loadRoutes();
         RouteManager lManager = RouteManager.instance();
         Route l2 = lManager.getRouteByName("Test Route C");

--- a/java/test/jmri/jmrit/operations/routes/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/routes/PackageTest.java
@@ -27,11 +27,7 @@ public class PackageTest extends TestCase {
         TestSuite suite = new TestSuite("jmri.jmrit.operations.routes.PackageTest"); // no tests in class itself
         suite.addTest(OperationsRoutesTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(OperationsRoutesGuiTest.suite());
-        }
+        suite.addTest(OperationsRoutesGuiTest.suite());
 
         return suite;
     }

--- a/java/test/jmri/jmrit/operations/setup/OperationsBackupGuiTest.java
+++ b/java/test/jmri/jmrit/operations/setup/OperationsBackupGuiTest.java
@@ -1,6 +1,7 @@
 //OperationsBackupGuiTest.java
 package jmri.jmrit.operations.setup;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -64,6 +65,9 @@ public class OperationsBackupGuiTest extends OperationsSwingTestCase {
     }
 
     public void testCreateBackupDialog() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         BackupDialog dlg = new BackupDialog();
         dlg.setLocationRelativeTo(null);
         dlg.setModal(false);
@@ -73,6 +77,9 @@ public class OperationsBackupGuiTest extends OperationsSwingTestCase {
     }
 
     public void testCreateRestoreDialog() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         RestoreDialog dlg = new RestoreDialog();
         dlg.setLocationRelativeTo(null);
         dlg.setModal(false);
@@ -82,6 +89,9 @@ public class OperationsBackupGuiTest extends OperationsSwingTestCase {
     }
 
     public void testCreateManageBackupsDialog() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         ManageBackupsDialog dlg = new ManageBackupsDialog();
         dlg.setLocationRelativeTo(null);
         dlg.setModal(false);

--- a/java/test/jmri/jmrit/operations/setup/OperationsSetupGuiTest.java
+++ b/java/test/jmri/jmrit/operations/setup/OperationsSetupGuiTest.java
@@ -1,6 +1,7 @@
 // OperationsSetupGuiTest.java
 package jmri.jmrit.operations.setup;
 
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.display.LocoIcon;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
@@ -17,6 +18,9 @@ public class OperationsSetupGuiTest extends OperationsSwingTestCase {
 
     public void testDirectionCheckBoxes() {
         // it may be possible to make this a headless test by only initializing the panel, not the frame
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         OperationsSetupFrame f = new OperationsSetupFrame();
         f.setLocation(0, 0); // entire panel must be visible for tests to work properly
         f.initComponents();
@@ -48,6 +52,9 @@ public class OperationsSetupGuiTest extends OperationsSwingTestCase {
 
     public void testSetupFrameWrite() {
         // it may be possible to make this a headless test by only initializing the panel, not the frame
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         // force creation of backup
         Setup.setCarTypes(Setup.AAR);
 
@@ -123,6 +130,9 @@ public class OperationsSetupGuiTest extends OperationsSwingTestCase {
     }
 
     public void testOptionFrameWrite() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         OptionFrame f = new OptionFrame();
         f.setLocation(0, 0); // entire panel must be visible for tests to work properly
         f.initComponents();
@@ -190,6 +200,9 @@ public class OperationsSetupGuiTest extends OperationsSwingTestCase {
     }
   
     public void testBuildReportOptionFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         BuildReportOptionFrame f = new BuildReportOptionFrame();
         f.setLocation(0, 0); // entire panel must be visible for tests to work properly
         f.initComponents();
@@ -201,6 +214,9 @@ public class OperationsSetupGuiTest extends OperationsSwingTestCase {
     }
       
     public void testPrintMoreOptionFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         PrintMoreOptionFrame f = new PrintMoreOptionFrame();
         f.setLocation(0, 0); // entire panel must be visible for tests to work properly
         f.initComponents();
@@ -212,6 +228,9 @@ public class OperationsSetupGuiTest extends OperationsSwingTestCase {
     }
     
     public void testEditManifestTextFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         EditManifestTextFrame f = new EditManifestTextFrame();
         f.setLocation(0, 0); // entire panel must be visible for tests to work properly
         f.initComponents();
@@ -223,6 +242,9 @@ public class OperationsSetupGuiTest extends OperationsSwingTestCase {
     }
     
     public void testEditSwitchListTextFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         EditSwitchListTextFrame f = new EditSwitchListTextFrame();
         f.setLocation(0, 0); // entire panel must be visible for tests to work properly
         f.initComponents();
@@ -234,6 +256,9 @@ public class OperationsSetupGuiTest extends OperationsSwingTestCase {
     }
     
     public void testEditManifestHeaderTextFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         EditManifestHeaderTextFrame f = new EditManifestHeaderTextFrame();
         f.setLocation(0, 0); // entire panel must be visible for tests to work properly
         f.initComponents();
@@ -245,6 +270,9 @@ public class OperationsSetupGuiTest extends OperationsSwingTestCase {
     }
     
     public void testPrintOptionFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         PrintOptionFrame f = new PrintOptionFrame();
         f.setLocation(0, 0); // entire panel must be visible for tests to work properly
         f.initComponents();

--- a/java/test/jmri/jmrit/operations/setup/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/setup/PackageTest.java
@@ -28,13 +28,8 @@ public class PackageTest extends TestCase {
         suite.addTest(OperationsSetupTest.suite());
         suite.addTest(OperationsBackupTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(OperationsSetupGuiTest.suite());
-            suite.addTest(OperationsBackupGuiTest.suite());
-        }
-
+        suite.addTest(OperationsSetupGuiTest.suite());
+        suite.addTest(OperationsBackupGuiTest.suite());
         return suite;
     }
 

--- a/java/test/jmri/jmrit/operations/trains/OperationsTrainsGuiTest.java
+++ b/java/test/jmri/jmrit/operations/trains/OperationsTrainsGuiTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.operations.trains;
 
 import java.awt.Component;
+import java.awt.GraphicsEnvironment;
 import java.util.List;
 import jmri.jmrit.display.PanelMenu;
 import jmri.jmrit.operations.OperationsSwingTestCase;
@@ -22,9 +23,9 @@ import jmri.jmrit.operations.trains.tools.TrainByCarTypeFrame;
 import jmri.util.JmriJFrame;
 import jmri.util.ThreadingUtil;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations Trains GUI class
@@ -36,6 +37,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
     private final int DIRECTION_ALL = Location.EAST + Location.WEST + Location.NORTH + Location.SOUTH;
 
     public void testTrainsTableFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         TrainManager tmanager = TrainManager.instance();
 
         TrainsTableFrame f = new TrainsTableFrame();
@@ -90,7 +94,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
      * the train fields.
      */
     public void testTrainEditFrame() {
-
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         TrainEditFrame trainEditFrame = new TrainEditFrame(null);
         trainEditFrame.setTitle("Test Edit Train Frame");
         ThreadingUtil.runOnGUI(()->{
@@ -254,6 +260,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
     }
 
     public void testTrainEditFrameBuildOptionFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         // test build options
         TrainManager tmanager = TrainManager.instance();
         Train t = tmanager.newTrain("Test Train New Name");
@@ -556,6 +565,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
 //    }
 
     public void testTrainSwitchListEditFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         // check defaults
         Assert.assertTrue("All Trains", Setup.isSwitchListAllTrainsEnabled());
         Assert.assertTrue("Page per Train", Setup.getSwitchListPageFormat().equals(Setup.PAGE_NORMAL));
@@ -623,6 +635,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
      * Test that delete train works
      */
     public void testTrainEditFrameDelete() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         TrainManager tmanager = TrainManager.instance();
         Train t = tmanager.getTrainByName("Test_Train 1");
         Assert.assertNotNull(t);
@@ -648,6 +663,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
     }
 
     public void testTrainByCarTypeFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         TrainManager tmanager = TrainManager.instance();
         Train train = tmanager.getTrainByName("Test Train Name");
         TrainByCarTypeFrame f = new TrainByCarTypeFrame();
@@ -658,6 +676,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
     }
 
     public void testTrainsScheduleTableFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         TrainsScheduleTableFrame f = new TrainsScheduleTableFrame();
         ThreadingUtil.runOnGUI(()->{
             f.setVisible(true);
@@ -693,6 +714,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
 
     // test TrainIcon attributes
     public void testTrainIconAttributes() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         Train train1 = new Train("TESTTRAINID", "TESTNAME");
 
         Assert.assertEquals("Train Id", "TESTTRAINID", train1.getId());
@@ -715,6 +739,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
     }
 
     public void testTrainIcon() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         TrainManager tmanager = TrainManager.instance();
         RouteManager rmanager = RouteManager.instance();
         LocationManager lmanager = LocationManager.instance();

--- a/java/test/jmri/jmrit/operations/trains/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/trains/PackageTest.java
@@ -35,10 +35,7 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.jmrit.operations.trains.excel.PackageTest.suite());
         suite.addTest(jmri.jmrit.operations.trains.timetable.PackageTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.operations.trains.configurexml.PackageTest.class));
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(OperationsTrainsGuiTest.suite());
-        }
+        suite.addTest(OperationsTrainsGuiTest.suite());
 
         return suite;
     }

--- a/java/test/jmri/jmrit/operations/trains/timetable/OperationsTrainsGuiTest.java
+++ b/java/test/jmri/jmrit/operations/trains/timetable/OperationsTrainsGuiTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.operations.trains.timetable;
 
 import java.awt.Component;
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.rollingstock.cars.Car;
@@ -10,9 +11,9 @@ import jmri.jmrit.operations.rollingstock.engines.EngineManager;
 import jmri.jmrit.operations.routes.RouteManager;
 import jmri.jmrit.operations.trains.TrainManager;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations Trains GUI class
@@ -22,6 +23,9 @@ import junit.framework.TestSuite;
 public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
 
     public void testTrainsScheduleTableFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         TrainsScheduleTableFrame f = new TrainsScheduleTableFrame();
         f.setVisible(true);
 
@@ -30,6 +34,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
     }
 
     public void testTrainsScheduleEditFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         TrainsScheduleEditFrame f = new TrainsScheduleEditFrame();
         Assert.assertNotNull("frame exists", f);
 

--- a/java/test/jmri/jmrit/operations/trains/timetable/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/trains/timetable/PackageTest.java
@@ -26,11 +26,7 @@ public class PackageTest extends TestCase {
     public static Test suite() {
         TestSuite suite = new TestSuite("jmri.jmrit.operations.trains.timetable.PackageTest"); // no tests in class itself
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(OperationsTrainsGuiTest.suite());
-        }
+        suite.addTest(OperationsTrainsGuiTest.suite());
 
         return suite;
     }

--- a/java/test/jmri/jmrit/operations/trains/tools/OperationsTrainsGuiTest.java
+++ b/java/test/jmri/jmrit/operations/trains/tools/OperationsTrainsGuiTest.java
@@ -1,8 +1,7 @@
 package jmri.jmrit.operations.trains.tools;
 
-import jmri.jmrit.operations.trains.timetable.TrainsScheduleTableFrame;
-
 import java.awt.Component;
+import java.awt.GraphicsEnvironment;
 import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.rollingstock.cars.Car;
@@ -13,10 +12,11 @@ import jmri.jmrit.operations.routes.RouteManager;
 import jmri.jmrit.operations.trains.Train;
 import jmri.jmrit.operations.trains.TrainIcon;
 import jmri.jmrit.operations.trains.TrainManager;
+import jmri.jmrit.operations.trains.timetable.TrainsScheduleTableFrame;
 import junit.extensions.jfcunit.eventdata.MouseEventData;
-import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.Assert;
 
 /**
  * Tests for the Operations Trains GUI class
@@ -27,6 +27,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
 
 
     public void testTrainModifyFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         // confirm that train default accepts Boxcars
         TrainManager tmanager = TrainManager.instance();
         Train t = tmanager.newTrain("Test Train Name 2");
@@ -51,6 +54,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
     }
 
     public void testTrainByCarTypeFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         TrainManager tmanager = TrainManager.instance();
         Train train = tmanager.getTrainByName("Test Train Name");
         TrainByCarTypeFrame f = new TrainByCarTypeFrame();
@@ -61,6 +67,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
     }
 
     public void testTrainsScheduleTableFrame() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         TrainsScheduleTableFrame f = new TrainsScheduleTableFrame();
         f.setVisible(true);
 
@@ -70,6 +79,9 @@ public class OperationsTrainsGuiTest extends OperationsSwingTestCase {
 
     // test TrainIcon attributes
     public void testTrainIconAttributes() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return; // can't use Assume in TestCase subclasses
+        }
         Train train1 = new Train("TESTTRAINID", "TESTNAME");
 
         Assert.assertEquals("Train Id", "TESTTRAINID", train1.getId());

--- a/java/test/jmri/jmrit/operations/trains/tools/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/trains/tools/PackageTest.java
@@ -26,11 +26,7 @@ public class PackageTest extends TestCase {
     public static Test suite() {
         TestSuite suite = new TestSuite("jmri.jmrit.operations.trains.tools.PackageTest"); // no tests in class itself
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-
-        // GUI tests start here
-        if (!System.getProperty("java.awt.headless", "false").equals("true")) {
-            suite.addTest(OperationsTrainsGuiTest.suite());
-        }
+        suite.addTest(OperationsTrainsGuiTest.suite());
 
         return suite;
     }


### PR DESCRIPTION
This completes the migration from checking the jmri.headless property in suites to checking that the GraphicsEnvironment is headless in individual tests.