### PR TITLE
Revert #3397

### DIFF
--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -537,7 +537,7 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
         try {
             // parse using ISO 8601 date format(s)
             this.setDateModified(new ISO8601DateFormat().parse(date));
-        } catch (ParseException | IllegalArgumentException ex) {
+        } catch (ParseException ex) {
             // parse using defaults since thats how it was saved if saved
             // by earlier versions of JMRI
             this.setDateModified(DateFormat.getDateTimeInstance().parse(date));


### PR DESCRIPTION
Reverting #3397 since it masks a bad classpath including older (pre-2.4.1) versions of the jackson JSON handling libraries.

The JSON processing library we use (jackson-databind) threw an IllegalArgumentException in contravention of its inherited specification (FasterXML/jackson-databind@b45f9e7dd7b1823fb3b0d66493ac3d53ceaccbe8) until version 2.4.1 of that library. When jackson-databind was updated from 2.0.6 to 2.8.5 (this improves date handling), exceptions not thrown by the library were removed from JMRI code.