### PR TITLE
Minor syntactic cleanup of jmrix.loconet package

### DIFF
--- a/java/src/jmri/jmrix/loconet/Intellibox/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/Intellibox/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.loconet.Intellibox;
 
 /**

--- a/java/src/jmri/jmrix/loconet/Intellibox/IbxConnectionTypeList.java
+++ b/java/src/jmri/jmrix/loconet/Intellibox/IbxConnectionTypeList.java
@@ -1,4 +1,3 @@
-// LnConnectionTypeList.java
 package jmri.jmrix.loconet.Intellibox;
 
 /**

--- a/java/src/jmri/jmrix/loconet/Intellibox/IntelliboxAdapter.java
+++ b/java/src/jmri/jmrix/loconet/Intellibox/IntelliboxAdapter.java
@@ -1,4 +1,3 @@
-// LocoBufferAdapter.java
 package jmri.jmrix.loconet.Intellibox;
 
 import jmri.jmrix.loconet.LnCommandStationType;

--- a/java/src/jmri/jmrix/loconet/LNCPSignalMast.java
+++ b/java/src/jmri/jmrix/loconet/LNCPSignalMast.java
@@ -1,4 +1,3 @@
-// LNCPSignalMast.java
 package jmri.jmrix.loconet;
 
 import jmri.NmraPacket;
@@ -20,11 +19,6 @@ import org.slf4j.LoggerFactory;
  * @author	Kevin Dickerson Copyright (C) 2002
  */
 public class LNCPSignalMast extends DccSignalMast implements LocoNetListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4564372505227894262L;
 
     public LNCPSignalMast(String sys, String user) {
         super(sys, user, "F$lncpsm");
@@ -140,6 +134,3 @@ public class LNCPSignalMast extends DccSignalMast implements LocoNetListener {
     private final static Logger log = LoggerFactory.getLogger(LNCPSignalMast.class.getName());
 
 }
-
-
-/* @(#)LNCPSignalMast.java */

--- a/java/src/jmri/jmrix/loconet/LnConnectionTypeList.java
+++ b/java/src/jmri/jmrix/loconet/LnConnectionTypeList.java
@@ -1,4 +1,3 @@
-// LnConnectionTypeList.java
 package jmri.jmrix.loconet;
 
 /**

--- a/java/src/jmri/jmrix/loconet/LnLightManager.java
+++ b/java/src/jmri/jmrix/loconet/LnLightManager.java
@@ -1,4 +1,3 @@
-// LnLightManager.java
 package jmri.jmrix.loconet;
 
 import jmri.Light;
@@ -16,11 +15,6 @@ import org.slf4j.LoggerFactory;
  * @author	Dave Duchamp Copyright (C) 2006
   */
 public class LnLightManager extends AbstractLightManager {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -2149079067924117653L;
 
     public LnLightManager(LnTrafficController tc, String prefix) {
         _trafficController = tc;
@@ -117,5 +111,3 @@ public class LnLightManager extends AbstractLightManager {
     private final static Logger log = LoggerFactory.getLogger(LnLightManager.class.getName());
 
 }
-
-/* @(#)LnLightManager.java */

--- a/java/src/jmri/jmrix/loconet/LnMessageManager.java
+++ b/java/src/jmri/jmrix/loconet/LnMessageManager.java
@@ -1,4 +1,3 @@
-// LnMessageManager.java
 package jmri.jmrix.loconet;
 
 /**
@@ -64,6 +63,3 @@ public class LnMessageManager implements LocoNetListener {
     public void message(LocoNetMessage m) {
     }
 }
-
-
-/* @(#)LnMessageManager.java */

--- a/java/src/jmri/jmrix/loconet/LnNetworkPortController.java
+++ b/java/src/jmri/jmrix/loconet/LnNetworkPortController.java
@@ -100,6 +100,3 @@ public abstract class LnNetworkPortController extends jmri.jmrix.AbstractNetwork
         setTurnoutHandling(value);
     }
 }
-
-
-/* @(#)LnNetworkPortController.java */

--- a/java/src/jmri/jmrix/loconet/LnPortController.java
+++ b/java/src/jmri/jmrix/loconet/LnPortController.java
@@ -1,4 +1,3 @@
-// LnPortController.java
 package jmri.jmrix.loconet;
 
 import java.io.DataInputStream;
@@ -108,6 +107,3 @@ public abstract class LnPortController extends jmri.jmrix.AbstractSerialPortCont
     }
     private final static Logger log = LoggerFactory.getLogger(LnPortController.class.getName());
 }
-
-
-/* @(#)LnPortController.java */

--- a/java/src/jmri/jmrix/loconet/LnPowerManager.java
+++ b/java/src/jmri/jmrix/loconet/LnPowerManager.java
@@ -1,4 +1,3 @@
-// LnPowerManager.java
 package jmri.jmrix.loconet;
 
 import jmri.JmriException;
@@ -165,5 +164,3 @@ public class LnPowerManager
     }
     private final static Logger log = LoggerFactory.getLogger(LnPowerManager.class.getName());
 }
-
-/* @(#)LnPowerManager.java */

--- a/java/src/jmri/jmrix/loconet/LnProgrammerManager.java
+++ b/java/src/jmri/jmrix/loconet/LnProgrammerManager.java
@@ -1,4 +1,3 @@
-/* LnProgrammerManager.java */
 package jmri.jmrix.loconet;
 
 import java.util.ArrayList;
@@ -60,6 +59,3 @@ public class LnProgrammerManager extends DefaultProgrammerManager {
     }
 
 }
-
-
-/* @(#)DefaultProgrammerManager.java */

--- a/java/src/jmri/jmrix/loconet/LnReporter.java
+++ b/java/src/jmri/jmrix/loconet/LnReporter.java
@@ -1,4 +1,3 @@
-// LnReporter.java
 package jmri.jmrix.loconet;
 
 import java.util.regex.Matcher;
@@ -38,11 +37,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2001, 2007
   */
 public class LnReporter extends AbstractReporter implements LocoNetListener, PhysicalLocationReporter {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4140421326633704317L;
 
     public LnReporter(int number, LnTrafficController tc, String prefix) {  // a human-readable Reporter number must be specified!
         super(prefix + "R" + number);  // can't use prefix here, as still in construction
@@ -220,5 +214,3 @@ public class LnReporter extends AbstractReporter implements LocoNetListener, Phy
     private final static Logger log = LoggerFactory.getLogger(LnReporter.class.getName());
 
 }
-
-/* @(#)LnReporter.java */

--- a/java/src/jmri/jmrix/loconet/LnReporterManager.java
+++ b/java/src/jmri/jmrix/loconet/LnReporterManager.java
@@ -1,4 +1,3 @@
-// LnReporterManager.java
 package jmri.jmrix.loconet;
 
 import jmri.Reporter;
@@ -76,5 +75,3 @@ public class LnReporterManager extends jmri.managers.AbstractReporterManager imp
 
     private final static Logger log = LoggerFactory.getLogger(LnReporterManager.class.getName());
 }
-
-/* @(#)LnReporterManager.java */

--- a/java/src/jmri/jmrix/loconet/LnSensorAddress.java
+++ b/java/src/jmri/jmrix/loconet/LnSensorAddress.java
@@ -1,4 +1,3 @@
-// LnSensorAddress.java
 package jmri.jmrix.loconet;
 
 import org.slf4j.Logger;
@@ -242,6 +241,3 @@ public class LnSensorAddress {
     private final static Logger log = LoggerFactory.getLogger(LnSensorAddress.class.getName());
 
 }
-
-
-/* @(#)LnSensorAddress.java */

--- a/java/src/jmri/jmrix/loconet/LnTrafficRouter.java
+++ b/java/src/jmri/jmrix/loconet/LnTrafficRouter.java
@@ -1,4 +1,3 @@
-// LnTrafficRouter.java
 package jmri.jmrix.loconet;
 
 import org.slf4j.Logger;
@@ -97,6 +96,3 @@ public class LnTrafficRouter extends LnTrafficController implements LocoNetListe
 
     private final static Logger log = LoggerFactory.getLogger(LnTrafficRouter.class.getName());
 }
-
-
-/* @(#)LnTrafficRouter.java */

--- a/java/src/jmri/jmrix/loconet/LnTurnout.java
+++ b/java/src/jmri/jmrix/loconet/LnTurnout.java
@@ -1,4 +1,3 @@
-// LnTurnout.java
 package jmri.jmrix.loconet;
 
 import jmri.NmraPacket;
@@ -36,11 +35,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2001
   */
 public class LnTurnout extends AbstractTurnout implements LocoNetListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8838048326340434647L;
 
     public LnTurnout(String prefix, int number, LocoNetInterface controller) throws IllegalArgumentException {
         // a human-readable turnout number must be specified!
@@ -376,5 +370,3 @@ public class LnTurnout extends AbstractTurnout implements LocoNetListener {
     private final static Logger log = LoggerFactory.getLogger(LnTurnout.class.getName());
 
 }
-
-/* @(#)LnTurnout.java */

--- a/java/src/jmri/jmrix/loconet/LocoNetException.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetException.java
@@ -1,4 +1,3 @@
-// LocoNetException.java
 package jmri.jmrix.loconet;
 
 import jmri.JmriException;
@@ -10,16 +9,8 @@ import jmri.JmriException;
   */
 public class LocoNetException extends JmriException {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7412254026659440390L;
-
     public LocoNetException(String m) {
         super(m);
     }
 
 }
-
-
-/* @(#)LocoNetException.java */

--- a/java/src/jmri/jmrix/loconet/LocoNetInterface.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetInterface.java
@@ -1,4 +1,3 @@
-// LocoNetInterface
 package jmri.jmrix.loconet;
 
 /**
@@ -105,6 +104,3 @@ public interface LocoNetInterface {
     public static final int POWER = 16;
 
 }
-
-
-/* @(#)LocoNetInterface.java */

--- a/java/src/jmri/jmrix/loconet/LocoNetListener.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetListener.java
@@ -1,4 +1,3 @@
-// LocoNetListener.java
 package jmri.jmrix.loconet;
 
 /**
@@ -25,6 +24,3 @@ public interface LocoNetListener extends java.util.EventListener {
      */
     public void message(LocoNetMessage msg);
 }
-
-
-/* @(#)LocoNetListener.java */

--- a/java/src/jmri/jmrix/loconet/LocoNetMessage.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetMessage.java
@@ -1,4 +1,3 @@
-// LocoNetMessage.java
 package jmri.jmrix.loconet;
 
 import java.io.Serializable;
@@ -33,8 +32,6 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class LocoNetMessage implements Serializable {
-
-    static final long serialVersionUID = -7904918731667071828L;
 
     /**
      * Create a new object, representing a specific-length message.
@@ -424,5 +421,3 @@ public class LocoNetMessage implements Serializable {
     private final static Logger log = LoggerFactory.getLogger(LocoNetMessage.class.getName());
 
 }
-
-/* @(#)LocoNetMessage.java */

--- a/java/src/jmri/jmrix/loconet/LocoNetMessageException.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetMessageException.java
@@ -1,4 +1,3 @@
-// LocoNetMessageException.java
 package jmri.jmrix.loconet;
 
 import jmri.JmriException;
@@ -10,11 +9,6 @@ import jmri.JmriException;
   */
 public class LocoNetMessageException extends JmriException {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6472332226397111753L;
-
     public LocoNetMessageException(String s) {
         super(s);
     }
@@ -22,6 +16,3 @@ public class LocoNetMessageException extends JmriException {
     public LocoNetMessageException() {
     }
 }
-
-
-/* @(#)LocoNetMessageException.java */

--- a/java/src/jmri/jmrix/loconet/LocoNetSlot.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSlot.java
@@ -1,4 +1,3 @@
-// LocoNetSlot.java
 package jmri.jmrix.loconet;
 
 import java.util.ArrayList;
@@ -607,6 +606,3 @@ public class LocoNetSlot {
 
     private final static Logger log = LoggerFactory.getLogger(LocoNetSlot.class.getName());
 }
-
-
-/* @(#)LocoNetSlot.java */

--- a/java/src/jmri/jmrix/loconet/LocoNetThrottledTransmitter.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottledTransmitter.java
@@ -1,4 +1,3 @@
-// LocoNetThrottledTransmitter
 package jmri.jmrix.loconet;
 
 import java.util.concurrent.DelayQueue;
@@ -203,5 +202,3 @@ public class LocoNetThrottledTransmitter implements LocoNetInterface {
     private final static Logger log = LoggerFactory.getLogger(LocoNetThrottledTransmitter.class.getName());
 
 }
-
-/* @(#)LocoNetThrottledTransmitter.java */

--- a/java/src/jmri/jmrix/loconet/SlotListener.java
+++ b/java/src/jmri/jmrix/loconet/SlotListener.java
@@ -1,4 +1,3 @@
-// SlotListener.java
 package jmri.jmrix.loconet;
 
 /**
@@ -11,6 +10,3 @@ public interface SlotListener extends java.util.EventListener {
 
     public void notifyChangedSlot(LocoNetSlot s);
 }
-
-
-/* @(#)SlotListener.java */

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -1,4 +1,3 @@
-/* SlotManager.java */
 package jmri.jmrix.loconet;
 
 import java.util.ArrayList;
@@ -1188,6 +1187,3 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(SlotManager.class.getName());
 }
-
-
-/* @(#)SlotManager.java */

--- a/java/src/jmri/jmrix/loconet/UhlenbrockSlot.java
+++ b/java/src/jmri/jmrix/loconet/UhlenbrockSlot.java
@@ -1,4 +1,3 @@
-// UhlenbrockSlot.java
 package jmri.jmrix.loconet;
 
 
@@ -84,6 +83,3 @@ public class UhlenbrockSlot extends LocoNetSlot {
         }
     }
 }
-
-
-/* @(#)UhlenbrockSlot.java */

--- a/java/src/jmri/jmrix/loconet/UhlenbrockSlotManager.java
+++ b/java/src/jmri/jmrix/loconet/UhlenbrockSlotManager.java
@@ -1,4 +1,3 @@
-/* UhlenbrockSlotManager.java */
 package jmri.jmrix.loconet;
 
 import jmri.CommandStation;
@@ -341,4 +340,3 @@ public class UhlenbrockSlotManager extends SlotManager implements LocoNetListene
     private final static Logger log = LoggerFactory.getLogger(UhlenbrockSlotManager.class.getName());
 
 }
-/* @(#)UhlenbrockSlotManager.java */

--- a/java/src/jmri/jmrix/loconet/bluetooth/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/bluetooth/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.loconet.bluetooth;
 
 import java.io.IOException;

--- a/java/src/jmri/jmrix/loconet/bluetooth/LocoNetBluetoothAdapter.java
+++ b/java/src/jmri/jmrix/loconet/bluetooth/LocoNetBluetoothAdapter.java
@@ -1,4 +1,3 @@
-// LocoNetBluetoothAdapter.java
 package jmri.jmrix.loconet.bluetooth;
 
 import java.io.DataInputStream;

--- a/java/src/jmri/jmrix/loconet/clockmon/ClockMonPane.java
+++ b/java/src/jmri/jmrix/loconet/clockmon/ClockMonPane.java
@@ -135,11 +135,6 @@ public class ClockMonPane extends LnPanel implements SlotListener {
      */
     static public class Default extends jmri.jmrix.loconet.swing.LnNamedPaneAction {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = 2901473960804245354L;
-
         public Default() {
             super(Bundle.getMessage("MenuItemClockMon"),
                     new jmri.util.swing.sdi.JmriJFrameInterface(),

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/CmdStnConfigPane.java
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/CmdStnConfigPane.java
@@ -46,10 +46,6 @@ import org.slf4j.LoggerFactory;
  */
 public class CmdStnConfigPane extends LnPanel implements LocoNetListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4164148406541743498L;
     int CONFIG_SLOT = 127;
     int MIN_OPTION = 1;
     int MAX_OPTION = 72;

--- a/java/src/jmri/jmrix/loconet/configurexml/LnLightManagerXml.java
+++ b/java/src/jmri/jmrix/loconet/configurexml/LnLightManagerXml.java
@@ -1,4 +1,3 @@
-// LnLightManagerXml.java
 package jmri.jmrix.loconet.configurexml;
 
 import org.jdom2.Element;

--- a/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
@@ -1,4 +1,3 @@
-// LoaderPane.java
 package jmri.jmrix.loconet.downloader;
 
 import java.awt.Color;

--- a/java/src/jmri/jmrix/loconet/duplexgroup/LnDplxGrpInfoImplConstants.java
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/LnDplxGrpInfoImplConstants.java
@@ -1,4 +1,3 @@
-// LnDplxGrpInfoImplConstants.java
 package jmri.jmrix.loconet.duplexgroup;
 
 /**

--- a/java/src/jmri/jmrix/loconet/duplexgroup/swing/DuplexGroupInfoPanel.java
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/swing/DuplexGroupInfoPanel.java
@@ -633,11 +633,6 @@ public class DuplexGroupInfoPanel extends jmri.jmrix.loconet.swing.LnPanel
      */
     static public class Default extends jmri.jmrix.loconet.swing.LnNamedPaneAction {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = -7467617476118982830L;
-
         public Default() {
             super(Bundle.getMessage("MenuItemDuplexInfo"),
                     new jmri.util.swing.sdi.JmriJFrameInterface(),

--- a/java/src/jmri/jmrix/loconet/duplexgroup/swing/DuplexGroupScanPanel.java
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/swing/DuplexGroupScanPanel.java
@@ -503,10 +503,6 @@ public class DuplexGroupScanPanel extends jmri.jmrix.loconet.swing.LnPanel
 
     private class duplexGroupChannelScanGuiCanvas extends java.awt.Canvas {
 
-        /**
-         *
-         */
-        private static final long serialVersionUID = 3311247866128360812L;
         private int barWidth = 7;
         private int barSpace = barWidth + 8;
         private int barOffset = (barSpace - barWidth) / 2;

--- a/java/src/jmri/jmrix/loconet/duplexgroup/swing/DuplexGroupTabbedPanel.java
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/swing/DuplexGroupTabbedPanel.java
@@ -18,10 +18,6 @@ import jmri.util.JmriJFrame;
  */
 public class DuplexGroupTabbedPanel extends LnPanel {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5891070481222820538L;
     javax.swing.JTabbedPane tabbedPane = null;
     DuplexGroupInfoPanel dgip = null;
     DuplexGroupScanPanel dgsp = null;

--- a/java/src/jmri/jmrix/loconet/duplexgroup/swing/LnIPLImplementation.java
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/swing/LnIPLImplementation.java
@@ -1,4 +1,3 @@
-// LnIPLImplementation.java
 package jmri.jmrix.loconet.duplexgroup.swing;
 
 import jmri.jmrix.loconet.LnConstants;
@@ -14,11 +13,6 @@ import jmri.jmrix.loconet.duplexgroup.LnDplxGrpInfoImplConstants;
  * @author B. Milhaupt Copyright 2010, 2011
  */
 public class LnIPLImplementation extends javax.swing.JComponent implements jmri.jmrix.loconet.LocoNetListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 451414694716197612L;
 
     /**
      * Constructor for LnIPMImplementation which uses a

--- a/java/src/jmri/jmrix/loconet/hexfile/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.loconet.hexfile;
 
 /**

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileFrame.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileFrame.java
@@ -1,4 +1,3 @@
-// HexFileFrame.java
 package jmri.jmrix.loconet.hexfile;
 
 import javax.swing.BoxLayout;
@@ -20,10 +19,6 @@ import org.slf4j.LoggerFactory;
  */
 public class HexFileFrame extends JmriJFrame {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -2625562807572301674L;
     // member declarations
     javax.swing.JButton openHexFileButton = new javax.swing.JButton();
     javax.swing.JButton filePauseButton = new javax.swing.JButton();

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileServer.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileServer.java
@@ -1,4 +1,3 @@
-// HexFileServer.java
 package jmri.jmrix.loconet.hexfile;
 
 import jmri.jmrix.loconet.LnCommandStationType;

--- a/java/src/jmri/jmrix/loconet/hexfile/LnHexFileAction.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/LnHexFileAction.java
@@ -1,4 +1,3 @@
-// LnHexFileAction.java
 package jmri.jmrix.loconet.hexfile;
 
 import java.awt.event.ActionEvent;
@@ -12,11 +11,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2001
   */
 public class LnHexFileAction extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1088838081840819866L;
 
     public LnHexFileAction(String s) {
         super(s);
@@ -39,6 +33,3 @@ public class LnHexFileAction extends AbstractAction {
     private final static Logger log = LoggerFactory.getLogger(LnHexFileAction.class.getName());
 
 }
-
-
-/* @(#)LnHexFileAction.java */

--- a/java/src/jmri/jmrix/loconet/hexfile/LnSensorManager.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/LnSensorManager.java
@@ -1,4 +1,3 @@
-// LnSensorManager.java
 package jmri.jmrix.loconet.hexfile;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -53,5 +52,3 @@ public class LnSensorManager extends jmri.jmrix.loconet.LnSensorManager implemen
 
     private final static Logger log = LoggerFactory.getLogger(LnSensorManager.class.getName());
 }
-
-/* @(#)LnSensorManager.java */

--- a/java/src/jmri/jmrix/loconet/hexfile/LocoNetSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/LocoNetSystemConnectionMemo.java
@@ -1,4 +1,3 @@
-// LocoNetSystemConnectionMemo.java
 package jmri.jmrix.loconet.hexfile;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -26,6 +25,3 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.loconet.LocoNetSyste
         return /*(jmri.jmrix.loconet.LnSensorManager)*/ sensorManager;
     }
 }
-
-
-/* @(#)LocoNetSystemConnectionMemo.java */

--- a/java/src/jmri/jmrix/loconet/locobuffer/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.loconet.locobuffer;
 
 /**

--- a/java/src/jmri/jmrix/loconet/locobufferii/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/locobufferii/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.loconet.locobufferii;
 
 /**

--- a/java/src/jmri/jmrix/loconet/locobufferii/LocoBufferIIAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobufferii/LocoBufferIIAdapter.java
@@ -1,4 +1,3 @@
-// LocoBufferAdapter.java
 package jmri.jmrix.loconet.locobufferii;
 
 import jmri.jmrix.loconet.locobuffer.LocoBufferAdapter;

--- a/java/src/jmri/jmrix/loconet/locobufferusb/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/locobufferusb/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.loconet.locobufferusb;
 
 import jmri.util.SystemType;

--- a/java/src/jmri/jmrix/loconet/locobufferusb/LocoBufferUsbAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobufferusb/LocoBufferUsbAdapter.java
@@ -1,4 +1,3 @@
-// LocoBufferUsbAdapter.java
 package jmri.jmrix.loconet.locobufferusb;
 
 import gnu.io.SerialPort;

--- a/java/src/jmri/jmrix/loconet/locogen/LocoGenPanel.java
+++ b/java/src/jmri/jmrix/loconet/locogen/LocoGenPanel.java
@@ -1,4 +1,3 @@
-// LocoGenPanel.java
 package jmri.jmrix.loconet.locogen;
 
 import java.awt.GridLayout;
@@ -32,10 +31,6 @@ import org.slf4j.LoggerFactory;
 public class LocoGenPanel extends jmri.jmrix.loconet.swing.LnPanel
         implements LocoNetListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8721664131869665655L;
     // member declarations
     javax.swing.JLabel jLabel1 = new javax.swing.JLabel();
     javax.swing.JButton sendButton = new javax.swing.JButton();

--- a/java/src/jmri/jmrix/loconet/locoio/LocoIOPanel.java
+++ b/java/src/jmri/jmrix/loconet/locoio/LocoIOPanel.java
@@ -1,4 +1,3 @@
-// LocoIOPanel.java
 package jmri.jmrix.loconet.locoio;
 
 import java.awt.event.ActionEvent;
@@ -33,11 +32,6 @@ import org.slf4j.LoggerFactory;
   */
 public class LocoIOPanel extends jmri.jmrix.loconet.swing.LnPanel
         implements java.beans.PropertyChangeListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 2652944223325097266L;
 
     public LocoIOPanel() {
         super();

--- a/java/src/jmri/jmrix/loconet/locomon/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/locomon/Bundle.java
@@ -96,5 +96,3 @@ public class Bundle extends jmri.jmrix.loconet.Bundle {
     }
 
 }
-
-/* @(#)Bundle.java */

--- a/java/src/jmri/jmrix/loconet/locomon/LocoMonPane.java
+++ b/java/src/jmri/jmrix/loconet/locomon/LocoMonPane.java
@@ -1,4 +1,3 @@
-// LocoMonPane.java
 package jmri.jmrix.loconet.locomon;
 
 import jmri.InstanceManager;
@@ -18,11 +17,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2001, 2008, 2010
  */
 public class LocoMonPane extends jmri.jmrix.AbstractMonPane implements LocoNetListener, LnPanelInterface {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 6661496696289363944L;
 
     public LocoMonPane() {
         super();
@@ -124,11 +118,6 @@ public class LocoMonPane extends jmri.jmrix.AbstractMonPane implements LocoNetLi
      * Nested class to create one of these using old-style defaults
      */
     static public class Default extends jmri.jmrix.loconet.swing.LnNamedPaneAction {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = -3893647635865243864L;
 
         public Default() {
             super(Bundle.getMessage("MenuItemLocoNetMonitor"),

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/ClientRxHandler.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/ClientRxHandler.java
@@ -1,4 +1,3 @@
-// ClientRxHandler.java
 package jmri.jmrix.loconet.loconetovertcp;
 
 import java.io.BufferedReader;

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.loconet.loconetovertcp;
 
 

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpDriverAdapter.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpDriverAdapter.java
@@ -1,4 +1,3 @@
-// LnTcpDriverAdapter.java
 package jmri.jmrix.loconet.loconetovertcp;
 
 import jmri.jmrix.loconet.LnNetworkPortController;

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/ServerAction.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/ServerAction.java
@@ -1,4 +1,3 @@
-// ServerAction.java
 package jmri.jmrix.loconet.loconetovertcp;
 
 import java.awt.event.ActionEvent;
@@ -11,11 +10,6 @@ import javax.swing.AbstractAction;
   */
 public class ServerAction
         extends AbstractAction {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7774780042559216689L;
 
     public ServerAction(String s) {
         super(s);

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/ServerListner.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/ServerListner.java
@@ -1,4 +1,3 @@
-// ServerListner.java
 package jmri.jmrix.loconet.loconetovertcp;
 
 /**

--- a/java/src/jmri/jmrix/loconet/locormi/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/locormi/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.loconet.locormi;
 
 import javax.swing.JLabel;

--- a/java/src/jmri/jmrix/loconet/locormi/LnMessageServer.java
+++ b/java/src/jmri/jmrix/loconet/locormi/LnMessageServer.java
@@ -1,11 +1,5 @@
 package jmri.jmrix.loconet.locormi;
 
-/**
- * Title: Description: Copyright: Copyright (c) 2002 Company:
- *
- * @author Alex Shepherd
- */
- // -Djava.security.policy=lib/security.policy
 import java.rmi.Naming;
 import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
@@ -14,9 +8,15 @@ import java.rmi.server.UnicastRemoteObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Copyright (c) 2002
+ *
+ * @author Alex Shepherd
+ */
 public class LnMessageServer extends UnicastRemoteObject implements LnMessageServerInterface {
 
     // versioned Jul 17, 2003 - was CVS revision 1.5
+    // This is required for RMI usage, do not remove
     static final long serialVersionUID = 8934498417916438203L;
 
     private static LnMessageServer self = null;

--- a/java/src/jmri/jmrix/loconet/locormi/LnMessageServerAction.java
+++ b/java/src/jmri/jmrix/loconet/locormi/LnMessageServerAction.java
@@ -14,11 +14,6 @@ import org.slf4j.LoggerFactory;
  */
 public class LnMessageServerAction extends AbstractAction {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5248571475794161828L;
-
     public LnMessageServerAction(String s) {
         super(s);
     }

--- a/java/src/jmri/jmrix/loconet/locostats/LocoStatsPanel.java
+++ b/java/src/jmri/jmrix/loconet/locostats/LocoStatsPanel.java
@@ -1,4 +1,3 @@
-// LocoStatsFrame.java
 package jmri.jmrix.loconet.locostats;
 
 import java.awt.event.ActionEvent;
@@ -40,10 +39,6 @@ import org.slf4j.LoggerFactory;
  */
 public class LocoStatsPanel extends LnPanel implements LocoNetListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5940710123873302443L;
     JPanel lb2Panel;
     JPanel rawPanel;
     JPanel pr2Panel;
@@ -288,11 +283,6 @@ public class LocoStatsPanel extends LnPanel implements LocoNetListener {
      * Nested class to create one of these using old-style defaults
      */
     static public class Default extends jmri.jmrix.loconet.swing.LnNamedPaneAction {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = -5534308120479708337L;
 
         public Default() {
             super(Bundle.getMessage("MenuItemLocoStats"),

--- a/java/src/jmri/jmrix/loconet/ms100/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/ms100/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.loconet.ms100;
 
 import jmri.util.SystemType;

--- a/java/src/jmri/jmrix/loconet/pm4/PM4Panel.java
+++ b/java/src/jmri/jmrix/loconet/pm4/PM4Panel.java
@@ -1,4 +1,3 @@
-// PM4Panel.java
 package jmri.jmrix.loconet.pm4;
 
 import java.awt.FlowLayout;
@@ -28,11 +27,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2002, 2004, 2007, 2010
   */
 public class PM4Panel extends jmri.jmrix.loconet.AbstractBoardProgPanel {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1373713395993058042L;
 
     public PM4Panel() {
         this(1);

--- a/java/src/jmri/jmrix/loconet/pr2/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/pr2/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.loconet.pr2;
 
 /**

--- a/java/src/jmri/jmrix/loconet/pr2/LnPr2Packetizer.java
+++ b/java/src/jmri/jmrix/loconet/pr2/LnPr2Packetizer.java
@@ -1,4 +1,3 @@
-// LnPr2Packetizer.java
 package jmri.jmrix.loconet.pr2;
 
 import org.slf4j.Logger;
@@ -24,5 +23,3 @@ public class LnPr2Packetizer extends jmri.jmrix.loconet.LnPacketizer {
 
     private final static Logger log = LoggerFactory.getLogger(LnPr2Packetizer.class.getName());
 }
-
-/* @(#)LnPr2Packetizer.java */

--- a/java/src/jmri/jmrix/loconet/pr2/LnPr2PowerManager.java
+++ b/java/src/jmri/jmrix/loconet/pr2/LnPr2PowerManager.java
@@ -1,4 +1,3 @@
-// LnPr2PowerManager.java
 package jmri.jmrix.loconet.pr2;
 
 import jmri.DccLocoAddress;
@@ -149,5 +148,3 @@ public class LnPr2PowerManager extends LnPowerManager {
     javax.swing.Timer timer = null;
 }
 
-
-/* @(#)LnPr2PowerManager.java */

--- a/java/src/jmri/jmrix/loconet/pr2/PR2Adapter.java
+++ b/java/src/jmri/jmrix/loconet/pr2/PR2Adapter.java
@@ -1,4 +1,3 @@
-// PR2Adapter.java
 package jmri.jmrix.loconet.pr2;
 
 import gnu.io.SerialPort;

--- a/java/src/jmri/jmrix/loconet/pr2/PR2SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/pr2/PR2SystemConnectionMemo.java
@@ -1,4 +1,3 @@
-// PR2SystemConnectionMemo.java
 package jmri.jmrix.loconet.pr2;
 
 import jmri.InstanceManager;
@@ -121,6 +120,3 @@ public class PR2SystemConnectionMemo extends LocoNetSystemConnectionMemo {
     }
 
 }
-
-
-/* @(#)PR2SystemConnectionMemo.java */

--- a/java/src/jmri/jmrix/loconet/pr3/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/pr3/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.loconet.pr3;
 
 import jmri.util.SystemType;

--- a/java/src/jmri/jmrix/loconet/pr3/PR3Adapter.java
+++ b/java/src/jmri/jmrix/loconet/pr3/PR3Adapter.java
@@ -1,4 +1,3 @@
-// PR3Adapter.java
 package jmri.jmrix.loconet.pr3;
 
 import gnu.io.SerialPort;

--- a/java/src/jmri/jmrix/loconet/pr3/PR3SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/pr3/PR3SystemConnectionMemo.java
@@ -161,5 +161,3 @@ public class PR3SystemConnectionMemo extends LocoNetSystemConnectionMemo {
     }
     private final static Logger log = LoggerFactory.getLogger(PR3SystemConnectionMemo.class.getName());
 }
-
-/* @(#)PR3SystemConnectionMemo.java */

--- a/java/src/jmri/jmrix/loconet/pr3/swing/Pr3SelectPane.java
+++ b/java/src/jmri/jmrix/loconet/pr3/swing/Pr3SelectPane.java
@@ -1,4 +1,3 @@
-// Pr3SelectPane.java
 package jmri.jmrix.loconet.pr3.swing;
 
 import java.awt.FlowLayout;
@@ -21,10 +20,6 @@ import org.slf4j.LoggerFactory;
   */
 public class Pr3SelectPane extends jmri.jmrix.loconet.swing.LnPanel implements LocoNetListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8933317271320213820L;
     static ResourceBundle res = ResourceBundle.getBundle("jmri.jmrix.loconet.pr3.Pr3Bundle");
 
     public String getHelpTarget() {
@@ -122,11 +117,6 @@ public class Pr3SelectPane extends jmri.jmrix.loconet.swing.LnPanel implements L
      * Nested class to create one of these using old-style defaults
      */
     static public class Default extends jmri.jmrix.loconet.swing.LnNamedPaneAction {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = -3595956373670767395L;
 
         public Default() {
             super(Bundle.getMessage("MenuItemPr3ModeSelect"),

--- a/java/src/jmri/jmrix/loconet/sdf/BranchTo.java
+++ b/java/src/jmri/jmrix/loconet/sdf/BranchTo.java
@@ -1,4 +1,3 @@
-// BranchTo.java
 package jmri.jmrix.loconet.sdf;
 
 /**
@@ -61,5 +60,3 @@ public class BranchTo extends SdfMacro {
         return indent + oneInstructionString();
     }
 }
-
-/* @(#)BranchTo.java */

--- a/java/src/jmri/jmrix/loconet/sdf/ChannelStart.java
+++ b/java/src/jmri/jmrix/loconet/sdf/ChannelStart.java
@@ -1,4 +1,3 @@
-// ChannelStart.java
 package jmri.jmrix.loconet.sdf;
 
 import java.util.ArrayList;
@@ -84,5 +83,3 @@ public class ChannelStart extends SdfMacro {
         return output;
     }
 }
-
-/* @(#)ChannelStart.java */

--- a/java/src/jmri/jmrix/loconet/sdf/CommentMacro.java
+++ b/java/src/jmri/jmrix/loconet/sdf/CommentMacro.java
@@ -1,4 +1,3 @@
-// CommentMacro.java
 package jmri.jmrix.loconet.sdf;
 
 /**
@@ -39,5 +38,3 @@ public class CommentMacro extends SdfMacro {
         return indent + oneInstructionString();
     }
 }
-
-/* @(#)CommentMacro.java */

--- a/java/src/jmri/jmrix/loconet/sdf/DelaySound.java
+++ b/java/src/jmri/jmrix/loconet/sdf/DelaySound.java
@@ -1,4 +1,3 @@
-// DelaySound.java
 package jmri.jmrix.loconet.sdf;
 
 /**
@@ -65,5 +64,3 @@ public class DelaySound extends SdfMacro {
         return indent + oneInstructionString();
     }
 }
-
-/* @(#)DelaySound.java */

--- a/java/src/jmri/jmrix/loconet/sdf/EndSound.java
+++ b/java/src/jmri/jmrix/loconet/sdf/EndSound.java
@@ -1,4 +1,3 @@
-// EndSound.java
 package jmri.jmrix.loconet.sdf;
 
 /**
@@ -56,5 +55,3 @@ public class EndSound extends SdfMacro {
         return indent + oneInstructionString();
     }
 }
-
-/* @(#)EndSound.java */

--- a/java/src/jmri/jmrix/loconet/sdf/FourByteMacro.java
+++ b/java/src/jmri/jmrix/loconet/sdf/FourByteMacro.java
@@ -1,4 +1,3 @@
-// FourByteMacro.java
 package jmri.jmrix.loconet.sdf;
 
 /**
@@ -63,5 +62,3 @@ public class FourByteMacro extends SdfMacro {
         return indent + oneInstructionString();
     }
 }
-
-/* @(#)FourByteMacro.java */

--- a/java/src/jmri/jmrix/loconet/sdf/GenerateTrigger.java
+++ b/java/src/jmri/jmrix/loconet/sdf/GenerateTrigger.java
@@ -1,4 +1,3 @@
-// GenerateTrigger.java
 package jmri.jmrix.loconet.sdf;
 
 /**
@@ -63,5 +62,3 @@ public class GenerateTrigger extends SdfMacro {
         return indent + oneInstructionString();
     }
 }
-
-/* @(#)GenerateTrigger.java */

--- a/java/src/jmri/jmrix/loconet/sdf/InitiateSound.java
+++ b/java/src/jmri/jmrix/loconet/sdf/InitiateSound.java
@@ -1,4 +1,3 @@
-// InitiateSound.java
 package jmri.jmrix.loconet.sdf;
 
 import java.util.ArrayList;
@@ -137,5 +136,3 @@ public class InitiateSound extends SdfMacro {
         return output;
     }
 }
-
-/* @(#)InitiateSound.java */

--- a/java/src/jmri/jmrix/loconet/sdf/LabelMacro.java
+++ b/java/src/jmri/jmrix/loconet/sdf/LabelMacro.java
@@ -1,4 +1,3 @@
-// LabelMacro.java
 package jmri.jmrix.loconet.sdf;
 
 /**
@@ -48,5 +47,3 @@ public class LabelMacro extends SdfMacro {
         return oneInstructionString();
     }
 }
-
-/* @(#)LabelMacro.java */

--- a/java/src/jmri/jmrix/loconet/sdf/LoadModifier.java
+++ b/java/src/jmri/jmrix/loconet/sdf/LoadModifier.java
@@ -1,4 +1,3 @@
-// LoadModifier.java
 package jmri.jmrix.loconet.sdf;
 
 import jmri.util.StringUtil;
@@ -249,5 +248,3 @@ public class LoadModifier extends SdfMacro {
         return indent + oneInstructionString();
     }
 }
-
-/* @(#)LoadModifier.java */

--- a/java/src/jmri/jmrix/loconet/sdf/MaskCompare.java
+++ b/java/src/jmri/jmrix/loconet/sdf/MaskCompare.java
@@ -1,4 +1,3 @@
-// MaskCompare.java
 package jmri.jmrix.loconet.sdf;
 
 /**
@@ -98,5 +97,3 @@ public class MaskCompare extends SdfMacro {
         return indent + oneInstructionString();
     }
 }
-
-/* @(#)TwoByteMacro.java */

--- a/java/src/jmri/jmrix/loconet/sdf/Play.java
+++ b/java/src/jmri/jmrix/loconet/sdf/Play.java
@@ -1,4 +1,3 @@
-// Play.java
 package jmri.jmrix.loconet.sdf;
 
 import jmri.util.StringUtil;
@@ -119,5 +118,3 @@ public class Play extends SdfMacro {
         return indent + oneInstructionString();
     }
 }
-
-/* @(#)Play.java */

--- a/java/src/jmri/jmrix/loconet/sdf/SdfBuffer.java
+++ b/java/src/jmri/jmrix/loconet/sdf/SdfBuffer.java
@@ -1,4 +1,3 @@
-// SdfBuffer.java
 package jmri.jmrix.loconet.sdf;
 
 import java.io.File;
@@ -146,5 +145,3 @@ public class SdfBuffer {
     private final static Logger log = LoggerFactory.getLogger(SdfBuffer.class.getName());
 
 }
-
-/* @(#)SdfBuffer.java */

--- a/java/src/jmri/jmrix/loconet/sdf/SdfConstants.java
+++ b/java/src/jmri/jmrix/loconet/sdf/SdfConstants.java
@@ -1,4 +1,3 @@
-// SdfConstants.java
 package jmri.jmrix.loconet.sdf;
 
 /**

--- a/java/src/jmri/jmrix/loconet/sdf/SdlVersion.java
+++ b/java/src/jmri/jmrix/loconet/sdf/SdlVersion.java
@@ -1,4 +1,3 @@
-// SdlVersion.java
 package jmri.jmrix.loconet.sdf;
 
 /**
@@ -54,5 +53,3 @@ public class SdlVersion extends SdfMacro {
         return indent + oneInstructionString();
     }
 }
-
-/* @(#)SdlVersion.java */

--- a/java/src/jmri/jmrix/loconet/sdf/SkemeStart.java
+++ b/java/src/jmri/jmrix/loconet/sdf/SkemeStart.java
@@ -1,4 +1,3 @@
-// SkemeStart.java
 package jmri.jmrix.loconet.sdf;
 
 import java.util.ArrayList;
@@ -113,5 +112,3 @@ public class SkemeStart extends SdfMacro {
         return output;
     }
 }
-
-/* @(#)SdfMacro.java */

--- a/java/src/jmri/jmrix/loconet/sdf/SkipOnTrigger.java
+++ b/java/src/jmri/jmrix/loconet/sdf/SkipOnTrigger.java
@@ -1,4 +1,3 @@
-// SkipOnTrigger.java
 package jmri.jmrix.loconet.sdf;
 
 /**
@@ -74,5 +73,3 @@ public class SkipOnTrigger extends SdfMacro {
         return indent + oneInstructionString();
     }
 }
-
-/* @(#)SkipOnTrigger.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/BranchToEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/BranchToEditor.java
@@ -1,4 +1,3 @@
-// BranchToEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import javax.swing.JLabel;
@@ -12,11 +11,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class BranchToEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7625740509332461282L;
-
     public BranchToEditor(SdfMacro inst) {
         super(inst);
 
@@ -27,5 +21,3 @@ class BranchToEditor extends SdfMacroEditor {
         add(new JLabel("No editor defined for this instruction yet."));
     }
 }
-
-/* @(#)BranchToEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/ChannelStartEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/ChannelStartEditor.java
@@ -1,4 +1,3 @@
-// ChannelStartEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import jmri.jmrix.loconet.sdf.SdfMacro;
@@ -11,15 +10,8 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class ChannelStartEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4814718693465031006L;
-
     public ChannelStartEditor(SdfMacro inst) {
         super(inst);
         // No editor needed, leave default message in place.
     }
 }
-
-/* @(#)ChannelStartEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/CommentMacroEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/CommentMacroEditor.java
@@ -1,4 +1,3 @@
-// CommentMacroEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import javax.swing.JLabel;
@@ -11,11 +10,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class CommentMacroEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5917155143113013316L;
-
     public CommentMacroEditor(SdfMacro inst) {
         super(inst);
 
@@ -26,5 +20,3 @@ class CommentMacroEditor extends SdfMacroEditor {
         add(new JLabel("No editor defined for this instruction yet."));
     }
 }
-
-/* @(#)CommentMacroEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/DelaySoundEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/DelaySoundEditor.java
@@ -1,4 +1,3 @@
-// DelaySoundEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import javax.swing.JLabel;
@@ -12,11 +11,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class DelaySoundEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8584517409405023951L;
-
     public DelaySoundEditor(SdfMacro inst) {
         super(inst);
 
@@ -28,5 +22,3 @@ class DelaySoundEditor extends SdfMacroEditor {
     }
 
 }
-
-/* @(#)DelaySoundEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/EditorFrame.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/EditorFrame.java
@@ -1,4 +1,3 @@
-// EditorFrame.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import java.util.ResourceBundle;
@@ -16,11 +15,6 @@ import jmri.util.JmriJFrame;
  * @author	Bob Jacobsen Copyright (C) 2007
  */
 public class EditorFrame extends JmriJFrame {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 7106886649627618274L;
 
     // GUI member declarations
     EditorPane pane;

--- a/java/src/jmri/jmrix/loconet/sdfeditor/EditorPane.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/EditorPane.java
@@ -1,4 +1,3 @@
-// EditorPane.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import java.awt.Dimension;
@@ -33,10 +32,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
   */
 public class EditorPane extends javax.swing.JPanel implements TreeSelectionListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1271269633621702533L;
     // GUI member declarations
     static ResourceBundle res = ResourceBundle.getBundle("jmri.jmrix.loconet.sdfeditor.Editor");
     static ResourceBundle exp = ResourceBundle.getBundle("jmri.jmrix.loconet.sdfeditor.Explanations");

--- a/java/src/jmri/jmrix/loconet/sdfeditor/EndSoundEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/EndSoundEditor.java
@@ -1,4 +1,3 @@
-// EndSoundEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import jmri.jmrix.loconet.sdf.SdfMacro;
@@ -10,11 +9,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class EndSoundEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6145204145169749923L;
-
     public EndSoundEditor(SdfMacro inst) {
         super(inst);
 
@@ -22,5 +16,3 @@ class EndSoundEditor extends SdfMacroEditor {
     }
 
 }
-
-/* @(#)EndSoundEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/GenerateTriggerEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/GenerateTriggerEditor.java
@@ -1,4 +1,3 @@
-// GenerateTriggerEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import javax.swing.JLabel;
@@ -12,11 +11,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class GenerateTriggerEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4809270548383400410L;
-
     public GenerateTriggerEditor(SdfMacro inst) {
         super(inst);
 
@@ -28,5 +22,3 @@ class GenerateTriggerEditor extends SdfMacroEditor {
     }
 
 }
-
-/* @(#)GenerateTriggerEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/InitiateSoundEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/InitiateSoundEditor.java
@@ -1,4 +1,3 @@
-// InitiateSoundEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import java.awt.FlowLayout;
@@ -18,11 +17,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  * @author	Bob Jacobsen Copyright (C) 2007
  */
 class InitiateSoundEditor extends SdfMacroEditor {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7107120240412402003L;
 
     public InitiateSoundEditor(SdfMacro inst) {
         super(inst);
@@ -113,5 +107,3 @@ class InitiateSoundEditor extends SdfMacroEditor {
     JCheckBox nottrig = new JCheckBox("Not triggered");
 
 }
-
-/* @(#)InitiateSoundEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/LabelMacroEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/LabelMacroEditor.java
@@ -1,4 +1,3 @@
-// LabelMacroEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import javax.swing.JLabel;
@@ -11,11 +10,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class LabelMacroEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3358357325534061565L;
-
     public LabelMacroEditor(SdfMacro inst) {
         super(inst);
 
@@ -27,5 +21,3 @@ class LabelMacroEditor extends SdfMacroEditor {
     }
 
 }
-
-/* @(#)LabelMacroEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/LoadModifierEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/LoadModifierEditor.java
@@ -1,4 +1,3 @@
-// LoadModifierEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import javax.swing.JLabel;
@@ -15,11 +14,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class LoadModifierEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8107914840589271502L;
-
     public LoadModifierEditor(SdfMacro inst) {
         super(inst);
 
@@ -30,5 +24,3 @@ class LoadModifierEditor extends SdfMacroEditor {
         add(new JLabel("No editor defined for this instruction yet."));
     }
 }
-
-/* @(#)LoadModifierEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/MaskCompareEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/MaskCompareEditor.java
@@ -1,4 +1,3 @@
-// MaskCompareEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import javax.swing.JLabel;
@@ -12,11 +11,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class MaskCompareEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1823359711169229533L;
-
     public MaskCompareEditor(SdfMacro inst) {
         super(inst);
 
@@ -27,5 +21,3 @@ class MaskCompareEditor extends SdfMacroEditor {
         add(new JLabel("No editor defined for this instruction yet."));
     }
 }
-
-/* @(#)MaskCompareEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/MonitoringLabel.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/MonitoringLabel.java
@@ -1,4 +1,3 @@
-// MonitoringPane.java
 package jmri.jmrix.loconet.sdfeditor;
 
 
@@ -8,11 +7,6 @@ package jmri.jmrix.loconet.sdfeditor;
  * @author	Bob Jacobsen Copyright (C) 2007
   */
 public class MonitoringLabel extends javax.swing.JTextArea implements java.beans.PropertyChangeListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 266331403840457618L;
 
     public MonitoringLabel() {
         super();

--- a/java/src/jmri/jmrix/loconet/sdfeditor/PlayEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/PlayEditor.java
@@ -1,4 +1,3 @@
-// PlayEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import java.awt.event.ActionListener;
@@ -21,11 +20,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  * @author	Bob Jacobsen Copyright (C) 2007
  */
 class PlayEditor extends SdfMacroEditor {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 6609198608813676953L;
 
     public PlayEditor(SdfMacro inst) {
         super(inst);
@@ -119,5 +113,3 @@ class PlayEditor extends SdfMacroEditor {
         wavbrk2.setSelected((flags & 0x02) != 0);
     }
 }
-
-/* @(#)PlayEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/SdfMacroEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/SdfMacroEditor.java
@@ -1,4 +1,3 @@
-// SdfMacroEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import javax.swing.JLabel;
@@ -28,11 +27,6 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2007
  */
 public abstract class SdfMacroEditor extends JPanel {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4518290766707658975L;
 
     public SdfMacroEditor(SdfMacro inst) {
         this.inst = inst;
@@ -134,4 +128,3 @@ public abstract class SdfMacroEditor extends JPanel {
     private final static Logger log = LoggerFactory.getLogger(SdfMacroEditor.class.getName());
 
 }
-/* @(#)SdfMacroEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/SdlVersionEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/SdlVersionEditor.java
@@ -1,4 +1,3 @@
-// SdlVersionEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import jmri.jmrix.loconet.sdf.SdfMacro;
@@ -11,15 +10,8 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class SdlVersionEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1892658707818585877L;
-
     public SdlVersionEditor(SdfMacro inst) {
         super(inst);
         // No editor needed, leave default message in place.
     }
 }
-
-/* @(#)SdlVersionEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/SkemeStartEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/SkemeStartEditor.java
@@ -1,4 +1,3 @@
-// SkemeStartEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import jmri.jmrix.loconet.sdf.SdfMacro;
@@ -13,15 +12,8 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class SkemeStartEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 4488606516130401644L;
-
     public SkemeStartEditor(SdfMacro inst) {
         super(inst);
         // No editor needed, leave default message in place.
     }
 }
-
-/* @(#)SkemeStartEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/SkipOnTriggerEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/SkipOnTriggerEditor.java
@@ -1,4 +1,3 @@
-// SkipOnTriggerEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import javax.swing.JLabel;
@@ -12,11 +11,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class SkipOnTriggerEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7444256530247471680L;
-
     public SkipOnTriggerEditor(SdfMacro inst) {
         super(inst);
 
@@ -27,5 +21,3 @@ class SkipOnTriggerEditor extends SdfMacroEditor {
         add(new JLabel("No editor defined for this instruction yet."));
     }
 }
-
-/* @(#)SkipOnTriggerEditor.java */

--- a/java/src/jmri/jmrix/loconet/sdfeditor/TwoByteMacroEditor.java
+++ b/java/src/jmri/jmrix/loconet/sdfeditor/TwoByteMacroEditor.java
@@ -1,4 +1,3 @@
-// TwoByteMacroEditor.java
 package jmri.jmrix.loconet.sdfeditor;
 
 import javax.swing.JLabel;
@@ -17,11 +16,6 @@ import jmri.jmrix.loconet.sdf.SdfMacro;
  */
 class TwoByteMacroEditor extends SdfMacroEditor {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5363908602077121350L;
-
     public TwoByteMacroEditor(SdfMacro inst) {
         super(inst);
 
@@ -33,5 +27,3 @@ class TwoByteMacroEditor extends SdfMacroEditor {
     }
 
 }
-
-/* @(#)TwoByteMacroEditor.java */

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonDataModel.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonDataModel.java
@@ -27,10 +27,6 @@ import org.slf4j.LoggerFactory;
  */
 public class SlotMonDataModel extends javax.swing.table.AbstractTableModel implements SlotListener {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 7189862416509314863L;
     static public final int SLOTCOLUMN = 0;
     static public final int ESTOPCOLUMN = 1;
     static public final int ADDRCOLUMN = 2;

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
@@ -14,7 +14,7 @@ import javax.swing.table.TableRowSorter;
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 
 /**
- * Frame provinging a command station slot manager.
+ * Frame providing a command station slot manager.
  * <P>
  * Slots 102 through 127 are normally not used for loco control, so are shown
  * separately.
@@ -23,10 +23,6 @@ import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
   */
 public class SlotMonPane extends jmri.jmrix.loconet.swing.LnPanel {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5149412620444668985L;
     /**
      * Controls whether not-in-use slots are shown
      */
@@ -160,11 +156,6 @@ public class SlotMonPane extends jmri.jmrix.loconet.swing.LnPanel {
      * Nested class to create one of these using old-style defaults
      */
     static public class Default extends jmri.jmrix.loconet.swing.LnNamedPaneAction {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 8377346674021280925L;
 
         public Default() {
             super(Bundle.getMessage("MenuItemSlotMonitor"),

--- a/java/src/jmri/jmrix/loconet/soundloader/EditorPane.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/EditorPane.java
@@ -52,11 +52,6 @@ public class EditorPane extends jmri.jmrix.loconet.swing.LnPanel {
         // add file button
         open = new JButton(res.getString("ButtonOpen"));
         open.addActionListener(new AbstractAction() {
-            /**
-             *
-             */
-            private static final long serialVersionUID = -6691600637263742650L;
-
             public void actionPerformed(java.awt.event.ActionEvent e) {
                 selectInputFile();
             }
@@ -64,11 +59,6 @@ public class EditorPane extends jmri.jmrix.loconet.swing.LnPanel {
 
         save = new JButton(res.getString("ButtonSave"));
         save.addActionListener(new AbstractAction() {
-            /**
-             *
-             */
-            private static final long serialVersionUID = -8592850250263713770L;
-
             public void actionPerformed(java.awt.event.ActionEvent e) {
                 selectSaveFile();
             }

--- a/java/src/jmri/jmrix/loconet/soundloader/LoaderEngine.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/LoaderEngine.java
@@ -164,12 +164,6 @@ public class LoaderEngine {
     }
 
     static class DelayException extends Exception {
-
-        /**
-         *
-         */
-        private static final long serialVersionUID = 5382070125978390478L;
-
         DelayException(String s) {
             super(s);
         }

--- a/java/src/jmri/jmrix/loconet/soundloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/LoaderPane.java
@@ -57,11 +57,6 @@ public class LoaderPane extends jmri.jmrix.loconet.swing.LnPanel {
             p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
             JButton b = new JButton(res.getString("ButtonSelect"));
             b.addActionListener(new AbstractAction() {
-                /**
-                 *
-                 */
-                private static final long serialVersionUID = 2498146136992279361L;
-
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     selectInputFile();
                 }
@@ -84,11 +79,6 @@ public class LoaderPane extends jmri.jmrix.loconet.swing.LnPanel {
             readButton.setToolTipText(res.getString("TipReadDisabled"));
             p.add(readButton);
             readButton.addActionListener(new AbstractAction() {
-                /**
-                 *
-                 */
-                private static final long serialVersionUID = -1408564712471319146L;
-
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     doRead();
                 }
@@ -118,11 +108,6 @@ public class LoaderPane extends jmri.jmrix.loconet.swing.LnPanel {
             loadButton.setToolTipText(res.getString("TipLoadDisabled"));
             p.add(loadButton);
             loadButton.addActionListener(new AbstractAction() {
-                /**
-                 *
-                 */
-                private static final long serialVersionUID = -1042657057160985067L;
-
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     doLoad();
                 }

--- a/java/src/jmri/jmrix/loconet/swing/LnComponentFactory.java
+++ b/java/src/jmri/jmrix/loconet/swing/LnComponentFactory.java
@@ -1,4 +1,3 @@
-// LnComponentFactory.java
 package jmri.jmrix.loconet.swing;
 
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
@@ -27,6 +26,3 @@ public class LnComponentFactory extends jmri.jmrix.swing.ComponentFactory {
         return new LocoNetMenu(memo);
     }
 }
-
-
-/* @(#)LnComponentFactory.java */

--- a/java/src/jmri/jmrix/loconet/swing/LnNamedPaneAction.java
+++ b/java/src/jmri/jmrix/loconet/swing/LnNamedPaneAction.java
@@ -21,11 +21,6 @@ import org.slf4j.LoggerFactory;
 public class LnNamedPaneAction extends JmriNamedPaneAction implements SystemConnectionAction {
 
     /**
-     *
-     */
-    private static final long serialVersionUID = 3189519475374368759L;
-
-    /**
      * Enhanced constructor for placing the pane in various GUIs
      */
     public LnNamedPaneAction(String s, WindowInterface wi, String paneClass, LocoNetSystemConnectionMemo memo) {

--- a/java/src/jmri/jmrix/loconet/swing/LnPanel.java
+++ b/java/src/jmri/jmrix/loconet/swing/LnPanel.java
@@ -1,4 +1,3 @@
-// LnPanel.java
 package jmri.jmrix.loconet.swing;
 
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;

--- a/java/src/jmri/jmrix/loconet/swing/LnPanelInterface.java
+++ b/java/src/jmri/jmrix/loconet/swing/LnPanelInterface.java
@@ -1,4 +1,3 @@
-// LnPanelInterface.java
 package jmri.jmrix.loconet.swing;
 
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;

--- a/java/src/jmri/jmrix/loconet/swing/LocoNetMenu.java
+++ b/java/src/jmri/jmrix/loconet/swing/LocoNetMenu.java
@@ -1,4 +1,3 @@
-// LocoNetMenu.java
 package jmri.jmrix.loconet.swing;
 
 import javax.swing.JMenu;
@@ -10,11 +9,6 @@ import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
  * @author	Bob Jacobsen Copyright 2003, 2010
  */
 public class LocoNetMenu extends JMenu {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5699192434035288187L;
 
     /**
      * Create a LocoNet menu. Preloads the TrafficController to certain actions.

--- a/java/src/jmri/jmrix/loconet/swing/throttlemsg/MessagePanel.java
+++ b/java/src/jmri/jmrix/loconet/swing/throttlemsg/MessagePanel.java
@@ -1,4 +1,3 @@
-// MessagePanel.java
 package jmri.jmrix.loconet.swing.throttlemsg;
 
 import java.awt.FlowLayout;
@@ -14,10 +13,6 @@ import javax.swing.JTextField;
  */
 public class MessagePanel extends jmri.jmrix.loconet.swing.LnPanel {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -729914131632149918L;
     // GUI member declarations
     JButton button = new JButton("Send");
     JTextField text = new JTextField(10);

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/ConnectionConfig.java
@@ -1,4 +1,3 @@
-// ConnectionConfig.java
 package jmri.jmrix.loconet.uhlenbrock;
 
 /**

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockAdapter.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockAdapter.java
@@ -1,4 +1,3 @@
-// LocoBufferAdapter.java
 package jmri.jmrix.loconet.uhlenbrock;
 
 import gnu.io.SerialPort;

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockConnectionTypeList.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockConnectionTypeList.java
@@ -1,4 +1,3 @@
-// UhlenbrockConnectionTypeList.java.java
 package jmri.jmrix.loconet.uhlenbrock;
 
 /**

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockSystemConnectionMemo.java
@@ -1,4 +1,3 @@
-// UhlenbrockSystemConnectionMemo.java
 package jmri.jmrix.loconet.uhlenbrock;
 
 import jmri.InstanceManager;
@@ -43,5 +42,3 @@ public class UhlenbrockSystemConnectionMemo extends LocoNetSystemConnectionMemo 
 }
 
 }
-
-/* @(#)UhlenbrockSystemConnectionMemo.java */


### PR DESCRIPTION
- remove `// filename.java` comments from top of files
- remove serialVersionUID definitions when not needed
- remove `/* @(#) filename.java */` from bottom of files
