### PR TITLE
AbstractMonitor file selection improvements

### DIFF
--- a/java/src/jmri/jmrix/AbstractMonPane.java
+++ b/java/src/jmri/jmrix/AbstractMonPane.java
@@ -524,67 +524,26 @@ public abstract class AbstractMonPane extends JmriPanel {
             monTextPane.setText("");
         }
     }
-    
-    public String getFilePathAndName() {
-        String returnString;
-        java.nio.file.Path p = logFileChooser.getSelectedFile().toPath();
-        if (p.getParent() == null) {
-            // This case is a file path with a "parent" of "null"
-            //
-            // Should instead use the profile directory, as "null" can default to 
-            // the JMRI program directory, which might not be user-writable.
-            returnString = FileUtil.getUserFilesPath()+p.getFileName().toString();
-            log.warn("File selection dialog box did not provide a path to the specified file.  Log will be saved to "+returnString);
-        } else {
-            returnString = p.toString();
-        }
-        return returnString;
-    }
 
     public synchronized void startLogButtonActionPerformed(java.awt.event.ActionEvent e) {
         // start logging by creating the stream
         if (logStream == null) {  // successive clicks don't restart the file
             // start logging
-            String filePathAndName = getFilePathAndName();
-            log.warn("startLogButtonActionPerformed: getSelectedFile() returns "+logFileChooser.getSelectedFile().getPath()+" "+logFileChooser.getSelectedFile().getName());
-            log.warn("startLogButtonActionPerformed: is attempting to use returned file path and file name "+filePathAndName);
-            File logFile = new File(filePathAndName);
             try {
-                logStream = new PrintStream(new FileOutputStream(logFile));
+                logStream = new PrintStream(new FileOutputStream(logFileChooser.getSelectedFile()));
             } catch (java.io.FileNotFoundException ex) {
-                if (logStream != null) {
-                    synchronized (logStream) {
-                        logStream.flush();
-                        logStream.close();
-                    }
-                    logStream = null;
-                }
                 log.error("startLogButtonActionPerformed: FileOutputStream cannot open the file '"+logFileChooser.getSelectedFile().getName() +
                         "'.  Exception: "+ex);
                 JOptionPane.showMessageDialog(this, 
+                        
                         (Bundle.getMessage("ErrorCannotOpenFileForWriting",
                             logFileChooser.getSelectedFile().getName(),
                             Bundle.getMessage("ErrorPossibleCauseCannotOpenForWrite"))),
                         Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
-                return;
-            }
 
-//            if (!logFile.canWrite()) {
-//                // cannot write to the selected file
-//                log.error("Cannot write the selected file: "+filePathAndName);
-//                if (logStream != null) {
-//                    synchronized (logStream) {
-//                        logStream.flush();
-//                        logStream.close();
-//                    }
-//                    logStream = null;
-//                }
-//                JOptionPane.showMessageDialog(this, 
-//                        (Bundle.getMessage("ErrorCannotOpenFileForWriting",
-//                            logFileChooser.getSelectedFile().getName(),
-//                            Bundle.getMessage("ErrorPossibleCauseCannotOpenForWrite"))),
-//                        Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
-//            }
+            } catch (Exception ex) {
+                log.error("exception " + ex);
+            }
         }
     }
 

--- a/java/src/jmri/jmrix/AbstractMonPane.java
+++ b/java/src/jmri/jmrix/AbstractMonPane.java
@@ -14,6 +14,7 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
@@ -530,6 +531,16 @@ public abstract class AbstractMonPane extends JmriPanel {
             // start logging
             try {
                 logStream = new PrintStream(new FileOutputStream(logFileChooser.getSelectedFile()));
+            } catch (java.io.FileNotFoundException ex) {
+                log.error("startLogButtonActionPerformed: FileOutputStream cannot open the file '"+logFileChooser.getSelectedFile().getName() +
+                        "'.  Exception: "+ex);
+                JOptionPane.showMessageDialog(this, 
+                        
+                        (Bundle.getMessage("ErrorCannotOpenFileForWriting",
+                            logFileChooser.getSelectedFile().getName(),
+                            Bundle.getMessage("ErrorPossibleCauseCannotOpenForWrite"))),
+                        Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
+
             } catch (Exception ex) {
                 log.error("exception " + ex);
             }

--- a/java/src/jmri/jmrix/AbstractMonPane.java
+++ b/java/src/jmri/jmrix/AbstractMonPane.java
@@ -524,26 +524,67 @@ public abstract class AbstractMonPane extends JmriPanel {
             monTextPane.setText("");
         }
     }
+    
+    public String getFilePathAndName() {
+        String returnString;
+        java.nio.file.Path p = logFileChooser.getSelectedFile().toPath();
+        if (p.getParent() == null) {
+            // This case is a file path with a "parent" of "null"
+            //
+            // Should instead use the profile directory, as "null" can default to 
+            // the JMRI program directory, which might not be user-writable.
+            returnString = FileUtil.getUserFilesPath()+p.getFileName().toString();
+            log.warn("File selection dialog box did not provide a path to the specified file.  Log will be saved to "+returnString);
+        } else {
+            returnString = p.toString();
+        }
+        return returnString;
+    }
 
     public synchronized void startLogButtonActionPerformed(java.awt.event.ActionEvent e) {
         // start logging by creating the stream
         if (logStream == null) {  // successive clicks don't restart the file
             // start logging
+            String filePathAndName = getFilePathAndName();
+            log.warn("startLogButtonActionPerformed: getSelectedFile() returns "+logFileChooser.getSelectedFile().getPath()+" "+logFileChooser.getSelectedFile().getName());
+            log.warn("startLogButtonActionPerformed: is attempting to use returned file path and file name "+filePathAndName);
+            File logFile = new File(filePathAndName);
             try {
-                logStream = new PrintStream(new FileOutputStream(logFileChooser.getSelectedFile()));
+                logStream = new PrintStream(new FileOutputStream(logFile));
             } catch (java.io.FileNotFoundException ex) {
+                if (logStream != null) {
+                    synchronized (logStream) {
+                        logStream.flush();
+                        logStream.close();
+                    }
+                    logStream = null;
+                }
                 log.error("startLogButtonActionPerformed: FileOutputStream cannot open the file '"+logFileChooser.getSelectedFile().getName() +
                         "'.  Exception: "+ex);
                 JOptionPane.showMessageDialog(this, 
-                        
                         (Bundle.getMessage("ErrorCannotOpenFileForWriting",
                             logFileChooser.getSelectedFile().getName(),
                             Bundle.getMessage("ErrorPossibleCauseCannotOpenForWrite"))),
                         Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
-
-            } catch (Exception ex) {
-                log.error("exception " + ex);
+                return;
             }
+
+//            if (!logFile.canWrite()) {
+//                // cannot write to the selected file
+//                log.error("Cannot write the selected file: "+filePathAndName);
+//                if (logStream != null) {
+//                    synchronized (logStream) {
+//                        logStream.flush();
+//                        logStream.close();
+//                    }
+//                    logStream = null;
+//                }
+//                JOptionPane.showMessageDialog(this, 
+//                        (Bundle.getMessage("ErrorCannotOpenFileForWriting",
+//                            logFileChooser.getSelectedFile().getName(),
+//                            Bundle.getMessage("ErrorPossibleCauseCannotOpenForWrite"))),
+//                        Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
+//            }
         }
     }
 

--- a/java/src/jmri/jmrix/AbstractMonPane.java
+++ b/java/src/jmri/jmrix/AbstractMonPane.java
@@ -108,6 +108,7 @@ public abstract class AbstractMonPane extends JmriPanel {
     
     /**
      * Do default configuration of a data pane
+     * @param textPane a JTextArea into which the data pane will be placed
      */
     protected void configureDataPane(JTextArea textPane) {
         textPane.setVisible(true);
@@ -142,12 +143,14 @@ public abstract class AbstractMonPane extends JmriPanel {
     /**
      * Provide initial preferred line length.
      * Used to size the initial GUI
+     * @return preferred initial number of columns
      */
     protected int getInitialPreferredLineLength() { return 80; }
     
     /**
      * Provide initial number of lines to display
      * Used to size the initial GUI
+     * @return preferred initial number of rows
      */
     protected int getInitialPreferredLineCount() { return 10; }
     
@@ -392,6 +395,7 @@ public abstract class AbstractMonPane extends JmriPanel {
      * By default, provides a generic help page that covers general features.
      * Specific implementations can override this to show their own help page if
      * desired.
+     * @return a String containing the name of the help target
      */
     @Override
     public String getHelpTarget() {
@@ -405,6 +409,8 @@ public abstract class AbstractMonPane extends JmriPanel {
     /**
      * Handle display of traffic.
      *
+     * @param timestamp timestamp to be pre-pended to the output line (if 
+     *                  timestamping is enabled)
      * @param line The traffic in normal parsed form, ending with \n
      * @param raw The traffic in raw form, ending with \n
      */
@@ -487,6 +493,11 @@ public abstract class AbstractMonPane extends JmriPanel {
      * than anything else, not clear it really works
      * for any system.  Override this in system-specific subclasses to do something 
      * useful.
+     * @param raw   A string containing the raw message hex information, in ASCII
+     *              encoding, with some "header" information pre-pended.
+     * @return      True if the opcode in the raw message matches one of the "filter"
+     *              opcodes.  False if the opcode does not match any of the "filter"
+     *              opcodes.
      */
     protected boolean isFiltered(String raw) {
         String checkRaw = getOpCodeForFilter(raw);
@@ -507,6 +518,16 @@ public abstract class AbstractMonPane extends JmriPanel {
     
     /** 
      * Get hex opcode for filtering
+     * 
+     * Reports the "opcode" byte from the string containing the ASCII string 
+     * representation of the message.  Assumes that there is a generic header on 
+     * string, like "Tx - ", and ignores it.
+     * 
+     * @param raw   a String containing the generic raw hex information, with 
+     *              pre-pended header.
+     * 
+     * @return      a two character String containing only the hex representation 
+     *              of the opcode from the raw message.
      */
     protected String getOpCodeForFilter(String raw) {
         //note: Generic raw is formatted like "Tx - BB 01 00 45", so extract the correct bytes from it (BB) for comparison
@@ -525,24 +546,47 @@ public abstract class AbstractMonPane extends JmriPanel {
         }
     }
 
+    public String getFilePathAndName() {
+        String returnString;
+        java.nio.file.Path p = logFileChooser.getSelectedFile().toPath();
+        if (p.getParent() == null) {
+            // This case is a file path with a "parent" of "null"
+            //
+            // Should instead use the profile directory, as "null" can default to 
+            // the JMRI program directory, which might not be user-writable.
+            returnString = FileUtil.getUserFilesPath()+p.getFileName().toString();
+            log.warn("File selection dialog box did not provide a path to the specified file.  Log will be saved to "+returnString);
+        } else {
+            returnString = p.toString();
+        }
+        return returnString;
+    }
+
     public synchronized void startLogButtonActionPerformed(java.awt.event.ActionEvent e) {
         // start logging by creating the stream
         if (logStream == null) {  // successive clicks don't restart the file
             // start logging
+            String filePathAndName = getFilePathAndName();
+            log.warn("startLogButtonActionPerformed: getSelectedFile() returns "+logFileChooser.getSelectedFile().getPath()+" "+logFileChooser.getSelectedFile().getName());
+            log.warn("startLogButtonActionPerformed: is attempting to use returned file path and file name "+filePathAndName);
+            File logFile = new File(filePathAndName);
             try {
-                logStream = new PrintStream(new FileOutputStream(logFileChooser.getSelectedFile()));
+                logStream = new PrintStream(new FileOutputStream(logFile));
             } catch (java.io.FileNotFoundException ex) {
+                if (logStream != null) {
+                    synchronized (logStream) {
+                        logStream.flush();
+                        logStream.close();
+                    }
+                    logStream = null;
+                }
                 log.error("startLogButtonActionPerformed: FileOutputStream cannot open the file '"+logFileChooser.getSelectedFile().getName() +
                         "'.  Exception: "+ex);
                 JOptionPane.showMessageDialog(this, 
-                        
                         (Bundle.getMessage("ErrorCannotOpenFileForWriting",
                             logFileChooser.getSelectedFile().getName(),
                             Bundle.getMessage("ErrorPossibleCauseCannotOpenForWrite"))),
                         Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
-
-            } catch (Exception ex) {
-                log.error("exception " + ex);
             }
         }
     }

--- a/java/src/jmri/jmrix/JmrixBundle.properties
+++ b/java/src/jmri/jmrix/JmrixBundle.properties
@@ -100,6 +100,8 @@ ErrorFileContentsError = <html><font color="#FF0000">Firmware content in the fil
 ErrorFileReadError = <html><font color\="\#FF0000">Firmware file cannot be read.</html>
 ErrorInvalidParameter = <html><font color\="\#FF0000">Invalid parameter(s) above.</html>
 ErrorEmptyFirmwareFile = "<html><font color=\"#ff0000\">Do not have any firmware information to send.</html>"
+ErrorCannotOpenFileForWriting = <html><font color\="\#FF0000">Cannot open file <font color\="\#000000">{0}<font color\="\#FF0000">.<p><font color\="\#000000">{1}</html>">
+ErrorPossibleCauseCannotOpenForWrite = <html>Possible solutions:<p><ul><li>Choose a different filename</li><li>Verify that directory exists and is writable</li><li>Verify that file is writable</li><<li>Verify that file is not open in another application</li><li>Verify your security settings</li></ul></html>
 
 # Note - The following message will be used when a firmware update file is read
 #       if the tool is not able to properly interpret the value assigned to 


### PR DESCRIPTION
Provides dialog box if selected file cannot be written.

Always uses active profile directory as default directory for monitorLog.txt file, even if user does not "choose log file" or if user "cancel"s out of "choose log file".

Cleans up JavaDocs.
