### PR TITLE
Infrastructure to normalize systemname

### DIFF
--- a/java/src/jmri/ConditionalVariable.java
+++ b/java/src/jmri/ConditionalVariable.java
@@ -622,6 +622,10 @@ public class ConditionalVariable {
         return (result);
     }
 
+    /**
+     * Note: _num1 determines the comparison used. Can be 0, LESS_THAN, LESS_THAN_OR_EQUAL,
+     * EQUAL, GREATER_THAN_OR_EQUAL or GREATER_THAN.
+     */
     boolean compare(String value1, String value2, boolean caseInsensitive) {
         if (value1 == null) {
             return value2 == null;

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -248,6 +248,6 @@ public interface Manager {
      * @return A system name in standard normalized form 
      */
     @CheckReturnValue
-    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws BadUserNameException;
-    public class BadUserNameException extends IllegalArgumentException {}
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws BadSystemNameException;
+    public class BadSystemNameException extends IllegalArgumentException {}
 }

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -238,4 +238,16 @@ public interface Manager {
     @CheckReturnValue
     @Nonnull
     public String getBeanTypeHandled();
+
+    /**
+     * Enforces, and as a user convenience converts to, the standard form for a system name
+     * for the NamedBeans handled by this manager.
+     *
+     * @param inputName System name to be normalized
+     * @throws BadSystemNameException If the inputName can't be converted to normalized form
+     * @return A system name in standard normalized form 
+     */
+    @CheckReturnValue
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws BadUserNameException;
+    public class BadUserNameException extends IllegalArgumentException {}
 }

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -248,6 +248,5 @@ public interface Manager {
      * @return A system name in standard normalized form 
      */
     @CheckReturnValue
-    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws BadSystemNameException;
-    public class BadSystemNameException extends IllegalArgumentException {}
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException;
 }

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -244,7 +244,7 @@ public interface Manager {
      * for the NamedBeans handled by this manager.
      *
      * @param inputName System name to be normalized
-     * @throws BadSystemNameException If the inputName can't be converted to normalized form
+     * @throws NamedBean.BadSystemNameException If the inputName can't be converted to normalized form
      * @return A system name in standard normalized form 
      */
     @CheckReturnValue

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -315,7 +315,7 @@ public interface NamedBean {
      * @return A user name in standard normalized form 
      */
     @CheckReturnValue
-    static public @Nonnull String normalizeUserName(@Nonnull String inputName) throws BadUserNameException {
+    static public @CheckForNull String normalizeUserName(@CheckForNull String inputName) throws BadUserNameException {
         // uncomment next line to allow debugging of trimmed user names
         // return inputName.trim();
         return inputName;

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -321,4 +321,5 @@ public interface NamedBean {
         return inputName;
     }
     public class BadUserNameException extends IllegalArgumentException {}
+    public class BadSystemNameException extends IllegalArgumentException {}
 }

--- a/java/src/jmri/jmrit/signalling/EntryExitPairs.java
+++ b/java/src/jmri/jmrit/signalling/EntryExitPairs.java
@@ -270,7 +270,7 @@ public class EntryExitPairs implements jmri.Manager, jmri.InstanceManagerAutoDef
      */
     @Override
     @CheckReturnValue
-    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws Manager.BadSystemNameException {
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
         return inputName;
     }
 

--- a/java/src/jmri/jmrit/signalling/EntryExitPairs.java
+++ b/java/src/jmri/jmrit/signalling/EntryExitPairs.java
@@ -265,7 +265,7 @@ public class EntryExitPairs implements jmri.Manager, jmri.InstanceManagerAutoDef
      * for the NamedBeans handled by this manager.
      *
      * @param inputName System name to be normalized
-     * @throws BadSystemNameException If the inputName can't be converted to normalized form
+     * @throws NamedBean.BadSystemNameException If the inputName can't be converted to normalized form
      * @return A system name in standard normalized form 
      */
     @Override

--- a/java/src/jmri/jmrit/signalling/EntryExitPairs.java
+++ b/java/src/jmri/jmrit/signalling/EntryExitPairs.java
@@ -14,9 +14,13 @@ import java.util.List;
 import java.util.Map.Entry;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import jmri.ConfigureManager;
 import jmri.InstanceManager;
 import jmri.JmriException;
+import jmri.Manager;
 import jmri.NamedBean;
 import jmri.Sensor;
 import jmri.jmrit.display.layoutEditor.LayoutBlock;
@@ -254,6 +258,20 @@ public class EntryExitPairs implements jmri.Manager, jmri.InstanceManagerAutoDef
     @Override
     public String makeSystemName(String s) {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    /**
+     * Enforces, and as a user convenience converts to, the standard form for a system name
+     * for the NamedBeans handled by this manager.
+     *
+     * @param inputName System name to be normalized
+     * @throws BadSystemNameException If the inputName can't be converted to normalized form
+     * @return A system name in standard normalized form 
+     */
+    @Override
+    @CheckReturnValue
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws Manager.BadSystemNameException {
+        return inputName;
     }
 
     @Override

--- a/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
@@ -51,7 +51,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      * for the NamedBeans handled by this manager.
      *
      * @param inputName System name to be normalized
-     * @throws BadSystemNameException If the inputName can't be converted to normalized form
+     * @throws NamedBean.BadSystemNameException If the inputName can't be converted to normalized form
      * @return A system name in standard normalized form 
      */
     @Override

--- a/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.grapevine;
 
 import jmri.Manager;
+import jmri.NamedBean;
 import jmri.Sensor;
 import javax.annotation.CheckForNull;
 import javax.annotation.CheckReturnValue;
@@ -55,7 +56,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      */
     @Override
     @CheckReturnValue
-    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws Manager.BadSystemNameException {
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
         return SerialAddress.normalizeSystemName(inputName);
     }
 

--- a/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
@@ -1,6 +1,10 @@
 package jmri.jmrix.grapevine;
 
+import jmri.Manager;
 import jmri.Sensor;
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,12 +45,18 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
         return "G";
     }
 
-    /*
-     * Normalize names
+    /**
+     * Enforces, and as a user convenience converts to, the standard form for a system name
+     * for the NamedBeans handled by this manager.
+     *
+     * @param inputName System name to be normalized
+     * @throws BadSystemNameException If the inputName can't be converted to normalized form
+     * @return A system name in standard normalized form 
      */
     @Override
-    protected String normalizeSystemName(String sysName) {
-        return SerialAddress.normalizeSystemName(sysName);
+    @CheckReturnValue
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws Manager.BadSystemNameException {
+        return SerialAddress.normalizeSystemName(inputName);
     }
 
     /**

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -412,7 +412,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
      * @return A system name in standard normalized form 
      */
     @CheckReturnValue
-    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws jmri.Manager.BadUserNameException {
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws jmri.Manager.BadSystemNameException {
         return inputName;
     }
 

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -408,7 +408,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
      * for the NamedBeans handled by this manager.
      *
      * @param inputName System name to be normalized
-     * @throws BadSystemNameException If the inputName can't be converted to normalized form
+     * @throws NamedBean.BadSystemNameException If the inputName can't be converted to normalized form
      * @return A system name in standard normalized form 
      */
     @CheckReturnValue

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -412,7 +412,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
      * @return A system name in standard normalized form 
      */
     @CheckReturnValue
-    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws jmri.Manager.BadSystemNameException {
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
         return inputName;
     }
 

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -11,6 +11,7 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.CheckReturnValue;
 import javax.annotation.OverridingMethodsMustInvokeSuper;
 import jmri.ConfigureManager;
 import jmri.InstanceManager;
@@ -400,6 +401,19 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
                 }
             }
         }
+    }
+
+    /**
+     * Enforces, and as a user convenience converts to, the standard form for a system name
+     * for the NamedBeans handled by this manager.
+     *
+     * @param inputName System name to be normalized
+     * @throws BadSystemNameException If the inputName can't be converted to normalized form
+     * @return A system name in standard normalized form 
+     */
+    @CheckReturnValue
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws jmri.Manager.BadUserNameException {
+        return inputName;
     }
 
     private final static Logger log = LoggerFactory.getLogger(AbstractManager.class.getName());

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -130,7 +130,7 @@ abstract public class AbstractProxyManager implements Manager {
      */
     @Override
     @CheckReturnValue
-    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws Manager.BadSystemNameException {
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
         int index = matchTentative(inputName);
         if (index >= 0) {
             return getMgr(index).normalizeSystemName(inputName);

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -8,6 +8,9 @@ import jmri.NamedBean;
 import jmri.util.SystemNameComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 
 /**
  * Implementation of a Manager that can serves as a proxy for multiple
@@ -115,6 +118,28 @@ abstract public class AbstractProxyManager implements Manager {
     }
 
     /**
+     * Enforces, and as a user convenience converts to, the standard form for a system name
+     * for the NamedBeans handled by this manager and its submanagers.
+     * <p>
+     * Attempts to match by system prefix first.
+     * <p> 
+     *
+     * @param inputName System name to be normalized
+     * @throws BadSystemNameException If the inputName can't be converted to normalized form
+     * @return A system name in standard normalized form 
+     */
+    @Override
+    @CheckReturnValue
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws Manager.BadSystemNameException {
+        int index = matchTentative(inputName);
+        if (index >= 0) {
+            return getMgr(index).normalizeSystemName(inputName);
+        }
+        log.debug("normalizeSystemName did not find manager for name " + inputName + ", defer to default");
+        return getMgr(0).normalizeSystemName(inputName);
+    }
+
+    /**
      * Locate via user name, then system name if needed. If that fails, create a
      * new NamedBean: If the name is a valid system name, it will be used for
      * the new NamedBean. Otherwise, the makeSystemName method will attempt to
@@ -137,7 +162,7 @@ abstract public class AbstractProxyManager implements Manager {
         if (index >= 0) {
             return makeBean(index, name, null);
         }
-        log.debug("Did not find manager for name " + name + ", defer to default");
+        log.debug("provideNamedBean did not find manager for name " + name + ", defer to default");
         return makeBean(0, getMgr(0).makeSystemName(name), null);
     }
 

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -125,7 +125,7 @@ abstract public class AbstractProxyManager implements Manager {
      * <p> 
      *
      * @param inputName System name to be normalized
-     * @throws BadSystemNameException If the inputName can't be converted to normalized form
+     * @throws NamedBean.BadSystemNameException If the inputName can't be converted to normalized form
      * @return A system name in standard normalized form 
      */
     @Override

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -83,10 +83,6 @@ public abstract class AbstractSensorManager extends AbstractManager implements S
         return (Sensor) _tuser.get(key);
     }
 
-    protected String normalizeSystemName(String sysName) {
-        return sysName;
-    }
-
     @Override
     public Sensor newSensor(String sysName, String userName) throws IllegalArgumentException {
         log.debug(" newSensor(\"{}\", \"{}\"", sysName, userName);

--- a/java/src/jmri/managers/DefaultSignalMastLogicManager.java
+++ b/java/src/jmri/managers/DefaultSignalMastLogicManager.java
@@ -22,6 +22,9 @@ import jmri.jmrit.display.layoutEditor.LayoutBlockConnectivityTools;
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 
 /**
  * Default implementation of a SignalMastLogicManager.
@@ -262,6 +265,20 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
     @Override
     public String makeSystemName(String s) {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    /**
+     * Enforces, and as a user convenience converts to, the standard form for a system name
+     * for the NamedBeans handled by this manager.
+     *
+     * @param inputName System name to be normalized
+     * @throws BadSystemNameException If the inputName can't be converted to normalized form
+     * @return A system name in standard normalized form 
+     */
+    @Override
+    @CheckReturnValue
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws Manager.BadSystemNameException {
+        return inputName;
     }
 
     @Override

--- a/java/src/jmri/managers/DefaultSignalMastLogicManager.java
+++ b/java/src/jmri/managers/DefaultSignalMastLogicManager.java
@@ -272,7 +272,7 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
      * for the NamedBeans handled by this manager.
      *
      * @param inputName System name to be normalized
-     * @throws BadSystemNameException If the inputName can't be converted to normalized form
+     * @throws NamedBean.BadSystemNameException If the inputName can't be converted to normalized form
      * @return A system name in standard normalized form 
      */
     @Override

--- a/java/src/jmri/managers/DefaultSignalMastLogicManager.java
+++ b/java/src/jmri/managers/DefaultSignalMastLogicManager.java
@@ -277,7 +277,7 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
      */
     @Override
     @CheckReturnValue
-    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws Manager.BadSystemNameException {
+    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
         return inputName;
     }
 

--- a/java/test/jmri/jmrix/can/cbus/CbusReporterManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusReporterManagerTest.java
@@ -16,7 +16,7 @@ import jmri.jmrix.can.TrafficControllerScaffold;
 public class CbusReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
-    public String getSystemName(int i) {
+    public String getSystemName(String i) {
         return "MR" + i;
     }
 

--- a/java/test/jmri/jmrix/dcc4pc/Dcc4PcReporterManagerTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/Dcc4PcReporterManagerTest.java
@@ -15,7 +15,7 @@ import org.junit.Before;
 public class Dcc4PcReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
-    public String getSystemName(int i) {
+    public String getSystemName(String i) {
         return "DPR" + i;
     }
 

--- a/java/test/jmri/jmrix/ecos/EcosReporterManagerTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosReporterManagerTest.java
@@ -13,7 +13,7 @@ import org.junit.Before;
 public class EcosReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
-    public String getSystemName(int i) {
+    public String getSystemName(String i) {
         return "UR" + i;
     }
 

--- a/java/test/jmri/jmrix/internal/InternalReporterManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalReporterManagerTest.java
@@ -13,7 +13,7 @@ import org.junit.Before;
 public class InternalReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
-    public String getSystemName(int i) {
+    public String getSystemName(String i) {
         return "IR" + i;
     }
 

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientReporterManagerTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientReporterManagerTest.java
@@ -14,7 +14,7 @@ import org.junit.Before;
 public class JMRIClientReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
-    public String getSystemName(int i) {
+    public String getSystemName(String i) {
         return "JR" + i;
     }
 

--- a/java/test/jmri/jmrix/loconet/LnReporterManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnReporterManagerTest.java
@@ -13,7 +13,7 @@ import org.junit.Before;
 public class LnReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
-    public String getSystemName(int i) {
+    public String getSystemName(String i) {
         return "LR" + i;
     }
 
@@ -37,29 +37,5 @@ public class LnReporterManagerTest extends jmri.managers.AbstractReporterMgrTest
     }
 
     @Override
-    protected int getNumToTest1() {
-        return 1;
-    }
-
-    @Override
-    protected int getNumToTest2() {
-        return 1;
-    }
-
-    @Override
-    protected int getNumToTest3() {
-        return 1;
-    }
-
-    @Override
-    protected int getNumToTest4() {
-        return 1;
-    }
-
-    @Override
-    protected int getNumToTest5() {
-        return 1;
-    }
-
-
+    protected int maxN() { return 1; }
 }

--- a/java/test/jmri/jmrix/rfid/RfidReporterManagerTest.java
+++ b/java/test/jmri/jmrix/rfid/RfidReporterManagerTest.java
@@ -18,7 +18,7 @@ public class RfidReporterManagerTest extends jmri.managers.AbstractReporterMgrTe
     RfidTrafficController tc = null;
 
     @Override
-    public String getSystemName(int i) {
+    public String getSystemName(String i) {
         return "RR" + i;
     }
 
@@ -33,6 +33,30 @@ public class RfidReporterManagerTest extends jmri.managers.AbstractReporterMgrTe
     @Override
     @Ignore("Abstract Class under test, test does not apply")
     public void testDefaultSystemName(){
+    }
+
+    @Test
+    @Override
+    @Ignore("Abstract Class under test, test does not apply")
+    public void testReporterProvideReporter(){
+    }
+
+    @Test
+    @Override
+    @Ignore("Abstract Class under test, test does not apply")
+    public void testReporterGetByDisplayName(){
+    }
+
+    @Test
+    @Override
+    @Ignore("Abstract Class under test, test does not apply")
+    public void testReporterGetBySystemName(){
+    }
+
+    @Test
+    @Override
+    @Ignore("Abstract Class under test, test does not apply")
+    public void testReporterGetByUserName(){
     }
 
     @Test

--- a/java/test/jmri/jmrix/rfid/generic/standalone/StandaloneReporterManagerTest.java
+++ b/java/test/jmri/jmrix/rfid/generic/standalone/StandaloneReporterManagerTest.java
@@ -2,18 +2,20 @@ package jmri.jmrix.rfid.generic.standalone;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
+
+import org.junit.Assert;
 
 /**
- * StandaloneReporterManagerTest.java
- *
- * Description:	tests for the StandaloneReporterManager class
+ * Note: Standalone only allows _one_ NamedBean, named e.g. RR1, which means certain tests
+ * are defaulted away.
  *
  * @author	Paul Bender Copyright (C) 2012,2016
  */
 public class StandaloneReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
-    public String getSystemName(int i) {
+    public String getSystemName(String i) {
         return "RR" + i;
     }
 
@@ -22,7 +24,7 @@ public class StandaloneReporterManagerTest extends jmri.managers.AbstractReporte
     // The minimal setup for log4J
     @Before
     @Override
-    public void setUp() {
+    public void setUp() {   
         apps.tests.Log4JFixture.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         tc = new StandaloneTrafficController(new StandaloneSystemConnectionMemo(){
@@ -45,29 +47,10 @@ public class StandaloneReporterManagerTest extends jmri.managers.AbstractReporte
     }
 
     @Override
-    protected int getNumToTest1() {
-        return 1;
-    }
+    protected int maxN() { return 1; }
 
     @Override
-    protected int getNumToTest2() {
-        return 1;
+    protected String getNameToTest1() {
+        return "1";
     }
-
-    @Override
-    protected int getNumToTest3() {
-        return 1;
-    }
-
-    @Override
-    protected int getNumToTest4() {
-        return 1;
-    }
-
-    @Override
-    protected int getNumToTest5() {
-        return 1;
-    }
-
-
 }

--- a/java/test/jmri/jmrix/rfid/merg/concentrator/ConcentratorReporterManagerTest.java
+++ b/java/test/jmri/jmrix/rfid/merg/concentrator/ConcentratorReporterManagerTest.java
@@ -16,30 +16,21 @@ import jmri.Reporter;
 public class ConcentratorReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
-    public String getSystemName(int i) {
+    public String getSystemName(String i) {
         return "RR" + "A";
     }
 
-    @Test
     @Override
-    public void testDefaultSystemName() {
-        // create - Merg Concentrator uses letters instead of numbers
-        Reporter t = l.provideReporter("" + "A");
-        // check
-        Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest3())));
-    }
-
-
-    @Test
+    protected int maxN() { return 1; }
+    
     @Override
-    public void testUpperLower() {
-        // Merg concentrator uses letters instead of numbers.
-        Reporter t = l.provideReporter("" + "C");
-        String name = t.getSystemName();
-        Assert.assertNull(l.getReporter(name.toLowerCase()));
+    protected String getNameToTest1() {
+        return "A";
     }
-
+    @Override
+    protected String getNameToTest2() {
+        return "C";
+    }
 
     ConcentratorTrafficController tc = null;
 

--- a/java/test/jmri/jmrix/roco/z21/Z21ReporterManagerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21ReporterManagerTest.java
@@ -1,10 +1,12 @@
 package jmri.jmrix.roco.z21;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 
 /**
- * Tests for Z21ReporterManager class.
+ * The class being tested only has one reporter, hence some tests pulled down.
  *
  * @author Paul Bender Copyright (C) 2016
  **/
@@ -12,7 +14,7 @@ import org.junit.Before;
 public class Z21ReporterManagerTest extends jmri.managers.AbstractReporterMgrTestBase {
 
     @Override
-    public String getSystemName(int i) {
+    public String getSystemName(String i) {
         return "ZR" + i;
     }
 
@@ -36,29 +38,11 @@ public class Z21ReporterManagerTest extends jmri.managers.AbstractReporterMgrTes
    }
 
     @Override
-    protected int getNumToTest1() {
-        return 1;
-    }
-
+    protected int maxN() { return 1; }
+    
     @Override
-    protected int getNumToTest2() {
-        return 1;
+    protected String getNameToTest1() {
+        return "1";
     }
-
-    @Override
-    protected int getNumToTest3() {
-        return 1;
-    }
-
-    @Override
-    protected int getNumToTest4() {
-        return 1;
-    }
-
-    @Override
-    protected int getNumToTest5() {
-        return 1;
-    }
-
 
 }

--- a/java/test/jmri/managers/AbstractReporterMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractReporterMgrTestBase.java
@@ -24,12 +24,16 @@ import org.junit.Ignore;
  */
 public abstract class AbstractReporterMgrTestBase {
 
+    /**
+     * Max number of Reporters supported.  Override to return 1 if 
+     * only 1 can be created, for example
+     */
+    protected int maxN() { return 100; }
+    
     // implementing classes must provide these abstract members:
-    //
-    @Before
-    abstract public void setUp();    	// load l with actual object; create scaffolds as needed
+    abstract public void setUp();    	// load l with actual object; create scaffolds as needed, tag @Before
 
-    abstract public String getSystemName(int i);
+    abstract public String getSystemName(String i);
 
     protected ReporterManager l = null;	// holds objects under test
 
@@ -56,17 +60,17 @@ public abstract class AbstractReporterMgrTestBase {
     }
 
     @Test
-    @Ignore("Bad test.  Where is the USER NAME Fred set?")
     public void testReporterProvideReporter() {
         // Create
-        Reporter t = l.provideReporter("" + getNumToTest1());
+        Reporter t = l.provideReporter("" + getNameToTest1());
+        t.setUserName("Fred");
         // check
         Assert.assertTrue("real object returned ", t != null);
         Assert.assertTrue("user name correct ", t == l.getByUserName("Fred"));
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
+        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNameToTest1())));
 
         // Check that "providing" an already-created reporter returns the same object.
-        Reporter t2 = l.provideReporter("" + getNumToTest2());
+        Reporter t2 = l.provideReporter(t.getSystemName());
         Assert.assertTrue("provided same object ", t == t2);
     }
 
@@ -77,22 +81,29 @@ public abstract class AbstractReporterMgrTestBase {
     }
 
     @Test
-    @Ignore("Bad test.  Depends on testReporterProvideReporter.  Must be independent or depend on BeforeClass and Before methods only.")
     public void testReporterGetBySystemName() {
-        // Try a successful one -- the one that was added in testReporterProvideReporter()
-        Reporter t = l.getBySystemName(getSystemName(getNumToTest1()));
+        // Create
+        Reporter t = l.provideReporter("" + getNameToTest1());
+        t.setUserName("Fred");
+
+        // Try a successful one
+        t = l.getBySystemName(getSystemName(getNameToTest1()));
         Assert.assertTrue("get retrieved existing object ", t != null);
 
         // Try a nonexistant one. Should return null
-        t = l.getBySystemName(getSystemName(getNumToTest2()));
+        if (maxN()<2) return;
+        t = l.getBySystemName(getSystemName(getNameToTest2()));
         Assert.assertTrue("get nonexistant object ", t == null);
     }
 
     @Test
-    @Ignore("Bad test.  Depends on testReporterProvideReporter.  Must be independent or depend on BeforeClass and Before methods only.")
     public void testReporterGetByUserName() {
-        // Try a successful one -- the one that was added in testReporterProvideReporter()
-        Reporter t = l.getByUserName("Fred");
+        // Create
+        Reporter t = l.provideReporter("" + getNameToTest1());
+        t.setUserName("Fred");
+
+        // Try a successful one
+        t = l.getByUserName("Fred");
         Assert.assertTrue("get retrieved existing object ", t != null);
 
         // Try a nonexistant one. Should return null
@@ -101,10 +112,13 @@ public abstract class AbstractReporterMgrTestBase {
     }
 
     @Test
-    @Ignore("Bad test.  Depends on testReporterProvideReporter.  Must be independent or depend on BeforeClass and Before methods only.")
     public void testReporterGetByDisplayName() {
-        // Try a successful one -- the one that was added in testReporterProvideReporter()
-        Reporter t = l.getByDisplayName(getSystemName(getNumToTest1()));
+        // Create
+        Reporter t = l.provideReporter("" + getNameToTest1());
+        t.setUserName("Fred");
+
+        // Try a successful one
+        t = l.getByDisplayName(getSystemName(getNameToTest1()));
         Assert.assertTrue("get retrieved existing object ", t != null);
 
         Reporter t2 = l.getByDisplayName("Fred");
@@ -114,21 +128,21 @@ public abstract class AbstractReporterMgrTestBase {
     @Test
     public void testDefaultSystemName() {
         // create
-        Reporter t = l.provideReporter("" + getNumToTest3());
+        Reporter t = l.provideReporter("" + getNameToTest1());
         // check
         Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest3())));
+        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNameToTest1())));
     }
 
     @Test
     public void testSingleObject() {
         // test that you always get the same representation
-        Reporter t1 = l.newReporter(getSystemName(getNumToTest4()), "mine");
+        Reporter t1 = l.newReporter(getSystemName(getNameToTest1()), "mine");
         Assert.assertTrue("t1 real object returned ", t1 != null);
         Assert.assertTrue("same by user ", t1 == l.getByUserName("mine"));
-        Assert.assertTrue("same by system ", t1 == l.getBySystemName(getSystemName(getNumToTest4())));
+        Assert.assertTrue("same by system ", t1 == l.getBySystemName(getSystemName(getNameToTest1())));
 
-        Reporter t2 = l.newReporter(getSystemName(getNumToTest4()), "mine");
+        Reporter t2 = l.newReporter(getSystemName(getNameToTest1()), "mine");
         Assert.assertTrue("t2 real object returned ", t2 != null);
         // check
         Assert.assertTrue("same new ", t1 == t2);
@@ -143,7 +157,7 @@ public abstract class AbstractReporterMgrTestBase {
 
     @Test
     public void testUpperLower() {
-        Reporter t = l.provideReporter("" + getNumToTest2());
+        Reporter t = l.provideReporter("" + getNameToTest1());
         String name = t.getSystemName();
         Assert.assertNull(l.getReporter(name.toLowerCase()));
     }
@@ -151,7 +165,7 @@ public abstract class AbstractReporterMgrTestBase {
     @Test
     public void testRename() {
         // get reporter
-        Reporter t1 = l.newReporter(getSystemName(getNumToTest5()), "before");
+        Reporter t1 = l.newReporter(getSystemName(getNameToTest1()), "before");
         Assert.assertNotNull("t1 real object ", t1);
         t1.setUserName("after");
         Reporter t2 = l.getByUserName("after");
@@ -163,23 +177,11 @@ public abstract class AbstractReporterMgrTestBase {
      * Number of light to test. Made a separate method so it can be overridden
      * in subclasses that do or don't support various numbers
      */
-    protected int getNumToTest1() {
-        return 9;
+    protected String getNameToTest1() {
+        return "1";
     }
 
-    protected int getNumToTest2() {
-        return 7;
-    }
-
-    protected int getNumToTest3() {
-        return 6;
-    }
-
-    protected int getNumToTest4() {
-        return 5;
-    }
-
-    protected int getNumToTest5() {
-        return 4;
+    protected String getNameToTest2() {
+        return "2";
     }
 }

--- a/java/test/jmri/managers/InternalReporterManagerTest.java
+++ b/java/test/jmri/managers/InternalReporterManagerTest.java
@@ -13,7 +13,7 @@ import org.junit.Before;
 public class InternalReporterManagerTest extends AbstractReporterMgrTestBase {
 
     @Override
-    public String getSystemName(int i) {
+    public String getSystemName(String i) {
         return "IR" + i;
     }
 

--- a/java/test/jmri/managers/ProxyLightManagerTest.java
+++ b/java/test/jmri/managers/ProxyLightManagerTest.java
@@ -53,6 +53,13 @@ public class ProxyLightManagerTest extends TestCase {
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
+    public void testNormalizeName() {
+        // create
+        String name = l.provideLight("" + getNumToTest1()).getSystemName();
+        // check
+        Assert.assertEquals(name, l.normalizeSystemName(name));
+    }
+
     public void testProvideFailure() {
         boolean correct = false;
         try {

--- a/java/test/jmri/managers/ProxyReporterManagerTest.java
+++ b/java/test/jmri/managers/ProxyReporterManagerTest.java
@@ -18,18 +18,18 @@ import org.junit.Test;
 public class ProxyReporterManagerTest extends AbstractReporterMgrTestBase {
 
     @Override
-    public String getSystemName(int i) {
+    public String getSystemName(String i) {
         return "IR" + i;
     }
 
     @Test
     public void testReporterPutGet() {
         // create
-        Reporter t = l.newReporter(getSystemName(getNumToTest1()), "mine");
+        Reporter t = l.newReporter(getSystemName(getNameToTest1()), "mine");
         // check
         Assert.assertTrue("real object returned ", t != null);
         Assert.assertTrue("user name correct ", t == l.getByUserName("mine"));
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
+        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNameToTest1())));
     }
 
     @Test
@@ -66,6 +66,14 @@ public class ProxyReporterManagerTest extends AbstractReporterMgrTestBase {
 
         Reporter l4 = l.getReporter("JLuser 1");
         Assert.assertNull(l4);
+    }
+
+    @Test
+    public void testNormalizeName() {
+        // create
+        String name = l.provideReporter("" + getNameToTest1()).getSystemName();
+        // check
+        Assert.assertEquals(name, l.normalizeSystemName(name));
     }
 
     @Test

--- a/java/test/jmri/managers/ProxySensorManagerTest.java
+++ b/java/test/jmri/managers/ProxySensorManagerTest.java
@@ -53,6 +53,13 @@ public class ProxySensorManagerTest extends TestCase {
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
+    public void testNormalizeName() {
+        // create
+        String name = l.provideSensor("" + getNumToTest1()).getSystemName();
+        // check
+        Assert.assertEquals(name, l.normalizeSystemName(name));
+    }
+
     public void testProvideFailure() {
         boolean correct = false;
         try {

--- a/java/test/jmri/managers/ProxyTurnoutManagerTest.java
+++ b/java/test/jmri/managers/ProxyTurnoutManagerTest.java
@@ -53,6 +53,13 @@ public class ProxyTurnoutManagerTest extends TestCase {
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
+    public void testNormalizeName() {
+        // create
+        String name = l.provideTurnout("" + getNumToTest1()).getSystemName();
+        // check
+        Assert.assertEquals(name, l.normalizeSystemName(name));
+    }
+
     public void testProvideFailure() {
         boolean correct = false;
         try {

--- a/java/test/jmri/managers/TurnoutManagerScaffold.java
+++ b/java/test/jmri/managers/TurnoutManagerScaffold.java
@@ -104,7 +104,7 @@ public class TurnoutManagerScaffold implements TurnoutManager {
     }
 
     @Override
-    public String normalizeSystemName(String inputName) throws jmri.Manager.BadSystemNameException {
+    public String normalizeSystemName(String inputName) throws NamedBean.BadSystemNameException {
         return inputName;
     }
 

--- a/java/test/jmri/managers/TurnoutManagerScaffold.java
+++ b/java/test/jmri/managers/TurnoutManagerScaffold.java
@@ -104,6 +104,11 @@ public class TurnoutManagerScaffold implements TurnoutManager {
     }
 
     @Override
+    public String normalizeSystemName(String inputName) throws jmri.Manager.BadSystemNameException {
+        return inputName;
+    }
+
+    @Override
     public void dispose() {
     }
 


### PR DESCRIPTION
Adds methods for normalizeSystemName (see prior discussion #3130 and jmri-developers), but leaves actual changes to name text to future.

Next step will be getting some GUI widgets to handle this.