### PR TITLE
Accessory OpsMode Programming Fixes.

### DIFF
--- a/java/src/jmri/NmraPacket.java
+++ b/java/src/jmri/NmraPacket.java
@@ -251,15 +251,24 @@ public class NmraPacket {
     }
 
     /**
-     * From the NMRA RP: Basic Accessory Decoder Packet address for operations
-     * mode programming 10AAAAAA 0 1AAACDDD 0 1110CCVV 0 VVVVVVVV 0 DDDDDDDD
+     * Provide a basic operations mode accessory CV programming packet.
+     * <br><br>
+     * From the NMRA Standard: Basic Accessory Decoder Packet address for
+     * operations mode programming
+     * <br><br>
+     * 10AAAAAA 0 1AAACDDD
+     * <br><br>
      * Where DDD is used to indicate the output whose CVs are being modified and
-     * C=1. If CDDD= 0000 then the CVs refer to the entire decoder. The
-     * resulting packet would be {preamble} 10AAAAAA 0 1AAACDDD 0 (1110CCVV 0
-     * VVVVVVVV 0 DDDDDDDD) 0 EEEEEEEE 1 Accessory Decoder Address
-     * (Configuration Variable Access Instruction) Error Byte
+     * C=1.
+     * <br>
+     * If CDDD= 0000 then the CVs refer to the entire decoder.
+     * <br><br>
+     * The resulting packet would be
+     * <br><br>
+     * {preamble} 10AAAAAA 0 1AAACDDD 0 (1110CCVV 0 VVVVVVVV 0 DDDDDDDD) 0
+     * EEEEEEEE 1
      *
-     * @param addr          the accessory address
+     * @param addr          the decoder address
      * @param active        1 or 0
      * @param outputChannel the output on the accessory
      * @param cvNum         the CV
@@ -281,7 +290,7 @@ public class NmraPacket {
             return null;
         }
 
-        if (cvNum < 1 || cvNum > 1023) {
+        if (cvNum < 1 || cvNum > 1024) {
             log.error("invalid CV number " + cvNum);
             return null;
         }
@@ -309,27 +318,30 @@ public class NmraPacket {
     }
 
     /**
-     * From the NMRA RP: The format for Accessory Decoder Configuration Variable
-     * Access Instructions is: {preamble} 0 10AAAAAA 0 0AAA11VV 0 VVVVVVVV 0
-     * DDDDDDDD 0 EEEEEEEE 1 Where: A = Decoder address bits V = Desired CV
-     * address - (CV 513 = 10 00000000) D = Data for CV
-     *
+     * Provide a legacy operations mode accessory CV programming packet via a
+     * simplified interface, given a decoder address.
+     * <br><br>
+     * From the NMRA Standard: The format for Accessory Decoder Configuration
+     * Variable Access Instructions is: {preamble} 0 10AAAAAA 0 0AAA11VV 0
+     * VVVVVVVV 0 DDDDDDDD 0 EEEEEEEE 1 Where: A = Decoder address bits V =
+     * Desired CV address - (CV 513 = 10 00000000) D = Data for CV
+     * <br><br>
      * This is the old "legacy" format, newer decoders use the "Basic Accessory
      * Decoder Packet"
      *
-     * @param addr  the accessory address
-     * @param cvNum the CV
-     * @param data  the data
+     * @param decAddr the decoder address
+     * @param cvNum   the CV
+     * @param data    the data
      * @return a packet
      */
-    public static byte[] accDecPktOpsModeLegacy(int addr, int cvNum, int data) {
+    public static byte[] accDecPktOpsModeLegacy(int decAddr, int cvNum, int data) {
 
-        if (addr < 1 || addr > 511) {
-            log.error("invalid address " + addr);
+        if (decAddr < 1 || decAddr > 511) {
+            log.error("invalid address " + decAddr);
             return null;
         }
 
-        if (cvNum < 1 || cvNum > 1023) {
+        if (cvNum < 1 || cvNum > 1024) {
             log.error("invalid CV number " + cvNum);
             return null;
         }
@@ -339,8 +351,8 @@ public class NmraPacket {
             return null;
         }
 
-        int lowAddr = addr & 0x3F;
-        int highAddr = ((~addr) >> 6) & 0x07;
+        int lowAddr = decAddr & 0x3F;
+        int highAddr = ((~decAddr) >> 6) & 0x07;
 
         int lowCVnum = (cvNum - 1) & 0xFF;
         int highCVnum = ((cvNum - 1) >> 8) & 0x03;
@@ -529,21 +541,22 @@ public class NmraPacket {
     }
 
     /**
-     * Provide an operation mode accessory control packet via a simplified
-     * interface
+     * Provide a basic operations mode accessory CV programming packet via a
+     * simplified interface, given an accessory address.
+     * <br><br>
      *
-     * @param number Address of accessory, starting with 1
-     * @param cvNum  CV number to access
-     * @param data   Data to be written
+     * @param accAddr Address of accessory, starting with 1
+     * @param cvNum   CV number to access
+     * @param data    Data to be written
      * @return a packet
      */
-    public static byte[] accDecoderPktOpsMode(int number, int cvNum, int data) {
+    public static byte[] accDecoderPktOpsMode(int accAddr, int cvNum, int data) {
         // dBit is the "channel" info, least 7 bits, for the packet
         // The lowest channel bit represents CLOSED (1) and THROWN (0)
-        int dBits = (((number - 1) & 0x03) << 1);  // without the low CLOSED vs THROWN bit
+        int dBits = (((accAddr - 1) & 0x03) << 1) | 1;  // assume CLOSED
 
         // aBits is the "address" part of the nmra packet, which starts with 1
-        int aBits = (number - 1) >> 2;      // Divide by 4 to get the 'base'
+        int aBits = (accAddr - 1) >> 2;      // Divide by 4 to get the 'base'
         aBits += 1;                       // Base is +1
 
         // cBit is the control bit, we're always setting it active
@@ -554,18 +567,51 @@ public class NmraPacket {
     }
 
     /**
-     * Provide a legacy operation mode accessory control packet via a simplified
-     * interface
+     * Provide a basic operations mode accessory CV programming packet via a
+     * simplified interface, given a decoder address.
+     * <br><br>
      *
-     * @param number Address of accessory, starting with 1
-     * @param cvNum  CV number to access
-     * @param data   Data to be written
+     * @param decAddr Address of accessory, starting with 1
+     * @param cvNum   CV number to access
+     * @param data    Data to be written
      * @return a packet
      */
-    public static byte[] accDecoderPktOpsModeLegacy(int number, int cvNum, int data) {
+    public static byte[] accDecPktOpsMode(int decAddr, int cvNum, int data) {
+        // dBit is the "channel" info, least 7 bits, for the packet
+        // The lowest channel bit represents CLOSED (1) and THROWN (0)
+        int dBits = 1;  // assume CLOSED
 
         // aBits is the "address" part of the nmra packet, which starts with 1
-        int aBits = (number - 1) >> 2;      // Divide by 4 to get the 'base'
+        int aBits = decAddr;
+
+        // cBit is the control bit, we're always setting it active
+        int cBit = 1;
+
+        // get the packet
+        return NmraPacket.accDecoderPktOpsMode(aBits, cBit, dBits, cvNum, data);
+    }
+
+    /**
+     * Provide a legacy operations mode accessory CV programming packet via a
+     * simplified interface, given an accessory address.
+     * <br><br>
+     * From the NMRA Standard: The format for Accessory Decoder Configuration
+     * Variable Access Instructions is: {preamble} 0 10AAAAAA 0 0AAA11VV 0
+     * VVVVVVVV 0 DDDDDDDD 0 EEEEEEEE 1 Where: A = Decoder address bits V =
+     * Desired CV address - (CV 513 = 10 00000000) D = Data for CV
+     * <br><br>
+     * This is the old "legacy" format, newer decoders use the "Basic Accessory
+     * Decoder Packet"
+     *
+     * @param accAddr Address of accessory, starting with 1
+     * @param cvNum   CV number to access
+     * @param data    Data to be written
+     * @return a packet
+     */
+    public static byte[] accDecoderPktOpsModeLegacy(int accAddr, int cvNum, int data) {
+
+        // aBits is the "address" part of the nmra packet, which starts with 1
+        int aBits = (accAddr - 1) >> 2;      // Divide by 4 to get the 'base'
         aBits += 1;                       // Base is +1
 
         // get the packet

--- a/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
+++ b/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
@@ -101,13 +101,21 @@ public class AccessoryOpsModeProgrammerFacade extends AbstractProgrammerFacade i
         _val = val;
         useProgrammer(p);
         state = ProgState.PROGRAMMING;
+        byte[] b;
 
-        // send DCC command to implement prog.writeCV(cv, val, this);
-        byte[] b = NmraPacket.accDecoderPktOpsMode(aprog.getAddressNumber(), Integer.parseInt(cv), val);
+        // Send DCC commands to implement prog.writeCV(cv, val, this);
+
+        // Send a legacy ops mode accessory CV programming packet for compatibility with older decoders
+        // (Sending both packet types was also observed to benefit timing considerations - spacing effect)
+        b = NmraPacket.accDecPktOpsModeLegacy(aprog.getAddressNumber(), Integer.parseInt(cv), val);
+        InstanceManager.getDefault(CommandStation.class).sendPacket(b, 1);
+
+        // Send a basic ops mode accessory CV programming packet for newer decoders
+        b = NmraPacket.accDecPktOpsMode(aprog.getAddressNumber(), Integer.parseInt(cv), val);
         InstanceManager.getDefault(CommandStation.class).sendPacket(b, 1);
 
         // and reply done
-        p.programmingOpReply(val, ProgListener.OK);
+        this.programmingOpReply(val, ProgListener.OK);
     }
 
     @Override

--- a/java/src/jmri/implementation/ProgrammerFacadeSelector.java
+++ b/java/src/jmri/implementation/ProgrammerFacadeSelector.java
@@ -98,13 +98,15 @@ public class ProgrammerFacadeSelector {
                 log.debug("new programmer " + pf);
                 programmer = pf; // to go around and see if there are more
 
-            } else if (programmer instanceof AddressedProgrammer && fname.equals("Ops Mode Accessory Programming")) {
+            } else if (fname.equals("Ops Mode Accessory Programming")) {
+                if (programmer instanceof AddressedProgrammer) {  // create if relevant to current mode, otherwise silently ignore
 
-                jmri.implementation.AccessoryOpsModeProgrammerFacade pf
-                        = new jmri.implementation.AccessoryOpsModeProgrammerFacade((AddressedProgrammer) programmer);
+                    jmri.implementation.AccessoryOpsModeProgrammerFacade pf
+                            = new jmri.implementation.AccessoryOpsModeProgrammerFacade((AddressedProgrammer) programmer);
 
-                log.debug("new programmer " + pf);
-                programmer = pf; // to go around and see if there are more
+                    log.debug("new programmer " + pf);
+                    programmer = pf; // to go around and see if there are more
+                }
 
             } else {
                 log.error("Cannot create programmer capability named: " + fname);

--- a/java/test/jmri/NmraPacketTest.java
+++ b/java/test/jmri/NmraPacketTest.java
@@ -382,35 +382,333 @@ public class NmraPacketTest {
     }
 
     @Test
-    public void testAccDecoderPktOpsModeLegacy1() {
-        int address = 12;
-        int cv = 556;
-        int data = 34;
-        byte[] ba = NmraPacket.accDecoderPktOpsMode(address, cv, data);
+    public void testAccDecPktOpsModeLegacy1() {
+        int address = 1;
+        int cv = 29;
+        int data = 136;
+        byte[] ba = NmraPacket.accDecPktOpsModeLegacy(address, cv, data);
 
-        // the following values have not been independently validated
-        Assert.assertEquals("length", 6, ba.length);
-        Assert.assertEquals("byte 0", 0x83, ba[0] & 0xFF);
-        Assert.assertEquals("byte 1", 0xFE, ba[1] & 0xFF);
-        Assert.assertEquals("byte 2", 0xEE, ba[2] & 0xFF);
-        Assert.assertEquals("byte 3", 0x2B, ba[3] & 0xFF);
-        Assert.assertEquals("byte 4", data, ba[4] & 0xFF);
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 5, ba.length);
+        Assert.assertEquals("byte 0", 0x81, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x7C, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0x1C, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x88, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x69, ba[4] & 0xFF);
     }
 
     @Test
-    public void testAccDecoderPktOpsModeLegacy2() {
-        int address = 13;
-        int cv = 557;
-        int data = 34;
+    public void testAccDecPktOpsMode1() {
+        int address = 1;
+        int cv = 29;
+        int data = 136;
+        byte[] ba = NmraPacket.accDecPktOpsMode(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0x81, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0xF9, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEC, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x1C, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x88, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x00, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecPktOpsModeLegacy2() {
+        int address = 2;
+        int cv = 41;
+        int data = 24;
+        byte[] ba = NmraPacket.accDecPktOpsModeLegacy(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 5, ba.length);
+        Assert.assertEquals("byte 0", 0x82, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x7C, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0x28, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x18, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xCE, ba[4] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecPktOpsMode2() {
+        int address = 2;
+        int cv = 41;
+        int data = 24;
+        byte[] ba = NmraPacket.accDecPktOpsMode(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0x82, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0xF9, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEC, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x28, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x18, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0xA7, ba[5] & 0xFF);
+    }
+
+   @Test
+    public void testAccDecPktOpsModeLegacy510() {
+        int address = 510;
+        int cv = 892;
+        int data = 135;
+        byte[] ba = NmraPacket.accDecPktOpsModeLegacy(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 5, ba.length);
+        Assert.assertEquals("byte 0", 0xBE, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x0F, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0x7B, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x87, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x4D, ba[4] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecPktOpsMode510() {
+        int address = 510;
+        int cv = 892;
+        int data = 135;
+        byte[] ba = NmraPacket.accDecPktOpsMode(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0xBE, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x89, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEF, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x7B, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x87, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x24, ba[5] & 0xFF);
+    }
+
+   @Test
+    public void testAccDecPktOpsModeLegacy511() {
+        int address = 511;
+        int cv = 275;
+        int data = 198;
+        byte[] ba = NmraPacket.accDecPktOpsModeLegacy(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 5, ba.length);
+        Assert.assertEquals("byte 0", 0xBF, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x0D, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0x12, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0xC6, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x66, ba[4] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecPktOpsMode511() {
+        int address = 511;
+        int cv = 275;
+        int data = 198;
+        byte[] ba = NmraPacket.accDecPktOpsMode(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0xBF, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x89, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xED, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x12, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xC6, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x0F, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecoderPktOpsModeLegacy1() {
+        int address = 1;
+        int cv = 384;
+        int data = 255;
+        byte[] ba = NmraPacket.accDecoderPktOpsModeLegacy(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 5, ba.length);
+        Assert.assertEquals("byte 0", 0x81, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x7D, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0x7F, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0xFF, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x7C, ba[4] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecoderPktOpsMode1() {
+        int address = 1;
+        int cv = 384;
+        int data = 255;
         byte[] ba = NmraPacket.accDecoderPktOpsMode(address, cv, data);
 
-        // the following values have not been independently validated
+        // the following values validated against NCE Power Pro output
         Assert.assertEquals("length", 6, ba.length);
-        Assert.assertEquals("byte 0", 0x84, ba[0] & 0xFF);
-        Assert.assertEquals("byte 1", 0xF8, ba[1] & 0xFF);
+        Assert.assertEquals("byte 0", 0x81, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0xF9, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xED, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x7F, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xFF, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x15, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecoderPktOpsModeLegacy4() {
+        int address = 4;
+        int cv = 56;
+        int data = 0;
+        byte[] ba = NmraPacket.accDecoderPktOpsModeLegacy(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 5, ba.length);
+        Assert.assertEquals("byte 0", 0x81, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x7C, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0x37, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x00, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xCA, ba[4] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecoderPktOpsMode4() {
+        int address = 4;
+        int cv = 56;
+        int data = 0;
+        byte[] ba = NmraPacket.accDecoderPktOpsMode(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0x81, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0xFF, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEC, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x37, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x00, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0xA5, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecoderPktOpsModeLegacy5() {
+        int address = 5;
+        int cv = 1;
+        int data = 30;
+        byte[] ba = NmraPacket.accDecoderPktOpsModeLegacy(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 5, ba.length);
+        Assert.assertEquals("byte 0", 0x82, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x7C, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0x00, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x1E, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xE0, ba[4] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecoderPktOpsMode5() {
+        int address = 5;
+        int cv = 1;
+        int data = 30;
+        byte[] ba = NmraPacket.accDecoderPktOpsMode(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0x82, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0xF9, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEC, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x00, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x1E, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x89, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecoderPktOpsModeLegacy2037() {
+        int address = 2037;
+        int cv = 556;
+        int data = 175;
+        byte[] ba = NmraPacket.accDecoderPktOpsModeLegacy(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 5, ba.length);
+        Assert.assertEquals("byte 0", 0xBE, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x0E, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0x2B, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0xAF, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x34, ba[4] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecoderPktOpsMode2037() {
+        int address = 2037;
+        int cv = 556;
+        int data = 175;
+        byte[] ba = NmraPacket.accDecoderPktOpsMode(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0xBE, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x89, ba[1] & 0xFF);
         Assert.assertEquals("byte 2", 0xEE, ba[2] & 0xFF);
-        Assert.assertEquals("byte 3", 0x2C, ba[3] & 0xFF);
-        Assert.assertEquals("byte 4", data, ba[4] & 0xFF);
+        Assert.assertEquals("byte 3", 0x2B, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xAF, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x5D, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecoderPktOpsModeLegacy2040() {
+        int address = 2040;
+        int cv = 771;
+        int data = 102;
+        byte[] ba = NmraPacket.accDecoderPktOpsModeLegacy(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 5, ba.length);
+        Assert.assertEquals("byte 0", 0xBE, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x0F, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0x02, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x66, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xD5, ba[4] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecoderPktOpsMode2040() {
+        int address = 2040;
+        int cv = 771;
+        int data = 102;
+        byte[] ba = NmraPacket.accDecoderPktOpsMode(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0xBE, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x8F, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEF, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x02, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x66, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0xBA, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecoderPktOpsModeLegacy2044() {
+        int address = 2044;
+        int cv = 1024;
+        int data = 151;
+        byte[] ba = NmraPacket.accDecoderPktOpsModeLegacy(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 5, ba.length);
+        Assert.assertEquals("byte 0", 0xBF, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x0F, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xFF, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x97, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xD8, ba[4] & 0xFF);
+    }
+
+    @Test
+    public void testAccDecoderPktOpsMode2044() {
+        int address = 2044;
+        int cv = 1024;
+        int data = 151;
+        byte[] ba = NmraPacket.accDecoderPktOpsMode(address, cv, data);
+
+        // the following values validated against NCE Power Pro output
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0xBF, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x8F, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEF, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0xFF, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x97, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0xB7, ba[5] & 0xFF);
     }
 
     @Test


### PR DESCRIPTION
Fixes and improvements for Accessory OpsMode Programming:
- Fix incorrect programming packet address calculation from Decoder Primary Address.
- Fix problem that prevented more than one CV from being programmed per instance.
- Now sends both legacy and new style commands, improving compatibility and also incidentally improving programming reliability.
- Prevent spurious error message from ProgrammerFacadeSelector when opening the accessory definition in Program Track mode.
- More improvements to come...
- Added a needed overloaded method to NmraPacket.
- Refactoring in NmraPacket to clarify difference between Decoder Address & Accessory Address.
- JavaDoc corrections and improvements.
- Added many extra tests, particularly corner cases. Test results now verify against actual packet captures from NCE system (has inbuilt Accessory OpsMode Programming).