### PR TITLE
Ensure comment filed complies with null when blank. And Transit allow…

### DIFF
--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -42,7 +42,11 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
      */
     public void setComment(String comment) {
         String old = this.comment;
-        this.comment = comment;
+        if ( comment.isEmpty() || comment.trim().length() < 1 ) {
+            this.comment = null;
+        } else {
+            this.comment = comment;
+        }
         firePropertyChange("Comment", old, comment);
     }
     private String comment;

--- a/xml/schema/types/transits-2-9-6.xsd
+++ b/xml/schema/types/transits-2-9-6.xsd
@@ -44,7 +44,8 @@
           <xs:complexType>
             <xs:sequence>
               <xs:element name="systemName" type="systemNameType" minOccurs="0" maxOccurs="1"/>
-              <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+	      <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+	      <xs:element name="comment" type="userNameType" minOccurs="0" maxOccurs="1"/>
               <xs:element name="transitsection" minOccurs="1" maxOccurs="unbounded" >
                 <xs:complexType>
                   <xs:sequence>


### PR DESCRIPTION
As we are now checking the sanity of panels on loading we need to ensure the data is written according to the rules. The first part of the change ensures comment fields when blank are null as described in the comment for the routine, The second allows comments to be stored on Transits.
