### PR TITLE
Add getWriteConfirmMode to Programmer

### DIFF
--- a/java/src/jmri/Programmer.java
+++ b/java/src/jmri/Programmer.java
@@ -229,12 +229,33 @@ public interface Programmer {
      */
     public boolean getCanWrite(String addr);
 
+    /**
+     * Learn about whether the programmer does any kind of verification of write operations
+     *
+     * @param addr A CV address to check (in case this varies with CV range) or null for any
+     * @return The confirmation behavior that can be counted on (might be better in some cases)
+     */
+    @Nonnull
+    public WriteConfirmMode getWriteConfirmMode(String addr);
+    
+    enum WriteConfirmMode {
+        /** No verification available, writes are blind */
+        NotVerified,
+        
+        /** Programmer signals error if there's no reply from the device */
+        DecoderReply,
+        
+        /** Programmer does a read after write to verify */
+        ReadAfterWrite
+    }
+    
     public void addPropertyChangeListener(PropertyChangeListener p);
 
     public void removePropertyChangeListener(PropertyChangeListener p);
 
     // error handling on request is via exceptions
     // results are returned via the ProgListener callback
+    @Nonnull
     public String decodeErrorCode(int i);
 
 }

--- a/java/src/jmri/jmrix/AbstractProgrammer.java
+++ b/java/src/jmri/jmrix/AbstractProgrammer.java
@@ -207,6 +207,16 @@ public abstract class AbstractProgrammer implements Programmer {
     }
 
     /**
+     * By default, say that no verification is done.
+     *
+     * @param addr A CV address to check (in case this varies with CV range) or null for any
+     * @return Always WriteConfirmMode.NotVerified
+     */
+    @Nonnull
+    public Programmer.WriteConfirmMode getWriteConfirmMode(String addr) { return WriteConfirmMode.NotVerified; }
+    
+
+    /**
      * Internal routine to start timer to protect the mode-change.
      */
     protected void startShortTimer() {

--- a/java/src/jmri/jmrix/AbstractProgrammerFacade.java
+++ b/java/src/jmri/jmrix/AbstractProgrammerFacade.java
@@ -2,6 +2,7 @@ package jmri.jmrix;
 
 import java.beans.PropertyChangeListener;
 import java.util.List;
+import javax.annotation.Nonnull;
 import jmri.ProgListener;
 import jmri.Programmer;
 import jmri.ProgrammerException;
@@ -130,5 +131,9 @@ public abstract class AbstractProgrammerFacade implements Programmer {
     public boolean getCanWrite(String addr) {
         return prog.getCanWrite(addr);
     }
+
+    @Override
+    @Nonnull
+    public WriteConfirmMode getWriteConfirmMode(String addr) { return prog.getWriteConfirmMode(addr); }
 
 }

--- a/java/src/jmri/jmrix/dccpp/DCCppProgrammer.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppProgrammer.java
@@ -2,7 +2,10 @@ package jmri.jmrix.dccpp;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
+
 import jmri.ProgrammingMode;
+import jmri.Programmer;
 import jmri.jmrix.AbstractProgrammer;
 import jmri.managers.DefaultProgrammerManager;
 import org.slf4j.Logger;
@@ -102,6 +105,13 @@ public class DCCppProgrammer extends AbstractProgrammer implements DCCppListener
             return Integer.parseInt(addr) <= 256;
         }
     }
+
+    /**
+     * 
+     */
+    @Nonnull
+    @Override
+    public Programmer.WriteConfirmMode getWriteConfirmMode(String addr) { return WriteConfirmMode.DecoderReply; }
 
     // members for handling the programmer interface
     protected int progState = 0;

--- a/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
@@ -4,8 +4,11 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
+
 import jmri.AddressedProgrammer;
 import jmri.ProgListener;
+import jmri.Programmer;
 import jmri.ProgrammerException;
 import jmri.ProgrammingMode;
 import jmri.managers.DefaultProgrammerManager;
@@ -284,6 +287,21 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
         ret.add(LnProgrammerManager.LOCONETSV1MODE);
         ret.add(LnProgrammerManager.LOCONETSV2MODE);
         return ret;
+    }
+
+    /**
+     * Confirmation mode by programming mode; not that this doesn't
+     * yet know whether BDL168 hardware is present to allow DecoderReply
+     * to function; that should be a preference eventually.  See also DCS240...
+     *
+     * @param addr CV address ignored, as there's no variance with this in LocoNet
+     * @return Depends on programming mode
+     */
+    @Nonnull
+    @Override
+    public Programmer.WriteConfirmMode getWriteConfirmMode(String addr) {
+        if (getMode().equals(DefaultProgrammerManager.OPSBYTEMODE)) return WriteConfirmMode.NotVerified;
+        return WriteConfirmMode.DecoderReply;
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -4,8 +4,11 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Vector;
+import javax.annotation.Nonnull;
+
 import jmri.CommandStation;
 import jmri.ProgListener;
+import jmri.Programmer;
 import jmri.ProgrammingMode;
 import jmri.jmrix.AbstractProgrammer;
 import jmri.managers.DefaultProgrammerManager;
@@ -705,6 +708,14 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
     public boolean getCanRead() {
         return mCanRead;
     }
+
+    /**
+     * Service mode always checks for DecoderReply.  (The DCS240 also seems to do
+     * ReadAfterWrite, but that's not fully understood yet)
+     */
+    @Nonnull
+    @Override
+    public Programmer.WriteConfirmMode getWriteConfirmMode(String addr) { return WriteConfirmMode.DecoderReply; }
 
     /**
      * Set the command station type to one of the known types in the

--- a/java/src/jmri/progdebugger/ProgDebugger.java
+++ b/java/src/jmri/progdebugger/ProgDebugger.java
@@ -5,8 +5,11 @@ import java.beans.PropertyChangeSupport;
 import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.List;
+import javax.annotation.Nonnull;
+
 import jmri.AddressedProgrammer;
 import jmri.ProgListener;
+import jmri.Programmer;
 import jmri.ProgrammerException;
 import jmri.ProgrammingMode;
 import jmri.managers.DefaultProgrammerManager;
@@ -319,6 +322,16 @@ public class ProgDebugger implements AddressedProgrammer {
         log.debug("getCanWrite(" + addr + ") returns " + (Integer.parseInt(addr) <= writeLimit));
         return Integer.parseInt(addr) <= writeLimit;
     }
+
+    /**
+     * By default, say that no verification is done.
+     *
+     * @param addr A CV address to check (in case this varies with CV range) or null for any
+     * @return Always WriteConfirmMode.NotVerified
+     */
+    @Nonnull
+    @Override
+    public Programmer.WriteConfirmMode getWriteConfirmMode(String addr) { return WriteConfirmMode.NotVerified; }
 
     /**
      * Provide a {@link java.beans.PropertyChangeSupport} helper.

--- a/java/test/jmri/ProgrammerScaffold.java
+++ b/java/test/jmri/ProgrammerScaffold.java
@@ -1,9 +1,11 @@
-/* ProgrammerScaffold.java */
 package jmri;
 
 import java.beans.PropertyChangeListener;
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nonnull;
+import jmri.Programmer;
+
 
 /**
  * Scaffold implementation of Programmer interface for testing.
@@ -96,6 +98,10 @@ public class ProgrammerScaffold implements Programmer {
     public boolean getCanWrite(String addr) {
         return Integer.parseInt(addr) <= 1024;
     }
+
+    @Override
+    @Nonnull
+    public Programmer.WriteConfirmMode getWriteConfirmMode(String addr) { return WriteConfirmMode.NotVerified; }
 
     @Override
     public void addPropertyChangeListener(PropertyChangeListener p) {


### PR DESCRIPTION
Base support for getWriteConfirmMode call, which lets a Programmer specify how the Programmer handles write verification. 

This defaults to not-verified for systems not updated.  Updates are in place for Digitrax and DCC++.  If you know of any other systems that do write verification, even checking for decoder ack, please comment.