### PR TITLE
Methods should not throw NoSuchMethodError

### DIFF
--- a/java/src/jmri/implementation/DefaultSignalAppearanceMap.java
+++ b/java/src/jmri/implementation/DefaultSignalAppearanceMap.java
@@ -136,7 +136,7 @@ public class DefaultSignalAppearanceMap extends AbstractNamedBean implements jmr
             loadAspectRelationMap(signalSystemName, aspectMapName, map, root);
             log.debug("loading complete");
         } catch (java.io.IOException | org.jdom2.JDOMException e) {
-            log.error("error reading file "+file.getPath(), e);
+            log.error("error reading file " + file.getPath(), e);
             return null;
         }
 
@@ -393,12 +393,26 @@ public class DefaultSignalAppearanceMap extends AbstractNamedBean implements jmr
     }
     protected SignalSystem systemDefn;
 
+    /**
+     * {@inheritDoc}
+     *
+     * This method returns a constant result on the DefaultSignalAppearanceMap.
+     *
+     * @return {@link jmri.NamedBean#INCONSISTENT}
+     */
+    @Override
     public int getState() {
-        throw new NoSuchMethodError();
+        return INCONSISTENT;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * This method has no effect on the DefaultSignalAppearanceMap.
+     */
+    @Override
     public void setState(int s) {
-        throw new NoSuchMethodError();
+        // do nothing
     }
 
     public int[] getAspectSettings(String aspect) {

--- a/java/src/jmri/implementation/DefaultSignalSystem.java
+++ b/java/src/jmri/implementation/DefaultSignalSystem.java
@@ -107,13 +107,26 @@ public class DefaultSignalSystem extends AbstractNamedBean implements SignalSyst
         setProperty(aspect, key, value);
 
     }
-
+    /**
+     * {@inheritDoc}
+     *
+     * This method returns a constant result on the DefaultSignalSystem.
+     *
+     * @return {@link jmri.NamedBean#INCONSISTENT}
+     */
+    @Override
     public int getState() {
-        throw new NoSuchMethodError();
+        return INCONSISTENT;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * This method has no effect on the DefaultSignalSystem.
+     */
+    @Override
     public void setState(int s) {
-        throw new NoSuchMethodError();
+        // do nothing
     }
 
     float maximumLineSpeed = 0.0f;

--- a/java/test/jmri/implementation/DefaultSignalSystemTest.java
+++ b/java/test/jmri/implementation/DefaultSignalSystemTest.java
@@ -1,62 +1,67 @@
 package jmri.implementation;
 
+import jmri.NamedBean;
 import jmri.SignalSystem;
+import org.junit.After;
 import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests for the DefaultSignalSystem interface implementation
  *
  * @author	Bob Jacobsen Copyright (C) 2009
  */
-public class DefaultSignalSystemTest extends TestCase {
+public class DefaultSignalSystemTest {
 
+    @Test
     public void testCtor() {
-        new DefaultSignalSystem("sys", "user");
+        DefaultSignalSystem dss = new DefaultSignalSystem("sys", "user");
+        Assert.assertNotNull(dss);
     }
 
+    @Test
     public void testOneAspectOneProperty() {
         SignalSystem t = new DefaultSignalSystem("sys", "user");
 
-        t.setProperty("Stop", "Speed", Integer.valueOf(0));
+        t.setProperty("Stop", "Speed", 0);
 
-        Assert.assertEquals(Integer.valueOf(0), t.getProperty("Stop", "Speed"));
+        Assert.assertEquals(0, t.getProperty("Stop", "Speed"));
     }
 
+    @Test
     public void testTwoAspectOneProperty() {
         SignalSystem t = new DefaultSignalSystem("sys", "user");
 
-        t.setProperty("Stop", "Speed", Integer.valueOf(0));
-        t.setProperty("Clear", "Speed", Integer.valueOf(10));
+        t.setProperty("Stop", "Speed", 0);
+        t.setProperty("Clear", "Speed", 10);
 
-        Assert.assertEquals("Stop", Integer.valueOf(0), t.getProperty("Stop", "Speed"));
-        Assert.assertEquals("Clear", Integer.valueOf(10), t.getProperty("Clear", "Speed"));
+        Assert.assertEquals("Stop", 0, t.getProperty("Stop", "Speed"));
+        Assert.assertEquals("Clear", 10, t.getProperty("Clear", "Speed"));
     }
 
+    @Test
     public void testTwoAspectTwoProperties() {
         SignalSystem t = new DefaultSignalSystem("sys", "user");
 
-        t.setProperty("Stop", "Speed", Integer.valueOf(0));
-        t.setProperty("Clear", "Speed", Integer.valueOf(10));
+        t.setProperty("Stop", "Speed", 0);
+        t.setProperty("Clear", "Speed", 10);
         t.setProperty("Stop", "Biff", "ffiB");
         t.setProperty("Clear", "Biff", "beef");
 
-        Assert.assertEquals("Stop", Integer.valueOf(0), t.getProperty("Stop", "Speed"));
-        Assert.assertEquals("Clear", Integer.valueOf(10), t.getProperty("Clear", "Speed"));
+        Assert.assertEquals("Stop", 0, t.getProperty("Stop", "Speed"));
+        Assert.assertEquals("Clear", 10, t.getProperty("Clear", "Speed"));
         Assert.assertEquals("Stop", "ffiB", t.getProperty("Stop", "Biff"));
         Assert.assertEquals("Clear", "beef", t.getProperty("Clear", "Biff"));
     }
 
+    @Test
     public void testGetAspects() {
         SignalSystem t = new DefaultSignalSystem("sys", "user");
 
-        t.setProperty("Stop", "Speed", Integer.valueOf(0));
-        t.setProperty("Approach", "Speed", Integer.valueOf(5));
-        t.setProperty("Clear", "Speed", Integer.valueOf(10));
+        t.setProperty("Stop", "Speed", 0);
+        t.setProperty("Approach", "Speed", 5);
+        t.setProperty("Clear", "Speed", 10);
 
         java.util.Enumeration<String> e = t.getAspects();
 
@@ -68,34 +73,37 @@ public class DefaultSignalSystemTest extends TestCase {
 
     }
 
+    @Test
     public void testGetNullProperties() {
         SignalSystem t = new DefaultSignalSystem("sys", "user");
 
-        t.setProperty("Stop", "Speed", Integer.valueOf(0));
-        t.setProperty("Approach", "Speed", Integer.valueOf(5));
+        t.setProperty("Stop", "Speed", 0);
+        t.setProperty("Approach", "Speed", 5);
 
         Assert.assertEquals("Stop", null, t.getProperty("Stop", "None"));
         Assert.assertEquals("Clear", null, t.getProperty("Clear", "Speed"));
 
     }
 
+    @Test
     public void testCheckAspect() {
         SignalSystem t = new DefaultSignalSystem("sys", "user");
 
-        t.setProperty("Stop", "Speed", Integer.valueOf(0));
-        t.setProperty("Approach", "Speed", Integer.valueOf(5));
+        t.setProperty("Stop", "Speed", 0);
+        t.setProperty("Approach", "Speed", 5);
 
         Assert.assertTrue("Stop", t.checkAspect("Stop"));
         Assert.assertFalse("Clear", t.checkAspect("Clear"));
 
     }
 
+    @Test
     public void testGetKeys() {
         SignalSystem t = new DefaultSignalSystem("sys", "user");
 
-        t.setProperty("Stop", "A", Integer.valueOf(0));
-        t.setProperty("Approach", "C", Integer.valueOf(5));
-        t.setProperty("Clear", "B", Integer.valueOf(10));
+        t.setProperty("Stop", "A", 0);
+        t.setProperty("Approach", "C", 5);
+        t.setProperty("Clear", "B", 10);
 
         java.util.Enumeration<String> e = t.getKeys();
 
@@ -107,14 +115,15 @@ public class DefaultSignalSystemTest extends TestCase {
 
     }
 
+    @Test
     public void testGetKeysOverlap() {
         SignalSystem t = new DefaultSignalSystem("sys", "user");
 
-        t.setProperty("Stop", "A", Integer.valueOf(0));
-        t.setProperty("Approach", "C", Integer.valueOf(5));
-        t.setProperty("Approach", "A", Integer.valueOf(5));
-        t.setProperty("Approach", "B", Integer.valueOf(5));
-        t.setProperty("Clear", "B", Integer.valueOf(10));
+        t.setProperty("Stop", "A", 0);
+        t.setProperty("Approach", "C", 5);
+        t.setProperty("Approach", "A", 5);
+        t.setProperty("Approach", "B", 5);
+        t.setProperty("Clear", "B", 10);
 
         java.util.Enumeration<String> e = t.getKeys();
 
@@ -126,6 +135,7 @@ public class DefaultSignalSystemTest extends TestCase {
 
     }
 
+    @Test
     public void testDefaults() {
         DefaultSignalSystem t = new DefaultSignalSystem("sys", "user");
 
@@ -151,30 +161,27 @@ public class DefaultSignalSystemTest extends TestCase {
 
     }
 
-    // from here down is testing infrastructure
-    public DefaultSignalSystemTest(String s) {
-        super(s);
+    @Test
+    public void testGetState() {
+        DefaultSignalSystem dss = new DefaultSignalSystem("sys", "user");
+        Assert.assertEquals(NamedBean.INCONSISTENT, dss.getState());
     }
 
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {DefaultSignalSystemTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
+    @Test
+    public void testSetState() {
+        DefaultSignalSystem dss = new DefaultSignalSystem("sys", "user");
+        dss.setState(NamedBean.UNKNOWN);
+        // verify getState did not change
+        Assert.assertEquals(NamedBean.INCONSISTENT, dss.getState());
     }
 
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(DefaultSignalSystemTest.class);
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    protected void setUp() {
+    @Before
+    public void setUp() {
         apps.tests.Log4JFixture.setUp();
     }
 
-    protected void tearDown() {
+    @After
+    public void tearDown() {
         apps.tests.Log4JFixture.tearDown();
     }
-    static protected Logger log = LoggerFactory.getLogger(DefaultSignalSystemTest.class.getName());
 }

--- a/java/test/jmri/implementation/PackageTest.java
+++ b/java/test/jmri/implementation/PackageTest.java
@@ -42,8 +42,8 @@ public class PackageTest extends TestCase {
         suite.addTest(DefaultConditionalActionTest.suite());
         suite.addTest(new JUnit4TestAdapter(DefaultIdTagTest.class));
         suite.addTest(DefaultLogixTest.suite());
-        suite.addTest(DefaultSignalSystemTest.suite());
-        suite.addTest(DefaultSignalAppearanceMapTest.suite());
+        suite.addTest(new JUnit4TestAdapter(DefaultSignalSystemTest.class));
+        suite.addTest(new JUnit4TestAdapter(DefaultSignalAppearanceMapTest.class));
         suite.addTest(MultiIndexProgrammerFacadeTest.suite());
         suite.addTest(OffsetHighCvProgrammerFacadeTest.suite());
         suite.addTest(ResettingOffsetHighCvProgrammerFacadeTest.suite());


### PR DESCRIPTION
NoSuchMethodError is a runtime throwable indicating a method was available at compile time, but is not available now, and should not be used to indicate that an overridden method is meaningless in the overriding class.