### PR TITLE
throw when AbstractMRMessage copy ctor called on null

### DIFF
--- a/java/src/jmri/jmrix/AbstractMRMessage.java
+++ b/java/src/jmri/jmrix/AbstractMRMessage.java
@@ -40,6 +40,7 @@ abstract public class AbstractMRMessage extends AbstractMessage {
         this();
         if (m == null) {
             log.error("copy ctor of null message");
+            throw new IllegalArgumentException("copy ctor of null message");
         }
         _nDataChars = m._nDataChars;
         _dataChars = new int[_nDataChars];


### PR DESCRIPTION
Probably not getting hit, but makes it a bit more robust if it is. See #3213