### PR TITLE
More allowable portable paths in web server

### DIFF
--- a/java/src/jmri/server/web/FilePaths.properties
+++ b/java/src/jmri/server/web/FilePaths.properties
@@ -9,19 +9,21 @@
 #
 # static items that ship with JMRI
 #
-/help           = program:help
-/resources      = program:resources
-/web            = program:web
-/xml            = program:xml
-/css            = program:web/css
-/images         = program:web/images
-/js             = program:web/js
-/fonts          = program:web/fonts
-/dist           = program:
-/favicon.ico    = program:web/favicon.ico
-/robots.txt     = program:web/robots.txt
-
+/help        = program:help
+/resources   = program:resources
+/web         = program:web
+/xml         = program:xml
+/css         = program:web/css
+/images      = program:web/images
+/js          = program:web/js
+/fonts       = program:web/fonts
+/dist        = program:
+/favicon.ico = program:web/favicon.ico
+/robots.txt  = program:web/robots.txt
 #
 # user manipulatable items
 #
-/prefs          = preference:
+/prefs       = preference:
+/settings    = settings:
+/project     = profile:
+/profile     = profile:

--- a/java/src/jmri/server/web/spi/WebServerConfiguration.java
+++ b/java/src/jmri/server/web/spi/WebServerConfiguration.java
@@ -16,8 +16,9 @@ public interface WebServerConfiguration {
     /**
      * Get paths that are to be returned by the web server as individual files
      * or directory listings. Note that all files or directories listed must be
-     * in either the {@link jmri.util.FileUtil#PROGRAM} JMRI portable path or
-     * the {@link jmri.util.FileUtil#PREFERENCES} JMRI portable path.
+     * in the
+     * {@link jmri.util.FileUtil#PREFERENCES}, {@link jmri.util.FileUtil#SETTINGS},
+     * or {@link jmri.util.FileUtil#PROGRAM} JMRI portable path.
      *
      * @return a map containing the web path as the key, and the path on disk as
      *         the value; return an empty map if none

--- a/java/src/jmri/server/web/spi/WebServerConfiguration.java
+++ b/java/src/jmri/server/web/spi/WebServerConfiguration.java
@@ -16,8 +16,8 @@ public interface WebServerConfiguration {
     /**
      * Get paths that are to be returned by the web server as individual files
      * or directory listings. Note that all files or directories listed must be
-     * in the
-     * {@link jmri.util.FileUtil#PREFERENCES}, {@link jmri.util.FileUtil#SETTINGS},
+     * in the {@link jmri.util.FileUtil#PREFERENCES},
+     * {@link jmri.util.FileUtil#PROFILE}, {@link jmri.util.FileUtil#SETTINGS},
      * or {@link jmri.util.FileUtil#PROGRAM} JMRI portable path.
      *
      * @return a map containing the web path as the key, and the path on disk as

--- a/java/src/jmri/web/server/WebServer.java
+++ b/java/src/jmri/web/server/WebServer.java
@@ -202,10 +202,10 @@ public final class WebServer implements LifeCycle.Listener {
      * Register a URL pattern to return resources from the file system. The
      * filePath may start with any of the following:
      * <ol>
-     * <ul>{@link jmri.util.FileUtil#PREFERENCES}</ul>
-     * <ul>{@link jmri.util.FileUtil#PROFILE}</ul>
-     * <ul>{@link jmri.util.FileUtil#SETTINGS}</ul>
-     * <ul>{@link jmri.util.FileUtil#PROGRAM}</ul>
+     * <li>{@link jmri.util.FileUtil#PREFERENCES}
+     * <li>{@link jmri.util.FileUtil#PROFILE}
+     * <li>{@link jmri.util.FileUtil#SETTINGS}
+     * <li>{@link jmri.util.FileUtil#PROGRAM}
      * </ol>
      * Note that the filePath can be overridden by an otherwise identical
      * filePath starting with any of the portable paths above it in the

--- a/java/src/jmri/web/servlet/ServletUtil.java
+++ b/java/src/jmri/web/servlet/ServletUtil.java
@@ -67,7 +67,7 @@ public class ServletUtil {
     }
 
     /**
-     * Create a common navigation footer.
+     * Create a common navigation header.
      *
      * @param locale  If a template is not available in locale, will return US
      *                English.

--- a/java/test/jmri/server/web/DefaultWebServerConfigurationTest.java
+++ b/java/test/jmri/server/web/DefaultWebServerConfigurationTest.java
@@ -46,7 +46,7 @@ public class DefaultWebServerConfigurationTest {
         DefaultWebServerConfiguration instance = new DefaultWebServerConfiguration();
         HashMap<String, String> result = instance.getFilePaths();
         Assert.assertNotNull("Default file paths", result);
-        Assert.assertEquals("Default file paths", 12, result.size());
+        Assert.assertEquals("Default file paths", 15, result.size());
     }
 
     /**


### PR DESCRIPTION
Allow ```profile:``` and ```settings:``` as well as ```preferences:```
and ```program:``` to be used as portable paths in defined paths handled by the web server.