### PR TITLE
Prevent NPE or IndexOutOfRange exceptions

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/ProgDefault.java
+++ b/java/src/jmri/jmrit/symbolicprog/ProgDefault.java
@@ -2,9 +2,8 @@ package jmri.jmrit.symbolicprog;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.List;
-import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import jmri.InstanceManager;
 import jmri.jmrit.XmlFile;
 import jmri.util.FileUtil;
@@ -35,10 +34,11 @@ public class ProgDefault {
         XmlFilenameFilter filter = new XmlFilenameFilter();
         if (fp.exists()) {
             sp = fp.list(filter);
-            if(sp!=null) { 
-               np = sp.length;
+            if (sp != null) {
+                np = sp.length;
             } else {
-               np = 0;
+                sp = new String[]{};
+                np = 0;
             }
         } else {
             log.warn(FileUtil.getUserFilesPath() + "programmers was missing, though tried to create it");
@@ -48,32 +48,30 @@ public class ProgDefault {
         }
         // create an array of file names from xml/programmers, count entries
         fp = new File(XmlFile.xmlDir() + "programmers");
-        int nx;
-        String[] sx;
+        int nx = 0;
+        String[] sx = {};
         if (fp.exists()) {
             sx = fp.list(filter);
-            if(sx!=null) {
-               nx = sx.length;
+            if (sx != null) {
+                nx = sx.length;
             } else {
-               nx = 0;
+                sx = new String[]{};
             }
-            if (log.isDebugEnabled()) {
-                log.debug("Got " + nx + " programmers from " + fp.getPath());
-            }
+            log.debug("Got {} programmers from {}", nx, fp.getPath());
         } else {
             // create an array of file names from jmri.jar!xml/programmers, count entries
-            List<String> sr = new ArrayList<String>();
-            Enumeration<JarEntry> je = FileUtil.jmriJarFile().entries();
-            while (je.hasMoreElements()) {
-                String name = je.nextElement().getName();
-                if (name.startsWith("xml" + File.separator + "programmers") && name.endsWith(".xml")) {
-                    sr.add(name.substring(name.lastIndexOf(File.separator)));
-                }
-            }
-            sx = sr.toArray(new String[sr.size()]);
-            nx = sx.length;
-            if (log.isDebugEnabled()) {
-                log.debug("Got " + nx + " programmers from jmri.jar");
+            List<String> sr = new ArrayList<>();
+            JarFile jar = FileUtil.jmriJarFile();
+            if (jar != null) {
+                jar.stream().forEach((je) -> {
+                    String name = je.getName();
+                    if (name.startsWith("xml" + File.separator + "programmers") && name.endsWith(".xml")) {
+                        sr.add(name.substring(name.lastIndexOf(File.separator)));
+                    }
+                });
+                sx = sr.toArray(new String[sr.size()]);
+                nx = sx.length;
+                log.debug("Got {} programmers from jmri.jar", nx);
             }
         }
         // copy the programmer entries to the final array
@@ -81,15 +79,15 @@ public class ProgDefault {
         // But for now I can live with that.
         String sbox[] = new String[np + nx];
         int n = 0;
-        if(np>0) {
+        if (np > 0) {
             for (String s : sp) {
-               sbox[n++] = s.substring(0, s.length() - 4);
+                sbox[n++] = s.substring(0, s.length() - 4);
             }
         }
-        if(nx>0) {
-           for (String s : sx) {
-               sbox[n++] = s.substring(0, s.length() - 4);
-           }
+        if (nx > 0) {
+            for (String s : sx) {
+                sbox[n++] = s.substring(0, s.length() - 4);
+            }
         }
         return sbox;
     }

--- a/java/src/jmri/util/FileUtil.java
+++ b/java/src/jmri/util/FileUtil.java
@@ -138,8 +138,8 @@ public final class FileUtil {
      * </ul>
      * In any case, absolute pathnames will work.
      *
-     * @param pName The name string, possibly starting with home:,
-     *              profile:, program:, preference:, scripts:, or settings:
+     * @param pName The name string, possibly starting with home:, profile:,
+     *              program:, preference:, scripts:, or settings:
      * @return Absolute file name to use, or null. This will include
      *         system-specific file separators.
      * @since 2.7.2
@@ -665,7 +665,8 @@ public final class FileUtil {
     /**
      * Get the JMRI distribution jar file.
      *
-     * @return a {@link java.util.jar.JarFile} pointing to jmri.jar or null
+     * @return the JAR file containing the JMRI library or null if not running
+     *         from a JAR file
      */
     static public JarFile jmriJarFile() {
         return FileUtilSupport.getDefault().getJmriJarFile();
@@ -808,11 +809,11 @@ public final class FileUtil {
      * @param extension The extension to use for the rotations. If null or an
      *                  empty string, the rotation number is used as the
      *                  extension.
-     * @throws java.io.IOException if a backup cannot be created
+     * @throws java.io.IOException      if a backup cannot be created
      * @throws IllegalArgumentException if max is less than one
      * @see jmri.util.FileUtilSupport#rotate(java.io.File, int,
      * java.lang.String)
-     * @see jmri.util.FileUtilSupport#backup(java.io.File) 
+     * @see jmri.util.FileUtilSupport#backup(java.io.File)
      */
     public static void rotate(File file, int max, String extension) throws IOException {
         FileUtilSupport.getDefault().rotate(file, max, extension);

--- a/java/src/jmri/util/FileUtilSupport.java
+++ b/java/src/jmri/util/FileUtilSupport.java
@@ -492,8 +492,8 @@ public class FileUtilSupport extends Bean {
     /**
      * Set the JMRI program directory.
      *
-     * Convenience method that calls
-     * {@link #setProgramPath(java.io.File)} with the passed in path.
+     * Convenience method that calls {@link #setProgramPath(java.io.File)} with
+     * the passed in path.
      *
      * @param path the path to the JMRI installation
      */
@@ -973,15 +973,21 @@ public class FileUtilSupport extends Bean {
     /**
      * Get the JMRI distribution jar file.
      *
-     * @return a {@link java.util.jar.JarFile} pointing to jmri.jar or null
+     * @return the JAR file containing the JMRI library or null if not running
+     *         from a JAR file
      */
     public JarFile getJmriJarFile() {
         if (jarPath == null) {
             CodeSource sc = FileUtilSupport.class.getProtectionDomain().getCodeSource();
             if (sc != null) {
                 jarPath = sc.getLocation().toString();
-                // 9 = length of jar:file:
-                jarPath = jarPath.substring(9, jarPath.lastIndexOf("!"));
+                if (jarPath.startsWith("jar:file:")) {
+                    // 9 = length of jar:file:
+                    jarPath = jarPath.substring(9, jarPath.lastIndexOf("!"));
+                } else {
+                    log.info("Running from classes not in jar file.");
+                    return null;
+                }
                 log.debug("jmri.jar path is {}", jarPath);
             }
             if (jarPath == null) {

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <name>JMRI</name>
     <groupId>org.jmri</groupId>
     <artifactId>jmri</artifactId>
     <version>0.1-SNAPSHOT</version>
@@ -118,12 +119,12 @@
                         <artifactId>coveralls-maven-plugin</artifactId>
                         <version>4.3.0</version>
                         <configuration>
-                           <sourceDirectories>
-                                  <!-- Additional source directories -->
-                                  <File>java/tmp</File>
-                                  <File>target/generated-sources/javacc</File>
-                                  <File>target/generated-sources/jjtree</File>
-                           </sourceDirectories>
+                            <sourceDirectories>
+                                <!-- Additional source directories -->
+                                <File>java/tmp</File>
+                                <File>target/generated-sources/javacc</File>
+                                <File>target/generated-sources/jjtree</File>
+                            </sourceDirectories>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -131,19 +132,19 @@
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <version>0.7.8</version>
                         <configuration>
-                           <dataFile>jacoco.exec</dataFile>
-                           <excludes>
-                               <File>**/*Test*.class</File>
-                               <!-- Exclude testing infrastructure classes -->
-                               <File>**/*Scaffold.class"</File>
-                               <File>**/*JUnit*.class</File>
-                               <File>**/*Demo.class</File>
-                               <File>**/*Mock*.class</File>
-                               <File>jmri/jmrit/symbolicprog/tabbedframe/CheckProgrammerNames.class</File>
-                               <File>jmri/jmrix/openlcb/SampleFactory.class</File>
-                               <File>jmri/util/swing/SamplePane.class</File>
-                               <File>apps/tests/Log4JFixture.class</File>
-                           </excludes>
+                            <dataFile>jacoco.exec</dataFile>
+                            <excludes>
+                                <File>**/*Test*.class</File>
+                                <!-- Exclude testing infrastructure classes -->
+                                <File>**/*Scaffold.class"</File>
+                                <File>**/*JUnit*.class</File>
+                                <File>**/*Demo.class</File>
+                                <File>**/*Mock*.class</File>
+                                <File>jmri/jmrit/symbolicprog/tabbedframe/CheckProgrammerNames.class</File>
+                                <File>jmri/jmrix/openlcb/SampleFactory.class</File>
+                                <File>jmri/util/swing/SamplePane.class</File>
+                                <File>apps/tests/Log4JFixture.class</File>
+                            </excludes>
                         </configuration>
                         <executions>
                             <execution>
@@ -322,7 +323,7 @@
                 <version>2.3.2</version>
                 <configuration>
                     <source>1.8</source>
-                    <target>1.8</target>                        
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -766,6 +767,9 @@
     </dependencies>
 
     <repositories>
+        <!--
+        Repository hosting libraries not available through maven.org
+        -->
         <repository>
             <id>lib</id>
             <name>lib</name>
@@ -779,4 +783,5 @@
             <url>file://${project.basedir}/lib</url>
         </repository>
     </repositories>
+
 </project>


### PR DESCRIPTION
If running without a JAR, an IndexOutOfRange exception is thrown if no programmers can be found in the ```program:``` path. This fixes that as well as follow-on NPEs caused by returning a null JarFile.

Also includes some whitespace changes in the pom.xml and JavaDoc changes in FileUtil.