### PR TITLE
Reuse Indexed CV writes

### DIFF
--- a/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
+++ b/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
@@ -631,11 +631,17 @@ selects the different algorithm needed here.
             &lt;parameter name="PI"&gt;31&lt;/parameter&gt;
             &lt;parameter name="SI"&gt;32&lt;/parameter&gt;
             &lt;parameter name="cvFirst"&gt;false&lt;/parameter&gt;
+            &lt;parameter name="skipDupIndexWrite"&gt;true&lt;/parameter&gt;
         &lt;/capability&gt;
-</pre>If cvFirst is true, the format is CV.PI or CV.PI.SI as used
+</pre>
+      <p>If cvFirst is true, the format is CV.PI or CV.PI.SI as used
 by QSI. If it's false, the format is PI.CV or PI.SI.CV as used by
 ESU.
-
+      <p>If skipDupIndexWrite is true, certain writes to the PI and SI
+      CVs will be skipped. This speeds up access.
+      Some decoders  require that the CVs be written for each operation, 
+      so this defaults to false.
+      
       <p>If both this and the "access to high CV" capabilities are
       present, this one should be listed second.</p>
 

--- a/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
+++ b/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
@@ -27,6 +27,11 @@ import org.slf4j.LoggerFactory;
  * CV, then does write/read/confirm to 123
  * </ul>
  * </ul>
+ *<p>
+ * Is skipDupIndexWrite is true, sequential operations with the same PI and SI values
+ * (and only immediately sequential operations with both PI and SI unchanged) will
+ * skip writing of the PI and SI CVs.  This might not work for some decoders, hence is
+ * configurable.
  *
  * @see jmri.implementation.ProgrammerFacadeSelector
  *
@@ -42,23 +47,34 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
      *                forms
      * @param cvFirst true if first value in parsed CV is to be written; false
      *                if second value is to be written
+     * @param skipDupIndexWrite true if heuristics can be used to skip PI and SI writes;
+     *                 false requires them to be written each time.
      */
-    public MultiIndexProgrammerFacade(Programmer prog, String indexPI, String indexSI, boolean cvFirst) {
+    public MultiIndexProgrammerFacade(Programmer prog, String indexPI, String indexSI, boolean cvFirst, boolean skipDupIndexWrite) {
         super(prog);
         this.indexPI = indexPI;
         this.indexSI = indexSI;
         this.cvFirst = cvFirst;
+        this.skipDupIndexWrite = skipDupIndexWrite;
     }
 
-    String indexPI;
-    String indexSI;
+    String  indexPI;
+    String  indexSI;
     boolean cvFirst;
+    boolean skipDupIndexWrite;
+
+    long    maxDelay = 1000;  // max mSec since last successful end-of-operation for skipDupIndexWrite; longer delay writes anyway
 
     // members for handling the programmer interface
     int _val;	// remember the value being read/written for confirmative reply
     String _cv;	// remember the cv number being read/written
-    int valuePI;  //  value to write to PI or -1
-    int valueSI;  //  value to write to SI or -1
+    int valuePI;  //  value to write to PI in current operation or -1
+    int valueSI;  //  value to write to SI in current operation or -1
+    
+    // remember last operation for skipDupIndexWrite
+    int lastValuePI = -1;  // value written in last operation
+    int lastValueSI = -1;  // value written in last operation
+    long lastOpTime = -1;  // time of last complete
 
     void parseCV(String cv) {
         valuePI = -1;
@@ -108,6 +124,16 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
         }
     }
 
+    /**
+     * Check to see if the last-written PI and SI values can still be counted on
+     */
+    boolean useCachePiSi() {
+        return skipDupIndexWrite
+            && (lastValuePI == valuePI) 
+            && (lastValueSI == valueSI)
+            && ((System.currentTimeMillis() - lastOpTime) < maxDelay);
+    }
+    
     // programming interface
     @Override
     synchronized public void writeCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
@@ -115,9 +141,20 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
         useProgrammer(p);
         parseCV(CV);
         if (valuePI == -1) {
+            lastValuePI = -1;  // next indexed operation needs to write PI, SI
+            lastValueSI = -1;
+
+            // non-indexed operation
+            state = ProgState.PROGRAMMING;
+            prog.writeCV(_cv, val, this);
+        } else if (useCachePiSi()) {
+            // indexed operation with set values is same as non-indexed operation
             state = ProgState.PROGRAMMING;
             prog.writeCV(_cv, val, this);
         } else {
+            lastValuePI = valuePI;  // after check in 'if' statement
+            lastValueSI = valueSI;
+
             // write index first
             state = ProgState.FINISHWRITE;
             prog.writeCV(indexPI, valuePI, this);
@@ -134,9 +171,19 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
         useProgrammer(p);
         parseCV(CV);
         if (valuePI == -1) {
+            lastValuePI = -1;  // next indexed operation needs to write PI, SI
+            lastValueSI = -1;
+
+            state = ProgState.PROGRAMMING;
+            prog.readCV(_cv, this);
+        } else if (useCachePiSi()) {
+            // indexed operation with set values is same as non-indexed operation
             state = ProgState.PROGRAMMING;
             prog.readCV(_cv, this);
         } else {
+            lastValuePI = valuePI;  // after check in 'if' statement
+            lastValueSI = valueSI;
+
             // write index first
             state = ProgState.FINISHREAD;
             prog.writeCV(indexPI, valuePI, this);
@@ -171,6 +218,11 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
         log.debug("notifyProgListenerEnd value {} status {} ", value, status);
 
         if (status != OK ) {
+            // clear memory of last PI, SI written
+            lastValuePI = -1;
+            lastValueSI = -1;
+            lastOpTime = -1;
+
             // pass abort up
             log.debug("Reset and pass abort up");
             jmri.ProgListener temp = _usingProgrammer;
@@ -193,6 +245,7 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
                 jmri.ProgListener temp = _usingProgrammer;
                 _usingProgrammer = null; // done
                 state = ProgState.NOTPROGRAMMING;
+                lastOpTime = System.currentTimeMillis();
                 temp.programmingOpReply(value, status);
                 break;
             case FINISHREAD:
@@ -238,6 +291,9 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
                 // clean up as much as possible
                 _usingProgrammer = null;
                 state = ProgState.NOTPROGRAMMING;
+                lastValuePI = -1;
+                lastValueSI = -1;
+                lastOpTime = -1;
 
         }
     }

--- a/java/src/jmri/implementation/ProgrammerFacadeSelector.java
+++ b/java/src/jmri/implementation/ProgrammerFacadeSelector.java
@@ -83,9 +83,10 @@ public class ProgrammerFacadeSelector {
                 String PI = parameters.get(0).getText();
                 String SI = (parameters.size() > 1) ? parameters.get(1).getText() : null;
                 boolean cvFirst = (parameters.size() > 2) ? (parameters.get(2).getText().equals("false") ? false : true) : true;
+                boolean skipDupIndexWrite = (parameters.size() > 3) ? (parameters.get(3).getText().equals("true") ? true : false) : false;
 
                 jmri.implementation.MultiIndexProgrammerFacade pf
-                        = new jmri.implementation.MultiIndexProgrammerFacade(programmer, PI, SI, cvFirst);
+                        = new jmri.implementation.MultiIndexProgrammerFacade(programmer, PI, SI, cvFirst, skipDupIndexWrite);
 
                 log.debug("new programmer " + pf);
                 programmer = pf; // to go around and see if there are more

--- a/java/test/jmri/implementation/MultiIndexProgrammerFacadeTest.java
+++ b/java/test/jmri/implementation/MultiIndexProgrammerFacadeTest.java
@@ -272,12 +272,31 @@ public class MultiIndexProgrammerFacadeTest extends TestCase {
         Assert.assertEquals("read back", 12, readValue);
         Assert.assertEquals("index 1 written", 45, dp.getCvVal(81));
         Assert.assertEquals("index 2 written", 46, dp.getCvVal(82));
+
+        dp.clearHasBeenWritten(81);
+        dp.clearHasBeenWritten(82);
+
+        p.readCV("45.46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(81));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(82));
+
+        dp.clearHasBeenWritten(81);
+        dp.clearHasBeenWritten(82);
+
+        p.readCV("45.46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(81));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(82));
+
     }
 
     public void testWriteReadDoubleIndexedCvListSkip() throws jmri.ProgrammerException, InterruptedException {
 
         ProgDebugger dp = new ProgDebugger();
-        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", false, true);
+        MultiIndexProgrammerFacade p = new MultiIndexProgrammerFacade(dp, "81", "82", false, true);
         ProgListener l = new ProgListener() {
             @Override
             public void programmingOpReply(int value, int status) {
@@ -301,6 +320,36 @@ public class MultiIndexProgrammerFacadeTest extends TestCase {
         Assert.assertEquals("read back", 12, readValue);
         Assert.assertTrue("index 1 not written", !dp.hasBeenWritten(81));
         Assert.assertTrue("index 2 not written", !dp.hasBeenWritten(82));
+
+        dp.clearHasBeenWritten(81);
+        dp.clearHasBeenWritten(82);
+
+        p.readCV("45.46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertTrue("index 1 not written", !dp.hasBeenWritten(81));
+        Assert.assertTrue("index 2 not written", !dp.hasBeenWritten(82));
+
+        dp.clearHasBeenWritten(81);
+        dp.clearHasBeenWritten(82);
+
+        p.readCV("45.46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertTrue("index 1 not written", !dp.hasBeenWritten(81));
+        Assert.assertTrue("index 2 not written", !dp.hasBeenWritten(82));
+
+        // add timeout
+        p.lastOpTime = p.lastOpTime - 2*p.maxDelay; 
+        
+        dp.clearHasBeenWritten(81);
+        dp.clearHasBeenWritten(82);
+
+        p.readCV("45.46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(81));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(82));
     }
 
     public void testWriteReadDoubleIndexedCvListDelayedSkip() throws jmri.ProgrammerException, InterruptedException {

--- a/java/test/jmri/implementation/MultiIndexProgrammerFacadeTest.java
+++ b/java/test/jmri/implementation/MultiIndexProgrammerFacadeTest.java
@@ -24,7 +24,31 @@ public class MultiIndexProgrammerFacadeTest extends TestCase {
     public void testWriteReadDirect() throws jmri.ProgrammerException, InterruptedException {
 
         ProgDebugger dp = new ProgDebugger();
-        Programmer p = new MultiIndexProgrammerFacade(dp, "81", null, true);
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", null, true, false);
+        ProgListener l = new ProgListener() {
+            @Override
+            public void programmingOpReply(int value, int status) {
+                log.debug("callback value=" + value + " status=" + status);
+                replied = true;
+                readValue = value;
+            }
+        };
+
+        p.writeCV("4", 12, l);
+        waitReply();
+        Assert.assertEquals("target written", 12, dp.getCvVal(4));
+        Assert.assertTrue("index not written", !dp.hasBeenWritten(81));
+
+        p.readCV("4", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertTrue("index not written", !dp.hasBeenWritten(81));
+    }
+
+    public void testWriteReadDirectSkip() throws jmri.ProgrammerException, InterruptedException {
+
+        ProgDebugger dp = new ProgDebugger();
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", null, true, true);
         ProgListener l = new ProgListener() {
             @Override
             public void programmingOpReply(int value, int status) {
@@ -48,7 +72,7 @@ public class MultiIndexProgrammerFacadeTest extends TestCase {
     public void testWriteReadSingleIndexed() throws jmri.ProgrammerException, InterruptedException {
 
         ProgDebugger dp = new ProgDebugger();
-        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", true);
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", true, false);
         ProgListener l = new ProgListener() {
             @Override
             public void programmingOpReply(int value, int status) {
@@ -75,10 +99,39 @@ public class MultiIndexProgrammerFacadeTest extends TestCase {
         Assert.assertEquals("index written", 45, dp.getCvVal(81));
     }
 
+    public void testWriteReadSingleIndexedSkip() throws jmri.ProgrammerException, InterruptedException {
+
+        ProgDebugger dp = new ProgDebugger();
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", true, true);
+        ProgListener l = new ProgListener() {
+            @Override
+            public void programmingOpReply(int value, int status) {
+                log.debug("callback value=" + value + " status=" + status);
+                replied = true;
+                readValue = value;
+            }
+        };
+
+        p.writeCV("123.45", 12, l);
+        waitReply();
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(81));
+        Assert.assertTrue("index 2 not written", !dp.hasBeenWritten(82));
+        Assert.assertEquals("value written", 12, dp.getCvVal(123));
+
+        dp.clearHasBeenWritten(81);
+        dp.clearHasBeenWritten(82);
+
+        p.readCV("123.45", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertTrue("index 1 not written", !dp.hasBeenWritten(81));
+        Assert.assertTrue("index 2 not written", !dp.hasBeenWritten(82));
+    }
+
     public void testWriteReadSingleIndexedCvLast() throws jmri.ProgrammerException, InterruptedException {
 
         ProgDebugger dp = new ProgDebugger();
-        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", false);
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", false, false);
         ProgListener l = new ProgListener() {
             @Override
             public void programmingOpReply(int value, int status) {
@@ -105,10 +158,39 @@ public class MultiIndexProgrammerFacadeTest extends TestCase {
         Assert.assertEquals("index written", 45, dp.getCvVal(81));
     }
 
+    public void testWriteReadSingleIndexedCvLastSkip() throws jmri.ProgrammerException, InterruptedException {
+
+        ProgDebugger dp = new ProgDebugger();
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", false, true);
+        ProgListener l = new ProgListener() {
+            @Override
+            public void programmingOpReply(int value, int status) {
+                log.debug("callback value=" + value + " status=" + status);
+                replied = true;
+                readValue = value;
+            }
+        };
+
+        p.writeCV("45.123", 12, l);
+        waitReply();
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(81));
+        Assert.assertTrue("index 2 not written", !dp.hasBeenWritten(82));
+        Assert.assertEquals("value written", 12, dp.getCvVal(123));
+
+        dp.clearHasBeenWritten(81);
+        dp.clearHasBeenWritten(82);
+
+        p.readCV("45.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertTrue("index 1 not written", !dp.hasBeenWritten(81));
+        Assert.assertTrue("index 2 not written", !dp.hasBeenWritten(82));
+    }
+
     public void testWriteReadDoubleIndexed() throws jmri.ProgrammerException, InterruptedException {
 
         ProgDebugger dp = new ProgDebugger();
-        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", true);
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", true, false);
         ProgListener l = new ProgListener() {
             @Override
             public void programmingOpReply(int value, int status) {
@@ -134,10 +216,39 @@ public class MultiIndexProgrammerFacadeTest extends TestCase {
         Assert.assertEquals("index 2 written", 46, dp.getCvVal(82));
     }
 
+    public void testWriteReadDoubleIndexedSkip() throws jmri.ProgrammerException, InterruptedException {
+
+        ProgDebugger dp = new ProgDebugger();
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", true, true);
+        ProgListener l = new ProgListener() {
+            @Override
+            public void programmingOpReply(int value, int status) {
+                log.debug("callback value=" + value + " status=" + status);
+                replied = true;
+                readValue = value;
+            }
+        };
+
+        p.writeCV("123.45.46", 12, l);
+        waitReply();
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(81));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(82));
+        Assert.assertEquals("value written", 12, dp.getCvVal(123));
+
+        dp.clearHasBeenWritten(81);
+        dp.clearHasBeenWritten(82);
+
+        p.readCV("123.45.46", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertTrue("index 1 not written", !dp.hasBeenWritten(81));
+        Assert.assertTrue("index 2 not written", !dp.hasBeenWritten(82));
+    }
+
     public void testWriteReadDoubleIndexedCvList() throws jmri.ProgrammerException, InterruptedException {
 
         ProgDebugger dp = new ProgDebugger();
-        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", false);
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", false, false);
         ProgListener l = new ProgListener() {
             @Override
             public void programmingOpReply(int value, int status) {
@@ -163,12 +274,73 @@ public class MultiIndexProgrammerFacadeTest extends TestCase {
         Assert.assertEquals("index 2 written", 46, dp.getCvVal(82));
     }
 
+    public void testWriteReadDoubleIndexedCvListSkip() throws jmri.ProgrammerException, InterruptedException {
+
+        ProgDebugger dp = new ProgDebugger();
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", false, true);
+        ProgListener l = new ProgListener() {
+            @Override
+            public void programmingOpReply(int value, int status) {
+                log.debug("callback value=" + value + " status=" + status);
+                replied = true;
+                readValue = value;
+            }
+        };
+
+        p.writeCV("45.46.123", 12, l);
+        waitReply();
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(81));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(82));
+        Assert.assertEquals("value written", 12, dp.getCvVal(123));
+
+        dp.clearHasBeenWritten(81);
+        dp.clearHasBeenWritten(82);
+
+        p.readCV("45.46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertTrue("index 1 not written", !dp.hasBeenWritten(81));
+        Assert.assertTrue("index 2 not written", !dp.hasBeenWritten(82));
+    }
+
+    public void testWriteReadDoubleIndexedCvListDelayedSkip() throws jmri.ProgrammerException, InterruptedException {
+
+        ProgDebugger dp = new ProgDebugger();
+        MultiIndexProgrammerFacade p = new MultiIndexProgrammerFacade(dp, "81", "82", false, true);
+        ProgListener l = new ProgListener() {
+            @Override
+            public void programmingOpReply(int value, int status) {
+                log.debug("callback value=" + value + " status=" + status);
+                replied = true;
+                readValue = value;
+            }
+        };
+
+        p.writeCV("45.46.123", 12, l);
+        waitReply();
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(81));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(82));
+        Assert.assertEquals("value written", 12, dp.getCvVal(123));
+
+        dp.clearHasBeenWritten(81);
+        dp.clearHasBeenWritten(82);
+        
+        // pretend too long has elapsed, so should still program
+        p.lastOpTime = p.lastOpTime - 2*p.maxDelay; 
+
+        p.readCV("45.46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(81));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(82));
+    }
+
     public void testCvLimit() {
         ProgDebugger dp = new ProgDebugger();
         dp.setTestReadLimit(1024);
         dp.setTestWriteLimit(1024);
 
-        Programmer p = new MultiIndexProgrammerFacade(dp, "81", null, true);
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", null, true, false);
 
         Assert.assertTrue("CV limit read OK", p.getCanRead("1024"));
         Assert.assertTrue("CV limit write OK", p.getCanWrite("1024"));

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -424,7 +424,7 @@ public class SlotManagerTest extends TestCase {
         String SI = "16";
         boolean cvFirst = false;
         jmri.implementation.MultiIndexProgrammerFacade pf2
-                = new jmri.implementation.MultiIndexProgrammerFacade(pf1, PI, SI, cvFirst);
+                = new jmri.implementation.MultiIndexProgrammerFacade(pf1, PI, SI, cvFirst, false);
 
         String CV1 = "16.2.257";
         int val2 = 55;
@@ -539,7 +539,7 @@ public class SlotManagerTest extends TestCase {
         String SI = "16";
         boolean cvFirst = false;
         jmri.implementation.MultiIndexProgrammerFacade pf2
-                = new jmri.implementation.MultiIndexProgrammerFacade(pf1, PI, SI, cvFirst);
+                = new jmri.implementation.MultiIndexProgrammerFacade(pf1, PI, SI, cvFirst, false);
 
         String CV1 = "16.2.257";
         int val2 = 55;
@@ -654,7 +654,7 @@ public class SlotManagerTest extends TestCase {
         String SI = "16";
         boolean cvFirst = false;
         jmri.implementation.MultiIndexProgrammerFacade pf2
-                = new jmri.implementation.MultiIndexProgrammerFacade(pf1, PI, SI, cvFirst);
+                = new jmri.implementation.MultiIndexProgrammerFacade(pf1, PI, SI, cvFirst, false);
 
         String CV1 = "16.2.257";
         int val2 = 55;

--- a/xml/decoders/ESU_LokSoundV4_0.xml
+++ b/xml/decoders/ESU_LokSoundV4_0.xml
@@ -144,6 +144,7 @@
                 <parameter name="PI">31</parameter>
                 <parameter name="SI">32</parameter>
                 <parameter name="cvFirst">false</parameter>
+                <parameter name="skipDupIndexWrite">true</parameter>
             </capability>
         </programming>
         <variables>


### PR DESCRIPTION
Allows reuse of the CV writes to PI and SI index CVs if specified in the decoder definition file.

See discussion in #3171