### PR TITLE
Infrastructure for normalizing usernames

### DIFF
--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -40,11 +40,10 @@
       <b>As of February 2017, we are considering a change to 
         the allowable user names: They can't have leading or trailing
         spaces.  If this change is made, the names will be "trimmed"
-        whenever entered.  You can try it out by executing
-        <code><pre>
-        jmri.NamedBean.doUserNameTrimming = True
-        </pre></code>
-        in a script.
+        whenever entered.  If you have a copy of the code 
+        checked out, you can test this by modifying the jmri.NamedBean
+        class following the instructions in the normalizeUserName(..) routine,
+        rebuilding and running </b> 
         
       <h2>What's in a name?</h2>Why do we need names at all, rather
       than just references within the code? There are several

--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -37,6 +37,15 @@
       objects (hardware and software), and how user-readable names
       are used.
 
+      <b>As of February 2017, we are considering a change to 
+        the allowable user names: They can't have leading or trailing
+        spaces.  If this change is made, the names will be "trimmed"
+        whenever entered.  You can try it out by executing
+        <code><pre>
+        jmri.NamedBean.doUserNameTrimming = True
+        </pre></code>
+        in a script.
+        
       <h2>What's in a name?</h2>Why do we need names at all, rather
       than just references within the code? There are several
       important uses:

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -63,7 +63,7 @@ public interface NamedBean {
     @CheckForNull
     public String getUserName();
 
-    public void setUserName(@CheckForNull String s);
+    public void setUserName(@CheckForNull String s) throws BadUserNameException;
 
     /**
      * Get a system-specific name. This encodes the hardware addressing
@@ -289,4 +289,21 @@ public interface NamedBean {
     @CheckReturnValue
     @Nonnull
     public String getBeanType();
+    
+    /**
+     * Enforces, and as a user convenience converts to, the standard form for a user name.
+     * <p>
+     * This implementation just passes the name through, but later versions might 
+     * e.g. trim leading and trailing spaces.
+     *
+     * @param inputName 
+     * @throws CantNormalizeNameException If the inputName can't be converted to normalized form
+     * @return A user name in standard normalized form 
+     */
+    @CheckReturnValue
+    static public @Nonnull String normalizeUserName(@Nonnull String inputName) throws BadUserNameException {
+        return inputName;
+    }
+    public class BadUserNameException extends IllegalArgumentException {}
+
 }

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -12,12 +12,20 @@ import javax.annotation.Nonnull;
  * Provides common services for classes representing objects on the layout, and
  * allows a common form of access by their Managers.
  * <P>
- * Each object has a two names. The "user" name is entirely free form, and can
- * be used for any purpose. The "system" name is provided by the system-specific
+ * Each object has a two names. The "user" name is free form text except for two restrictions:
+ * <ul>
+ * <li>It can't be the empty string "".  No user name is coded as a null.
+ * <li>And eventually, we may insist on normalizing user names to e.g. remove leading and trailing white space; 
+ *     see see the normalizeUserName method
+ * </ul><p> 
+ * The "system" name is provided by the system-specific
  * implementations, and provides a unique mapping to the layout control system
- * (e.g. LocoNet, NCE, etc) and address within that system. Each of these two
- * names must be unique for every NamedBean on the layout and a single NamedBean
- * cannot have a user name that is the same as its system name. Note that this
+ * (e.g. LocoNet, NCE, etc) and address within that system. 
+ * <p>
+ * Each of these two
+ * names must be unique for every NamedBean of the same type on the layout and a single NamedBean
+ * cannot have a user name that is the same as another of the same type's system name. 
+ * Note that this
  * restriction is not currently enforced, only warned about; a future version of
  * JMRI will enforce this restriction.
  *

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -304,8 +304,8 @@ public interface NamedBean {
      * This implementation just passes the name through, but later versions might 
      * e.g. trim leading and trailing spaces.
      *
-     * @param inputName 
-     * @throws CantNormalizeNameException If the inputName can't be converted to normalized form
+     * @param inputName User name to be normalized
+     * @throws BadUserNameException If the inputName can't be converted to normalized form
      * @return A user name in standard normalized form 
      */
     @CheckReturnValue

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -12,23 +12,29 @@ import javax.annotation.Nonnull;
  * Provides common services for classes representing objects on the layout, and
  * allows a common form of access by their Managers.
  * <P>
- * Each object has a two names. The "user" name is free form text except for two restrictions:
- * <ul>
- * <li>It can't be the empty string "".  No user name is coded as a null.
- * <li>And eventually, we may insist on normalizing user names to e.g. remove leading and trailing white space; 
- *     see see the normalizeUserName method
- * </ul><p> 
+ * Each object has two types of names:<p>
  * The "system" name is provided by the system-specific
  * implementations, and provides a unique mapping to the layout control system
- * (e.g. LocoNet, NCE, etc) and address within that system. 
+ * (e.g. LocoNet, NCE, etc) and address within that system. It must 
+ * be present and unique across the JMRI instance.
  * <p>
+ * The "user" name is optional. It's free form text except for two restrictions:
+ * <ul>
+ * <li>It can't be the empty string "".  (A non-existant user name is coded as a null)
+ * <li>And eventually, we may insist on normalizing user names to a specific form, 
+ *     e.g. remove leading and trailing white space; 
+ *     see the {@link #normalizeUserName(java.lang.String)} method
+ * </ul><p> 
  * Each of these two
  * names must be unique for every NamedBean of the same type on the layout and a single NamedBean
- * cannot have a user name that is the same as another of the same type's system name. 
- * Note that this
- * restriction is not currently enforced, only warned about; a future version of
- * JMRI will enforce this restriction.
- *
+ * cannot have a user name that is the same as the system name of another NamedBean of the same type. 
+ * (The complex wording is saying that a single NamedBean object is allowed to have its 
+ * system name and user name be the same, but that's the only non-uniqueness that's allowed within a specific type).
+ * Note that the uniqueness restrictions are currently not completely 
+ * enforced, only warned about; a future version of JMRI will enforce this restriction.
+ *<p>
+ * For more information, see the <a href="http://jmri.org/help/en/html/doc/Technical/Names.shtml">Names and Naming</a> page
+ * in the <a href="http://jmri.org/help/en/html/doc/Technical/index.shtml">Technical Info</a> pages.
  * <hr>
  * This file is part of JMRI.
  * <P>

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -302,8 +302,11 @@ public interface NamedBean {
      */
     @CheckReturnValue
     static public @Nonnull String normalizeUserName(@Nonnull String inputName) throws BadUserNameException {
+        // doUserNameTrim is a _temporary_ control value to allow debugging of trimmed user names
+        if (doUserNameTrimming) return inputName.trim();
         return inputName;
     }
     public class BadUserNameException extends IllegalArgumentException {}
-
+    // an Ugly Hack to permit e.g. turning on "trim usernames" via a script
+    public static boolean doUserNameTrimming = false;
 }

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -302,11 +302,9 @@ public interface NamedBean {
      */
     @CheckReturnValue
     static public @Nonnull String normalizeUserName(@Nonnull String inputName) throws BadUserNameException {
-        // doUserNameTrim is a _temporary_ control value to allow debugging of trimmed user names
-        if (doUserNameTrimming) return inputName.trim();
+        // uncomment next line to allow debugging of trimmed user names
+        // return inputName.trim();
         return inputName;
     }
     public class BadUserNameException extends IllegalArgumentException {}
-    // an Ugly Hack to permit e.g. turning on "trim usernames" via a script
-    public static boolean doUserNameTrimming = false;
 }

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -23,9 +23,12 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
         mUserName = null;
     }
 
-    protected AbstractNamedBean(String sys, String user) {
+    protected AbstractNamedBean(String sys, String user) throws NamedBean.BadUserNameException {
         this(sys);
-        mUserName = user;
+        if (user != null)
+            mUserName = NamedBean.normalizeUserName(user);
+        else
+            mUserName = null;
     }
 
     /**
@@ -174,10 +177,13 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
     }
 
     @Override
-    public void setUserName(String s) {
+    public void setUserName(String s) throws NamedBean.BadUserNameException {
         String old = mUserName;
-        mUserName = s;
-        firePropertyChange("UserName", old, s);
+        if (s != null)
+            mUserName = NamedBean.normalizeUserName(s);
+        else
+            mUserName = null;
+        firePropertyChange("UserName", old, mUserName);
     }
 
     @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC",

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -2,6 +2,7 @@ package jmri.implementation;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.CheckReturnValue;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -25,10 +26,10 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
 
     protected AbstractNamedBean(String sys, String user) throws NamedBean.BadUserNameException {
         this(sys);
-        if (user != null)
-            mUserName = NamedBean.normalizeUserName(user);
-        else
-            mUserName = null;
+
+        // this is really a transition from null -> name, but nobody is
+        // listening yet
+        setUserName(user);
     }
 
     /**
@@ -47,6 +48,7 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
      * @param comment Null means no comment associated.
      */
     @Override
+    @OverridingMethodsMustInvokeSuper
     public void setComment(String comment) {
         String old = this.comment;
         if (comment == null || comment.isEmpty() || comment.trim().length() < 1 ) {
@@ -92,6 +94,7 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
     final Hashtable<PropertyChangeListener, String> listenerRefs = new Hashtable<>();
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public synchronized void addPropertyChangeListener(PropertyChangeListener l, String beanRef, String listenerRef) {
         pcs.addPropertyChangeListener(l);
         if (beanRef != null) {
@@ -103,11 +106,13 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
     }
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public synchronized void addPropertyChangeListener(PropertyChangeListener l) {
         pcs.addPropertyChangeListener(l);
     }
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public synchronized void removePropertyChangeListener(PropertyChangeListener l) {
         pcs.removePropertyChangeListener(l);
         if (l != null) {
@@ -142,6 +147,7 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
     }
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public synchronized void updateListenerRef(PropertyChangeListener l, String newName) {
         if (listenerRefs.containsKey(l)) {
             listenerRefs.put(l, newName);
@@ -177,6 +183,7 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
     }
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public void setUserName(String s) throws NamedBean.BadUserNameException {
         String old = mUserName;
         if (s != null)
@@ -192,11 +199,13 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
 
     protected String mSystemName;
 
+    @OverridingMethodsMustInvokeSuper
     protected void firePropertyChange(String p, Object old, Object n) {
         pcs.firePropertyChange(p, old, n);
     }
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public void dispose() {
         PropertyChangeListener[] listeners = pcs.getPropertyChangeListeners();
         for (PropertyChangeListener l : listeners) {
@@ -217,7 +226,8 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
     }
 
     @Override
-    public void setProperty(String key, Object value) {
+    @OverridingMethodsMustInvokeSuper
+        public void setProperty(String key, Object value) {
         if (parameters == null) {
             parameters = new HashMap<String, Object>();
         }
@@ -225,6 +235,7 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
     }
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public Object getProperty(String key) {
         if (parameters == null) {
             parameters = new HashMap<String, Object>();
@@ -233,6 +244,7 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
     }
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public java.util.Set<String> getPropertyKeys() {
         if (parameters == null) {
             parameters = new HashMap<String, Object>();
@@ -241,6 +253,7 @@ public abstract class AbstractNamedBean implements NamedBean, java.io.Serializab
     }
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public void removeProperty(String key) {
         if (parameters == null || key == null) {
             return;

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -137,6 +137,8 @@ public class LayoutBlock extends AbstractNamedBean implements java.beans.Propert
      * Note: initializeLayoutBlock() must be called to complete the process. They are split
      *       so  that loading of panel files will be independent of whether LayoutBlocks or
      *       Blocks are loaded first.
+     * @param sName System name of this LayoutBlock; will be converted to upper case
+     * @param uName User name of this LayoutBlock but also the user name of the associated Block
      */
     public LayoutBlock(String sName, String uName) {
         super(sName.toUpperCase(), uName);
@@ -3121,32 +3123,21 @@ public class LayoutBlock extends AbstractNamedBean implements java.beans.Propert
         return false;
     }
 
-    java.beans.PropertyChangeSupport pcs = new java.beans.PropertyChangeSupport(this);
-
     @Override
     public synchronized void addPropertyChangeListener(java.beans.PropertyChangeListener l) {
         if (l == this) {
             if (enableAddRouteLogging) {
-                log.info("adding ourselves as a listener for some strange reason!");
+                log.info("adding ourselves as a listener for some strange reason! Skipping");
             }
             return;
         }
 
-        pcs.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public synchronized void removePropertyChangeListener(java.beans.PropertyChangeListener l) {
-        pcs.removePropertyChangeListener(l);
-    }
-
-    @Override
-    protected void firePropertyChange(String p, Object old, Object n) {
-        pcs.firePropertyChange(p, old, n);
+        super.addPropertyChangeListener(l);
     }
 
     @Override
     public void propertyChange(java.beans.PropertyChangeEvent e) {
+        
         if (e.getSource() instanceof LayoutBlock) {
             LayoutBlock srcEvent = (LayoutBlock) e.getSource();
 

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -176,7 +176,14 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
         String systemName = s.getSystemName();
         _tsys.put(systemName, s);
         String userName = s.getUserName();
+        
         if (userName != null) {
+            // enforce uniqueness of user names
+            // by setting username to null in any existing bean with the same name
+            // Note that this is not a "move" operation for the user name
+            if (_tuser.get(userName)!=null && _tuser.get(userName)!=s ) _tuser.get(userName).setUserName(null);
+            
+            // store the new bean under the name
             _tuser.put(userName, s);
         }
         firePropertyChange("length", null, _tsys.size());

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -11,6 +11,7 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 import jmri.ConfigureManager;
 import jmri.InstanceManager;
 import jmri.Manager;
@@ -23,6 +24,10 @@ import org.slf4j.LoggerFactory;
  * <P>
  * Note that this does not enforce any particular system naming convention at
  * the present time. They're just names...
+ * <P>
+ * It does include, with AbstractNamedBean, the implementation of the 
+ * normalized user name.  
+ * @see jmri.NamedBean#normalizeUserName
  *
  * @author Bob Jacobsen Copyright (C) 2003
  */
@@ -32,16 +37,12 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
         registerSelf();
     }
 
-    /*public AbstractManager(int order) {
-     // register the result for later configuration
-     xmlorder = order;
-     registerSelf();
-     }*/
     /**
      * By default, register this manager to store as configuration information.
      * Override to change that.
      *
      */
+    @OverridingMethodsMustInvokeSuper
     protected void registerSelf() {
         log.debug("registerSelf for config of type {}", getClass());
         ConfigureManager cm = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
@@ -60,6 +61,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
     }
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public void dispose() {
         ConfigureManager cm = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
         if (cm != null) {
@@ -95,7 +97,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
      * @return requested Turnout object or null if none exists
      */
     protected Object getInstanceByUserName(String userName) {
-        return _tuser.get(userName);
+        return _tuser.get(NamedBean.normalizeUserName(userName));
     }
 
     /**
@@ -119,7 +121,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
      */
     @Override
     public NamedBean getBeanByUserName(String userName) {
-        return _tuser.get(userName);
+        return _tuser.get(NamedBean.normalizeUserName(userName));
     }
 
     /**
@@ -131,7 +133,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
      */
     @Override
     public NamedBean getNamedBean(String name) {
-        NamedBean b = getBeanByUserName(name);
+        NamedBean b = getBeanByUserName(NamedBean.normalizeUserName(name));
         if (b != null) {
             return b;
         }
@@ -152,6 +154,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
      *                               be aborted.
      */
     @Override
+    @OverridingMethodsMustInvokeSuper
     public void deleteBean(@Nonnull NamedBean bean, @Nonnull String property) throws PropertyVetoException {
         try {
             fireVetoableChange(property, bean, null);
@@ -172,6 +175,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
      * @param s the bean to register
      */
     @Override
+    @OverridingMethodsMustInvokeSuper
     public void register(NamedBean s) {
         String systemName = s.getSystemName();
         _tsys.put(systemName, s);
@@ -199,6 +203,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
      * @param s the bean to forget
      */
     @Override
+    @OverridingMethodsMustInvokeSuper
     public void deregister(NamedBean s) {
         s.removePropertyChangeListener(this);
         String systemName = s.getSystemName();
@@ -220,6 +225,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
      * @param e the event
      */
     @Override
+    @OverridingMethodsMustInvokeSuper
     public void propertyChange(PropertyChangeEvent e) {
         if (e.getPropertyName().equals("UserName")) {
             String old = (String) e.getOldValue();  // previous user name
@@ -284,15 +290,18 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
     PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public synchronized void addPropertyChangeListener(PropertyChangeListener l) {
         pcs.addPropertyChangeListener(l);
     }
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public synchronized void removePropertyChangeListener(PropertyChangeListener l) {
         pcs.removePropertyChangeListener(l);
     }
 
+    @OverridingMethodsMustInvokeSuper
     protected void firePropertyChange(String p, Object old, Object n) {
         pcs.firePropertyChange(p, old, n);
     }
@@ -300,11 +309,13 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
     VetoableChangeSupport vcs = new VetoableChangeSupport(this);
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public synchronized void addVetoableChangeListener(VetoableChangeListener l) {
         vcs.addVetoableChangeListener(l);
     }
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public synchronized void removeVetoableChangeListener(VetoableChangeListener l) {
         vcs.removeVetoableChangeListener(l);
     }
@@ -326,6 +337,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
      * @throws PropertyVetoException - if the recipients wishes the delete to be
      *                               aborted.
      */
+    @OverridingMethodsMustInvokeSuper
     protected void fireVetoableChange(String p, Object old, Object n) throws PropertyVetoException {
         PropertyChangeEvent evt = new PropertyChangeEvent(this, p, old, n);
         if (p.equals("CanDelete")) { //IN18N
@@ -353,6 +365,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
     }
 
     @Override
+    @OverridingMethodsMustInvokeSuper
     public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
 
         if ("CanDelete".equals(evt.getPropertyName())) { //IN18N

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -215,14 +215,20 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
     @Override
     public void propertyChange(PropertyChangeEvent e) {
         if (e.getPropertyName().equals("UserName")) {
-            String old = (String) e.getOldValue();  // OldValue is actually system name
-            String now = (String) e.getNewValue();
+            String old = (String) e.getOldValue();  // previous user name
+            String now = (String) e.getNewValue();  // current user name
             NamedBean t = (NamedBean) e.getSource();
             if (old != null) {
-                _tuser.remove(old);
+                _tuser.remove(old); // remove old name for this bean
             }
             if (now != null) {
-                _tuser.put(now, t);
+                // was there previously a bean with the new name?
+                if (_tuser.get(now) != null) {
+                    // If so, clear. Note that this is not a "move" operation
+                    _tuser.get(now).setUserName(null);
+                }
+                
+                _tuser.put(now, t); // put new name for this bean
             }
 
             //called DisplayListName, as DisplayName might get used at some point by a NamedBean

--- a/java/src/jmri/managers/configurexml/AbstractLightManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractLightManagerConfigXML.java
@@ -145,6 +145,8 @@ public abstract class AbstractLightManagerConfigXML extends AbstractNamedBeanMan
 
             String userName = getUserName(lightList.get(i));
 
+            checkNameNormalization(sysName, userName, tm);
+
             if (log.isDebugEnabled()) {
                 log.debug("create light: (" + sysName + ")("
                         + (userName == null ? "<null>" : userName) + ")");

--- a/java/src/jmri/managers/configurexml/AbstractMemoryManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractMemoryManagerConfigXML.java
@@ -135,6 +135,8 @@ public abstract class AbstractMemoryManagerConfigXML extends AbstractNamedBeanMa
 
             String userName = getUserName(memoryList.get(i));
 
+            checkNameNormalization(sysName, userName, tm);
+
             if (log.isDebugEnabled()) {
                 log.debug("create Memory: (" + sysName + ")(" + (userName == null ? "<null>" : userName) + ")");
             }

--- a/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
@@ -169,7 +169,7 @@ public abstract class AbstractNamedBeanManagerConfigXML extends jmri.configurexm
             }
             
             NamedBean bean = manager.getBeanByUserName(normalizedUserName);
-            if (bean != null) {
+            if (bean != null && !bean.getSystemName().equals(rawSystemName)) {
                 log.warn("User name \"{}\" already exists as system name \"{}\"", normalizedUserName, bean.getSystemName());
             }
         }

--- a/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractNamedBeanManagerConfigXML.java
@@ -2,6 +2,7 @@ package jmri.managers.configurexml;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
+import javax.annotation.Nonnull;
 import jmri.NamedBean;
 import org.jdom2.Attribute;
 import org.jdom2.Element;
@@ -140,6 +141,38 @@ public abstract class AbstractNamedBeanManagerConfigXML extends jmri.configurexm
             return elem.getAttribute("systemName").getValue();
         }
         return null;
+    }
+
+    /**
+     * Common service routine to check for and report on
+     * normalization (errors) in the incoming NamedBean's 
+     * name(s)
+     * <p>
+     * If NamedBeam.normalizeUserName changes, this may want to be updated.
+     * <p>
+     * Right now, this just logs. Someday, perhaps it should notify
+     * upward of found issues by e.g. throwing or returning a error object.
+     *
+     * Package-level access to allow testing
+     *
+     * @param rawSystemName The proposed system name string, before normalization
+     * @param rawUserName The proposed user name string, before normalization
+     * @param manager The NamedBeanManager that will be storing this
+     */
+    void checkNameNormalization(@Nonnull String rawSystemName, String rawUserName, @Nonnull jmri.Manager manager) {
+        // just check and log
+        if (rawUserName!= null) {
+            String normalizedUserName = NamedBean.normalizeUserName(rawUserName);
+            if (! rawUserName.equals(normalizedUserName)) {
+                log.warn("Requested user name \"{}\" for system name \"{}\" was normalized to \"{}\"",
+                        rawUserName, rawSystemName, normalizedUserName);
+            }
+            
+            NamedBean bean = manager.getBeanByUserName(normalizedUserName);
+            if (bean != null) {
+                log.warn("User name \"{}\" already exists as system name \"{}\"", normalizedUserName, bean.getSystemName());
+            }
+        }
     }
 
     /**

--- a/java/src/jmri/managers/configurexml/AbstractSensorManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractSensorManagerConfigXML.java
@@ -161,6 +161,8 @@ public abstract class AbstractSensorManagerConfigXML extends AbstractNamedBeanMa
 
             String userName = getUserName(sensorList.get(i));
 
+            checkNameNormalization(sysName, userName, tm);
+
             if (sensorList.get(i).getAttribute("inverted") != null) {
                 if (sensorList.get(i).getAttribute("inverted").getValue().equals("true")) {
                     inverted = true;

--- a/java/src/jmri/managers/configurexml/AbstractTurnoutManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractTurnoutManagerConfigXML.java
@@ -223,6 +223,9 @@ public abstract class AbstractTurnoutManagerConfigXML extends AbstractNamedBeanM
                 break;
             }
             String userName = getUserName(elem);
+
+            checkNameNormalization(sysName, userName, tm);
+
             if (log.isDebugEnabled()) {
                 log.debug("create turnout: (" + sysName + ")(" + (userName == null ? "<null>" : userName) + ")");
             }

--- a/java/test/jmri/BlockManagerTest.java
+++ b/java/test/jmri/BlockManagerTest.java
@@ -45,17 +45,17 @@ public class BlockManagerTest extends TestCase {
 
     public void testNameIncrement() {
         // original create with no systemname and an empty username
-        Block b1 = InstanceManager.getDefault(jmri.BlockManager.class).createNewBlock("");
+        Block b1 = InstanceManager.getDefault(jmri.BlockManager.class).createNewBlock(null);
         Assert.assertEquals("system name 1", "IB:AUTO:0001", b1.getSystemName());
-        Assert.assertEquals("user name 1", "", b1.getUserName());
+        Assert.assertEquals("user name 1", null, b1.getUserName());
 
-        Block b2 = InstanceManager.getDefault(jmri.BlockManager.class).createNewBlock("");
+        Block b2 = InstanceManager.getDefault(jmri.BlockManager.class).createNewBlock(null);
         Assert.assertEquals("system name 2", "IB:AUTO:0002", b2.getSystemName());
-        Assert.assertEquals("user name 2", "", b2.getUserName());
+        Assert.assertEquals("user name 2", null, b2.getUserName());
 
         // and b1 still OK
         Assert.assertEquals("system name 1", "IB:AUTO:0001", b1.getSystemName());
-        Assert.assertEquals("user name 1", "", b1.getUserName());
+        Assert.assertEquals("user name 1", null, b1.getUserName());
     }
 
     public void testProvideWorksTwice() {

--- a/java/test/jmri/NamedBeanTest.java
+++ b/java/test/jmri/NamedBeanTest.java
@@ -1,0 +1,53 @@
+package jmri;
+
+import jmri.util.JUnitUtil;
+import org.junit.Assert;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Tests for the NamedBean interface
+ *
+ * @author	Bob Jacobsen Copyright (C) 2017
+ */
+public class NamedBeanTest extends TestCase {
+
+    // Note: This shows that BadUserNameException doesn't (yet) have to be caught or declared
+    // Eventually that will go away, and that'll be OK
+    public void testNormalizePassThrough() {
+        String testString = "  foo ";
+        String normalForm = NamedBean.normalizeUserName(testString);
+        Assert.assertEquals(testString, normalForm);
+    }
+
+    
+    // from here down is testing infrastructure
+    public NamedBeanTest(String s) {
+        super(s);
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {NamedBeanTest.class.getName()};
+        junit.textui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        TestSuite suite = new TestSuite(NamedBeanTest.class);
+        return suite;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        apps.tests.Log4JFixture.setUp();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        apps.tests.Log4JFixture.tearDown();
+    }
+}

--- a/java/test/jmri/PackageTest.java
+++ b/java/test/jmri/PackageTest.java
@@ -34,6 +34,7 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.BlockManagerTest.suite());
         suite.addTest(jmri.DccLocoAddressTest.suite());
         suite.addTest(jmri.InstanceManagerTest.suite());
+        suite.addTest(jmri.NamedBeanTest.suite());
         suite.addTest(jmri.LightTest.suite());
         suite.addTest(new JUnit4TestAdapter(NmraPacketTest.class));
         suite.addTest(jmri.ConditionalVariableTest.suite());

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
@@ -48,6 +48,20 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         Assert.assertNull(l.getSensor(name.toLowerCase()));
     }
 
+    @Override
+    @Test
+    public void testMoveUserName() {
+        Sensor t1 = l.provideSensor("MSX0A;+N15E" + getNumToTest1());
+        Sensor t2 = l.provideSensor("MSX0A;+N15E" + getNumToTest2());
+        t1.setUserName("UserName");
+        Assert.assertTrue(t1 == l.getByUserName("UserName"));
+        
+        t2.setUserName("UserName");
+        Assert.assertTrue(t2 == l.getByUserName("UserName"));
+
+        Assert.assertTrue(null == t1.getUserName());
+    }
+
     // The minimal setup for log4J
     @Override
     @Before

--- a/java/test/jmri/jmrix/ieee802154/xbee/XBeeSensorManagerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/XBeeSensorManagerTest.java
@@ -66,6 +66,20 @@ public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         Assert.assertNull(l.getSensor(name.toLowerCase()));
     }
 
+    @Test
+    public void testMoveUserName() {
+        Sensor t1 = l.provideSensor("ABCS2:" + getNumToTest1());
+        Sensor t2 = l.provideSensor("ABCS2:" + getNumToTest2());
+        t1.setUserName("UserName");
+        Assert.assertTrue(t1 == l.getByUserName("UserName"));
+        
+        t2.setUserName("UserName");
+        Assert.assertTrue(t2 == l.getByUserName("UserName"));
+
+        Assert.assertTrue(null == t1.getUserName());
+    }
+
+
 
     // The minimal setup for log4J
     @Override

--- a/java/test/jmri/jmrix/openlcb/OlcbSensorManagerTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSensorManagerTest.java
@@ -43,6 +43,20 @@ public class OlcbSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         Assert.assertNull(l.getSensor(name.toLowerCase()));
     }
 
+    @Override
+    @Test
+    public void testMoveUserName() {
+        Sensor t1 = l.provideSensor("MSx010203040506070" + getNumToTest1());
+        Sensor t2 = l.provideSensor("MSx010203040506070" + getNumToTest2());
+        t1.setUserName("UserName");
+        Assert.assertTrue(t1 == l.getByUserName("UserName"));
+        
+        t2.setUserName("UserName");
+        Assert.assertTrue(t2 == l.getByUserName("UserName"));
+
+        Assert.assertTrue(null == t1.getUserName());
+    }
+
     @Test
     public void testDotted() {
         // olcb addresses are hex values requirng 16 digits.

--- a/java/test/jmri/jmrix/pi/RaspberryPiSensorManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiSensorManagerTest.java
@@ -14,7 +14,10 @@ import jmri.Sensor;
 /**
  * <P>
  * Tests for RaspberryPiSensorManager
- * </P>
+ * </P><p>
+ * This is somehow not reseting the GPIO support, so each reference to a "pin"
+ * needs to be do a different one, even across multiple test types
+ *
  * @author Paul Bender Copyright (C) 2016
  */
 public class RaspberryPiSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
@@ -65,7 +68,6 @@ public class RaspberryPiSensorManagerTest extends jmri.managers.AbstractSensorMg
     @Override
     @Test
     public void testRename() {
-        // get light
         Sensor t1 = l.newSensor(getSystemName(12), "before");
         Assert.assertNotNull("t1 real object ", t1);
         t1.setUserName("after");
@@ -84,6 +86,19 @@ public class RaspberryPiSensorManagerTest extends jmri.managers.AbstractSensorMg
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(13)));
     }
 
+    @Override
+    @Test
+    public void testMoveUserName() {
+        Sensor t1 = l.provideSensor("21");
+        Sensor t2 = l.provideSensor("22");
+        t1.setUserName("UserName");
+        Assert.assertTrue(t1 == l.getByUserName("UserName"));
+        
+        t2.setUserName("UserName");
+        Assert.assertTrue(t2 == l.getByUserName("UserName"));
+
+        Assert.assertTrue(null == t1.getUserName());
+    }
 
 
     @Override

--- a/java/test/jmri/jmrix/powerline/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/powerline/SerialSensorManagerTest.java
@@ -20,6 +20,18 @@ public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest
         return "PSP" + i;
     }
 
+    /**
+     * Number of sensor to test. Made a separate method so it can be overridden
+     * in subclasses that do or don't support various numbers
+     */
+    protected int getNumToTest1() {
+        return 8;
+    }
+
+    protected int getNumToTest2() {
+        return 9;
+    }
+
     @Test
     public void testSensorCreationAndRegistration() {
         l.provideSensor("PSA3");
@@ -66,6 +78,20 @@ public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest
         String name = t.getSystemName();
         Assert.assertNull(l.getSensor(name.toLowerCase()));
     }
+
+    @Test
+    public void testMoveUserName() {
+        Sensor t1 = l.provideSensor("PSP" + getNumToTest1());
+        Sensor t2 = l.provideSensor("PSP" + getNumToTest2());
+        t1.setUserName("UserName");
+        Assert.assertTrue(t1 == l.getByUserName("UserName"));
+        
+        t2.setUserName("UserName");
+        Assert.assertTrue(t2 == l.getByUserName("UserName"));
+
+        Assert.assertTrue(null == t1.getUserName());
+    }
+
 
     // The minimal setup for log4J
     @Override

--- a/java/test/jmri/jmrix/rps/RpsSensorManagerTest.java
+++ b/java/test/jmri/jmrix/rps/RpsSensorManagerTest.java
@@ -47,6 +47,18 @@ public class RpsSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBas
         Assert.assertNull(l.getSensor(name.toLowerCase()));
     }
 
+    @Test
+    public void testMoveUserName() {
+        Sensor t1 = l.provideSensor("RS(0,0,0);(1,0,0);(1,1,0);(0,1,0)");
+        Sensor t2 = l.provideSensor("RS(0,0,0);(1,0,0);(1,1,0);(0,1,2)");
+        t1.setUserName("UserName");
+        Assert.assertTrue(t1 == l.getByUserName("UserName"));
+        
+        t2.setUserName("UserName");
+        Assert.assertTrue(t2 == l.getByUserName("UserName"));
+
+        Assert.assertTrue(null == t1.getUserName());
+    }
 
     @Override
     @Before

--- a/java/test/jmri/managers/AbstractSensorMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractSensorMgrTestBase.java
@@ -98,6 +98,19 @@ public abstract class AbstractSensorMgrTestBase {
     }
 
     @Test
+    public void testMoveUserName() {
+        Sensor t1 = l.provideSensor("" + getNumToTest1());
+        Sensor t2 = l.provideSensor("" + getNumToTest2());
+        t1.setUserName("UserName");
+        Assert.assertTrue(t1 == l.getByUserName("UserName"));
+        
+        t2.setUserName("UserName");
+        Assert.assertTrue(t2 == l.getByUserName("UserName"));
+
+        Assert.assertTrue(null == t1.getUserName());
+    }
+
+    @Test
     public void testUpperLower() {
         Sensor t = l.provideSensor("" + getNumToTest2());
         String name = t.getSystemName();


### PR DESCRIPTION
Adds infrastructure and associated corrections for normalizing (in whatever form decided) the format of user names on all NamedBeans.

- The normalization is currently turned off.  To e.g. add a `trim(..)` operation, add it in the `normalizeUserNames(..)` method at the bottom of `jmri.NamedBean`

- When normalization is finally turned on, it'll be enforced when a bean is created or has it's user name changed, including when loading from a Panel XML file.  If the normalization operation changes the name, a message like the falling is logged. Note removal of trailing spaces.
```
WARN  - Requested user name "Biff  " for system name "LS3" was normalized to "Biff"
```

- If a duplicate user name appears while loading (either due to normalization or for any other reason), a message will be logged:
```
WARN  - User name "Biff" already exists as system name "LS1"
```

Note: No significant user cueing has been added to GUI elements.  That's for another day, when hopefully we'll create a small number of standard input widgets to handle this.