### PR TITLE
Better message when roster date parse fails

### DIFF
--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -541,7 +541,7 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
         try {
             this.setDateModified(s);
         } catch (ParseException ex) {
-            log.warn("Unable to parse {} as a date.", s);
+            log.warn("Unable to parse \"{}\" as a date in roster entry \"{}\".", s, getId());
             // property change is fired by setDateModified if s parses as a date
             firePropertyChange(RosterEntry.DATE_UPDATED, old, s);
         }

--- a/java/test/jmri/jmrit/roster/RosterEntryTest.java
+++ b/java/test/jmri/jmrit/roster/RosterEntryTest.java
@@ -116,6 +116,15 @@ public class RosterEntryTest extends TestCase {
 
     }
 
+    public void testModifyDate() {
+        RosterEntry r = new RosterEntry("file here");
+
+        r.setId("test Id");
+        r.setDateUpdated("unparseable date");
+        
+        jmri.util.JUnitAppender.assertWarnMessage("Unable to parse \"unparseable date\" as a date in roster entry \"test Id\"."); 
+    }
+
     public void testStoreFunctionLockable() {
         RosterEntry r = new RosterEntry("file here");
 


### PR DESCRIPTION
includes test case.