### PR TITLE
Allow 'output' as a synonym for 'accessory' in Address Type

### DIFF
--- a/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
+++ b/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
@@ -599,8 +599,9 @@ selects the different algorithm needed here.
 
         <li>"Indicator" - value added to the value being stored to
         High Address CV to tell the decoder to use this mode.</li>
-      </ul><a id="accessoryops" name="accessoryops"></a>
+      </ul>
 
+      <a id="accessoryops" name="accessoryops"></a>
       <h4>Accessory Decoder Ops Mode</h4>Special programming
       packets are used by certain accessory decoders to configure
       their CVs from the DCC track signal. The capability to do
@@ -613,7 +614,7 @@ selects the different algorithm needed here.
 </pre>The "Address Type" parameter is optional:
       <ul>
           <li>If it is "decoder" or omitted, the current address is interpreted as a 9-bit decoder address.</li>
-          <li>If it is "accessory", the current address is interpreted as a 14-bit accessory address.</li>
+          <li>If it is "accessory" or "output", the current address is interpreted as an 11-bit accessory address.</li>
       </ul>
       <p>
         Note that this only works for

--- a/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
+++ b/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
@@ -115,7 +115,7 @@ public class AccessoryOpsModeProgrammerFacade extends AbstractProgrammerFacade i
         byte[] b;
 
         // Send DCC commands to implement prog.writeCV(cv, val, this);
-        if ((_addrType != null) && _addrType.equalsIgnoreCase("accessory")) {  // interpret address as accessory address
+        if ((_addrType != null) && (_addrType.equalsIgnoreCase("accessory") || _addrType.equalsIgnoreCase("output"))) {  // interpret address as accessory address
             // Send a basic ops mode accessory CV programming packet for newer decoders
             b = NmraPacket.accDecoderPktOpsMode(aprog.getAddressNumber(), Integer.parseInt(cv), val);
             InstanceManager.getDefault(CommandStation.class).sendPacket(b, 1);


### PR DESCRIPTION
- Allow 'output' as a synonym for 'accessory' address type as per S9.2.2 usage.
- Fix typo.