### PR TITLE
Add missing '=' in resource files

### DIFF
--- a/java/src/jmri/jmrit/beantable/MaintenanceBundle_fr.properties
+++ b/java/src/jmri/jmrit/beantable/MaintenanceBundle_fr.properties
@@ -28,7 +28,7 @@ OrphanName = {0}: "{1}" ({2})
 ReferenceFound = Trouv\u00e9 {0} r\u00e9f\u00e9rences \u00e0 "{1}" ({2}).
 ControlReference = Utilis\u00e9 comme une Commande {0}\n
 OutputReference = Utilis\u00e9 comme une Sortie {0}\n
-ForwardBlocking {0} Utilis\u00e9 comme Capteur de Cantonnement Avant\n
+ForwardBlocking = {0} Utilis\u00e9 comme Capteur de Cantonnement Avant\n
 ForwardStopping = {0} Utilis\u00e9 comme Capteur d''Arr\u00eat Avant\n
 ReverseBlocking = {0} Utilis\u00e9 comme Capteur de Cantonnement Inverse\n
 ReverseStopping = {0}Utilis\u00e9 comme Capteur d''Arr\u00eat Inverse\n

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelBundle_fr.properties
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelBundle_fr.properties
@@ -26,7 +26,7 @@ blockNeedsIconsItem = Circuits sans ic\u00f4nes
 iconsNeedConversionItem = Mise en \u00e9vidence des ic\u00f4nes de voie n\u00e9cessitant une conversion
 iconsNeedsBlocksItem = Mise en \u00e9vidence des indicateurs de voie sans circuits
 blocksNeedConversionItem = Circuits dont les ic\u00f4nes ont besoin de conversion
-portalsMisplaced Circuits avec des ic\u00f4nes Portail mal plac\u00e9es
+portalsMisplaced = Circuits avec des ic\u00f4nes Portail mal plac\u00e9es
 portalsInPlace = Positionnement ic\u00f4nes Portail OK
 CheckPortalPaths =  V\u00e9rifiez erreurs Portail & Chemin
 noTrackCircuits = Pas de circuits de voie (OCantons) de d\u00e9finis


### PR DESCRIPTION
Addresses two issues found by "i18n-consistency-check"

	modified:   java/src/jmri/jmrit/beantable/MaintenanceBundle_fr.properties
	modified:   java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelBundle_fr.properties