### PR TITLE
Correction to update decoder definition code.

### DIFF
--- a/java/src/jmri/jmrit/roster/UpdateDecoderDefinitionAction.java
+++ b/java/src/jmri/jmrit/roster/UpdateDecoderDefinitionAction.java
@@ -51,16 +51,21 @@ public class UpdateDecoderDefinitionAction extends JmriAbstractAction {
                 if (decoder.getReplacementFamily() != null || decoder.getReplacementModel() != null) {
                     log.info("   Recommended replacement is family \"" + decoder.getReplacementFamily() + "\" model \"" + decoder.getReplacementModel() + "\"");
                 }
-                replacementFamily = (decoder.getReplacementFamily() != null) ? decoder.getReplacementFamily() : replacementFamily;
-                replacementModel = (decoder.getReplacementModel() != null) ? decoder.getReplacementModel() : replacementModel;
+                replacementFamily = (decoder.getReplacementFamily() != null) ? decoder.getReplacementFamily() : null;
+                replacementModel = (decoder.getReplacementModel() != null) ? decoder.getReplacementModel() : null;
             }
 
-            if (replacementModel != null && replacementFamily != null) {
-                log.info("   *** Will update");
+            if (replacementModel != null || replacementFamily != null) {
 
                 // change the roster entry
+            if (replacementFamily != null) {
+                log.info("   *** Will update. replacementFamily='{}'",replacementFamily);
                 entry.setDecoderFamily(replacementFamily);
+            }
+            if (replacementModel != null) {
+                log.info("   *** Will update. replacementModel='{}'",replacementModel);
                 entry.setDecoderModel(replacementModel);
+            }
 
                 // write it out (not bothering to do backup?)
                 entry.updateFile();

--- a/java/src/jmri/jmrit/roster/UpdateDecoderDefinitionAction.java
+++ b/java/src/jmri/jmrit/roster/UpdateDecoderDefinitionAction.java
@@ -58,14 +58,14 @@ public class UpdateDecoderDefinitionAction extends JmriAbstractAction {
             if (replacementModel != null || replacementFamily != null) {
 
                 // change the roster entry
-            if (replacementFamily != null) {
-                log.info("   *** Will update. replacementFamily='{}'",replacementFamily);
-                entry.setDecoderFamily(replacementFamily);
-            }
-            if (replacementModel != null) {
-                log.info("   *** Will update. replacementModel='{}'",replacementModel);
-                entry.setDecoderModel(replacementModel);
-            }
+                if (replacementFamily != null) {
+                    log.info("   *** Will update. replacementFamily='{}'", replacementFamily);
+                    entry.setDecoderFamily(replacementFamily);
+                }
+                if (replacementModel != null) {
+                    log.info("   *** Will update. replacementModel='{}'", replacementModel);
+                    entry.setDecoderModel(replacementModel);
+                }
 
                 // write it out (not bothering to do backup?)
                 entry.updateFile();


### PR DESCRIPTION
Correct decoder definition update code so behaviour is as documented at [Advanced Decoder Defintions](http://jmri.org/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml#update):

> definition with replacementModel and/OR replacementFamily defined

"OR" did not work.