### PR TITLE
RaspberryPi Input provisioning

### DIFF
--- a/java/src/jmri/jmrix/pi/RaspberryPiSensor.java
+++ b/java/src/jmri/jmrix/pi/RaspberryPiSensor.java
@@ -51,7 +51,7 @@ public class RaspberryPiSensor extends AbstractSensor implements GpioPinListener
            gpio=_gpio;
         address=Integer.parseInt(id.substring(id.lastIndexOf("S")+1));
         try {
-           pin = gpio.provisionDigitalInputPin(RaspiPin.getPinByName("GPIO "+address),getSystemName(),PinPullResistance.PULL_DOWN);
+           pin = gpio.provisionDigitalInputPin(RaspiPin.getPinByName("GPIO "+address),getSystemName(),PinPullResistance.PULL_UP);
         } catch(java.lang.RuntimeException re) {
             log.error("Provisioning sensor {} failed with: {}", id, re.getMessage());
             throw new IllegalArgumentException(re.getMessage());


### PR DESCRIPTION
The RaspberryPiSensor.java init() code currently provisions all Pi input
pins to have PULL_DOWN termination.  While most pins can be configured
to have either PullDown or PullUp configuration, there are some pins
that have fixed hardware PullUp termination.  As a result attempting to
create a Sensor in JMRI using a pin with fixed hardware PullUp
termination fails.  This applies to IO 8 and 9 for all Pi models and
also to IO 30 and 31 for models that support those pins.

Since all Pi input pins appear to support PullUp termination, my
recommendation is to change the init() method to provision the pins
using the PinPullResistance.PULL_UP argument rather than the
PinPullResistance.PULL_DOWN.  This change will allow use of all the GPIO
pins as Sensor inputs and will provide a the same termination on all
pins (PullUp) for consistency.

See
https://github.com/Pi4J/pi4j/blob/master/pi4j-core/src/main/java/com/pi4j/io/gpio/RaspiPin.java#L82
for the pin definitions.