### PR TITLE
Start marking system and user name normalization sites

### DIFF
--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -1351,7 +1351,7 @@ public class DefaultConditional extends AbstractNamedBean
     static private Memory getMemory(String name) {
         Memory m = InstanceManager.memoryManagerInstance().getMemory(name);
         if (m == null) {
-            String sName = name.toUpperCase().trim();
+            String sName = name.toUpperCase().trim();  // N11N
             m = InstanceManager.memoryManagerInstance().getMemory(sName);
         }
         return m;

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -652,7 +652,7 @@ abstract public class BeanTableDataModel extends AbstractTableModel implements P
         if (retval != 1) {
             return;
         }
-        String value = _newName.getText().trim();
+        String value = _newName.getText().trim(); // N11N
 
         if (value.equals(oldName)) {
             //name not changed.

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -1062,10 +1062,10 @@ public class LightTableAction extends AbstractTableAction {
     private int defaultControlIndex = 0;
     private boolean inEditControlMode = false;
     private LightControl lc = null;
-    private JTextField field1a = new JTextField(10);  // Sensor 
-    private JTextField field1a2 = new JTextField(10);  // Sensor 2 
+    private JTextField field1a = new JTextField(10);  // Sensor // N11N
+    private JTextField field1a2 = new JTextField(10);  // Sensor 2  // N11N
     private JTextField field1b = new JTextField(8);  // Fast Clock
-    private JTextField field1c = new JTextField(10);  // Turnout
+    private JTextField field1c = new JTextField(10);  // Turnout // N11N
     private JTextField field1d = new JTextField(10);  // Timed ON
     private JLabel f1Label = new JLabel(Bundle.getMessage("LightSensor"));
     private JTextField field2a = new JTextField(8);  // Fast Clock
@@ -1395,7 +1395,7 @@ public class LightTableAction extends AbstractTableAction {
             // Set type of control
             g.setControlType(Light.SENSOR_CONTROL);
             // Get sensor control information
-            String sensorName = field1a.getText().trim();
+            String sensorName = field1a.getText().trim(); // N11N
             Sensor s = null;
             if (sensorName.length() < 1) {
                 // no sensor name entered
@@ -1503,7 +1503,7 @@ public class LightTableAction extends AbstractTableAction {
             // Set type of control
             g.setControlType(Light.TURNOUT_STATUS_CONTROL);
             // Get turnout control information
-            String turnoutName = field1c.getText().trim();
+            String turnoutName = field1c.getText().trim(); // N11N
             if (turnoutName.length() < 1) {
                 // valid turnout system name was not entered
                 g.setControlType(Light.NO_CONTROL);
@@ -1593,9 +1593,9 @@ public class LightTableAction extends AbstractTableAction {
             // Set type of control
             g.setControlType(Light.TWO_SENSOR_CONTROL);
             // Get sensor control information
-            String sensorName = field1a.getText().trim();
+            String sensorName = field1a.getText().trim(); // N11N
             Sensor s = null;
-            String sensor2Name = field1a2.getText().trim();
+            String sensor2Name = field1a2.getText().trim(); // N11N
             Sensor s2 = null;
             if ((sensorName.length() < 1) || (sensor2Name.length() < 1)) {
                 // no sensor name entered

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -527,8 +527,8 @@ public class LogixTableAction extends AbstractTableAction {
 
     // Add Logix Variables
     JmriJFrame addLogixFrame = null;
-    JTextField _systemName = new JTextField(20);
-    JTextField _addUserName = new JTextField(20);
+    JTextField _systemName = new JTextField(20); // N11N
+    JTextField _addUserName = new JTextField(20); // N11N
     JCheckBox _autoSystemName = new JCheckBox(Bundle.getMessage("LabelAutoSysName"));
     JLabel _sysNameLabel = new JLabel(Bundle.getMessage("BeanNameLogix") + " " + Bundle.getMessage("ColumnSystemName") + ":");
     JLabel _userNameLabel = new JLabel(Bundle.getMessage("BeanNameLogix") + " " + Bundle.getMessage("ColumnUserName") + ":");
@@ -865,7 +865,7 @@ public class LogixTableAction extends AbstractTableAction {
      * @param e the event heard
      */
     void copyLogixPressed(ActionEvent e) {
-        String uName = _addUserName.getText().trim();
+        String uName = _addUserName.getText().trim(); // N11N
         if (uName.length() == 0) {
             uName = null;
         }
@@ -879,7 +879,7 @@ public class LogixTableAction extends AbstractTableAction {
             if (!checkLogixSysName()) {
                 return;
             }
-            String sName = _systemName.getText().trim();
+            String sName = _systemName.getText().trim(); // N11N
             // check if a Logix with this name already exists
             boolean createLogix = true;
             targetLogix = _logixManager.getBySystemName(sName);
@@ -1005,7 +1005,7 @@ public class LogixTableAction extends AbstractTableAction {
      * @return false if name has length &lt; 1 after displaying a dialog
      */
     boolean checkLogixSysName() {
-        String sName = _systemName.getText().trim();
+        String sName = _systemName.getText().trim(); // N11N
         if ((sName.length() < 1)) {
             // Entered system name is blank or too short
             javax.swing.JOptionPane.showMessageDialog(addLogixFrame,
@@ -1073,11 +1073,11 @@ public class LogixTableAction extends AbstractTableAction {
     void createPressed(ActionEvent e) {
         // possible change
         _showReminder = true;
-        String uName = _addUserName.getText().trim();
+        String uName = _addUserName.getText().trim(); // N11N
         if (uName.length() == 0) {
             uName = null;
         }
-        String sName = _systemName.getText().trim();
+        String sName = _systemName.getText().trim(); // N11N
         if (_autoSystemName.isSelected()) {
             if (!checkLogixUserName(uName)) {
                 return;
@@ -1432,7 +1432,7 @@ public class LogixTableAction extends AbstractTableAction {
             return;
         }
         // Check if the User Name has been changed
-        String uName = editUserName.getText().trim();
+        String uName = editUserName.getText().trim(); // N11N
         if (!(uName.equals(_curLogix.getUserName()))) {
             // user name has changed - check if already in use
             if (uName.length() > 0) {
@@ -2250,7 +2250,7 @@ public class LogixTableAction extends AbstractTableAction {
             return;
         }
         // Check if the User Name has been changed
-        String uName = conditionalUserName.getText().trim();
+        String uName = conditionalUserName.getText().trim(); // N11N
         if (!uName.equals(_curConditional.getUserName())) {
             // user name has changed - check if already in use
             if (!checkConditionalUserName(uName, _curLogix)) {
@@ -5570,11 +5570,11 @@ public class LogixTableAction extends AbstractTableAction {
             } else if (col == UNAME_COLUMN) {
                 String uName = (String) value;
                 Conditional cn = _conditionalManager.getByUserName(_curLogix,
-                        uName.trim());
+                        uName.trim()); // N11N
                 if (cn == null) {
                     _conditionalManager.getBySystemName(
                             _curLogix.getConditionalByNumberOrder(rx))
-                            .setUserName(uName.trim());
+                            .setUserName(uName.trim()); // N11N
                     fireTableRowsUpdated(rx, rx);
                 } else {
                     String svName = _curLogix.getConditionalByNumberOrder(rx);

--- a/java/src/jmri/jmrit/beantable/Maintenance.java
+++ b/java/src/jmri/jmrit/beantable/Maintenance.java
@@ -336,7 +336,7 @@ public class Maintenance {
      * @return 4 element String: {Type, userName, sysName, numListeners}
      */
     static String[] getTypeAndNames(String name) {
-        String userName = name.trim();
+        String userName = name.trim(); // N11N
         String sysName = userName;
         // String sysName = userName.toUpperCase();
         boolean found = false;

--- a/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
@@ -364,8 +364,8 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
         box.setSelectedItem(result);
     }
 
-    JTextField _systemName = new JTextField(10);
-    JTextField _userName = new JTextField(22);
+    JTextField _systemName = new JTextField(10); // N11N
+    JTextField _userName = new JTextField(22); // N11N
 
     JmriJFrame addFrame = null;
 
@@ -760,10 +760,10 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
      */
     boolean checkNewNamesOK() {
         // Get system name and user name from Add Signal Group pane
-        String sName = _systemName.getText().toUpperCase().trim();
+        String sName = _systemName.getText().toUpperCase().trim(); // N11N
         // seems field _systemName is not properly filled in when editing an existing mast
         // so prevent it from being called (in line 900)
-        String uName = _userName.getText(); // may be empty
+        String uName = _userName.getText(); // may be empty // N11N
         if (sName.length() == 0) {
             javax.swing.JOptionPane.showMessageDialog(null, "System Name field can not be left blank.",
                     Bundle.getMessage("ErrorTitle"), javax.swing.JOptionPane.WARNING_MESSAGE);

--- a/java/src/jmri/jmrit/beantable/signalmast/AddSignalMastPanel.java
+++ b/java/src/jmri/jmrit/beantable/signalmast/AddSignalMastPanel.java
@@ -67,7 +67,7 @@ public class AddSignalMastPanel extends JPanel {
 
     jmri.UserPreferencesManager prefs = jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class);
     String systemSelectionCombo = this.getClass().getName() + ".SignallingSystemSelected";
-    String mastSelectionCombo = this.getClass().getName() + ".SignallingMastSelected";
+    String mastSelectionCombo = this.getClass().getName() + ".SignallingMastSelected"; // N11N
     String driverSelectionCombo = this.getClass().getName() + ".SignallingDriverSelected";
     String matrixBitNumSelectionCombo = this.getClass().getName() + ".matrixBitNumSelected";
     List<NamedBean> alreadyUsed = new ArrayList<NamedBean>();
@@ -587,7 +587,7 @@ public class AddSignalMastPanel extends JPanel {
         repaint();
     }
 
-    JTextField userName = new JTextField(20);
+    JTextField userName = new JTextField(20); // N11N
     JComboBox<String> sigSysBox = new JComboBox<String>();
     JComboBox<String> mastBox = new JComboBox<String>(new String[]{Bundle.getMessage("MastEmpty")});
     JCheckBox includeUsed = new JCheckBox(Bundle.getMessage("IncludeUsedHeads"));
@@ -740,7 +740,7 @@ public class AddSignalMastPanel extends JPanel {
     void okPressed(ActionEvent e) {
         String mastname = mastNames.get(mastBox.getSelectedIndex()).getName();
 
-        String user = userName.getText().trim();
+        String user = userName.getText().trim(); // N11N
         if (user.equals("")) {
             int i = JOptionPane.showConfirmDialog(null, "No Username has been defined, this may cause issues when editing the mast later.\nAre you sure that you want to continue?",
                     "No UserName Given",

--- a/java/src/jmri/jmrit/sensorgroup/SensorGroup.java
+++ b/java/src/jmri/jmrit/sensorgroup/SensorGroup.java
@@ -14,6 +14,8 @@ import org.slf4j.LoggerFactory;
  * Object for representing, creating and editing sensor groups.
  * <P>
  * Sensor groups are implemented by (groups) of Routes, not by any other object.
+ * <p>
+ * They are not (currently) NamedBean objects.
  *
  * @author	Bob Jacobsen Copyright (C) 2007
   */

--- a/java/src/jmri/jmrit/speedometer/SpeedometerFrame.java
+++ b/java/src/jmri/jmrit/speedometer/SpeedometerFrame.java
@@ -45,17 +45,17 @@ import org.slf4j.LoggerFactory;
 public class SpeedometerFrame extends jmri.util.JmriJFrame {
 
     final String blank = "       ";
-    JTextField startSensor = new JTextField(5);
+    JTextField startSensor = new JTextField(5); // N11N
     javax.swing.ButtonGroup startGroup = new javax.swing.ButtonGroup();
     javax.swing.JRadioButton startOnEntry = new javax.swing.JRadioButton(Bundle.getMessage("RadioButtonEntry"));
     javax.swing.JRadioButton startOnExit = new javax.swing.JRadioButton(Bundle.getMessage("RadioButtonExit"));
 
-    JTextField stopSensor1 = new JTextField(5);
+    JTextField stopSensor1 = new JTextField(5);  // N11N
     javax.swing.ButtonGroup stopGroup1 = new javax.swing.ButtonGroup();
     javax.swing.JRadioButton stopOnEntry1 = new javax.swing.JRadioButton(Bundle.getMessage("RadioButtonEntry"));
     javax.swing.JRadioButton stopOnExit1 = new javax.swing.JRadioButton(Bundle.getMessage("RadioButtonExit"));
 
-    public JTextField stopSensor2 = new JTextField(5);
+    public JTextField stopSensor2 = new JTextField(5);  // N11N
     javax.swing.ButtonGroup stopGroup2 = new javax.swing.ButtonGroup();
     javax.swing.JRadioButton stopOnEntry2 = new javax.swing.JRadioButton(Bundle.getMessage("RadioButtonEntry"));
     javax.swing.JRadioButton stopOnExit2 = new javax.swing.JRadioButton(Bundle.getMessage("RadioButtonExit"));

--- a/java/src/jmri/util/SystemNameComparator.java
+++ b/java/src/jmri/util/SystemNameComparator.java
@@ -9,6 +9,9 @@ import java.util.Comparator;
  * the number case, this does a numeric comparison. If the number is appended
  * with letters, does the numeric sort on the digits followed by a lexigraphic
  * sort on the remainder.
+ * <p>
+ * Note this is intended to take names as provided:  It does not do normalization or 
+ * expansion.
  *
  * @author	Bob Jacobsen Copyright (C) 2004
  * @author Howard Penny


### PR DESCRIPTION
Started marking places where system names and/or user names enter JMRI with a `// N11N` (for NormalizatioN) comment.  No functional changes.

Some background comments:

Inconsistent user interfaces, sometimes trimming & sometimes not, capitalizing here but not there, etc, should be avoided.  So flagging these places will make it more likely that we'll be able to change them all (or almost all) before turning on normalization.

In some cases, there's already a `trim()` operation that should be replaced.  But doing that now will be removing that trim, which people might be counting on.  Etc.

In other places, the best approach is to replace the input field with a widget of some kind.  Would be good to have those.