### PR TITLE
DoubleTurnoutSignalHead with turnout feedback

### DIFF
--- a/java/src/jmri/implementation/DoubleTurnoutSignalHead.java
+++ b/java/src/jmri/implementation/DoubleTurnoutSignalHead.java
@@ -157,10 +157,17 @@ public class DoubleTurnoutSignalHead extends DefaultSignalHead {
         @Override
         public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
             if (propertyChangeEvent.getPropertyName().equals("KnownState")) {
+                if (propertyChangeEvent.getSource().equals(mRed.getBean()) && propertyChangeEvent.getNewValue().equals(mRedCommanded)) {
+                    return; // ignore change that we commanded
+                }
+                if (propertyChangeEvent.getSource().equals(mGreen.getBean()) && propertyChangeEvent.getNewValue().equals(mGreenCommanded)) {
+                    return; // ignore change that we commanded
+                }
                 if (readUpdateTimer == null) {
                     readUpdateTimer = new javax.swing.Timer(200, (ActionEvent actionEvent) ->
                             readOutput());
                     readUpdateTimer.setRepeats(false);
+                    readUpdateTimer.start();
                 } else {
                     readUpdateTimer.restart();
                 }

--- a/java/src/jmri/implementation/DoubleTurnoutSignalHead.java
+++ b/java/src/jmri/implementation/DoubleTurnoutSignalHead.java
@@ -6,6 +6,11 @@ import jmri.Turnout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
 /**
  * Drive a single signal head via two "Turnout" objects.
  * <P>
@@ -16,23 +21,23 @@ import org.slf4j.LoggerFactory;
  * specific color (RED and GREEN). Normally, "THROWN" is on, and "CLOSED" is
  * off. YELLOW is provided by turning both on ("THROWN")
  * <P>
- * This class doesn't currently listen to the Turnout's to see if they've been
+ * This class also listens to the Turnouts to see if they've been
  * changed via some other mechanism.
  *
  * @author Bob Jacobsen Copyright (C) 2003, 2008
  */
-public class DoubleTurnoutSignalHead extends DefaultSignalHead implements java.beans.VetoableChangeListener {
+public class DoubleTurnoutSignalHead extends DefaultSignalHead {
 
     public DoubleTurnoutSignalHead(String sys, String user, NamedBeanHandle<Turnout> green, NamedBeanHandle<Turnout> red) {
         super(sys, user);
-        mRed = red;
-        mGreen = green;
+        setRed(red);
+        setGreen(green);
     }
 
     public DoubleTurnoutSignalHead(String sys, NamedBeanHandle<Turnout> green, NamedBeanHandle<Turnout> red) {
         super(sys);
-        mRed = red;
-        mGreen = green;
+        setRed(red);
+        setGreen(green);
     }
 
     @SuppressWarnings("fallthrough")
@@ -41,44 +46,51 @@ public class DoubleTurnoutSignalHead extends DefaultSignalHead implements java.b
     protected void updateOutput() {
         // assumes that writing a turnout to an existing state is cheap!
         if (mLit == false) {
-            mRed.getBean().setCommandedState(Turnout.CLOSED);
-            mGreen.getBean().setCommandedState(Turnout.CLOSED);
+            commandState(Turnout.CLOSED, Turnout.CLOSED);
             return;
         } else if (!mFlashOn
                 && ((mAppearance == FLASHGREEN)
                 || (mAppearance == FLASHYELLOW)
                 || (mAppearance == FLASHRED))) {
             // flash says to make output dark
-            mRed.getBean().setCommandedState(Turnout.CLOSED);
-            mGreen.getBean().setCommandedState(Turnout.CLOSED);
+            commandState(Turnout.CLOSED, Turnout.CLOSED);
             return;
 
         } else {
             switch (mAppearance) {
                 case RED:
                 case FLASHRED:
-                    mRed.getBean().setCommandedState(Turnout.THROWN);
-                    mGreen.getBean().setCommandedState(Turnout.CLOSED);
+                    commandState(Turnout.THROWN, Turnout.CLOSED);
                     break;
                 case YELLOW:
                 case FLASHYELLOW:
-                    mRed.getBean().setCommandedState(Turnout.THROWN);
-                    mGreen.getBean().setCommandedState(Turnout.THROWN);
+                    commandState(Turnout.THROWN, Turnout.THROWN);
                     break;
                 case GREEN:
                 case FLASHGREEN:
-                    mRed.getBean().setCommandedState(Turnout.CLOSED);
-                    mGreen.getBean().setCommandedState(Turnout.THROWN);
+                    commandState(Turnout.CLOSED, Turnout.THROWN);
                     break;
                 default:
                     log.warn("Unexpected new appearance: " + mAppearance);
                 // go dark by falling through
                 case DARK:
-                    mRed.getBean().setCommandedState(Turnout.CLOSED);
-                    mGreen.getBean().setCommandedState(Turnout.CLOSED);
+                    commandState(Turnout.CLOSED, Turnout.CLOSED);
                     break;
             }
         }
+    }
+
+    /**
+     * Sets the output turnouts' commanded state.
+     *
+     * @param red   state to set the mRed turnout
+     * @param green state to set the mGreen turnout.
+     */
+    void commandState(int red, int green) {
+        mRedCommanded = red;
+        mRed.getBean().setCommandedState(red);
+        mGreenCommanded = green;
+        mGreen.getBean().setCommandedState(green);
     }
 
     /**
@@ -87,6 +99,12 @@ public class DoubleTurnoutSignalHead extends DefaultSignalHead implements java.b
      */
     @Override
     public void dispose() {
+        if (mRed != null) {
+            mRed.getBean().removePropertyChangeListener(turnoutChangeListener);
+        }
+        if (mGreen != null) {
+            mGreen.getBean().removePropertyChangeListener(turnoutChangeListener);
+        }
         mRed = null;
         mGreen = null;
         jmri.InstanceManager.turnoutManagerInstance().removeVetoableChangeListener(this);
@@ -95,6 +113,8 @@ public class DoubleTurnoutSignalHead extends DefaultSignalHead implements java.b
 
     NamedBeanHandle<Turnout> mRed;
     NamedBeanHandle<Turnout> mGreen;
+    int mRedCommanded;
+    int mGreenCommanded;
 
     public NamedBeanHandle<Turnout> getRed() {
         return mRed;
@@ -105,11 +125,19 @@ public class DoubleTurnoutSignalHead extends DefaultSignalHead implements java.b
     }
 
     public void setRed(NamedBeanHandle<Turnout> t) {
+        if (mRed != null) {
+            mRed.getBean().removePropertyChangeListener(turnoutChangeListener);
+        }
         mRed = t;
+        mRed.getBean().addPropertyChangeListener(turnoutChangeListener);
     }
 
     public void setGreen(NamedBeanHandle<Turnout> t) {
+        if (mGreen != null) {
+            mGreen.getBean().removePropertyChangeListener(turnoutChangeListener);
+        }
         mGreen = t;
+        mGreen.getBean().addPropertyChangeListener(turnoutChangeListener);
     }
 
     @Override
@@ -121,6 +149,54 @@ public class DoubleTurnoutSignalHead extends DefaultSignalHead implements java.b
             return true;
         }
         return false;
+    }
+
+    javax.swing.Timer readUpdateTimer;
+
+    private PropertyChangeListener turnoutChangeListener = new PropertyChangeListener() {
+        @Override
+        public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+            if (propertyChangeEvent.getPropertyName().equals("KnownState")) {
+                if (readUpdateTimer == null) {
+                    readUpdateTimer = new javax.swing.Timer(200, (ActionEvent actionEvent) ->
+                            readOutput());
+                    readUpdateTimer.setRepeats(false);
+                } else {
+                    readUpdateTimer.restart();
+                }
+            }
+        }
+    };
+
+    /**
+     * Checks if the turnouts' output state matches the commanded output state; if not, then
+     * changes the appearance to match the output's current state.
+     */
+    void readOutput() {
+        if ((mAppearance == FLASHGREEN)
+                || (mAppearance == FLASHYELLOW)
+                || (mAppearance == FLASHRED)
+                || (mAppearance == FLASHLUNAR)) {
+            // If we are actively flashing right now, then we ignore external changes, since
+            // those might be coming from ourselves and will be overwritten shortly.
+            return;
+        }
+        int red = mRed.getBean().getKnownState();
+        int green = mGreen.getBean().getKnownState();
+        if (mRedCommanded == red && mGreenCommanded == green) return;
+        // The turnouts' known state has diverged from what we set. We attempt to decode the
+        // actual state to an appearance. This is a lossy operation, but the user has done
+        // something very explicitly to make this happen, like manually clicking the turnout throw
+        // button, or setting up an external signaling logic system.
+        if (red == Turnout.CLOSED && green == Turnout.CLOSED) {
+            setAppearance(DARK);
+        } else if (red == Turnout.THROWN && green == Turnout.CLOSED) {
+            setAppearance(RED);
+        } else if (red == Turnout.THROWN && green == Turnout.THROWN) {
+            setAppearance(YELLOW);
+        } else if (red == Turnout.CLOSED && green == Turnout.THROWN) {
+            setAppearance(GREEN);
+        }
     }
 
     private final static Logger log = LoggerFactory.getLogger(DoubleTurnoutSignalHead.class.getName());

--- a/java/src/jmri/implementation/DoubleTurnoutSignalHead.java
+++ b/java/src/jmri/implementation/DoubleTurnoutSignalHead.java
@@ -129,7 +129,9 @@ public class DoubleTurnoutSignalHead extends DefaultSignalHead {
             mRed.getBean().removePropertyChangeListener(turnoutChangeListener);
         }
         mRed = t;
-        mRed.getBean().addPropertyChangeListener(turnoutChangeListener);
+        if (mRed != null) {
+            mRed.getBean().addPropertyChangeListener(turnoutChangeListener);
+        }
     }
 
     public void setGreen(NamedBeanHandle<Turnout> t) {
@@ -137,7 +139,9 @@ public class DoubleTurnoutSignalHead extends DefaultSignalHead {
             mGreen.getBean().removePropertyChangeListener(turnoutChangeListener);
         }
         mGreen = t;
-        mGreen.getBean().addPropertyChangeListener(turnoutChangeListener);
+        if (mGreen != null) {
+            mGreen.getBean().addPropertyChangeListener(turnoutChangeListener);
+        }
     }
 
     @Override

--- a/java/src/jmri/implementation/TripleOutputSignalHead.java
+++ b/java/src/jmri/implementation/TripleOutputSignalHead.java
@@ -161,5 +161,11 @@ public class TripleOutputSignalHead extends DoubleTurnoutSignalHead {
         return false;
     }
 
+    /**
+     * Disables the feedback mechanism of the DoubleTurnoutSignalHead.
+     */
+    @Override
+    void readOutput() { }
+
     private final static Logger log = LoggerFactory.getLogger(TripleOutputSignalHead.class.getName());
 }

--- a/java/src/jmri/implementation/TripleTurnoutSignalHead.java
+++ b/java/src/jmri/implementation/TripleTurnoutSignalHead.java
@@ -116,5 +116,11 @@ public class TripleTurnoutSignalHead extends DoubleTurnoutSignalHead {
         return false;
     }
 
+    /**
+     * Disables the feedback mechanism of the DoubleTurnoutSignalHead.
+     */
+    @Override
+    void readOutput() { }
+
     private final static Logger log = LoggerFactory.getLogger(TripleTurnoutSignalHead.class.getName());
 }

--- a/java/test/jmri/implementation/DoubleTurnoutSignalHeadTest.java
+++ b/java/test/jmri/implementation/DoubleTurnoutSignalHeadTest.java
@@ -3,29 +3,193 @@ package jmri.implementation;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.SwingUtilities;
+
 import jmri.InstanceManager;
+import jmri.SignalHead;
 import jmri.TurnoutManager;
 import jmri.Turnout;
 import jmri.NamedBeanHandle;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 /**
  *
  * @author Paul Bender Copyright (C) 2017	
+ * @author Balazs Racz Copyright (C) 2017
  */
 public class DoubleTurnoutSignalHeadTest {
+
+    interface MockablePropertyChangeListener {
+        void onChange(String property, Object newValue);
+    }
+
+    class FakePropertyChangeListener implements PropertyChangeListener {
+        MockablePropertyChangeListener m;
+
+        FakePropertyChangeListener() {
+            m = mock(MockablePropertyChangeListener.class);
+        }
+
+        @Override
+        public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+            m.onChange(propertyChangeEvent.getPropertyName(), propertyChangeEvent.getNewValue());
+        }
+    }
+
+    protected FakePropertyChangeListener l = new FakePropertyChangeListener();
 
     @Test
     public void testCTor() {
         Turnout it = (InstanceManager.getDefault(TurnoutManager.class)).provideTurnout("IT1");
-        NamedBeanHandle green = new NamedBeanHandle("green handle",it);
+        NamedBeanHandle green = new NamedBeanHandle("green handle", it);
         Turnout it2 = (InstanceManager.getDefault(TurnoutManager.class)).provideTurnout("IT1");
-        NamedBeanHandle red = new NamedBeanHandle("red handle",it2);
-        DoubleTurnoutSignalHead t = new DoubleTurnoutSignalHead("Test Head",green,red);
+        NamedBeanHandle red = new NamedBeanHandle("red handle", it2);
+        DoubleTurnoutSignalHead t = new DoubleTurnoutSignalHead("Test Head", green, red);
         //Assert.assertNotNull("exists",t);
+    }
+
+    void createHead() {
+        mGreenTurnout = (InstanceManager.getDefault(TurnoutManager.class)).provideTurnout("IT1");
+        NamedBeanHandle green = new NamedBeanHandle("green handle", mGreenTurnout);
+        mRedTurnout = (InstanceManager.getDefault(TurnoutManager.class)).provideTurnout("IT2");
+        NamedBeanHandle red = new NamedBeanHandle("red handle", mRedTurnout);
+        mHead = new DoubleTurnoutSignalHead("Test Head", green, red);
+    }
+
+    void waitForTimer() {
+        if (mHead.readUpdateTimer == null) return;
+        while (mHead.readUpdateTimer.isRunning()) {
+            try {
+                Thread.sleep(60);
+            } catch (InterruptedException e) {
+            }
+        }
+        // Makes sure that the timer's callback is not still pending in the Swing execution
+        // thread by scheduling an execution there and waiting for it.
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+            });
+        } catch (InterruptedException e) {
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private Turnout mRedTurnout;
+    private Turnout mGreenTurnout;
+    private DoubleTurnoutSignalHead mHead;
+
+    @Test
+    public void testSetAppearance() {
+        createHead();
+
+        mHead.setAppearance(SignalHead.RED);
+        Assert.assertEquals(Turnout.THROWN, mRedTurnout.getKnownState());
+        Assert.assertEquals(Turnout.CLOSED, mGreenTurnout.getKnownState());
+        mHead.setAppearance(SignalHead.GREEN);
+        Assert.assertEquals(Turnout.CLOSED, mRedTurnout.getKnownState());
+        Assert.assertEquals(Turnout.THROWN, mGreenTurnout.getKnownState());
+        mHead.setAppearance(SignalHead.YELLOW);
+        Assert.assertEquals(Turnout.THROWN, mRedTurnout.getKnownState());
+        Assert.assertEquals(Turnout.THROWN, mGreenTurnout.getKnownState());
+        mHead.setAppearance(SignalHead.RED);
+        Assert.assertEquals(Turnout.THROWN, mRedTurnout.getKnownState());
+        Assert.assertEquals(Turnout.CLOSED, mGreenTurnout.getKnownState());
+    }
+
+    @Test
+    public void testNotify() {
+        createHead();
+        mHead.setAppearance(SignalHead.RED);
+        mHead.addPropertyChangeListener(l);
+
+        mHead.setAppearance(SignalHead.YELLOW);
+        verify(l.m).onChange("Appearance", SignalHead.YELLOW);
+        verifyNoMoreInteractions(l.m);
+
+        waitForTimer();
+        verifyNoMoreInteractions(l.m);
+
+        mHead.setAppearance(SignalHead.GREEN);
+        verify(l.m).onChange("Appearance", SignalHead.GREEN);
+        verifyNoMoreInteractions(l.m);
+
+        waitForTimer();
+        verifyNoMoreInteractions(l.m);
+    }
+
+    @Test
+    public void testReadOutput() {
+        createHead();
+
+        mHead.setAppearance(SignalHead.RED);
+        mHead.addPropertyChangeListener(l);
+        Assert.assertEquals(SignalHead.RED, mHead.getAppearance());
+
+        mRedTurnout.setCommandedState(Turnout.CLOSED);
+        mGreenTurnout.setCommandedState(Turnout.THROWN);
+        Assert.assertEquals(SignalHead.RED, mHead.getAppearance());
+        verifyNoMoreInteractions(l.m);
+        Assert.assertNotNull(mHead.readUpdateTimer); // Should be running.
+
+        waitForTimer();
+        verify(l.m).onChange("Appearance", SignalHead.GREEN);
+        Assert.assertEquals(SignalHead.GREEN, mHead.getAppearance());
+        reset(l.m);
+
+        mRedTurnout.setCommandedState(Turnout.THROWN);
+        verifyNoMoreInteractions(l.m);
+        waitForTimer();
+        verify(l.m).onChange("Appearance", SignalHead.YELLOW);
+        Assert.assertEquals(SignalHead.YELLOW, mHead.getAppearance());
+        verifyNoMoreInteractions(l.m);
+
+        mRedTurnout.setCommandedState(Turnout.CLOSED);
+        mGreenTurnout.setCommandedState(Turnout.CLOSED);
+        verifyNoMoreInteractions(l.m);
+        waitForTimer();
+        verify(l.m).onChange("Appearance", SignalHead.DARK);
+    }
+
+    @Test
+    public void testFlashingIgnoresTurnoutFeedback() {
+        createHead();
+        mHead.setAppearance(SignalHead.FLASHRED);
+        mHead.addPropertyChangeListener(l);
+        Assert.assertEquals(Turnout.THROWN, mRedTurnout.getKnownState());
+        Assert.assertEquals(Turnout.CLOSED, mGreenTurnout.getKnownState());
+        Assert.assertEquals(SignalHead.FLASHRED, mHead.getAppearance());
+        Assert.assertNotNull(mHead.readUpdateTimer); // Should be running.
+        verifyNoMoreInteractions(l.m);
+
+        // Wait for the flash
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+        }
+        Assert.assertEquals(SignalHead.FLASHRED, mHead.getAppearance()); // hasn't changed
+        verifyNoMoreInteractions(l.m); // also no notification
+
+        Assert.assertEquals(Turnout.CLOSED, mRedTurnout.getKnownState());
+        Assert.assertEquals(Turnout.CLOSED, mGreenTurnout.getKnownState());
+
+        mGreenTurnout.setCommandedState(Turnout.THROWN);
+        verifyNoMoreInteractions(l.m);
+        waitForTimer();
+        verifyNoMoreInteractions(l.m);
+        Assert.assertEquals(SignalHead.FLASHRED, mHead.getAppearance()); // hasn't changed
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/implementation/DoubleTurnoutSignalHeadTest.java
+++ b/java/test/jmri/implementation/DoubleTurnoutSignalHeadTest.java
@@ -171,7 +171,8 @@ public class DoubleTurnoutSignalHeadTest {
         Assert.assertEquals(Turnout.THROWN, mRedTurnout.getKnownState());
         Assert.assertEquals(Turnout.CLOSED, mGreenTurnout.getKnownState());
         Assert.assertEquals(SignalHead.FLASHRED, mHead.getAppearance());
-        Assert.assertNotNull(mHead.readUpdateTimer); // Should be running.
+        // Should not be running, since all commands came from us.
+        Assert.assertNull(mHead.readUpdateTimer);
         verifyNoMoreInteractions(l.m);
 
         // Wait for the flash
@@ -187,6 +188,7 @@ public class DoubleTurnoutSignalHeadTest {
 
         mGreenTurnout.setCommandedState(Turnout.THROWN);
         verifyNoMoreInteractions(l.m);
+        Assert.assertNotNull(mHead.readUpdateTimer); // now it's started
         waitForTimer();
         verifyNoMoreInteractions(l.m);
         Assert.assertEquals(SignalHead.FLASHRED, mHead.getAppearance()); // hasn't changed


### PR DESCRIPTION
Updates the DoubleTurnoutSignalHead to listen for feedback on the turnouts. Updates the appearance when the underlying turnout changes from what the commanded setting is.

Delays the feedback interpretation by 200 msec to avoid transitional states creating unintended notifications.

Adds unit test for DoubleTurnoutSignalHead, both for the basic functionality as well as the new feedback mechanism.