### PR TITLE
A number of improvements to SCWarrants:

### DIFF
--- a/java/src/jmri/jmrit/logix/SCWarrant.java
+++ b/java/src/jmri/jmrit/logix/SCWarrant.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.logix;
 
+import java.util.List;
 import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.NamedBean;
@@ -31,7 +32,7 @@ public class SCWarrant extends Warrant {
      */
     public SCWarrant(String sName, String uName, long TTP) {
         super(sName.toUpperCase(), uName);
-        log.debug("new SCWarrant "+uName);
+        log.debug("new SCWarrant "+uName+" TTP="+TTP);
         timeToPlatform = TTP;
     }
 
@@ -39,6 +40,10 @@ public class SCWarrant extends Warrant {
         return timeToPlatform;
     }
     
+    public void setTimeToPlatform(long TTP) {
+        timeToPlatform = TTP;
+    }
+
     public void setForward(boolean set) {
         forward = set;
     }
@@ -48,7 +53,27 @@ public class SCWarrant extends Warrant {
     }
 
     /**
-     * Callback from acquireThrottle() when the throttle has become available.
+     * This method has been overridden in order to avoid allocation of occupied blocks.
+     */
+     public String setRoute(int delay, List<BlockOrder> orders) {
+        _orders = getBlockOrders();
+        BlockOrder bo = getBlockOrderAt(0);
+        OBlock block = bo.getBlock();
+        String message = block.allocate(this);
+        if (message != null) {
+           log.info(_trainName+" START-block allocation failed "+ message);
+           return message;
+        }
+        message = bo.setPath(this);
+        if (message != null) {
+           log.info(_trainName+" setting path in START-block failed "+ message);
+           return message;
+        }
+        return null;
+    }
+
+    /**
+     * Callback from acquireThrottle() when the throttle has become available.sync
      */
     public void notifyThrottleFound(DccThrottle throttle) {
         if (throttle == null) {
@@ -68,6 +93,30 @@ public class SCWarrant extends Warrant {
         _engineer = new Engineer(this, throttle);
         firePropertyChange("runMode", Integer.valueOf(MODE_NONE), Integer.valueOf(_runMode));
         runSignalControlledTrain();
+    }
+
+    /**
+     * Generate status message to show in warrant table
+     **/
+    synchronized protected String getRunningMessage() {
+        if (_engineer == null) {
+            // The warrant is not active
+            return super.getRunningMessage();
+        } else {
+            String block = getBlockOrderAt(_idxCurrentOrder).getBlock().getDisplayName();
+            String signal = "no signal";
+            String aspect = "none";
+            if (_nextSignal != null) {
+                signal = _nextSignal.getDisplayName();
+                if (_nextSignal instanceof SignalHead) {
+                    int appearance = ((SignalHead) _nextSignal).getAppearance();
+                    aspect = "appearance "+appearance;
+                } else {
+                    aspect = ((SignalMast) _nextSignal).getAspect();
+                }
+            }
+            return Bundle.getMessage("SCWStatus", block, _idxCurrentOrder, _engineer.getSpeed(),signal,aspect);
+        }
     }
 
     /******************************************************************************************************
@@ -185,7 +234,12 @@ public class SCWarrant extends Warrant {
                 speed = _speedMap.getAspectSpeed(aspect, ((SignalMast) _nextSignal).getSignalSystem());
                 log.debug("SignalMast "+((SignalMast) _nextSignal).getDisplayName()+" shows aspect "+aspect+" which maps to speed "+speed);
             }
-            _engineer.setSpeed(_speedMap.getSpeed(speed) / (float) 125);
+            float speed_f = _speedMap.getSpeed(speed) / (float) 125;
+            // Ease the speed, if we are approaching the destination block
+            if ((_idxCurrentOrder == _orders.size()-2) && (speed_f > SPEED_UNSIGNALLED)) {
+                speed_f = SPEED_UNSIGNALLED;
+            }
+            _engineer.setSpeed(speed_f);
         }
     }
     
@@ -195,7 +249,6 @@ public class SCWarrant extends Warrant {
      */
     protected void allocateBlocksAndSetTurnouts(int startIndex) {
         log.debug(_trainName+" allocateBlocksAndSetTurnouts startIndex="+startIndex+" _orders.size()="+_orders.size());
-        ensureRouteConsecutivity();
         for (int i = startIndex; i < _orders.size(); i++) {
             log.debug(_trainName+" allocateBlocksAndSetTurnouts for loop #"+i);
             BlockOrder bo = getBlockOrderAt(i);
@@ -229,38 +282,14 @@ public class SCWarrant extends Warrant {
                     return;
                 }
             } else if (pathAlreadySet.equals(this.getDisplayName())) {
-                log.debug(_trainName+" Path already set (and thereby block allocated) for "+bo.getPathName());
+                log.debug(_trainName+" Path "+bo.getPathName()+" already set (and thereby block allocated) for "+pathAlreadySet);
             } else {
-                log.info(_trainName+" Block allocation failed: Path already set (and thereby block allocated) for "+bo.getPathName());
+                log.info(_trainName+" Block allocation failed: Path "+bo.getPathName()+" already set (and thereby block allocated) for "+pathAlreadySet);
                 return;
             }
         }
     }
     
-    /**
-     * This should not be necessary, but it turns out that if three or more trains are running on a small layout, 
-     * at some point in time a deadlock will occur where more trains want to run on the same line in the same direction,
-     * but the train behind have allocated a block ahead of the front train.
-     * The task of this function is therefore to deallocate any such block.
-     **/
-    protected void ensureRouteConsecutivity () {
-        boolean deAllocateRestOfRoute = false;
-        for (int i = _idxCurrentOrder+1; i < _orders.size(); i++) {
-            log.debug(_trainName+" ensureRouteConsecutivity for loop #"+i);
-            BlockOrder bo = getBlockOrderAt(i);
-            OBlock block = bo.getBlock();
-            if (!block.isAllocatedTo(this) && (block.getState() & OBlock.OCCUPIED) != 0) {
-                deAllocateRestOfRoute = true;
-            }
-            if (deAllocateRestOfRoute) {
-                if (block.isAllocatedTo(this)) {
-                    log.info(_trainName+" deallocating "+block.getDisplayName()+" due to risk of deadlock");
-                    block.deAllocate(this);
-                }
-            }
-        }
-    }
-
     /**
      * Block in the route going active.
      * Make sure to allocate the rest of the route, update our present location and then tell
@@ -268,6 +297,11 @@ public class SCWarrant extends Warrant {
      */
     protected void goingActive(OBlock block) {
         if (_runMode != MODE_RUN) {
+            // if we are not running, we must not think that we are going to the next block - it must be another train
+            return;
+        }
+        if (_engineer.getSpeed() == SPEED_STOP) {
+            // if we are not running, we must not think that we are going to the next block - it must be another train
             return;
         }
         int activeIdx = getIndexOfBlock(block, _idxCurrentOrder);
@@ -396,16 +430,16 @@ public class SCWarrant extends Warrant {
                 return;
             }
         }
-        if (_stoppingBlock != null) {
-            log.debug(_trainName+" CHECKING STOPPINGBLOCKEVENT ((NamedBean) evt.getSource()).getDisplayName() = '"+((NamedBean) evt.getSource()).getDisplayName()+"'");
-            if (((NamedBean) evt.getSource()).getDisplayName().equals(_stoppingBlock.getDisplayName()) &&
-                    evt.getPropertyName().equals("state") &&
-                    (((Number) evt.getNewValue()).intValue() & OBlock.UNOCCUPIED) == OBlock.UNOCCUPIED) {
-                log.debug(_trainName+" being aware that Block "+((NamedBean) evt.getSource()).getDisplayName()+" has become free");
-                _stoppingBlock.removePropertyChangeListener(this);
-                _stoppingBlock = null;
-                // we might be waiting for this block to become free
-                synchronized(this) {
+        synchronized(this) {
+            if (_stoppingBlock != null) {
+                log.debug(_trainName+" CHECKING STOPPINGBLOCKEVENT ((NamedBean) evt.getSource()).getDisplayName() = '"+((NamedBean) evt.getSource()).getDisplayName()+"'");
+                if (((NamedBean) evt.getSource()).getDisplayName().equals(_stoppingBlock.getDisplayName()) &&
+                        evt.getPropertyName().equals("state") &&
+                        (((Number) evt.getNewValue()).intValue() & OBlock.UNOCCUPIED) == OBlock.UNOCCUPIED) {
+                    log.debug(_trainName+" being aware that Block "+((NamedBean) evt.getSource()).getDisplayName()+" has become free");
+                    _stoppingBlock.removePropertyChangeListener(this);
+                    _stoppingBlock = null;
+                    // we might be waiting for this block to become free
                     // Give the warrant that now has _stoppingBlock allocated a little time to deallocate it
                     try {
                         wait(100);
@@ -413,8 +447,8 @@ public class SCWarrant extends Warrant {
                     }
                     // And then let our main loop continue
                     notify();
+                    return;
                 }
-                return;
             }
         }
     }
@@ -454,17 +488,10 @@ public class SCWarrant extends Warrant {
                     allocateBlocksAndSetTurnouts(_warrant._idxCurrentOrder);
                     if (isNextBlockFreeAndAllocated()) {
                         getAndGetNotifiedFromNextSignal();
-                        if (log.isDebugEnabled()) {
-                            log.debug(_warrant._trainName+" runSignalControlledTrain lets train run according to signal ");
-                            if (_nextSignal == null) {
-                                log.debug(_warrant._trainName+" _nextSignal == null");
-                            } else {
-                                log.debug(_warrant._trainName+" _nextSignal = "+_nextSignal.getDisplayName());
-                            }
-                        }
                         setSpeedFromNextSignal();
+                        log.debug(_warrant._trainName+" "+_warrant.getDisplayName()+" "+_warrant.getRunningMessage());
                     } else {
-                        log.debug(_warrant._trainName+" runSignalControlledTrain stops train due to block not free.");
+                        log.debug(_warrant._trainName+" runSignalControlledTrain stops train due to block not free: "+getBlockOrderAt(_idxCurrentOrder+1).getBlock().getDisplayName());
                         if (_engineer == null) { // If the warrant is already aborted, _engineer is gone too
                             return;
                         } else {

--- a/java/src/jmri/jmrit/logix/WarrantBundle.properties
+++ b/java/src/jmri/jmrit/logix/WarrantBundle.properties
@@ -233,6 +233,7 @@ Idle            = Idle
 Idle1           = Idle ({0})
 Mark            = Enter Block
 Skip            = Skipped Block
+SCWStatus       = Block: {0} (index {1}) Speed: {2,number,#.#} Signal: {3} showing {4}
 ManualRunning   = Manual control in Block {0}.
 ChangedRoute    = Warrant {0} Location of "{2}" unknown. Train left route at block "{1}".
 LostTrain       = Train "{0}" lost occupancy at block "{1}".

--- a/java/src/jmri/jmrit/logix/WarrantBundle_da.properties
+++ b/java/src/jmri/jmrit/logix/WarrantBundle_da.properties
@@ -229,6 +229,7 @@ Idle            = Idle
 Idle1           = Idle ({0})
 Mark            = Enter Block
 Skip            = Skipped Block
+SCWStatus       = Blok: {0} (indeks {1}) Fart: {2,number,#.#} Signal: {3} viser {4}
 ManualRunning   = Manual control in Block {0}.
 ChangedRoute    = Warrant {0} Location of "{2}" unknown. Train left route at block "{1}".
 LostTrain       = Train "{0}" lost occupancy at block "{1}".

--- a/java/src/jmri/jmrit/logix/WarrantFrame.java
+++ b/java/src/jmri/jmrit/logix/WarrantFrame.java
@@ -1339,6 +1339,7 @@ public class WarrantFrame extends WarrantRoute {
 
         if (_isSCWarrant.isSelected()) {
             ((SCWarrant)_warrant).setForward(_runForward.isSelected());
+            ((SCWarrant)_warrant).setTimeToPlatform((long)_TTPtextField.getValue());
         }
         _warrant.setDccAddress(getTrainId());
         _warrant.setTrainName(getTrainName());


### PR DESCRIPTION
1. The function that was de-allocating occupied blocks ahead on the route has been removed, since it could happen that a block just entered by "ourselves" was being de-allocated. And thereby the train stopped.

2. A special SCWarrant version of setRoute implemented to ensure that no occupied block is being allocated, except for the starting block.

3. The train speed is reduced in the block before the destination block.

4. Corrected a race-condition in handling the event telling us that a block is becoming free. The race happened when the event was received twice.

5. SCWarrant no longer reacts on the next block becoming occupied, if the train is not moving.

6. Editing the time-to-platform had no effect.

7. An SCWarrant specific version of getRunningMessage implemented.