### PR TITLE
Fix L&F restart needed

### DIFF
--- a/java/src/apps/gui/GuiLafPreferencesManager.java
+++ b/java/src/apps/gui/GuiLafPreferencesManager.java
@@ -95,7 +95,7 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesManager
             this.applyFontSize();
             SwingSettings.setNonStandardMouseEvent(this.isNonStandardMouseEvent());
             this.setDirty(false);
-            this.setRestartRequired(true);
+            this.setRestartRequired(false);
             this.initialized = true;
         }
     }
@@ -264,7 +264,7 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesManager
         boolean oldNonStandardMouseEvent = this.nonStandardMouseEvent;
         this.nonStandardMouseEvent = nonStandardMouseEvent;
         this.setDirty(true);
-        this.setRestartRequired(false);
+        this.setRestartRequired(true);
         firePropertyChange(NONSTANDARD_MOUSE_EVENT, oldNonStandardMouseEvent, nonStandardMouseEvent);
     }
 

--- a/java/src/apps/gui/GuiLafPreferencesManager.java
+++ b/java/src/apps/gui/GuiLafPreferencesManager.java
@@ -95,7 +95,7 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesManager
             this.applyFontSize();
             SwingSettings.setNonStandardMouseEvent(this.isNonStandardMouseEvent());
             this.setDirty(false);
-            this.setRestartRequired(false);
+            this.setRestartRequired(true);
             this.initialized = true;
         }
     }


### PR DESCRIPTION
Significant L&F settings cannot be applied without restarting JMRI, so partly reverting 95f3307 that prevented the L&F manager from flagging a need to restart.