### PR TITLE
Conditional names partially unique

### DIFF
--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -364,17 +364,21 @@ knows to look for routes of this name.
       <p>The list of tools currently working this way is:</p>
 
       <ul>
+        <li>Logix - auto-generated 
+            <a href="http://www.jmri.org/JavaDoc/doc/java/src/jmri/Logix.html">Logix</a> 
+            system names are of the form IX:AUTO:0001</li>
         <li>SENSOR GROUPS - <a href=
         "http://www.jmri.org/JavaDoc/doc/jmri/jmrit/sensorgroup/package-summary.html">
         jmri.jmrit.sensorgroup</a></li>
+
+        <li>SignalHeads - particularly the <a href=
+        "http://www.jmri.org/JavaDoc/doc/jmri/implementation/SE8cSignalHead.html">
+        SE8C signal head</a></li>
 
         <li>USS CTC - <a href=
         "http://www.jmri.org/JavaDoc/doc/jmri/jmrit/ussctc/package-summary.html">
         jmri.jmrit.ussctc</a></li>
 
-        <li>SignalHeads - particularly the <a href=
-        "http://www.jmri.org/JavaDoc/doc/jmri/implementation/SE8cSignalHead.html">
-        SE8C signal head</a></li>
       </ul>
 
       <h2>Notes</h2>
@@ -384,6 +388,13 @@ knows to look for routes of this name.
         of more than one yet. The DCC programmer is the first
         example, but there may be others.</li>
 
+        <li><a href="http://www.jmri.org/JavaDoc/doc/java/src/jmri/Conditional.html">Conditionals</a>
+        are a special case.  Although they have things called
+        "System Names" and "User Names", they don't really obey the 
+        conventions here.  See the 
+        <a href="http://www.jmri.org/JavaDoc/doc/java/src/jmri/ConditionalManager.html">ConditionalManager Javadoc</a>
+        for more information.</li>
+        
         <li>The system name convention doesn't provide a specific
         way to identify more than one adapter of a given type. E.g.
         if you're connected to more than one LocoNet, or more than

--- a/java/src/jmri/LogixManager.java
+++ b/java/src/jmri/LogixManager.java
@@ -29,7 +29,7 @@ public interface LogixManager extends Manager {
      *
      * @param systemName the system name
      * @param userName   the user name
-     * @return a new Logix or null if unable to create
+     * @return a new Logix or null if unable to create: An error, or the Logix already exists
      */
     public Logix createNewLogix(String systemName, String userName);
 

--- a/java/src/jmri/jmrix/PortAdapter.java
+++ b/java/src/jmri/jmrix/PortAdapter.java
@@ -112,6 +112,7 @@ public interface PortAdapter {
     /**
      * Sets whether the connection is disabled
      *
+     * @param disabled When true, disables operation
      */
     public void setDisabled(boolean disabled);
 

--- a/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
@@ -9,9 +9,27 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Turnout for OpenLCB connections.
+ * <p>
+ * State Diagram for read and write operations  (click to magnify):
+ * <a href="doc-files/OlcbTurnout-State-Diagram.png"><img src="doc-files/OlcbTurnout-State-Diagram.png" alt="UML State diagram" height="50%" width="50%"></a>
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2008, 2010, 2011
  */
+ 
+ /*
+ * @startuml jmri/jmrix/openlcb/doc-files/OlcbTurnout-State-Diagram.png
+ * CLOSED --> CLOSED: Event 1
+ * THROWN --> CLOSED: Event 1
+ * THROWN --> THROWN: Event 0
+ * CLOSED --> THROWN: Event 0
+ * [*] --> UNKNOWN 
+ * UNKNOWN --> CLOSED: Event 1\nEvent 1 Produced msg with valid set\nEvent 1 Consumed msg with valid set
+ * UNKNOWN --> THROWN: Event 0\nEvent 1 Produced msg with valid set\nEvent 0 Consumed msg with valid set
+ * state INCONSISTENT
+ * @enduml
+*/
+
+
 public class OlcbTurnout extends jmri.implementation.AbstractTurnout {
 
     OlcbAddress addrThrown;   // go to thrown state
@@ -116,6 +134,7 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout {
      */
     @Override
     protected void forwardCommandChangeToLayout(int s) {
+        System.out.println("forward to layout "+s);
         if (s == Turnout.THROWN) {
             turnoutListener.setFromOwner(true);
             if (_activeFeedbackType == MONITORING) {

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -189,7 +189,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
     }
     
     /**
-     * Invoked by {@link #register()} to register 
+     * Invoked by {@link #register(NamedBean)} to register 
      * the user name of the bean
      */
     protected void registerUserName(NamedBean s) {
@@ -203,7 +203,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
     }
     
     /**
-     * Invoked by {@link #registerUserName()} to 
+     * Invoked by {@link #registerUserName(NamedBean)} to 
      * ensure uniqueness of the NamedBean during registration
      */
     protected void handleUserNameUniqueness(NamedBean s) {

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -189,7 +189,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
     }
     
     /**
-     * Invoked by {@see #register()} to register 
+     * Invoked by {@link #register()} to register 
      * the user name of the bean
      */
     protected void registerUserName(NamedBean s) {
@@ -203,7 +203,7 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
     }
     
     /**
-     * Invoked by {@see #registerUserName()} to 
+     * Invoked by {@link #registerUserName()} to 
      * ensure uniqueness of the NamedBean during registration
      */
     protected void handleUserNameUniqueness(NamedBean s) {

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -180,22 +180,42 @@ abstract public class AbstractManager implements Manager, PropertyChangeListener
     public void register(NamedBean s) {
         String systemName = s.getSystemName();
         _tsys.put(systemName, s);
+
+        registerUserName(s);
+
+        firePropertyChange("length", null, _tsys.size());
+        // listen for name and state changes to forward
+        s.addPropertyChangeListener(this, "", "Manager");
+    }
+    
+    /**
+     * Invoked by {@see #register()} to register 
+     * the user name of the bean
+     */
+    protected void registerUserName(NamedBean s) {
         String userName = s.getUserName();
+        if (userName == null) return;
         
+        handleUserNameUniqueness(s);
+        // since we've handled uniqueness,
+        // store the new bean under the name
+        _tuser.put(userName, s);        
+    }
+    
+    /**
+     * Invoked by {@see #registerUserName()} to 
+     * ensure uniqueness of the NamedBean during registration
+     */
+    protected void handleUserNameUniqueness(NamedBean s) {
+        String userName = s.getUserName();        
         if (userName != null) {
             // enforce uniqueness of user names
             // by setting username to null in any existing bean with the same name
             // Note that this is not a "move" operation for the user name
             if (_tuser.get(userName)!=null && _tuser.get(userName)!=s ) _tuser.get(userName).setUserName(null);
-            
-            // store the new bean under the name
-            _tuser.put(userName, s);
         }
-        firePropertyChange("length", null, _tsys.size());
-        // listen for name and state changes to forward
-        s.addPropertyChangeListener(this, "", "Manager");
     }
-
+    
     /**
      * Forget a NamedBean Object created outside the manager.
      * <P>

--- a/java/src/jmri/managers/DefaultConditionalManager.java
+++ b/java/src/jmri/managers/DefaultConditionalManager.java
@@ -24,7 +24,10 @@ import org.slf4j.LoggerFactory;
  * Conditional system names are set automatically when the Conditional is
  * created. All alphabetic characters in a Conditional system name must be upper
  * case. This is enforced when a new Conditional is created via
- * LogixTableAction.java.
+ * {@link jmri.jmrit.beantable.LogixTableAction}
+ * <p>
+ * Conditional user names have specific requirements that are
+ * addressed in the {@link jmri.Conditional} class.
  *
  * @author Dave Duchamp Copyright (C) 2007
  * @author Pete Cresman Copyright (C) 2009
@@ -57,6 +60,8 @@ public class DefaultConditionalManager extends AbstractManager
      * Conditional is still created. The scenario can happen when a Logix is
      * loaded from a file after its Conditionals.
      *
+     * @param systemName properly formatted system name for the new Conditional
+     * @param userName must not be null, use "" instead
      * @return null if a Conditional with the same systemName or userName
      *         already exists, or if there is trouble creating a new Conditional
      */
@@ -96,6 +101,15 @@ public class DefaultConditionalManager extends AbstractManager
         // save in the maps
         register(c);
         return c;
+    }
+
+    /**
+     * Do not insist that Conditional user names are unique,
+     * unlike the usual NamedBean support
+     */
+    @Override
+    protected void handleUserNameUniqueness(jmri.NamedBean s) {
+        // eventually needs error checking and reporting
     }
 
     /**

--- a/java/src/jmri/managers/DefaultLogixManager.java
+++ b/java/src/jmri/managers/DefaultLogixManager.java
@@ -57,7 +57,9 @@ public class DefaultLogixManager extends AbstractManager
     }
 
     /**
-     * Method to create a new Logix if the Logix does not exist Returns null if
+     * Method to create a new Logix if the Logix does not exist. 
+     * <p>
+     * Returns null if
      * a Logix with the same systemName or userName already exists, or if there
      * is trouble creating a new Logix.
      */

--- a/java/test/jmri/managers/DefaultConditionalManagerTest.java
+++ b/java/test/jmri/managers/DefaultConditionalManagerTest.java
@@ -3,6 +3,10 @@ package jmri.managers;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
+import junit.framework.Assert;
+
+import jmri.Conditional;
+import jmri.ConditionalManager;
 
 /**
  * Tests for the jmri.managers.DefaultConditionalManager class.
@@ -13,6 +17,28 @@ public class DefaultConditionalManagerTest extends TestCase {
 
     public void testCtor() {
         new DefaultConditionalManager();
+    }
+
+    public void testCreate() {
+        ConditionalManager m = new DefaultConditionalManager();
+
+        Conditional c1 = m.createNewConditional("IX01C01", "");        
+        Conditional c2 = m.createNewConditional("IX01C02", "");
+        
+        Assert.assertFalse(c1 == c2);
+        Assert.assertFalse(c1.equals(c2));
+        
+    }
+
+    public void testUserNameOverlap() {
+        ConditionalManager m = new DefaultConditionalManager();
+
+        Conditional c1 = m.createNewConditional("IX01C01", "Foo");        
+        Conditional c2 = m.createNewConditional("IX01C02", "Foo");
+        
+        Assert.assertTrue(c1.getUserName().equals("Foo"));
+        Assert.assertTrue(c2.getUserName().equals("Foo"));
+        
     }
 
     // from here down is testing infrastructure

--- a/java/test/jmri/managers/DefaultLogixManagerTest.java
+++ b/java/test/jmri/managers/DefaultLogixManagerTest.java
@@ -43,7 +43,7 @@ public class DefaultLogixManagerTest extends TestCase {
 
         // test of some fails
         Assert.assertNull(m.createNewLogix(l1.getUserName()));
-        Assert.assertNull(m.createNewLogix(l1.getSystemName(),""));      
+        Assert.assertNull(m.createNewLogix(l1.getSystemName(),""));  
     }
 
     public void testEmptyUserName() {

--- a/java/test/jmri/managers/DefaultLogixManagerTest.java
+++ b/java/test/jmri/managers/DefaultLogixManagerTest.java
@@ -3,6 +3,10 @@ package jmri.managers;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
+import junit.framework.Assert;
+
+import jmri.Logix;
+import jmri.LogixManager;
 
 /**
  * Tests for the jmri.managers.DefaultLogixManager class.
@@ -13,6 +17,51 @@ public class DefaultLogixManagerTest extends TestCase {
 
     public void testCtor() {
         new DefaultLogixManager();
+    }
+
+    public void testCreateForms() {
+        LogixManager m = new DefaultLogixManager();
+        
+        Logix l1 = m.createNewLogix("User name 1");
+        Logix l2 = m.createNewLogix("User name 2");
+
+        Assert.assertNotNull(m.getByUserName("User name 1"));
+        Assert.assertNotNull(m.getByUserName("User name 2"));
+        
+        Assert.assertTrue(l1 != l2);
+        Assert.assertTrue(! l1.equals(l2));
+        
+        Assert.assertNotNull(m.getBySystemName(l1.getSystemName()));
+        Assert.assertNotNull(m.getBySystemName(l2.getSystemName()));
+
+        Logix l3 = m.createNewLogix("IX03", "User name 3");
+
+        Assert.assertTrue(l1 != l3);
+        Assert.assertTrue(l2 != l3);
+        Assert.assertTrue(! l1.equals(l3));
+        Assert.assertTrue(! l2.equals(l3));
+
+        // test of some fails
+        Assert.assertNull(m.createNewLogix(l1.getUserName()));
+        Assert.assertNull(m.createNewLogix(l1.getSystemName(),""));      
+    }
+
+    public void testEmptyUserName() {
+        LogixManager m = new DefaultLogixManager();
+        
+        Logix l1 = m.createNewLogix("IX01", "");
+        Logix l2 = m.createNewLogix("IX02", "");
+        
+        Assert.assertTrue(l1 != l2);
+        Assert.assertTrue(! l1.equals(l2));
+        
+        Assert.assertNotNull(m.getBySystemName(l1.getSystemName()));
+        Assert.assertNotNull(m.getBySystemName(l2.getSystemName()));
+
+        Logix l3 = m.createNewLogix("IX03", "User name 3");
+        
+        // test of some fails
+        Assert.assertNull(m.createNewLogix(l1.getSystemName(),""));      
     }
 
     // from here down is testing infrastructure

--- a/java/test/jmri/managers/LogixSystemTest.java
+++ b/java/test/jmri/managers/LogixSystemTest.java
@@ -1,0 +1,90 @@
+package jmri.managers;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import junit.framework.Assert;
+
+import jmri.*;
+
+/**
+ * Overall tests of Logix operation, including operation of 
+ * conditionals.  To ease setup, reads from XML files.
+ *
+ * @author	Bob Jacobsen Copyright (C) 2015
+ */
+public class LogixSystemTest extends TestCase {
+
+    /** 
+     * Test of inter-Logix references for Conditionals
+     * 
+     * Creates a sensor, which is watched by a Conditional in Logix 1, 
+     * which in turn is watched by two Conditionals in Logix 2 
+     *     (once by system name and once by user name), 
+     * which in turn each toggle one of two internal Turnouts on changes
+     */
+    public void testLogixReferenceSetup() throws jmri.JmriException {        
+
+        // load and activate sample file
+        java.io.File f = new java.io.File("java/test/jmri/managers/LogixSystemTestConditionaReferenceCheck.xml");
+        jmri.configurexml.ConfigXmlManager cm = new jmri.configurexml.ConfigXmlManager() {};
+        cm.load(f);
+        InstanceManager.getDefault(jmri.LogixManager.class).activateAllLogixs();
+        
+        // get references, in process checking load
+        Sensor is1 = InstanceManager.getDefault(jmri.SensorManager.class).getSensor("IS1");
+        Turnout it1 = InstanceManager.getDefault(jmri.TurnoutManager.class).getTurnout("IT1");
+        Turnout it2 = InstanceManager.getDefault(jmri.TurnoutManager.class).getTurnout("IT2");
+        Assert.assertNotNull(is1);
+        Assert.assertNotNull(it1);
+        Assert.assertNotNull(it2);
+        
+        // remember startup state for Turnouts, so can detect change
+        int oldIt1 = it1.getState();
+        int oldIt2 = it2.getState();
+        
+        // drive the sensor change that should cause the Conditionals to change
+        is1.setState(jmri.Sensor.ACTIVE);
+        
+        // check for propagation (maybe needs a wait someday?)
+        Assert.assertTrue("IT1", oldIt1 != it1.getState());
+        Assert.assertTrue("IT2", oldIt2 != it2.getState());
+    }
+
+    // from here down is testing infrastructure
+    public LogixSystemTest(String s) {
+        super(s);
+    }
+
+    // The minimal setup for log4J
+    @Override
+    protected void setUp() throws Exception {
+        apps.tests.Log4JFixture.setUp();
+        super.setUp();
+        jmri.util.JUnitUtil.resetInstanceManager();
+        jmri.util.JUnitUtil.initInternalTurnoutManager();
+        jmri.util.JUnitUtil.initInternalLightManager();
+        jmri.util.JUnitUtil.initInternalSensorManager();
+        jmri.util.JUnitUtil.initIdTagManager();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        jmri.util.JUnitUtil.resetInstanceManager();
+        super.tearDown();
+        apps.tests.Log4JFixture.tearDown();
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {"-noloading", LogixSystemTest.class.getName()};
+        junit.textui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        TestSuite suite = new TestSuite(LogixSystemTest.class);
+        return suite;
+    }
+
+}

--- a/java/test/jmri/managers/LogixSystemTestConditionaReferenceCheck.xml
+++ b/java/test/jmri/managers/LogixSystemTestConditionaReferenceCheck.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-2-9-6.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-2-9-6.xsd">
+  <!-- creates a sensor, which is watched by a Conditional in Logix 1, which in -->
+  <!-- turn is watched by two Conditionals in Logix 2 (once by system name and -->
+  <!-- once by user name, which in turn toggle two Turnouts on changes -->
+  <!-- For unit testing of the whole Logix mess. See jmri.managers.LogixSystemTest -->
+  <jmriversion>
+    <major>4</major>
+    <minor>7</minor>
+    <test>3</test>
+    <modifier>ish</modifier>
+  </jmriversion>
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
+    <defaultInitialState>unknown</defaultInitialState>
+    <sensor systemName="IS1" inverted="false" userName="Drives conditionals">
+      <systemName>IS1</systemName>
+      <userName>Drives conditionals</userName>
+    </sensor>
+  </sensors>
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
+    <operations automate="false">
+      <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
+      <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
+      <operation name="Sensor" class="jmri.configurexml.turnoutoperations.SensorTurnoutOperationXml" interval="300" maxtries="3" />
+    </operations>
+    <defaultclosedspeed>Normal</defaultclosedspeed>
+    <defaultthrownspeed>Restricted</defaultthrownspeed>
+    <turnout systemName="IT1" userName="Toggled by system name reference" feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT1</systemName>
+      <userName>Toggled by system name reference</userName>
+    </turnout>
+    <turnout systemName="IT2" userName="Toggled by user name reference" feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT2</systemName>
+      <userName>Toggled by user name reference</userName>
+    </turnout>
+  </turnouts>
+  <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
+    <logix systemName="IX:AUTO:0001" userName="Conditional listens to IS1" enabled="yes">
+      <systemName>IX:AUTO:0001</systemName>
+      <userName>Conditional listens to IS1</userName>
+      <logixConditional systemName="IX:AUTO:0001C1" order="0" />
+    </logix>
+    <logix systemName="IX:AUTO:0002" userName="Listen to conditional, write turnouts" enabled="yes">
+      <systemName>IX:AUTO:0002</systemName>
+      <userName>Listen to conditional, write turnouts</userName>
+      <logixConditional systemName="IX:AUTO:0002C1" order="0" />
+      <logixConditional systemName="IX:AUTO:0002C2" order="1" />
+    </logix>
+  </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX:AUTO:0001C1" userName="User 1C1" antecedent="R1" logicType="1" triggerOnChange="yes">
+      <systemName>IX:AUTO:0001C1</systemName>
+      <userName>User 1C1</userName>
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+    </conditional>
+    <conditional systemName="IX:AUTO:0002C1" userName="Via System Name" antecedent="R1" logicType="1" triggerOnChange="yes">
+      <systemName>IX:AUTO:0002C1</systemName>
+      <userName>Via System Name</userName>
+      <conditionalStateVariable operator="4" negated="no" type="5" systemName="IX:AUTO:0001C1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="3" type="2" systemName="IT1" data="8" delay="0" string="" />
+    </conditional>
+    <conditional systemName="IX:AUTO:0002C2" userName="Via User Name" antecedent="R1" logicType="1" triggerOnChange="yes">
+      <systemName>IX:AUTO:0002C2</systemName>
+      <userName>Via User Name</userName>
+      <conditionalStateVariable operator="4" negated="no" type="5" systemName="User 1C1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="3" type="2" systemName="IT2" data="8" delay="0" string="" />
+    </conditional>
+  </conditionals>
+  <!--Written by JMRI version 4.7.3ish+jake+20170401T1603Z+R61e8425 on Sat Apr 01 09:16:32 PDT 2017 $Id$-->
+</layout-config>

--- a/java/test/jmri/managers/PackageTest.java
+++ b/java/test/jmri/managers/PackageTest.java
@@ -8,6 +8,7 @@ import org.junit.runners.Suite;
     DefaultConditionalManagerTest.class,
     DefaultIdTagManagerTest.class,
     DefaultLogixManagerTest.class,
+    LogixSystemTest.class,
     DefaultSignalSystemManagerTest.class,
     DefaultUserMessagePreferencesTest.class, // no longer used in JMRI - may be used in other applications
     InternalLightManagerTest.class,


### PR DESCRIPTION
Allows user names for Conditionals to be partially unique by removing (just for Conditionals) the check on duplicate user names (for all other NamedBean types, this causes the user name of the previous bean to be set to "" when an attempt to create a duplicate happens)

This restores behavior pre-4.7.2 for duplicate Conditional user names.  It does _not_ fix any of the problems in that area.

Includes new test cases and a warning in the documentation.