### PR TITLE
Reduce message severity in roco.z21.Z21InterfaceScaffold

### DIFF
--- a/java/test/jmri/jmrix/lenz/XNetInterfaceScaffold.java
+++ b/java/test/jmri/jmrix/lenz/XNetInterfaceScaffold.java
@@ -80,6 +80,20 @@ public class XNetInterfaceScaffold extends XNetTrafficController {
     public void receiveLoop() {
     }
 
+
+
+    /**
+     * This is normal, don't log at ERROR level
+     */
+    @Override 
+    protected void reportReceiveLoopException(Exception e) {
+        log.debug("run: Exception: {} in {} (considered normal in testing)", e.toString(), this.getClass().toString(), e);
+        jmri.jmrix.ConnectionStatus.instance().setConnectionState(controller.getCurrentPortName(), jmri.jmrix.ConnectionStatus.CONNECTION_DOWN);
+        if (controller instanceof jmri.jmrix.AbstractNetworkPortController) {
+            portWarnTCP(e);
+        }
+    }
+
     private final static Logger log = LoggerFactory.getLogger(XNetInterfaceScaffold.class.getName());
 
 }

--- a/java/test/jmri/jmrix/roco/z21/Z21InterfaceScaffold.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21InterfaceScaffold.java
@@ -76,6 +76,18 @@ public class Z21InterfaceScaffold extends Z21TrafficController {
     public void receiveLoop() {
     }
 
+    /**
+     * This is normal, don't log at ERROR level
+     */
+    @Override 
+    protected void reportReceiveLoopException(Exception e) {
+        log.debug("run: Exception: {} in {}", e.toString(), this.getClass().toString(), e);
+        jmri.jmrix.ConnectionStatus.instance().setConnectionState(controller.getCurrentPortName(), jmri.jmrix.ConnectionStatus.CONNECTION_DOWN);
+        if (controller instanceof jmri.jmrix.AbstractNetworkPortController) {
+            portWarnTCP(e);
+        }
+    }
+    
     private final static Logger log = LoggerFactory.getLogger(Z21InterfaceScaffold.class.getName());
 
 }

--- a/java/test/jmri/jmrix/roco/z21/Z21InterfaceScaffold.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21InterfaceScaffold.java
@@ -81,7 +81,7 @@ public class Z21InterfaceScaffold extends Z21TrafficController {
      */
     @Override 
     protected void reportReceiveLoopException(Exception e) {
-        log.debug("run: Exception: {} in {}", e.toString(), this.getClass().toString(), e);
+        log.debug("run: Exception: {} in {} (considered normal in testing)", e.toString(), this.getClass().toString(), e);
         jmri.jmrix.ConnectionStatus.instance().setConnectionState(controller.getCurrentPortName(), jmri.jmrix.ConnectionStatus.CONNECTION_DOWN);
         if (controller instanceof jmri.jmrix.AbstractNetworkPortController) {
             portWarnTCP(e);


### PR DESCRIPTION
Drops Error message causing #2671 to Debug level by inheriting the error reporter routine in roco.z21.Z21InterfaceScaffold
