### PR TITLE
Reduce verbosity of warnings discussed in #2539

### DIFF
--- a/java/src/jmri/jmrit/audio/JoalAudioBuffer.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioBuffer.java
@@ -210,7 +210,7 @@ public class JoalAudioBuffer extends AbstractAudioBuffer {
         try {
             ALut.alutLoadWAVFile(stream, format, data, size, freq, loop);
         } catch (ALException e) {
-            log.warn("Error loading JoalAudioBuffer from stream", e);
+            log.warn("Exception loading JoalAudioBuffer from stream: {}", e.toString());
             return false;
         }
 
@@ -232,7 +232,7 @@ public class JoalAudioBuffer extends AbstractAudioBuffer {
         try {
             ALut.alutLoadWAVFile(FileUtil.getExternalFilename(this.getURL()), format, data, size, freq, loop);
         } catch (ALException e) {
-            log.warn("Error loading JoalAudioBuffer from file", e);
+            log.warn("Exception loading JoalAudioBuffer from file: {}", e.toString());
             return false;
         }
 


### PR DESCRIPTION
Remove stack trace from Joal warnings during CI.  These are documented in #2539 and there's no need to have users keep skipping over them when reading logs, etc.