### PR TITLE
Resolve intermediate SNIP frames in OLCB monitor

### DIFF
--- a/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
@@ -105,6 +105,17 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
                     formatted = prefix + ": (Start of Datagram)";
                 } else if ((header & 0x0F000000) == 0x0C000000) {
                     formatted = prefix + ": (Middle of Datagram)";
+                } else if (((header & 0xFFFF0000) == 0x19A00000) && (content.length > 0)) {
+                    // SNIP multi frame reply
+                    if ((content[0] & 0xF0) == 0x10) {
+                        formatted = prefix + ": SNIP Reply 1st frame";
+                    } else if ((content[0] & 0xF0) == 0x20) {
+                        formatted = prefix + ": SNIP Reply last frame";
+                    } else if ((content[0] & 0xF0) == 0x30) {
+                        formatted = prefix + ": SNIP Reply middle frame";
+                    } else {
+                        formatted = prefix + ": SNIP Reply unknown";
+                    }
                 } else {
                     formatted = prefix + ": Unknown message " + raw;
                 }

--- a/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/monitor/MonitorPane.java
@@ -105,7 +105,7 @@ public class MonitorPane extends jmri.jmrix.AbstractMonPane implements CanListen
                     formatted = prefix + ": (Start of Datagram)";
                 } else if ((header & 0x0F000000) == 0x0C000000) {
                     formatted = prefix + ": (Middle of Datagram)";
-                } else if (((header & 0xFFFF0000) == 0x19A00000) && (content.length > 0)) {
+                } else if (((header & 0x0FFFF000) == 0x09A08000) && (content.length > 0)) {
                     // SNIP multi frame reply
                     if ((content[0] & 0xF0) == 0x10) {
                         formatted = prefix + ": SNIP Reply 1st frame";

--- a/java/src/jmri/jmrix/openlcb/swing/networktree/NetworkTreePane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/networktree/NetworkTreePane.java
@@ -1,16 +1,7 @@
 package jmri.jmrix.openlcb.swing.networktree;
 
 import java.awt.Dimension;
-import java.awt.FlowLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import javax.swing.JButton;
-import javax.swing.JFormattedTextField;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTextField;
 import javax.swing.JTree;
-import javax.swing.Timer;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -25,10 +16,6 @@ import org.openlcb.Connection;
 import org.openlcb.MimicNodeStore;
 import org.openlcb.NodeID;
 import org.openlcb.OlcbInterface;
-import org.openlcb.cdi.impl.ConfigRepresentation;
-import org.openlcb.cdi.jdom.CdiMemConfigReader;
-import org.openlcb.cdi.jdom.JdomCdiReader;
-import org.openlcb.cdi.swing.CdiPanel;
 import org.openlcb.implementations.MemoryConfigurationService;
 import org.openlcb.swing.memconfig.MemConfigDescriptionPane;
 import org.openlcb.swing.memconfig.MemConfigReadWritePane;
@@ -70,6 +57,7 @@ public class NetworkTreePane extends jmri.util.swing.JmriPanel implements CanLis
         setLayout(new javax.swing.BoxLayout(this, javax.swing.BoxLayout.Y_AXIS));
 
         treePane = new TreePane();
+        treePane.setPreferredSize(new Dimension(300, 300));
 
         treePane.initComponents(
                 (MimicNodeStore) memo.get(MimicNodeStore.class),


### PR DESCRIPTION
I just don't like the look of saying 'unknown' when we know what it is. Since they are multiple frames to make a message, the data isn't meaningful at this point.