### PR TITLE
Remove duplicate property keys inadvertently added

### DIFF
--- a/java/src/jmri/NamedBeanBundle_ca.properties
+++ b/java/src/jmri/NamedBeanBundle_ca.properties
@@ -171,7 +171,6 @@ ButtonClear = Neteja
 ButtonEdit = Edita
 ButtonApply = S\u00ed
 ButtonSelect = Select
-ButtonSave = Desa
 ButtonCopy = Copia
 ButtonUpdate = Actualitza
 ButtonYes=S\u00ed

--- a/java/src/jmri/jmrit/Bundle_de.properties
+++ b/java/src/jmri/jmrit/Bundle_de.properties
@@ -176,5 +176,4 @@ Name=Name
 #Xml file validation action title
 XmlFileValidateAction=Verifiziere XML Datei
 
-Color=Farbe
 Options=Optionen


### PR DESCRIPTION
Same change as in #2686 but for 4.5.8/4.6 release