### PR TITLE
Address issues reported with 4.7.0 launcher

### DIFF
--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -519,9 +519,9 @@ EXIT_STATUS=${RESTART_CODE}
 while [ "${EXIT_STATUS}" -eq "${RESTART_CODE}" ] ; do
 
     if [ "$OS" = "macosx" ] ; then
-        "${JAVACMD}" "${DOCK_OPTIONS[@]}" ${OPTIONS} ${ALTPORTS} ${CONFIGFILE} -cp "${CP}" "${CLASSNAME}" ${ARGS}
+        "${JAVACMD}" "${DOCK_OPTIONS[@]}" ${OPTIONS} ${CONFIGFILE} -cp "${CP}" "${CLASSNAME}" ${ARGS}
     else
-        "${JAVACMD}" ${OPTIONS} ${ALTPORTS} ${CONFIGFILE} -cp "${CP}" "${CLASSNAME}" ${ARGS}
+        "${JAVACMD}" ${OPTIONS} ${CONFIGFILE} -cp "${CP}" "${CLASSNAME}" ${ARGS}
     fi
 
     EXIT_STATUS=$?


### PR DESCRIPTION
@dsand47 noted that ALTPORTS needed to be defined. This variable is no longer filled out by the JMRI launcher, so it needs to be removed completely.

 Since PJC uses a different property (and one that is not amenable to path completion) than RXTX, alternate ports need to be defined using the ```-J-Dpurejavacomm.portnamepattern=PORTNAME``` property as documented in JMRI/website#123 (awaiting merge of the PJC branch into JMRI/master before being merged itself).