### PR TITLE
Fix ToolBox Content Problem

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -1152,7 +1152,7 @@ public class LayoutEditor extends jmri.jmrit.display.panelEditor.PanelEditor imp
     private void createFloatingEditToolBox() {
         if (floatingEditToolBox == null) {
             if (floatingEditContent == null) {
-                // Create the window content on the first call
+                // Create the window content if necessary, normally on first load or switching from toolbox to toolbar to toolbox
                 createFloatingEditContent();
             }
 
@@ -1176,7 +1176,6 @@ public class LayoutEditor extends jmri.jmrit.display.panelEditor.PanelEditor imp
     }
 
     private void createFloatingEditContent() {
-        log.info("#### createFloatingEditContent");  // DIAG
         /*
          * JFrame - floatingEditToolBox
          *     JScrollPane - floatingEditContent
@@ -2805,6 +2804,7 @@ public class LayoutEditor extends jmri.jmrit.display.panelEditor.PanelEditor imp
             setDirty(true);
 
             if (toolBarSide.equals(eToolBarSide.eFLOAT) && isEditable()) {
+            	// Rebuild the toolbox after a name change.
                 deleteFloatingEditToolBox();
                 createFloatingEditToolBox();
             }
@@ -3208,6 +3208,7 @@ public class LayoutEditor extends jmri.jmrit.display.panelEditor.PanelEditor imp
                 if (null != floatingEditToolBox) {
                     deleteFloatingEditToolBox();
                 }
+				floatingEditContent = null;  // The switch to toolbar will move the toolbox content to the new toolbar
                 editToolBarContainer.setVisible(isEditable());
             }
             toolBarSideTopButton.setSelected(toolBarSide.equals(eToolBarSide.eTOP));


### PR DESCRIPTION
When the toolbar selection process moves from toolbox to toolbar to
toolbox, the toolbox content is missing.  Step 3 requires re-building
the content.