### PR TITLE
Change ECO/Tsu2 productID to include CV253.

### DIFF
--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -72,15 +72,15 @@ abstract public class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             statusUpdate("Read decoder ID CV 250");
             readCV(250);
             return false;
-        } else if (mfgID == 141 && (modelID == 70 || modelID == 71)) {  // SoundTraxx
-            statusUpdate("Read productID CV256");
-            readCV(256);
+        } else if (mfgID == 141 && (modelID == 70 || modelID == 71)) {  // SoundTraxx Econami and Tsunami2
+            statusUpdate("Read productID high CV253");
+            readCV(253);
             return false;
         } else if (mfgID == 98) {  // Harman
             statusUpdate("Read decoder ID high CV 112");
             readCV(112);
             return false;
-        } else if (mfgID == 151) {  // ESU
+        } else if (mfgID == 151 && modelID == 255) {  // ESU recent
             statusUpdate("Set PI for Read productID");
             writeCV(31, 0);
             return false;
@@ -103,9 +103,10 @@ abstract public class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             productID = value;
             return true;
         } else if (mfgID == 141 && (modelID == 70 || modelID == 71)) {  // SoundTraxx
-            productID = value;
-            log.info("Decoder returns mfgID:" + mfgID + ";modelID:" + modelID + ";productID:" + productID);
-            return true;
+            productIDhigh = value;
+            statusUpdate("Read decoder productID low CV256");
+            readCV(256);
+            return false;
         } else if (mfgID == 98) {  // Harman
             productIDhigh = value;
             statusUpdate("Read decoder ID low CV 113");
@@ -125,6 +126,11 @@ abstract public class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             statusUpdate("Read Product ID High Byte");
             readCV(56);
             return false;
+        } else if (mfgID == 141 && (modelID == 70 || modelID == 71)) {  // SoundTraxx
+            productIDlow = value;
+            productID = (productIDhigh << 8) | productIDlow;
+            log.info("Decoder returns mfgID:" + mfgID + ";modelID:" + modelID + ";productID:" + productID);
+            return true;
         } else if (mfgID == 98) {  // Harman
             productIDlow = value;
             productID = (productIDhigh << 8) | productIDlow;

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -104,6 +104,56 @@ public class IdentifyDecoderTest extends TestCase {
 
     }
 
+    public void testIdentifyTsu2() {
+        // initialize the system
+        jmri.progdebugger.ProgDebugger p = new jmri.progdebugger.ProgDebugger() {
+            public void readCV(int CV, jmri.ProgListener p) throws jmri.ProgrammerException {
+                cvRead = CV;
+            }
+        };
+        jmri.InstanceManager.setProgrammerManager(new jmri.managers.DefaultProgrammerManager(p));
+
+        // create our test object
+        IdentifyDecoder i = new IdentifyDecoder(p) {
+            public void done(int mfgID, int modelID, int productID) {
+            }
+
+            public void message(String m) {
+            }
+
+            public void error() {
+            }
+        };
+
+        i.start();
+        Assert.assertEquals("step 1 reads CV ", 8, cvRead);
+        Assert.assertEquals("running after 1 ", true, i.isRunning());
+
+        // simulate CV read complete on CV8, start 7
+        i.programmingOpReply(141, 0);
+        Assert.assertEquals("step 2 reads CV ", 7, cvRead);
+        Assert.assertEquals("running after 2 ", true, i.isRunning());
+
+        // simulate CV read complete on CV7, start 253
+        i.programmingOpReply(71, 0);
+        Assert.assertEquals("step 3 reads CV ", 253, cvRead);
+        Assert.assertEquals("running after 3 ", true, i.isRunning());
+
+        // simulate CV read complete on CV253, does 256 and ends
+        i.programmingOpReply(1, 0);
+        Assert.assertEquals("step 4 reads CV ", 256, cvRead);
+        Assert.assertEquals("running after 4 ", true, i.isRunning());
+
+        // simulate CV read complete on CV256, ends
+        i.programmingOpReply(29, 0);
+        Assert.assertEquals("running after 5 ", false, i.isRunning());
+
+        Assert.assertEquals("found mfg ID ", 141, i.mfgID);
+        Assert.assertEquals("found model ID ", 71, i.modelID);
+        Assert.assertEquals("found product ID ", 285, i.productID);
+
+    }
+
     // from here down is testing infrastructure
     public IdentifyDecoderTest(String s) {
         super(s);

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <!--Written by JMRI version 4.7.1ish-201612150541-jake-Ra39facb on Wed Dec 14 21:42:13 PST 2016 $Id$-->
-  <decoderIndex version="786">
+  <!--Written by JMRI version 4.7.1ish-201612212009-heap-R4fbea8b on Thu Dec 22 07:14:25 AEDT 2016 $Id$-->
+  <decoderIndex version="792">
     <mfgList nmraListDate="2015-03-06" updated="2015-03-25" lastadd="107,124,126,128,134">
       <manufacturer mfg="NMRA" mfgID="999" />
       <manufacturer mfg="A-Train Electronics" mfgID="137" />
@@ -2395,6 +2395,365 @@
           </protocols>
         </model>
       </family>
+      <family name="Sound Decoders (2016)" mfg="Doehler und Haass" file="Doehler_Haass_fw1.06-07_SD10-16-18-21-22A.xml">
+        <!--family name="Combo sound decoders" mfg="Doehler und Haass"-->
+        <model model="SD10A (firmware 1.06+)" lowVersionID="026" highVersionID="026" numOuts="6" numFns="16" productID="SD10A_1.06" comment="SD10A-0 / SD10A-1 / SD10A-3 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+            <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          </output>
+          <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+            <label xml:lang="de">AUX 4|(or SUSI ZDAT)</label>
+          </output>
+          <output name="7" label="Dimmed Lights|(or AUX 5)">
+            <label xml:lang="de">Abblend-|licht (o. AUX 5)</label>
+          </output>
+          <output name="8" label="Shunting Speed|(or AUX 6)">
+            <label xml:lang="de">Rangiergang|(o. AUX 6)</label>
+          </output>
+          <size length="21.4" width="9.1" height="3.4" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="SD16A (firmware 1.06+)" lowVersionID="026" highVersionID="026" numOuts="8" numFns="16" productID="SD16A_1.06" comment="SD16A-4 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1,5A" maxTotalCurrent="1,5A" connector="PluX16">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 5</label>
+          </output>
+          <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 6</label>
+          </output>
+          <output name="9" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="10" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="21.5" width="10.5" height="3.0" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="SD18A (firmware 1.06+)" lowVersionID="026" highVersionID="026" numOuts="6" numFns="16" productID="SD18A_1.06" comment="SD18A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+            <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          </output>
+          <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+            <label xml:lang="de">AUX 4|(or SUSI ZDAT)</label>
+          </output>
+          <output name="7" label="Dimmed Lights|(or AUX 5)">
+            <label xml:lang="de">Abblend-|licht (o. AUX 5)</label>
+          </output>
+          <output name="8" label="Shunting Speed|(or AUX 6)">
+            <label xml:lang="de">Rangiergang|(o. AUX 6)</label>
+          </output>
+          <size length="25.0" width="9.5" height="2.8" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="SD21A (firmware 1.06+)" lowVersionID="026" highVersionID="026" numOuts="8" numFns="16" productID="SD21A_1.06" comment="SD21A-4 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 5</label>
+          </output>
+          <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 6</label>
+          </output>
+          <output name="9" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="10" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="30.2" width="15.8" height="5.2" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="SD22A (firmware 1.06+)" lowVersionID="026" highVersionID="026" numOuts="8" numFns="16" productID="SD22A_1.06" comment="SD22A-4 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 5</label>
+          </output>
+          <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 6</label>
+          </output>
+          <output name="9" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="10" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="30.2" width="15.8" height="5.2" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="SD10A (firmware 1.07+)" lowVersionID="056" highVersionID="056" numOuts="6" numFns="16" productID="SD10A_1.07" comment="SD10A-0 / SD10A-1 / SD10A-3 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+            <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          </output>
+          <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+            <label xml:lang="de">AUX 4|(or SUSI ZDAT)</label>
+          </output>
+          <output name="7" label="Dimmed Lights|(or AUX 5)">
+            <label xml:lang="de">Abblend-|licht (o. AUX 5)</label>
+          </output>
+          <output name="8" label="Shunting Speed|(or AUX 6)">
+            <label xml:lang="de">Rangiergang|(o. AUX 6)</label>
+          </output>
+          <size length="21.4" width="9.1" height="3.4" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="SD16A (firmware 1.07+)" lowVersionID="056" highVersionID="056" numOuts="8" numFns="16" productID="SD16A_1.07" comment="SD16A-4 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1,5A" maxTotalCurrent="1,5A" connector="PluX16">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 5</label>
+          </output>
+          <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 6</label>
+          </output>
+          <output name="9" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="10" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="21.5" width="10.5" height="3.0" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="SD18A (firmware 1.07+)" lowVersionID="056" highVersionID="056" numOuts="6" numFns="16" productID="SD18A_1.07" comment="SD18A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Next18">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+            <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          </output>
+          <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+            <label xml:lang="de">AUX 4|(or SUSI ZDAT)</label>
+          </output>
+          <output name="7" label="Dimmed Lights|(or AUX 5)">
+            <label xml:lang="de">Abblend-|licht (o. AUX 5)</label>
+          </output>
+          <output name="8" label="Shunting Speed|(or AUX 6)">
+            <label xml:lang="de">Rangiergang|(o. AUX 6)</label>
+          </output>
+          <size length="25.0" width="9.5" height="2.8" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="SD21A (firmware 1.07+)" lowVersionID="056" highVersionID="056" numOuts="8" numFns="16" productID="SD21A_1.07" comment="SD21A-4 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 5</label>
+          </output>
+          <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 6</label>
+          </output>
+          <output name="9" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="10" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="30.2" width="15.8" height="5.2" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="SD22A (firmware 1.07+)" lowVersionID="056" highVersionID="056" numOuts="8" numFns="16" productID="SD22A_1.07" comment="SD22A-4 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 5</label>
+          </output>
+          <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 6</label>
+          </output>
+          <output name="9" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="10" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="30.2" width="15.8" height="5.2" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+      </family>
       <family name="Train Decoders (firmware 3.02+)" mfg="Doehler und Haass" file="Doehler_Haass_fw3.02_DH05-10AB.xml">
         <model model="DH05A/B" lowVersionID="1" highVersionID="2" numOuts="4" numFns="16" productID="DH05AB" comment="DH05A/B-0 / DH05A/B-1 / DH05A/B-3" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
           <output name="1" label="Front|Light" maxcurrent="150mA" />
@@ -3603,12 +3962,707 @@
           </protocols>
         </model>
       </family>
+      <family name="Function Decoders (firmware 3.05 - Oct 2014)" mfg="Doehler und Haass" file="Doehler_Haass_fw3.05_FH05B.xml">
+        <model model="FH05B v3.05.15 (firmware 3.05+)" lowVersionID="15" highVersionID="15" numOuts="6" numFns="16" productID="FH05B_2014.10" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from October 2014" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+          <output name="1" label="Front|Light" maxcurrent="150mA" />
+          <output name="2" label="Rear|Light" maxcurrent="150mA" />
+          <output name="3" label="AUX|1" maxcurrent="300mA" />
+          <output name="4" label="AUX|2" maxcurrent="300mA" />
+          <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA" />
+          <!-- New from fw3.03  -->
+          <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA" />
+          <!-- New from fw3.03  -->
+          <output name="7" label="Dimmed|Lights" />
+          <output name="8" label="Shunting|Speed" />
+          <size length="13.7" width="7.8" height="1.5" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+          </protocols>
+        </model>
+      </family>
       <family name="Train Decoders (firmware 3.05 - Oct 2014)" mfg="Doehler und Haass" file="Doehler_Haass_fw3.05_generic.xml">
         <model model="Generic DH v3.05 (firmware 3.05+)" numOuts="6" numFns="16" productID="GenericDH_2014.10" comment="Generic DH profile for unknown or unlisted decoders with update from October 2014">
           <protocols>
             <protocol>dcc</protocol>
             <protocol>selectrix</protocol>
             <protocol>motorola</protocol>
+          </protocols>
+        </model>
+      </family>
+      <family name="Train Decoders (2016)" mfg="Doehler und Haass" file="Doehler_Haass_fw3.06-07_DH05-10C_12-16-18-21-22A_PD12A.xml">
+        <model model="DH05C v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="4" numFns="16" productID="DH05C_2016.03" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from March 2016" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          </output>
+          <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 4|(o. SUSI ZDAT)</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="13.2" width="6.8" height="1.4" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="DH10C v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="4" numFns="16" productID="DH10C_2016.03" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          </output>
+          <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 4|(o. SUSI ZDAT)</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="14.2" width="9.3" height="1.5" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="DH12A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="6" numFns="16" productID="DH12A_2016.03" comment="DH12A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="14.5" width="8" height="2.8" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="DH16A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="6" numFns="16" productID="DH16A_2016.03" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="16.7" width="10.9" height="2.8" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="DH18A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="8" numFns="16" productID="DH18A_2016.03" comment="DH18A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 5</label>
+          </output>
+          <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 6</label>
+          </output>
+          <output name="9" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="10" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="13.5" width="9.0" height="2.8" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="DH21A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="8" numFns="16" productID="DH21A_2016.03" comment="DH21A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 5</label>
+          </output>
+          <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 6</label>
+          </output>
+          <output name="9" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="10" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="20.7" width="15.8" height="5.2" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="DH22A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="6" numFns="16" productID="DH22A_2016.03" comment="DH22A with update from March 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="20.7" width="15.8" height="5.2" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="PD12A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="4" numFns="16" productID="PD12A_2016.03" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from March 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangier-|gang</label>
+          </output>
+          <size length="24.2" width="11.0" height="2.4" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+          </protocols>
+        </model>
+        <model model="DH05C v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="4" numFns="16" productID="DH05C_2016.06" comment="DH05C-0 / DH05C-1 / DH05C-3 with update from June 2016" maxInputVolts="18V" maxMotorCurrent="0.5A" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          </output>
+          <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 4|(o. SUSI ZDAT)</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="13.2" width="6.8" height="1.4" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="DH10C v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="4" numFns="16" productID="DH10C_2016.06" comment="DH10C-0 / DH10C-1 / DH10C-3 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="Wires/NEM651">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          </output>
+          <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 4|(o. SUSI ZDAT)</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="14.2" width="9.3" height="1.5" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="DH12A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="6" numFns="16" productID="DH12A_2016.06" comment="DH12A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX12">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="14.5" width="8" height="2.8" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="DH16A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="6" numFns="16" productID="DH16A_2016.06" comment="DH16A-0 /DH16A-1 /DH16A-2 /DH16A-3 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="PluX16">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="16.7" width="10.9" height="2.8" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="DH18A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="8" numFns="16" productID="DH18A_2016.06" comment="DH18A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" connector="Next18">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 5</label>
+          </output>
+          <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 6</label>
+          </output>
+          <output name="9" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="10" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="13.5" width="9.0" height="2.8" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="DH21A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="8" numFns="16" productID="DH21A_2016.06" comment="DH21A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="21MTC">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="AUX|5" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 5</label>
+          </output>
+          <output name="8" label="AUX|6" maxcurrent="NC - Logic Level">
+            <label xml:lang="de">AUX 6</label>
+          </output>
+          <output name="9" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="10" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="20.7" width="15.8" height="5.2" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="DH22A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="6" numFns="16" productID="DH22A_2016.06" comment="DH22A with update from June 2016" maxInputVolts="30V" maxMotorCurrent="2A" maxTotalCurrent="2A" connector="PluX22">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1.0A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="20.7" width="15.8" height="5.2" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="PD12A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="4" numFns="16" productID="PD12A_2016.06" comment="PD12A-0 / PD12A-2 / PD12A-3 / PD12A-4 with update from June 2016" maxInputVolts="30V" maxMotorCurrent="1A" maxTotalCurrent="1A" connector="PluX12">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangier-|gang</label>
+          </output>
+          <size length="24.2" width="11.0" height="2.4" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+          </protocols>
+        </model>
+      </family>
+      <family name="Function Decoders (2016)" mfg="Doehler und Haass" file="Doehler_Haass_fw3.06-07_FH05B-22A.xml">
+        <model model="FH05B v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="6" numFns="16" productID="FH05B_2016.03" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from March 2016" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          </output>
+          <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 4|(o. SUSI ZDAT)</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="13.7" width="7.8" height="1.5" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+          </protocols>
+        </model>
+        <model model="FH22A v3.06.26 (firmware 3.06+)" lowVersionID="26" highVersionID="26" numOuts="8" numFns="16" productID="FH22A_2016.03" comment="FH22A with update from March 2016" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="AUX 5|(or SUSI ZCLK)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 5|(o. SUSI ZCLK)</label>
+          </output>
+          <output name="8" label="AUX 6|(or SUSI ZDAT)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 6|(o. SUSI ZDAT)</label>
+          </output>
+          <output name="9" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="10" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="16.1" width="15.8" height="3.3" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+          </protocols>
+        </model>
+        <model model="FH05B v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="6" numFns="16" productID="FH05B_2016.06" comment="FH05B-0 / FH05B-1 / FH05B-3 with update from June 2016" maxInputVolts="30V" maxTotalCurrent="0.5A" connector="Wires/NEM651">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX 3|(or SUSI ZCLK)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 3|(o. SUSI ZCLK)</label>
+          </output>
+          <output name="6" label="AUX 4|(or SUSI ZDAT)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 4|(o. SUSI ZDAT)</label>
+          </output>
+          <output name="7" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="8" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="13.7" width="7.8" height="1.5" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
+          </protocols>
+        </model>
+        <model model="FH22A v3.07.66 (firmware 3.07+)" lowVersionID="66" highVersionID="66" numOuts="8" numFns="16" productID="FH22A_2016.06" comment="FH22A with update from June 2016" maxInputVolts="30V" maxTotalCurrent="2.0A" connector="PluX22">
+          <output name="1" label="Front|Light" maxcurrent="150mA">
+            <label xml:lang="de">LV</label>
+          </output>
+          <output name="2" label="Rear|Light" maxcurrent="150mA">
+            <label xml:lang="de">LR</label>
+          </output>
+          <output name="3" label="AUX|1" maxcurrent="300mA">
+            <label xml:lang="de">AUX 1</label>
+          </output>
+          <output name="4" label="AUX|2" maxcurrent="300mA">
+            <label xml:lang="de">AUX 2</label>
+          </output>
+          <output name="5" label="AUX|3" maxcurrent="1A">
+            <label xml:lang="de">AUX 3</label>
+          </output>
+          <output name="6" label="AUX|4" maxcurrent="1A">
+            <label xml:lang="de">AUX 4</label>
+          </output>
+          <output name="7" label="AUX 5|(or SUSI ZCLK)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 5|(o. SUSI ZCLK)</label>
+          </output>
+          <output name="8" label="AUX 6|(or SUSI ZDAT)" maxcurrent="20mA">
+            <!-- New from fw3.03  -->
+            <label xml:lang="de">AUX 6|(o. SUSI ZDAT)</label>
+          </output>
+          <output name="9" label="Dimmed|Lights">
+            <label xml:lang="de">Abblend-|licht</label>
+          </output>
+          <output name="10" label="Shunting|Speed">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <size length="16.1" width="15.8" height="3.3" units="mm" />
+          <protocols>
+            <protocol>dcc</protocol>
+            <protocol>selectrix</protocol>
           </protocols>
         </model>
       </family>
@@ -3793,6 +4847,16 @@
           <size length="20" width="12" height="1.9" units="mm" />
         </model>
         <model model="SH10A (firmware 1.07+)" numOuts="2" numFns="30" productID="SH10A_1.07" comment="SH10A with firmware 1.07 or later" maxInputVolts="30V" connector="SUSI">
+          <output name="1" label="AUX|1" maxcurrent="20mA" />
+          <output name="2" label="AUX|2" maxcurrent="20mA" />
+          <size length="20" width="12" height="1.9" units="mm" />
+        </model>
+        <model model="SH10A (firmware 1.08+)" numOuts="2" numFns="30" productID="SH10A_1.08" comment="SH10A with firmware 1.08 or later" maxInputVolts="30V" connector="SUSI">
+          <output name="1" label="AUX|1" maxcurrent="20mA" />
+          <output name="2" label="AUX|2" maxcurrent="20mA" />
+          <size length="20" width="12" height="1.9" units="mm" />
+        </model>
+        <model model="SH10A (firmware 1.09+)" numOuts="2" numFns="30" productID="SH10A_1.09" comment="SH10A with firmware 1.09 or later" maxInputVolts="30V" connector="SUSI">
           <output name="1" label="AUX|1" maxcurrent="20mA" />
           <output name="2" label="AUX|2" maxcurrent="20mA" />
           <size length="20" width="12" height="1.9" units="mm" />
@@ -11408,7 +12472,7 @@
         </model>
       </family>
       <family name="Econami Diesel" mfg="SoundTraxx (Throttle-Up)" comment="These are the -retail- version Econami Diesel decoders" file="SoundTraxx_Eco_Diesel.xml">
-        <model model="ECO-100 Diesel" numOuts="4" numFns="20" maxMotorCurrent="1A" connector="other" productID="2" comment="Model 882001">
+        <model model="ECO-100 Diesel" numOuts="4" numFns="20" maxMotorCurrent="1A" connector="other" productID="258" comment="Model 882001">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11443,7 +12507,7 @@
           </output>
           <size length="27" width="10.5" height="5" units="mm" />
         </model>
-        <model model="ECO-200 Diesel" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="11" comment="Model 882002">
+        <model model="ECO-200 Diesel" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="267" comment="Model 882002">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11478,7 +12542,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="ECO-21P Diesel" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21pin" productID="8" comment="Model 882003">
+        <model model="ECO-21P Diesel" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21pin" productID="264" comment="Model 882003">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11513,7 +12577,7 @@
           </output>
           <size length="30.5" width="15.5" height="6.5" units="mm" />
         </model>
-        <model model="ECO-400 Diesel" numOuts="6" numFns="30" maxMotorCurrent="4A" connector="other" productID="5" comment="Model 882005">
+        <model model="ECO-400 Diesel" numOuts="6" numFns="30" maxMotorCurrent="4A" connector="other" productID="261" comment="Model 882005">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11548,7 +12612,7 @@
           </output>
           <size length="69" width="30.5" height="14" units="mm" />
         </model>
-        <model model="ECO-PNP Diesel" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="14" comment="Model 882004">
+        <model model="ECO-PNP Diesel" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="270" comment="Model 882004">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11604,7 +12668,7 @@
         </functionlabels>
       </family>
       <family name="Econami Electric" mfg="SoundTraxx (Throttle-Up)" comment="These are the -retail- version Econami Electric decoders" file="SoundTraxx_Eco_Electric.xml">
-        <model model="ECO-100 Electric" numOuts="4" numFns="20" maxMotorCurrent="1A" connector="other" productID="3" comment="Model 883001">
+        <model model="ECO-100 Electric" numOuts="4" numFns="20" maxMotorCurrent="1A" connector="other" productID="259" comment="Model 883001">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11641,7 +12705,7 @@
           </output>
           <size length="27" width="10.5" height="5" units="mm" />
         </model>
-        <model model="ECO-200 Electric" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="12" comment="Model 883002">
+        <model model="ECO-200 Electric" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="268" comment="Model 883002">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11678,7 +12742,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="ECO-21P Electric" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21pin" productID="9" comment="Model 883003">
+        <model model="ECO-21P Electric" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21pin" productID="265" comment="Model 883003">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11715,7 +12779,7 @@
           </output>
           <size length="30.5" width="15.5" height="6.5" units="mm" />
         </model>
-        <model model="ECO-400 Electric" numOuts="6" numFns="30" maxMotorCurrent="4A" connector="other" productID="6" comment="Model 883005">
+        <model model="ECO-400 Electric" numOuts="6" numFns="30" maxMotorCurrent="4A" connector="other" productID="262" comment="Model 883005">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11752,7 +12816,7 @@
           </output>
           <size length="69" width="30.5" height="14" units="mm" />
         </model>
-        <model model="ECO-PNP Electric" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="15" comment="Model 883004">
+        <model model="ECO-PNP Electric" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="271" comment="Model 883004">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11811,7 +12875,7 @@
         </functionlabels>
       </family>
       <family name="Econami Steam" mfg="SoundTraxx (Throttle-Up)" comment="These are the -retail- version Econami Steam decoders" file="SoundTraxx_Eco_Steam.xml">
-        <model model="ECO-100 Steam" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="9pin" productID="1" comment="Model 881001">
+        <model model="ECO-100 Steam" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="9pin" productID="257" comment="Model 881001">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11848,7 +12912,7 @@
           </output>
           <size length="27" width="10.5" height="5" units="mm" />
         </model>
-        <model model="ECO-200 Steam" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="10" comment="Model 881002">
+        <model model="ECO-200 Steam" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="266" comment="Model 881002">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11885,7 +12949,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="ECO-21P Steam" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21pin" productID="7" comment="Model 881003">
+        <model model="ECO-21P Steam" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21pin" productID="263" comment="Model 881003">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11922,7 +12986,7 @@
           </output>
           <size length="30.5" width="15.5" height="6.5" units="mm" />
         </model>
-        <model model="ECO-400 Steam" numOuts="6" numFns="30" maxMotorCurrent="4A" connector="other" productID="4" comment="Model 881005">
+        <model model="ECO-400 Steam" numOuts="6" numFns="30" maxMotorCurrent="4A" connector="other" productID="260" comment="Model 881005">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -11959,7 +13023,7 @@
           </output>
           <size length="69" width="30.5" height="14" units="mm" />
         </model>
-        <model model="ECO-PNP Steam" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="13" comment="Model 881004">
+        <model model="ECO-PNP Steam" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="269" comment="Model 881004">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12321,6 +13385,7 @@
       </family>
       <family name="OEM PIKO" mfg="SoundTraxx (Throttle-Up)" comment="These are the PIKO OEM G scale steam decoders" file="SoundTraxx_OEM_PIKO.xml">
         <model model="Mogul" numOuts="2" numFns="14" connector="other" productID="Mogul">
+          <versionCV lowVersionID="84" />
           <output name="Whistle" />
           <output name="Bell" />
           <output name="(Not used)" />
@@ -12394,7 +13459,7 @@
         </model>
       </family>
       <family name="Tsunami2 Diesel" mfg="SoundTraxx (Throttle-Up)" comment="These are the -retail- version Econami Diesel decoders" file="SoundTraxx_Tsu2_Diesel.xml">
-        <model model="TSU-1100 EMD Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="20" comment="Model 885001">
+        <model model="TSU-1100 EMD Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="276" comment="Model 885001">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12425,7 +13490,7 @@
           </output>
           <size length="27" width="10.5" height="5" units="mm" />
         </model>
-        <model model="TSU-1100 GE Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="21" comment="Model 885002">
+        <model model="TSU-1100 GE Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="277" comment="Model 885002">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12456,7 +13521,7 @@
           </output>
           <size length="27" width="10.5" height="5" units="mm" />
         </model>
-        <model model="TSU-1100 Alco Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="22" comment="Model 885003">
+        <model model="TSU-1100 Alco Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="278" comment="Model 885003">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12487,7 +13552,7 @@
           </output>
           <size length="27" width="10.5" height="5" units="mm" />
         </model>
-        <model model="TSU-1100 Baldwin Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="23" comment="Model 885004">
+        <model model="TSU-1100 Baldwin Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="279" comment="Model 885004">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12518,7 +13583,7 @@
           </output>
           <size length="27" width="10.5" height="5" units="mm" />
         </model>
-        <model model="TSU-2200 EMD Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="24" comment="Model 885005">
+        <model model="TSU-2200 EMD Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="280" comment="Model 885005">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12553,7 +13618,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-2200 GE Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="25" comment="Model 885006">
+        <model model="TSU-2200 GE Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="281" comment="Model 885006">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12588,7 +13653,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-2200 Alco Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="26" comment="Model 885007">
+        <model model="TSU-2200 Alco Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="282" comment="Model 885007">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12623,7 +13688,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-2200 Baldwin Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="27" comment="Model 885008">
+        <model model="TSU-2200 Baldwin Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="283" comment="Model 885008">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12658,7 +13723,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-21PNEM EMD Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="28" comment="Model 885009">
+        <model model="TSU-21PNEM EMD Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="284" comment="Model 885009">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12693,7 +13758,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-21PNEM GE Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="29" comment="Model 885010">
+        <model model="TSU-21PNEM GE Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="285" comment="Model 885010">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12728,7 +13793,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-21PNEM Alco Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="30" comment="Model 885011">
+        <model model="TSU-21PNEM Alco Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="286" comment="Model 885011">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12763,7 +13828,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-21PNEM Baldwin Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="31" comment="Model 885012">
+        <model model="TSU-21PNEM Baldwin Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="287" comment="Model 885012">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12798,7 +13863,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-PNP EMD Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="32" comment="Model 885013">
+        <model model="TSU-PNP EMD Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="288" comment="Model 885013">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12833,7 +13898,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-PNP GE Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="33" comment="Model 885014">
+        <model model="TSU-PNP GE Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="289" comment="Model 885014">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12868,7 +13933,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-PNP Alco Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="34" comment="Model 885015">
+        <model model="TSU-PNP Alco Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="290" comment="Model 885015">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12903,7 +13968,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-PNP Baldwin Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="35" comment="Model 885016">
+        <model model="TSU-PNP Baldwin Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="291" comment="Model 885016">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -12969,7 +14034,7 @@
         </functionlabels>
       </family>
       <family name="Tsunami2 Electric" mfg="SoundTraxx (Throttle-Up)" comment="These are the -retail- version Tsunami2 Electric decoders" file="SoundTraxx_Tsu2_Electric.xml">
-        <model model="TSU-1100 Electric" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="40" comment="Model 886001">
+        <model model="TSU-1100 Electric" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="296" comment="Model 886001">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -13004,7 +14069,7 @@
           </output>
           <size length="27" width="10.5" height="5" units="mm" />
         </model>
-        <model model="TSU-2200 Electric" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="41" comment="Model 886002">
+        <model model="TSU-2200 Electric" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="297" comment="Model 886002">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -13039,7 +14104,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-21PNEM Electric" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="42" comment="Model 886003">
+        <model model="TSU-21PNEM Electric" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="298" comment="Model 886003">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -13103,7 +14168,7 @@
         </functionlabels>
       </family>
       <family name="Tsunami2 Steam" mfg="SoundTraxx (Throttle-Up)" comment="These are the -retail- version Econami Steam decoders" file="SoundTraxx_Tsu2_Steam.xml">
-        <model model="TSU-1100 Steam" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="9pin" productID="16" comment="Model 884001">
+        <model model="TSU-1100 Steam" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="9pin" productID="272" comment="Model 884001">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -13139,7 +14204,7 @@
           </output>
           <size length="27" width="10.5" height="5" units="mm" />
         </model>
-        <model model="TSU-2200 Steam" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="17" comment="Model 884002">
+        <model model="TSU-2200 Steam" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="273" comment="Model 884002">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -13174,7 +14239,7 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="TSU-21PNEM Steam" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="18" comment="Model 884003">
+        <model model="TSU-21PNEM Steam" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="274" comment="Model 884003">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -26152,6 +27217,71 @@
           <size length="55" width="26" height="18" units="mm" />
         </model>
       </family>
+      <family name="Zimo Function Decoders" mfg="Zimo" file="Zimo_Unified_software_v30_MX681.xml">
+        <model model="MX681 version 30+" lowVersionID="30" highVersionID="30" maxInputVolts="10-35V" maxTotalCurrent="0.7A" productID="228" formFactor="N" numOuts="6" numFns="14">
+          <output name="1" label="Front Light">
+            <label xml:lang="de">Lvor</label>
+          </output>
+          <output name="2" label="Rear Light">
+            <label xml:lang="de">Lrück</label>
+          </output>
+          <output name="3" label="FO 1">
+            <label xml:lang="de">FA1</label>
+          </output>
+          <output name="4" label="FO 2">
+            <label xml:lang="de">FA2</label>
+          </output>
+          <output name="5" label="FO 3">
+            <label xml:lang="de">FA3</label>
+          </output>
+          <output name="6" label="FO 4">
+            <label xml:lang="de">FA4</label>
+          </output>
+          <size length="12" width="8.5" height="2.2" units="mm" />
+        </model>
+        <model model="MX681R version 30+" lowVersionID="30" highVersionID="30" maxInputVolts="10-35V" maxTotalCurrent="0.7A" productID="228" formFactor="N" numOuts="6" numFns="14" connector="NMRAmedium">
+          <output name="1" label="Front Light">
+            <label xml:lang="de">Lvor</label>
+          </output>
+          <output name="2" label="Rear Light">
+            <label xml:lang="de">Lrück</label>
+          </output>
+          <output name="3" label="FO 1">
+            <label xml:lang="de">FA1</label>
+          </output>
+          <output name="4" label="FO 2">
+            <label xml:lang="de">FA2</label>
+          </output>
+          <output name="5" label="FO 3">
+            <label xml:lang="de">FA3</label>
+          </output>
+          <output name="6" label="FO 4">
+            <label xml:lang="de">FA4</label>
+          </output>
+          <size length="12" width="8.5" height="2.2" units="mm" />
+        </model>
+        <model model="MX681N version 30+" lowVersionID="30" highVersionID="30" maxInputVolts="10-35V" maxTotalCurrent="0.7A" productID="228" formFactor="N" numOuts="6" numFns="14" connector="NMRAsmall">
+          <output name="1" label="Front Light">
+            <label xml:lang="de">Lvor</label>
+          </output>
+          <output name="2" label="Rear Light">
+            <label xml:lang="de">Lrück</label>
+          </output>
+          <output name="3" label="FO 1">
+            <label xml:lang="de">FA1</label>
+          </output>
+          <output name="4" label="FO 2">
+            <label xml:lang="de">FA2</label>
+          </output>
+          <output name="5" label="FO 3">
+            <label xml:lang="de">FA3</label>
+          </output>
+          <output name="6" label="FO 4">
+            <label xml:lang="de">FA4</label>
+          </output>
+          <size length="12" width="8.5" height="2.2" units="mm" />
+        </model>
+      </family>
       <family name="Zimo Unified software (version 32+)" mfg="Zimo" file="Zimo_Unified_software_v32_MX633.xml">
         <model show="no" model="MX633 version 32+" replacementModel="MX633 version 25+" replacementFamily="Zimo Unified software (version 25+)" lowVersionID="32" highVersionID="42" maxInputVolts="35V" maxMotorCurrent="1.2A" maxTotalCurrent="1.2A" formFactor="HO" numOuts="10" numFns="14" productID="237">
           <output name="1" label="Front Light" />
@@ -26818,6 +27948,89 @@
           <output name="5" label="FO 3 (+5v)" />
           <output name="6" label="FO 4 (+5v)" />
           <size length="25" width="10.5" height="4" units="mm" />
+        </model>
+      </family>
+      <family name="Zimo Function Decoders" mfg="Zimo" file="Zimo_Unified_software_v32_MX685.xml">
+        <model model="MX685 version 32+" lowVersionID="32" highVersionID="32" maxInputVolts="10-35V" maxTotalCurrent="1.0A" productID="226" formFactor="N" numOuts="8" numFns="14">
+          <output name="1" label="Front Light">
+            <label xml:lang="de">Lvor</label>
+          </output>
+          <output name="2" label="Rear Light">
+            <label xml:lang="de">Lrück</label>
+          </output>
+          <output name="3" label="FO 1">
+            <label xml:lang="de">FA1</label>
+          </output>
+          <output name="4" label="FO 2">
+            <label xml:lang="de">FA2</label>
+          </output>
+          <output name="5" label="FO 3">
+            <label xml:lang="de">FA3</label>
+          </output>
+          <output name="6" label="FO 4">
+            <label xml:lang="de">FA4</label>
+          </output>
+          <output name="7" label="FO 5">
+            <label xml:lang="de">FA5</label>
+          </output>
+          <output name="8" label="FO 6">
+            <label xml:lang="de">FA6</label>
+          </output>
+          <size length="20" width="11" height="3.5" units="mm" />
+        </model>
+        <model model="MX685P16 version 32+" lowVersionID="32" highVersionID="32" maxInputVolts="10-35V" maxTotalCurrent="1.0A" productID="226" formFactor="N" numOuts="8" numFns="14" connector="PluX16">
+          <output name="1" label="Front Light">
+            <label xml:lang="de">Lvor</label>
+          </output>
+          <output name="2" label="Rear Light">
+            <label xml:lang="de">Lrück</label>
+          </output>
+          <output name="3" label="FO 1">
+            <label xml:lang="de">FA1</label>
+          </output>
+          <output name="4" label="FO 2">
+            <label xml:lang="de">FA2</label>
+          </output>
+          <output name="5" label="FO 3">
+            <label xml:lang="de">FA3</label>
+          </output>
+          <output name="6" label="FO 4">
+            <label xml:lang="de">FA4</label>
+          </output>
+          <output name="7" label="FO 5">
+            <label xml:lang="de">FA5</label>
+          </output>
+          <output name="8" label="FO 6">
+            <label xml:lang="de">FA6</label>
+          </output>
+          <size length="20" width="11" height="3.5" units="mm" />
+        </model>
+        <model model="MX685R version 32+" lowVersionID="32" highVersionID="32" maxInputVolts="10-35V" maxTotalCurrent="1.0A" productID="226" formFactor="N" numOuts="8" numFns="14" connector="NMRAmedium">
+          <output name="1" label="Front Light">
+            <label xml:lang="de">Lvor</label>
+          </output>
+          <output name="2" label="Rear Light">
+            <label xml:lang="de">Lrück</label>
+          </output>
+          <output name="3" label="FO 1">
+            <label xml:lang="de">FA1</label>
+          </output>
+          <output name="4" label="FO 2">
+            <label xml:lang="de">FA2</label>
+          </output>
+          <output name="5" label="FO 3">
+            <label xml:lang="de">FA3</label>
+          </output>
+          <output name="6" label="FO 4">
+            <label xml:lang="de">FA4</label>
+          </output>
+          <output name="7" label="FO 5">
+            <label xml:lang="de">FA5</label>
+          </output>
+          <output name="8" label="FO 6">
+            <label xml:lang="de">FA6</label>
+          </output>
+          <size length="20" width="11" height="3.5" units="mm" />
         </model>
       </family>
       <family name="Zimo Unified software (version 32+)" mfg="Zimo" file="Zimo_Unified_software_v32_MX695KN_696N.xml">

--- a/xml/decoders/SoundTraxx_Eco_Diesel.xml
+++ b/xml/decoders/SoundTraxx_Eco_Diesel.xml
@@ -80,6 +80,12 @@
             <authorinitials>MJM</authorinitials>
             <revremark>Add ID CV 253,254,255,256 and change product ID to values in CV256</revremark>
         </revision>
+        <revision>
+            <revnumber>3.1</revnumber>
+            <date>2016-12-21</date>
+            <authorinitials>DGH</authorinitials>
+            <revremark>Change product ID to values in CVs 253(high byte) and 256(low byte)</revremark>
+        </revision>
     </revhistory>
     <version author="Michael Mosher" version="1" lastUpdated="20150725"/>
     <version author="Alain Le Marchand" version="1.1" lastUpdated="20150726"/>
@@ -89,10 +95,11 @@
     <version author="Michael Mosher" version="2" lastUpdated="20160529"/>
     <version author="Alain Le Marchand" version="2.1" lastUpdated="20160604"/>
     <version author="Michael Mosher" version="3" lastUpdated="20161021"/>
+    <version author="Dave Heap" version="3.1" lastUpdated="20161221"/>
     <!-- Decoder Model information follows -->
     <decoder>
         <family name="Econami Diesel" mfg="SoundTraxx (Throttle-Up)" comment="These are the -retail- version Econami Diesel decoders">
-            <model model="ECO-100 Diesel" numOuts="4" numFns="20" maxMotorCurrent="1A" connector="other" productID="2" comment="Model 882001">
+            <model model="ECO-100 Diesel" numOuts="4" numFns="20" maxMotorCurrent="1A" connector="other" productID="258" comment="Model 882001">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -123,7 +130,7 @@
                 </output>
                 <size length="27" width="10.5" height="5" units="mm"/>
             </model>
-            <model model="ECO-200 Diesel" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="11" comment="Model 882002">
+            <model model="ECO-200 Diesel" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="267" comment="Model 882002">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -154,7 +161,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="ECO-21P Diesel" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21pin" productID="8" comment="Model 882003">
+            <model model="ECO-21P Diesel" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21pin" productID="264" comment="Model 882003">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -185,7 +192,7 @@
                 </output>
                 <size length="30.5" width="15.5" height="6.5" units="mm"/>
             </model>
-            <model model="ECO-400 Diesel" numOuts="6" numFns="30" maxMotorCurrent="4A" connector="other" productID="5" comment="Model 882005">
+            <model model="ECO-400 Diesel" numOuts="6" numFns="30" maxMotorCurrent="4A" connector="other" productID="261" comment="Model 882005">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -216,7 +223,7 @@
                 </output>
                 <size length="69" width="30.5" height="14" units="mm"/>
             </model>
-            <model model="ECO-PNP Diesel" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="14" comment="Model 882004">
+            <model model="ECO-PNP Diesel" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="270" comment="Model 882004">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>

--- a/xml/decoders/SoundTraxx_Eco_Electric.xml
+++ b/xml/decoders/SoundTraxx_Eco_Electric.xml
@@ -86,6 +86,12 @@
             <authorinitials>MJM</authorinitials>
             <revremark>Add ID CV 253,254,255,256 and change product ID to values in CV256</revremark>
         </revision>
+        <revision>
+            <revnumber>3.1</revnumber>
+            <date>2016-12-21</date>
+            <authorinitials>DGH</authorinitials>
+            <revremark>Change product ID to values in CVs 253(high byte) and 256(low byte)</revremark>
+        </revision>
     </revhistory>
     <version author="Michael Mosher" version="1" lastUpdated="20150725"/>
     <version author="Alain Le Marchand" version="1.1" lastUpdated="20150726"/>
@@ -96,10 +102,11 @@
     <version author="Michael Mosher" version="2" lastUpdated="20160529"/>
     <version author="Alain Le Marchand" version="2.1" lastUpdated="20160604"/>
     <version author="Michael Mosher" version="3" lastUpdated="20161021"/>
+    <version author="Dave Heap" version="3.1" lastUpdated="20161221"/>
     <!-- Decoder Model information follows -->
     <decoder>
         <family name="Econami Electric" mfg="SoundTraxx (Throttle-Up)" comment="These are the -retail- version Econami Electric decoders">
-            <model model="ECO-100 Electric" numOuts="4" numFns="20" maxMotorCurrent="1A" connector="other" productID="3" comment="Model 883001">
+            <model model="ECO-100 Electric" numOuts="4" numFns="20" maxMotorCurrent="1A" connector="other" productID="259" comment="Model 883001">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -134,7 +141,7 @@
                 </output>
                 <size length="27" width="10.5" height="5" units="mm"/>
             </model>
-            <model model="ECO-200 Electric" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="12" comment="Model 883002">
+            <model model="ECO-200 Electric" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="268" comment="Model 883002">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -169,7 +176,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="ECO-21P Electric" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21pin" productID="9" comment="Model 883003">
+            <model model="ECO-21P Electric" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21pin" productID="265" comment="Model 883003">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -204,7 +211,7 @@
                 </output>
                 <size length="30.5" width="15.5" height="6.5" units="mm"/>
             </model>
-            <model model="ECO-400 Electric" numOuts="6" numFns="30" maxMotorCurrent="4A" connector="other" productID="6" comment="Model 883005">
+            <model model="ECO-400 Electric" numOuts="6" numFns="30" maxMotorCurrent="4A" connector="other" productID="262" comment="Model 883005">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -239,7 +246,7 @@
                 </output>
                 <size length="69" width="30.5" height="14" units="mm"/>
             </model>
-            <model model="ECO-PNP Electric" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="15" comment="Model 883004">
+            <model model="ECO-PNP Electric" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="271" comment="Model 883004">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>

--- a/xml/decoders/SoundTraxx_Eco_Steam.xml
+++ b/xml/decoders/SoundTraxx_Eco_Steam.xml
@@ -98,6 +98,12 @@
             <authorinitials>MJM</authorinitials>
             <revremark>Add ID CV 253,254,255,256 and change product ID to values in CV256</revremark>
         </revision>
+        <revision>
+            <revnumber>3.1</revnumber>
+            <date>2016-12-21</date>
+            <authorinitials>DGH</authorinitials>
+            <revremark>Change product ID to values in CVs 253(high byte) and 256(low byte)</revremark>
+        </revision>
     </revhistory>
     <version author="Michael Mosher" version="1" lastUpdated="20150725"/>
     <version author="Alain Le Marchand" version="1.1" lastUpdated="20150726"/>
@@ -113,7 +119,7 @@
     <!-- Decoder Model information follows -->
     <decoder>
         <family name="Econami Steam" mfg="SoundTraxx (Throttle-Up)" comment="These are the -retail- version Econami Steam decoders">
-            <model model="ECO-100 Steam" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="9pin" productID="1" comment="Model 881001">
+            <model model="ECO-100 Steam" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="9pin" productID="257" comment="Model 881001">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -148,7 +154,7 @@
                 </output>
                 <size length="27" width="10.5" height="5" units="mm"/>
             </model>
-            <model model="ECO-200 Steam" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="10" comment="Model 881002">
+            <model model="ECO-200 Steam" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="266" comment="Model 881002">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -183,7 +189,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="ECO-21P Steam" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21pin" productID="7" comment="Model 881003">
+            <model model="ECO-21P Steam" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21pin" productID="263" comment="Model 881003">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -218,7 +224,7 @@
                 </output>
                 <size length="30.5" width="15.5" height="6.5" units="mm"/>
             </model>
-            <model model="ECO-400 Steam" numOuts="6" numFns="30" maxMotorCurrent="4A" connector="other" productID="4" comment="Model 881005">
+            <model model="ECO-400 Steam" numOuts="6" numFns="30" maxMotorCurrent="4A" connector="other" productID="260" comment="Model 881005">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -253,7 +259,7 @@
                 </output>
                 <size length="69" width="30.5" height="14" units="mm"/>
             </model>
-            <model model="ECO-PNP Steam" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="13" comment="Model 881004">
+            <model model="ECO-PNP Steam" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="269" comment="Model 881004">
                 <versionCV lowVersionID="70"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>

--- a/xml/decoders/SoundTraxx_Tsu2_Diesel.xml
+++ b/xml/decoders/SoundTraxx_Tsu2_Diesel.xml
@@ -73,11 +73,17 @@
             <authorinitials>MJM</authorinitials>
             <revremark>Add ID CV 253,254,255,256 and change product ID to values in CV256</revremark>
         </revision>
+        <revision>
+            <revnumber>4.1</revnumber>
+            <date>2016-12-21</date>
+            <authorinitials>DGH</authorinitials>
+            <revremark>Change product ID to values in CVs 253(high byte) and 256(low byte)</revremark>
+        </revision>
     </revhistory>
     <!-- Decoder Model information follows -->
     <decoder>
         <family name="Tsunami2 Diesel" mfg="SoundTraxx (Throttle-Up)" comment="These are the -retail- version Econami Diesel decoders">
-            <model model="TSU-1100 EMD Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="20" comment="Model 885001">
+            <model model="TSU-1100 EMD Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="276" comment="Model 885001">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -108,7 +114,7 @@
                 </output>
                 <size length="27" width="10.5" height="5" units="mm"/>
             </model>
-            <model model="TSU-1100 GE Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="21" comment="Model 885002">
+            <model model="TSU-1100 GE Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="277" comment="Model 885002">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -139,7 +145,7 @@
                 </output>
                 <size length="27" width="10.5" height="5" units="mm"/>
             </model>
-            <model model="TSU-1100 Alco Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="22" comment="Model 885003">
+            <model model="TSU-1100 Alco Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="278" comment="Model 885003">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -170,7 +176,7 @@
                 </output>
                 <size length="27" width="10.5" height="5" units="mm"/>
             </model>
-            <model model="TSU-1100 Baldwin Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="23" comment="Model 885004">
+            <model model="TSU-1100 Baldwin Diesels" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="279" comment="Model 885004">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -201,7 +207,7 @@
                 </output>
                 <size length="27" width="10.5" height="5" units="mm"/>
             </model>
-            <model model="TSU-2200 EMD Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="24" comment="Model 885005">
+            <model model="TSU-2200 EMD Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="280" comment="Model 885005">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -236,7 +242,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-2200 GE Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="25" comment="Model 885006">
+            <model model="TSU-2200 GE Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="281" comment="Model 885006">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -271,7 +277,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-2200 Alco Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="26" comment="Model 885007">
+            <model model="TSU-2200 Alco Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="282" comment="Model 885007">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -306,7 +312,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-2200 Baldwin Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="27" comment="Model 885008">
+            <model model="TSU-2200 Baldwin Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="283" comment="Model 885008">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -341,7 +347,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-21PNEM EMD Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="28" comment="Model 885009">
+            <model model="TSU-21PNEM EMD Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="284" comment="Model 885009">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -376,7 +382,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-21PNEM GE Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="29" comment="Model 885010">
+            <model model="TSU-21PNEM GE Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="285" comment="Model 885010">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -411,7 +417,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-21PNEM Alco Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="30" comment="Model 885011">
+            <model model="TSU-21PNEM Alco Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="286" comment="Model 885011">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -446,7 +452,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-21PNEM Baldwin Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="31" comment="Model 885012">
+            <model model="TSU-21PNEM Baldwin Diesels" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="287" comment="Model 885012">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -481,7 +487,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-PNP EMD Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="32" comment="Model 885013">
+            <model model="TSU-PNP EMD Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="288" comment="Model 885013">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -516,7 +522,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-PNP GE Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="33" comment="Model 885014">
+            <model model="TSU-PNP GE Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="289" comment="Model 885014">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -551,7 +557,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-PNP Alco Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="34" comment="Model 885015">
+            <model model="TSU-PNP Alco Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="290" comment="Model 885015">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -586,7 +592,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-PNP Baldwin Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="35" comment="Model 885016">
+            <model model="TSU-PNP Baldwin Diesels" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="291" comment="Model 885016">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -1168,23 +1174,23 @@
                 </enumVal>
                 <label>Auxiliary Airhorn Select</label>
             </variable>
-            <variable CV="122" mask="XXVVVVVV" item="Sound Option 8" include="20,24,28,32" default="18" tooltip="Bell sound effect and ring-rate">
+            <variable CV="122" mask="XXVVVVVV" item="Sound Option 8" include="276,280,284,288" default="18" tooltip="Bell sound effect and ring-rate">
                 <xi:include href="http://jmri.org/xml/decoders/soundtraxx/TSU2enumDieselBell.xml"/>
                 <label>Bell Select</label>
             </variable>
-            <variable CV="122" mask="XXVVVVVV" item="Sound Option 8" include="21,25,29,33" default="36" tooltip="Bell sound effect and ring-rate">
+            <variable CV="122" mask="XXVVVVVV" item="Sound Option 8" include="277,281,285,289" default="36" tooltip="Bell sound effect and ring-rate">
                 <xi:include href="http://jmri.org/xml/decoders/soundtraxx/TSU2enumDieselBell.xml"/>
                 <label>Bell Select</label>
             </variable>
-            <variable CV="122" mask="XXVVVVVV" item="Sound Option 8" include="22,26,30,34" default="10" tooltip="Bell sound effect and ring-rate">
+            <variable CV="122" mask="XXVVVVVV" item="Sound Option 8" include="278,282,286,290" default="10" tooltip="Bell sound effect and ring-rate">
                 <xi:include href="http://jmri.org/xml/decoders/soundtraxx/TSU2enumDieselBell.xml"/>
                 <label>Bell Select</label>
             </variable>
-            <variable CV="122" mask="XXVVVVVV" item="Sound Option 8" include="23,27,31,35" default="47" tooltip="Bell sound effect and ring-rate">
+            <variable CV="122" mask="XXVVVVVV" item="Sound Option 8" include="279,283,287,291" default="47" tooltip="Bell sound effect and ring-rate">
                 <xi:include href="http://jmri.org/xml/decoders/soundtraxx/TSU2enumDieselBell.xml"/>
                 <label>Bell Select</label>
             </variable>
-            <variable CV="123" mask="XXXXVVVV" item="Sound Option 5" include="20,24,28,32" default="0" tooltip="Select one of prime mover sound effects">
+            <variable CV="123" mask="XXXXVVVV" item="Sound Option 5" include="276,280,284,288" default="0" tooltip="Select one of prime mover sound effects">
                 <enumVal>
                     <enumChoice>
                         <choice>EMD 567 (No Transition)</choice>
@@ -1216,7 +1222,7 @@
                 </enumVal>
                 <label>Prime Mover Select</label>
             </variable>
-            <variable CV="123" mask="XXXXVVVV" item="Sound Option 5" include="21,25,29,33" default="2" tooltip="Select one of prime mover sound effects">
+            <variable CV="123" mask="XXXXVVVV" item="Sound Option 5" include="277,281,285,289" default="2" tooltip="Select one of prime mover sound effects">
                 <enumVal>
                     <enumChoice>
                         <choice>FDL-12</choice>
@@ -1242,7 +1248,7 @@
                 </enumVal>
                 <label>Prime Mover Select</label>
             </variable>
-            <variable CV="123" mask="XXXXVVVV" item="Sound Option 5" include="22,26,30,34" default="0" tooltip="Select one of prime mover sound effects">
+            <variable CV="123" mask="XXXXVVVV" item="Sound Option 5" include="278,282,286,290" default="0" tooltip="Select one of prime mover sound effects">
                 <enumVal>
                     <enumChoice>
                         <choice>ALCO 539 Turbo</choice>
@@ -1274,7 +1280,7 @@
                 </enumVal>
                 <label>Prime Mover Select</label>
             </variable>
-            <variable CV="123" mask="XXXXXVVV" item="Sound Option 5" include="23,27,31,35" default="0" tooltip="Select one of prime mover sound effects">
+            <variable CV="123" mask="XXXXXVVV" item="Sound Option 5" include="279,283,287,291" default="0" tooltip="Select one of prime mover sound effects">
                 <enumVal>
                     <enumChoice>
                         <choice>Baldwin VO</choice>
@@ -1300,15 +1306,15 @@
                 </enumVal>
                 <label>Prime Mover Select</label>
             </variable>
-            <variable CV="124" mask="XXXXXXVV" item="Sound Option 10" include="20,24,28,32" default="3" tooltip="Select one of air compressor sound effects">
+            <variable CV="124" mask="XXXXXXVV" item="Sound Option 10" include="276,280,284,288" default="3" tooltip="Select one of air compressor sound effects">
                 <xi:include href="http://jmri.org/xml/decoders/soundtraxx/TSU2enumDieselComp.xml"/>
                 <label>Air Compressor Select</label>
             </variable>
-            <variable CV="124" mask="XXXXXXVV" item="Sound Option 10" include="21,25,29,33" default="1" tooltip="Select one of air compressor sound effects">
+            <variable CV="124" mask="XXXXXXVV" item="Sound Option 10" include="277,281,285,289" default="1" tooltip="Select one of air compressor sound effects">
                 <xi:include href="http://jmri.org/xml/decoders/soundtraxx/TSU2enumDieselComp.xml"/>
                 <label>Air Compressor Select</label>
             </variable>
-            <variable CV="124" mask="XXXXXXVV" item="Sound Option 10" include="22,26,30,34,23,27,31,35" default="0" tooltip="Select one of air compressor sound effects">
+            <variable CV="124" mask="XXXXXXVV" item="Sound Option 10" include="278,282,286,34,280,283,287,291" default="0" tooltip="Select one of air compressor sound effects">
                 <xi:include href="http://jmri.org/xml/decoders/soundtraxx/TSU2enumDieselComp.xml"/>
                 <label>Air Compressor Select</label>
             </variable>

--- a/xml/decoders/SoundTraxx_Tsu2_Electric.xml
+++ b/xml/decoders/SoundTraxx_Tsu2_Electric.xml
@@ -55,12 +55,18 @@
             <authorinitials>MJM</authorinitials>
             <revremark>Add ID CV 253,254,255,256 and change product ID to values in CV256</revremark>
         </revision>
+        <revision>
+            <revnumber>4.1</revnumber>
+            <date>2016-12-21</date>
+            <authorinitials>DGH</authorinitials>
+            <revremark>Change product ID to values in CVs 253(high byte) and 256(low byte)</revremark>
+        </revision>
     </revhistory>
     <version author="Alain Le Marchand" version="1" lastUpdated="20160604"/>
     <!-- Decoder Model information follows -->
     <decoder>
         <family name="Tsunami2 Electric" mfg="SoundTraxx (Throttle-Up)" comment="These are the -retail- version Tsunami2 Electric decoders">
-            <model model="TSU-1100 Electric" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="40" comment="Model 886001">
+            <model model="TSU-1100 Electric" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="other" productID="296" comment="Model 886001">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -95,7 +101,7 @@
                 </output>
                 <size length="27" width="10.5" height="5" units="mm"/>
             </model>
-            <model model="TSU-2200 Electric" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="41" comment="Model 886002">
+            <model model="TSU-2200 Electric" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="297" comment="Model 886002">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -130,7 +136,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-21PNEM Electric" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="42" comment="Model 886003">
+            <model model="TSU-21PNEM Electric" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="298" comment="Model 886003">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>

--- a/xml/decoders/SoundTraxx_Tsu2_Steam.xml
+++ b/xml/decoders/SoundTraxx_Tsu2_Steam.xml
@@ -61,6 +61,12 @@
             <authorinitials>MJM</authorinitials>
             <revremark>Add ID CV 253,254,255,256 and change product ID to values in CV256</revremark>
         </revision>
+        <revision>
+            <revnumber>4.1</revnumber>
+            <date>2016-12-21</date>
+            <authorinitials>DGH</authorinitials>
+            <revremark>Change product ID to values in CVs 253(high byte) and 256(low byte)</revremark>
+        </revision>
     </revhistory>
     <version author="Michael Mosher" version="1" lastUpdated="20160529"/>
     <!-- Version 1:   Based on Tsunami2 Steam Technical Reference version 1.0    -->
@@ -71,7 +77,7 @@
     <!-- Decoder Model information follows -->
     <decoder>
         <family name="Tsunami2 Steam" mfg="SoundTraxx (Throttle-Up)" comment="These are the -retail- version Econami Steam decoders">
-            <model model="TSU-1100 Steam" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="9pin" productID="16" comment="Model 884001">
+            <model model="TSU-1100 Steam" numOuts="4" numFns="30" maxMotorCurrent="1A" connector="9pin" productID="272" comment="Model 884001">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -106,7 +112,7 @@
                 </output>
                 <size length="27" width="10.5" height="5" units="mm"/>
             </model>
-            <model model="TSU-2200 Steam" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="17" comment="Model 884002">
+            <model model="TSU-2200 Steam" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="273" comment="Model 884002">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>
@@ -141,7 +147,7 @@
                 </output>
                 <size length="35" width="18" height="6" units="mm"/>
             </model>
-            <model model="TSU-21PNEM Steam" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="18" comment="Model 884003">
+            <model model="TSU-21PNEM Steam" numOuts="6" numFns="30" maxMotorCurrent="1A" connector="21MTC" productID="274" comment="Model 884003">
                 <versionCV lowVersionID="71"/>
                 <output name="3" label="  FX3  "/>
                 <output name="4" label="  FX4  "/>

--- a/xml/decoders/soundtraxx/TSU2CV.xml
+++ b/xml/decoders/soundtraxx/TSU2CV.xml
@@ -30,11 +30,11 @@
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-AddSubtract2.xml"/>
         <label>Train Brake Rate Sign</label>
     </variable>
-    <variable CV="138" mask="VVVVVVVV" item="Sound Setting 11" default="128" exclude="40,41,42">
+    <variable CV="138" mask="VVVVVVVV" item="Sound Setting 11" default="128" exclude="296,297,298"> <!-- should this be ="Tsunami2 Electric"? -->
         <decVal/>
         <label>Train Brake Apply/Release Volume</label>
     </variable>
-    <variable CV="138" mask="VVVVVVVV" item="Sound Setting 11" default="65" include="40,41,42"> <!-- Steam -->
+    <variable CV="138" mask="VVVVVVVV" item="Sound Setting 11" default="65" include="296,297,298"> <!-- should this be ="Tsunami2 Electric"? --> <!-- Steam -->
         <decVal/>
         <label>Train Brake Apply/Release Volume</label>
     </variable>
@@ -46,11 +46,11 @@
         <decVal/>
         <label>Sander Valve Volume</label>
     </variable>
-    <variable CV="155" mask="VVVVVVVV" item="Sound Setting 28" default="50" exclude="40,41,42">
+    <variable CV="155" mask="VVVVVVVV" item="Sound Setting 28" default="50" exclude="296,297,298"> <!-- should this be ="Tsunami2 Electric"? -->
         <decVal/>
         <label>Fuel Loading Volume</label>
     </variable>
-    <variable CV="155" mask="VVVVVVVV" item="Sound Setting 28" default="55" include="40,41,42"> <!-- Electrical -->
+    <variable CV="155" mask="VVVVVVVV" item="Sound Setting 28" default="55" include="296,297,298"> <!-- should this be ="Tsunami2 Electric"? --> <!-- Electrical -->
         <decVal/>
         <label>Electrical Arcing</label>
     </variable>
@@ -103,11 +103,11 @@
         <decVal/>
         <label>Sander Valve Reverb Level</label>
     </variable>
-    <variable CV="187" mask="VVVVVVVV" item="Reverb187" default="0" exclude="40,41,42">
+    <variable CV="187" mask="VVVVVVVV" item="Reverb187" default="0" exclude="296,297,298"> <!-- should this be ="Tsunami2 Electric"? -->
         <decVal/>
         <label>Fuel Loading Reverb Level</label>
     </variable>
-    <variable CV="187" mask="VVVVVVVV" item="Reverb187" default="0" include="40,41,42"> <!-- Electrical -->
+    <variable CV="187" mask="VVVVVVVV" item="Reverb187" default="0" include="296,297,298"> <!-- should this be ="Tsunami2 Electric"? --> <!-- Electrical -->
         <decVal/>
         <label>Electrical Arcing Reverb Level</label>
     </variable>
@@ -115,7 +115,7 @@
         <decVal/>
         <label>Wrenches Reverb Level</label>
     </variable>
-    <variable CV="190" mask="VVVVVVVV" item="Reverb190" default="0" exclude="40,41,42"> <!-- exclude Electrical -->
+    <variable CV="190" mask="VVVVVVVV" item="Reverb190" default="0" exclude="296,297,298"> <!-- should this be ="Tsunami2 Electric"? --> <!-- exclude Electrical -->
         <decVal/>
         <label>Pneumatic Oilers Reverb Level</label>
     </variable>


### PR DESCRIPTION
In response to a [request](https://sourceforge.net/p/jmri/mailman/jmri-developers/thread/f8e099ac-c589-4a85-6953-0d077ea9cde4%40comcast.net/#msg35563818) by @mmosher5501 on jmri-developers list for the productID to include CV253 as a high byte.

Includes necessary code in IdentifyDecoder and updates to productID throughout the affected files.
(There is also a minor update to the ESU identify code.)

I have calculated the productID mapping for retail decoders in this file:
[productID.xlsx](https://github.com/JMRI/JMRI/files/667502/productID.xlsx)

@mmosher5501 I have suggested possible substitution of productID with family name in a couple of places (comments in XML code). You may like to review these once this PR is merged.