### PR TITLE
Preferences for Write-Verify-Read and Cache-Index-CV-Write

### DIFF
--- a/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
+++ b/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
@@ -634,16 +634,15 @@ selects the different algorithm needed here.
             &lt;parameter name="PI"&gt;31&lt;/parameter&gt;
             &lt;parameter name="SI"&gt;32&lt;/parameter&gt;
             &lt;parameter name="cvFirst"&gt;false&lt;/parameter&gt;
-            &lt;parameter name="skipDupIndexWrite"&gt;true&lt;/parameter&gt;
         &lt;/capability&gt;
 </pre>
       <p>If cvFirst is true, the format is CV.PI or CV.PI.SI as used
 by QSI. If it's false, the format is PI.CV or PI.SI.CV as used by
 ESU.
       <p>If skipDupIndexWrite is true, certain writes to the PI and SI
-      CVs will be skipped. This speeds up access.
+      CVs can be skipped if the user selects skipping them. This speeds up access.
       Some decoders  require that the CVs be written for each operation, 
-      so this defaults to false.
+      in which case this should be set to false.  The default is true.
       
       <p>If both this and the "access to high CV" capabilities are
       present, this one should be listed second.</p>

--- a/java/src/apps/AppsConfigBundle.properties
+++ b/java/src/apps/AppsConfigBundle.properties
@@ -46,6 +46,8 @@ LabelTabbedLayoutConsole = Select your preferred appearance for the JMRI System 
 
 ProgShowEmptyTabs = Show empty Programmer tabs
 ProgShowCVInTips = Show CV numbers in tool tips
+ProgCanCacheDefault = Allow caching when writing/reading index CVs
+ProgDoConfirmRead = When possible, confirm index CV writes
 ButtonShowAdv = Show Advanced Preferences
 ButtonDisableConnection = Disable this Connection
 

--- a/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
+++ b/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
@@ -34,11 +34,30 @@ import org.slf4j.LoggerFactory;
  * skip writing of the PI and SI CVs.  This might not work for some decoders, hence is
  * configurable. See the logic in {@link jmri.implementation.ProgrammerFacadeSelector}
  * for how the decoder file contents and default (preferences) interact.
+ * <p>
+ * State Diagram for read and write operations: <img src="doc-files/MultiIndexProgrammerFacade-State-Diagram.png" alt="UML State diagram"><p>
  *
  * @see jmri.implementation.ProgrammerFacadeSelector
  *
  * @author Bob Jacobsen Copyright (C) 2013
  */
+ 
+/*
+ * @startuml jmri/implementation/doc-files/MultiIndexProgrammerFacade-State-Diagram.png
+ * [*] --> NOTPROGRAMMING : Error reply received
+ * [*] --> NOTPROGRAMMING 
+ * NOTPROGRAMMING --> PROGRAMMING: readCV() & & PI==-1 (read CV)
+ * NOTPROGRAMMING --> FINISHREAD: readCV() & PI!=-1 (write PI)
+ * NOTPROGRAMMING --> PROGRAMMING: writeCV() & single CV (write CV)
+ * NOTPROGRAMMING --> FINISHWRITE: writeCV() & PI write needed (write PI)
+ * FINISHREAD --> FINISHREAD: OK reply & SI!=-1 (write SI)
+ * FINISHREAD --> PROGRAMMING: OK reply & SI==-1 (read CV)
+ * FINISHWRITE --> FINISHWRITE: OK reply & SI!=-1 (write SI)
+ * FINISHWRITE --> PROGRAMMING: OK reply & SI==-1 (write CV)
+ * PROGRAMMING --> NOTPROGRAMMING: OK reply received (return status and value)
+ * @enduml
+*/
+
 public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade implements ProgListener {
 
     /**

--- a/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
+++ b/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
@@ -12,26 +12,28 @@ import org.slf4j.LoggerFactory;
  * Used through the String write/read/confirm interface. Accepts address
  * formats:
  * <ul>
- * <li>If cvFirst is true:<ul>
- * <li> 123 Do write/read/confirm to 123
- * <li> 123.11 Writes 11 to the first index CV, then does write/read/confirm to
- * 123
- * <li> 123.11.12 Writes 11 to the first index CV, then 12 to the second index
- * CV, then does write/read/confirm to 123
+ * <li>If cvFirst is true:
+ * <ul>
+ *   <li> 123 Do write/read/confirm to 123
+ *   <li> 123.11 Writes 11 to the first index CV, then does write/read/confirm to 123
+ *   <li> 123.11.12 Writes 11 to the first index CV, then 12 to the second index CV, 
+ *                    then does write/read/confirm to 123
  * </ul>
- * <li>If cvFirst is false:<ul>
- * <li> 123 Do write/read/confirm to 123
- * <li> 11.123 Writes 11 to the first index CV, then does write/read/confirm to
- * 123
- * <li> 11.12.123 Writes 11 to the first index CV, then 12 to the second index
- * CV, then does write/read/confirm to 123
+ * <li>If cvFirst is false:
+ * <ul>
+ *   <li> 123 Do write/read/confirm to 123
+ *   <li> 11.123 Writes 11 to the first index CV, then does write/read/confirm to 123
+ *   <li> 11.12.123 Writes 11 to the first index CV, then 12 to the second index CV, 
+ *              then does write/read/confirm to 123
  * </ul>
  * </ul>
+ *
  *<p>
  * Is skipDupIndexWrite is true, sequential operations with the same PI and SI values
  * (and only immediately sequential operations with both PI and SI unchanged) will
  * skip writing of the PI and SI CVs.  This might not work for some decoders, hence is
- * configurable.
+ * configurable. See the logic in {@link jmri.implementation.ProgrammerFacadeSelector}
+ * for how the decoder file contents and default (preferences) interact.
  *
  * @see jmri.implementation.ProgrammerFacadeSelector
  *

--- a/java/src/jmri/implementation/ProgrammerFacadeSelector.java
+++ b/java/src/jmri/implementation/ProgrammerFacadeSelector.java
@@ -89,7 +89,7 @@ public class ProgrammerFacadeSelector {
                 String PI = parameters.get(0).getText();
                 String SI = (parameters.size() > 1) ? parameters.get(1).getText() : null;
                 boolean cvFirst = (parameters.size() > 2) ? (parameters.get(2).getText().equals("false") ? false : true) : true;
-                boolean skipDupIndexWrite = (parameters.size() > 3) ? (parameters.get(3).getText().equals("true") ? true : false) : allowCache; // not present, use default
+                boolean skipDupIndexWrite = (parameters.size() > 3) ? (parameters.get(3).getText().equals("false") ? false : allowCache) : allowCache; // if not present, use default
 
                 jmri.implementation.MultiIndexProgrammerFacade pf
                         = new jmri.implementation.MultiIndexProgrammerFacade(programmer, PI, SI, cvFirst, skipDupIndexWrite);

--- a/java/src/jmri/implementation/ProgrammerFacadeSelector.java
+++ b/java/src/jmri/implementation/ProgrammerFacadeSelector.java
@@ -14,7 +14,13 @@ import org.slf4j.LoggerFactory;
  */
 public class ProgrammerFacadeSelector {
 
-    public static Programmer loadFacadeElements(Element element, Programmer programmer) {
+    /**
+     * Add facades specified in an XML decoder definition element to the front of a programmer.
+     * @param element Contains "capability" elements that define the Facades
+     * @param programmer Programmer implementation to decorate
+     * @param allowCache Passed to facades that optionally cache
+     */
+    public static Programmer loadFacadeElements(Element element, Programmer programmer, boolean allowCache) {
         // iterate over any facades and add them
         List<Element> facades = element.getChildren("capability");
         if (log.isDebugEnabled()) {
@@ -83,7 +89,7 @@ public class ProgrammerFacadeSelector {
                 String PI = parameters.get(0).getText();
                 String SI = (parameters.size() > 1) ? parameters.get(1).getText() : null;
                 boolean cvFirst = (parameters.size() > 2) ? (parameters.get(2).getText().equals("false") ? false : true) : true;
-                boolean skipDupIndexWrite = (parameters.size() > 3) ? (parameters.get(3).getText().equals("true") ? true : false) : jmri.jmrix.AbstractProgrammerFacade.isCanCacheDefault(); // not present, use default
+                boolean skipDupIndexWrite = (parameters.size() > 3) ? (parameters.get(3).getText().equals("true") ? true : false) : allowCache; // not present, use default
 
                 jmri.implementation.MultiIndexProgrammerFacade pf
                         = new jmri.implementation.MultiIndexProgrammerFacade(programmer, PI, SI, cvFirst, skipDupIndexWrite);

--- a/java/src/jmri/implementation/ProgrammerFacadeSelector.java
+++ b/java/src/jmri/implementation/ProgrammerFacadeSelector.java
@@ -83,7 +83,7 @@ public class ProgrammerFacadeSelector {
                 String PI = parameters.get(0).getText();
                 String SI = (parameters.size() > 1) ? parameters.get(1).getText() : null;
                 boolean cvFirst = (parameters.size() > 2) ? (parameters.get(2).getText().equals("false") ? false : true) : true;
-                boolean skipDupIndexWrite = (parameters.size() > 3) ? (parameters.get(3).getText().equals("true") ? true : false) : false;
+                boolean skipDupIndexWrite = (parameters.size() > 3) ? (parameters.get(3).getText().equals("true") ? true : false) : jmri.jmrix.AbstractProgrammerFacade.isCanCacheDefault(); // not present, use default
 
                 jmri.implementation.MultiIndexProgrammerFacade pf
                         = new jmri.implementation.MultiIndexProgrammerFacade(programmer, PI, SI, cvFirst, skipDupIndexWrite);

--- a/java/src/jmri/implementation/VerifyWriteProgrammerFacade.java
+++ b/java/src/jmri/implementation/VerifyWriteProgrammerFacade.java
@@ -11,11 +11,29 @@ import org.slf4j.LoggerFactory;
  * <p>
  * If the underlying programmer can read, each write operation is followed by a readback.
  * If the value doesn't match, an error is signaled.
+ * <p>
+ * State Diagram for read and write operations: <img src="doc-files/VerifyWriteProgrammerFacade-State-Diagram.png" alt="UML State diagram"><p>
  *
  * @see jmri.implementation.ProgrammerFacadeSelector
  *
  * @author Bob Jacobsen Copyright (C) 2017
  */
+ 
+ /*
+ * @startuml jmri/implementation/doc-files/VerifyWriteProgrammerFacade-State-Diagram.png
+ * [*] --> NOTPROGRAMMING : Error reply received
+ * [*] --> NOTPROGRAMMING 
+ * NOTPROGRAMMING --> READING: readCV() (read CV)
+ * READING --> NOTPROGRAMMING: OK reply received (return status and value)
+ * NOTPROGRAMMING --> FINISHWRITE: writeCV() (write CV)
+ * FINISHWRITE --> FINISHREAD: OK reply & getCanRead() (read CV)
+ * FINISHWRITE --> NOTPROGRAMMING: OK reply received (&& !getCanRead() return OK status and value)
+ * FINISHREAD --> NOTPROGRAMMING: OK reply & value matches (return OK status reply and value)
+ * FINISHREAD --> NOTPROGRAMMING: OK reply & value not match (return error status reply and value)
+ * @enduml
+*/
+
+
 public class VerifyWriteProgrammerFacade extends AbstractProgrammerFacade implements ProgListener {
 
     /**

--- a/java/src/jmri/implementation/VerifyWriteProgrammerFacade.java
+++ b/java/src/jmri/implementation/VerifyWriteProgrammerFacade.java
@@ -1,0 +1,151 @@
+package jmri.implementation;
+
+import jmri.ProgListener;
+import jmri.Programmer;
+import jmri.jmrix.AbstractProgrammerFacade;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Programmer facade which verifies each write via a read, if possible.
+ * <p>
+ * If the underlying programmer can read, each write operation is followed by a readback.
+ * If the value doesn't match, an error is signaled.
+ *
+ * @see jmri.implementation.ProgrammerFacadeSelector
+ *
+ * @author Bob Jacobsen Copyright (C) 2017
+ */
+public class VerifyWriteProgrammerFacade extends AbstractProgrammerFacade implements ProgListener {
+
+    /**
+     * @param prog    the programmer to which this facade is attached
+     */
+    public VerifyWriteProgrammerFacade(Programmer prog) {
+        super(prog);
+    }
+
+    // members for handling the programmer interface
+    int _val;	// remember the value being read/written for confirmative reply
+    String _cv;	// remember the cv number being read/written
+    
+    // programming interface
+    @Override
+    synchronized public void writeCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+        _val = val;
+        _cv = CV;
+        useProgrammer(p);
+
+        // write value first
+        state = ProgState.FINISHWRITE;
+        prog.writeCV(CV, val, this);
+    }
+
+    @Override
+    synchronized public void confirmCV(String CV, int val, jmri.ProgListener p) throws jmri.ProgrammerException {
+        readCV(CV, p);
+    }
+
+    @Override
+    synchronized public void readCV(String CV, jmri.ProgListener p) throws jmri.ProgrammerException {
+        useProgrammer(p);
+
+        state = ProgState.READING;
+        prog.readCV(_cv, this);
+    }
+
+    private jmri.ProgListener _usingProgrammer = null;
+
+    // internal method to remember who's using the programmer
+    protected void useProgrammer(jmri.ProgListener p) throws jmri.ProgrammerException {
+        // test for only one!
+        if (_usingProgrammer != null && _usingProgrammer != p) {
+            log.info("programmer already in use by {}", _usingProgrammer);
+            throw new jmri.ProgrammerException("programmer in use");
+        } else {
+            _usingProgrammer = p;
+        }
+    }
+
+    enum ProgState {
+        READING, 
+        FINISHWRITE, // doing write, issue verify read next
+        FINISHREAD,  // doing verify read, will end next
+        NOTPROGRAMMING
+    }
+    ProgState state = ProgState.NOTPROGRAMMING;
+
+    // Get notified of the result from the underlying programmer, and work
+    // through the state machine for needed requests
+    @Override
+    public void programmingOpReply(int value, int status) {
+        log.debug("notifyProgListenerEnd value {} status {} ", value, status);
+
+        if (status != OK ) {
+            // pass abort up
+            jmri.ProgListener temp = _usingProgrammer;
+            _usingProgrammer = null; // done
+            state = ProgState.NOTPROGRAMMING;
+            temp.programmingOpReply(value, status);
+            return;
+        }
+        
+        if (_usingProgrammer == null) {
+            log.error("No listener to notify, reset and ignore");
+            state = ProgState.NOTPROGRAMMING;
+            return;
+        }
+
+        jmri.ProgListener temp = _usingProgrammer;
+        
+        switch (state) {
+            case FINISHWRITE:
+                // write completed, can we do read, and do we have permission?
+                if (prog.getCanRead(_cv)) {
+                    state = ProgState.FINISHREAD;
+                    try {
+                        prog.readCV(_cv, this);
+                    } catch (jmri.ProgrammerException e) {
+                        // pass abort up
+                        _usingProgrammer = null; // done
+                        state = ProgState.NOTPROGRAMMING;
+                        temp.programmingOpReply(value, ProgListener.ConfirmFailed);
+                        return;         
+                    }
+                    break;
+                }
+                // can't read
+                // deliberately fall through to normal completion
+            case READING: // done, forward the return code and data
+                // the programmingOpReply handler might send an immediate reply, so
+                // clear the current listener _first_
+                _usingProgrammer = null; // done
+                state = ProgState.NOTPROGRAMMING;
+                temp.programmingOpReply(value, status);
+                break;
+                
+            case FINISHREAD:
+                _usingProgrammer = null; // done
+                state = ProgState.NOTPROGRAMMING;
+                // check if we got it right
+                if (value == _val) {
+                    // ok, reply OK
+                    temp.programmingOpReply(value, status);
+                } else {
+                    // error, reply error
+                    temp.programmingOpReply(value, ProgListener.ConfirmFailed);
+                }
+                break;
+
+            default:
+                log.error("Unexpected state on reply: " + state);
+                // clean up as much as possible
+                _usingProgrammer = null;
+                state = ProgState.NOTPROGRAMMING;
+                break;
+        }
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(VerifyWriteProgrammerFacade.class.getName());
+
+}

--- a/java/src/jmri/implementation/VerifyWriteProgrammerFacade.java
+++ b/java/src/jmri/implementation/VerifyWriteProgrammerFacade.java
@@ -66,10 +66,11 @@ public class VerifyWriteProgrammerFacade extends AbstractProgrammerFacade implem
 
     @Override
     synchronized public void readCV(String CV, jmri.ProgListener p) throws jmri.ProgrammerException {
+        _cv = CV;
         useProgrammer(p);
 
         state = ProgState.READING;
-        prog.readCV(_cv, this);
+        prog.readCV(CV, this);
     }
 
     private jmri.ProgListener _usingProgrammer = null;

--- a/java/src/jmri/jmrit/mailreport/ReportContext.java
+++ b/java/src/jmri/jmrit/mailreport/ReportContext.java
@@ -128,6 +128,10 @@ public class ReportContext {
         addProperty("user.language");
         addProperty("user.timezone");
         addProperty("jmri.log.path");
+        
+        addString("FileSystemView#getDefaultDirectory(): "+javax.swing.filechooser.FileSystemView.getFileSystemView().getDefaultDirectory().getPath() );
+        addString("FileSystemView#getHomeDirectory(): "+javax.swing.filechooser.FileSystemView.getFileSystemView().getHomeDirectory().getPath() );
+        addString("Default JFileChooser(): "+(new javax.swing.JFileChooser()).getCurrentDirectory().getPath() );
 
         addScreenSize();
 

--- a/java/src/jmri/jmrit/symbolicprog/ProgrammerConfigManager.java
+++ b/java/src/jmri/jmrit/symbolicprog/ProgrammerConfigManager.java
@@ -23,9 +23,13 @@ public class ProgrammerConfigManager extends AbstractPreferencesManager {
     public final static String DEFAULT_FILE = "defaultFile";
     public final static String SHOW_EMPTY_PANES = "showEmptyPanes";
     public final static String SHOW_CV_NUMBERS = "showCvNumbers";
+    public final static String CAN_CACHE_DEFAULT = "canCacheDefault";
+    public final static String DO_CONFIRM_READ = "doConfirmRead";
     private String defaultFile = null;
     private boolean showEmptyPanes = true;
     private boolean showCvNumbers = false;
+    private boolean canCacheDefault = false;
+    private boolean doConfirmRead = false;
 
     @Override
     public void initialize(Profile profile) throws InitializationException {
@@ -39,6 +43,10 @@ public class ProgrammerConfigManager extends AbstractPreferencesManager {
             PaneProgFrame.setShowEmptyPanes(this.isShowEmptyPanes());
             this.setShowCvNumbers(preferences.getBoolean(SHOW_CV_NUMBERS, this.isShowCvNumbers()));
             PaneProgFrame.setShowCvNumbers(this.isShowCvNumbers());
+            this.setCanCacheDefault(preferences.getBoolean(CAN_CACHE_DEFAULT, this.isCanCacheDefault()));
+            jmri.jmrix.AbstractProgrammerFacade.setCanCacheDefault(this.isCanCacheDefault());
+            this.setDoConfirmRead(preferences.getBoolean(DO_CONFIRM_READ, this.isDoConfirmRead()));
+            jmri.jmrix.AbstractProgrammerFacade.setDoConfirmRead(this.isDoConfirmRead());
             this.setInitialized(profile, true);
         }
     }
@@ -69,6 +77,8 @@ public class ProgrammerConfigManager extends AbstractPreferencesManager {
         }
         preferences.putBoolean(SHOW_EMPTY_PANES, this.showEmptyPanes);
         preferences.putBoolean(SHOW_CV_NUMBERS, this.showCvNumbers);
+        preferences.putBoolean(CAN_CACHE_DEFAULT, this.canCacheDefault);
+        preferences.putBoolean(DO_CONFIRM_READ, this.doConfirmRead);
         try {
             preferences.sync();
         } catch (BackingStoreException ex) {
@@ -122,6 +132,38 @@ public class ProgrammerConfigManager extends AbstractPreferencesManager {
         boolean oldShowCvNumbers = this.showCvNumbers;
         this.showCvNumbers = showCvNumbers;
         firePropertyChange(SHOW_CV_NUMBERS, oldShowCvNumbers, showCvNumbers);
+    }
+
+    /**
+     * @return the canCacheDefault
+     */
+    public boolean isCanCacheDefault() {
+        return canCacheDefault;
+    }
+
+    /**
+     * @param canCacheDefault the canCacheDefault to set
+     */
+    public void setCanCacheDefault(boolean canCacheDefault) {
+        boolean oldCanCacheDefault = this.canCacheDefault;
+        this.canCacheDefault = canCacheDefault;
+        firePropertyChange(CAN_CACHE_DEFAULT, oldCanCacheDefault, canCacheDefault);
+    }
+
+    /**
+     * @return the doConfirmRead
+     */
+    public boolean isDoConfirmRead() {
+        return doConfirmRead;
+    }
+
+    /**
+     * @param canCacheDefault the canCacheDefault to set
+     */
+    public void setDoConfirmRead(boolean doConfirmRead) {
+        boolean oldDoConfirmRead = this.doConfirmRead;
+        this.doConfirmRead = doConfirmRead;
+        firePropertyChange(DO_CONFIRM_READ, oldDoConfirmRead, doConfirmRead);
     }
 
 }

--- a/java/src/jmri/jmrit/symbolicprog/ProgrammerConfigManager.java
+++ b/java/src/jmri/jmrit/symbolicprog/ProgrammerConfigManager.java
@@ -142,7 +142,7 @@ public class ProgrammerConfigManager extends AbstractPreferencesManager {
     }
 
     /**
-     * @param canCacheDefault the canCacheDefault to set
+     * @param canCacheDefault new value
      */
     public void setCanCacheDefault(boolean canCacheDefault) {
         boolean oldCanCacheDefault = this.canCacheDefault;
@@ -158,7 +158,7 @@ public class ProgrammerConfigManager extends AbstractPreferencesManager {
     }
 
     /**
-     * @param canCacheDefault the canCacheDefault to set
+     * @param doConfirmRead new value
      */
     public void setDoConfirmRead(boolean doConfirmRead) {
         boolean oldDoConfirmRead = this.doConfirmRead;

--- a/java/src/jmri/jmrit/symbolicprog/ProgrammerConfigManager.java
+++ b/java/src/jmri/jmrit/symbolicprog/ProgrammerConfigManager.java
@@ -39,14 +39,19 @@ public class ProgrammerConfigManager extends AbstractPreferencesManager {
                 this.setDefaultFile(preferences.get(DEFAULT_FILE, this.getDefaultFile()));
                 ProgDefault.setDefaultProgFile(this.getDefaultFile());
             }
+            
             this.setShowEmptyPanes(preferences.getBoolean(SHOW_EMPTY_PANES, this.isShowEmptyPanes()));
             PaneProgFrame.setShowEmptyPanes(this.isShowEmptyPanes());
+            
             this.setShowCvNumbers(preferences.getBoolean(SHOW_CV_NUMBERS, this.isShowCvNumbers()));
             PaneProgFrame.setShowCvNumbers(this.isShowCvNumbers());
+            
             this.setCanCacheDefault(preferences.getBoolean(CAN_CACHE_DEFAULT, this.isCanCacheDefault()));
-            jmri.jmrix.AbstractProgrammerFacade.setCanCacheDefault(this.isCanCacheDefault());
+            PaneProgFrame.setCanCacheDefault(this.isCanCacheDefault());
+            
             this.setDoConfirmRead(preferences.getBoolean(DO_CONFIRM_READ, this.isDoConfirmRead()));
-            jmri.jmrix.AbstractProgrammerFacade.setDoConfirmRead(this.isDoConfirmRead());
+            PaneProgFrame.setDoConfirmRead(this.isDoConfirmRead());
+            
             this.setInitialized(profile, true);
         }
     }

--- a/java/src/jmri/jmrit/symbolicprog/ProgrammerConfigPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/ProgrammerConfigPane.java
@@ -19,7 +19,7 @@ import jmri.swing.PreferencesPanel;
 /**
  * Provide GUI to configure symbolic programmer defaults.
  *
- * @author Bob Jacobsen Copyright (C) 2001, 2003
+ * @author Bob Jacobsen Copyright (C) 2001, 2003, 2017
  */
 public class ProgrammerConfigPane extends JPanel implements PreferencesPanel {
 
@@ -40,16 +40,31 @@ public class ProgrammerConfigPane extends JPanel implements PreferencesPanel {
         // also create the advanced panel
         advancedPanel = new JPanel();
         advancedPanel.setLayout(new BoxLayout(advancedPanel, BoxLayout.Y_AXIS));
+        
         advancedPanel.add(showEmptyTabs = new JCheckBox(this.apb.getString("ProgShowEmptyTabs")));
         showEmptyTabs.setSelected(PaneProgFrame.getShowEmptyPanes());
         showEmptyTabs.addItemListener((ItemEvent e) -> {
             InstanceManager.getDefault(ProgrammerConfigManager.class).setShowEmptyPanes(showEmptyTabs.isSelected());
         });
-        advancedPanel.add(ShowCvNums = new JCheckBox(this.apb.getString("ProgShowCVInTips")));
-        ShowCvNums.setSelected(PaneProgFrame.getShowCvNumbers());
-        ShowCvNums.addItemListener((ItemEvent e) -> {
-            InstanceManager.getDefault(ProgrammerConfigManager.class).setShowCvNumbers(ShowCvNums.isSelected());
+        
+        advancedPanel.add(showCvNums = new JCheckBox(this.apb.getString("ProgShowCVInTips")));
+        showCvNums.setSelected(PaneProgFrame.getShowCvNumbers());
+        showCvNums.addItemListener((ItemEvent e) -> {
+            InstanceManager.getDefault(ProgrammerConfigManager.class).setShowCvNumbers(showCvNums.isSelected());
         });
+        
+        advancedPanel.add(canCacheDefault = new JCheckBox(this.apb.getString("ProgCanCacheDefault")));
+        canCacheDefault.setSelected(jmri.jmrix.AbstractProgrammerFacade.isCanCacheDefault());
+        canCacheDefault.addItemListener((ItemEvent e) -> {
+            InstanceManager.getDefault(ProgrammerConfigManager.class).setCanCacheDefault(canCacheDefault.isSelected());
+        });
+
+        advancedPanel.add(doConfirmRead = new JCheckBox(this.apb.getString("ProgDoConfirmRead")));
+        doConfirmRead.setSelected(jmri.jmrix.AbstractProgrammerFacade.isDoConfirmRead());
+        doConfirmRead.addItemListener((ItemEvent e) -> {
+            InstanceManager.getDefault(ProgrammerConfigManager.class).setDoConfirmRead(doConfirmRead.isSelected());
+        });
+
         this.add(advancedPanel);
         this.add(Box.createVerticalGlue());
     }
@@ -77,16 +92,26 @@ public class ProgrammerConfigPane extends JPanel implements PreferencesPanel {
 
     JPanel advancedPanel;
     JCheckBox showEmptyTabs;
-    JCheckBox ShowCvNums;
-
+    JCheckBox showCvNums;
+    JCheckBox canCacheDefault;
+    JCheckBox doConfirmRead;
+    
     public boolean getShowEmptyTabs() {
         return showEmptyTabs.isSelected();
     }
 
     public boolean getShowCvNums() {
-        return ShowCvNums.isSelected();
+        return showCvNums.isSelected();
     }
 
+    public boolean getCanCacheDefault() {
+        return canCacheDefault.isSelected();
+    }
+    
+    public boolean getDoConfirmRead() {
+        return doConfirmRead.isSelected();
+    }
+    
     @Override
     public String getPreferencesItem() {
         return "ROSTER"; // NOI18N
@@ -132,6 +157,8 @@ public class ProgrammerConfigPane extends JPanel implements PreferencesPanel {
         String programmer = this.getSelectedItem();
         return (this.getShowEmptyTabs() != PaneProgFrame.getShowEmptyPanes()
                 || this.getShowCvNums() != PaneProgFrame.getShowCvNumbers()
+                || this.getCanCacheDefault() != jmri.jmrix.AbstractProgrammerFacade.isCanCacheDefault()
+                || this.getDoConfirmRead() != jmri.jmrix.AbstractProgrammerFacade.isDoConfirmRead()
                 || ((programmer != null)
                         ? !programmer.equals(ProgDefault.getDefaultProgFile())
                         : ProgDefault.getDefaultProgFile() != null));

--- a/java/src/jmri/jmrit/symbolicprog/ProgrammerConfigPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/ProgrammerConfigPane.java
@@ -54,13 +54,13 @@ public class ProgrammerConfigPane extends JPanel implements PreferencesPanel {
         });
         
         advancedPanel.add(canCacheDefault = new JCheckBox(this.apb.getString("ProgCanCacheDefault")));
-        canCacheDefault.setSelected(jmri.jmrix.AbstractProgrammerFacade.isCanCacheDefault());
+        canCacheDefault.setSelected(PaneProgFrame.getCanCacheDefault());
         canCacheDefault.addItemListener((ItemEvent e) -> {
             InstanceManager.getDefault(ProgrammerConfigManager.class).setCanCacheDefault(canCacheDefault.isSelected());
         });
 
         advancedPanel.add(doConfirmRead = new JCheckBox(this.apb.getString("ProgDoConfirmRead")));
-        doConfirmRead.setSelected(jmri.jmrix.AbstractProgrammerFacade.isDoConfirmRead());
+        doConfirmRead.setSelected(PaneProgFrame.getDoConfirmRead());
         doConfirmRead.addItemListener((ItemEvent e) -> {
             InstanceManager.getDefault(ProgrammerConfigManager.class).setDoConfirmRead(doConfirmRead.isSelected());
         });
@@ -157,8 +157,8 @@ public class ProgrammerConfigPane extends JPanel implements PreferencesPanel {
         String programmer = this.getSelectedItem();
         return (this.getShowEmptyTabs() != PaneProgFrame.getShowEmptyPanes()
                 || this.getShowCvNums() != PaneProgFrame.getShowCvNumbers()
-                || this.getCanCacheDefault() != jmri.jmrix.AbstractProgrammerFacade.isCanCacheDefault()
-                || this.getDoConfirmRead() != jmri.jmrix.AbstractProgrammerFacade.isDoConfirmRead()
+                || this.getCanCacheDefault() != PaneProgFrame.getCanCacheDefault()
+                || this.getDoConfirmRead() != PaneProgFrame.getDoConfirmRead()
                 || ((programmer != null)
                         ? !programmer.equals(ProgDefault.getDefaultProgFile())
                         : ProgDefault.getDefaultProgFile() != null));

--- a/java/src/jmri/jmrit/symbolicprog/configurexml/ProgrammerConfigPaneXml.java
+++ b/java/src/jmri/jmrit/symbolicprog/configurexml/ProgrammerConfigPaneXml.java
@@ -44,6 +44,16 @@ public class ProgrammerConfigPaneXml extends jmri.configurexml.AbstractXmlAdapte
         if (p.getShowCvNums()) {
             programmer.setAttribute("showCvNumbers", "yes");
         }
+        if (jmri.jmrix.AbstractProgrammerFacade.isCanCacheDefault()) {
+            programmer.setAttribute("canCacheDefault", "yes");
+        } else {
+            programmer.setAttribute("canCacheDefault", "no");
+        }
+        if (jmri.jmrix.AbstractProgrammerFacade.isDoConfirmRead()) {
+            programmer.setAttribute("doConfirmRead", "yes");
+        } else {
+            programmer.setAttribute("doConfirmRead", "no");
+        }
         programmer.setAttribute("class", this.getClass().getName());
         return programmer;
     }
@@ -65,6 +75,12 @@ public class ProgrammerConfigPaneXml extends jmri.configurexml.AbstractXmlAdapte
         }
         if (null != (a = shared.getAttribute("showCvNumbers"))) {
             InstanceManager.getDefault(ProgrammerConfigManager.class).setShowCvNumbers(a.getValue().equals("yes"));
+        }
+        if (null != (a = shared.getAttribute("canCacheDefault"))) {
+            jmri.jmrix.AbstractProgrammerFacade.setCanCacheDefault(a.getValue().equals("yes"));
+        }
+        if (null != (a = shared.getAttribute("doConfirmRead"))) {
+            jmri.jmrix.AbstractProgrammerFacade.setDoConfirmRead(a.getValue().equals("yes"));
         }
         ConfigureManager cm = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
         if (cm != null) {

--- a/java/src/jmri/jmrit/symbolicprog/configurexml/ProgrammerConfigPaneXml.java
+++ b/java/src/jmri/jmrit/symbolicprog/configurexml/ProgrammerConfigPaneXml.java
@@ -44,12 +44,12 @@ public class ProgrammerConfigPaneXml extends jmri.configurexml.AbstractXmlAdapte
         if (p.getShowCvNums()) {
             programmer.setAttribute("showCvNumbers", "yes");
         }
-        if (jmri.jmrix.AbstractProgrammerFacade.isCanCacheDefault()) {
+        if (p.getCanCacheDefault()) {
             programmer.setAttribute("canCacheDefault", "yes");
         } else {
             programmer.setAttribute("canCacheDefault", "no");
         }
-        if (jmri.jmrix.AbstractProgrammerFacade.isDoConfirmRead()) {
+        if (p.getDoConfirmRead()) {
             programmer.setAttribute("doConfirmRead", "yes");
         } else {
             programmer.setAttribute("doConfirmRead", "no");
@@ -77,10 +77,10 @@ public class ProgrammerConfigPaneXml extends jmri.configurexml.AbstractXmlAdapte
             InstanceManager.getDefault(ProgrammerConfigManager.class).setShowCvNumbers(a.getValue().equals("yes"));
         }
         if (null != (a = shared.getAttribute("canCacheDefault"))) {
-            jmri.jmrix.AbstractProgrammerFacade.setCanCacheDefault(a.getValue().equals("yes"));
+            InstanceManager.getDefault(ProgrammerConfigManager.class).setCanCacheDefault(a.getValue().equals("yes"));
         }
         if (null != (a = shared.getAttribute("doConfirmRead"))) {
-            jmri.jmrix.AbstractProgrammerFacade.setDoConfirmRead(a.getValue().equals("yes"));
+            InstanceManager.getDefault(ProgrammerConfigManager.class).setDoConfirmRead(a.getValue().equals("yes"));
         }
         ConfigureManager cm = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
         if (cm != null) {

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
@@ -497,8 +497,12 @@ abstract public class PaneProgFrame extends JmriJFrame
                 if (decoderRoot != null
                         && (programming = decoderRoot.getChild("decoder").getChild("programming")) != null) {
 
-                    // add any needed facades
-                    Programmer pf = jmri.implementation.ProgrammerFacadeSelector.loadFacadeElements(programming, mProgrammer);
+                    // add a verify-write facade if configured
+                    Programmer pf = mProgrammer;
+                    if (getDoConfirmRead()) pf = new jmri.implementation.VerifyWriteProgrammerFacade(pf);
+                    // add any facades defined in the decoder file
+                    pf = jmri.implementation.ProgrammerFacadeSelector
+                                    .loadFacadeElements(programming, pf, getCanCacheDefault());
                     log.debug("new programmer " + pf);
                     mProgrammer = pf;
                     cvModel.setProgrammer(pf);
@@ -1815,6 +1819,28 @@ abstract public class PaneProgFrame extends JmriJFrame
         return (InstanceManager.getNullableDefault(ProgrammerConfigManager.class) == null ) ?
             true :
             InstanceManager.getDefault(ProgrammerConfigManager.class).isShowCvNumbers();
+    }
+
+    public static void setCanCacheDefault(boolean yes) {
+        if (InstanceManager.getNullableDefault(ProgrammerConfigManager.class) != null)
+            InstanceManager.getDefault(ProgrammerConfigManager.class).setCanCacheDefault(yes);
+    }
+
+    public static boolean getCanCacheDefault() {
+        return (InstanceManager.getNullableDefault(ProgrammerConfigManager.class) == null ) ?
+            true :
+            InstanceManager.getDefault(ProgrammerConfigManager.class).isCanCacheDefault();
+    }
+
+    public static void setDoConfirmRead(boolean yes) {
+        if (InstanceManager.getNullableDefault(ProgrammerConfigManager.class) != null)
+            InstanceManager.getDefault(ProgrammerConfigManager.class).setDoConfirmRead(yes);
+    }
+
+    public static boolean getDoConfirmRead() {
+        return (InstanceManager.getNullableDefault(ProgrammerConfigManager.class) == null ) ?
+            true :
+            InstanceManager.getDefault(ProgrammerConfigManager.class).isDoConfirmRead();
     }
 
     public RosterEntry getRosterEntry() {

--- a/java/src/jmri/jmrix/AbstractProgrammerFacade.java
+++ b/java/src/jmri/jmrix/AbstractProgrammerFacade.java
@@ -37,32 +37,6 @@ public abstract class AbstractProgrammerFacade implements Programmer {
     }
 
     /**
-     * Are facades allowed to cache programming operations?
-     * E.g. skip writing a PI or SI CV if the correct value 
-     * has already been written.<p>
-     * Unbound parameter.<p>
-     * This is common across all facades to simplify user
-     * decision making. Someday, finer granularity might be desired.
-     */
-    static boolean canCacheDefault = false;
-    
-    static public boolean isCanCacheDefault() { return canCacheDefault; }
-    static public void setCanCacheDefault(boolean v) { canCacheDefault = v; }
-    
-    /**
-     * Should facades check index values after writing them?
-     * E.g. read back a PI or SI value to confirm it has the
-     * right value, and error out if not<p>
-     * Unbound parameter.<p>
-     * This is common across all facades to simplify user
-     * decision making. Someday, finer granularity might be desired.
-     */
-    static boolean doConfirmRead = false;
-    
-    static public boolean isDoConfirmRead() { return doConfirmRead; }
-    static public void setDoConfirmRead(boolean v) { doConfirmRead = v; }
-    
-    /**
      * @param CV  the CV to write
      * @param val the value to write
      * @param p   the listener that will be notified of the write

--- a/java/src/jmri/jmrix/AbstractProgrammerFacade.java
+++ b/java/src/jmri/jmrix/AbstractProgrammerFacade.java
@@ -37,6 +37,32 @@ public abstract class AbstractProgrammerFacade implements Programmer {
     }
 
     /**
+     * Are facades allowed to cache programming operations?
+     * E.g. skip writing a PI or SI CV if the correct value 
+     * has already been written.<p>
+     * Unbound parameter.<p>
+     * This is common across all facades to simplify user
+     * decision making. Someday, finer granularity might be desired.
+     */
+    static boolean canCacheDefault = false;
+    
+    static public boolean isCanCacheDefault() { return canCacheDefault; }
+    static public void setCanCacheDefault(boolean v) { canCacheDefault = v; }
+    
+    /**
+     * Should facades check index values after writing them?
+     * E.g. read back a PI or SI value to confirm it has the
+     * right value, and error out if not<p>
+     * Unbound parameter.<p>
+     * This is common across all facades to simplify user
+     * decision making. Someday, finer granularity might be desired.
+     */
+    static boolean doConfirmRead = false;
+    
+    static public boolean isDoConfirmRead() { return doConfirmRead; }
+    static public void setDoConfirmRead(boolean v) { doConfirmRead = v; }
+    
+    /**
      * @param CV  the CV to write
      * @param val the value to write
      * @param p   the listener that will be notified of the write

--- a/java/test/jmri/implementation/MultiIndexProgrammerFacadeTest.java
+++ b/java/test/jmri/implementation/MultiIndexProgrammerFacadeTest.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Test the SingleIndexProgrammerFacade class.
+ * Test the MultiIndexProgrammerFacade class.
  *
  * @author	Bob Jacobsen Copyright 2013
  * 

--- a/java/test/jmri/implementation/PackageTest.java
+++ b/java/test/jmri/implementation/PackageTest.java
@@ -1,10 +1,3 @@
-/**
- * PackageTest.java
- *
- * Description:	tests for the jmri.implementation package
- *
- * @author	Bob Jacobsen 2009
- */
 package jmri.implementation;
 
 import junit.framework.JUnit4TestAdapter;
@@ -12,6 +5,13 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
+/**
+ * PackageTest.java
+ *
+ * Description:	tests for the jmri.implementation package
+ *
+ * @author	Bob Jacobsen 2009, 2017
+ */
 public class PackageTest extends TestCase {
 
     // from here down is testing infrastructure
@@ -45,6 +45,7 @@ public class PackageTest extends TestCase {
         suite.addTest(new JUnit4TestAdapter(DefaultSignalSystemTest.class));
         suite.addTest(new JUnit4TestAdapter(DefaultSignalAppearanceMapTest.class));
         suite.addTest(MultiIndexProgrammerFacadeTest.suite());
+        suite.addTest(VerifyWriteProgrammerFacadeTest.suite());
         suite.addTest(OffsetHighCvProgrammerFacadeTest.suite());
         suite.addTest(ResettingOffsetHighCvProgrammerFacadeTest.suite());
         suite.addTest(RouteTest.suite());

--- a/java/test/jmri/implementation/VerifyWriteProgrammerFacadeTest.java
+++ b/java/test/jmri/implementation/VerifyWriteProgrammerFacadeTest.java
@@ -1,0 +1,130 @@
+package jmri.implementation;
+
+import jmri.ProgListener;
+import jmri.Programmer;
+import jmri.ProgrammerException;
+import jmri.progdebugger.ProgDebugger;
+import org.junit.Assert;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test the VerifyWriteProgrammerFacade class.
+ *
+ * @author	Bob Jacobsen Copyright 2013
+ * 
+ */
+public class VerifyWriteProgrammerFacadeTest extends TestCase {
+
+    int readValue = -2;
+    int readCount = 0;
+    boolean replied = false;
+
+    public void testWriteReadDirect() throws jmri.ProgrammerException, InterruptedException {
+
+        readCount = 0;
+        ProgDebugger dp = new ProgDebugger() {
+            @Override
+            public boolean getCanRead(String cv) { return false; }
+            @Override
+            public boolean getCanRead() { return false; }
+            @Override
+            public void readCV(String cv, ProgListener p) throws ProgrammerException { readCount++; super.readCV(cv, p); }
+        };
+        Programmer p = new VerifyWriteProgrammerFacade(dp);
+        ProgListener l = new ProgListener() {
+            @Override
+            public void programmingOpReply(int value, int status) {
+                log.debug("callback value=" + value + " status=" + status);
+                replied = true;
+                readValue = value;
+            }
+        };
+
+        p.writeCV("4", 12, l);
+        waitReply();
+        Assert.assertEquals("target written", 12, dp.getCvVal(4));
+        Assert.assertEquals("reads", 0, readCount);
+        
+        p.readCV("4", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+    }
+
+    public void testWriteReadVerify() throws jmri.ProgrammerException, InterruptedException {
+
+        readCount = 0;
+        ProgDebugger dp = new ProgDebugger() {
+            @Override
+            public boolean getCanRead(String cv) { return true; }
+            @Override
+            public boolean getCanRead() { return true; }
+            @Override
+            public void readCV(String cv, ProgListener p) throws ProgrammerException { readCount++; super.readCV(cv, p); }
+        };
+        Programmer p = new VerifyWriteProgrammerFacade(dp);
+        ProgListener l = new ProgListener() {
+            @Override
+            public void programmingOpReply(int value, int status) {
+                log.debug("callback value=" + value + " status=" + status);
+                replied = true;
+                readValue = value;
+            }
+        };
+
+        p.writeCV("4", 12, l);
+        waitReply();
+        Assert.assertEquals("target written", 12, dp.getCvVal(4));
+        Assert.assertEquals("reads", 1, readCount);
+
+        p.readCV("4", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+    }
+
+
+    public void testCvLimit() {
+        ProgDebugger dp = new ProgDebugger();
+        dp.setTestReadLimit(1024);
+        dp.setTestWriteLimit(1024);
+
+        Programmer p = new VerifyWriteProgrammerFacade(dp);
+
+        Assert.assertTrue("CV limit read OK", p.getCanRead("1024"));
+        Assert.assertTrue("CV limit write OK", p.getCanWrite("1024"));
+        Assert.assertTrue("CV limit read fail", !p.getCanRead("1025"));
+        Assert.assertTrue("CV limit write fail", !p.getCanWrite("1025"));
+    }
+
+    // from here down is testing infrastructure
+    synchronized void waitReply() throws InterruptedException {
+        while (!replied) {
+            wait(200);
+        }
+        replied = false;
+    }
+
+    // from here down is testing infrastructure
+    public VerifyWriteProgrammerFacadeTest(String s) {
+        super(s);
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {VerifyWriteProgrammerFacadeTest.class.getName()};
+        junit.textui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        apps.tests.AllTest.initLogging();
+        TestSuite suite = new TestSuite(VerifyWriteProgrammerFacadeTest.class);
+        return suite;
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(VerifyWriteProgrammerFacadeTest.class.getName());
+
+}

--- a/xml/schema/layout-2-9-6.xsd
+++ b/xml/schema/layout-2-9-6.xsd
@@ -215,24 +215,28 @@ signals - obsolete, EMPTY, never used
                 <xs:attribute name="verifyBeforeWrite" type="yesNoType" default="no"/>
                 <xs:attribute name="showEmptyPanes" type="yesNoType" default="yes" />
                 <xs:attribute name="canCacheDefault" type="yesNoType" default="yes">
-                  <xs:documentation>
-                    Defines default for whether to cache index CV writes,
-                    which can be overridden in a decoder definition file if desired.
-                  </xs:documentation>
-                  <xs:appinfo>
-                    <jmri:usingclass configurexml="yes">jmri.jmrit.symbolicprog.configurexml.ProgrammerConfigPaneXml</jmri:usingclass>
-                    <jmri:usingclass configurexml="no">jmri.jmrix.AbstractProgrammerFacade</jmri:usingclass>
-                  </xs:appinfo>
+                  <xs:annotation>
+                    <xs:documentation>
+                      Defines default for whether to cache index CV writes,
+                      which can be overridden in a decoder definition file if desired.
+                    </xs:documentation>
+                    <xs:appinfo>
+                      <jmri:usingclass configurexml="yes">jmri.jmrit.symbolicprog.configurexml.ProgrammerConfigPaneXml</jmri:usingclass>
+                      <jmri:usingclass configurexml="no">jmri.jmrix.AbstractProgrammerFacade</jmri:usingclass>
+                    </xs:appinfo>
+                  </xs:annotation>
                 </xs:attribute>
                 <xs:attribute name="doConfirmWrite" type="yesNoType" default="yes">
-                  <xs:documentation>
-                    Defines default for whether index CVs should be read for confirmation after being written,
-                    which can be overridden in a decoder definition file if desired.
-                  </xs:documentation>
-                  <xs:appinfo>
-                    <jmri:usingclass configurexml="yes">jmri.jmrit.symbolicprog.configurexml.ProgrammerConfigPaneXml</jmri:usingclass>
-                    <jmri:usingclass configurexml="no">jmri.jmrix.AbstractProgrammerFacade</jmri:usingclass>
-                  </xs:appinfo>
+                  <xs:annotation>
+                    <xs:documentation>
+                      Defines default for whether index CVs should be read for confirmation after being written,
+                      which can be overridden in a decoder definition file if desired.
+                    </xs:documentation>
+                    <xs:appinfo>
+                      <jmri:usingclass configurexml="yes">jmri.jmrit.symbolicprog.configurexml.ProgrammerConfigPaneXml</jmri:usingclass>
+                      <jmri:usingclass configurexml="no">jmri.jmrix.AbstractProgrammerFacade</jmri:usingclass>
+                    </xs:appinfo>
+                  </xs:annotation>
                 </xs:attribute>
                 <xs:attribute name="defaultFile" type="xs:string" default="Basic.xml"/>
             </xs:complexType>

--- a/xml/schema/layout-2-9-6.xsd
+++ b/xml/schema/layout-2-9-6.xsd
@@ -214,6 +214,26 @@ signals - obsolete, EMPTY, never used
                 <xs:attribute name="class" type="classType" use="required"/>
                 <xs:attribute name="verifyBeforeWrite" type="yesNoType" default="no"/>
                 <xs:attribute name="showEmptyPanes" type="yesNoType" default="yes" />
+                <xs:attribute name="canCacheDefault" type="yesNoType" default="yes">
+                  <xs:documentation>
+                    Defines default for whether to cache index CV writes,
+                    which can be overridden in a decoder definition file if desired.
+                  </xs:documentation>
+                  <xs:appinfo>
+                    <jmri:usingclass configurexml="yes">jmri.jmrit.symbolicprog.configurexml.ProgrammerConfigPaneXml</jmri:usingclass>
+                    <jmri:usingclass configurexml="no">jmri.jmrix.AbstractProgrammerFacade</jmri:usingclass>
+                  </xs:appinfo>
+                </xs:attribute>
+                <xs:attribute name="doConfirmWrite" type="yesNoType" default="yes">
+                  <xs:documentation>
+                    Defines default for whether index CVs should be read for confirmation after being written,
+                    which can be overridden in a decoder definition file if desired.
+                  </xs:documentation>
+                  <xs:appinfo>
+                    <jmri:usingclass configurexml="yes">jmri.jmrit.symbolicprog.configurexml.ProgrammerConfigPaneXml</jmri:usingclass>
+                    <jmri:usingclass configurexml="no">jmri.jmrix.AbstractProgrammerFacade</jmri:usingclass>
+                  </xs:appinfo>
+                </xs:attribute>
                 <xs:attribute name="defaultFile" type="xs:string" default="Basic.xml"/>
             </xs:complexType>
         </xs:element>


### PR DESCRIPTION
Add preferences on the Programmer pane (under Roster) to control

- After write, read a CV to verify success (when read is possible)
- Suppress redundant index CV writes 

Those can, and probably should, be used together. 