### PR TITLE
Support older class names in ConfigXml files

### DIFF
--- a/help/en/html/doc/Technical/XmlPersistance.shtml
+++ b/help/en/html/doc/Technical/XmlPersistance.shtml
@@ -145,6 +145,22 @@
       <p>If you do add new attributes or elements, don't forget to
       update the format definition, see below.</p>
 
+      <h3>Class Migration</h3>
+      Sometimes, classes need to be moved to another package as part of
+      code maintenance.  Since the fully-qualified class name, including package name,
+      has been written to files, if we just move the class it will break reading of those
+      files (in addition to breaking any user-written code that might refer to them).
+      To handle this:
+      <ul>
+        <li>Move the *Xml file to its new location, just below the class it's loading and storing
+        <li>Make an entry in the <code>java/src/jmri/configurexml/ClassMigration.properties</code> 
+            file to map the old location to the new location
+        <li>Optionally, create an empty *Xml class in the old location that just inherits from the
+            *Xml class in the new location (so that it will still work) and mark it deprecated.
+            This keeps functional other people's code that e.g. might inherit from it.
+            You can remove this after a decent interval.
+      </ul>
+      
       <h2><a id="schema" name="schema">Schema
       Management</a></h2><a id="schema" name="schema">JMRI controls
       XML semantics using</a> <a href="XmlSchema.shtml">XML

--- a/java/src/jmri/configurexml/ClassMigration.properties
+++ b/java/src/jmri/configurexml/ClassMigration.properties
@@ -1,0 +1,28 @@
+# ClassMigration.properties
+#
+# Maps previous class names to current class names for the ConfigureXML system.
+# See http://jmri.org/help/en/html/doc/Technical/XmlPersistance.shtml
+# 
+# Entries are:
+#  (original/older fully-qualified class name) = (new/current fully-qualified class name)
+#
+# DO NOT TRANSLATE THIS FILE!  NOI18N
+#
+
+jmri.configurexml.AbstractLightManagerConfigXML     = jmri.managers.configurexml.AbstractLightManagerConfigXML
+jmri.configurexml.AbstractMemoryManagerConfigXML    = jmri.managers.configurexml.AbstractMemoryManagerConfigXML
+jmri.configurexml.AbstractReporterManagerConfigXML  = jmri.managers.configurexml.AbstractReporterManagerConfigXML
+jmri.configurexml.AbstractSensorManagerConfigXML    = jmri.managers.configurexml.AbstractSensorManagerConfigXML
+jmri.configurexml.AbstractSignalHeadManagerXml      = jmri.managers.configurexml.AbstractSignalHeadManagerXml
+jmri.configurexml.AbstractTurnoutManagerConfigXML   = jmri.managers.configurexml.AbstractTurnoutManagerConfigXML
+
+jmri.configurexml.DccSignalHeadXml                  = jmri.managers.configurexml.DccSignalHeadXml
+jmri.configurexml.DefaultConditionalManagerXml      = jmri.managers.configurexml.DefaultConditionalManagerXml
+jmri.configurexml.DefaultLogixManagerXml            = jmri.managers.configurexml.DefaultLogixManagerXml
+jmri.configurexml.DefaultMemoryManagerXml           = jmri.managers.configurexml.DefaultMemoryManagerXml
+jmri.configurexml.DefaultRouteManagerXml            = jmri.managers.configurexml.DefaultRouteManagerXml
+jmri.configurexml.DoubleTurnoutSignalHeadXml        = jmri.managers.configurexml.DoubleTurnoutSignalHeadXml
+jmri.configurexml.GuiLafConfigPaneXml               = jmri.managers.configurexml.GuiLafConfigPaneXml
+jmri.configurexml.LsDecSignalHeadXml                = jmri.managers.configurexml.LsDecSignalHeadXml
+jmri.configurexml.TripleTurnoutSignalHeadXml        = jmri.managers.configurexml.TripleTurnoutSignalHeadXml
+jmri.configurexml.VirtualSignalHeadXml              = jmri.managers.configurexml.VirtualSignalHeadXml

--- a/java/src/jmri/configurexml/ConfigXmlManager.java
+++ b/java/src/jmri/configurexml/ConfigXmlManager.java
@@ -76,6 +76,18 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
     }
 
     /**
+    * Handles classes who's location has migrated,
+    * e.g. so that it's now in a different package.
+    */
+    static public String currentClassName(String name) {
+        if (! classMigrationBundle.containsKey(name)) return name;
+        String migratedName = classMigrationBundle.getString(name);
+        log.debug("Using migrated class name {} for {}", migratedName, name);
+        return migratedName;
+    }
+    static java.util.ResourceBundle classMigrationBundle = java.util.ResourceBundle.getBundle("jmri.configurexml.ClassMigration");
+    
+    /**
      * Remove the registered preference items. This is used e.g. when a GUI
      * wants to replace the preferences with new values.
      */
@@ -616,6 +628,7 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
                 if (log.isDebugEnabled()) {
                     log.debug("attempt to get adapter {} for {}", adapterName, item);
                 }
+                adapterName = currentClassName(adapterName);
                 XmlAdapter adapter = null;
 
                 adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
@@ -634,6 +647,7 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
             for (int i = 0; i < l.size(); i++) {
                 Element item = l.get(i).getKey();
                 String adapterName = item.getAttribute("class").getValue();
+                adapterName = currentClassName(adapterName);
                 if (log.isDebugEnabled()) {
                     log.debug("load " + item + " via " + adapterName);
                 }

--- a/java/test/jmri/configurexml/ConfigXmlManagerTest.java
+++ b/java/test/jmri/configurexml/ConfigXmlManagerTest.java
@@ -73,6 +73,13 @@ public class ConfigXmlManagerTest extends TestCase {
                 ConfigXmlManager.adapterName(""));
     }
 
+    public void testCurrentClassName() {
+        Assert.assertEquals("unmigrated", "jmri.managers.configurexml.DccSignalHeadXml",
+                ConfigXmlManager.currentClassName("jmri.managers.configurexml.DccSignalHeadXml"));
+        Assert.assertEquals("migrated", "jmri.managers.configurexml.DccSignalHeadXml",
+                ConfigXmlManager.currentClassName("jmri.configurexml.DccSignalHeadXml"));
+    }
+    
     public void testFindFile() throws FileNotFoundException, IOException {
         ConfigXmlManager configxmlmanager = new ConfigXmlManager() {
             void locateClassFailed(Throwable ex, String adapterName, Object o) {

--- a/java/test/jmri/configurexml/load/LoadFileTest277.xml
+++ b/java/test/jmri/configurexml/load/LoadFileTest277.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="http://www.jmri.org/xml/XSLT/panelfile.xsl" type="text/xsl"?>
+<!DOCTYPE layout-config SYSTEM "layout-config-2-7-7.dtd">
+
+<layout-config>
+  <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
+    <operations automate="false">
+      <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
+      <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
+      <operation name="Sensor" class="jmri.configurexml.turnoutoperations.SensorTurnoutOperationXml" interval="300" maxtries="3" />
+    </operations>
+    <turnout systemName="IT1" userName="User 1" feedback="DIRECT" inverted="false" automate="Default">
+      <comment>Comment on Turnout 1</comment>
+    </turnout>
+    <turnout systemName="IT101" feedback="DIRECT" inverted="false" automate="Default">
+      <comment>Input for IR1, don't change</comment>
+    </turnout>
+    <turnout systemName="IT2" feedback="DIRECT" inverted="false" automate="Default" />
+    <turnout systemName="IT21" userName="For Signal IH2 R" feedback="DIRECT" inverted="false" automate="Default" />
+    <turnout systemName="IT22" userName="For Signal IH2 Y" feedback="DIRECT" inverted="false" automate="Default" />
+    <turnout systemName="IT23" userName="For Signal IH2 G" feedback="DIRECT" inverted="false" automate="Default" />
+    <turnout systemName="IT3" userName="User 3" feedback="DIRECT" inverted="false" automate="Default" />
+    <turnout systemName="IT4" feedback="DIRECT" inverted="false" automate="Default" />
+  </turnouts>
+  <lights class="jmri.managers.configurexml.InternalLightManagerXml">
+    <light systemName="IL1" userName="User 1" controlType="0" minIntensity="0.0" maxIntensity="1.0" transitionTime="0.0" />
+  </lights>
+  <sensors class="jmri.managers.configurexml.InternalSensorManagerXml">
+    <sensor systemName="IS1" inverted="false" userName="User 1" />
+    <sensor systemName="IS100" inverted="false">
+      <comment>Input for IR1, don't change</comment>
+    </sensor>
+    <sensor systemName="IS101" inverted="false">
+      <comment>Input for IR1, don't change</comment>
+    </sensor>
+    <sensor systemName="ISCLOCKRUNNING" inverted="false" />
+  </sensors>
+  <memories class="jmri.managers.configurexml.DefaultMemoryManagerXml">
+    <memory systemName="IM1" userName="Memory 1" value="Value 1">
+      <comment>Has value</comment>
+    </memory>
+    <memory systemName="IM2" userName="Memory 2" value="0.89">
+      <comment>null value</comment>
+    </memory>
+    <memory systemName="IM3" userName="Memory 3" />
+    <memory systemName="IMCURRENTTIME" value="12:01 PM" />
+    <memory systemName="IMDUMMY" />
+  </memories>
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 05 23:42:04 PDT 2009" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" />
+  <logixs class="jmri.configurexml.DefaultLogixManagerXml">
+    <logix systemName="IX1" userName="Test logix" enabled="yes">
+      <logixConditional systemName="IX1C1" order="0" />
+    </logix>
+  </logixs>
+  <blocks class="jmri.configurexml.BlockManagerXml">
+    <block systemName="IB1" />
+    <block systemName="IB1" userName="Block 1" length="25.4" curve="0">
+      <comment>Length 1</comment>
+    </block>
+  </blocks>
+  <signalheads class="jmri.configurexml.AbstractSignalHeadManagerXml">
+    <signalhead class="jmri.implementation.configurexml.VirtualSignalHeadXml" systemName="IH1" userName="Virtual 1">
+      <comment>Virtual</comment>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.TripleTurnoutSignalHeadXml" systemName="IH2" userName="Signal 2">
+      <comment>Triple head</comment>
+      <turnoutname defines="green">For Signal IH2 G</turnoutname>
+      <turnoutname defines="yellow">For Signal IH2 Y</turnoutname>
+      <turnoutname defines="red">For Signal IH2 R</turnoutname>
+    </signalhead>
+  </signalheads>
+  <routes class="jmri.configurexml.DefaultRouteManagerXml">
+    <route systemName="IR1" userName="random route 1" controlTurnout="IT101" controlTurnoutState="CLOSED">
+      <routeOutputTurnout systemName="IT1" state="THROWN" />
+      <routeOutputTurnout systemName="IT2" state="CLOSED" />
+      <routeOutputTurnout systemName="IT3" state="TOGGLE" />
+      <routeOutputSensor systemName="ISCLOCKRUNNING" state="ACTIVE" />
+      <routeOutputSensor systemName="IS1" state="INACTIVE" />
+      <routeSensor systemName="IS100" mode="onActive" />
+      <routeSensor systemName="IS101" mode="onInactive" />
+    </route>
+  </routes>
+  <conditionals class="jmri.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX1C1" userName="" antecedent="R1 and R2" logicType="1">
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="User 1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="17" systemName="User 1" data="2" delay="1" string="1" />
+    </conditional>
+  </conditionals>
+  <!--Written by JMRI version 2.7.6 on Thu Oct 15 23:16:50 PDT 2009 $Id: LoadFileTest277.xml,v 1.2 2009-10-16 07:16:24 jacobsen Exp $-->
+</layout-config>
+

--- a/java/test/jmri/configurexml/load/LoadFileTest277.xml
+++ b/java/test/jmri/configurexml/load/LoadFileTest277.xml
@@ -2,6 +2,9 @@
 <?xml-stylesheet href="http://www.jmri.org/xml/XSLT/panelfile.xsl" type="text/xsl"?>
 <!DOCTYPE layout-config SYSTEM "layout-config-2-7-7.dtd">
 
+<!-- This is the original version of the LoadFileTest277.xml file, with the original -->
+<!-- format and class names. Please do not update/migrate to newer, as it tests old load -->
+
 <layout-config>
   <turnouts class="jmri.managers.configurexml.InternalTurnoutManagerXml">
     <operations automate="false">


### PR DESCRIPTION
Allow older (migrated) fully-qualified pathnames in configxml files for e.g. panels. 