### PR TITLE
Fix leaking threads from the OlcbConfigurationManager.

### DIFF
--- a/java/src/jmri/jmrix/openlcb/OlcbConfigurationManager.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbConfigurationManager.java
@@ -427,6 +427,7 @@ public class OlcbConfigurationManager extends jmri.jmrix.can.ConfigurationManage
                     new Thread(() -> {
                         olcbCanInterface.initialize();
                     }).start();
+                    timer.stop();
                 }
             };
 


### PR DESCRIPTION
Turns out javax.swing.Timer is by default a repeated timer,
unlike java.util.Timer which is by default a single-shot timer. Go figure.

The previous code was leaking one thread every 2.5 seconds since the initialize method cannot be called multiple times.