### PR TITLE
Length LocoNet programming timeout

### DIFF
--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -1036,9 +1036,10 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
      * is only needed in service mode.
      */
     protected void restartEndOfProgrammingTimer() {
+        final int delay = 10000;
         if (mProgEndSequence) {
             if (mPowerTimer == null) {
-                mPowerTimer = new javax.swing.Timer(2000, new java.awt.event.ActionListener() {
+                mPowerTimer = new javax.swing.Timer(delay, new java.awt.event.ActionListener() {
                     @Override
                     public void actionPerformed(java.awt.event.ActionEvent e) {
                         doEndOfProgramming();
@@ -1046,7 +1047,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
                 });
             }
             mPowerTimer.stop();
-            mPowerTimer.setInitialDelay(2000);
+            mPowerTimer.setInitialDelay(delay);
             mPowerTimer.setRepeats(false);
             mPowerTimer.start();
         }


### PR DESCRIPTION
Lengthen LocoNet programming timeout to try to fix #3171. Includes test from #3171 sequence.