### PR TITLE
Prevent AddressedHighCvProgrammerFacade from enabling invalid modes.

### DIFF
--- a/java/src/jmri/implementation/AddressedHighCvProgrammerFacade.java
+++ b/java/src/jmri/implementation/AddressedHighCvProgrammerFacade.java
@@ -41,8 +41,7 @@ public class AddressedHighCvProgrammerFacade extends AbstractProgrammerFacade im
         this.addrCVlow = Integer.parseInt(addrCVlow);
         this.valueCV = Integer.parseInt(valueCV);
         this.modulo = Integer.parseInt(modulo);
-        progCanRead = prog.getCanRead();
-        progCanWrite = prog.getCanWrite();
+        _prog = prog;
         log.debug("Created with " + prog + ", " + this.top + ", " + this.addrCVhigh + ", " + this.addrCVlow + ", " + this.valueCV + ", " + this.modulo);
     }
 
@@ -51,8 +50,7 @@ public class AddressedHighCvProgrammerFacade extends AbstractProgrammerFacade im
     int addrCVlow;
     int valueCV;
     int modulo;
-    boolean progCanRead;
-    boolean progCanWrite;
+    Programmer _prog;
 
     // members for handling the programmer interface
     int _val;	// remember the value being read/written for confirmative reply
@@ -226,22 +224,22 @@ public class AddressedHighCvProgrammerFacade extends AbstractProgrammerFacade im
     // Access to full address space provided by this.
     @Override
     public boolean getCanRead() {
-        return progCanRead;
+        return _prog.getCanRead();
     }
 
     @Override
     public boolean getCanRead(String addr) {
-        return progCanRead && (Integer.parseInt(addr) <= 1024);
+        return _prog.getCanRead() && (Integer.parseInt(addr) <= 1024);
     }
 
     @Override
     public boolean getCanWrite() {
-        return progCanWrite;
+        return _prog.getCanWrite();
     }
 
     @Override
     public boolean getCanWrite(String addr) {
-        return progCanWrite && (Integer.parseInt(addr) <= 1024);
+        return _prog.getCanWrite() && (Integer.parseInt(addr) <= 1024);
     }
 
     private final static Logger log = LoggerFactory.getLogger(AddressedHighCvProgrammerFacade.class.getName());

--- a/java/src/jmri/implementation/AddressedHighCvProgrammerFacade.java
+++ b/java/src/jmri/implementation/AddressedHighCvProgrammerFacade.java
@@ -41,6 +41,8 @@ public class AddressedHighCvProgrammerFacade extends AbstractProgrammerFacade im
         this.addrCVlow = Integer.parseInt(addrCVlow);
         this.valueCV = Integer.parseInt(valueCV);
         this.modulo = Integer.parseInt(modulo);
+        progCanRead = prog.getCanRead();
+        progCanWrite = prog.getCanWrite();
         log.debug("Created with " + prog + ", " + this.top + ", " + this.addrCVhigh + ", " + this.addrCVlow + ", " + this.valueCV + ", " + this.modulo);
     }
 
@@ -49,6 +51,8 @@ public class AddressedHighCvProgrammerFacade extends AbstractProgrammerFacade im
     int addrCVlow;
     int valueCV;
     int modulo;
+    boolean progCanRead;
+    boolean progCanWrite;
 
     // members for handling the programmer interface
     int _val;	// remember the value being read/written for confirmative reply
@@ -116,22 +120,30 @@ public class AddressedHighCvProgrammerFacade extends AbstractProgrammerFacade im
     }
 
     enum ProgState {
-        /** A pass-through operation, waiting reply, when done the entire operation is done */
-        PROGRAMMING, 
-        
-        /** Wrote 1st index on a read operation, waiting for reply */
-        WRITELOWREAD, 
-
-        /** Wrote 1st index on a write operation, waiting for reply */
-        WRITELOWWRITE, 
-
-        /** Wrote 2nd index on a read operation, waiting for reply */
-        FINISHREAD, 
-
-        /** Wrote 2nd index on a write operation, waiting for reply */
-        FINISHWRITE, 
-        
-        /** nothing happening, no reply expected */
+        /**
+         * A pass-through operation, waiting reply, when done the entire
+         * operation is done
+         */
+        PROGRAMMING,
+        /**
+         * Wrote 1st index on a read operation, waiting for reply
+         */
+        WRITELOWREAD,
+        /**
+         * Wrote 1st index on a write operation, waiting for reply
+         */
+        WRITELOWWRITE,
+        /**
+         * Wrote 2nd index on a read operation, waiting for reply
+         */
+        FINISHREAD,
+        /**
+         * Wrote 2nd index on a write operation, waiting for reply
+         */
+        FINISHWRITE,
+        /**
+         * nothing happening, no reply expected
+         */
         NOTPROGRAMMING
     }
     ProgState state = ProgState.NOTPROGRAMMING;
@@ -144,7 +156,7 @@ public class AddressedHighCvProgrammerFacade extends AbstractProgrammerFacade im
             log.debug("notifyProgListenerEnd value " + value + " status " + status);
         }
 
-        if (status != OK ) {
+        if (status != OK) {
             // pass abort up
             log.debug("Reset and pass abort up");
             jmri.ProgListener temp = _usingProgrammer;
@@ -153,7 +165,7 @@ public class AddressedHighCvProgrammerFacade extends AbstractProgrammerFacade im
             temp.programmingOpReply(value, status);
             return;
         }
-        
+
         if (_usingProgrammer == null) {
             log.error("No listener to notify, reset and ignore");
             state = ProgState.NOTPROGRAMMING;
@@ -214,22 +226,22 @@ public class AddressedHighCvProgrammerFacade extends AbstractProgrammerFacade im
     // Access to full address space provided by this.
     @Override
     public boolean getCanRead() {
-        return true;
+        return progCanRead;
     }
 
     @Override
     public boolean getCanRead(String addr) {
-        return Integer.parseInt(addr) <= 1024;
+        return progCanRead && (Integer.parseInt(addr) <= 1024);
     }
 
     @Override
     public boolean getCanWrite() {
-        return true;
+        return progCanWrite;
     }
 
     @Override
     public boolean getCanWrite(String addr) {
-        return Integer.parseInt(addr) <= 1024;
+        return progCanWrite && (Integer.parseInt(addr) <= 1024);
     }
 
     private final static Logger log = LoggerFactory.getLogger(AddressedHighCvProgrammerFacade.class.getName());


### PR DESCRIPTION
AddressedHighCvProgrammerFacade did not respect the available modes of the underlying programmer.

As a result, for example, doing sheet operations in any pane while Programming on Main would enable the Read buttons on that pane.

A few formatting tidy-ups also snuck in as a result of using the Source->Format command in NetBeans.