### PR TITLE
Refactor abstract test base classes

### DIFF
--- a/java/test/jmri/implementation/AbstractLightTestBase.java
+++ b/java/test/jmri/implementation/AbstractLightTestBase.java
@@ -12,7 +12,7 @@ import junit.framework.TestCase;
  *
  * @author	Bob Jacobsen 2002, 2004, 2005, 2007, 2008
   */
-public abstract class AbstractLightTest extends TestCase {
+public abstract class AbstractLightTestBase extends TestCase {
 
     // implementing classes must provide these abstract members:
     //
@@ -24,7 +24,7 @@ public abstract class AbstractLightTest extends TestCase {
 
     abstract public void checkOffMsgSent();
 
-    public AbstractLightTest(String s) {
+    public AbstractLightTestBase(String s) {
         super(s);
     }
 

--- a/java/test/jmri/implementation/AbstractSensorTest.java
+++ b/java/test/jmri/implementation/AbstractSensorTest.java
@@ -14,7 +14,7 @@ import junit.framework.TestSuite;
  * itself a test class, e.g. should not be added to a suite. Instead, this forms
  * the base for test classes, including providing some common tests.
  *
- * @author	Bob Jacobsen 2016 from AbstractLightTest
+ * @author	Bob Jacobsen 2016 from AbstractLightTestBase (which was called AbstractLightTest at the time)
  */
 public /*abstract*/ class AbstractSensorTest extends TestCase {
 

--- a/java/test/jmri/implementation/AbstractTurnoutTestBase.java
+++ b/java/test/jmri/implementation/AbstractTurnoutTestBase.java
@@ -1,15 +1,3 @@
-/**
- * AbstractTurnoutTest.java
- *
- * Description:	AbsBaseClass for Turnout tests in specific jmrix. packages
- *
- * @author	Bob Jacobsen
- */
-/**
- * This is not itself a test class, e.g. should not be added to a suite.
- * Instead, this forms the base for test classes, including providing some
- * common tests
- */
 package jmri.implementation;
 
 import java.beans.PropertyChangeListener;
@@ -19,8 +7,15 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-
-public abstract class AbstractTurnoutTest {
+/**
+ * Abstract base class for Turnout tests in specific jmrix. packages
+ *
+ * This is not itself a test class, e.g. should not be added to a suite.
+ * Instead, this forms the base for test classes, including providing some
+ * common tests
+ * @author	Bob Jacobsen
+ */
+public abstract class AbstractTurnoutTestBase {
 
     // implementing classes must provide these abstract members:
     //

--- a/java/test/jmri/jmrix/AbstractMonPaneTestBase.java
+++ b/java/test/jmri/jmrix/AbstractMonPaneTestBase.java
@@ -13,12 +13,14 @@ import jmri.util.JmriJFrame;
 /**
  * JUnit tests for the AbstractMonPane class
  * <p>
+ * Not intended to be run by itself, but rather as part of inherited tests
+ * <p>
  * Copyright: Copyright (c) 2015</p>
  *
  * @author Bob Jacobsen
  * @author      Paul Bender Copyright (C) 2016
  */
-public class AbstractMonPaneTest {
+public abstract class AbstractMonPaneTestBase {
 
     // implementing classes must set pane to the pane under test in setUp.
     protected AbstractMonPane pane = null;

--- a/java/test/jmri/jmrix/AbstractNetworkPortControllerTestBase.java
+++ b/java/test/jmri/jmrix/AbstractNetworkPortControllerTestBase.java
@@ -9,10 +9,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * JUnit tests for the AbstractSerialPortController class
+ * JUnit tests for the AbstractNetworkPortController class
  * <p>
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class AbstractSerialPortControllerTest extends AbstractPortControllerTest {
+public abstract class AbstractNetworkPortControllerTestBase extends AbstractPortControllerTestBase {
 }

--- a/java/test/jmri/jmrix/AbstractPortControllerTestBase.java
+++ b/java/test/jmri/jmrix/AbstractPortControllerTestBase.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 /**
  * @author Bob Jacobsen Copyright (C) 2015
  */
-public class AbstractPortControllerTest {
+public abstract class AbstractPortControllerTestBase {
 
     @Test
     public void testisDirtyNotNPE() {

--- a/java/test/jmri/jmrix/AbstractPowerManagerTestBase.java
+++ b/java/test/jmri/jmrix/AbstractPowerManagerTestBase.java
@@ -1,11 +1,3 @@
-/**
- * AbstractPowerManagerTest.java
- *
- * Description:	AbsBaseClass for PowerManager tests in specific jmrix. packages
- *
- * @author	Bob Jacobsen Copyright 2007
- * @author	Bob Jacobsen Copyright (C) 2017
-  */
 package jmri.jmrix;
 
 import java.beans.PropertyChangeListener;
@@ -16,7 +8,16 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public abstract class AbstractPowerManagerTest {
+/**
+ * Abstract base class for PowerManager tests in specific jmrix. packages
+ *
+ * This is not itself a test class, e.g. should not be added to a suite.
+ * Instead, this forms the base for test classes, including providing some
+ * common tests
+ * @author	Bob Jacobsen Copyright 2007
+ * @author	Bob Jacobsen Copyright (C) 2017
+  */
+public abstract class AbstractPowerManagerTestBase {
 
     // required setup routine, must set p to an appropriate value.
     @Before
@@ -27,7 +28,7 @@ public abstract class AbstractPowerManagerTest {
 
     protected abstract void hearOff();
 
-    protected abstract void sendOnReply();	  // get a reply to On command from layou
+    protected abstract void sendOnReply();	  // get a reply to On command from layout
 
     protected abstract void sendOffReply();   // get a reply to Off command from layout
 

--- a/java/test/jmri/jmrix/AbstractSerialPortControllerTestBase.java
+++ b/java/test/jmri/jmrix/AbstractSerialPortControllerTestBase.java
@@ -9,10 +9,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * JUnit tests for the AbstractStreamPortController class
+ * JUnit tests for the AbstractSerialPortController class
  * <p>
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class AbstractStreamPortControllerTest extends AbstractPortControllerTest {
+public abstract class AbstractSerialPortControllerTestBase extends AbstractPortControllerTestBase {
 }

--- a/java/test/jmri/jmrix/AbstractStreamPortControllerTestBase.java
+++ b/java/test/jmri/jmrix/AbstractStreamPortControllerTestBase.java
@@ -9,10 +9,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * JUnit tests for the AbstractNetworkPortController class
+ * JUnit tests for the AbstractStreamPortController class
  * <p>
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class AbstractNetworkPortControllerTest extends AbstractPortControllerTest {
+public abstract class AbstractStreamPortControllerTestBase extends AbstractPortControllerTestBase {
 }

--- a/java/test/jmri/jmrix/PackageTest.java
+++ b/java/test/jmri/jmrix/PackageTest.java
@@ -29,11 +29,7 @@ public class PackageTest extends TestCase {
         suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractMRNodeTrafficControllerTest.class));
 
         suite.addTest(jmri.jmrix.ActiveSystemFlagTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractMonPaneTest.class));
         suite.addTest(jmri.jmrix.AbstractProgrammerTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractNetworkPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractStreamPortControllerTest.class));
         suite.addTest(jmri.jmrix.AbstractMRReplyTest.suite());
         suite.addTest(new TestSuite(jmri.jmrix.AbstractThrottleTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));

--- a/java/test/jmri/jmrix/acela/AcelaLightManagerTest.java
+++ b/java/test/jmri/jmrix/acela/AcelaLightManagerTest.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Coleman Copyright 2008
  */
-public class AcelaLightManagerTest extends jmri.managers.AbstractLightMgrTest {
+public class AcelaLightManagerTest extends jmri.managers.AbstractLightMgrTestBase {
 
     private AcelaSystemConnectionMemo _memo = null;
     private AcelaTrafficControlScaffold tcis = null;

--- a/java/test/jmri/jmrix/acela/AcelaPortControllerTest.java
+++ b/java/test/jmri/jmrix/acela/AcelaPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class AcelaPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class AcelaPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/acela/AcelaTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/acela/AcelaTurnoutManagerTest.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Coleman Copyright 2008
  */
-public class AcelaTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class AcelaTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     private AcelaTrafficControlScaffold tcis = null; 
     private AcelaSystemConnectionMemo memo = null; 

--- a/java/test/jmri/jmrix/acela/AcelaTurnoutTest.java
+++ b/java/test/jmri/jmrix/acela/AcelaTurnoutTest.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Coleman
  */
-public class AcelaTurnoutTest extends jmri.implementation.AbstractTurnoutTest {
+public class AcelaTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
 
     private AcelaTrafficControlScaffold tcis = null;
     private AcelaSystemConnectionMemo memo = null;

--- a/java/test/jmri/jmrix/bachrus/SpeedoPortControllerTest.java
+++ b/java/test/jmri/jmrix/bachrus/SpeedoPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SpeedoPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class SpeedoPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/GcPortControllerTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/GcPortControllerTest.java
@@ -15,7 +15,7 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class GcPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class GcPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/can/adapters/lawicell/PortControllerTest.java
+++ b/java/test/jmri/jmrix/can/adapters/lawicell/PortControllerTest.java
@@ -15,7 +15,7 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class PortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class PortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/can/cbus/CbusReporterManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusReporterManagerTest.java
@@ -17,7 +17,7 @@ import jmri.jmrix.can.TrafficControllerScaffold;
  *
  * @author	Paul Bender Copyright (C) 2012,2016
  */
-public class CbusReporterManagerTest extends jmri.managers.AbstractReporterMgrTest {
+public class CbusReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen Copyright 2008
  * @author	Paul Bender Copyright (C) 2016
  */
-public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
         
     private CanSystemConnectionMemo memo = null;
 

--- a/java/test/jmri/jmrix/cmri/serial/SerialNetworkPortControllerTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialNetworkPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SerialNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTest {
+public class SerialNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/cmri/serial/SerialPortControllerTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/cmri/serial/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialSensorManagerTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen Copyright 2003
  * @author	Paul Bender Copyright (C) 2016
  */
-public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     private jmri.jmrix.cmri.CMRISystemConnectionMemo memo = null;
     private SerialTrafficControlScaffold stcs = null;

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutManagerTest.java
@@ -9,13 +9,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * SerialTurnoutManagerTest.java
- *
- * Description:	tests for the jmri.jmrix.cmri.SerialTurnoutManager class
+ * Tests for the jmri.jmrix.cmri.SerialTurnoutManager class
  *
  * @author	Bob Jacobsen
  */
-public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     private jmri.jmrix.cmri.CMRISystemConnectionMemo memo = null;
     private SerialTrafficControlScaffold stcs = null;

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.cmri.serial;
 
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -11,7 +11,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
  */
-public class SerialTurnoutTest extends AbstractTurnoutTest {
+public class SerialTurnoutTest extends AbstractTurnoutTestBase {
 
     private jmri.jmrix.cmri.CMRISystemConnectionMemo memo = null;
     private SerialTrafficControlScaffold tcis = null;

--- a/java/test/jmri/jmrix/dcc/DccTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/dcc/DccTurnoutManagerTest.java
@@ -1,10 +1,3 @@
-/**
- * DccTurnoutManagerTest.java
- *
- * Description:	tests for the jmri.jmrix.dcc.DccTurnoutManager class
- *
- * @author	Bob Jacobsen
- */
 package jmri.jmrix.dcc;
 
 import jmri.Turnout;
@@ -15,7 +8,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DccTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+/**
+ * Tests for the jmri.jmrix.dcc.DccTurnoutManager class
+ *
+ * @author	Bob Jacobsen
+ */
+public class DccTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @After
     public void tearDown() {

--- a/java/test/jmri/jmrix/dcc/DccTurnoutTest.java
+++ b/java/test/jmri/jmrix/dcc/DccTurnoutTest.java
@@ -1,21 +1,19 @@
-/**
- * DccTurnoutTest.java
- *
- * Description:	tests for the jmri.jmrix.dcc.DccTurnout class
- *
- * @author	Bob Jacobsen
- */
 package jmri.jmrix.dcc;
 
 import jmri.CommandStation;
 import jmri.InstanceManager;
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class DccTurnoutTest extends AbstractTurnoutTest {
+/**
+ * Tests for the jmri.jmrix.dcc.DccTurnout class
+ *
+ * @author	Bob Jacobsen
+ */
+public class DccTurnoutTest extends AbstractTurnoutTestBase {
 
     CommandStationScaffold tcis;
 

--- a/java/test/jmri/jmrix/dcc4pc/Dcc4PcPortControllerTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/Dcc4PcPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class Dcc4PcPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class Dcc4PcPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/dcc4pc/Dcc4PcReporterManagerTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/Dcc4PcReporterManagerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen
  * @author      Paul Bender Copyright (C) 2016
  */
-public class Dcc4PcReporterManagerTest extends jmri.managers.AbstractReporterMgrTest {
+public class Dcc4PcReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/dcc4pc/swing/monitor/Dcc4PcMonPaneTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/swing/monitor/Dcc4PcMonPaneTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class Dcc4PcMonPaneTest extends jmri.jmrix.AbstractMonPaneTest {
+public class Dcc4PcMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
 
     @Test
     public void testMemoCtor() {

--- a/java/test/jmri/jmrix/dccpp/DCCppLightManagerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppLightManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
  * @author Paul Bender Copyright (C) 2010
  * @author Mark Underwood Copyright (C) 2015
  */
-public class DCCppLightManagerTest extends jmri.managers.AbstractLightMgrTest {
+public class DCCppLightManagerTest extends jmri.managers.AbstractLightMgrTestBase {
 
     DCCppInterfaceScaffold xnis = null;
 

--- a/java/test/jmri/jmrix/dccpp/DCCppLightTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppLightTest.java
@@ -8,7 +8,7 @@ import org.junit.Assert;
  * @author	Paul Bender
  * @author	Mark Underwood (C) 2015
  */
-public class DCCppLightTest extends jmri.implementation.AbstractLightTest {
+public class DCCppLightTest extends jmri.implementation.AbstractLightTestBase {
 
     public int numListeners() {
         return xnis.numListeners();

--- a/java/test/jmri/jmrix/dccpp/DCCppNetworkPortControllerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppNetworkPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class DCCppNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTest {
+public class DCCppNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/dccpp/DCCppSensorManagerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppSensorManagerTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
  * @author	Paul Bender Copyright (c) 2003,2016
  * @author	Mark Underwood Copyright (c) 2015
  */
-public class DCCppSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class DCCppSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     private DCCppInterfaceScaffold xnis = null;
 

--- a/java/test/jmri/jmrix/dccpp/DCCppSerialPortControllerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppSerialPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class DCCppSerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class DCCppSerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/dccpp/DCCppSimulatorPortControllerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppSimulatorPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class DCCppSimulatorPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class DCCppSimulatorPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/dccpp/DCCppStreamPortControllerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppStreamPortControllerTest.java
@@ -18,7 +18,7 @@ import jmri.util.JUnitUtil;
  * @author	Paul Bender Copyright (C) 2012,2016
  * @author	Mark Underwood (C) 2015
  */
-public class DCCppStreamPortControllerTest extends jmri.jmrix.AbstractStreamPortControllerTest {
+public class DCCppStreamPortControllerTest extends jmri.jmrix.AbstractStreamPortControllerTestBase {
 
     @Test
     public void testCtor() {

--- a/java/test/jmri/jmrix/dccpp/swing/mon/DCCppMonPaneTest.java
+++ b/java/test/jmri/jmrix/dccpp/swing/mon/DCCppMonPaneTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class DCCppMonPaneTest extends jmri.jmrix.AbstractMonPaneTest {
+public class DCCppMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
 
     jmri.jmrix.dccpp.DCCppSystemConnectionMemo memo = null;
 

--- a/java/test/jmri/jmrix/direct/PortControllerTest.java
+++ b/java/test/jmri/jmrix/direct/PortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class PortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class PortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/easydcc/EasyDccNetworkPortControllerTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccNetworkPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class EasyDccNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTest {
+public class EasyDccNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/easydcc/EasyDccPortControllerTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class EasyDccPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class EasyDccPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/easydcc/EasyDccPowerManagerTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccPowerManagerTest.java
@@ -2,7 +2,7 @@ package jmri.jmrix.easydcc;
 
 import java.util.Vector;
 import jmri.JmriException;
-import jmri.jmrix.AbstractPowerManagerTest;
+import jmri.jmrix.AbstractPowerManagerTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2006
  */
-public class EasyDccPowerManagerTest extends AbstractPowerManagerTest {
+public class EasyDccPowerManagerTest extends AbstractPowerManagerTestBase {
 
     // service routines to simulate recieving on, off from interface
     @Override

--- a/java/test/jmri/jmrix/easydcc/EasyDccTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccTurnoutManagerTest.java
@@ -1,10 +1,3 @@
-/**
- * EasyDccTurnoutManagerTest.java
- *
- * Description:	tests for the jmri.jmrix.easydcc.EasyDccTurnoutManager class
- *
- * @author	Bob Jacobsen
- */
 package jmri.jmrix.easydcc;
 
 import jmri.Turnout;
@@ -15,7 +8,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class EasyDccTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+/**
+ * Tests for the jmri.jmrix.easydcc.EasyDccTurnoutManager class
+ *
+ * @author	Bob Jacobsen
+ */
+public class EasyDccTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @After
     public void tearDown() {

--- a/java/test/jmri/jmrix/easydcc/EasyDccTurnoutTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccTurnoutTest.java
@@ -1,19 +1,17 @@
-/**
- * EasyDccTurnoutTest.java
- *
- * Description:	tests for the jmri.jmrix.nce.EasyDccTurnout class
- *
- * @author	Bob Jacobsen
- */
 package jmri.jmrix.easydcc;
 
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class EasyDccTurnoutTest extends AbstractTurnoutTest {
+/**
+ * Tests for the jmri.jmrix.nce.EasyDccTurnout class
+ *
+ * @author	Bob Jacobsen
+ */
+public class EasyDccTurnoutTest extends AbstractTurnoutTestBase {
 
     private EasyDccTrafficControlScaffold tcis = null;
 

--- a/java/test/jmri/jmrix/ecos/EcosPortControllerTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class EcosPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTest {
+public class EcosPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/ecos/EcosReporterManagerTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosReporterManagerTest.java
@@ -14,7 +14,7 @@ import jmri.Reporter;
  *
  * @author	Paul Bender Copyright (C) 2012,2016
  */
-public class EcosReporterManagerTest extends jmri.managers.AbstractReporterMgrTest {
+public class EcosReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/ecos/EcosSensorManagerTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosSensorManagerTest.java
@@ -14,7 +14,7 @@ import jmri.Sensor;
  *
  * @author	Paul Bender Copyright (C) 2012,2016
  */
-public class EcosSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class EcosSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/ecos/EcosTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosTurnoutManagerTest.java
@@ -14,7 +14,7 @@ import jmri.Turnout;
  *
  * @author	Paul Bender Copyright (C) 2012,2016
  */
-public class EcosTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class EcosTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/ecos/swing/monitor/EcosMonPaneTest.java
+++ b/java/test/jmri/jmrix/ecos/swing/monitor/EcosMonPaneTest.java
@@ -19,7 +19,7 @@ import jmri.jmrix.AbstractMonPaneScaffold;
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class EcosMonPaneTest extends jmri.jmrix.AbstractMonPaneTest {
+public class EcosMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
 
     jmri.jmrix.ecos.EcosSystemConnectionMemo memo = null;
 

--- a/java/test/jmri/jmrix/grapevine/SerialLightManagerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialLightManagerTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2004, 2007, 2008
  */
-public class SerialLightManagerTest extends jmri.managers.AbstractLightMgrTest {
+public class SerialLightManagerTest extends jmri.managers.AbstractLightMgrTestBase {
 
     @Before
     public void setUp() {

--- a/java/test/jmri/jmrix/grapevine/SerialLightTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialLightTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.grapevine;
 
-import jmri.implementation.AbstractLightTest;
+import jmri.implementation.AbstractLightTestBase;
 import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -10,7 +10,7 @@ import junit.framework.TestSuite;
  *
  * @author	Bob Jacobsen
   */
-public class SerialLightTest extends AbstractLightTest {
+public class SerialLightTest extends AbstractLightTestBase {
 
     private SerialTrafficControlScaffold tcis = null;
 

--- a/java/test/jmri/jmrix/grapevine/SerialPortControllerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/grapevine/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialSensorManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen Copyright 2003, 2007, 2008
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     private SerialNode n1 = null; 
     private SerialNode n2 = null;

--- a/java/test/jmri/jmrix/grapevine/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialTurnoutManagerTest.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright 2004, 2007, 2008
  */
-public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/grapevine/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialTurnoutTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.grapevine;
 
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -11,7 +11,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
   */
-public class SerialTurnoutTest extends AbstractTurnoutTest {
+public class SerialTurnoutTest extends AbstractTurnoutTestBase {
 
     private SerialTrafficControlScaffold tcis = null;
 

--- a/java/test/jmri/jmrix/grapevine/SerialTurnoutTest1.java
+++ b/java/test/jmri/jmrix/grapevine/SerialTurnoutTest1.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.grapevine;
 
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -11,7 +11,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
   */
-public class SerialTurnoutTest1 extends AbstractTurnoutTest {
+public class SerialTurnoutTest1 extends AbstractTurnoutTestBase {
 
     private SerialTrafficControlScaffold tcis = null;
 

--- a/java/test/jmri/jmrix/grapevine/SerialTurnoutTest2.java
+++ b/java/test/jmri/jmrix/grapevine/SerialTurnoutTest2.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.grapevine;
 
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -12,7 +12,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
   */
-public class SerialTurnoutTest2 extends AbstractTurnoutTest {
+public class SerialTurnoutTest2 extends AbstractTurnoutTestBase {
 
     private SerialTrafficControlScaffold tcis = null;
 

--- a/java/test/jmri/jmrix/grapevine/SerialTurnoutTest3.java
+++ b/java/test/jmri/jmrix/grapevine/SerialTurnoutTest3.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.grapevine;
 
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -12,7 +12,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
   */
-public class SerialTurnoutTest3 extends AbstractTurnoutTest {
+public class SerialTurnoutTest3 extends AbstractTurnoutTestBase {
 
     private SerialTrafficControlScaffold tcis = null;
 

--- a/java/test/jmri/jmrix/ieee802154/IEEE802154PortControllerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/IEEE802154PortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class IEEE802154PortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class IEEE802154PortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/ieee802154/xbee/XBeeLightManagerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/XBeeLightManagerTest.java
@@ -20,7 +20,7 @@ import org.powermock.core.classloader.annotations.MockPolicy;
  * @author	Paul Bender Copyright (C) 2012,2016
  */
 @RunWith(PowerMockRunner.class)
-public class XBeeLightManagerTest extends jmri.managers.AbstractLightMgrTest {
+public class XBeeLightManagerTest extends jmri.managers.AbstractLightMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/ieee802154/xbee/XBeeSensorManagerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/XBeeSensorManagerTest.java
@@ -36,7 +36,7 @@ import org.powermock.core.classloader.annotations.MockPolicy;
  * @author	Paul Bender Copyright (C) 2012,2016
  */
 @RunWith(PowerMockRunner.class)
-public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     private static final String NODE_ID = "id";
         

--- a/java/test/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManagerTest.java
@@ -21,7 +21,7 @@ import org.powermock.core.classloader.annotations.MockPolicy;
  * @author	Paul Bender Copyright (C) 2012,2016
  */
 @RunWith(PowerMockRunner.class)
-public class XBeeTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class XBeeTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     XBeeTrafficController tc = null;
 

--- a/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2009
  */
-public class InternalLightManagerTest extends jmri.managers.AbstractLightMgrTest {
+public class InternalLightManagerTest extends jmri.managers.AbstractLightMgrTestBase {
 
     public String getSystemName(int i) {
         return "IL" + i;

--- a/java/test/jmri/jmrix/internal/InternalReporterManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalReporterManagerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  * @author	Mark Underwood 2012
  * @author	Paul Bender 2016
  */
-public class InternalReporterManagerTest extends jmri.managers.AbstractReporterMgrTest {
+public class InternalReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2016
  */
-public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     public String getSystemName(int i) {
         return "IS" + i;

--- a/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2016
  */
-public class InternalTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class InternalTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     public String getSystemName(int i) {
         return "IT" + i;

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientPortControllerTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class JMRIClientPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTest {
+public class JMRIClientPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientPowerManagerTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientPowerManagerTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen
  * @author  Paul Bender Copyright (C) 2017
  */
-public class JMRIClientPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTest {
+public class JMRIClientPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTestBase {
 
     private JMRIClientTrafficControlScaffold stc = null;
 

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientReporterManagerTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientReporterManagerTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
  */
-public class JMRIClientReporterManagerTest extends jmri.managers.AbstractReporterMgrTest {
+public class JMRIClientReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientSensorManagerTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientSensorManagerTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen
  * @author      Paul Bender Copyright (C) 2016
  */
-public class JMRIClientSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class JMRIClientSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientTurnoutManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen
  * @author      Paul Bender Copyright (C) 2012,2016	
  */
-public class JMRIClientTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class JMRIClientTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @Override
     public String getSystemName(int i){

--- a/java/test/jmri/jmrix/jmriclient/json/JsonNetworkPortControllerTest.java
+++ b/java/test/jmri/jmrix/jmriclient/json/JsonNetworkPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class JsonNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTest {
+public class JsonNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/lenz/XNetLightManagerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetLightManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
  *
  * @author Paul Bender Copyright (C) 2010
  */
-public class XNetLightManagerTest extends jmri.managers.AbstractLightMgrTest {
+public class XNetLightManagerTest extends jmri.managers.AbstractLightMgrTestBase {
 
     XNetInterfaceScaffold xnis = null;
 
@@ -91,7 +91,7 @@ public class XNetLightManagerTest extends jmri.managers.AbstractLightMgrTest {
         // prepare an interface, register
         xnis = new XNetInterfaceScaffold(new LenzCommandStation());
         // create and register the manager object
-        l = new XNetLightManager(xnis, "X"); // l is defined in AbstractLightMgrTest.
+        l = new XNetLightManager(xnis, "X"); // l is defined in AbstractLightMgrTestBase.
         jmri.InstanceManager.setLightManager(l);
         
     }

--- a/java/test/jmri/jmrix/lenz/XNetLightTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetLightTest.java
@@ -7,7 +7,7 @@ import org.junit.Assert;
  *
  * @author	Paul Bender
  */
-public class XNetLightTest extends jmri.implementation.AbstractLightTest {
+public class XNetLightTest extends jmri.implementation.AbstractLightTestBase {
 
     public int numListeners() {
         return xnis.numListeners();

--- a/java/test/jmri/jmrix/lenz/XNetNetworkPortControllerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetNetworkPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class XNetNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTest {
+public class XNetNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/lenz/XNetPowerManagerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetPowerManagerTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender
  */
-public class XNetPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTest {
+public class XNetPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTestBase {
 
     private XNetPowerManager pm = null;
     private XNetInterfaceScaffold tc = null;

--- a/java/test/jmri/jmrix/lenz/XNetSensorManagerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetSensorManagerTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender Copyright (c) 2003
  */
-public class XNetSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class XNetSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
         
     private XNetInterfaceScaffold xnis; 
 

--- a/java/test/jmri/jmrix/lenz/XNetSerialPortControllerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetSerialPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class XNetSerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class XNetSerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/lenz/XNetSimulatorPortControllerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetSimulatorPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class XNetSimulatorPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class XNetSimulatorPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/lenz/XNetStreamPortControllerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetStreamPortControllerTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender
  */
-public class XNetStreamPortControllerTest extends jmri.jmrix.AbstractStreamPortControllerTest {
+public class XNetStreamPortControllerTest extends jmri.jmrix.AbstractStreamPortControllerTestBase {
 
     @Test
     public void testCtor() {

--- a/java/test/jmri/jmrix/lenz/XNetTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetTurnoutManagerTest.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright 2004
  */
-public class XNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class XNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/lenz/XNetTurnoutTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetTurnoutTest.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen
  */
-public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTest {
+public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
 
     @Override
     public int numListeners() {

--- a/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetTurnoutManagerTest.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright 2004
  */
-public class EliteXNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class EliteXNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/lenz/swing/mon/XNetMonPaneTest.java
+++ b/java/test/jmri/jmrix/lenz/swing/mon/XNetMonPaneTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender Copyright (C) 2014,2016
  */
-public class XNetMonPaneTest extends jmri.jmrix.AbstractMonPaneTest {
+public class XNetMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
         
     private jmri.jmrix.lenz.XNetSystemConnectionMemo memo = null;
 

--- a/java/test/jmri/jmrix/loconet/LnNetworkPortControllerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnNetworkPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class LnNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTest {
+public class LnNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/loconet/LnPortControllerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class LnPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class LnPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/loconet/LnPowerManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnPowerManagerTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.loconet;
 
-import jmri.jmrix.AbstractPowerManagerTest;
+import jmri.jmrix.AbstractPowerManagerTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -11,7 +11,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2001
  */
-public class LnPowerManagerTest extends AbstractPowerManagerTest {
+public class LnPowerManagerTest extends AbstractPowerManagerTestBase {
 
     /**
      * service routines to simulate receiving on, off from interface

--- a/java/test/jmri/jmrix/loconet/LnReporterManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnReporterManagerTest.java
@@ -14,7 +14,7 @@ import jmri.Reporter;
  *
  * @author	Paul Bender Copyright (C) 2012,2016
  */
-public class LnReporterManagerTest extends jmri.managers.AbstractReporterMgrTest {
+public class LnReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/loconet/LnSensorManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnSensorManagerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2001
  */
-public class LnSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class LnSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     private LocoNetInterfaceScaffold lnis = null;
 

--- a/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright 2005
  */
-public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/loconet/LnTurnoutTest.java
+++ b/java/test/jmri/jmrix/loconet/LnTurnoutTest.java
@@ -1,4 +1,3 @@
-//LnTurnoutTest.java
 package jmri.jmrix.loconet;
 
 import org.junit.After;
@@ -13,7 +12,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen
  */
-public class LnTurnoutTest extends jmri.implementation.AbstractTurnoutTest {
+public class LnTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/loconet/locomon/LocoMonPaneTest.java
+++ b/java/test/jmri/jmrix/loconet/locomon/LocoMonPaneTest.java
@@ -23,7 +23,7 @@ import jmri.jmrix.AbstractMonPaneScaffold;
  *
  * @author	Bob Jacobsen   Copyright 2015
  */
-public class LocoMonPaneTest extends jmri.jmrix.AbstractMonPaneTest {
+public class LocoMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
 
     @Test
     public void testLifeCycle() throws Exception {

--- a/java/test/jmri/jmrix/maple/SerialPortControllerTest.java
+++ b/java/test/jmri/jmrix/maple/SerialPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/maple/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/maple/SerialSensorManagerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2003, 2008
   */
-public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/maple/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/maple/SerialTurnoutManagerTest.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen
  */
-public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @After
     public void tearDown(){

--- a/java/test/jmri/jmrix/maple/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/maple/SerialTurnoutTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.maple;
 
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -11,7 +11,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
   */
-public class SerialTurnoutTest extends AbstractTurnoutTest {
+public class SerialTurnoutTest extends AbstractTurnoutTestBase {
 
     private SerialTrafficControlScaffold tcis = null;
     private SerialNode n = new SerialNode();

--- a/java/test/jmri/jmrix/marklin/MarklinPortControllerTest.java
+++ b/java/test/jmri/jmrix/marklin/MarklinPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class MarklinPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTest {
+public class MarklinPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/marklin/swing/monitor/MarklinMonPaneTest.java
+++ b/java/test/jmri/jmrix/marklin/swing/monitor/MarklinMonPaneTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class MarklinMonPaneTest extends jmri.jmrix.AbstractMonPaneTest {
+public class MarklinMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
 
 
     @Test

--- a/java/test/jmri/jmrix/mrc/MrcPortControllerTest.java
+++ b/java/test/jmri/jmrix/mrc/MrcPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class MrcPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class MrcPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/mrc/swing/monitor/MrcMonPanelTest.java
+++ b/java/test/jmri/jmrix/mrc/swing/monitor/MrcMonPanelTest.java
@@ -19,7 +19,7 @@ import jmri.jmrix.AbstractMonPaneScaffold;
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class MrcMonPanelTest extends jmri.jmrix.AbstractMonPaneTest {
+public class MrcMonPanelTest extends jmri.jmrix.AbstractMonPaneTestBase {
 
     jmri.jmrix.mrc.MrcSystemConnectionMemo memo = null;
 

--- a/java/test/jmri/jmrix/nce/NceNetworkPortControllerTest.java
+++ b/java/test/jmri/jmrix/nce/NceNetworkPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class NceNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTest {
+public class NceNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/nce/NcePortControllerTest.java
+++ b/java/test/jmri/jmrix/nce/NcePortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class NcePortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class NcePortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/nce/NcePowerManagerTest.java
+++ b/java/test/jmri/jmrix/nce/NcePowerManagerTest.java
@@ -2,7 +2,7 @@ package jmri.jmrix.nce;
 
 import java.util.Vector;
 import jmri.JmriException;
-import jmri.jmrix.AbstractPowerManagerTest;
+import jmri.jmrix.AbstractPowerManagerTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
   */
-public class NcePowerManagerTest extends AbstractPowerManagerTest {
+public class NcePowerManagerTest extends AbstractPowerManagerTestBase {
 
     // service routines to simulate receiving on, off from interface
     @Override

--- a/java/test/jmri/jmrix/nce/NceSensorManagerTest.java
+++ b/java/test/jmri/jmrix/nce/NceSensorManagerTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen Copyright 2002
  * @author      Paul Bender Copyright (C) 2016
  */
-public class NceSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class NceSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
         
     private NceInterfaceScaffold lnis = null;
 

--- a/java/test/jmri/jmrix/nce/NceTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/nce/NceTurnoutManagerTest.java
@@ -1,10 +1,3 @@
-/**
- * NceTurnoutManagerTest.java
- *
- * Description:	tests for the jmri.jmrix.nce.NceTurnoutManager class
- *
- * @author	Bob Jacobsen
- */
 package jmri.jmrix.nce;
 
 import jmri.Turnout;
@@ -15,7 +8,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class NceTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+/**
+ * Tests for the jmri.jmrix.nce.NceTurnoutManager class
+ *
+ * @author	Bob Jacobsen
+ */
+public class NceTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     private NceInterfaceScaffold nis = null;
 

--- a/java/test/jmri/jmrix/nce/NceTurnoutTest.java
+++ b/java/test/jmri/jmrix/nce/NceTurnoutTest.java
@@ -1,20 +1,18 @@
-/**
- * NceTurnoutTest.java
- *
- * Description:	tests for the jmri.jmrix.nce.NceTurnout class
- *
- * @author	Bob Jacobsen
-  */
 package jmri.jmrix.nce;
 
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import junit.framework.TestSuite;
 
-public class NceTurnoutTest extends AbstractTurnoutTest {
+/**
+ * Tests for the jmri.jmrix.nce.NceTurnout class
+ *
+ * @author	Bob Jacobsen
+  */
+public class NceTurnoutTest extends AbstractTurnoutTestBase {
 
     private NceTrafficControlScaffold tcis = null;
 

--- a/java/test/jmri/jmrix/nce/ncemon/NceMonPanelTest.java
+++ b/java/test/jmri/jmrix/nce/ncemon/NceMonPanelTest.java
@@ -1,10 +1,3 @@
-/**
- * NceMonPanelTest.java
- *
- * Description:	JUnit tests for the NceProgrammer class
- *
- * @author	Bob Jacobsen
- */
 package jmri.jmrix.nce.ncemon;
 
 import java.util.Vector;
@@ -26,7 +19,12 @@ import java.awt.GraphicsEnvironment;
 import jmri.util.JmriJFrame;
 import jmri.jmrix.AbstractMonPaneScaffold;
 
-public class NceMonPanelTest extends jmri.jmrix.AbstractMonPaneTest {
+/**
+ * JUnit tests for the NceProgrammer class
+ *
+ * @author	Bob Jacobsen
+ */
+public class NceMonPanelTest extends jmri.jmrix.AbstractMonPaneTestBase {
 
     private NceSystemConnectionMemo memo = null;
 

--- a/java/test/jmri/jmrix/oaktree/SerialPortControllerTest.java
+++ b/java/test/jmri/jmrix/oaktree/SerialPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/oaktree/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/oaktree/SerialSensorManagerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2003
  */
-public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     private SerialNode n0 = null;
     private SerialNode n1 = null;

--- a/java/test/jmri/jmrix/oaktree/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/oaktree/SerialTurnoutManagerTest.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen
  */
-public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @Before
     @Override

--- a/java/test/jmri/jmrix/oaktree/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/oaktree/SerialTurnoutTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.oaktree;
 
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -11,7 +11,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
   */
-public class SerialTurnoutTest extends AbstractTurnoutTest {
+public class SerialTurnoutTest extends AbstractTurnoutTestBase {
 
     private SerialTrafficControlScaffold tcis = null;
     //private SerialNode n = new SerialNode();

--- a/java/test/jmri/jmrix/openlcb/OlcbSensorManagerTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSensorManagerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2008, 2010
  */
-public class OlcbSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class OlcbSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutManagerTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2008, 2010, 2011
  */
-public class OlcbTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class OlcbTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/pi/RaspberryPiSensorManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiSensorManagerTest.java
@@ -20,7 +20,7 @@ import jmri.Sensor;
  * </P>
  * @author Paul Bender Copyright (C) 2016
  */
-public class RaspberryPiSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class RaspberryPiSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     private GpioProvider myprovider = null;
 

--- a/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
@@ -14,7 +14,7 @@ import com.pi4j.io.gpio.GpioProvider;
  * </P>
  * @author Paul Bender Copyright (C) 2016
  */
-public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @Override
     public String getSystemName(int i){

--- a/java/test/jmri/jmrix/powerline/SerialPortControllerTest.java
+++ b/java/test/jmri/jmrix/powerline/SerialPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/powerline/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/powerline/SerialSensorManagerTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
  * @author kcameron Copyright (C) 2011
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
     @Override
     public String getSystemName(int i) {
         return "PSP" + i;

--- a/java/test/jmri/jmrix/powerline/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/powerline/SerialTurnoutManagerTest.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright 2004, 2008 Converted to multiple connection
  * @author kcameron Copyright (C) 2011
  */
-public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     private SerialTrafficControlScaffold nis = null;
 

--- a/java/test/jmri/jmrix/powerline/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/powerline/SerialTurnoutTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.powerline;
 
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import jmri.jmrix.powerline.simulator.SpecificSystemConnectionMemo;
 import org.junit.After;
 import org.junit.Assert;
@@ -13,7 +13,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen Copyright 2008 Converted to multiple connection
  * @author kcameron Copyright (C) 2011
   */
-public class SerialTurnoutTest extends AbstractTurnoutTest {
+public class SerialTurnoutTest extends AbstractTurnoutTestBase {
 
     private SerialSystemConnectionMemo memo = null;
     private SerialTrafficControlScaffold tc = null;

--- a/java/test/jmri/jmrix/powerline/swing/serialmon/SerialMonPaneTest.java
+++ b/java/test/jmri/jmrix/powerline/swing/serialmon/SerialMonPaneTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class SerialMonPaneTest extends jmri.jmrix.AbstractMonPaneTest {
+public class SerialMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
 
 
     private SerialTrafficControlScaffold tc = null;

--- a/java/test/jmri/jmrix/qsi/QsiPortControllerTest.java
+++ b/java/test/jmri/jmrix/qsi/QsiPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class QsiPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class QsiPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/rfid/RfidNetworkPortControllerTest.java
+++ b/java/test/jmri/jmrix/rfid/RfidNetworkPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class RfidNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTest {
+public class RfidNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/rfid/RfidPortControllerTest.java
+++ b/java/test/jmri/jmrix/rfid/RfidPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class RfidPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class RfidPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/rfid/RfidReporterManagerTest.java
+++ b/java/test/jmri/jmrix/rfid/RfidReporterManagerTest.java
@@ -14,7 +14,7 @@ import jmri.Reporter;
  *
  * @author	Paul Bender Copyright (C) 2012,2016
  */
-public class RfidReporterManagerTest extends jmri.managers.AbstractReporterMgrTest {
+public class RfidReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     RfidTrafficController tc = null;
 

--- a/java/test/jmri/jmrix/rfid/RfidStreamPortControllerTest.java
+++ b/java/test/jmri/jmrix/rfid/RfidStreamPortControllerTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender
  */
-public class RfidStreamPortControllerTest extends jmri.jmrix.AbstractStreamPortControllerTest {
+public class RfidStreamPortControllerTest extends jmri.jmrix.AbstractStreamPortControllerTestBase {
 
     @Test
     public void testCtor() {

--- a/java/test/jmri/jmrix/rfid/generic/standalone/StandaloneReporterManagerTest.java
+++ b/java/test/jmri/jmrix/rfid/generic/standalone/StandaloneReporterManagerTest.java
@@ -14,7 +14,7 @@ import jmri.Reporter;
  *
  * @author	Paul Bender Copyright (C) 2012,2016
  */
-public class StandaloneReporterManagerTest extends jmri.managers.AbstractReporterMgrTest {
+public class StandaloneReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/rfid/merg/concentrator/ConcentratorReporterManagerTest.java
+++ b/java/test/jmri/jmrix/rfid/merg/concentrator/ConcentratorReporterManagerTest.java
@@ -14,7 +14,7 @@ import jmri.Reporter;
  *
  * @author	Paul Bender Copyright (C) 2012,2016
  */
-public class ConcentratorReporterManagerTest extends jmri.managers.AbstractReporterMgrTest {
+public class ConcentratorReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/rfid/swing/serialmon/SerialMonPaneTest.java
+++ b/java/test/jmri/jmrix/rfid/swing/serialmon/SerialMonPaneTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class SerialMonPaneTest extends jmri.jmrix.AbstractMonPaneTest {
+public class SerialMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
 
     @Test
     public void testMemoCtor() {

--- a/java/test/jmri/jmrix/roco/z21/Z21ReporterManagerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21ReporterManagerTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
  * @author Paul Bender Copyright (C) 2016
  **/
 
-public class Z21ReporterManagerTest extends jmri.managers.AbstractReporterMgrTest {
+public class Z21ReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetStreamPortControllerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetStreamPortControllerTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender
  */
-public class Z21XNetStreamPortControllerTest extends jmri.jmrix.AbstractStreamPortControllerTest {
+public class Z21XNetStreamPortControllerTest extends jmri.jmrix.AbstractStreamPortControllerTestBase {
 
     @Test
     public void testCtor() {

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetTurnoutManagerTest.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright 2004
  * @author	Paul Bender Copyright 2016
  */
-public class Z21XNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class Z21XNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/rps/RpsSensorManagerTest.java
+++ b/java/test/jmri/jmrix/rps/RpsSensorManagerTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen Copyright 2007
  * @author      Paul Bender Copyright (C) 2016
  */
-public class RpsSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class RpsSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/secsi/SerialPortControllerTest.java
+++ b/java/test/jmri/jmrix/secsi/SerialPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/secsi/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/secsi/SerialSensorManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen Copyright 2003, 2007
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     private SerialNode n0 = null;
     private SerialNode n1 = null;

--- a/java/test/jmri/jmrix/secsi/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/secsi/SerialTurnoutManagerTest.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen Copyright 2004, 2008
  */
-public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/secsi/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/secsi/SerialTurnoutTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.secsi;
 
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -11,7 +11,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
   */
-public class SerialTurnoutTest extends AbstractTurnoutTest {
+public class SerialTurnoutTest extends AbstractTurnoutTestBase {
 
     private SerialTrafficControlScaffold tcis = null;
     //private SerialNode n = new SerialNode();

--- a/java/test/jmri/jmrix/sprog/SprogCSStreamPortControllerTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogCSStreamPortControllerTest.java
@@ -19,7 +19,7 @@ import jmri.util.JUnitUtil;
  *
  * @author	Paul Bender Copyright (C) 2014-2016
  */
-public class SprogCSStreamPortControllerTest extends jmri.jmrix.AbstractStreamPortControllerTest {
+public class SprogCSStreamPortControllerTest extends jmri.jmrix.AbstractStreamPortControllerTestBase {
 
     @Test
     public void testCtor() {

--- a/java/test/jmri/jmrix/sprog/SprogCSTurnoutTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogCSTurnoutTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
  * </P>
  * @author Paul Bender Copyright (C) 2016
  */
-public class SprogCSTurnoutTest extends jmri.implementation.AbstractTurnoutTest {
+public class SprogCSTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
 
     private SprogTrafficControlScaffold stcs = null;
     private SprogSystemConnectionMemo m = null;

--- a/java/test/jmri/jmrix/sprog/SprogPortControllerTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SprogPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class SprogPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/sprog/SprogPowerManagerTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogPowerManagerTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
  * </P>
  * @author Paul Bender Copyright (C) 2016
  */
-public class SprogPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTest{
+public class SprogPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTestBase {
 
     private SprogTrafficControlScaffold stc = null;
 

--- a/java/test/jmri/jmrix/sprog/SprogTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogTurnoutManagerTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
  * </P>
  * @author Paul Bender Copyright (C) 2016
  */
-public class SprogTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class SprogTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
    private SprogSystemConnectionMemo m = null;
 
    @Override

--- a/java/test/jmri/jmrix/sprog/SprogTurnoutTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogTurnoutTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
  * </P>
  * @author Paul Bender Copyright (C) 2016
  */
-public class SprogTurnoutTest extends jmri.implementation.AbstractTurnoutTest {
+public class SprogTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
 
    private SprogTrafficControlScaffold stcs = null;
 

--- a/java/test/jmri/jmrix/srcp/SRCPPortControllerTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SRCPPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTest {
+public class SRCPPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/srcp/SRCPPowerManagerTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPPowerManagerTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
  */
-public class SRCPPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTest {
+public class SRCPPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTestBase {
 
     private SRCPTrafficControlScaffold stc = null;
   

--- a/java/test/jmri/jmrix/srcp/SRCPSensorManagerTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPSensorManagerTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen
  * @author      Paul Bender Copyright (C) 2016	
  */
-public class SRCPSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class SRCPSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/jmrix/srcp/SRCPTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPTurnoutManagerTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
  */
-public class SRCPTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class SRCPTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @Override
     public String getSystemName(int i){

--- a/java/test/jmri/jmrix/srcp/SRCPTurnoutTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPTurnoutTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen
  * @author  Paul Bender Copyright (C) 2017
  */
-public class SRCPTurnoutTest extends jmri.implementation.AbstractTurnoutTest {
+public class SRCPTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
 
     private SRCPTrafficControlScaffold stc = null;
 

--- a/java/test/jmri/jmrix/tams/TamsPortControllerTest.java
+++ b/java/test/jmri/jmrix/tams/TamsPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class TamsPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class TamsPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/tams/TamsTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/tams/TamsTurnoutManagerTest.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen  Copyright 2013, 2016
  */
-public class TamsTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class TamsTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     private TamsInterfaceScaffold nis = null;
     private TamsSystemConnectionMemo tm = null;

--- a/java/test/jmri/jmrix/tams/swing/monitor/TamsMonPaneTest.java
+++ b/java/test/jmri/jmrix/tams/swing/monitor/TamsMonPaneTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender Copyright (C) 2016
  */
-public class TamsMonPaneTest extends jmri.jmrix.AbstractMonPaneTest {
+public class TamsMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
 
 
     @Test

--- a/java/test/jmri/jmrix/tmcc/SerialPortControllerTest.java
+++ b/java/test/jmri/jmrix/tmcc/SerialPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class SerialPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/tmcc/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/tmcc/SerialTurnoutManagerTest.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Bob Jacobsen
  */
-public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     @After
     public void tearDown() throws Exception {

--- a/java/test/jmri/jmrix/tmcc/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/tmcc/SerialTurnoutTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.tmcc;
 
-import jmri.implementation.AbstractTurnoutTest;
+import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -11,7 +11,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
   */
-public class SerialTurnoutTest extends AbstractTurnoutTest {
+public class SerialTurnoutTest extends AbstractTurnoutTestBase {
 
     private SerialTrafficControlScaffold tcis = null;
 

--- a/java/test/jmri/jmrix/xpa/XpaPortControllerTest.java
+++ b/java/test/jmri/jmrix/xpa/XpaPortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class XpaPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class XpaPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/jmrix/xpa/XpaPowerManagerTest.java
+++ b/java/test/jmri/jmrix/xpa/XpaPowerManagerTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
  * <P>
  * @author	Paul Bender
  */
-public class XpaPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTest {
+public class XpaPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTestBase {
 
     private XpaTrafficControlScaffold tc = null;
 

--- a/java/test/jmri/jmrix/xpa/XpaTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/xpa/XpaTurnoutManagerTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  *
  * @author	Paul Bender Copyright (C) 2012,2016
  */
-public class XpaTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest {
+public class XpaTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
     private XpaSystemConnectionMemo memo = null;
 

--- a/java/test/jmri/jmrix/xpa/swing/xpamon/XpaMonPaneTest.java
+++ b/java/test/jmri/jmrix/xpa/swing/xpamon/XpaMonPaneTest.java
@@ -11,7 +11,7 @@ import java.awt.GraphicsEnvironment;
 /**
  * @author Paul Bender Copyright(C) 2016
  */
-public class XpaMonPaneTest extends jmri.jmrix.AbstractMonPaneTest {
+public class XpaMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
 
     @Test
     public void testCtor() {

--- a/java/test/jmri/jmrix/zimo/Mx1PortControllerTest.java
+++ b/java/test/jmri/jmrix/zimo/Mx1PortControllerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  *
  * @author      Paul Bender Copyright (C) 2016
  */
-public class Mx1PortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTest {
+public class Mx1PortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
     @Override
     @Before

--- a/java/test/jmri/managers/AbstractLightMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractLightMgrTestBase.java
@@ -1,8 +1,3 @@
-/**
- * This is not itself a test class, e.g. should not be added to a suite.
- * Instead, this forms the base for test classes, including providing some
- * common tests
- */
 package jmri.managers;
 
 import java.beans.PropertyChangeListener;
@@ -19,10 +14,14 @@ import org.junit.Test;
  * is not itself a test class, e.g. should not be added to a suite. Instead,
  * this forms the base for test classes, including providing some common tests
  *
+ * This is not itself a test class, e.g. should not be added to a suite.
+ * Instead, this forms the base for test classes, including providing some
+ * common tests
+ *
  * @author	Bob Jacobsen 2003, 2006, 2008
  * @author      Paul Bender Copyright (C) 2016
  */
-public abstract class AbstractLightMgrTest {
+public abstract class AbstractLightMgrTestBase {
 
     // implementing classes must provide these abstract members:
     //

--- a/java/test/jmri/managers/AbstractReporterMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractReporterMgrTestBase.java
@@ -1,8 +1,3 @@
-/**
- * This is not itself a test class, e.g. should not be added to a suite.
- * Instead, this forms the base for test classes, including providing some
- * common tests
- */
 package jmri.managers;
 
 import java.beans.PropertyChangeListener;
@@ -21,10 +16,14 @@ import org.junit.Ignore;
  * is not itself a test class, e.g. should not be added to a suite. Instead,
  * this forms the base for test classes, including providing some common tests
  *
+ * This is not itself a test class, e.g. should not be added to a suite.
+ * Instead, this forms the base for test classes, including providing some
+ * common tests
+ *
  * @author	Bob Jacobsen 2003, 2006, 2008
  * @author      Paul Bender Copyright (C) 2016
  */
-public abstract class AbstractReporterMgrTest {
+public abstract class AbstractReporterMgrTestBase {
 
     // implementing classes must provide these abstract members:
     //

--- a/java/test/jmri/managers/AbstractSensorMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractSensorMgrTestBase.java
@@ -21,7 +21,7 @@ import org.junit.Test;
  * @author	Bob Jacobsen 2003, 2006, 2008, 2016
  * @author      Paul Bender Copyright(C) 2016
  */
-public abstract class AbstractSensorMgrTest {
+public abstract class AbstractSensorMgrTestBase {
 
     // implementing classes must provide these abstract members:
     //

--- a/java/test/jmri/managers/AbstractTurnoutMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractTurnoutMgrTestBase.java
@@ -17,7 +17,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen
  */
-public abstract class AbstractTurnoutMgrTest {
+public abstract class AbstractTurnoutMgrTestBase {
 
     // implementing classes must implement to convert integer (count) to a system name
     abstract public String getSystemName(int i);

--- a/java/test/jmri/managers/InternalLightManagerTest.java
+++ b/java/test/jmri/managers/InternalLightManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2009
  */
-public class InternalLightManagerTest extends jmri.managers.AbstractLightMgrTest {
+public class InternalLightManagerTest extends jmri.managers.AbstractLightMgrTestBase {
 
     public String getSystemName(int i) {
         return "IL" + i;

--- a/java/test/jmri/managers/InternalReporterManagerTest.java
+++ b/java/test/jmri/managers/InternalReporterManagerTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
  * @author	Mark Underwood 2012
  * @author	Paul Bender 2016
  */
-public class InternalReporterManagerTest extends AbstractReporterMgrTest {
+public class InternalReporterManagerTest extends AbstractReporterMgrTestBase {
 
     @Override
     public String getSystemName(int i) {

--- a/java/test/jmri/managers/InternalSensorManagerTest.java
+++ b/java/test/jmri/managers/InternalSensorManagerTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
  *
  * @author	Bob Jacobsen Copyright 2016
  */
-public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTest {
+public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
     public String getSystemName(int i) {
         return "IS" + i;

--- a/java/test/jmri/managers/ProxyReporterManagerTest.java
+++ b/java/test/jmri/managers/ProxyReporterManagerTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
  * @author	Mark Underwood 2012
  * @author	Paul Bender 2016
  */
-public class ProxyReporterManagerTest extends AbstractReporterMgrTest {
+public class ProxyReporterManagerTest extends AbstractReporterMgrTestBase {
 
     @Override
     public String getSystemName(int i) {


### PR DESCRIPTION
Rename `Abstract(*)Test` classes to `Abstract(*)TestBase` classes to make it really clear that they're not self-contained tests.

(See #1947 for some background discussion)