### PR TITLE
Deprecate OBE Wrappers

### DIFF
--- a/java/src/jmri/configurexml/turnoutoperations/TurnoutOperationXml.java
+++ b/java/src/jmri/configurexml/turnoutoperations/TurnoutOperationXml.java
@@ -98,7 +98,7 @@ public abstract class TurnoutOperationXml extends jmri.configurexml.AbstractXmlA
         try {
             Class<?> configClass = Class.forName(fullConfigName);
             adapter = (TurnoutOperationXml) configClass.newInstance();
-        } catch (Throwable e) { // too many possible to list them all
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
             log.error("exception in getAdapter", e);
         }
         if (adapter == null) {

--- a/java/src/jmri/jmrit/display/PositionablePopupUtil.java
+++ b/java/src/jmri/jmrit/display/PositionablePopupUtil.java
@@ -414,7 +414,7 @@ public class PositionablePopupUtil {
     }
 
     public void setFontStyle(int style) {
-        _textComponent.setFont(jmri.util.FontUtil.deriveFont(_textComponent.getFont(), style));
+        _textComponent.setFont(_textComponent.getFont().deriveFont(style));
         _parent.updateSize();
     }
 
@@ -427,7 +427,7 @@ public class PositionablePopupUtil {
         if (italic != null) {
             italic.setSelected((styleValue & Font.ITALIC) != 0);
         }
-        _textComponent.setFont(jmri.util.FontUtil.deriveFont(_textComponent.getFont(), styleValue));
+        _textComponent.setFont(_textComponent.getFont().deriveFont(styleValue));
 
         //setSize(getPreferredSize().width, getPreferredSize().height);
         _parent.updateSize();

--- a/java/src/jmri/jmrit/display/ToolTip.java
+++ b/java/src/jmri/jmrit/display/ToolTip.java
@@ -84,7 +84,7 @@ public class ToolTip {
     }
 
     public final void setfontSize(int size) {
-        _tFont = jmri.util.FontUtil.deriveFont(_tFont, size);
+        _tFont = _tFont.deriveFont(size);
     }
 
     public final int getFontSize() {

--- a/java/src/jmri/jmrit/logix/WarrantTableFrame.java
+++ b/java/src/jmri/jmrit/logix/WarrantTableFrame.java
@@ -185,7 +185,7 @@ public class WarrantTableFrame extends jmri.util.JmriJFrame implements MouseList
         panel.add(new JLabel("status"));
         _status.addMouseListener(this);
         _status.setBackground(Color.white);
-        _status.setFont(jmri.util.FontUtil.deriveFont(_status.getFont(), java.awt.Font.BOLD));
+        _status.setFont(_status.getFont().deriveFont(Font.BOLD));
         _status.setEditable(false);
         setStatusText(BLANK.substring(0, 90), null, false);
         panel.add(_status);

--- a/java/src/jmri/jmrix/dccpp/dccppovertcp/Server.java
+++ b/java/src/jmri/jmrix/dccpp/dccppovertcp/Server.java
@@ -14,7 +14,6 @@ import jmri.InstanceManager;
 import jmri.implementation.QuietShutDownTask;
 import jmri.jmrix.dccpp.DCCppConstants;
 import jmri.util.FileUtil;
-import jmri.util.SocketUtil;
 import jmri.util.zeroconf.ZeroConfService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -223,10 +222,10 @@ public class Server {
             String remoteAddress;
             try {
                 serverSocket = new ServerSocket(getPortNumber());
-                SocketUtil.setReuseAddress(serverSocket, true);
+                serverSocket.setReuseAddress(true);
                 while (!socketListener.isInterrupted()) {
                     newClientConnection = serverSocket.accept();
-                    remoteAddress = SocketUtil.getRemoteSocketAddress(newClientConnection);
+                    remoteAddress = newClientConnection.getRemoteSocketAddress().toString();
                     log.info("Server: Connection from: " + remoteAddress);
                     addClient(new ClientRxHandler(remoteAddress, newClientConnection));
                 }

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/Server.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/Server.java
@@ -13,7 +13,6 @@ import java.util.Properties;
 import jmri.InstanceManager;
 import jmri.implementation.QuietShutDownTask;
 import jmri.util.FileUtil;
-import jmri.util.SocketUtil;
 import jmri.util.zeroconf.ZeroConfService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -221,10 +220,10 @@ public class Server {
             String remoteAddress;
             try {
                 serverSocket = new ServerSocket(getPortNumber());
-                SocketUtil.setReuseAddress(serverSocket, true);
+                serverSocket.setReuseAddress(true);
                 while (!socketListener.isInterrupted()) {
                     newClientConnection = serverSocket.accept();
-                    remoteAddress = SocketUtil.getRemoteSocketAddress(newClientConnection);
+                    remoteAddress = newClientConnection.getRemoteSocketAddress().toString();
                     log.info("Server: Connection from: " + remoteAddress);
                     addClient(new ClientRxHandler(remoteAddress, newClientConnection));
                 }

--- a/java/src/jmri/util/FontUtil.java
+++ b/java/src/jmri/util/FontUtil.java
@@ -13,9 +13,18 @@ import java.awt.Font;
  * 1.1.8 system, or at least try to fake it.
  *
  * @author Bob Jacobsen Copyright 2003
+ * @deprecated since 4.7.1; use methods in {@link java.awt.Font}
  */
+@Deprecated
 public class FontUtil {
 
+    /**
+     * Return a constant value of true.
+     *
+     * @return true
+     * @deprecated since 4.7.1 without replacement
+     */
+    @Deprecated
     static public boolean canRestyle() {
         return true;
     }
@@ -31,6 +40,17 @@ public class FontUtil {
         }
     }
 
+    /**
+     * Creates a new Font object by replicating the current Font object and
+     * applying a new style to it.
+     *
+     * @param f     the font
+     * @param style the style for the new Font
+     * @return a new Font object
+     * @deprecated since 4.7.1; use {@link java.awt.Font#deriveFont(int)}
+     * instead
+     */
+    @Deprecated
     static public Font deriveFont(Font f, int style) {
         if (doInit) {
             init();
@@ -50,10 +70,28 @@ public class FontUtil {
         }
     }
 
+    /**
+     * Return a constant value of true.
+     *
+     * @return true
+     * @deprecated since 4.7.1 without replacement
+     */
+    @Deprecated
     static public boolean canResize() {
         return true;
     }
 
+    /**
+     * Creates a new Font object by replicating the current Font object and
+     * applying a new size to it.
+     *
+     * @param f    the font
+     * @param size the size for the new Font
+     * @return a new Font object
+     * @deprecated since 4.7.1; use {@link java.awt.Font#deriveFont(float)}
+     * instead
+     */
+    @Deprecated
     static public Font deriveFont(Font f, float size) {
         if (doInit) {
             init();

--- a/java/src/jmri/util/SocketUtil.java
+++ b/java/src/jmri/util/SocketUtil.java
@@ -14,7 +14,10 @@ import java.net.Socket;
  * an explicit implementation when running on Java 1.1
  *
  * @author Bob Jacobsen Copyright 2006
+ * @deprecated since 4.7.1; use methods of {@link java.net.Socket} or
+ * {@link java.net.ServerSocket} directly
  */
+@Deprecated
 public class SocketUtil {
 
     /**
@@ -22,7 +25,10 @@ public class SocketUtil {
      *
      * @param socket the remotely connected socket
      * @return the address or {@literal <unknown>}
+     * @deprecated since 4.7.1; use
+     * {@link java.net.Socket#getRemoteSocketAddress()} instead
      */
+    @Deprecated
     static public String getRemoteSocketAddress(Socket socket) {
         try {
             return socket.getRemoteSocketAddress().toString();
@@ -37,9 +43,12 @@ public class SocketUtil {
      * Set the Socket's reuseAddress parameter while protecting against failure
      *
      * @param socket the socket to set
-     * @param on true if the address should be reused; false otherwise
-     * @see java.net.ServerSocket#setReuseAddress(boolean) 
+     * @param on     true if the address should be reused; false otherwise
+     * @see java.net.ServerSocket#setReuseAddress(boolean)
+     * @deprecated since 4.7.1; use
+     * {@link java.net.ServerSocket#setReuseAddress(boolean)} instead
      */
+    @Deprecated
     static public void setReuseAddress(ServerSocket socket, boolean on) {
         try {
             socket.setReuseAddress(on);


### PR DESCRIPTION
FontUtil provides wrappers around methods introduced to in Java 1.2 for objects available in earlier versions of Java. Since we only support Java 1.8 or newer, these are no longer needed.