### PR TITLE
Allow control over whether Sensors invert

### DIFF
--- a/java/src/jmri/Sensor.java
+++ b/java/src/jmri/Sensor.java
@@ -69,6 +69,14 @@ public interface Sensor extends NamedBean {
      */
     public boolean getInverted();
 
+     /**
+     * Determine if sensor can be inverted. When a turnout is inverted the
+     * {@link #ACTIVE} and {@link #INACTIVE} states are inverted on the layout.
+     *
+     * @return true if can be inverted; false otherwise
+     */
+    public boolean canInvert();
+
     /**
      * Remove references to and from this object, so that it can eventually be
      * garbage-collected.

--- a/java/src/jmri/implementation/AbstractSensor.java
+++ b/java/src/jmri/implementation/AbstractSensor.java
@@ -282,6 +282,11 @@ public abstract class AbstractSensor extends AbstractNamedBean implements Sensor
         return _inverted;
     }
 
+    /**
+     * By default, all implementations based on this can invert
+     */
+    public boolean canInvert() { return true; }
+
     protected boolean _inverted = false;
 
     // internal data members

--- a/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
@@ -190,7 +190,13 @@ public class SensorTableDataModel extends BeanTableDataModel {
 
     @Override
     public boolean isCellEditable(int row, int col) {
-        if (col == INVERTCOL || col == EDITCOL) {
+        String name = sysNameList.get(row);
+        Sensor sen = senManager.getBySystemName(name);
+        if (sen == null) return false;
+        if (col == INVERTCOL) {
+            return sen.canInvert();
+        }
+        if (col == EDITCOL) {
             return true;
         }
         if (col == USEGLOBALDELAY) {
@@ -198,16 +204,10 @@ public class SensorTableDataModel extends BeanTableDataModel {
         }
         //Need to do something here to make it disable 
         if (col == ACTIVEDELAY || col == INACTIVEDELAY) {
-            String name = sysNameList.get(row);
-            Sensor sen = senManager.getBySystemName(name);
-            if (sen == null) {
+            if (sen.useDefaultTimerSettings()) {
                 return false;
             } else {
-                if (sen.useDefaultTimerSettings()) {
-                    return false;
-                } else {
-                    return true;
-                }
+                return true;
             }
         } else {
             return super.isCellEditable(row, col);


### PR DESCRIPTION
- Added `canInvert()` to Sensor interface, by analogy to Turnout.  
- Sensor table will show invert checkbox disabled if `canInvert()` returns false

Systems that aren't able to invert (don't obey that part of the interface) should please re-implement `canInvert()` to return `true`, or even better implement the invert calls.  I haven't scanned to determine which systems don't do invert properly.