### PR TITLE
Add control of XML validation upon reading

### DIFF
--- a/java/src/jmri/configurexml/ConfigXmlManager.java
+++ b/java/src/jmri/configurexml/ConfigXmlManager.java
@@ -66,7 +66,7 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
      * Note: Should only be called for debugging purposes,, for example, when
      * Log4J DEBUG level is selected, to load fewer classes at startup.
      *
-     * @param o object to verify XML adapter exists for
+     * @param o object to confirm XML adapter exists for
      */
     void confirmAdapterAvailable(Object o) {
         String adapter = adapterName(o);
@@ -639,6 +639,14 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
         }
     }
 
+    private XmlFile.Validate validate = XmlFile.Validate.CheckDtdThenSchema;
+    /** Default XML verification.
+     * Public to allow scripting. */
+    public void setValidate(XmlFile.Validate v) { validate = v;}
+    /** Default XML verification.
+     * Public to allow scripting. */
+    public XmlFile.Validate getValidate() { return validate; }
+
     private boolean loadOnSwingThread(URL url, boolean registerDeferred) throws JmriConfigureXmlException {
         boolean result = true;
         Element root = null;
@@ -648,9 +656,8 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
          */
         Map<Element, Integer> loadlist = Collections.synchronizedMap(new LinkedHashMap<>());
 
-        boolean verify = XmlFile.getVerify();
         try {
-            XmlFile.setVerify(true);
+            setValidate(validate);
             root = super.rootFromURL(url);
             // get the objects to load
             List<Element> items = root.getChildren();
@@ -753,7 +760,6 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
             result = false;
         } finally {
             // no matter what, close error reporting
-            XmlFile.setVerify(verify);
             handler.done();
         }
 
@@ -771,7 +777,6 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
         } else {
             log.info("Not recording file history");
         }
-        XmlFile.setVerify(verify);
         return result;
     }
 

--- a/java/src/jmri/implementation/JmriConfigurationManager.java
+++ b/java/src/jmri/implementation/JmriConfigurationManager.java
@@ -18,6 +18,7 @@ import jmri.JmriException;
 import jmri.configurexml.ConfigXmlManager;
 import jmri.configurexml.swing.DialogErrorHandler;
 import jmri.profile.Profile;
+import jmri.jmrit.XmlFile;
 import jmri.profile.ProfileManager;
 import jmri.spi.PreferencesManager;
 import jmri.util.FileUtil;
@@ -36,6 +37,9 @@ public class JmriConfigurationManager implements ConfigureManager {
     private final HashMap<PreferencesManager, InitializationException> initializationExceptions = new HashMap<>();
     private final List<PreferencesManager> initialized = new ArrayList<>();
 
+    public void setValidate(XmlFile.Validate v) { legacy.setValidate(v);}
+    public XmlFile.Validate getValidate() { return legacy.getValidate(); }
+    
     @SuppressWarnings("unchecked") // For types in InstanceManager.store()
     public JmriConfigurationManager() {
         ServiceLoader<PreferencesManager> sl = ServiceLoader.load(PreferencesManager.class);

--- a/java/src/jmri/jmrit/XmlFile.java
+++ b/java/src/jmri/jmrit/XmlFile.java
@@ -42,18 +42,19 @@ import org.slf4j.LoggerFactory;
  * <p>
  * We implement this using our own EntityResolver, the
  * {@link jmri.util.JmriLocalEntityResolver} class.
+ * <p>
+ * When reading a file, validation is controlled heirarchically:
+ * <ul>
+ * <li>There's a global default
+ * <li>Which can be overridden on a particular XmlFile object
+ * <li>Finally, the static call to create a builder can be invoked with a validation specification.
+ * </ul>
+ *
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2002, 2007, 2012, 2014
  */
 public abstract class XmlFile {
 
-    static boolean verify = false;
-    static boolean include = true;
-
-    /**
-     * Specify a standard prefix for DTDs in new XML documents
-     */
-    static public final String dtdLocation = "/xml/DTD/";
 
     /**
      * Define root part of URL for XSLT style page processing instructions.
@@ -71,6 +72,22 @@ public abstract class XmlFile {
      */
     public static final String xsltLocation = "/xml/XSLT/";
 
+    /**
+     * Specify validation operations on input.
+     * The available choices are restricted to what
+     * the underlying SAX Xerces and JDOM implementations allow.
+     */
+    public enum Validate {
+        /** Don't validate input */
+        None, 
+        /** Require that the input specifies a Schema which validates */
+        RequireSchema,
+        /** Validate against DTD if present (no DTD passes too) */
+        CheckDtd,
+        /** Validate against DTD if present, else Schema must be present and valid */
+        CheckDtdThenSchema
+    }
+    
     /**
      * Read the contents of an XML file from its filename. The name is expanded
      * by the {@link #findFile} routine. If the file is not found, attempts to
@@ -119,7 +136,7 @@ public abstract class XmlFile {
         }
 
         try (FileInputStream fs = new FileInputStream(file)) {
-            return getRoot(verify, fs);
+            return getRoot(fs);
         }
     }
 
@@ -135,7 +152,7 @@ public abstract class XmlFile {
      *         exception should be thrown if anything goes wrong.
      */
     public Element rootFromInputStream(InputStream stream) throws JDOMException, IOException {
-        return getRoot(verify, stream);
+        return getRoot(stream);
     }
 
     /**
@@ -153,27 +170,51 @@ public abstract class XmlFile {
         if (log.isDebugEnabled()) {
             log.debug("reading xml from URL: " + url.toString());
         }
-        return getRoot(verify, url.openConnection().getInputStream());
+        return getRoot(url.openConnection().getInputStream());
     }
 
     /**
      * Get the root element from an XML document in a stream.
      *
-     * @param verify true if the XML document should be validated against its
-     *               schema
+     * @param verifySchema true if the XML document should be validated against its schema
+     * @param verifyDTD true if the XML document should be validated against its DTD
      * @param stream input containing the XML document
      * @return the root element of the XML document
      * @throws org.jdom2.JDOMException if the XML document is invalid
      * @throws java.io.IOException     if the input cannot be read
      */
-    protected Element getRoot(boolean verify, InputStream stream) throws JDOMException, IOException {
+    protected Element getRoot(InputStream stream) throws JDOMException, IOException {
         log.trace("getRoot from stream");
 
-        SAXBuilder builder = getBuilder(verify);  // argument controls validation
+        SAXBuilder builder = getBuilder(getValidate());
         Document doc = builder.build(new BufferedInputStream(stream));
         doc = processInstructions(doc);  // handle any process instructions
         // find root
         return doc.getRootElement();
+    }
+
+
+    /**
+     * While the various Deprecated methods are present, this 
+     * provides a warning against their continued use.  JMRI itself
+     * stopped using these with JMRI 4.7.2
+     */
+    protected static void warnDeprecated() {
+        if (warned) return;
+        log.warn("Deprecated XmlFile method was used, validation may be ignored; only mentioning once");
+        warned = true;
+    }
+    static protected boolean warned = false;
+
+    /**
+     * @deprecated 4.7.2 use setVerifySchema, setVerifyDTD methods
+     * @param verify true if the XML document should be validated (but this is now ignored)
+     * @param stream input containing the XML document
+     */
+    @Deprecated
+    protected Element getRoot(boolean verify, InputStream stream) throws JDOMException, IOException {
+        warnDeprecated();
+        return getRoot(stream);
     }
 
     /**
@@ -182,22 +223,36 @@ public abstract class XmlFile {
      * Runs through a BufferedReader for increased performance.
      *
      *
-     * @param verify true if the XML document should be validated against its
-     *               schema
+     * @param verifySchema true if the XML document should be validated against its schema
+     * @param verifyDTD true if the XML document should be validated against its DTD
      * @param reader input containing the XML document
      * @return the root element of the XML document
      * @throws org.jdom2.JDOMException if the XML document is invalid
      * @throws java.io.IOException     if the input cannot be read
      * @since 3.1.5
+     * @deprecated 4.7.2 use setVerifySchema, setVerifyDTD methods
      */
-    protected Element getRoot(boolean verify, InputStreamReader reader) throws JDOMException, IOException {
+    @Deprecated
+    protected Element getRoot(boolean verifySchema, boolean verifyDTD, InputStreamReader reader) throws JDOMException, IOException {
+        warnDeprecated();
         log.trace("getRoot from reader with encoding {}", reader.getEncoding());
 
-        SAXBuilder builder = getBuilder(verify);  // argument controls validation
+        SAXBuilder builder = getBuilder(getValidate());  // argument controls validation
         Document doc = builder.build(new BufferedReader(reader));
         doc = processInstructions(doc);  // handle any process instructions
         // find root
         return doc.getRootElement();
+    }
+
+    /**
+     * @param verify true if the XML document should be validated (but this is now ignored)
+     * @deprecated 4.7.2 use setVerifySchema, setVerifyDTD methods
+     * @param reader input containing the XML document
+     */
+    @Deprecated
+    protected Element getRoot(boolean verify, InputStreamReader reader) throws JDOMException, IOException {
+        warnDeprecated();
+        return getRoot(verify, verify, reader);
     }
 
     /**
@@ -504,7 +559,7 @@ public abstract class XmlFile {
         }
 
         // read the XSLT transform into a Document to get XInclude done
-        SAXBuilder builder = getBuilder(false);  // argument controls validation
+        SAXBuilder builder = getBuilder(Validate.None); 
         Document xdoc = builder.build(new BufferedInputStream(new FileInputStream(findFile(href))));
         org.jdom2.transform.XSLTransformer transformer = new org.jdom2.transform.XSLTransformer(xdoc);
         return transformer.transform(doc);
@@ -571,13 +626,57 @@ public abstract class XmlFile {
         return FileUtil.getProgramPath() + "xml" + File.separator;
     }
 
-    static public boolean getVerify() {
-        return verify;
+    
+    /** Whether to, by global default, validate the file being read.
+     * Public so it can be set by scripting and for debug
+     */ 
+    static public Validate getDefaultValidate() {
+        return defaultValidate;
     }
 
-    static public void setVerify(boolean v) {
-        verify = v;
+    static public void setDefaultValidate(Validate v) {
+        defaultValidate = v;
     }
+ 
+    static private Validate defaultValidate = Validate.None;
+
+    /** Whether to verify the DTD of this XML file when read.
+     */ 
+    public Validate getValidate() {
+        return validate;
+    }
+
+    public void setValidate(Validate v) {
+        validate = v;
+    }
+ 
+    private Validate validate = defaultValidate;
+
+    /** Specify a default standard prefix for DTDs in new XML documents
+     * Public so it can be set by scripting and for debug
+     */ 
+    static public String getDefaultDtdLocation() {
+        return defaultDtdLocation;
+    }
+
+    static public void setDefaultDtdLocation(String v) {
+        defaultDtdLocation = v;
+    }
+ 
+    static public String defaultDtdLocation = "/xml/DTD/";
+
+    /** Specify the prefix for DTDs in this XML documents
+    */ 
+    public String getDtdLocation() {
+        return dtdLocation;
+    }
+
+    public void setDtdLocation(String v) {
+        dtdLocation = v;
+    }
+ 
+    public String dtdLocation = defaultDtdLocation;
+
 
     /**
      * Provide a JFileChooser initialized to the default user location, and with
@@ -619,25 +718,45 @@ public abstract class XmlFile {
         return userFileChooser(filter, suffix1, null);
     }
 
+    /**
+     * @deprecated 4.7.2
+     */
+    @Deprecated
     public static SAXBuilder getBuilder(boolean verify) {
-        SAXBuilder builder = new SAXBuilder("org.apache.xerces.parsers.SAXParser", verify);  // argument controls validation
-
+        warnDeprecated();
+        return getBuilder(Validate.None);
+    }
+    
+    public static SAXBuilder getBuilder(Validate validate) {  // should really be a Verify enum
+        SAXBuilder builder; 
+        
+        boolean verifyDTD = (validate == Validate.CheckDtd) || (validate == Validate.CheckDtdThenSchema);
+        boolean verifySchema = (validate == Validate.RequireSchema) || (validate == Validate.CheckDtdThenSchema);
+                
+        // old style 
+        builder = new SAXBuilder("org.apache.xerces.parsers.SAXParser", verifyDTD);  // argument controls DTD validation
+        
+        // insert local resolver for includes, schema, DTDs
         builder.setEntityResolver(new JmriLocalEntityResolver());
+
+        // configure XInclude handling
         builder.setFeature("http://apache.org/xml/features/xinclude", true);
         builder.setFeature("http://apache.org/xml/features/xinclude/fixup-base-uris", false);
+        
+        // only validate if grammar is available, making ABSENT OK
+        builder.setFeature("http://apache.org/xml/features/validation/dynamic", verifyDTD && ! verifySchema);
+        
+        // control Schema validation
+        builder.setFeature("http://apache.org/xml/features/validation/schema", verifySchema);
+        builder.setFeature("http://apache.org/xml/features/validation/schema-full-checking", verifySchema);
+
+        // if not validating DTD, just validate Schema
+        builder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", verifyDTD);
+        if (!verifyDTD) builder.setProperty("http://java.sun.com/xml/jaxp/properties/schemaLanguage", "http://www.w3.org/2001/XMLSchema");
+
+        // allow Java character encodings
         builder.setFeature("http://apache.org/xml/features/allow-java-encodings", true);
-
-        // for schema validation. Not needed for DTDs, so continue if not found now
-        try {
-            builder.setFeature("http://apache.org/xml/features/validation/schema", verify);
-            builder.setFeature("http://apache.org/xml/features/validation/schema-full-checking", verify);
-
-            // parse namespaces, including the noNamespaceSchema
-            builder.setFeature("http://xml.org/sax/features/namespaces", true);
-
-        } catch (Exception e) {
-            log.warn("Could not set schema validation feature: " + e);
-        }
+        
         return builder;
     }
     // initialize logging

--- a/java/src/jmri/jmrit/XmlFile.java
+++ b/java/src/jmri/jmrit/XmlFile.java
@@ -176,8 +176,6 @@ public abstract class XmlFile {
     /**
      * Get the root element from an XML document in a stream.
      *
-     * @param verifySchema true if the XML document should be validated against its schema
-     * @param verifyDTD true if the XML document should be validated against its DTD
      * @param stream input containing the XML document
      * @return the root element of the XML document
      * @throws org.jdom2.JDOMException if the XML document is invalid

--- a/java/src/jmri/jmrit/XmlFileCheckAction.java
+++ b/java/src/jmri/jmrit/XmlFileCheckAction.java
@@ -14,7 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Make sure an XML file is readable, without doing a Schema validation.
+ * Make sure an XML file is readable, without doing a DTD or Schema validation.
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2005, 2007
  * @see jmri.jmrit.XmlFile
@@ -34,6 +34,8 @@ public class XmlFileCheckAction extends JmriAbstractAction {
     JFileChooser fci;
 
     Component _who;
+    
+    XmlFile xmlfile = new XmlFile() {};   // odd syntax is due to XmlFile being abstract
 
     @Override
     public void actionPerformed(ActionEvent e) {
@@ -48,15 +50,12 @@ public class XmlFileCheckAction extends JmriAbstractAction {
             File file = fci.getSelectedFile();
             log.debug("located file {} for XML processing", file);
             // handle the file (later should be outside this thread?)
-            boolean original = XmlFile.verify;
             try {
-                XmlFile.verify = false;
+                xmlfile.setValidate(XmlFile.Validate.None);
                 readFile(file);
                 JOptionPane.showMessageDialog(_who, "OK");
             } catch (IOException | JDOMException ex) {
                 JOptionPane.showMessageDialog(_who, "Error: " + ex);
-            } finally {
-                XmlFile.verify = original;
             }
             log.debug("parsing complete");
 
@@ -73,10 +72,7 @@ public class XmlFileCheckAction extends JmriAbstractAction {
      * @throws java.io.IOException     if unable to read file
      */
     void readFile(File file) throws JDOMException, IOException {
-        XmlFile xf = new XmlFile() {
-        };   // odd syntax is due to XmlFile being abstract
-
-        xf.rootFromFile(file);
+        xmlfile.rootFromFile(file);
 
     }
 

--- a/java/src/jmri/jmrit/XmlFileValidateAction.java
+++ b/java/src/jmri/jmrit/XmlFileValidateAction.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Make sure an XML file is readable, and validates OK.
+ * Make sure an XML file is readable, and validates OK against its schema and DTD.
  * <p>
  * Can also be run from the command line with e.g. ./runtest.csh
  * jmri/jmrit/XmlFileValidateAction foo.xml in which case if there's a filename
@@ -52,6 +52,8 @@ public class XmlFileValidateAction extends jmri.util.swing.JmriAbstractAction {
 
     Component _who;
 
+    XmlFile xmlfile = new XmlFile() {};   // odd syntax is due to XmlFile being abstract
+    
     @Override
     public void actionPerformed(ActionEvent e) {
         if (fci == null) {
@@ -73,15 +75,13 @@ public class XmlFileValidateAction extends jmri.util.swing.JmriAbstractAction {
             log.debug("located file " + file + " for XML processing");
         }
         // handle the file (later should be outside this thread?)
-        boolean original = XmlFile.verify;
         try {
-            XmlFile.verify = true;
+            xmlfile.setValidate(XmlFile.Validate.CheckDtdThenSchema);
             readFile(file);
         } catch (Exception ex) {
             // because of XInclude, we're doing this
             // again to validate the entire file
             // without losing the error message
-            XmlFile.verify = false;
             Document doc;
             try {
                 InputStream stream = new BufferedInputStream(new FileInputStream(file));
@@ -117,7 +117,6 @@ public class XmlFileValidateAction extends jmri.util.swing.JmriAbstractAction {
             builder.setFeature("http://apache.org/xml/features/validation/schema-full-checking", true);
             builder.setFeature("http://xml.org/sax/features/namespaces", true);
             try {
-                XmlFile.verify = true;
                 builder.build(input).getRootElement();
             } catch (JDOMException | IOException ex2) {
                 showFailResults(_who, "Err(2): " + ex2);
@@ -126,8 +125,6 @@ public class XmlFileValidateAction extends jmri.util.swing.JmriAbstractAction {
 
             showFailResults(_who, "Err(3): " + ex);
             return;
-        } finally {
-            XmlFile.verify = original;
         }
         showOkResults(_who, "OK");
         if (log.isDebugEnabled()) {
@@ -151,10 +148,7 @@ public class XmlFileValidateAction extends jmri.util.swing.JmriAbstractAction {
      * @throws java.io.IOException     if unable to read file
      */
     void readFile(File file) throws org.jdom2.JDOMException, java.io.IOException {
-        XmlFile xf = new XmlFile() {
-        };   // odd syntax is due to XmlFile being abstract
-
-        xf.rootFromFile(file);
+        xmlfile.rootFromFile(file);
 
     }
 

--- a/java/src/jmri/jmrit/symbolicprog/symbolicframe/SymbolicProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/symbolicframe/SymbolicProgFrame.java
@@ -458,7 +458,7 @@ public class SymbolicProgFrame extends jmri.util.JmriJFrame {
             // This is taken in large part from "Java and XML" page 368
             // create root element
             Element root = new Element("locomotive-config");
-            Document doc = jmri.jmrit.XmlFile.newDocument(root, jmri.jmrit.XmlFile.dtdLocation + "locomotive-config.dtd");
+            Document doc = jmri.jmrit.XmlFile.newDocument(root, jmri.jmrit.XmlFile.getDefaultDtdLocation() + "locomotive-config.dtd");
 
             // add XSLT processing instruction
             // <?xml-stylesheet type="text/xsl" href="XSLT/locomotive.xsl"?>

--- a/java/src/jmri/jmrit/throttle/StoreXmlThrottlesLayoutAction.java
+++ b/java/src/jmri/jmrit/throttle/StoreXmlThrottlesLayoutAction.java
@@ -64,7 +64,7 @@ public class StoreXmlThrottlesLayoutAction extends AbstractAction {
 
         try {
             Element root = new Element("throttle-layout-config");
-            Document doc = XmlFile.newDocument(root, XmlFile.dtdLocation + "throttle-layout-config.dtd");
+            Document doc = XmlFile.newDocument(root, XmlFile.getDefaultDtdLocation() + "throttle-layout-config.dtd");
 
             // add XSLT processing instruction
             // <?xml-stylesheet type="text/xsl" href="XSLT/throttle-layout-config.xsl"?>

--- a/java/src/jmri/jmrit/throttle/ThrottleFrame.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleFrame.java
@@ -167,7 +167,7 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
 
         try {
             Element root = new Element("throttle-config");
-            Document doc = XmlFile.newDocument(root, XmlFile.dtdLocation + "throttle-config.dtd");
+            Document doc = XmlFile.newDocument(root, XmlFile.getDefaultDtdLocation() + "throttle-config.dtd");
             // add XSLT processing instruction
             // <?xml-stylesheet type="text/xsl" href="XSLT/throttle.xsl"?>
 /*			java.util.Map<String,String> m = new java.util.HashMap<String,String>();

--- a/java/src/jmri/jmrit/throttle/ThrottlesPreferences.java
+++ b/java/src/jmri/jmrit/throttle/ThrottlesPreferences.java
@@ -186,7 +186,7 @@ public class ThrottlesPreferences {
 
         try {
             Element root = new Element("throttles-preferences");
-            Document doc = XmlFile.newDocument(root, XmlFile.dtdLocation + "throttles-preferences.dtd");
+            Document doc = XmlFile.newDocument(root, XmlFile.getDefaultDtdLocation() + "throttles-preferences.dtd");
             // add XSLT processing instruction
             // <?xml-stylesheet type="text/xsl" href="XSLT/throttle.xsl"?>
 /*TODO    		java.util.Map<String,String> m = new java.util.HashMap<String,String>();

--- a/java/src/jmri/jmrit/vsdecoder/StoreXmlVSDecoderAction.java
+++ b/java/src/jmri/jmrit/vsdecoder/StoreXmlVSDecoderAction.java
@@ -68,7 +68,7 @@ public class StoreXmlVSDecoderAction extends AbstractAction {
 
         try {
             Element root = new Element("VSDecoderConfig");
-            Document doc = XmlFile.newDocument(root, XmlFile.dtdLocation + "vsdecoder-config.dtd");
+            Document doc = XmlFile.newDocument(root, XmlFile.getDefaultDtdLocation() + "vsdecoder-config.dtd");
 
             // add XSLT processing instruction
             // <?xml-stylesheet type="text/xsl" href="XSLT/throttle-layout-config.xsl"?>

--- a/java/test/jmri/configurexml/SchemaTestBase.java
+++ b/java/test/jmri/configurexml/SchemaTestBase.java
@@ -25,7 +25,7 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class SchemaTestBase {
 
-    private boolean verifySchema;
+    private XmlFile.Validate validate;
     private final File file;
     private final boolean pass;
 
@@ -37,7 +37,7 @@ public class SchemaTestBase {
     @Test
     public void validate() {
         Assume.assumeFalse("Ignoring schema validation.", Boolean.getBoolean("jmri.skipschematests"));
-        XmlFile.setVerify(true);
+        XmlFile.setDefaultValidate(XmlFile.Validate.CheckDtdThenSchema);
         XmlFile xf = new XmlFileImpl();
         try {
             xf.rootFromFile(file);
@@ -114,12 +114,12 @@ public class SchemaTestBase {
     public void setUp() throws Exception {
         Log4JFixture.setUp();
         JUnitUtil.resetInstanceManager();
-        this.verifySchema = XmlFile.getVerify();
+        this.validate = XmlFile.getDefaultValidate();
     }
 
     @After
     public void tearDown() throws Exception {
-        XmlFile.setVerify(this.verifySchema);
+        XmlFile.setDefaultValidate(this.validate);
         JUnitUtil.resetInstanceManager();
         Log4JFixture.tearDown();
     }

--- a/java/test/jmri/implementation/testAspects.xml
+++ b/java/test/jmri/implementation/testAspects.xml
@@ -8,10 +8,16 @@
 
     <name>JUnit Test Signals</name>
     <reference>Dummy definition for JUnit testing</reference>
+    <copyright xmlns="http://docbook.org/ns/docbook">
+      <year>2009</year>
+      <year>2010</year>
+      <holder>JMRI</holder>
+    </copyright>
 
     <aspects>
 
     </aspects>
+    
     <appearancefiles>
     </appearancefiles>
 

--- a/java/test/jmri/jmrit/XmlFileTest.java
+++ b/java/test/jmri/jmrit/XmlFileTest.java
@@ -33,43 +33,115 @@ public class XmlFileTest extends TestCase {
             + "util" + File.separator
             + "xml" + File.separator;
 
+    // Test cases to make sure schema and DTD validation 
+    // is properly controlled.  For each of DTD valid, invalid and absent
+    // (ditto schema), check with validate on and off that proper result is obtained.
+    // That's 3*3*2*2 cases!
+    enum Type { ABSENT, VALID, INVALID }
+    public void testValidationControl() {
+    
+        final String docTypeValid = "<!DOCTYPE decoderIndex-config SYSTEM \"decoderIndex-config.dtd\">";
+        final String docTypeInvalid = "<!DOCTYPE layout-config SYSTEM \"layout-config-2-5-4.dtd\">";
+
+        final String contentSchemaValid = "<decoderIndex-config xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://jmri.org/xml/schema/decoder.xsd\">";
+        final String contentSchemaInvalid = "<decoderIndex-config xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://jmri.org/xml/schema/layout-2-9-6.xsd \">";
+        final String contentSchemaAbsent = "<decoderIndex-config>";
+        
+        final String ending = "<decoderIndex><mfgList nmraListDate=\"\" updated=\"\"><manufacturer mfg=\"\"/></mfgList><familyList><family mfg=\"\" name=\"\" file=\"\"/></familyList></decoderIndex></decoderIndex-config>";
+
+        for (XmlFile.Validate validate : XmlFile.Validate.values()) {
+            for (Type theDTD : Type.values()) {
+                for (Type theSchema : Type.values()) {
+                    boolean passes = true;
+                                     
+                    boolean checkDTD = (validate == XmlFile.Validate.CheckDtd) || (validate == XmlFile.Validate.CheckDtdThenSchema);
+                    boolean checkSchema = (validate == XmlFile.Validate.RequireSchema) || (validate == XmlFile.Validate.CheckDtdThenSchema);
+                           
+                    if (theSchema == Type.INVALID && checkSchema) passes = false; // Cannot find the declaration of element 'decoderIndex-config'.
+                    if (theSchema == Type.ABSENT && checkSchema) passes = false; // Cannot find the declaration of element 'decoderIndex-config'.
+                    
+                    if (theDTD == Type.INVALID && checkDTD) passes = false; // Document root element "decoderIndex-config", must match DOCTYPE root "layout-config".
+                    
+                    // but if you're checking both
+                    if ( checkDTD  && checkSchema) {
+                        // a pass is a pass
+                        if (theDTD == Type.VALID) passes = true; 
+                        if (theSchema == Type.VALID) passes = true;       
+                        
+                        // but a DTD fail is a fail
+                        if (theDTD == Type.INVALID) passes = false; 
+                    }
+                    
+                    // create input
+                    
+                    String content = "";
+                    
+                    if (theDTD == Type.VALID) content += docTypeValid;
+                    if (theDTD == Type.INVALID) content += docTypeInvalid;
+
+                    if (theSchema == Type.VALID) content += contentSchemaValid;
+                    if (theSchema == Type.INVALID) content += contentSchemaInvalid;
+                    if (theSchema == Type.ABSENT) content += contentSchemaAbsent;
+                    
+                    content += ending;
+
+                    boolean result = false;
+
+                    try {
+                        XmlFile xf = new XmlFile() {
+                            { warned = false; }
+                        };   // odd syntax is due to XmlFile being abstract
+                        xf.setValidate(validate);
+                        xf.rootFromInputStream(new java.io.ByteArrayInputStream(content.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+                        result = true;
+                    } catch (Exception ex) {
+                        result = false;
+                        log.debug(ex.toString());
+                    }
+
+                    log.debug("DTD: "+theDTD+" SCHEMA: "+theSchema+" ("+validate+") expects "+passes+" was "+result+(passes!=result?" !!!!!!!!!!!!!!!!!!!!!!!!!":"") );
+                    Assert.assertEquals("DTD: "+theDTD+" SCHEMA: "+theSchema+" ("+validate+")", passes, result);
+
+                }
+            }
+        }
+    }
+    
+    
     public void testProgIncludeRelative() {
-        validate(new File(testFileDir + "ProgramMainRelative.xml"));
+        validateFileAndDtdAccess(new File(testFileDir + "ProgramMainRelative.xml"));
     }
 
     public void testProgIncludeURL() {
-        validate(new File(testFileDir + "ProgramMainURL.xml"));
+        validateFileAndDtdAccess(new File(testFileDir + "ProgramMainURL.xml"));
     }
 
     public void testDotDotDTD() {
-        validate(new File(testFileDir + "DotDotDTD.xml"));
+        validateFileAndDtdAccess(new File(testFileDir + "DotDotDTD.xml"));
     }
 
     public void testHttpURL() {
-        validate(new File(testFileDir + "HttpURL.xml"));
+        validateFileAndDtdAccess(new File(testFileDir + "HttpURL.xml"));
     }
 
     public void testJustFilename() {
-        validate(new File(testFileDir + "JustFilename.xml"));
+        validateFileAndDtdAccess(new File(testFileDir + "JustFilename.xml"));
     }
 
     public void testPathname() {
-        validate(new File(testFileDir + "Pathname.xml"));
+        validateFileAndDtdAccess(new File(testFileDir + "Pathname.xml"));
     }
 
-    public void validate(File file) {
-        boolean original = XmlFile.getVerify();
+
+    private void validateFileAndDtdAccess(File file) {  // don't check Schema so can check DTD
         try {
-            XmlFile.setVerify(true);
             XmlFile xf = new XmlFile() {
             };   // odd syntax is due to XmlFile being abstract
+            xf.setValidate(XmlFile.Validate.CheckDtd);
             xf.rootFromFile(file);
         } catch (Exception ex) {
-            XmlFile.setVerify(original);
             Assert.fail(ex.toString());
             return;
-        } finally {
-            XmlFile.setVerify(original);
         }
     }
 
@@ -103,6 +175,10 @@ public class XmlFileTest extends TestCase {
         };
         // create a minimal XML file
         Element root = new Element("decoder-config");
+        root.setAttribute("noNamespaceSchemaLocation",
+                "http://jmri.org/xml/schema/decoder.xsd",
+                org.jdom2.Namespace.getNamespace("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance"));
         Document doc = new Document(root);
         doc.setDocType(new DocType("decoder-config", "decoder-config.dtd"));
 
@@ -122,6 +198,10 @@ public class XmlFileTest extends TestCase {
         // try to read
         XmlFile x = new XmlFile() {
         };
+        
+        // not a real file
+        x.setValidate(XmlFile.Validate.None);
+        
         Element e = x.rootFromName("temp" + File.separator + "prefs" + File.separator + "test.xml");
         Assert.assertTrue("Element found", e != null);
     }
@@ -132,7 +212,7 @@ public class XmlFileTest extends TestCase {
         Element e;
         FileInputStream fs = new FileInputStream(new File("java/test/jmri/jmrit/XmlFileTest_PI.xml"));
         try {
-            SAXBuilder builder = XmlFile.getBuilder(false);  // argument controls validation
+            SAXBuilder builder = XmlFile.getBuilder(XmlFile.Validate.None);  // argument controls validation
             doc = builder.build(new BufferedInputStream(fs));
             Assert.assertNotNull("Original Document found", doc);
             e = doc.getRootElement();

--- a/java/test/jmri/jmrit/jython/SampleScriptTest.java
+++ b/java/test/jmri/jmrit/jython/SampleScriptTest.java
@@ -58,6 +58,7 @@ public class SampleScriptTest extends TestCase {
             super.setUp();
         
             jmri.util.JUnitUtil.resetInstanceManager();
+            jmri.util.JUnitUtil.initConfigureManager();
             jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
             jmri.util.JUnitUtil.initDebugPowerManager();
             jmri.util.JUnitUtil.initInternalSensorManager();

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -6,6 +6,7 @@ import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
+import java.beans.*;
 
 public class SlotManagerTest extends TestCase {
 
@@ -19,7 +20,6 @@ public class SlotManagerTest extends TestCase {
     private LocoNetSlot testSlot;
 
     public void testGetDirectFunctionAddressOK() {
-        SlotManager slotmanager = new SlotManager(lnis);
         LocoNetMessage m1;
 
         m1 = new LocoNetMessage(11);
@@ -54,7 +54,6 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testGetDirectDccPacketOK() {
-        SlotManager slotmanager = new SlotManager(lnis);
         LocoNetMessage m1;
 
         m1 = new LocoNetMessage(11);
@@ -89,7 +88,6 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testGetSlotSend() {
-        SlotManager slotmanager = new SlotManager(lnis);
         testSlot = null;
         SlotListener p2 = new SlotListener() {
             @Override
@@ -109,7 +107,6 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testGetSlotRcv() {
-        SlotManager slotmanager = new SlotManager(lnis);
         testSlot = null;
         SlotListener p2 = new SlotListener() {
             @Override
@@ -150,7 +147,6 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testReadCVPaged() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         int CV1 = 12;
         ProgListener p2 = null;
         slotmanager.setMode(DefaultProgrammerManager.PAGEMODE);
@@ -165,7 +161,6 @@ public class SlotManagerTest extends TestCase {
     // you can rename these. Note that not all (int,...) tests may have a 
     // String(String, ...) test defined, in which case you should create those.
     public void testReadCVPagedString() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         String CV1 = "12";
         ProgListener p2 = null;
         slotmanager.setMode(DefaultProgrammerManager.PAGEMODE);
@@ -176,7 +171,6 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testReadCVRegister() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         int CV1 = 2;
         ProgListener p2 = null;
         slotmanager.setMode(DefaultProgrammerManager.REGISTERMODE);
@@ -187,7 +181,6 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testReadCVRegisterString() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         String CV1 = "2";
         ProgListener p2 = null;
         slotmanager.setMode(DefaultProgrammerManager.REGISTERMODE);
@@ -198,18 +191,34 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testReadCVDirect() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
-        int CV1 = 12;
-        ProgListener p2 = null;
+        log.debug(".... start ...");
+        int CV1 = 29;
         slotmanager.setMode(DefaultProgrammerManager.DIRECTBYTEMODE);
-        slotmanager.readCV(CV1, p2);
+        slotmanager.readCV(CV1, lstn);
         Assert.assertEquals("read message",
-                "EF 0E 7C 2B 00 00 00 00 02 0B 7F 7F 7F 00",
+                "EF 0E 7C 2B 00 00 00 00 02 1C 7F 7F 7F 00",
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+ 
+        // LACK received back (DCS240 sequence)
+        log.debug("send LACK back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
+        Assert.assertEquals("post-LACK status", -999, status);
+        
+        // 1st read received back (DCS240 sequence)
+        log.debug("send 1st reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x2B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1C, 0x23, 0x7F, 0x7F, 0x3B}));
+        Assert.assertEquals("1st reply status", -999, status);
+
+        // 2nd read received back (DCS240 sequence)
+        log.debug("send 2nd reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x2B, 0x00, 0x00, 0x00, 0x00, 0x02, 0x42, 0x7F, 0x7F, 0x7F, 0x76}));
+        Assert.assertEquals("2nd reply status", -999, status);
+        log.debug(".... end ...");
     }
 
     public void testReadCVOpsModeLong() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         int CV1 = 12;
         ProgListener p2 = null;
         slotmanager.readCVOpsMode(CV1, p2, 4 * 128 + 0x23, true);
@@ -219,7 +228,6 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testReadCVOpsModeShort() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         int CV1 = 12;
         ProgListener p2 = null;
         slotmanager.readCVOpsMode(CV1, p2, 22, false);
@@ -229,7 +237,6 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testWriteCVPaged() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         int CV1 = 12;
         int val2 = 34;
         ProgListener p3 = null;
@@ -241,7 +248,6 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testWriteCVPagedString() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         String CV1 = "12";
         int val2 = 34;
         ProgListener p3 = null;
@@ -253,7 +259,6 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testWriteCVRegister() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         int CV1 = 2;
         int val2 = 34;
         ProgListener p3 = null;
@@ -265,7 +270,6 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testWriteCVDirect() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         int CV1 = 12;
         int val2 = 34;
         ProgListener p3 = null;
@@ -277,7 +281,6 @@ public class SlotManagerTest extends TestCase {
     }
 
     public void testWriteCVDirectString() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         String CV1 = "12";
         int val2 = 34;
         ProgListener p3 = null;
@@ -288,19 +291,39 @@ public class SlotManagerTest extends TestCase {
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
     }
 
+    public void testWriteCVDirectStringDCS240() throws jmri.ProgrammerException {
+        String CV1 = "12";
+        int val2 = 34;
+        slotmanager.setMode(DefaultProgrammerManager.DIRECTBYTEMODE);
+        slotmanager.writeCV(CV1, val2, lstn);
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+        Assert.assertEquals("write message",
+                "EF 0E 7C 6B 00 00 00 00 00 0B 22 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+                
+        // [B4 6F 01 25] LONG_ACK: The Slot Write command was accepted.
+        
+        // write not complete
+        
+        // [E7 0E 7C 6B 00 00 02 47 00 1E 10 7F 7F 4A] Programming Response: Write Byte in Direct Mode on Service Track to CV31 value 16 (0x10, 10000).
+
+        // Then write complete
+    }
+
     public void testWriteCVOpsLongAddr() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         int CV1 = 12;
         int val2 = 34;
         ProgListener p3 = null;
         slotmanager.writeCVOpsMode(CV1, val2, p3, 4 * 128 + 0x23, true);
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
         Assert.assertEquals("write message",
                 "EF 0E 7C 67 00 04 23 00 00 0B 22 7F 7F 00",
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
     }
 
     public void testWriteCVOpsShortAddr() throws jmri.ProgrammerException {
-        SlotManager slotmanager = new SlotManager(lnis);
         int CV1 = 12;
         int val2 = 34;
         ProgListener p3 = null;
@@ -324,12 +347,30 @@ public class SlotManagerTest extends TestCase {
 
     // The minimal setup for log4J
     LocoNetInterfaceScaffold lnis;
-
+    SlotManager slotmanager;
+    int status;
+    int value;
+    
+    ProgListener lstn;
+    
     @Override
     protected void setUp() {
         jmri.util.JUnitUtil.resetInstanceManager();
+        
         // prepare an interface
         lnis = new LocoNetInterfaceScaffold();
+        slotmanager = new SlotManager(lnis);
+        status = -999;
+        value = -999;
+        
+        lstn = new ProgListener(){
+            public void programmingOpReply(int val, int stat) {
+                System.out.println("reply "+val+" "+stat);
+                status = stat;
+                value = val;
+            }
+        };
+        
         apps.tests.Log4JFixture.setUp();
     }
 
@@ -337,5 +378,7 @@ public class SlotManagerTest extends TestCase {
     protected void tearDown() {
         apps.tests.Log4JFixture.tearDown();
     }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SlotManager.class.getName());
 
 }

--- a/jython/TurnOffXmlValidation.py
+++ b/jython/TurnOffXmlValidation.py
@@ -1,0 +1,13 @@
+# Sample script to turn off validation when reading XML files
+#
+# Author: Bob Jacobsen, copyright 2017
+# Part of the JMRI distribution
+
+import java
+import jmri
+
+# to turn off panel file
+jmri.InstanceManager.getDefault(jmri.ConfigureManager).setValidate(jmri.jmrit.XmlFile.Validate.None)
+
+# to turn off globally (but might be overridden locally)
+jmri.jmrit.XmlFile.setDefaultValidate(jmri.jmrit.XmlFile.Validate.None)

--- a/jython/test/TurnOffXmlValidationTest.py
+++ b/jython/test/TurnOffXmlValidationTest.py
@@ -1,0 +1,20 @@
+# Test the TurnoffXmlValidation.py script
+import jmri
+
+# capture before values
+v1before = jmri.InstanceManager.getDefault(jmri.ConfigureManager).getValidate()
+v2before = jmri.jmrit.XmlFile.getDefaultValidate()
+
+execfile("jython/TurnOffXmlValidation.py")
+
+# capture after values
+v1after = jmri.InstanceManager.getDefault(jmri.ConfigureManager).getValidate()
+v2after = jmri.jmrit.XmlFile.getDefaultValidate()
+
+# restore before
+jmri.InstanceManager.getDefault(jmri.ConfigureManager).setValidate(v1before)
+jmri.jmrit.XmlFile.setDefaultValidate(v2before)
+
+# check results
+if (v1after != jmri.jmrit.XmlFile.Validate.None) : raise AssertionError('ConfigureManager not set')
+if (v2after != jmri.jmrit.XmlFile.Validate.None) : raise AssertionError('XmlFile not set')

--- a/xml/DTD/decoderIndex-config.dtd
+++ b/xml/DTD/decoderIndex-config.dtd
@@ -13,7 +13,8 @@
 <!-- for more details.                                                      -->
 
 <!ELEMENT decoderIndex-config (decoderIndex)>
-<!ATTLIST decoderIndex-config>
+<!ATTLIST decoderIndex-config xmlns:xsi	CDATA #IMPLIED> <!-- to allow XML Schema reference to be DTD valid -->
+<!ATTLIST decoderIndex-config xsi:noNamespaceSchemaLocation	CDATA #IMPLIED> <!-- to allow XML Schema reference to be DTD valid -->
 
 <!ELEMENT decoderIndex (mfgList, familyList)>
 <!ATTLIST decoderIndex version	CDATA #IMPLIED>   <!-- version of the index, controls update -->

--- a/xml/DTD/layout-config-2-5-4.dtd
+++ b/xml/DTD/layout-config-2-5-4.dtd
@@ -25,6 +25,8 @@
 			signalheads | conditionals | logixs | application | signalelements | reporters |
 			memories | memorys | timebase |
 			layoutblocks )*>
+  <!ATTLIST layout-config xmlns:xsi	CDATA #IMPLIED> <!-- to allow XML Schema reference to be DTD valid -->
+  <!ATTLIST layout-config xsi:noNamespaceSchemaLocation	CDATA #IMPLIED> <!-- to allow XML Schema reference to be DTD valid -->
 
 <!-- Overall application configuration -->
 <!ELEMENT application (connection*, gui*, programmer, roster?, perform*)>


### PR DESCRIPTION
- XmlFile.Validate enum specifies four levels of validation
- Expose validation for all files and ConfigureXml reads so can be controlled separately
- Sample script for turning off validation - users can use this as a bypass if they run into trouble
- tests, tests and more tests