### PR TITLE
Bundle name null issue

### DIFF
--- a/java/src/apps/DecoderPro/Bundle.java
+++ b/java/src/apps/DecoderPro/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends apps.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "apps.DecoderPro.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/apps/DecoderPro/Bundle.properties
+++ b/java/src/apps/DecoderPro/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/apps/DispatcherPro/Bundle.java
+++ b/java/src/apps/DispatcherPro/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends apps.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "apps.DispatcherPro.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/apps/DispatcherPro/Bundle.properties
+++ b/java/src/apps/DispatcherPro/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/apps/InstallTest/Bundle.java
+++ b/java/src/apps/InstallTest/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends apps.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "apps.InstallTest.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/apps/InstallTest/Bundle.properties
+++ b/java/src/apps/InstallTest/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/apps/JmriDemo/Bundle.java
+++ b/java/src/apps/JmriDemo/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends apps.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "apps.JmriDemo.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/apps/JmriDemo/Bundle.properties
+++ b/java/src/apps/JmriDemo/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/apps/PacketPro/Bundle.java
+++ b/java/src/apps/PacketPro/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends apps.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "apps.PanelPro.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/apps/PacketPro/Bundle.properties
+++ b/java/src/apps/PacketPro/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/apps/PacketScript/Bundle.java
+++ b/java/src/apps/PacketScript/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends apps.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "apps.PacketScript.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/apps/PacketScript/Bundle.properties
+++ b/java/src/apps/PacketScript/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/apps/PanelPro/Bundle.java
+++ b/java/src/apps/PanelPro/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends apps.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "apps.PanelPro.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/apps/PanelPro/Bundle.properties
+++ b/java/src/apps/PanelPro/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/apps/SignalPro/Bundle.java
+++ b/java/src/apps/SignalPro/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends apps.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "apps.SignalPro.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/apps/SignalPro/Bundle.properties
+++ b/java/src/apps/SignalPro/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/apps/SoundPro/Bundle.java
+++ b/java/src/apps/SoundPro/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends apps.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "apps.SoundPro.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/apps/SoundPro/Bundle.properties
+++ b/java/src/apps/SoundPro/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/apps/gui3/Bundle.java
+++ b/java/src/apps/gui3/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends apps.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "apps.gui3.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/apps/gui3/Bundle.properties
+++ b/java/src/apps/gui3/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/apps/startup/configurexml/Bundle.java
+++ b/java/src/apps/startup/configurexml/Bundle.java
@@ -22,7 +22,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends apps.startup.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "apps.startup.configurexml.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/apps/startup/configurexml/Bundle.properties
+++ b/java/src/apps/startup/configurexml/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/Bundle.java
+++ b/java/src/jmri/Bundle.java
@@ -142,14 +142,10 @@ public class Bundle {
      * @throws MissingResourceException if message cannot be found
      */
     public String handleGetMessage(Locale locale, String key) {
-        if (bundleName() != null) {
-            ResourceBundle rb = ResourceBundle.getBundle(bundleName(), locale);
-            if (rb.containsKey(key)) {
-                return rb.getString(key);
-            } else {
-                return retry(locale,key);
-            }
-        } else {  // case of no local bundle
+        ResourceBundle rb = ResourceBundle.getBundle(bundleName(), locale);
+        if (rb.containsKey(key)) {
+            return rb.getString(key);
+        } else {
             return retry(locale,key);
         }
     }

--- a/java/src/jmri/configurexml/Bundle.java
+++ b/java/src/jmri/configurexml/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = null; // No local resources
+    private final static String name = "jmri.configurexml.SaveMenuBundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/ampmeter/Bundle.java
+++ b/java/src/jmri/jmrit/ampmeter/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrit.Bundle {
 
-    private final static String name = null; // No local resources
+    private final static String name = "jmri.jmrit.ampmeter.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/ampmeter/Bundle.properties
+++ b/java/src/jmri/jmrit/ampmeter/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/analogclock/Bundle.java
+++ b/java/src/jmri/jmrit/analogclock/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrit.Bundle {
 
-    private final static String name = null; // No local resources
+    private final static String name = "jmri.jmrit.analogclock.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/analogclock/Bundle.properties
+++ b/java/src/jmri/jmrit/analogclock/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/audio/Bundle.java
+++ b/java/src/jmri/jmrit/audio/Bundle.java
@@ -24,7 +24,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrit.Bundle {
 
-    @Nullable private static final String name = null; // No local resources
+    @Nullable private static final String name = "jmri.jmrit.audio.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/audio/Bundle.properties
+++ b/java/src/jmri/jmrit/audio/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/beantable/sensor/Bundle.java
+++ b/java/src/jmri/jmrit/beantable/sensor/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrit.beantable.Bundle {
 
-    private final static String name = null;
+    private final static String name = "jmri.jmrit.beantable.sensor.Bundle";
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/beantable/sensor/Bundle.properties
+++ b/java/src/jmri/jmrit/beantable/sensor/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/display/layoutEditor/blockRoutingTable/Bundle.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/blockRoutingTable/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrit.display.layoutEditor.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.jmrit.display.layoutEditor.blockRoutingTable.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/display/layoutEditor/blockRoutingTable/Bundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/blockRoutingTable/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/display/panelEditor/Bundle.java
+++ b/java/src/jmri/jmrit/display/panelEditor/Bundle.java
@@ -24,7 +24,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class Bundle extends jmri.jmrit.display.Bundle {
 
     @Nullable
-    private final static String name = null; // no local Bundle
+    private final static String name = "jmri.jmrit.display.panelEditor.Bundle"; // no local Bundle
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/display/panelEditor/Bundle.properties
+++ b/java/src/jmri/jmrit/display/panelEditor/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/display/switchboardEditor/Bundle.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrit.display.controlPanelEditor.Bundle {
 
-    private final static String name = null; // No local resources
+    private final static String name = "jmri.jmrit.display.switchboardEditor.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/display/switchboardEditor/Bundle.properties
+++ b/java/src/jmri/jmrit/display/switchboardEditor/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/dualdecoder/Bundle.java
+++ b/java/src/jmri/jmrit/dualdecoder/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrit.Bundle {
 
-    private final static String name = null; // No local resources
+    private final static String name = "jmri.jmrit.dualdecoder.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/dualdecoder/Bundle.properties
+++ b/java/src/jmri/jmrit/dualdecoder/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/lcdclock/Bundle.java
+++ b/java/src/jmri/jmrit/lcdclock/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrit.Bundle {
 
-    private final static String name = null; // No local resources
+    private final static String name = "jmri.jmrit.lcdclock.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/lcdclock/Bundle.properties
+++ b/java/src/jmri/jmrit/lcdclock/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/log/Bundle.java
+++ b/java/src/jmri/jmrit/log/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrit.Bundle {
 
-    private final static String name = null;  // No local bundle
+    private final static String name = "jmri.jmrit.log.Bundle";  // No local bundle
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/log/Bundle.properties
+++ b/java/src/jmri/jmrit/log/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/nixieclock/Bundle.java
+++ b/java/src/jmri/jmrit/nixieclock/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrit.Bundle {
 
-    private final static String name = null; // No local resources
+    private final static String name = "jmri.jmrit.nixieclock.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/nixieclock/Bundle.properties
+++ b/java/src/jmri/jmrit/nixieclock/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/picker/Bundle.java
+++ b/java/src/jmri/jmrit/picker/Bundle.java
@@ -21,7 +21,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @net.jcip.annotations.Immutable
 public class Bundle extends jmri.jmrit.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "jmri.jmrit.picker.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/picker/Bundle.properties
+++ b/java/src/jmri/jmrit/picker/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/roster/swing/Bundle.java
+++ b/java/src/jmri/jmrit/roster/swing/Bundle.java
@@ -24,7 +24,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class Bundle extends jmri.jmrit.roster.Bundle {
 
     @Nullable
-    private static final String name = "jmri.jmrit.roster.swing.Bundle"; // no local resources
+    private static final String name = "jmri.jmrit.roster.swing.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/roster/swing/rostergroup/Bundle.java
+++ b/java/src/jmri/jmrit/roster/swing/rostergroup/Bundle.java
@@ -24,7 +24,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class Bundle extends jmri.jmrit.roster.swing.Bundle {
 
     @Nullable
-    private static final String name = null; // no local resources
+    private static final String name = "jmri.jmrit.roster.swing.rostergroup.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/roster/swing/rostergroup/Bundle.properties
+++ b/java/src/jmri/jmrit/roster/swing/rostergroup/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/simpleprog/Bundle.java
+++ b/java/src/jmri/jmrit/simpleprog/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrit.Bundle {
 
-    private final static String name = null; // No local resources
+    private final static String name = "jmri.jmrit.simpleprog.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/simpleprog/Bundle.properties
+++ b/java/src/jmri/jmrit/simpleprog/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/Bundle.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrit.symbolicprog.Bundle {
 
-    private final static String name = null; // No local resources
+    private final static String name = "jmri.jmrit.symbolicprog.tabbedframe.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/Bundle.properties
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/can/cbus/swing/eventtable/Bundle.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventtable/Bundle.java
@@ -1,10 +1,10 @@
 package jmri.jmrix.can.cbus.swing.eventtable;
 
-import javax.annotation.CheckReturnValue;
-import java.util.Locale;
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Locale;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 @CheckReturnValue
@@ -23,7 +23,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 public class Bundle extends jmri.jmrix.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "jmri.jmrix.can.cbus.swing.eventtable.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/can/cbus/swing/eventtable/Bundle.properties
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventtable/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/ecos/swing/Bundle.java
+++ b/java/src/jmri/jmrix/ecos/swing/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.ecos.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "jmri.jmrix.ecos.swing.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/ecos/swing/Bundle.properties
+++ b/java/src/jmri/jmrix/ecos/swing/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/ecos/swing/locodatabase/Bundle.java
+++ b/java/src/jmri/jmrix/ecos/swing/locodatabase/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.ecos.swing.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "jmri.jmrix.ecos.swing.locodatabase.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/ecos/swing/locodatabase/Bundle.properties
+++ b/java/src/jmri/jmrix/ecos/swing/locodatabase/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/ieee802154/Bundle.java
+++ b/java/src/jmri/jmrix/ieee802154/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "jmri.jmrix.ieee802154.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/ieee802154/Bundle.properties
+++ b/java/src/jmri/jmrix/ieee802154/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/ieee802154/swing/Bundle.java
+++ b/java/src/jmri/jmrix/ieee802154/swing/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "jmri.jmrix.ieee802154.swing.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/ieee802154/swing/Bundle.properties
+++ b/java/src/jmri/jmrix/ieee802154/swing/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/ieee802154/swing/packetgen/Bundle.java
+++ b/java/src/jmri/jmrix/ieee802154/swing/packetgen/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "jmri.jmrix.ieee802154.swing.packetgen.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/ieee802154/swing/packetgen/Bundle.properties
+++ b/java/src/jmri/jmrix/ieee802154/swing/packetgen/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/ieee802154/xbee/Bundle.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "jmri.jmrix.ieee802154.xbee.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/ieee802154/xbee/Bundle.properties
+++ b/java/src/jmri/jmrix/ieee802154/xbee/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/ieee802154/xbee/swing/Bundle.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/swing/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "jmri.jmrix.ieee802154.xbee.swing.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/ieee802154/xbee/swing/Bundle.properties
+++ b/java/src/jmri/jmrix/ieee802154/xbee/swing/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/ieee802154/xbee/swing/packetgen/Bundle.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/swing/packetgen/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = "jmri.jmirx.ieee802154.xbee.swing.packetgen.Bundle"; // NOI18N
+    private final static String name = "jmri.jmrix.ieee802154.xbee.swing.packetgen.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/ieee802154/xbee/swing/packetgen/Bundle.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/swing/packetgen/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "jmri.jmirx.ieee802154.xbee.swing.packetgen.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/ieee802154/xbee/swing/packetgen/Bundle.properties
+++ b/java/src/jmri/jmrix/ieee802154/xbee/swing/packetgen/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/jmriclient/Bundle.java
+++ b/java/src/jmri/jmrix/jmriclient/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "jmri.jmrix.jmriclient.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/jmriclient/Bundle.properties
+++ b/java/src/jmri/jmrix/jmriclient/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/bdl16/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/bdl16/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.bdl16.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/bdl16/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/bdl16/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/clockmon/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/clockmon/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.clockmon.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/clockmon/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/clockmon/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.cmdstnconfig.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/cmdstnconfig/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/cmdstnconfig/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/duplexgroup/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.duplexgroup.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/duplexgroup/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/duplexgroup/swing/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/swing/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.duplexgroup.swing.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/duplexgroup/swing/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/swing/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/locogen/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/locogen/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.locogen.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/locogen/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/locogen/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/locoid/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/locoid/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.locoid.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/locoid/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/locoid/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/locoio/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/locoio/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.locoio.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/locoio/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/locoio/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/pm4/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/pm4/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.pm4.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/pm4/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/pm4/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/pr3/swing/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/pr3/swing/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.pr3.Bundle {
 
-    private final static String name = null; //NOI18N
+    private final static String name = "jmri.jmrix.loconet.pr3.swing.Bundle"; //NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/pr3/swing/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/pr3/swing/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/se8/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/se8/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.se8.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/se8/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/se8/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/slotmon/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.slotmon.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/slotmon/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/slotmon/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/soundloader/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.soundloader.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/soundloader/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/soundloader/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/swing/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/swing/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.swing.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/swing/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/swing/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/loconet/swing/throttlemsg/Bundle.java
+++ b/java/src/jmri/jmrix/loconet/swing/throttlemsg/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.jmrix.loconet.Bundle {
 
-    private final static String name = null;// NOI18N
+    private final static String name = "jmri.jmrix.loconet.swing.throttlemsg.Bundle";// NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/loconet/swing/throttlemsg/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/swing/throttlemsg/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/jmrix/rps/swing/Bundle.java
+++ b/java/src/jmri/jmrix/rps/swing/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = null; // NOI18N
+    private final static String name = "jmri.jmrix.rps.swing.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/jmrix/rps/swing/Bundle.properties
+++ b/java/src/jmri/jmrix/rps/swing/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/Bundle.java
+++ b/java/src/jmri/server/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/Bundle.properties
+++ b/java/src/jmri/server/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/Bundle.java
+++ b/java/src/jmri/server/json/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.Bundle {
 
-    private final static String name = "jmri.server.json.Bundle"; // no local resources
+    private final static String name = "jmri.server.json.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/block/Bundle.java
+++ b/java/src/jmri/server/json/block/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.block.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/block/Bundle.properties
+++ b/java/src/jmri/server/json/block/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/consist/Bundle.java
+++ b/java/src/jmri/server/json/consist/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.consist.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/consist/Bundle.properties
+++ b/java/src/jmri/server/json/consist/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/layoutblock/Bundle.java
+++ b/java/src/jmri/server/json/layoutblock/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.layoutblock.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/layoutblock/Bundle.properties
+++ b/java/src/jmri/server/json/layoutblock/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/light/Bundle.java
+++ b/java/src/jmri/server/json/light/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.light.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/light/Bundle.properties
+++ b/java/src/jmri/server/json/light/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/memory/Bundle.java
+++ b/java/src/jmri/server/json/memory/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.memory.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/memory/Bundle.properties
+++ b/java/src/jmri/server/json/memory/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/operations/Bundle.java
+++ b/java/src/jmri/server/json/operations/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.operations.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/operations/Bundle.properties
+++ b/java/src/jmri/server/json/operations/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/power/Bundle.java
+++ b/java/src/jmri/server/json/power/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.power.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/power/Bundle.properties
+++ b/java/src/jmri/server/json/power/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/reporter/Bundle.java
+++ b/java/src/jmri/server/json/reporter/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.reporter.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/reporter/Bundle.properties
+++ b/java/src/jmri/server/json/reporter/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/roster/Bundle.java
+++ b/java/src/jmri/server/json/roster/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.roster.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/roster/Bundle.properties
+++ b/java/src/jmri/server/json/roster/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/route/Bundle.java
+++ b/java/src/jmri/server/json/route/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.route.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/route/Bundle.properties
+++ b/java/src/jmri/server/json/route/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/sensor/Bundle.java
+++ b/java/src/jmri/server/json/sensor/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.sensor.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/sensor/Bundle.properties
+++ b/java/src/jmri/server/json/sensor/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/signalHead/Bundle.java
+++ b/java/src/jmri/server/json/signalHead/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.signalHead.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/signalHead/Bundle.properties
+++ b/java/src/jmri/server/json/signalHead/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/signalMast/Bundle.java
+++ b/java/src/jmri/server/json/signalMast/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.signalMast.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/signalMast/Bundle.properties
+++ b/java/src/jmri/server/json/signalMast/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/turnout/Bundle.java
+++ b/java/src/jmri/server/json/turnout/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.turnout.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/turnout/Bundle.properties
+++ b/java/src/jmri/server/json/turnout/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/server/json/util/Bundle.java
+++ b/java/src/jmri/server/json/util/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.server.json.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.server.json.util.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/server/json/util/Bundle.properties
+++ b/java/src/jmri/server/json/util/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/swing/Bundle.java
+++ b/java/src/jmri/swing/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.swing.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/swing/Bundle.properties
+++ b/java/src/jmri/swing/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/util/davidflanagan/Bundle.java
+++ b/java/src/jmri/util/davidflanagan/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.util.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.util.davidflanagan.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/util/davidflanagan/Bundle.properties
+++ b/java/src/jmri/util/davidflanagan/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/web/Bundle.java
+++ b/java/src/jmri/web/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.Bundle {
 
-    private final static String name = null; // no local resources
+    private final static String name = "jmri.web.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/web/Bundle.properties
+++ b/java/src/jmri/web/Bundle.properties
@@ -1,0 +1,2 @@
+# Bundle.properties
+#

--- a/java/src/jmri/web/servlet/Bundle.java
+++ b/java/src/jmri/web/servlet/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.web.Bundle {
 
-    private final static String name = "jmri.web.servlet.Bundle"; // no local resources
+    private final static String name = "jmri.web.servlet.Bundle"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly

--- a/java/src/jmri/web/servlet/frameimage/Bundle.java
+++ b/java/src/jmri/web/servlet/frameimage/Bundle.java
@@ -23,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 public class Bundle extends jmri.web.Bundle {
 
-    private final static String name = "jmri.web.servlet.frameimage.JmriJFrameServlet"; // no local resources
+    private final static String name = "jmri.web.servlet.frameimage.JmriJFrameServlet"; // NOI18N
 
     //
     // below here is boilerplate to be copied exactly


### PR DESCRIPTION
JavaDoc warnings about name being null if no properties file, but name
is declared to be international, so can't be null, and parent also says
it can't be null. So all Bundle.java point to a Bundle.properties, even
if it is only a file with a header comment.
This clears the warning and sets the place for later strings that likely
hide in the code that should be translated someday.