### PR TITLE
Ignore collection in hashCode

### DIFF
--- a/java/src/jmri/jmrit/logix/OBlock.java
+++ b/java/src/jmri/jmrit/logix/OBlock.java
@@ -183,7 +183,6 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
         hash = 97 * hash + Objects.hashCode(this._pathName);
         hash = 97 * hash + (int) (this._entryTime ^ (this._entryTime >>> 32));
         hash = 97 * hash + (this._metric ? 1 : 0);
-        hash = 97 * hash + Objects.hashCode(this._sharedTO);
         hash = 97 * hash + Objects.hashCode(this._markerForeground);
         hash = 97 * hash + Objects.hashCode(this._markerBackground);
         hash = 97 * hash + Objects.hashCode(this._markerFont);


### PR DESCRIPTION
Addresses #2976.

The removed problematic line can cause a circular reference and eventual stack overflow if an item in the referred to collection refers back to the OBlock.