### PR TITLE
Fix LayoutEditor NPE

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -8547,7 +8547,7 @@ public class LayoutEditor extends jmri.jmrit.display.panelEditor.PanelEditor imp
             }
         }
 
-        String turnoutName = turnoutNameComboBox.getUserName();
+        String turnoutName = turnoutNameComboBox.getDisplayName();
 
         if (validatePhysicalTurnout(turnoutName, this)) {
             //turnout is valid and unique.
@@ -8561,7 +8561,7 @@ public class LayoutEditor extends jmri.jmrit.display.panelEditor.PanelEditor imp
             turnoutNameComboBox.getEditor().setItem("");
             turnoutNameComboBox.setSelectedIndex(-1);
         }
-        turnoutName = extraTurnoutNameComboBox.getUserName();
+        turnoutName = extraTurnoutNameComboBox.getDisplayName();
 
         if (validatePhysicalTurnout(turnoutName, this)) {
             //turnout is valid and unique.
@@ -8644,7 +8644,7 @@ public class LayoutEditor extends jmri.jmrit.display.panelEditor.PanelEditor imp
         o.setContinuingSense(Turnout.CLOSED);
 
         //check on a physical turnout
-        String turnoutName = turnoutNameComboBox.getUserName();
+        String turnoutName = turnoutNameComboBox.getDisplayName();
 
         if (validatePhysicalTurnout(turnoutName, this)) {
             //turnout is valid and unique.

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
@@ -1097,7 +1097,7 @@ public class LayoutSlip extends LayoutTurnout {
     TestState testPanel;
 
     void slipEditDonePressed(ActionEvent a) {
-        String newName = turnoutAComboBox.getUserName();
+        String newName = turnoutAComboBox.getDisplayName();
         if (!turnoutName.equals(newName)) {
             if (layoutEditor.validatePhysicalTurnout(newName, editLayoutTurnoutFrame)) {
                 setTurnout(newName);
@@ -1107,7 +1107,7 @@ public class LayoutSlip extends LayoutTurnout {
             }
             needRedraw = true;
         }
-        newName = turnoutBComboBox.getUserName();
+        newName = turnoutBComboBox.getDisplayName();
         if (!turnoutBName.equals(newName)) {
             if (layoutEditor.validatePhysicalTurnout(newName,
                     editLayoutTurnoutFrame)) {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
@@ -2790,7 +2790,7 @@ public class LayoutTurnout extends LayoutTrack {
 
     void turnoutEditDonePressed(ActionEvent a) {
         // check if Turnout changed
-        String newName = firstTurnoutComboBox.getUserName();
+        String newName = firstTurnoutComboBox.getDisplayName();
         if (!turnoutName.equals(newName)) {
             // turnout has changed
             if (layoutEditor.validatePhysicalTurnout(newName, editLayoutTurnoutFrame)) {
@@ -2804,7 +2804,7 @@ public class LayoutTurnout extends LayoutTrack {
         }
 
         if (additionalTurnout.isSelected()) {
-            newName = secondTurnoutComboBox.getSelectedItem().toString();
+            newName = secondTurnoutComboBox.getDisplayName();
             if (!secondTurnoutName.equals(newName)) {
                 if ((type == DOUBLE_XOVER)
                         || (type == RH_XOVER)


### PR DESCRIPTION
LayoutEditor. validatePhysicalTurnout() fails when a null name is supplied by LayoutEditor, LayoutSlip or LayoutTurnout turnout processes.

When a turnout does not have a user name, the combo box was returning a null getUserName().  These were changed to getDisplayName().