### PR TITLE
More work on threading in NXFrameTest

### DIFF
--- a/java/test/jmri/jmrit/logix/NXFrameTest.java
+++ b/java/test/jmri/jmrit/logix/NXFrameTest.java
@@ -239,6 +239,7 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
                         state == (OBlock.ALLOCATED | OBlock.RUNNING | OBlock.DARK);
             }, "Train occupies block "+i+" of "+route.length);
             flushAWT();
+            jmri.util.JUnitUtil.releaseThread(this);
 
             block = _OBlockMgr.getOBlock(route[i]);
             Sensor nextSensor;
@@ -253,8 +254,15 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
                     }
                 });
                 jmri.util.JUnitUtil.releaseThread(this);
-                nextSensor.setState(Sensor.ACTIVE);
+                jmri.util.ThreadingUtil.runOnLayout(() -> {
+                    try {
+                        nextSensor.setState(Sensor.ACTIVE);
+                    } catch (jmri.JmriException e) {
+                        Assert.fail("Unexpected Exception: " + e);
+                    }
+                });
                 flushAWT();                                
+                jmri.util.JUnitUtil.releaseThread(this);
             } else {
                 nextSensor = null;
             }


### PR DESCRIPTION
More work on (what I think is) a threading problem in NXFrameTest that causes:

```
    [junit] Testcase: testNXWarrant(jmri.jmrit.logix.NXFrameTest):	Caused an ERROR
    [junit] "Train occupies block 3 of 7" did not occur in time
    [junit] java.lang.AssertionError: "Train occupies block 3 of 7" did not occur in time
    [junit] 	at jmri.util.JUnitUtil.waitFor(JUnitUtil.java:150)
    [junit] 	at jmri.jmrit.logix.NXFrameTest.runtimes(NXFrameTest.java:236)
    [junit] 	at jmri.jmrit.logix.NXFrameTest.testNXWarrant(NXFrameTest.java:162)
    [junit] 	at junit.extensions.jfcunit.JFCTestCase$5.run(JFCTestCase.java:580)
```

