### PR TITLE
Maven is preinstalled on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,10 @@
 version: '{build}'
 clone_depth: 50
 install:
-  - SET MAVEN_VERSION=3.3.9
-  - SET MAVEN_HOME=C:\Users\appveyor\maven\apache-maven-%MAVEN_VERSION%
-  - ps: |
-      Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\Users\appveyor\maven" )) {
-        (new-object System.Net.WebClient).DownloadFile(
-          "http://www.apache.org/dyn/closer.cgi?action=download&filename=maven/maven-3/$($env:MAVEN_VERSION)/binaries/apache-maven-$($env:MAVEN_VERSION)-bin.zip",
-          "C:\Users\appveyor\maven.zip"
-        )
-        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\Users\appveyor\maven.zip", "C:\Users\appveyor\maven")
-      }
   - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-  - SET PATH=%MAVEN_HOME%\bin;%JAVA_HOME%\bin;%PATH%
+  - SET PATH=%JAVA_HOME%\bin;%PATH%
 #  - echo PATH %PATH%
 #  - echo JAVA_HOME %JAVA_HOME%
-#  - echo MAVEN_HOME %MAVEN_HOME%
   - java -version
 #  - javac -version
   - mvn -version
@@ -28,7 +16,7 @@ before_test:
 
 test_script:
 - ps: |
-    mvn test -P appveyor --quiet --batch-mode
+    mvn test -P appveyor --batch-mode
 
 on_finish:
 - ps: |
@@ -40,5 +28,4 @@ on_finish:
 deploy: off
 
 cache:
-  - C:\Users\appveyor\maven -> appveyor.yml
   - C:\Users\appveyor\.m2 -> pom.xml


### PR DESCRIPTION
Maven is now preinstalled on AppVeyor, so we no longer need to download it ourselves (appveyor/ci#998).