### PR TITLE
Remove "Serializable" inheritance

### DIFF
--- a/help/en/html/doc/Technical/I8N.shtml
+++ b/help/en/html/doc/Technical/I8N.shtml
@@ -301,11 +301,21 @@ than providing multiple lines in the code itself.
 Some parts of JMRI remain English only due to our developer population.
 In particular, comments and variable names in the code should remain in
 English, as should messages sent to the logging system. Keys for 
-the translation bundles are another example. 
+the translation bundles should also stay in English. 
 In the Java code, these strings can be marked with a "<code>// NOI18N</code>"
 comment at the end of the line. If needed, put that after another comment:
 <pre style="font-family: monospace;">
-  firePropertyChange("size", oldSize, newSize); // promptly! // NOI18N
+           Sensor thisSensorVariableNameIsInEnglish;
+
+           String message = "THAT_ONE_MESSAGE";  // NOI18N
+           JLabel jl1 = new JLabel(Bundle.getMessage(message));
+
+           JLabel jl2 = new JLabel(Bundle.getMessage("LABELKEY"));  // NOI18N
+
+           log.debug("The process failed account of user error"); // NOI18N
+
+           // This comment is in English and need not be annotated w.r.t. internationalization
+
 </pre>
 
 <h3>Adding a new Bundle</h3>

--- a/java/src/jmri/NamedBeanHandle.java
+++ b/java/src/jmri/NamedBeanHandle.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
  *
  * @author Bob Jacobsen Copyright 2009
  */
-public class NamedBeanHandle<T extends NamedBean> implements java.io.Serializable {
+public class NamedBeanHandle<T extends NamedBean> {
 
     /**
      * Create a handle to a particular bean accessed by a specific name.

--- a/java/src/jmri/NamedBeanHandleManager.java
+++ b/java/src/jmri/NamedBeanHandleManager.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kevin Dickerson Copyright (C) 2011
  */
-public class NamedBeanHandleManager extends jmri.managers.AbstractManager implements java.io.Serializable {
+public class NamedBeanHandleManager extends jmri.managers.AbstractManager {
 
     public NamedBeanHandleManager() {
         super();

--- a/java/src/jmri/Section.java
+++ b/java/src/jmri/Section.java
@@ -98,8 +98,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dave Duchamp Copyright (C) 2008,2010
  */
-public class Section extends AbstractNamedBean
-        implements java.io.Serializable {
+public class Section extends AbstractNamedBean {
 
     /**
      * The value of {@link #getState()} if section state is unknown.

--- a/java/src/jmri/Transit.java
+++ b/java/src/jmri/Transit.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dave Duchamp Copyright (C) 2008-2011
  */
-public class Transit extends AbstractNamedBean implements java.io.Serializable {
+public class Transit extends AbstractNamedBean {
 
     /**
      * The idle, or available for assignment to an ActiveTrain state.

--- a/java/src/jmri/util/LocoAddressComparator.java
+++ b/java/src/jmri/util/LocoAddressComparator.java
@@ -10,7 +10,7 @@ import jmri.LocoAddress;
  *
  * @author	Paul Bender Copyright (C) 2015
  */
-public class LocoAddressComparator implements Comparator<LocoAddress>, java.io.Serializable {
+public class LocoAddressComparator implements Comparator<LocoAddress> {
 
     public LocoAddressComparator() {
     }

--- a/java/src/jmri/util/NamedBeanHandle.java
+++ b/java/src/jmri/util/NamedBeanHandle.java
@@ -5,7 +5,7 @@ package jmri.util;
  *
  * @author Bob Jacobsen Copyright 2009
  */
-public class NamedBeanHandle<T> implements java.io.Serializable {
+public class NamedBeanHandle<T> {
 
     public NamedBeanHandle(String name, T bean) {
         this.name = name;

--- a/java/src/jmri/util/PreferNumericComparator.java
+++ b/java/src/jmri/util/PreferNumericComparator.java
@@ -8,7 +8,7 @@ import java.util.Comparator;
  *
  * @author	Bob Jacobsen Copyright (C) 2013
  */
-public class PreferNumericComparator implements Comparator<Object>, java.io.Serializable {
+public class PreferNumericComparator implements Comparator<Object> {
 
     public PreferNumericComparator() {
     }

--- a/java/src/jmri/util/SystemNameComparator.java
+++ b/java/src/jmri/util/SystemNameComparator.java
@@ -17,7 +17,7 @@ import java.util.Comparator;
  * @author Howard Penny
  * @author Pete Cressman
  */
-public class SystemNameComparator implements Comparator<Object>, java.io.Serializable {
+public class SystemNameComparator implements Comparator<Object> {
 
     public SystemNameComparator() {
     }


### PR DESCRIPTION
Remove instances of "Serializable" inheritance from the jmri package.  See #2985 for background.

Also, update the example in the I18N doc.

No functional changes.