### PR TITLE
OLCB does not need inversion on turnout and sensor

### DIFF
--- a/java/src/jmri/jmrix/openlcb/OlcbSensor.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbSensor.java
@@ -1,16 +1,14 @@
 package jmri.jmrix.openlcb;
 
+import java.util.Timer;
+import jmri.Sensor;
+import jmri.implementation.AbstractSensor;
 import org.openlcb.EventID;
 import org.openlcb.OlcbInterface;
 import org.openlcb.implementations.BitProducerConsumer;
 import org.openlcb.implementations.VersionedValueListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Timer;
-
-import jmri.Sensor;
-import jmri.implementation.AbstractSensor;
 
 /**
  * Extend jmri.AbstractSensor for OpenLCB controls.
@@ -127,6 +125,15 @@ public class OlcbSensor extends AbstractSensor {
                 }
             }
         }, ON_TIME);
+    }
+    
+    /*
+     * since the events that drive a sensor can be whichever state a user
+     * wants, the order of the event pair determines what is the 'active' state
+     */
+    @Override
+    public boolean canInvert() {
+        return false;
     }
 
     @Override

--- a/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
@@ -1,13 +1,11 @@
 package jmri.jmrix.openlcb;
 
+import jmri.Turnout;
 import org.openlcb.OlcbInterface;
 import org.openlcb.implementations.BitProducerConsumer;
 import org.openlcb.implementations.VersionedValueListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jmri.Turnout;
-import jmri.jmrix.can.CanMessage;
 
 /**
  * Turnout for OpenLCB connections.
@@ -118,7 +116,6 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout {
      */
     @Override
     protected void forwardCommandChangeToLayout(int s) {
-        CanMessage m;
         if (s == Turnout.THROWN) {
             turnoutListener.setFromOwner(true);
             if (_activeFeedbackType == MONITORING) {
@@ -136,6 +133,15 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout {
     protected void turnoutPushbuttonLockout(boolean locked) {
         // TODO: maybe we could get another pair of events in the address and use that event pair
         // to perform a lockout change on the turnout decoder itself.
+    }
+
+    /*
+     * since the events that drive a turnout can be whichever state a user
+     * wants, the order of the event pair determines what is the 'closed' state
+     */
+    @Override
+    public boolean canInvert() {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Since the whole concept of active or not doesn't fit OLCB. The order of
the events is the way to control which is which.