### PR TITLE
Prevent the folder field in the new profile dialog from being edited

### DIFF
--- a/java/src/jmri/profile/AddProfileDialog.form
+++ b/java/src/jmri/profile/AddProfileDialog.form
@@ -169,9 +169,11 @@
     </Component>
     <Component class="javax.swing.JTextField" name="profileFolder">
       <Properties>
+        <Property name="editable" type="boolean" value="false"/>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
           <Connection code="ProfileManager.getDefault().getDefaultSearchPath().getPath()" type="code"/>
         </Property>
+        <Property name="enabled" type="boolean" value="false"/>
       </Properties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="profileFolderActionPerformed"/>

--- a/java/src/jmri/profile/AddProfileDialog.java
+++ b/java/src/jmri/profile/AddProfileDialog.java
@@ -142,7 +142,9 @@ public class AddProfileDialog extends javax.swing.JDialog {
             }
         });
 
+        profileFolder.setEditable(false);
         profileFolder.setText(ProfileManager.getDefault().getDefaultSearchPath().getPath());
+        profileFolder.setEnabled(false);
         profileFolder.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent evt) {
                 profileFolderActionPerformed(evt);


### PR DESCRIPTION
Since the folder field contains the results of combining the location field and the normalized contents of the name filed, prevent direct editing of the folder field. This will likely reduce some confusion that led to the [Config profile file/directory structure](https://sourceforge.net/p/jmri/mailman/jmri-developers/thread/147B44B1-8D49-4F2D-9E04-1D116C5173B5%40pacbell.net/#msg35734113) questions.

(Because I accidentally did #3259 on my master and then merged my master into the branch for this PR, this also includes the contents of 3259. Once that is merged, the changes for this PR should be clear.)