### PR TITLE
Update timing for DCS240; programming facade error handling

### DIFF
--- a/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
+++ b/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
@@ -175,8 +175,20 @@ public class AccessoryOpsModeProgrammerFacade extends AbstractProgrammerFacade i
             log.debug("notifyProgListenerEnd value " + value + " status " + status);
         }
 
+        if (status != OK ) {
+            // pass abort up
+            log.error("Reset and pass abort up");
+            jmri.ProgListener temp = _usingProgrammer;
+            _usingProgrammer = null; // done
+            state = ProgState.NOTPROGRAMMING;
+            temp.programmingOpReply(value, status);
+            return;
+        }
+        
         if (_usingProgrammer == null) {
-            log.error("No listener to notify");
+            log.error("No listener to notify, reset and ignore");
+            state = ProgState.NOTPROGRAMMING;
+            return;
         }
 
         switch (state) {

--- a/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
+++ b/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
@@ -177,7 +177,7 @@ public class AccessoryOpsModeProgrammerFacade extends AbstractProgrammerFacade i
 
         if (status != OK ) {
             // pass abort up
-            log.error("Reset and pass abort up");
+            log.debug("Reset and pass abort up");
             jmri.ProgListener temp = _usingProgrammer;
             _usingProgrammer = null; // done
             state = ProgState.NOTPROGRAMMING;

--- a/java/src/jmri/implementation/AddressedHighCvProgrammerFacade.java
+++ b/java/src/jmri/implementation/AddressedHighCvProgrammerFacade.java
@@ -144,8 +144,20 @@ public class AddressedHighCvProgrammerFacade extends AbstractProgrammerFacade im
             log.debug("notifyProgListenerEnd value " + value + " status " + status);
         }
 
+        if (status != OK ) {
+            // pass abort up
+            log.error("Reset and pass abort up");
+            jmri.ProgListener temp = _usingProgrammer;
+            _usingProgrammer = null; // done
+            state = ProgState.NOTPROGRAMMING;
+            temp.programmingOpReply(value, status);
+            return;
+        }
+        
         if (_usingProgrammer == null) {
-            log.error("No listener to notify");
+            log.error("No listener to notify, reset and ignore");
+            state = ProgState.NOTPROGRAMMING;
+            return;
         }
 
         switch (state) {

--- a/java/src/jmri/implementation/AddressedHighCvProgrammerFacade.java
+++ b/java/src/jmri/implementation/AddressedHighCvProgrammerFacade.java
@@ -146,7 +146,7 @@ public class AddressedHighCvProgrammerFacade extends AbstractProgrammerFacade im
 
         if (status != OK ) {
             // pass abort up
-            log.error("Reset and pass abort up");
+            log.debug("Reset and pass abort up");
             jmri.ProgListener temp = _usingProgrammer;
             _usingProgrammer = null; // done
             state = ProgState.NOTPROGRAMMING;

--- a/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
+++ b/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
@@ -170,8 +170,20 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
     public void programmingOpReply(int value, int status) {
         log.debug("notifyProgListenerEnd value {} status {} ", value, status);
 
+        if (status != OK ) {
+            // pass abort up
+            log.error("Reset and pass abort up");
+            jmri.ProgListener temp = _usingProgrammer;
+            _usingProgrammer = null; // done
+            state = ProgState.NOTPROGRAMMING;
+            temp.programmingOpReply(value, status);
+            return;
+        }
+        
         if (_usingProgrammer == null) {
-            log.error("No listener to notify");
+            log.error("No listener to notify, reset and ignore");
+            state = ProgState.NOTPROGRAMMING;
+            return;
         }
 
         switch (state) {

--- a/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
+++ b/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
@@ -172,7 +172,7 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
 
         if (status != OK ) {
             // pass abort up
-            log.error("Reset and pass abort up");
+            log.debug("Reset and pass abort up");
             jmri.ProgListener temp = _usingProgrammer;
             _usingProgrammer = null; // done
             state = ProgState.NOTPROGRAMMING;

--- a/java/src/jmri/implementation/OffsetHighCvProgrammerFacade.java
+++ b/java/src/jmri/implementation/OffsetHighCvProgrammerFacade.java
@@ -131,8 +131,20 @@ public class OffsetHighCvProgrammerFacade extends AbstractProgrammerFacade imple
             log.debug("notifyProgListenerEnd value " + value + " status " + status);
         }
 
+        if (status != OK ) {
+            // pass abort up
+            log.error("Reset and pass abort up");
+            jmri.ProgListener temp = _usingProgrammer;
+            _usingProgrammer = null; // done
+            state = ProgState.NOTPROGRAMMING;
+            temp.programmingOpReply(value, status);
+            return;
+        }
+        
         if (_usingProgrammer == null) {
-            log.error("No listener to notify");
+            log.error("No listener to notify, reset and ignore");
+            state = ProgState.NOTPROGRAMMING;
+            return;
         }
 
         switch (state) {

--- a/java/src/jmri/implementation/OffsetHighCvProgrammerFacade.java
+++ b/java/src/jmri/implementation/OffsetHighCvProgrammerFacade.java
@@ -133,7 +133,7 @@ public class OffsetHighCvProgrammerFacade extends AbstractProgrammerFacade imple
 
         if (status != OK ) {
             // pass abort up
-            log.error("Reset and pass abort up");
+            log.debug("Reset and pass abort up");
             jmri.ProgListener temp = _usingProgrammer;
             _usingProgrammer = null; // done
             state = ProgState.NOTPROGRAMMING;

--- a/java/src/jmri/implementation/ResettingOffsetHighCvProgrammerFacade.java
+++ b/java/src/jmri/implementation/ResettingOffsetHighCvProgrammerFacade.java
@@ -138,8 +138,20 @@ public class ResettingOffsetHighCvProgrammerFacade extends AbstractProgrammerFac
             log.debug("notifyProgListenerEnd value " + value + " status " + status);
         }
 
+        if (status != OK ) {
+            // pass abort up
+            log.error("Reset and pass abort up");
+            jmri.ProgListener temp = _usingProgrammer;
+            _usingProgrammer = null; // done
+            state = ProgState.NOTPROGRAMMING;
+            temp.programmingOpReply(value, status);
+            return;
+        }
+        
         if (_usingProgrammer == null) {
-            log.error("No listener to notify");
+            log.error("No listener to notify, reset and ignore");
+            state = ProgState.NOTPROGRAMMING;
+            return;
         }
 
         switch (state) {

--- a/java/src/jmri/implementation/ResettingOffsetHighCvProgrammerFacade.java
+++ b/java/src/jmri/implementation/ResettingOffsetHighCvProgrammerFacade.java
@@ -140,7 +140,7 @@ public class ResettingOffsetHighCvProgrammerFacade extends AbstractProgrammerFac
 
         if (status != OK ) {
             // pass abort up
-            log.error("Reset and pass abort up");
+            log.debug("Reset and pass abort up");
             jmri.ProgListener temp = _usingProgrammer;
             _usingProgrammer = null; // done
             state = ProgState.NOTPROGRAMMING;

--- a/java/src/jmri/implementation/TwoIndexTcsProgrammerFacade.java
+++ b/java/src/jmri/implementation/TwoIndexTcsProgrammerFacade.java
@@ -191,7 +191,7 @@ public class TwoIndexTcsProgrammerFacade extends AbstractProgrammerFacade implem
     protected void processProgrammingOpReply(int value, int status) {
         if (status != OK ) {
             // pass abort up
-            log.error("Reset and pass abort up");
+            log.debug("Reset and pass abort up");
             jmri.ProgListener temp = _usingProgrammer;
             _usingProgrammer = null; // done
             state = ProgState.NOTPROGRAMMING;

--- a/java/src/jmri/implementation/TwoIndexTcsProgrammerFacade.java
+++ b/java/src/jmri/implementation/TwoIndexTcsProgrammerFacade.java
@@ -167,7 +167,9 @@ public class TwoIndexTcsProgrammerFacade extends AbstractProgrammerFacade implem
         }
 
         if (_usingProgrammer == null) {
-            log.error("No listener to notify");
+            log.error("No listener to notify, reset and ignore");
+            state = ProgState.NOTPROGRAMMING;
+            return;
         }
         
         // Complete processing later so that WOWDecoder will go through a complete power on reset and not brown out between CV read/writes
@@ -187,6 +189,16 @@ public class TwoIndexTcsProgrammerFacade extends AbstractProgrammerFacade implem
     
     // After a Swing delay, this processes the reply
     protected void processProgrammingOpReply(int value, int status) {
+        if (status != OK ) {
+            // pass abort up
+            log.error("Reset and pass abort up");
+            jmri.ProgListener temp = _usingProgrammer;
+            _usingProgrammer = null; // done
+            state = ProgState.NOTPROGRAMMING;
+            temp.programmingOpReply(value, status);
+            return;
+        }
+
         switch (state) {
             case DOSIFORREAD:
                 try {

--- a/java/src/jmri/jmrix/AbstractProgrammer.java
+++ b/java/src/jmri/jmrix/AbstractProgrammer.java
@@ -13,6 +13,13 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Common implementations for the Programmer interface.
+ * <p>
+ * Contains two time-out handlers:
+ * <ul>
+ * <li> SHORT_TIMEOUT, the "short timer", is on operations other than reads
+ * <li> LONG_TIMEOUT, the "long timer", is for the "read from decoder" step, which can take a long time.
+ *</ul>
+ * The duration of these can be adjusted by changing the values of those constants in subclasses.
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2012, 2013
  */
@@ -203,6 +210,7 @@ public abstract class AbstractProgrammer implements Programmer {
      * Internal routine to start timer to protect the mode-change.
      */
     protected void startShortTimer() {
+        log.debug("startShortTimer");
         restartTimer(SHORT_TIMEOUT);
     }
 
@@ -210,6 +218,7 @@ public abstract class AbstractProgrammer implements Programmer {
      * Internal routine to restart timer with a long delay
      */
     protected void startLongTimer() {
+        log.debug("startLongTimer");
         restartTimer(LONG_TIMEOUT);
     }
 
@@ -217,6 +226,7 @@ public abstract class AbstractProgrammer implements Programmer {
      * Internal routine to stop timer, as all is well
      */
     protected synchronized void stopTimer() {
+        log.debug("stop timer");
         if (timer != null) {
             timer.stop();
         }
@@ -226,9 +236,8 @@ public abstract class AbstractProgrammer implements Programmer {
      * Internal routine to handle timer starts {@literal &} restarts
      */
     protected synchronized void restartTimer(int delay) {
-        if (log.isDebugEnabled()) {
-            log.debug("restart timer with delay " + delay);
-        }
+        log.debug("(re)start timer with delay {}", delay);
+
         if (timer == null) {
             timer = new javax.swing.Timer(delay, new java.awt.event.ActionListener() {
                 @Override

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockPacketizer.java
@@ -48,7 +48,7 @@ public class UhlenbrockPacketizer extends LnPacketizer implements LocoNetInterfa
     public static final int NOTIFIEDSTATE = 15;    // xmt notified, will next wake
     public static final int WAITMSGREPLYSTATE = 25;  // xmt has sent, await reply to message
 
-    static int defaultWaitTimer = 2000;
+    static int defaultWaitTimer = 10000;
 
     /**
      * Forward a preformatted LocoNetMessage to the actual interface.

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -683,6 +683,9 @@ public class SlotManagerTest extends TestCase {
         jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
         Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
         
+        jmri.util.JUnitAppender.suppressErrorMessage("Reset and pass abort up ");
+        jmri.util.JUnitAppender.suppressErrorMessage("Reset and pass abort up ");
+        
         log.debug(".... end testReadThroughFacadeFail ...");
     }
 

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -203,14 +203,19 @@ public class SlotManagerTest extends TestCase {
  
         // LACK received back (DCS240 sequence)
         log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;
+
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
-        jmri.util.JUnitUtil.releaseThread(this, 150);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
         Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started long timer", startedLongTimer);
+        Assert.assertFalse("didn't start short timer", startedShortTimer);
         
         // read received back (DCS240 sequence)
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x2B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1C, 0x23, 0x7F, 0x7F, 0x3B}));
-        jmri.util.JUnitUtil.releaseThread(this, 150);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
         log.debug("checking..");
         Assert.assertEquals("reply status", 0, status);
         Assert.assertEquals("reply value", 35, value);
@@ -307,15 +312,19 @@ public class SlotManagerTest extends TestCase {
  
         // LACK received back (DCS240 sequence)
         log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
-        jmri.util.JUnitUtil.releaseThread(this, 150);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
         Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started short timer", startedShortTimer);
+        Assert.assertFalse("didn't start long timer", startedLongTimer);
         
         // read received back (DCS240 sequence)
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1E, 0x10, 0x7F, 0x7F, 0x4A}));
         Assert.assertEquals("no immediate reply", -999, status);
-        jmri.util.JUnitUtil.releaseThread(this, 150);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
         log.debug("checking..");
         Assert.assertEquals("reply status", 0, status);
         Assert.assertEquals("reply value", -1, value);
@@ -323,6 +332,13 @@ public class SlotManagerTest extends TestCase {
         log.debug(".... end testWriteCVDirectStringDCS240 ...");
     }
 
+    public void testLackLogic() {
+        LocoNetMessage m = new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25});
+        Assert.assertTrue("checkLackTaskAccepted(m.getElement(2))", slotmanager.checkLackTaskAccepted(m.getElement(2)));
+        Assert.assertFalse("checkLackProgrammerBusy(m.getElement(2))", slotmanager.checkLackProgrammerBusy(m.getElement(2)));
+        Assert.assertFalse("checkLackAcceptedBlind(m.getElement(2))", slotmanager.checkLackAcceptedBlind(m.getElement(2)));
+    }
+    
     public void testWriteCVDirectStringDCS240Interrupted() throws jmri.ProgrammerException {
         log.debug(".... start testWriteCVDirectStringDCS240 ...");
         String CV1 = "31";
@@ -339,21 +355,26 @@ public class SlotManagerTest extends TestCase {
  
         // LACK received back (DCS240 sequence)
         log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;
+
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
-        jmri.util.JUnitUtil.releaseThread(this, 150);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
         Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started short timer", startedShortTimer);
+        Assert.assertFalse("didn't start long timer", startedLongTimer);
         
         // CS check received back (DCS240 sequence)
         log.debug("send CS check back");
         slotmanager.message(new LocoNetMessage(new int[]{0xBB, 0x7F, 0x00, 0x3B}));
-        jmri.util.JUnitUtil.releaseThread(this, 150);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
         Assert.assertEquals("post-CS-check status", -999, status);
         
         // read received back (DCS240 sequence)
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1E, 0x10, 0x7F, 0x7F, 0x4A}));
         Assert.assertEquals("no immediate reply", -999, status);
-        jmri.util.JUnitUtil.releaseThread(this, 150);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
         log.debug("checking..");
         Assert.assertEquals("reply status", 0, status);
         Assert.assertEquals("reply value", -1, value);
@@ -383,6 +404,289 @@ public class SlotManagerTest extends TestCase {
                 lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
     }
 
+    public void testWriteThroughFacade() throws jmri.ProgrammerException {
+        log.debug(".... start testWriteThroughFacade ...");
+        slotmanager.setMode(DefaultProgrammerManager.DIRECTBYTEMODE);
+        
+        // install Facades from ESU_LokSoundV4_0.xml
+
+        // <name>High Access via Double Index</name>
+        String top = "256";
+        String addrCVhigh = "96";
+        String addrCVlow = "97";
+        String valueCV = "99";
+        String modulo = "100";
+        jmri.implementation.AddressedHighCvProgrammerFacade pf1
+                = new jmri.implementation.AddressedHighCvProgrammerFacade(slotmanager, top, addrCVhigh, addrCVlow, valueCV, modulo);
+
+        // <name>Indexed CV access</name>
+        String PI = "31";
+        String SI = "16";
+        boolean cvFirst = false;
+        jmri.implementation.MultiIndexProgrammerFacade pf2
+                = new jmri.implementation.MultiIndexProgrammerFacade(pf1, PI, SI, cvFirst);
+
+        String CV1 = "16.2.257";
+        int val2 = 55;
+          
+        // Start overall sequence
+        pf2.writeCV(CV1, val2, lstn);
+        
+        // Check for PI write
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+        Assert.assertEquals("write PI message",
+                "EF 0E 7C 6B 00 00 00 00 00 1E 10 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+ 
+        // LACK received back (DCS240 sequence) to PI write
+        log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;        
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started short timer", startedShortTimer);
+        Assert.assertFalse("didn't start long timer", startedLongTimer);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+        
+        // completion received back (DCS240 sequence) to PI write
+        log.debug("send E7 reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1E, 0x10, 0x7F, 0x7F, 0x4A}));
+        Assert.assertEquals("no immediate reply", -999, status);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        Assert.assertEquals("initial status", -999, status);
+        
+        // check that SI write happened
+        Assert.assertEquals("two messages sent", 2, lnis.outbound.size());
+        Assert.assertEquals("write SI message",
+                "EF 0E 7C 6B 00 00 00 00 00 0F 02 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("initial status", -999, status);
+
+        // LACK received back (DCS240 sequence) to SI write
+        log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;        
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started short timer", startedShortTimer);
+        Assert.assertFalse("didn't start long timer", startedLongTimer);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        Assert.assertEquals("still two messages sent", 2, lnis.outbound.size());
+
+        // completion received back (DCS240 sequence) to SI write
+        log.debug("send E7 reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x0F, 0x02, 0x7F, 0x7F, 0x4A}));
+        Assert.assertEquals("no immediate reply", -999, status);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        Assert.assertEquals("initial status", -999, status);
+        
+        // check that final CV write happened
+        Assert.assertEquals("three messages sent", 3, lnis.outbound.size());
+        Assert.assertEquals("write final CV message",
+                "EF 0E 7C 6B 00 00 00 00 10 00 37 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("initial status", -999, status);
+
+        // LACK received back (DCS240 sequence) to final CV write
+        log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;        
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started short timer", startedShortTimer);
+        Assert.assertFalse("didn't start long timer", startedLongTimer);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        Assert.assertEquals("three messages sent", 3, lnis.outbound.size());
+
+        // completion received back (DCS240 sequence)
+        log.debug("send E7 reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x10, 0x00, 0x37, 0x7F, 0x7F, 0x4A}));
+        Assert.assertEquals("no immediate reply", -999, status);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        log.debug("checking..");
+        Assert.assertEquals("reply status", 0, status);
+        Assert.assertEquals("reply value", -1, value);
+        Assert.assertEquals("three messages sent", 3, lnis.outbound.size());
+
+        log.debug(".... end testWriteThroughFacade ...");
+    }
+
+    public void testReadThroughFacade() throws jmri.ProgrammerException {
+        log.debug(".... start testReadThroughFacade ...");
+        slotmanager.setMode(DefaultProgrammerManager.DIRECTBYTEMODE);
+        
+        // install Facades from ESU_LokSoundV4_0.xml
+
+        // <name>High Access via Double Index</name>
+        String top = "256";
+        String addrCVhigh = "96";
+        String addrCVlow = "97";
+        String valueCV = "99";
+        String modulo = "100";
+        jmri.implementation.AddressedHighCvProgrammerFacade pf1
+                = new jmri.implementation.AddressedHighCvProgrammerFacade(slotmanager, top, addrCVhigh, addrCVlow, valueCV, modulo);
+
+        // <name>Indexed CV access</name>
+        String PI = "31";
+        String SI = "16";
+        boolean cvFirst = false;
+        jmri.implementation.MultiIndexProgrammerFacade pf2
+                = new jmri.implementation.MultiIndexProgrammerFacade(pf1, PI, SI, cvFirst);
+
+        String CV1 = "16.2.257";
+        int val2 = 55;
+          
+        // Start overall sequence
+        pf2.readCV(CV1, lstn);
+        
+        // Check for PI write
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+        Assert.assertEquals("write PI message",
+                "EF 0E 7C 6B 00 00 00 00 00 1E 10 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+ 
+        // LACK received back (DCS240 sequence) to PI write
+        log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;        
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started short timer", startedShortTimer);
+        Assert.assertFalse("didn't start long timer", startedLongTimer);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+        
+        // completion received back (DCS240 sequence) to PI write
+        log.debug("send E7 reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1E, 0x10, 0x7F, 0x7F, 0x4A}));
+        Assert.assertEquals("no immediate reply", -999, status);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        Assert.assertEquals("initial status", -999, status);
+        
+        // check that SI write happened
+        Assert.assertEquals("two messages sent", 2, lnis.outbound.size());
+        Assert.assertEquals("write SI message",
+                "EF 0E 7C 6B 00 00 00 00 00 0F 02 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("initial status", -999, status);
+
+        // LACK received back (DCS240 sequence) to SI write
+        log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;        
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started short timer", startedShortTimer);
+        Assert.assertFalse("didn't start long timer", startedLongTimer);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        Assert.assertEquals("still two messages sent", 2, lnis.outbound.size());
+
+        // completion received back (DCS240 sequence) to SI write
+        log.debug("send E7 reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x0F, 0x02, 0x7F, 0x7F, 0x4A}));
+        Assert.assertEquals("no immediate reply", -999, status);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        Assert.assertEquals("initial status", -999, status);
+        
+        // check that final CV write happened
+        Assert.assertEquals("three messages sent", 3, lnis.outbound.size());
+        Assert.assertEquals("write final CV message",
+                "EF 0E 7C 2B 00 00 00 00 12 00 7F 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("initial status", -999, status);
+
+        // LACK received back (DCS240 sequence) to final CV write
+        log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;        
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started long timer", startedLongTimer);
+        Assert.assertFalse("didn't start short timer", startedShortTimer);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        Assert.assertEquals("three messages sent", 3, lnis.outbound.size());
+
+        // completion received back (DCS240 sequence)
+        log.debug("send E7 reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x10, 0x00, 0x37, 0x7F, 0x7F, 0x4A}));
+        Assert.assertEquals("no immediate reply", -999, status);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        log.debug("checking..");
+        Assert.assertEquals("reply status", 0, status);
+        Assert.assertEquals("reply value", 55, value);
+        Assert.assertEquals("three messages sent", 3, lnis.outbound.size());
+
+        log.debug(".... end testReadThroughFacade ...");
+    }
+
+    public void testReadThroughFacadeFail() throws jmri.ProgrammerException {
+        log.debug(".... start testReadThroughFacadeFail ...");
+        slotmanager.setMode(DefaultProgrammerManager.DIRECTBYTEMODE);
+        
+        // install Facades from ESU_LokSoundV4_0.xml
+
+        // <name>High Access via Double Index</name>
+        String top = "256";
+        String addrCVhigh = "96";
+        String addrCVlow = "97";
+        String valueCV = "99";
+        String modulo = "100";
+        jmri.implementation.AddressedHighCvProgrammerFacade pf1
+                = new jmri.implementation.AddressedHighCvProgrammerFacade(slotmanager, top, addrCVhigh, addrCVlow, valueCV, modulo);
+
+        // <name>Indexed CV access</name>
+        String PI = "31";
+        String SI = "16";
+        boolean cvFirst = false;
+        jmri.implementation.MultiIndexProgrammerFacade pf2
+                = new jmri.implementation.MultiIndexProgrammerFacade(pf1, PI, SI, cvFirst);
+
+        String CV1 = "16.2.257";
+        int val2 = 55;
+          
+        // Start overall sequence
+        pf2.readCV(CV1, lstn);
+        
+        // Check for PI write
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+        Assert.assertEquals("write PI message",
+                "EF 0E 7C 6B 00 00 00 00 00 1E 10 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+ 
+        // LACK received back (DCS240 sequence) to PI write: rejected
+        log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;        
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x0, 0x24}));
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        Assert.assertEquals("post-LACK status is fail", 4, status);
+        Assert.assertFalse("didn't start short timer", startedShortTimer);
+        Assert.assertFalse("didn't start long timer", startedLongTimer);
+        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
+        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
+        
+        log.debug(".... end testReadThroughFacadeFail ...");
+    }
+
+
     // Main entry point
     static public void main(String[] args) {
         String[] testCaseName = {SlotManagerTest.class.getName()};
@@ -400,8 +704,12 @@ public class SlotManagerTest extends TestCase {
     SlotManager slotmanager;
     int status;
     int value;
+    boolean startedShortTimer = false;
+    boolean startedLongTimer = false;
+    boolean stoppedTimer = false;
     
     ProgListener lstn;
+    int releaseTestDelay = 150; // probably needs to be at least 150, see SlotManager.postProgDelay
     
     @Override
     protected void setUp() {
@@ -409,9 +717,29 @@ public class SlotManagerTest extends TestCase {
         
         // prepare an interface
         lnis = new LocoNetInterfaceScaffold();
-        slotmanager = new SlotManager(lnis);
+        
+        slotmanager = new SlotManager(lnis) {
+            @Override
+            protected void startLongTimer() {
+                super.startLongTimer();
+                startedLongTimer = true;
+            }   
+            @Override
+            protected void startShortTimer() {
+                super.startShortTimer();
+                startedShortTimer = true;
+            }
+            @Override
+            protected void stopTimer() {
+                super.stopTimer();
+                stoppedTimer = true;
+            }
+        };
+        
         status = -999;
         value = -999;
+        startedShortTimer = false;
+        startedLongTimer = false;
         
         lstn = new ProgListener(){
             @Override

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -683,9 +683,6 @@ public class SlotManagerTest extends TestCase {
         jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);  // wait for slow reply
         Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
         
-        jmri.util.JUnitAppender.suppressErrorMessage("Reset and pass abort up ");
-        jmri.util.JUnitAppender.suppressErrorMessage("Reset and pass abort up ");
-        
         log.debug(".... end testReadThroughFacadeFail ...");
     }
 


### PR DESCRIPTION
- Raise "short" timeout, used for write operations, on LocoNet command stations to 8 seconds.  (Looks like DCS240 can take a long time to do a write, which seems ungood, but there it is; not made DCS240-specific because (a) timeouts are in any case abnormal conditions and (b) not really sure it's DCS240-specific)
- Improve/simplify how programming facade classes handle overlapping errors & error propagation: once you're hosed, you're hosed, so just back out and allow higher levels to handle the retry

Plus Javadoc and logging improvements, replacement of numerical constants with symbolized values.

See #3171 for further discussion 