### PR TITLE
Align Conditional states with NamedBean states

### DIFF
--- a/java/src/jmri/Conditional.java
+++ b/java/src/jmri/Conditional.java
@@ -39,10 +39,14 @@ import java.util.ArrayList;
  */
 public interface Conditional extends NamedBean {
 
-    // states 
-    public static final int TRUE = 0x01;
+    // states
+    /**
+     * @deprecated since 4.7.1; use {@link jmri.NamedBean#UNKNOWN} instead
+     */
+    @Deprecated
+    public static final int UNKNOWN = NamedBean.UNKNOWN;
     public static final int FALSE = 0x02;
-    public static final int UNKNOWN = 0x04;
+    public static final int TRUE = 0x04;
 
     // logic operators used in antecedent
     public static final int ALL_AND = 0x01;

--- a/java/src/jmri/ConditionalVariable.java
+++ b/java/src/jmri/ConditionalVariable.java
@@ -61,7 +61,7 @@ public class ConditionalVariable {
     // Conditionals and this parameter nows controls whether, if its change of state changes the
     // state of the conditional, should that also  trigger the actions.
     private boolean _triggersActions = true;
-    private int _state = Conditional.UNKNOWN;        // tri-state
+    private int _state = NamedBean.UNKNOWN;        // tri-state
 
     public ConditionalVariable() {
     }

--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -91,7 +91,7 @@ public class DefaultConditional extends AbstractNamedBean
     // actions (consequent) parameters
     protected ArrayList<ConditionalAction> _actionList = new ArrayList<ConditionalAction>();
 
-    private int _currentState = Conditional.UNKNOWN;
+    private int _currentState = NamedBean.UNKNOWN;
     private boolean _triggerActionsOnChange = true;
 
     /**
@@ -131,7 +131,7 @@ public class DefaultConditional extends AbstractNamedBean
     public void setLogicType(int type, String antecedent) {
         _logicType = type;
         _antecedent = antecedent;
-        setState(Conditional.UNKNOWN);
+        setState(NamedBean.UNKNOWN);
     }
 
     @Override
@@ -236,9 +236,9 @@ public class DefaultConditional extends AbstractNamedBean
         }
 
         // check if  there are no state variables
-        if (_variableList.size() == 0) {
+        if (_variableList.isEmpty()) {
             // if there are no state variables, no state can be calculated
-            setState(Conditional.UNKNOWN);
+            setState(NamedBean.UNKNOWN);
             return _currentState;
         }
         boolean result = true;

--- a/java/src/jmri/implementation/DefaultLogix.java
+++ b/java/src/jmri/implementation/DefaultLogix.java
@@ -260,7 +260,7 @@ public class DefaultLogix extends AbstractNamedBean
             Conditional conditional = cm.getBySystemName(_conditionalSystemNames.get(i));
             if (conditional != null) {
                 try {
-                    conditional.setState(Conditional.UNKNOWN);
+                    conditional.setState(NamedBean.UNKNOWN);
                 } catch (JmriException e) {
                     // ignore
                 }

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -5365,7 +5365,7 @@ public class LogixTableAction extends AbstractTableAction {
                             return rbx.getString("True");
                         case Conditional.FALSE:
                             return rbx.getString("False");
-                        case Conditional.UNKNOWN:
+                        case NamedBean.UNKNOWN:
                             return Bundle.getMessage("BeanStateUnknown");
                     }
                     break;
@@ -5401,7 +5401,7 @@ public class LogixTableAction extends AbstractTableAction {
                     } else if (state.equals(rbx.getString("False").toUpperCase().trim())) {
                         variable.setState(Conditional.FALSE);
                     } else {
-                        variable.setState(Conditional.UNKNOWN);
+                        variable.setState(NamedBean.UNKNOWN);
                     }
                     break;
                 case TRIGGERS_COLUMN:


### PR DESCRIPTION
Sets the Conditional UNKNOWN state to be the same as the UNKNOWN state for all other NamedBeans. This is accomplished by switching the numerical values of Conditional UNKNOWN and Conditional TRUE. It is possible some user's Jython scripts will need to be edited to reflect this.

See #2583 for the original discussion.