### PR TITLE
Silence most outputs from Jemmy

### DIFF
--- a/java/test/apps/tests/Log4JFixture.java
+++ b/java/test/apps/tests/Log4JFixture.java
@@ -1,5 +1,7 @@
 package apps.tests;
 
+import jmri.util.JUnitUtil;
+
 public class Log4JFixture extends java.lang.Object {
 
     public Log4JFixture() {
@@ -15,6 +17,8 @@ public class Log4JFixture extends java.lang.Object {
         } catch (Throwable e) {
             System.err.println("Could not start JUnitAppender, but test continues:\n" + e);
         }
+        // silence the Jemmy GUI unit testing framework
+        JUnitUtil.silenceGUITestOutput();
     }
 
     static public void tearDown() {

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -42,6 +42,7 @@ import jmri.profile.Profile;
 import jmri.profile.ProfileManager;
 import jmri.progdebugger.DebugProgrammerManager;
 import org.junit.Assert;
+import org.netbeans.jemmy.TestOut;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -469,6 +470,30 @@ public class JUnitUtil {
      */
     public static void resetProfileManager(Profile profile) {
         ProfileManager.getDefault().setActiveProfile(profile);
+    }
+
+    /**
+     * Silences the outputs from the Jemmy GUI Test framework.
+     */
+    public static void silenceGUITestOutput() {
+        JUnitUtil.setGUITestOutput(TestOut.getNullOutput());
+    }
+
+    /**
+     * Sets the outputs for the Jemmy GUI Test framework to the defaults. Call
+     * this after setting up logging to enable outputs for a specific test.
+     */
+    public static void verboseGUITestOutput() {
+        JUnitUtil.setGUITestOutput(new TestOut());
+    }
+
+    /**
+     * Set the outputs for the Jemmy GUI Test framework.
+     *
+     * @param output a container for the input, output, and error streams
+     */
+    public static void setGUITestOutput(TestOut output) {
+        org.netbeans.jemmy.JemmyProperties.setCurrentOutput(output);
     }
 
     private final static Logger log = LoggerFactory.getLogger(JUnitUtil.class.getName());


### PR DESCRIPTION
This silences most outputs from the Jemmy GUI testing library while allowing individual tests to override that behavior. To ensure that Jemmy remains silences, any call to Log4JFixture.setUp also silences Jemmy.