### PR TITLE
Temporarily disable macOS checks in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ cache:
 
 os:
   - linux
-  - osx 
+#  - osx # temporarilly disabled -- its more complex than originally anticipated to do conditional matrixes based on PR/push differentiation
 
 sudo: required
 


### PR DESCRIPTION
This may turn out to be a longterm change.