### PR TITLE
Remove awt_multiclick_time when setting double click speed

### DIFF
--- a/java/src/jmri/jmrit/beantable/ListedTableFrame.java
+++ b/java/src/jmri/jmrit/beantable/ListedTableFrame.java
@@ -511,20 +511,12 @@ public class ListedTableFrame extends BeanTableFrame {
                 }
             });
             try {
-                Object p2 = Toolkit.getDefaultToolkit().getDesktopProperty("awt_multiclick_time");
-                if (p2 != null) {
-                    clickDelay = ((Integer) p2).intValue();
-                }
-            } catch (Exception e2) {
-                log.error("Error parsing DesktopProperty awt_multiclick_time to set double click interval ", e2.toString());
-            }
-            try {
                 Object p2 = Toolkit.getDefaultToolkit().getDesktopProperty("awt.multiClickInterval");
                 if (p2 != null) {
                     clickDelay = ((Integer) p2).intValue();
                 }
             } catch (Exception e1) {
-                log.error("Error parsing DesktopProperty awt.multiClickInterval to set double click interval ", e1.toString());
+                log.debug("Cannot parse DesktopProperty awt.multiClickInterval to set double click interval ", e1.toString());
             }
             currentItemSelected = 0;
         }

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -529,12 +529,8 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
         try {
             clickDelay = ((Integer) Toolkit.getDefaultToolkit().getDesktopProperty("awt.multiClickInterval"));
         } catch (RuntimeException e) {
-            try {
-                clickDelay = ((Integer) Toolkit.getDefaultToolkit().getDesktopProperty("awt_multiclick_time"));
-            } catch (RuntimeException ex) {
-                clickDelay = 500;
-                log.warn("Unable to get the double click speed, Using JMRI default of half a second" + e.toString());
-            }
+            clickDelay = 500;
+            log.debug("Unable to get the double click speed, Using JMRI default of half a second" + e.toString());
         }
 
         // assemble roster/groups splitpane


### PR DESCRIPTION
Removes the reference to `awt_multiclick_time` when trying to set the double-click speed.  

Lowers the messages from that to DEBUG level (from ERROR and WARNING) since they Happen All The Time. 

Closes #2797 when merged.