### PR TITLE
handle duplicate set of username

### DIFF
--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -237,7 +237,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
             }
             if (now != null) {
                 // was there previously a bean with the new name?
-                if (_tuser.get(now) != null) {
+                if (_tuser.get(now) != null && _tuser.get(now) != t) {
                     // If so, clear. Note that this is not a "move" operation
                     _tuser.get(now).setUserName(null);
                 }


### PR DESCRIPTION
This is an update of #3195 that does _not_ include the test file nor attempt to get Warrants to store on headless systems.  This doesn't have any JUnit tests associated with it (because oblock.xml had to be removed)

#3195 will be repurposed to be about the NxFrame problems with headless, being written without being loaded, etc.