### PR TITLE
SE8c SignalHead should follow turnouts

### DIFF
--- a/java/src/jmri/implementation/SE8cSignalHead.java
+++ b/java/src/jmri/implementation/SE8cSignalHead.java
@@ -48,9 +48,6 @@ public class SE8cSignalHead extends DefaultSignalHead {
         this.highTurnout = highTO;
         systemName = makeSystemName(lowTO, highTO);
         init();
-
-        // Add listeners to track other changes on LocoNet
-        addListeners();
     }
 
     /**
@@ -174,6 +171,9 @@ public class SE8cSignalHead extends DefaultSignalHead {
         // ensure default appearance
         mAppearance = DARK;  // start turned off
         updateOutput();
+
+        // Add listeners to track other changes on LocoNet
+        addListeners();
     }
 
     @Override
@@ -259,10 +259,10 @@ public class SE8cSignalHead extends DefaultSignalHead {
                     @Override
                     public void propertyChange(java.beans.PropertyChangeEvent e) {
                         // we're not tracking state, we're tracking changes in state
-                        if (e.getPropertyName().equals("CommandedState")) {
-                            if (e.getNewValue().equals(Turnout.CLOSED) && !e.getOldValue().equals(Turnout.CLOSED)) {
+                        if (e.getPropertyName().equals("KnownState")) {
+                            if (e.getNewValue().equals(Turnout.CLOSED) && !e.getOldValue().equals(Turnout.CLOSED) && getAppearance() != GREEN) {
                                 setAppearance(GREEN);
-                            } else if (e.getNewValue().equals(Turnout.THROWN) && !e.getOldValue().equals(Turnout.THROWN)) {
+                            } else if (e.getNewValue().equals(Turnout.THROWN) && !e.getOldValue().equals(Turnout.THROWN) && getAppearance() != RED) {
                                 setAppearance(RED);
                             }
                         }
@@ -275,9 +275,9 @@ public class SE8cSignalHead extends DefaultSignalHead {
                     public void propertyChange(java.beans.PropertyChangeEvent e) {
                         // we're not tracking state, we're tracking changes in state
                         if (e.getPropertyName().equals("CommandedState")) {
-                            if (e.getNewValue().equals(Turnout.CLOSED) && !e.getOldValue().equals(Turnout.CLOSED)) {
+                            if (e.getNewValue().equals(Turnout.CLOSED) && !e.getOldValue().equals(Turnout.CLOSED) && getAppearance() != DARK) {
                                 setAppearance(DARK);
-                            } else if (e.getNewValue().equals(Turnout.THROWN) && !e.getOldValue().equals(Turnout.THROWN)) {
+                            } else if (e.getNewValue().equals(Turnout.THROWN) && !e.getOldValue().equals(Turnout.THROWN) && getAppearance() != YELLOW) {
                                 setAppearance(YELLOW);
                             }
                         }

--- a/java/src/jmri/implementation/SignalHeadSignalMast.java
+++ b/java/src/jmri/implementation/SignalHeadSignalMast.java
@@ -222,6 +222,7 @@ public class SignalHeadSignalMast extends AbstractSignalMast implements java.bea
             };
             Thread thr = new Thread(r);
             thr.setName(getDisplayName() + " delayed set appearance");
+            thr.setDaemon(true);
             try {
                 thr.start();
             } catch (java.lang.IllegalThreadStateException ex) {
@@ -252,6 +253,7 @@ public class SignalHeadSignalMast extends AbstractSignalMast implements java.bea
 
             Thread thr = new Thread(r);
             thr.setName(getDisplayName());
+            thr.setDaemon(true);
             try {
                 thr.start();
                 thr.join();

--- a/java/test/jmri/implementation/SE8cSignalHeadTest.java
+++ b/java/test/jmri/implementation/SE8cSignalHeadTest.java
@@ -64,7 +64,7 @@ public class SE8cSignalHeadTest {
 
     @Test
     public void testCtor4() {
-        // original ctor from number and user name
+        // original ctor from number only 
         SE8cSignalHead s = new SE8cSignalHead(11);
 
         Assert.assertEquals("system name", "LH11", s.getSystemName());
@@ -139,7 +139,7 @@ public class SE8cSignalHeadTest {
     }
 
     @Test
-    public void testStateFollowing() {
+    public void testStateFollowingCtor1() {
         Turnout it11 = InstanceManager.turnoutManagerInstance().provideTurnout("11");
         Turnout it12 = InstanceManager.turnoutManagerInstance().provideTurnout("12");
         SE8cSignalHead s1 = new SE8cSignalHead(
@@ -148,11 +148,105 @@ public class SE8cSignalHeadTest {
                 "user name"
         );
 
+        // s2 should follow s1
+        SE8cSignalHead s2 = new SE8cSignalHead(
+                new NamedBeanHandle<Turnout>("11", it11),
+                new NamedBeanHandle<Turnout>("12", it12)
+        );
+
+        s1.setAppearance(SignalHead.DARK);
+        Assert.assertEquals("s2 after DARK", SignalHead.DARK, s2.getAppearance());
+
+        s1.setAppearance(SignalHead.RED);
+        Assert.assertEquals("s2 after RED", SignalHead.RED, s2.getAppearance());
+
+        s1.setAppearance(SignalHead.GREEN);
+        Assert.assertEquals("s2 after GREEN", SignalHead.GREEN, s2.getAppearance());
+
+        s1.setAppearance(SignalHead.YELLOW);
+        Assert.assertEquals("s2 after YELLOW", SignalHead.YELLOW, s2.getAppearance());
+
+        s1.setAppearance(SignalHead.DARK);
+        Assert.assertEquals("s2 after DARK", SignalHead.DARK, s2.getAppearance());
+
+    }
+
+    @Test
+    public void testStateFollowingCtor2() {
+        Turnout it11 = InstanceManager.turnoutManagerInstance().provideTurnout("11");
+        Turnout it12 = InstanceManager.turnoutManagerInstance().provideTurnout("12");
+        SE8cSignalHead s1 = new SE8cSignalHead(
+                new NamedBeanHandle<Turnout>("11", it11),
+                new NamedBeanHandle<Turnout>("12", it12),
+                "user name"
+        );
+
+        // s2 should follow s1
         SE8cSignalHead s2 = new SE8cSignalHead(
                 new NamedBeanHandle<Turnout>("11", it11),
                 new NamedBeanHandle<Turnout>("12", it12),
                 "user name"
         );
+
+        s1.setAppearance(SignalHead.DARK);
+        Assert.assertEquals("s2 after DARK", SignalHead.DARK, s2.getAppearance());
+
+        s1.setAppearance(SignalHead.RED);
+        Assert.assertEquals("s2 after RED", SignalHead.RED, s2.getAppearance());
+
+        s1.setAppearance(SignalHead.GREEN);
+        Assert.assertEquals("s2 after GREEN", SignalHead.GREEN, s2.getAppearance());
+
+        s1.setAppearance(SignalHead.YELLOW);
+        Assert.assertEquals("s2 after YELLOW", SignalHead.YELLOW, s2.getAppearance());
+
+        s1.setAppearance(SignalHead.DARK);
+        Assert.assertEquals("s2 after DARK", SignalHead.DARK, s2.getAppearance());
+
+    }
+
+    @Test
+    public void testStateFollowingCtor3() {
+        Turnout it11 = InstanceManager.turnoutManagerInstance().provideTurnout("11");
+        Turnout it12 = InstanceManager.turnoutManagerInstance().provideTurnout("12");
+        SE8cSignalHead s1 = new SE8cSignalHead(
+                new NamedBeanHandle<Turnout>("11", it11),
+                new NamedBeanHandle<Turnout>("12", it12),
+                "user name"
+        );
+
+        // s2 should follow s1
+        SE8cSignalHead s2 = new SE8cSignalHead(11, "user name");
+
+        s1.setAppearance(SignalHead.DARK);
+        Assert.assertEquals("s2 after DARK", SignalHead.DARK, s2.getAppearance());
+
+        s1.setAppearance(SignalHead.RED);
+        Assert.assertEquals("s2 after RED", SignalHead.RED, s2.getAppearance());
+
+        s1.setAppearance(SignalHead.GREEN);
+        Assert.assertEquals("s2 after GREEN", SignalHead.GREEN, s2.getAppearance());
+
+        s1.setAppearance(SignalHead.YELLOW);
+        Assert.assertEquals("s2 after YELLOW", SignalHead.YELLOW, s2.getAppearance());
+
+        s1.setAppearance(SignalHead.DARK);
+        Assert.assertEquals("s2 after DARK", SignalHead.DARK, s2.getAppearance());
+
+    }
+
+    @Test
+    public void testStateFollowingCtor4() {
+        Turnout it11 = InstanceManager.turnoutManagerInstance().provideTurnout("11");
+        Turnout it12 = InstanceManager.turnoutManagerInstance().provideTurnout("12");
+        SE8cSignalHead s1 = new SE8cSignalHead(
+                new NamedBeanHandle<Turnout>("11", it11),
+                new NamedBeanHandle<Turnout>("12", it12),
+                "user name"
+        );
+
+        // s2 should follow s1
+        SE8cSignalHead s2 = new SE8cSignalHead(11);
 
         s1.setAppearance(SignalHead.DARK);
         Assert.assertEquals("s2 after DARK", SignalHead.DARK, s2.getAppearance());


### PR DESCRIPTION
The SE8c SignalHead wasn't always following the status of the associated Turnouts. Fixed.

Note:  This doesn't completely resolve the recent jmriusers thread, as that was about SignalHeadSignalMast masts not following SE8c heads.