### PR TITLE
Reduce test output

### DIFF
--- a/java/test/jmri/jmrit/display/PositionableLabelTest.java
+++ b/java/test/jmri/jmrit/display/PositionableLabelTest.java
@@ -238,7 +238,7 @@ public class PositionableLabelTest extends jmri.util.SwingTestCase {
         }
 
         if (System.getProperty("jmri.migrationtests", "false").equals("false")) { // skip test for migration, but warn about it
-            log.warn("skipping testDisplayAnimatedRGB because jmri.migrationtests not set true");
+            log.info("skipping testDisplayAnimatedRGB because jmri.migrationtests not set true");
             return;
         }
 
@@ -318,7 +318,7 @@ public class PositionableLabelTest extends jmri.util.SwingTestCase {
         }
 
          if (System.getProperty("jmri.migrationtests","false").equals("false")) { // skip test for migration, but warn about it
-            log.warn("skipping testDisplayAnimatedRGBrotated45degrees because jmri.migrationtests not set true");
+            log.info("skipping testDisplayAnimatedRGBrotated45degrees because jmri.migrationtests not set true");
             return;
         }
 

--- a/java/test/jmri/jmrit/display/SignalSystemTest.java
+++ b/java/test/jmri/jmrit/display/SignalSystemTest.java
@@ -155,7 +155,7 @@ public class SignalSystemTest {
         jmri.util.JUnitAppender.assertErrorMessage("No facing block found for source mast IF$vsm:BNSF-1996:SL-2A($0100)");
         jmri.util.JUnitAppender.clearBacklog();
         jmri.util.JUnitAppender.verifyNoBacklog();
-        log.warn("suppressing multiple \"No facing block found ...\" messages from AA1UPtest.xml file");
+        log.info("suppressing multiple \"No facing block found ...\" messages from AA1UPtest.xml file");
     }
 
     void checkAspect(String mastName, String aspect) {

--- a/java/test/jmri/jmrit/logix/OBlockTest.java
+++ b/java/test/jmri/jmrit/logix/OBlockTest.java
@@ -168,6 +168,9 @@ public class OBlockTest extends TestCase {
         Assert.assertEquals("Two portals", 2, b.getPortals().size());
 
         Assert.assertEquals("Same Portal", p, b.getPortalByName("barp"));
+        
+        jmri.util.JUnitAppender.assertWarnMessage("Portal \"foop\" from block \"null\" to block \"null\" not in block OB0"); 
+        jmri.util.JUnitAppender.assertWarnMessage("Portal \"barp\" from block \"null\" to block \"null\" not in block OB0"); 
     }
         
     public void testAddPath() {

--- a/java/test/jmri/jmrit/logix/PortalTest.java
+++ b/java/test/jmri/jmrit/logix/PortalTest.java
@@ -78,7 +78,7 @@ public class PortalTest extends TestCase {
 
     // Main entry point
     static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", OBlockTest.class.getName()};
+        String[] testCaseName = {"-noloading", PortalTest.class.getName()};
         junit.textui.TestRunner.main(testCaseName);
     }
 

--- a/java/test/jmri/jmrit/logix/PortalTest.java
+++ b/java/test/jmri/jmrit/logix/PortalTest.java
@@ -69,6 +69,10 @@ public class PortalTest extends TestCase {
         p.removePath(path2);
         Assert.assertEquals("Number of toPaths", 2, p.getToPaths().size());
         Assert.assertEquals("Number of fromPaths", 1, p.getFromPaths().size());
+        
+        jmri.util.JUnitAppender.assertWarnMessage("Path path_1 already in block OB2, cannot be added to block OB1");
+        jmri.util.JUnitAppender.assertWarnMessage("Path \"path_3\" is duplicate of path \"path_2\" in Portal \"portal_3\" from block OB1.");
+        jmri.util.JUnitAppender.assertWarnMessage("Path \"path_2\" is duplicate name for another path in Portal \"portal_3\" from block OB1.");
     }
 
     // from here down is testing infrastructure


### PR DESCRIPTION
Capture and test some WARN messages; make a few "normal warnings" from tests into INFO level.  

My long term goal is to have CI tests run silently, so that all WARN messages will fail and have to be examined, similarly to how ERROR is handled now.