### PR TITLE
Prevent error on empty array in bash 4.3+

### DIFF
--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -264,7 +264,7 @@ if [ $# -gt 0 ] ; then
         all_options=("${all_options[@]-}" "${option}")
     done
 fi
-parse_args "${all_options[@]}"
+parse_args "${all_options[@]:-}"
 
 # define JAVA_HOME if needed
 if [ -z "${JAVA_HOME}" ] ; then


### PR DESCRIPTION
This made it into 4.5.7 and 4.5.8, but not into master when originally identified.