### PR TITLE
Improve C/MRI multi-system startup

### DIFF
--- a/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
@@ -90,6 +90,7 @@ public class CMRISystemConnectionMemo extends SystemConnectionMemo {
     public void configureManagers() {
         InstanceManager.setSensorManager(
                 getSensorManager());
+        getTrafficController().setSensorManager(getSensorManager());
 
         InstanceManager.setTurnoutManager(
                 getTurnoutManager());


### PR DESCRIPTION
Moves SensorManager init in TC earlier to ensure it happens before script init