### PR TITLE
Add undecorate() method to JmriJFrame

### DIFF
--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -245,6 +245,28 @@ public class JmriJFrame extends JFrame implements java.awt.event.WindowListener,
     }
 
     /**
+     * Remove any decoration, e.g. title bar or close window, from the JFrame.
+     * <p>
+     * JmriJFrames are often built internally and presented to the user
+     * before any scripting action can interact with them.  At that point
+     * it's too late to directly invoke setUndecorated(true) because the JFrame
+     * is already displayable.  This method uses dispose() to drop the windowing
+     * resources, sets undecorated, and then redisplays the window.
+     */
+    public void undecorate() {
+        boolean visible = isVisible();
+        
+        setVisible(false);
+        super.dispose();
+
+        setUndecorated(true);
+        getRootPane().setWindowDecorationStyle(javax.swing.JRootPane.NONE);
+        
+        pack();
+        setVisible(visible);
+    }
+    
+    /**
      * Tries to get window to fix entirely on screen. First choice is to move
      * the origin up and left as needed, then to make the window smaller
      */


### PR DESCRIPTION
Provide a method to remove frame decorations (menu bar, close buttons, etc) from a JmriJFrame after it's been built and displayed, e.g. in scripting.