### PR TITLE
SignalGroup schema update and test file

### DIFF
--- a/java/test/jmri/configurexml/load/testStoreSignalGroup.xml
+++ b/java/test/jmri/configurexml/load/testStoreSignalGroup.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-2-9-6.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-2-9-6.xsd">
+  <jmriversion>
+    <major>4</major>
+    <minor>7</minor>
+    <test>2</test>
+    <modifier>.2ish</modifier>
+  </jmriversion>
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
+    <defaultInitialState>unknown</defaultInitialState>
+    <sensor systemName="ISCLOCKRUNNING" inverted="false">
+      <systemName>ISCLOCKRUNNING</systemName>
+    </sensor>
+  </sensors>
+  <memories class="jmri.managers.configurexml.DefaultMemoryManagerXml">
+    <memory systemName="IMCURRENTTIME" value="8:43 AM">
+      <systemName>IMCURRENTTIME</systemName>
+    </memory>
+    <memory systemName="IMRATEFACTOR" value="1.0">
+      <systemName>IMRATEFACTOR</systemName>
+    </memory>
+  </memories>
+  <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml">
+    <virtualsignalmast class="jmri.implementation.configurexml.VirtualSignalMastXml" userName="virtmast1">
+      <systemName>IF$vsm:AAR-1946:CPL($0001)</systemName>
+      <userName>virtmast1</userName>
+      <unlit allowed="no" />
+    </virtualsignalmast>
+  </signalmasts>
+  <signalgroups class="jmri.managers.configurexml.DefaultSignalGroupManagerXml">
+    <signalgroup systemName="R12" userName="mygroup" signalMast="virtmast1">
+      <systemName>R12</systemName>
+      <aspect valid="Clear" />
+      <aspect valid="Approach" />
+    </signalgroup>
+  </signalgroups>
+  <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
+  <warrants class="jmri.jmrit.logix.configurexml.WarrantManagerXml" />
+  <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
+    <logicDelay>500</logicDelay>
+  </signalmastlogics>
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Mon Mar 13 08:40:48 CET 2017" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
+  <!--Written by JMRI version 4.7.2ish-201703121643-jenkins-Rd22234a on Mon Mar 13 08:43:58 CET 2017 $Id$-->
+</layout-config>

--- a/xml/schema/types/signalgroups-2-9-6.xsd
+++ b/xml/schema/types/signalgroups-2-9-6.xsd
@@ -67,7 +67,7 @@
           </xs:complexType>
         </xs:element>
 
-        <xs:element name="signalHead" minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="signalHead" minOccurs="0" maxOccurs="unbounded">
           <xs:complexType>
             <xs:sequence>
               <xs:element name="turnout" minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
More on this-date comments on #3109.  Allows a SignalGroup with no signalhead elements to validate.