### PR TITLE
The Roco Z21 doesn't support the XPressNet command to emergency stop …

### DIFF
--- a/java/src/jmri/jmrix/roco/z21/Z21XNetThrottle.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetThrottle.java
@@ -178,6 +178,13 @@ public class Z21XNetThrottle extends jmri.jmrix.lenz.XNetThrottle {
         queueMessage(msg7, THROTTLEFUNCSENT);
     }
 
+    // The Z21 Doesn't support the XPressNet directed emergency stop
+    // instruction, so override sendEmergencyStop in the parent, and
+    // just send speed step 0.
+    @Override
+    protected void sendEmergencyStop(){
+       setSpeedSetting(0);
+    }
 
     // Handle incoming messages for This throttle.
     @Override


### PR DESCRIPTION
…a specific locomotive, so set speed to 0 instead.