### PR TITLE
Bypass WARN message routinely issued in CI test

### DIFF
--- a/java/test/jmri/jmrix/openlcb/swing/monitor/MonitorFrameTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/monitor/MonitorFrameTest.java
@@ -46,6 +46,9 @@ public class MonitorFrameTest {
         Assert.assertEquals("formatted", "S: Alias 0x678 CID 2 frame\n", testFormatted);
         Assert.assertEquals("raw", "[12345678] 01 02                  ", testRaw);
         f.dispose();
+        
+        // accept WARN message due to defect in code as written - see #3091
+        jmri.util.JUnitAppender.assertWarnMessage("No User Preferences Manager, not saving format"); 
     }
 
     @Test
@@ -72,6 +75,9 @@ public class MonitorFrameTest {
         Assert.assertEquals("formatted", "R: Alias 0x678 CID 2 frame\n", testFormatted);
         Assert.assertEquals("raw", "[12345678] 01 02                  ", testRaw);
         f.dispose();
+        
+        // accept WARN message due to defect in code as written - see #3091
+        jmri.util.JUnitAppender.assertWarnMessage("No User Preferences Manager, not saving format"); 
     }
 
     // The minimal setup for log4J


### PR DESCRIPTION
See #3091 

Bypass WARN message routinely (due to existing issue in code, not transient defect) emitted in CI test.  Part of trying to make "WARN" happen in CI only when there's something to, well, warn against.

Note: #3091 is about the issue in the code and should stay open; this is just about the repetitive message during testing.