### PR TITLE
Fix exception error when trying to set signal mast at point to null. …

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -433,6 +433,9 @@ public class PositionablePoint {
                 log.error("Unable to find Signal Mast " + signalMast);
                 return;
             }
+        } else {
+            eastBoundSignalMastNamed = null;
+            return;
         }
         if (getType() == EDGE_CONNECTOR) {
             int dir = getConnect1Dir();
@@ -494,6 +497,9 @@ public class PositionablePoint {
                 log.error("Unable to find Signal Mast " + signalMast);
                 return;
             }
+        } else {
+            westBoundSignalMastNamed = null;
+            return;
         }
         if (getType() == EDGE_CONNECTOR) {
             int dir = getConnect1Dir();

--- a/java/src/jmri/jmrit/signalling/SignallingSourcePanel.java
+++ b/java/src/jmri/jmrit/signalling/SignallingSourcePanel.java
@@ -294,7 +294,7 @@ public class SignallingSourcePanel extends jmri.util.swing.JmriPanel implements 
                 fireTableDataChanged();
             } else if ((e.getPropertyName().equals("state")) || (e.getPropertyName().equals("Enabled"))) {
                 fireTableDataChanged();
-                fireTableRowsUpdated(0, _signalMastList.size());
+                fireTableRowsUpdated(0, _signalMastList.size()-1);
             }
         }
 


### PR DESCRIPTION
…(java.lang.NullPointerException: bean must be nonnull)

Also fix out of bounds error occuring during updating of Signal Mast Logic for a signal mast.