### PR TITLE
Fix bad error logging in configxml

### DIFF
--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -318,7 +318,7 @@ runs a specific test or test suite.<br>
      <p>
      If the PackageTest has not been converted to JUnit4 format yet, the following line needs to be added to the list of test classes in the "suite" method:</p>
      <p>
-     <code>suite.addTest(new junit.framework.JUnit4TestAdapter(FooTest.class));
+     <code>suite.addTest(new junit.framework.JUnit4TestAdapter(FooTest.class));</code>
      </p>
 
      <p>
@@ -363,7 +363,7 @@ runs a specific test or test suite.<br>
      <p>
      If the enclosing PackageTest has not been converted to JUnit4 format yet, the following line needs to be added to the list of test classes in the "suite" method:</p>
      <p>
-     <code>suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.foo.PackageTest.clas));
+     <code>suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.foo.PackageTest.clas));</code>
      </p>
 
      <p>

--- a/java/src/jmri/configurexml/ConfigXmlManager.java
+++ b/java/src/jmri/configurexml/ConfigXmlManager.java
@@ -278,8 +278,8 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
                     root.addContent(e);
                 }
             } catch (Exception e) {
-                storingErrorEncountered(null, "storing to file",
-                        "Unknown error (Exception)", null, null, e);
+                storingErrorEncountered(null, "storing to file in addConfigStore",
+                        "Exception thrown", null, null, e);
                 result = false;
             }
         }
@@ -297,8 +297,8 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
                 }
             } catch (Exception e) {
                 result = false;
-                storingErrorEncountered(((XmlAdapter) o), "storing to file",
-                        "Unknown error (Exception)", null, null, e);
+                storingErrorEncountered(null, "storing to file in addToolsStore",
+                        "Exception thrown", null, null, e);
             }
         }
         return result;
@@ -315,8 +315,8 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
                 }
             } catch (Exception e) {
                 result = false;
-                storingErrorEncountered((XmlAdapter) o, "storing to file",
-                        "Unknown error (Exception)", null, null, e);
+                storingErrorEncountered(null, "storing to file in addUserStore",
+                        "Exception thrown", null, null, e);
             }
         }
         return result;

--- a/java/test/jmri/ConfigXmlHandle.java
+++ b/java/test/jmri/ConfigXmlHandle.java
@@ -1,0 +1,12 @@
+package jmri;
+
+/**
+ * Testing dummy class used in jmri.configurexml.ConfigXmlManagerTest
+ *
+ * Needs to be in the jmri package to drive the auto-class resolution methods
+ *
+ * @author Bob Jacobsen Copyright 2017
+ */
+ 
+public class ConfigXmlHandle {}
+ 

--- a/java/test/jmri/configurexml/ConfigXmlHandleXml.java
+++ b/java/test/jmri/configurexml/ConfigXmlHandleXml.java
@@ -1,0 +1,33 @@
+package jmri.configurexml;
+
+import org.jdom2.Element;
+
+/**
+ * Testing dummy class used in jmri.configurexml.ConfigXmlManagerTest
+ *
+ * Needs to be in the jmri package to drive the auto-class resolution methods
+ *
+ * @author Bob Jacobsen Copyright 2017
+ */
+ 
+class ConfigXmlHandleXml implements XmlAdapter {
+    public boolean load(Element e) throws Exception { return true; }
+    public boolean load(Element shared, Element perNode) throws Exception { return true; }
+    public boolean loadDeferred() { return false; }
+    public void load(Element e, Object o) throws Exception { return; }
+    public void load(Element shared, Element perNode, Object o) throws Exception { return; }
+    public Element store(Object o) { return null; }
+    public Element store(Object o, boolean shared) { 
+        throw new IllegalArgumentException("for testing");
+    }
+    public int loadOrder() { return 3; }
+    
+    
+    public void creationErrorEncountered(
+            String description,
+            String systemName,
+            String userName,
+            Throwable exception) throws JmriConfigureXmlException {
+    }
+ }
+ 

--- a/java/test/jmri/configurexml/ConfigXmlManagerTest.java
+++ b/java/test/jmri/configurexml/ConfigXmlManagerTest.java
@@ -33,6 +33,7 @@ public class ConfigXmlManagerTest extends TestCase {
             void locateFailed(Throwable ex, String adapterName, Object o) {
             }
         };
+
         Object o1 = new jmri.implementation.TripleTurnoutSignalHead("", "", null, null, null);
         configxmlmanager.registerConfig(o1);
         Assert.assertTrue("stored in clist", configxmlmanager.clist.size() == 1);
@@ -40,6 +41,27 @@ public class ConfigXmlManagerTest extends TestCase {
         Assert.assertTrue("removed from clist", configxmlmanager.clist.size() == 0);
     }
 
+    public void testLogErrorOnStore() {
+        ConfigXmlManager configxmlmanager = new ConfigXmlManager();
+        innerFlag = false;
+        configxmlmanager.setErrorHandler(new ErrorHandler(){
+            public void handle(ErrorMemo e) {
+                innerFlag = true;
+            }
+        });
+        
+        Object o1 = new jmri.ConfigXmlHandle();
+        configxmlmanager.registerConfig(o1);
+     
+        // this will fail before reaching file
+        try {
+            configxmlmanager.storeAll(new File("none"));
+        } catch (Exception e) {
+            // check that the handler was invoked
+            Assert.assertTrue(innerFlag);
+        }
+    }
+    
     public void testFind() throws ClassNotFoundException {
         ConfigXmlManager configxmlmanager = new ConfigXmlManager() {
             @SuppressWarnings("unused")
@@ -145,6 +167,7 @@ public class ConfigXmlManagerTest extends TestCase {
     // The minimal setup for log4J
     protected void setUp() {
         apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.resetInstanceManager();
     }
 
     protected void tearDown() {

--- a/java/test/jmri/configurexml/ConfigXmlManagerTest.java
+++ b/java/test/jmri/configurexml/ConfigXmlManagerTest.java
@@ -51,7 +51,7 @@ public class ConfigXmlManagerTest extends TestCase {
         });
         
         Object o1 = new jmri.ConfigXmlHandle();
-        configxmlmanager.registerConfig(o1);
+        configxmlmanager.registerUser(o1);
      
         // this will fail before reaching file
         try {


### PR DESCRIPTION
An error during by-stored-type initialization of a ConfigXml store would log a type-cast error instead of the underlying error.  Added some code to reproduce this, and then fixed it.