### PR TITLE
Fix commented out test classes

### DIFF
--- a/java/test/jmri/jmrix/rps/AbstractAlgorithmTest.java
+++ b/java/test/jmri/jmrix/rps/AbstractAlgorithmTest.java
@@ -1,8 +1,10 @@
 package jmri.jmrix.rps;
 
 import javax.vecmath.Point3d;
+import org.junit.After;
 import org.junit.Assert;
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Common test scaffolding for Algorithm implementations.
@@ -14,8 +16,8 @@ import junit.framework.TestCase;
  * Implementing subclasses should provide static "main" and "suite" methods.
  *
  * @author	Bob Jacobsen Copyright 2008
-  */
-abstract public class AbstractAlgorithmTest extends TestCase {
+ */
+abstract public class AbstractAlgorithmTest {
 
     abstract Calculator getAlgorithm(Point3d[] pts, double vs);
 
@@ -32,6 +34,7 @@ abstract public class AbstractAlgorithmTest extends TestCase {
     Point3d result1 = new Point3d(3.0, 2.0, 1.0);
     double[] distances1 = distances(receivers1, vs, result1);
 
+    @Test
     public void testCalc1() {
         testCalc(receivers1, distances1, result1, "Test 1", distances1.length, 3);
     }
@@ -47,6 +50,7 @@ abstract public class AbstractAlgorithmTest extends TestCase {
     Point3d result2 = new Point3d(3.0, 2.0, 1.0);
     double[] distances2 = distances(receivers2, vs, result2);
 
+    @Test
     public void testCalc2() {
         testCalc(receivers2, distances2, result2, "Test 2", distances2.length, 3);
     }
@@ -69,6 +73,7 @@ abstract public class AbstractAlgorithmTest extends TestCase {
     Point3d result3 = new Point3d(3.0, 2.0, 1.0);
     double[] distances3 = distances(receivers3, vs, result3);
 
+    @Test
     public void testCalc3() {
         testCalc(receivers3, distances3, result3, "Test 3", distances3.length, 3);
     }
@@ -85,6 +90,7 @@ abstract public class AbstractAlgorithmTest extends TestCase {
     Point3d result4 = new Point3d(3.0, 2.0, 1.0);
     double[] distances4 = distances(receivers4, vs, result4);
 
+    @Test
     public void testCalc4() {
         distances4[distances4.length - 1] = 9999.;
         testCalc(receivers4, distances4, result4, "Test 4", distances4.length - 1, 3);
@@ -100,6 +106,7 @@ abstract public class AbstractAlgorithmTest extends TestCase {
     Point3d result5 = new Point3d(3.0, 2.0, 1.0);
     double[] distances5 = distances(receivers5, vs, result5);
 
+    @Test
     public void testCalc5() {
         testCalc(receivers5, distances5, result5, "Test 5", distances5.length, 3);
     }
@@ -114,6 +121,7 @@ abstract public class AbstractAlgorithmTest extends TestCase {
     Point3d result6 = new Point3d(3.0, 2.0, 1.0);
     double[] distances6 = distances(receivers6, vs, result6);
 
+    @Test
     public void testCalc6() {
         testCalc(receivers6, distances6, result6, "Test 6", distances6.length, 3);
     }
@@ -128,6 +136,7 @@ abstract public class AbstractAlgorithmTest extends TestCase {
     Point3d result7 = new Point3d(3.0, 2.0, 1.0);
     double[] distances7 = distances(receivers7, vs, result7);
 
+    @Test
     public void testCalc7() {
         testCalc(receivers7, distances7, result7, "Test 7", distances7.length, 3);
     }
@@ -190,6 +199,16 @@ abstract public class AbstractAlgorithmTest extends TestCase {
         }
         Assert.assertTrue(label + " code > min", m.getCode() >= codemin);
         Assert.assertTrue(label + " code <= max", m.getCode() <= codemax);
+    }
+
+    @Before
+    public void setUp() {
+        apps.tests.Log4JFixture.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        apps.tests.Log4JFixture.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/rps/Analytic_AAlgorithmTest.java
+++ b/java/test/jmri/jmrix/rps/Analytic_AAlgorithmTest.java
@@ -1,41 +1,47 @@
 package jmri.jmrix.rps;
 
 import javax.vecmath.Point3d;
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * JUnit tests for the rps.Analytic_AAlgorithm class.
  *
  *
  * @author	Bob Jacobsen Copyright 2008
-  */
+ */
 public class Analytic_AAlgorithmTest extends AbstractAlgorithmTest {
 
+    @Override
     Calculator getAlgorithm(Point3d[] pts, double vs) {
         return new Analytic_AAlgorithm(pts, vs);
     }
 
-    // from here down is testing infrastructure
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {Analytic_AAlgorithmTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
+    @Test
+    @Ignore // fails for unknown reasons
+    @Override
+    public void testCalc4() {
+        super.testCalc4();
     }
 
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite(Analytic_AAlgorithmTest.class);
-        return suite;
+    @Test
+    @Ignore // fails for unknown reasons
+    @Override
+    public void testCalc5() {
+        super.testCalc5();
     }
 
-    // The minimal setup for log4J
-    protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
+    @Test
+    @Ignore // fails for unknown reasons
+    @Override
+    public void testCalc6() {
+        super.testCalc6();
     }
 
-    protected void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
+    @Test
+    @Ignore // fails for unknown reasons
+    @Override
+    public void testCalc7() {
+        super.testCalc7();
     }
 }

--- a/java/test/jmri/jmrix/rps/Ash1_0AlgorithmTest.java
+++ b/java/test/jmri/jmrix/rps/Ash1_0AlgorithmTest.java
@@ -2,10 +2,11 @@ package jmri.jmrix.rps;
 
 import apps.tests.Log4JFixture;
 import javax.vecmath.Point3d;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * JUnit tests for the rps.Ash1_0Algorithm class.
@@ -17,11 +18,13 @@ import org.junit.Assert;
  *
  * @author	Bob Jacobsen Copyright 2006
  */
-public class Ash1_0AlgorithmTest extends TestCase {
+public class Ash1_0AlgorithmTest {
 
     double vs = 0.0344;  // SI default for testing
 
     // right answer to these is 0,0,12
+    @Test
+    @Ignore // fails for unknown reasons
     public void testCalc5() {
         Reading r = new Reading("21", new double[]{7. / vs, 13. / vs, 13. / vs, 13. / vs, 3. / vs});
 
@@ -41,6 +44,8 @@ public class Ash1_0AlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 12.) < 0.001);
     }
 
+    @Test
+    @Ignore // fails for unknown reasons
     public void testCalc4_not1() {
         Reading r = new Reading("21", new double[]{13. / vs, 13. / vs, 13. / vs, 3. / vs});
 
@@ -60,6 +65,8 @@ public class Ash1_0AlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 12.) < 0.001);
     }
 
+    @Test
+    @Ignore // fails for unknown reasons
     public void testCalc4_not2() {
         Reading r = new Reading("21", new double[]{7. / vs, 13. / vs, 13. / vs, 3. / vs});
 
@@ -79,6 +86,8 @@ public class Ash1_0AlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 12.) < 0.001);
     }
 
+    @Test
+    @Ignore // fails for unknown reasons
     public void testCalc4_not3() {
         Reading r = new Reading("21", new double[]{7. / vs, 13. / vs, 13. / vs, 3. / vs});
 
@@ -98,29 +107,12 @@ public class Ash1_0AlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 12.) < 0.001);
     }
 
-    // from here down is testing infrastructure
-    public Ash1_0AlgorithmTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {Ash1_0AlgorithmTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(Ash1_0AlgorithmTest.class);
-        return suite;
-    }
-
-    @Override
+    @Before
     public void setUp() {
         Log4JFixture.setUp();
     }
     
-    @Override
+    @After
     public void tearDown() {
         Log4JFixture.tearDown();
     }

--- a/java/test/jmri/jmrix/rps/Ash1_1AlgorithmTest.java
+++ b/java/test/jmri/jmrix/rps/Ash1_1AlgorithmTest.java
@@ -2,10 +2,11 @@ package jmri.jmrix.rps;
 
 import apps.tests.Log4JFixture;
 import javax.vecmath.Point3d;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * JUnit tests for the rps.Ash1_1Algorithm class.
@@ -16,8 +17,8 @@ import org.junit.Assert;
  * The default transmitter location is (3,2,1)
  *
  * @author	Bob Jacobsen Copyright 2006
-  */
-public class Ash1_1AlgorithmTest extends TestCase {
+ */
+public class Ash1_1AlgorithmTest {
 
     double vs = 0.0344;  // SI default for testing
 
@@ -29,6 +30,8 @@ public class Ash1_1AlgorithmTest extends TestCase {
         ) / vs;
     }
 
+    @Test
+    @Ignore // fails for unknown reasons
     public void testCalc5() {
 
         Point3d s1 = new Point3d(10.0f, 0.0f, 12.0f);
@@ -50,6 +53,8 @@ public class Ash1_1AlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 1.) < 0.001);
     }
 
+    @Test
+    @Ignore // fails for unknown reasons
     public void testCalc4_not1() {
         Point3d s2 = new Point3d(-3.0f, 4.0f, 9.0f);
         Point3d s3 = new Point3d(-3.0f, -4.0f, 10.0f);
@@ -69,6 +74,8 @@ public class Ash1_1AlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 1.) < 0.001);
     }
 
+    @Test
+    @Ignore // fails for unknown reasons
     public void testCalc4_not2() {
         Point3d s1 = new Point3d(10.0f, 0.0f, 12.0f);
         Point3d s3 = new Point3d(-3.0f, -4.0f, 10.0f);
@@ -88,6 +95,8 @@ public class Ash1_1AlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 1.) < 0.001);
     }
 
+    @Test
+    @Ignore // fails for unknown reasons
     public void testCalc4_not3() {
         Point3d s1 = new Point3d(10.0f, 0.0f, 12.0f);
         Point3d s2 = new Point3d(-3.0f, 4.0f, 9.0f);
@@ -107,29 +116,12 @@ public class Ash1_1AlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 1.) < 0.001);
     }
 
-    // from here down is testing infrastructure
-    public Ash1_1AlgorithmTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {Ash1_1AlgorithmTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(Ash1_1AlgorithmTest.class);
-        return suite;
-    }
-
-    @Override
+    @Before
     public void setUp() {
         Log4JFixture.setUp();
     }
-    
-    @Override
+
+    @After
     public void tearDown() {
         Log4JFixture.tearDown();
     }

--- a/java/test/jmri/jmrix/rps/Ash2_0AlgorithmTest.java
+++ b/java/test/jmri/jmrix/rps/Ash2_0AlgorithmTest.java
@@ -1,8 +1,6 @@
 package jmri.jmrix.rps;
 
 import javax.vecmath.Point3d;
-import junit.framework.Test;
-import junit.framework.TestSuite;
 
 /**
  * JUnit tests for the rps.Ash2_0Algorithm class.
@@ -16,30 +14,8 @@ import junit.framework.TestSuite;
   */
 public class Ash2_0AlgorithmTest extends AbstractAlgorithmTest {
 
+    @Override
     Calculator getAlgorithm(Point3d[] pts, double vs) {
         return new Ash2_0Algorithm(pts, vs);
-    }
-
-    // from here down is testing infrastructure
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {Ash2_0AlgorithmTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite(Ash2_0AlgorithmTest.class);
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
-    }
-
-    protected void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/rps/Ash2_1AlgorithmTest.java
+++ b/java/test/jmri/jmrix/rps/Ash2_1AlgorithmTest.java
@@ -1,8 +1,6 @@
 package jmri.jmrix.rps;
 
 import javax.vecmath.Point3d;
-import junit.framework.Test;
-import junit.framework.TestSuite;
 
 /**
  * JUnit tests for the rps.Ash2_1Algorithm class.
@@ -16,29 +14,8 @@ import junit.framework.TestSuite;
   */
 public class Ash2_1AlgorithmTest extends AbstractAlgorithmTest {
 
+    @Override
     Calculator getAlgorithm(Point3d[] pts, double vs) {
         return new Ash2_1Algorithm(pts, vs);
-    }
-
-    // from here down is testing infrastructure
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {Ash2_1AlgorithmTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(Ash2_1AlgorithmTest.class);
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
-    }
-
-    protected void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/rps/Ash2_2AlgorithmTest.java
+++ b/java/test/jmri/jmrix/rps/Ash2_2AlgorithmTest.java
@@ -1,8 +1,6 @@
 package jmri.jmrix.rps;
 
 import javax.vecmath.Point3d;
-import junit.framework.Test;
-import junit.framework.TestSuite;
 
 /**
  * JUnit tests for the rps.Ash2_2Algorithm class.
@@ -14,30 +12,8 @@ import junit.framework.TestSuite;
   */
 public class Ash2_2AlgorithmTest extends AbstractAlgorithmTest {
 
+    @Override
     Calculator getAlgorithm(Point3d[] pts, double vs) {
         return new Ash2_2Algorithm(pts, vs);
-    }
-
-    // from here down is testing infrastructure
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {Ash2_2AlgorithmTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite(Ash2_2AlgorithmTest.class);
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
-    }
-
-    protected void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/rps/InitialAlgorithmTest.java
+++ b/java/test/jmri/jmrix/rps/InitialAlgorithmTest.java
@@ -1,10 +1,10 @@
 package jmri.jmrix.rps;
 
 import javax.vecmath.Point3d;
+import org.junit.After;
 import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * JUnit tests for the rps.Measurement class.
@@ -12,11 +12,12 @@ import junit.framework.TestSuite;
  * The default transmitter location for the 7, 13, 13, 13 readings is (0,0,12)
  *
  * @author	Bob Jacobsen Copyright 2006
-  */
-public class InitialAlgorithmTest extends TestCase {
+ */
+public class InitialAlgorithmTest {
 
     double vs = 0.0344; // SI default for testing
 
+    @Test
     public void testCalc4() {
         Reading r = new Reading("21", new double[]{0., 7. / vs, 13. / vs, 13. / vs, 13. / vs});
 
@@ -34,6 +35,7 @@ public class InitialAlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 12.) < 0.001);
     }
 
+    @Test
     public void testCalc3_not4() {
         Reading r = new Reading("21", new double[]{0., 7. / vs, 13. / vs, 13. / vs});
 
@@ -50,6 +52,7 @@ public class InitialAlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 12.) < 0.001);
     }
 
+    @Test
     public void testCalc3_not1() {
         Reading r = new Reading("21", new double[]{0., 13. / vs, 13. / vs, 13. / vs});
 
@@ -66,6 +69,7 @@ public class InitialAlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 12.) < 0.001);
     }
 
+    @Test
     public void testCalc3_not2() {
         Reading r = new Reading("21", new double[]{0., 7. / vs, 13. / vs, 13. / vs});
 
@@ -82,6 +86,7 @@ public class InitialAlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 12.) < 0.001);
     }
 
+    @Test
     public void testCalc3_not3() {
         Reading r = new Reading("21", new double[]{0., 7. / vs, 13. / vs, 13. / vs});
 
@@ -98,22 +103,14 @@ public class InitialAlgorithmTest extends TestCase {
         Assert.assertEquals("z close", true, Math.abs(m.z - 12.) < 0.001);
     }
 
-    // from here down is testing infrastructure
-    public InitialAlgorithmTest(String s) {
-        super(s);
+    @Before
+    public void setUp() {
+        apps.tests.Log4JFixture.setUp();
     }
 
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {InitialAlgorithmTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite(InitialAlgorithmTest.class);
-        return suite;
+    @After
+    public void tearDown() {
+        apps.tests.Log4JFixture.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/rps/PackageTest.java
+++ b/java/test/jmri/jmrix/rps/PackageTest.java
@@ -46,7 +46,7 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.jmrix.rps.csvinput.CsvTest.suite()); // do 3rd to display in front
         suite.addTest(new JUnit4TestAdapter(jmri.jmrix.rps.trackingpanel.PackageTest.class)); // do 4th to display in front
         // test all algorithms as a bunch
-        suite.addTest(jmri.jmrix.rps.algorithms.PackageTest.suite());
+        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.rps.algorithms.PackageTest.class));
 
         return suite;
     }

--- a/java/test/jmri/jmrix/rps/algorithms/PackageTest.java
+++ b/java/test/jmri/jmrix/rps/algorithms/PackageTest.java
@@ -1,12 +1,14 @@
 package jmri.jmrix.rps.algorithms;
 
+import jmri.jmrix.rps.Analytic_AAlgorithmTest;
+import jmri.jmrix.rps.Ash1_0AlgorithmTest;
+import jmri.jmrix.rps.Ash1_1AlgorithmTest;
 import jmri.jmrix.rps.Ash2_0AlgorithmTest;
 import jmri.jmrix.rps.Ash2_1AlgorithmTest;
 import jmri.jmrix.rps.Ash2_2AlgorithmTest;
 import jmri.jmrix.rps.InitialAlgorithmTest;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 /**
  * Test all the RPS algorithms.
@@ -16,34 +18,15 @@ import junit.framework.TestSuite;
  *
  * @author Bob Jacobsen Copyright 2008
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.rps.algorithms");
-
-        suite.addTest(InitialAlgorithmTest.suite());
-
-        // suite.addTest(Ash1_0AlgorithmTest.suite());
-        // suite.addTest(Ash1_1AlgorithmTest.suite());
-        suite.addTest(Ash2_0AlgorithmTest.suite());
-        suite.addTest(Ash2_1AlgorithmTest.suite());
-        suite.addTest(Ash2_2AlgorithmTest.suite());
-
-        // suite.addTest(Analytic_AAlgorithmTest.suite());
-        return suite;
-    }
-
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    InitialAlgorithmTest.class,
+    Ash1_0AlgorithmTest.class,
+    Ash1_1AlgorithmTest.class,
+    Ash2_0AlgorithmTest.class,
+    Ash2_1AlgorithmTest.class,
+    Ash2_2AlgorithmTest.class,
+    Analytic_AAlgorithmTest.class
+})
+public class PackageTest {
 }


### PR DESCRIPTION
Fix test classes commented out because they failed by ignoring them (this required porting the tests to JUnit 4 first). Fixes #2577.