### PR TITLE
Fix to exception while writing NX EntryExit pairs

### DIFF
--- a/java/src/jmri/jmrit/signalling/configurexml/EntryExitPairsXml.java
+++ b/java/src/jmri/jmrit/signalling/configurexml/EntryExitPairsXml.java
@@ -120,8 +120,10 @@ public class EntryExitPairsXml extends AbstractXmlAdapter {
                     source.addContent(dest);
                 }
                 panelElem.addContent(source);
-                element.addContent(panelElem);
+                System.out.println("source: "+source.toString());
             }
+            element.addContent(panelElem);
+            System.out.println("element: "+element.toString());
         }
         return element;
     }


### PR DESCRIPTION
Fix problem with nesting of XML writes that caused JDOM exception