### PR TITLE
Fix allocation problem in Dispatcher / Open up several methods in Dispatcher to scripting

### DIFF
--- a/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
@@ -914,13 +914,6 @@ public class ActivateTrainFrame {
         if (b != null) {
             String sName = b.getSystemName();
             String uName = b.getUserName();
-            // Jay Janzen
-            // Add Block's Comment field to description
-            // for easier identification of block in drop down box
-            String bComment = b.getComment();
-            if ( (bComment!=null) && (bComment!="") ) {
-                sName = sName+"( "+bComment+" )";
-            }
             if ((uName != null) && (!uName.equals("")) && (!uName.equals(sName))) {
                 return (sName + "(" + uName + ")");
             }

--- a/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
@@ -914,6 +914,13 @@ public class ActivateTrainFrame {
         if (b != null) {
             String sName = b.getSystemName();
             String uName = b.getUserName();
+            // Jay Janzen
+            // Add Block's Comment field to description
+            // for easier identification of block in drop down box
+            String bComment = b.getComment();
+            if ( (bComment!=null) && (bComment!="") ) {
+                sName = sName+"( "+bComment+" )";
+            }
             if ((uName != null) && (!uName.equals("")) && (!uName.equals(sName))) {
                 return (sName + "(" + uName + ")");
             }

--- a/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
@@ -88,7 +88,6 @@ public class AutoAllocate {
     private ConnectivityUtil _conUtil = null;
     private ArrayList<AllocationPlan> _planList = new ArrayList<AllocationPlan>();
     private int nextPlanNum = 1;
-    private boolean allocateAll;
     private ArrayList<AllocationRequest> orderedRequests = new ArrayList<AllocationRequest>();
 
     /**

--- a/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
@@ -88,6 +88,7 @@ public class AutoAllocate {
     private ConnectivityUtil _conUtil = null;
     private ArrayList<AllocationPlan> _planList = new ArrayList<AllocationPlan>();
     private int nextPlanNum = 1;
+    private boolean allocateAll;
     private ArrayList<AllocationRequest> orderedRequests = new ArrayList<AllocationRequest>();
 
     /**

--- a/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoAllocate.java
@@ -88,6 +88,20 @@ public class AutoAllocate {
     private ConnectivityUtil _conUtil = null;
     private ArrayList<AllocationPlan> _planList = new ArrayList<AllocationPlan>();
     private int nextPlanNum = 1;
+    // Jay Janzen
+    // Flag to control type of allocations (classic or NX)
+    // Currently there are no methods provided to set or change this flag.
+    // It is created here in anticipation of future capabilities.
+    // Terms classic and NX are my descriptions only. Classic refers to 
+    // allowing Dispatcher to allocate no more than three blocks ahead (which 
+    // has always been therefore I label it classic). NX (which has no 
+    // connection with the "Entry/Exit (NX) Routing" feature of JMRI) refers to
+    // allowing Dispatcher to allocate without bounds as to the number of blocks.
+    // I label this NX because that best describes the way I am using transits.
+    // The starting block of the transit is the N and the ending block of the transit
+    // is the X. Most of the time these two blocks are NOT the very first block or 
+    // the very last block of the transit.
+    private boolean allocateAllTheWay = false;   
     private ArrayList<AllocationRequest> orderedRequests = new ArrayList<AllocationRequest>();
 
     /**
@@ -225,13 +239,43 @@ public class AutoAllocate {
             }
             log.warn("Failure of prepared choice of next Section in AutoAllocate");
         }
+        // Jay Janzen 
+        // If there is an AP check to see if the AP's target is on the list of choices
+        // and if so, return that.
+        ActiveTrain at = ar.getActiveTrain();
+        AllocationPlan ap = getPlanThisTrain(at);
+        Section as = null;
+        if (ap != null) {
+            if      (ap.getActiveTrain(1) == at) {
+                as = ap.getTargetSection(1);
+            }
+            else if (ap.getActiveTrain(2) == at) {
+                as = ap.getTargetSection(2);
+            }
+            else {
+                return null;
+            }
+            for (int i = 0; i < sList.size(); i++) {
+                if (as != null && as == sList.get(i)) return as;
+            }
+        }
+        // If our end block section is on the list of choices
+        // return that occupied or not. In the list of choices the primary occurs
+        // ahead any alternates, so if our end block is an alternate and its
+        // primary is unoccupied, the search will select the primary and
+        // we wind up skipping right over our end section.
+        for (int i = 0; i < sList.size(); i++) {
+            if (at.getEndBlockSection().getSystemName().equals(sList.get(i).getSystemName())) {
+                return sList.get(i);
+            }
+        }        
         // no prepared choice, or prepared choice failed, is there an unoccupied Section available
         for (int i = 0; i < sList.size(); i++) {
             if ((sList.get(i).getOccupancy() == Section.UNOCCUPIED)
                     && (sList.get(i).getState() == Section.FREE)
                     && (_dispatcher.getSignalType() == DispatcherFrame.SIGNALHEAD
                     || (_dispatcher.getSignalType() == DispatcherFrame.SIGNALMAST
-                    && _dispatcher.checkBlocksNotInAllocatedSection(ar.getSection(), ar) == null))) {
+                    && _dispatcher.checkBlocksNotInAllocatedSection(sList.get(i), ar) == null))) {
                 return sList.get(i);
             }
         }
@@ -345,6 +389,13 @@ public class AutoAllocate {
     }
 
     private boolean allocateIfLessThanThreeAhead(AllocationRequest ar) {
+        // Jay Janzen for NX type operation we want to allocate from eNtrance to eXit
+        // regardless of the number of sections allocated. 
+        // See comments on declaration of allocateAllTheWay.
+        if (allocateAllTheWay == true) {
+            _dispatcher.allocateSection(ar, null);
+            return true;
+        }        
         // test how far ahead of occupied track this requested section is
         ArrayList<AllocatedSection> aSectionList = ar.getActiveTrain().getAllocatedSectionList();
         if (aSectionList.size() >= 4) {

--- a/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
@@ -2245,7 +2245,8 @@ public class DispatcherFrame extends jmri.util.JmriJFrame {
 
     // called by ActivateTrainFrame after a new train is all set up
     //      Dispatcher side of activating a new train should be completed here
-    protected void newTrainDone(ActiveTrain at) {
+    // Jay Janzen protection changed to public for access via scripting
+    public void newTrainDone(ActiveTrain at) {
         if (at != null) {
             // a new active train was created, check for delayed start
             if (at.getDelayedStart() != ActiveTrain.NODELAY && (!at.getStarted())) {
@@ -2291,7 +2292,9 @@ public class DispatcherFrame extends jmri.util.JmriJFrame {
         }
     }
 
-    protected AutoTrainsFrame getAutoTrainsFrame() {
+    // Jay Janzen
+    // Protection changed to public to allow access via scripting
+    public AutoTrainsFrame getAutoTrainsFrame() {
         return _autoTrainsFrame;
     }
 


### PR DESCRIPTION
Request involves three parts: 1. When specifying an end block in a transit and that end block is an alternate and the corresponding primary is unoccupied, autoallocate allocates the primary completely skipping the alternate. 2. Request that several methods be changed to public protection to allow scripting access. 3. Request a way to 'turn off' Dispatcher's limit of allocating no more than three blocks in advance. This then allows allocation to be made from a specified start block all the way to a specified end block within the transit.