### PR TITLE
Warn on library mismatch

### DIFF
--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -537,7 +537,14 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
         try {
             // parse using ISO 8601 date format(s)
             this.setDateModified(new ISO8601DateFormat().parse(date));
-        } catch (ParseException | IllegalArgumentException ex) {
+        } catch (ParseException ex) {
+            log.debug("ParseException in setDateModified");
+            // parse using defaults since thats how it was saved if saved
+            // by earlier versions of JMRI
+            this.setDateModified(DateFormat.getDateTimeInstance().parse(date));
+        } catch (IllegalArgumentException ex2) {
+            // warn that there's perhaps something wrong with the classpath
+            log.error("IllegalArgumentException in RosterEntry.setDateModified - this may indicate a problem with the classpath, specifically multiple copies of the 'jackson` library. See release notes" );
             // parse using defaults since thats how it was saved if saved
             // by earlier versions of JMRI
             this.setDateModified(DateFormat.getDateTimeInstance().parse(date));


### PR DESCRIPTION
This extends #3397 (superseding #3399) to provide a log message if the exception from the older library set is encountered again.