### PR TITLE
Quieter tests

### DIFF
--- a/java/src/jmri/jmrix/nce/NceSensorManager.java
+++ b/java/src/jmri/jmrix/nce/NceSensorManager.java
@@ -150,6 +150,7 @@ public class NceSensorManager extends jmri.managers.AbstractSensorManager
                     }
                 });
                 pollThread.setName("NCE Sensor Poll");
+                pollThread.setDaemon(true);
                 pollThread.start();
             } else {
                 synchronized (this) {
@@ -234,7 +235,7 @@ public class NceSensorManager extends jmri.managers.AbstractSensorManager
                         delay = longCycleInterval;
                     }
                     synchronized (this) {
-                        if (awaitingReply) {
+                        if (awaitingReply && !stopPolling) {
                             log.warn("timeout awaiting poll response for AIU " + aiuNo);
                             // slow down the poll since we're not getting responses
                             // this lets NceConnectionStatus to do its thing

--- a/java/test/jmri/jmrix/dccpp/network/DCCppEthernetPacketizerTest.java
+++ b/java/test/jmri/jmrix/dccpp/network/DCCppEthernetPacketizerTest.java
@@ -17,7 +17,11 @@ public class DCCppEthernetPacketizerTest extends jmri.jmrix.dccpp.DCCppPacketize
     @Override
     public void setUp() {
         apps.tests.Log4JFixture.setUp();
-        tc = new DCCppEthernetPacketizer(new jmri.jmrix.dccpp.DCCppCommandStation());
+        tc = new DCCppEthernetPacketizer(new jmri.jmrix.dccpp.DCCppCommandStation()) {
+            @Override
+            protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {
+            }
+        };
     }
 
     @After

--- a/java/test/jmri/jmrix/dccpp/serial/SerialDCCppPacketizerTest.java
+++ b/java/test/jmri/jmrix/dccpp/serial/SerialDCCppPacketizerTest.java
@@ -17,7 +17,11 @@ public class SerialDCCppPacketizerTest extends jmri.jmrix.dccpp.DCCppPacketizerT
     @Override
     public void setUp() {
         apps.tests.Log4JFixture.setUp();
-        tc = new SerialDCCppPacketizer(new jmri.jmrix.dccpp.DCCppCommandStation());
+        tc = new SerialDCCppPacketizer(new jmri.jmrix.dccpp.DCCppCommandStation()) {
+            @Override
+            protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {
+            }
+        };
     }
 
     @After

--- a/java/test/jmri/jmrix/lenz/li100/LI100XNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/lenz/li100/LI100XNetPacketizerTest.java
@@ -17,7 +17,11 @@ public class LI100XNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketizerTest 
     @Override
     public void setUp() {
         apps.tests.Log4JFixture.setUp();
-        tc = new LI100XNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation());
+        tc = new LI100XNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
+            @Override
+            protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {
+            }
+        };
     }
 
     @After

--- a/java/test/jmri/jmrix/lenz/liusb/LIUSBXNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/lenz/liusb/LIUSBXNetPacketizerTest.java
@@ -45,7 +45,11 @@ public class LIUSBXNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketizerTest 
     @Override
     public void setUp() {
         apps.tests.Log4JFixture.setUp();
-        tc = new LIUSBXNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation());
+        tc = new LIUSBXNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
+            @Override
+            protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {
+            }
+        };
     }
 
     @After

--- a/java/test/jmri/jmrix/lenz/liusbethernet/LIUSBEthernetXNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/lenz/liusbethernet/LIUSBEthernetXNetPacketizerTest.java
@@ -43,7 +43,11 @@ public class LIUSBEthernetXNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketi
     @Override
     public void setUp() {
         apps.tests.Log4JFixture.setUp();
-        tc = new LIUSBEthernetXNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation());
+        tc = new LIUSBEthernetXNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
+            @Override
+            protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {
+            }
+        };
     }
 
     @After

--- a/java/test/jmri/jmrix/lenz/liusbserver/LIUSBServerXNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/lenz/liusbserver/LIUSBServerXNetPacketizerTest.java
@@ -50,7 +50,11 @@ public class LIUSBServerXNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketize
     @Override
     public void setUp() {
         apps.tests.Log4JFixture.setUp();
-        tc = new LIUSBServerXNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation());
+        tc = new LIUSBServerXNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
+            @Override
+            protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {
+            }
+        };
     }
 
     @After

--- a/java/test/jmri/jmrix/lenz/xntcp/XnTcpXNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/lenz/xntcp/XnTcpXNetPacketizerTest.java
@@ -151,7 +151,11 @@ public class XnTcpXNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketizerTest 
     @Override
     public void setUp() {
         apps.tests.Log4JFixture.setUp();
-        tc = new XnTcpXNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation());
+        tc = new XnTcpXNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
+            @Override
+            protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {
+            }
+        };
     }
 
     @After

--- a/java/test/jmri/jmrix/lenz/ztc640/ZTC640XNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/lenz/ztc640/ZTC640XNetPacketizerTest.java
@@ -18,7 +18,11 @@ public class ZTC640XNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketizerTest
     @Override
     public void setUp() {
         apps.tests.Log4JFixture.setUp();
-        tc = new ZTC640XNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation());
+        tc = new ZTC640XNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
+            @Override
+            protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {
+            }
+        };
     }
 
     @After

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetPacketizerTest.java
@@ -21,7 +21,11 @@ public class Z21XNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketizerTest {
         apps.tests.Log4JFixture.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         LenzCommandStation lcs = new LenzCommandStation();
-        tc = new Z21XNetPacketizer(lcs);
+        tc = new Z21XNetPacketizer(lcs) {
+            @Override
+            protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {
+            }
+        };
     }
 
     @After

--- a/java/test/jmri/managers/AbstractSensorMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractSensorMgrTestBase.java
@@ -34,7 +34,6 @@ public abstract class AbstractSensorMgrTestBase {
     static protected boolean listenerResult = false;
 
     protected class Listen implements PropertyChangeListener {
-
         @Override
         public void propertyChange(java.beans.PropertyChangeEvent e) {
             listenerResult = true;
@@ -92,7 +91,7 @@ public abstract class AbstractSensorMgrTestBase {
 
     @Test
     public void testMisses() {
-        // try to get nonexistant lights
+        // try to get nonexistant sensors
         Assert.assertTrue(null == l.getByUserName("foo"));
         Assert.assertTrue(null == l.getBySystemName("bar"));
     }


### PR DESCRIPTION
Remove some always-present log.warn messages in CI testing. Should be close to none left after this and #3361 are merged.