### PR TITLE
Work on CI fail in AbstractMRTrafficController

### DIFF
--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -727,7 +727,7 @@ abstract public class AbstractMRTrafficController {
             }
         }
         ConnectionStatus.instance().setConnectionState(controller.getCurrentPortName(), ConnectionStatus.CONNECTION_DOWN);
-        log.error("Exit from rcv loop");
+        log.error("Exit from rcv loop in {}", this.getClass().toString());
         recovery();
     }
 
@@ -742,7 +742,7 @@ abstract public class AbstractMRTrafficController {
      * though message is asynchronous.
      */
     protected void reportReceiveLoopException(Exception e) {
-        log.error("run: Exception: {}", e.toString());
+        log.error("run: Exception: {} in {}", e.toString(), this.getClass().toString(), e);
         jmri.jmrix.ConnectionStatus.instance().setConnectionState(controller.getCurrentPortName(), jmri.jmrix.ConnectionStatus.CONNECTION_DOWN);
         if (controller instanceof AbstractNetworkPortController) {
             portWarnTCP(e);


### PR DESCRIPTION
Adds more debugging info to try to localize the cause of the AbstractMRTrafficController failure in #2671.  