### PR TITLE
Allows multiple OpenLCB firmware upgrade downloads from a single HEX file.

### DIFF
--- a/java/src/jmri/jmrix/openlcb/swing/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/downloader/LoaderPane.java
@@ -152,6 +152,7 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
                     setOperationAborted(true);
                     log.info(msg);
                 }
+                enableDownloadVerifyButtons();
             }
         });
     }


### PR DESCRIPTION
This fixes an annoying UI bug: the user has to select the HEX file again and again between upgrading multiple nodes, even if the firmware file is the same. There was no way to press the load button again.