### PR TITLE
Fix startup crash in Roster due to date parsing

### DIFF
--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -537,7 +537,7 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
         try {
             // parse using ISO 8601 date format(s)
             this.setDateModified(new ISO8601DateFormat().parse(date));
-        } catch (ParseException ex) {
+        } catch (ParseException | IllegalArgumentException ex) {
             // parse using defaults since thats how it was saved if saved
             // by earlier versions of JMRI
             this.setDateModified(DateFormat.getDateTimeInstance().parse(date));


### PR DESCRIPTION
Add IllegalArgumentException type to catch