### PR TITLE
Fix roster entry print fail when no pane name

### DIFF
--- a/java/src/jmri/jmrit/roster/PrintRosterEntry.java
+++ b/java/src/jmri/jmrit/roster/PrintRosterEntry.java
@@ -26,6 +26,7 @@ import jmri.util.BusyGlassPane;
 import jmri.util.FileUtil;
 import jmri.util.JmriJFrame;
 import jmri.util.davidflanagan.HardcopyWriter;
+import org.jdom2.Attribute;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -130,10 +131,16 @@ public class PrintRosterEntry implements PaneContainer {
 
         @SuppressWarnings("unchecked")
         List<Element> rawPaneList = base.getChildren("pane");
-        for (int i = 0; i < rawPaneList.size(); i++) {
+        for (Element elPane : rawPaneList) {
             // load each pane
-            String name = rawPaneList.get(i).getAttribute("name").getValue();
-            PaneProgPane p = new PaneProgPane(this, name, rawPaneList.get(i), cvModel, iCvModel, variableModel, d.getModelElement(), _rosterEntry);
+            Attribute attr = elPane.getAttribute("name");
+            String name = "";
+            if (attr != null) {
+                name = attr.getValue();
+            } else {
+                log.debug("Did not find name attribute in pane");
+            }
+            PaneProgPane p = new PaneProgPane(this, name, elPane, cvModel, iCvModel, variableModel, d.getModelElement(), _rosterEntry);
             _paneList.add(p);
         }
     }

--- a/java/src/jmri/util/swing/GuiUtilBase.java
+++ b/java/src/jmri/util/swing/GuiUtilBase.java
@@ -190,12 +190,8 @@ public class GuiUtilBase {
         public void actionPerformed(java.awt.event.ActionEvent e) {
             try {
                 method.invoke(obj, args);
-            } catch (IllegalArgumentException ex) {
-                System.out.println("IllegalArgument " + ex);
-            } catch (IllegalAccessException ex) {
-                System.out.println("IllegalAccess " + ex);
-            } catch (java.lang.reflect.InvocationTargetException ex) {
-                System.out.println("InvocationTarget " + ex.toString());
+            } catch (IllegalArgumentException |  IllegalAccessException | java.lang.reflect.InvocationTargetException ex) {
+               log.error("Exception in actionPerformed", ex);
             }
         }
     }

--- a/java/src/jmri/util/swing/JMenuUtil.java
+++ b/java/src/jmri/util/swing/JMenuUtil.java
@@ -175,13 +175,13 @@ public class JMenuUtil extends GuiUtilBase {
                 }
             });
         } catch (IllegalArgumentException ex) {
-            System.out.println("IllegalArgument " + ex);
+            log.error("IllegalArgument in setMenuItemInterAction ", ex);
         } catch (IllegalAccessException ex) {
-            System.out.println("IllegalAccess " + ex);
+            log.error("IllegalAccess in setMenuItemInterAction ", ex);
         } catch (java.lang.reflect.InvocationTargetException ex) {
-            System.out.println("InvocationTarget " + ref + " " + ex.getCause());
+            log.error("InvocationTarget {} in setMenuItemInterAction ", ref, ex);
         } catch (java.lang.NullPointerException ex) {
-            System.out.println("NPE " + context.getClass().getName() + " " + ex.toString());
+            log.error("NPE {} in setMenuItemInterAction ", context.getClass().getName(), ex);
         }
 
     }


### PR DESCRIPTION
Closes #3156 

Print would fail when one or more panes didn't have a specific name.  Also improved some logging.