### PR TITLE
web server: handle redirects with extra slash, don't send extra 404

### DIFF
--- a/java/src/jmri/web/servlet/home/HomeServlet.java
+++ b/java/src/jmri/web/servlet/home/HomeServlet.java
@@ -22,11 +22,12 @@ import jmri.web.servlet.ServletUtil;
             "/prefs/index.html" // some WiThrottle clients require this URL to show web services
         })
 public class HomeServlet extends HttpServlet {
-
+    
     protected void processRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        if (request.getRequestURI().equals("/index.html")
-                || request.getRequestURI().equals("/prefs/index.html")) {
+        if (request.getRequestURI().startsWith("/index.html")
+                || request.getRequestURI().startsWith("/prefs/index.html")) {
             response.sendRedirect("/");
+            return;
         }
         if (!request.getRequestURI().equals("/")) {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);

--- a/java/src/jmri/web/servlet/roster/RosterServlet.java
+++ b/java/src/jmri/web/servlet/roster/RosterServlet.java
@@ -85,7 +85,7 @@ public class RosterServlet extends HttpServlet {
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        if (request.getRequestURI().equals("/prefs/roster.xml")) { // NOI18N
+        if (request.getRequestURI().startsWith("/prefs/roster.xml")) { // NOI18N
             response.sendRedirect("/roster?format=xml"); // NOI18N
             return;
         }


### PR DESCRIPTION
The hard-coded urlPatterns now seem to be getting a redirect with an extra slash appended from somewhere.
Specifically causing a comparison failure on "/prefs/roster.xml", "/index.html" and "/prefs/index.html".  The first was causing a null pointer error.
I was not able to find where the extra slash was added, so I changed the checks to ignore it.
