### PR TITLE
Add thread names

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderManagerThread.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderManagerThread.java
@@ -38,6 +38,7 @@ class VSDecoderManagerThread extends Thread {
     public static VSDecoderManagerThread instance() {
         if (instance == null) {
             VSDecoderManagerThread temp = new VSDecoderManagerThread();
+            temp.setName("VSDecoderManagerThread");
             temp.start();
             instance = temp; // don't allow escape of VSDecoderManagerThread object until running
 

--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -648,7 +648,12 @@ abstract public class AbstractMRTrafficController {
                     }
                 }
             });
-            xmtThread.setName("Transmit");
+            
+            String[] packages = this.getClass().getName().split("\\.");
+            xmtThread.setName(
+                (packages.length>=2 ? packages[packages.length-2]+"." :"")
+                +(packages.length>=1 ? packages[packages.length-1] :"")
+                +" Transmit thread");
             xmtThread.start();
             rcvThread = new Thread(new Runnable() {
                 @Override
@@ -656,7 +661,10 @@ abstract public class AbstractMRTrafficController {
                     receiveLoop();
                 }
             });
-            rcvThread.setName("Receive");
+            rcvThread.setName(
+                (packages.length>=2 ? packages[packages.length-2]+"." :"")
+                +(packages.length>=1 ? packages[packages.length-1] :"")
+                +" Receive thread");
             int xr = rcvThread.getPriority();
             xr++;
             rcvThread.setPriority(xr);      //bump up the priority

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeIOStream.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeIOStream.java
@@ -56,10 +56,12 @@ final public class XBeeIOStream extends AbstractPortController {
 
         // start the transmit thread
         sourceThread = new Thread(new TransmitThread(remoteXBee, tc, inpipe));
+        sourceThread.setName("xbee.XBeeIOStream Transmit thread");
         sourceThread.start();
 
         // start the receive thread
         sinkThread = new Thread(new ReceiveThread(remoteXBee, tc, outpipe));
+        sourceThread.setName("xbee.XBeeIOStream Receive thread");
         sinkThread.start();
 
     }

--- a/java/src/jmri/jmrix/jinput/TreeModel.java
+++ b/java/src/jmri/jmrix/jinput/TreeModel.java
@@ -48,7 +48,9 @@ public final class TreeModel extends DefaultTreeModel {
         // needed to get the display to start
         // insertNodeInto(new UsbNode("System", null, null), dRoot, 0);
         // start the USB gathering
-        (new Runner()).start();
+        Runner r = new Runner();
+        r.setName("TreeModel loader");
+        r.start();
     }
 
     /**

--- a/java/src/jmri/jmrix/roco/z21/Z21TrafficController.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21TrafficController.java
@@ -224,7 +224,7 @@ public class Z21TrafficController extends jmri.jmrix.AbstractMRTrafficController
                 }
             }
         });
-        xmtThread.setName("Transmit");
+        xmtThread.setName("z21.Z21TrafficController Transmit thread");
         xmtThread.start();
         rcvThread = new Thread(new Runnable() {
             @Override
@@ -232,7 +232,7 @@ public class Z21TrafficController extends jmri.jmrix.AbstractMRTrafficController
                 receiveLoop();
             }
         });
-        rcvThread.setName("Receive");
+        rcvThread.setName("z21.Z21TrafficController Receive thread");
         int xr = rcvThread.getPriority();
         xr++;
         rcvThread.setPriority(xr);      //bump up the priority

--- a/java/src/jmri/jmrix/roco/z21/Z21XPressNetTunnel.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XPressNetTunnel.java
@@ -54,6 +54,7 @@ public class Z21XPressNetTunnel implements Z21Listener, XNetListener, Runnable {
 
         // start a thread to read from the input pipe.
         sourceThread = new Thread(this);
+        sourceThread.setName("z21.Z21XPressNetTunnel sourceThread");
         sourceThread.start();
 
         // Then use those pipes as the input and output pipes for


### PR DESCRIPTION
Set the name of threads that JMRI creates.  Pretty good coverage, at least when sampling ci-test, with (most of?) the remaining default-name threads from other packages.