### PR TITLE
Updated ARNOLD 81210-81 decoder definition xml

### DIFF
--- a/AlainC updated Arnold decoder definition
+++ b/AlainC updated Arnold decoder definition
@@ -1,0 +1,816 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2002, 2017 All rights reserved -->
+<!-- $Id$ -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.                                                      -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" showEmptyPanes="no">
+  <version author="Alain CARASSO" version="2" lastUpdated="20170123"/>
+<!-- Added undocumented CV19 consist                          -->
+  <version author="Alain CARASSO" version="1" lastUpdated="20100714"/>
+  <decoder>
+    <family name="ARNOLD Digital" mfg="Arnold - Rivarossi">
+      <model model="ARNOLD 81210-81"> </model>
+    </family>
+    <programming direct="yes" paged="no" register="yes" ops="yes"/>
+    <variables>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/shortAndLongAddress.xml"/>
+      <variable item="Vstart" CV="2" comment="A value of 255 corresponds to 100%" default="000">
+        <decVal max="255"/>
+        <label>Vstart</label>
+        <label xml:lang="it">Volt Partenza</label>
+        <label xml:lang="fr">V dÃ©marr.</label>
+        <label xml:lang="de">Startspannung</label>
+      </variable>
+      <variable CV="3" item="Accel" default="002">
+        <decVal max="255"/>
+        <label>Acceleration Rate</label>
+        <label xml:lang="it">Accellerazione (0-255)</label>
+        <label xml:lang="fr">AccelÃ©ration (0-255)</label>
+        <label xml:lang="de">AnfahrverzÃ¶gerung (0-255)</label>
+      </variable>
+      <variable CV="4" item="Decel" default="004">
+        <decVal max="255"/>
+        <label>Deceleration Rate</label>
+        <label xml:lang="it">Decellerazione (0-255)</label>
+        <label xml:lang="fr">DÃ©cÃ©lÃ©ration (0-255)</label>
+        <label xml:lang="de">Bremszeit (0-255)</label>
+      </variable>
+      <variable CV="5" item="Vmax" default="255">
+        <decVal max="255"/>
+        <label>Vhigh</label>
+        <label xml:lang="it">Volt Massimi (0-255):</label>
+        <label xml:lang="de">HÃ¶chstgeschwindigkeit</label>
+      </variable>
+      <variable CV="6" item="Vmid" default="128">
+        <decVal max="255"/>
+        <label>Vmid</label>
+        <label xml:lang="it">Volts intermedi (0-255)</label>
+        <label xml:lang="de">Vmittel (0-255)</label>
+      </variable>
+      <variable CV="7" readOnly="yes" item="Decoder Version" default="02">
+        <decVal/>
+        <label>Manufacturer Version No: </label>
+        <label xml:lang="it">Versione Decoder: </label>
+        <label xml:lang="fr">Version dÃ©codeur: </label>
+        <label xml:lang="de">Decoder Version: </label>
+      </variable>
+      <variable CV="8" readOnly="yes" item="Manufacturer" default="173">
+        <decVal/>
+        <label>Manufacturer ID: </label>
+        <label xml:lang="it">ID Costruttore: </label>
+        <label xml:lang="fr">ID constructeur: </label>
+        <label xml:lang="de">Hersteller ID: </label>
+      </variable>
+      <!---Undocumented CV-->
+      <variable item="Total PWM Period" CV="9" default="0">
+        <decVal max="255"/>
+        <label>Total PWM Period</label>
+      </variable>
+      <variable item="EMF Feedback Cutout" CV="10" default="175">
+        <decVal max="255"/>
+        <label>EMF Feedback Cutout</label>
+      </variable>
+      <variable item="DCC or Marklin" CV="12" default="0">
+        <decVal max="2"/>
+        <label>DCC or Marklin</label>
+      </variable>
+     <variable
+            label="Consist Address"
+            CV="19"
+            mask="XVVVVVVV"
+            default="0"
+            item="Consist Address"
+            tooltip="CV19-XVVVVVVV  (0 -127) default=0">
+            <decVal
+                min="0"
+                max="127"
+                />
+      </variable>
+     <!-- CV 19 -->
+     <variable
+            label="Consist Direction"
+            CV="19"
+            mask="VXXXXXXX"
+            default="0"
+            item="Consist Direction"
+            tooltip="CV19-VXXXXXXX  default=0">
+            <enumVal>
+                <enumChoice choice="Forward"></enumChoice>
+                <enumChoice choice="Reverse"></enumChoice>
+              </enumVal>
+     </variable>     <variable item="Lenz BM1 Management" CV="27" comment="0 not managed, 1 FW, 2 Reverse, 3 both" default="0">
+        <decVal max="3"/>
+        <label>Lenz BM1 Management</label>
+      </variable>
+      <!---documented CV-->
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29direction.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29speedSteps.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29AdvAck.xml"/>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/cv29table3-28.xml"/>
+      <!--Undocumented CV-->
+      <variable item="FL(f) controls output 1" CV="33" mask="XXXXXXXV" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 1</label>
+      </variable>
+      <variable item="FL(f) controls output 2" CV="33" mask="XXXXXXVX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 2</label>
+      </variable>
+      <variable item="FL(f) controls output 3" CV="33" mask="XXXXXVXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 3</label>
+      </variable>
+      <variable item="FL(f) controls output 4" CV="33" mask="XXXXVXXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 4</label>
+      </variable>
+      <variable item="FL(f) controls output 5" CV="33" mask="XXXVXXXX" minOut="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 5</label>
+      </variable>
+      <variable item="FL(f) controls output 6" CV="33" mask="XXVXXXXX" minOut="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 6</label>
+      </variable>
+      <variable item="FL(f) controls output 7" CV="33" mask="XVXXXXXX" minOut="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 7</label>
+      </variable>
+      <variable item="FL(f) controls output 8" CV="33" mask="VXXXXXXX" minOut="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 8</label>
+      </variable>
+      <variable item="FL(r) controls output 1" CV="34" mask="XXXXXXXV" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 1</label>
+      </variable>
+      <variable item="FL(r) controls output 2" CV="34" mask="XXXXXXVX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 2</label>
+      </variable>
+      <variable item="FL(r) controls output 3" CV="34" mask="XXXXXVXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 3</label>
+      </variable>
+      <variable item="FL(r) controls output 4" CV="34" mask="XXXXVXXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 4</label>
+      </variable>
+      <variable item="FL(r) controls output 5" CV="34" mask="XXXVXXXX" minOut="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 5</label>
+      </variable>
+      <variable item="FL(r) controls output 6" CV="34" mask="XXVXXXXX" minOut="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 6</label>
+      </variable>
+      <variable item="FL(r) controls output 7" CV="34" mask="XVXXXXXX" minOut="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 7</label>
+      </variable>
+      <variable item="FL(r) controls output 8" CV="34" mask="VXXXXXXX" minOut="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 8</label>
+      </variable>
+      <variable item="F1 controls output 1" CV="35" mask="XXXXXXXV" minOut="1" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 1</label>
+      </variable>
+      <variable item="F1 controls output 2" CV="35" mask="XXXXXXVX" minOut="2" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 2</label>
+      </variable>
+      <variable item="F1 controls output 3" CV="35" mask="XXXXXVXX" minOut="3" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 3</label>
+      </variable>
+      <variable item="F1 controls output 4" CV="35" mask="XXXXVXXX" minOut="4" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 4</label>
+      </variable>
+      <variable item="F1 controls output 5" CV="35" mask="XXXVXXXX" minOut="5" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 5</label>
+      </variable>
+      <variable item="F1 controls output 6" CV="35" mask="XXVXXXXX" minOut="6" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 6</label>
+      </variable>
+      <variable item="F1 controls output 7" CV="35" mask="XVXXXXXX" minOut="7" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 7</label>
+      </variable>
+      <variable item="F1 controls output 8" CV="35" mask="VXXXXXXX" minOut="8" minFn="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 8</label>
+      </variable>
+      <variable item="F2 controls output 1" CV="36" mask="XXXXXXXV" minOut="1" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 1</label>
+      </variable>
+      <variable item="F2 controls output 2" CV="36" mask="XXXXXXVX" minOut="2" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 2</label>
+      </variable>
+      <variable item="F2 controls output 3" CV="36" mask="XXXXXVXX" minOut="3" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 3</label>
+      </variable>
+      <variable item="F2 controls output 4" CV="36" mask="XXXXVXXX" minOut="4" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 4</label>
+      </variable>
+      <variable item="F2 controls output 5" CV="36" mask="XXXVXXXX" minOut="5" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 5</label>
+      </variable>
+      <variable item="F2 controls output 6" CV="36" mask="XXVXXXXX" minOut="6" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 6</label>
+      </variable>
+      <variable item="F2 controls output 7" CV="36" mask="XVXXXXXX" minOut="7" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 7</label>
+      </variable>
+      <variable item="F2 controls output 8" CV="36" mask="VXXXXXXX" minOut="8" minFn="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 8</label>
+      </variable>
+      <variable item="F3 controls output 1" CV="37" mask="XXXXXXXV" minOut="1" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 1</label>
+      </variable>
+      <variable item="F3 controls output 2" CV="37" mask="XXXXXXVX" minOut="2" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 2</label>
+      </variable>
+      <variable item="F3 controls output 3" CV="37" mask="XXXXXVXX" minOut="3" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 3</label>
+      </variable>
+      <variable item="F3 controls output 4" CV="37" mask="XXXXVXXX" minOut="4" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 4</label>
+      </variable>
+      <variable item="F3 controls output 5" CV="37" mask="XXXVXXXX" minOut="5" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 5</label>
+      </variable>
+      <variable item="F3 controls output 6" CV="37" mask="XXVXXXXX" minOut="6" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 6</label>
+      </variable>
+      <variable item="F3 controls output 7" CV="37" mask="XVXXXXXX" minOut="7" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 7</label>
+      </variable>
+      <variable item="F3 controls output 8" CV="37" mask="VXXXXXXX" minOut="8" minFn="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 8</label>
+      </variable>
+      <variable item="F4 controls output 4" CV="38" mask="XXXXXXXV" minOut="4" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 4</label>
+      </variable>
+      <variable item="F4 controls output 5" CV="38" mask="XXXXXXVX" minOut="5" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 5</label>
+      </variable>
+      <variable item="F4 controls output 6" CV="38" mask="XXXXXVXX" minOut="6" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 6</label>
+      </variable>
+      <variable item="F4 controls output 7" CV="38" mask="XXXXVXXX" minOut="7" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 7</label>
+      </variable>
+      <variable item="F4 controls output 8" CV="38" mask="XXXVXXXX" minOut="8" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 8</label>
+      </variable>
+      <variable item="F4 controls output 9" CV="38" mask="XXVXXXXX" minOut="9" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 9</label>
+      </variable>
+      <variable item="F4 controls output 10" CV="38" mask="XVXXXXXX" minOut="10" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 10</label>
+      </variable>
+      <variable item="F4 controls output 11" CV="38" mask="VXXXXXXX" minOut="11" minFn="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 11</label>
+      </variable>
+      <variable item="F5 controls output 4" CV="39" mask="XXXXXXXV" minOut="4" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 4</label>
+      </variable>
+      <variable item="F5 controls output 5" CV="39" mask="XXXXXXVX" minOut="5" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 5</label>
+      </variable>
+      <variable item="F5 controls output 6" CV="39" mask="XXXXXVXX" minOut="6" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 6</label>
+      </variable>
+      <variable item="F5 controls output 7" CV="39" mask="XXXXVXXX" minOut="7" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 7</label>
+      </variable>
+      <variable item="F5 controls output 8" CV="39" mask="XXXVXXXX" minOut="8" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 8</label>
+      </variable>
+      <variable item="F5 controls output 9" CV="39" mask="XXVXXXXX" minOut="9" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 9</label>
+      </variable>
+      <variable item="F5 controls output 10" CV="39" mask="XVXXXXXX" minOut="10" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 10</label>
+      </variable>
+      <variable item="F5 controls output 11" CV="39" mask="VXXXXXXX" minOut="11" minFn="5">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 11</label>
+      </variable>
+      <variable item="F6 controls output 4" CV="40" mask="XXXXXXXV" minOut="4" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 4</label>
+      </variable>
+      <variable item="F6 controls output 5" CV="40" mask="XXXXXXVX" minOut="5" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 5</label>
+      </variable>
+      <variable item="F6 controls output 6" CV="40" mask="XXXXXVXX" minOut="6" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 6</label>
+      </variable>
+      <variable item="F6 controls output 7" CV="40" mask="XXXXVXXX" minOut="7" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 7</label>
+      </variable>
+      <variable item="F6 controls output 8" CV="40" mask="XXXVXXXX" minOut="8" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 8</label>
+      </variable>
+      <variable item="F6 controls output 9" CV="40" mask="XXVXXXXX" minOut="9" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 9</label>
+      </variable>
+      <variable item="F6 controls output 10" CV="40" mask="XVXXXXXX" minOut="10" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 10</label>
+      </variable>
+      <variable item="F6 controls output 11" CV="40" mask="VXXXXXXX" minOut="11" minFn="6">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 11</label>
+      </variable>
+      <variable item="F7 controls output 4" CV="41" mask="XXXXXXXV" minOut="4" minFn="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F7 controls output 4</label>
+      </variable>
+      <variable item="F7 controls output 5" CV="41" mask="XXXXXXVX" minOut="5" minFn="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F7 controls output 5</label>
+      </variable>
+      <variable item="F7 controls output 6" CV="41" mask="XXXXXVXX" minOut="6" minFn="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F7 controls output 6</label>
+      </variable>
+      <variable item="F7 controls output 7" CV="41" mask="XXXXVXXX" minOut="7" minFn="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F7 controls output 7</label>
+      </variable>
+      <variable item="F7 controls output 8" CV="41" mask="XXXVXXXX" minOut="8" minFn="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F7 controls output 8</label>
+      </variable>
+      <variable item="F7 controls output 9" CV="41" mask="XXVXXXXX" minOut="9" minFn="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F7 controls output 9</label>
+      </variable>
+      <variable item="F7 controls output 10" CV="41" mask="XVXXXXXX" minOut="10" minFn="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F7 controls output 10</label>
+      </variable>
+      <variable item="F7 controls output 11" CV="41" mask="VXXXXXXX" minOut="11" minFn="7">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F7 controls output 11</label>
+      </variable>
+      <variable item="F8 controls output 4" CV="42" mask="XXXXXXXV" minOut="4" minFn="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F8 controls output 4</label>
+      </variable>
+      <variable item="F8 controls output 5" CV="42" mask="XXXXXXVX" minOut="5" minFn="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F8 controls output 5</label>
+      </variable>
+      <variable item="F8 controls output 6" CV="42" mask="XXXXXVXX" minOut="6" minFn="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F8 controls output 6</label>
+      </variable>
+      <variable item="F8 controls output 7" CV="42" mask="XXXXVXXX" minOut="7" minFn="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F8 controls output 7</label>
+      </variable>
+      <variable item="F8 controls output 8" CV="42" mask="XXXVXXXX" minOut="8" minFn="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F8 controls output 8</label>
+      </variable>
+      <variable item="F8 controls output 9" CV="42" mask="XXVXXXXX" minOut="9" minFn="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F8 controls output 9</label>
+      </variable>
+      <variable item="F8 controls output 10" CV="42" mask="XVXXXXXX" minOut="10" minFn="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F8 controls output 10</label>
+      </variable>
+      <variable item="F8 controls output 11" CV="42" mask="VXXXXXXX" minOut="11" minFn="8">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F8 controls output 11</label>
+      </variable>
+      <variable item="F9 controls output 7" CV="43" mask="XXXXXXXV" minOut="7" minFn="9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F9 controls output 7</label>
+      </variable>
+      <variable item="F9 controls output 8" CV="43" mask="XXXXXXVX" minOut="8" minFn="9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F9 controls output 8</label>
+      </variable>
+      <variable item="F9 controls output 9" CV="43" mask="XXXXXVXX" minOut="9" minFn="9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F9 controls output 9</label>
+      </variable>
+      <variable item="F9 controls output 10" CV="43" mask="XXXXVXXX" minOut="10" minFn="9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F9 controls output 10</label>
+      </variable>
+      <variable item="F9 controls output 11" CV="43" mask="XXXVXXXX" minOut="11" minFn="9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F9 controls output 11</label>
+      </variable>
+      <variable item="F9 controls output 12" CV="43" mask="XXVXXXXX" minOut="12" minFn="9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F9 controls output 12</label>
+      </variable>
+      <variable item="F9 controls output 13" CV="43" mask="XVXXXXXX" minOut="13" minFn="9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F9 controls output 13</label>
+      </variable>
+      <variable item="F9 controls output 14" CV="43" mask="VXXXXXXX" minOut="14" minFn="9">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F9 controls output 14</label>
+      </variable>
+      <variable item="F10 controls output 7" CV="44" mask="XXXXXXXV" minOut="7" minFn="10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F10 controls output 7</label>
+      </variable>
+      <variable item="F10 controls output 8" CV="44" mask="XXXXXXVX" minOut="8" minFn="10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F10 controls output 8</label>
+      </variable>
+      <variable item="F10 controls output 9" CV="44" mask="XXXXXVXX" minOut="9" minFn="10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F10 controls output 9</label>
+      </variable>
+      <variable item="F10 controls output 10" CV="44" mask="XXXXVXXX" minOut="10" minFn="10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F10 controls output 10</label>
+      </variable>
+      <variable item="F10 controls output 11" CV="44" mask="XXXVXXXX" minOut="11" minFn="10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F10 controls output 11</label>
+      </variable>
+      <variable item="F10 controls output 12" CV="44" mask="XXVXXXXX" minOut="12" minFn="10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F10 controls output 12</label>
+      </variable>
+      <variable item="F10 controls output 13" CV="44" mask="XVXXXXXX" minOut="13" minFn="10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F10 controls output 13</label>
+      </variable>
+      <variable item="F10 controls output 14" CV="44" mask="VXXXXXXX" minOut="14" minFn="10">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F10 controls output 14</label>
+      </variable>
+      <!-- Undocumented CV-->
+      <variable item="CV45(Range 0 - 255)" CV="45" default="64">
+        <decVal max="255"/>
+        <label>CV45(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV46(Range 0 - 255)" CV="46" default="128">
+        <decVal max="255"/>
+        <label>CV46(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV47(Range 0 - 255)" CV="47" default="0">
+        <decVal max="255"/>
+        <label>CV47(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV48(Range 0 - 255)" CV="48" default="0">
+        <decVal max="255"/>
+        <label>CV48(Range 0 - 255)</label>
+      </variable>
+      <!---documented CV-->
+      <variable item="BEMF On Off" CV="49" mask="XXXXXXXV">
+        <enumVal>
+          <enumChoice choice="On"/>
+          <enumChoice choice="Off"/>
+        </enumVal>
+        <label>BEMF On Off</label>
+      </variable>
+      <variable item="Short Circuit detection On Off" CV="49" mask="XXXXXXVX">
+        <enumVal>
+          <enumChoice choice="On"/>
+          <enumChoice choice="Off"/>
+        </enumVal>
+        <label>Short Circuit detection On Off</label>
+      </variable>
+      <variable item="Data Memory" CV="49" mask="XXXXXVXX">
+        <enumVal>
+          <enumChoice choice="On"/>
+          <enumChoice choice="Off"/>
+        </enumVal>
+        <label>Data Memory</label>
+      </variable>
+      <variable CV="49" mask="XXXXVXXX" default="0" item="DCC control" tooltip="DCC or Analog">
+        <enumVal>
+          <enumChoice choice="DCC On"/>
+          <enumChoice choice="Analog On"/>
+        </enumVal>
+        <label>DCC control</label>
+      </variable>
+      <variable item="Motorola Detection" CV="49" mask="XXXVXXXX">
+        <enumVal>
+          <enumChoice choice="On"/>
+          <enumChoice choice="Off"/>
+        </enumVal>
+        <label>Motorola Detection</label>
+      </variable>
+      <variable item="CV50 BEMF Pulse Intensity (0 - 255)" CV="50" default="20">
+        <decVal max="255"/>
+        <label>CV50 BEMF Pulse Intensity (0 - 255)</label>
+      </variable>
+      <!--Undocumented CV-->
+      <variable item="CV51(Range 0 - 255)" CV="51" default="0">
+        <decVal max="255"/>
+        <label>CV51(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV52(Range 0 - 255)" CV="52" default="0">
+        <decVal max="255"/>
+        <label>CV52(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV53(Range 0 - 255)" CV="53" default="0">
+        <decVal max="255"/>
+        <label>CV53(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV54(Range 0 - 255)" CV="54" default="8">
+        <decVal max="255"/>
+        <label>CV54(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV55(Range 0 - 255)" CV="55" default="4">
+        <decVal max="255"/>
+        <label>CV55(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV56(Range 0 - 255)" CV="56" default="0">
+        <decVal max="255"/>
+        <label>CV56(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV57(Range 0 - 255" CV="57" default="0">
+        <decVal max="255"/>
+        <label>CV57(Range 0 - 255</label>
+      </variable>
+      <variable item="CV58 (Range 0 - 255)" CV="58" default="0">
+        <decVal max="255"/>
+        <label>CV58 (Range 0 - 255)</label>
+      </variable>
+      <variable item="CV59(Range 0 - 255)" CV="59" default="0">
+        <decVal max="255"/>
+        <label>CV59(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV60(Range 0-255)" CV="60" default="0">
+        <decVal max="255"/>
+        <label>CV60(Range 0-255)</label>
+      </variable>
+      <variable item="CV61(Range 0 - 255)" CV="61" default="25">
+        <decVal max="255"/>
+        <label>CV61(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV62(Range 0 - 255)" CV="62" default="192">
+        <decVal max="255"/>
+        <label>CV62(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV63(Range 0-255)" CV="63" default="255">
+        <decVal max="255"/>
+        <label>CV63(Range 0-255)</label>
+      </variable>
+      <variable item="CV64(Range 0 - 255)" CV="64" default="25">
+        <decVal max="255"/>
+        <label>CV64(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV65(Range 0-255)" CV="65" default="192">
+        <decVal max="255"/>
+        <label>CV65(Range 0-255)</label>
+      </variable>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/fwdTrim.xml"/>
+      <variable item="Speed Table" CV="67">
+        <speedTableVal/>
+        <label>Speed Table</label>
+      </variable>
+      <variable item="CV67(Range 0 - 255)" CV="67" default="9">
+        <decVal max="255"/>
+        <label>CV67(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV68(Range 0 - 255)" CV="68" default="18">
+        <decVal max="255"/>
+        <label>CV68(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV69(Range 0 - 255)" CV="69" default="27">
+        <decVal max="255"/>
+        <label>CV69(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV70(Range 0 - 255)" CV="70" default="36">
+        <decVal max="255"/>
+        <label>CV70(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV71(Range 0 - 255)" CV="71" default="45">
+        <decVal max="255"/>
+        <label>CV71(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV72(Range 0 - 255)" CV="72" default="55">
+        <decVal max="255"/>
+        <label>CV72(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV73(Range 0 - 255)" CV="73" default="64">
+        <decVal max="255"/>
+        <label>CV73(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV74(Range 0 - 255)" CV="74" default="73">
+        <decVal max="255"/>
+        <label>CV74(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV75(Range 0 - 255)" CV="75" default="82">
+        <decVal max="255"/>
+        <label>CV75(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV76(Range 0 - 255)" CV="76" default="91">
+        <decVal max="255"/>
+        <label>CV76(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV77(Range 0 - 255)" CV="77" default="100">
+        <decVal max="255"/>
+        <label>CV77(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV78(Range 0 - 255)" CV="78" default="109">
+        <decVal max="255"/>
+        <label>CV78(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV79(Range 0 - 255)" CV="79" default="118">
+        <decVal max="255"/>
+        <label>CV79(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV80(Range 0 - 255)" CV="80" default="127">
+        <decVal max="255"/>
+        <label>CV80(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV81(Range 0 - 255)" CV="81" default="137">
+        <decVal max="255"/>
+        <label>CV81(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV82(Range 0 - 255)" CV="82" default="146">
+        <decVal max="255"/>
+        <label>CV82(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV83(Range 0 - 255)" CV="83" default="155">
+        <decVal max="255"/>
+        <label>CV83(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV84(Range 0 - 255)" CV="84" default="164">
+        <decVal max="255"/>
+        <label>CV84(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV85(Range 0 - 255)" CV="85" default="173">
+        <decVal max="255"/>
+        <label>CV85(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV86(Range 0 - 255)" CV="86" default="182">
+        <decVal max="255"/>
+        <label>CV86(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV87(Range 0 - 255)" CV="87" default="191">
+        <decVal max="255"/>
+        <label>CV87(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV88(Range 0 - 255)" CV="88" default="200">
+        <decVal max="255"/>
+        <label>CV88(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV89(Range 0 - 255)" CV="89" default="209">
+        <decVal max="255"/>
+        <label>CV89(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV90(Range 0 - 255)" CV="90" default="219">
+        <decVal max="255"/>
+        <label>CV90(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV91(Range 0 - 255)" CV="91" default="228">
+        <decVal max="255"/>
+        <label>CV91(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV92(Range 0 - 255)" CV="92" default="237">
+        <decVal max="255"/>
+        <label>CV92(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV93(Range 0 - 255)" CV="93" default="246">
+        <decVal max="255"/>
+        <label>CV93(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV94(Range 0 - 255)" CV="94" default="255">
+        <decVal max="255"/>
+        <label>CV94(Range 0 - 255)</label>
+      </variable>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/revTrim.xml"/>
+      <variable item="CV96(Range 0 - 255)" CV="96" default="0">
+        <decVal max="255"/>
+        <label>CV96(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV97(Range 0 - 255)" CV="97" default="0">
+        <decVal max="255"/>
+        <label>CV97(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV98(Range 0 - 255)" CV="98" default="0">
+        <decVal max="255"/>
+        <label>CV98(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV99(Range 0 - 255)" CV="99" default="0">
+        <decVal max="255"/>
+        <label>CV99(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV100(Range 0 - 255)" CV="100" default="0">
+        <decVal max="255"/>
+        <label>CV100(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV101(Range 0 - 255)" CV="101" default="0">
+        <decVal max="255"/>
+        <label>CV101(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV102(Range 0 - 255)" CV="102" default="0">
+        <decVal max="255"/>
+        <label>CV102(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV103(Range 0 - 255)" CV="103" default="0">
+        <decVal max="255"/>
+        <label>CV103(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV104(Range 0 - 255)" CV="104" default="0">
+        <decVal max="255"/>
+        <label>CV104(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV105(Range 0 - 255)" CV="105" default="0">
+        <decVal max="255"/>
+        <label>CV105(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV106(Range 0 - 255)" CV="106" default="0">
+        <decVal max="255"/>
+        <label>CV106(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV107(Range 0 - 255)" CV="107" default="0">
+        <decVal max="255"/>
+        <label>CV107(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV108(Range 0 - 255)" CV="108" default="0">
+        <decVal max="255"/>
+        <label>CV108(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV109(Range 0 - 255)" CV="109" default="0">
+        <decVal max="255"/>
+        <label>CV109(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV110(Range 0 - 255)" CV="110" default="0">
+        <decVal max="255"/>
+        <label>CV110(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV111(Range 0 - 255)" CV="111" default="0">
+        <decVal max="255"/>
+        <label>CV111(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV112(Range 0 - 255)" CV="112" default="8">
+        <decVal max="255"/>
+        <label>CV112(Range 0 - 255)</label>
+      </variable>
+      <variable item="CV113 (Range 0 - 255)" CV="113" default="200">
+        <decVal max="255"/>
+        <label>CV113 (Range 0 - 255)</label>
+      </variable>
+      <!-- CV 114 to 256 available but also undocumented-->
+    </variables>
+  </decoder>
+</decoder-config>


### PR DESCRIPTION
In the former Arnold.xml file definition I created in July 2010 (years ago), the consist CV (not documented by Arnold) was missing as it was not documented in the Arnold manual. However when resetting the decoder it was set to 255 (Consist address 127, reverse).
I opened issue #2921 including a zip with the updated xml, but I think it was not the right place to do it. Thus this pull request.
Thanks to validate and include in a future release.
Alain
[Arnold.zip](https://github.com/JMRI/JMRI/files/731894/Arnold.zip)
