### PR TITLE
Fix warning when adding lots of objects

### DIFF
--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -80,6 +80,7 @@ Sensors = Sensors
 SignalMasts = Signal Masts
 SignalHeads = Signal Heads
 Reporters = Reporters
+Memories = Memories
 
 SignalHeadStateRed = Red
 SignalHeadStateYellow = Yellow

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -212,7 +212,7 @@ WarningSystemNameAsUser = System Name "{0}" has already been used as a User Name
 WarningNoTurnout = Could not provide "{0}" - "{1}".
 AddNoTurnout = Cannot add Signal Head because could not provide "{0}" - "{1}".
 WarningEdit = Please finish editing "{0}" before editing "{1}".
-WarnExcessBeans = You are about to add {1} {0} into the configuration\nAre you sure?
+WarnExcessBeans = You are about to add {1} {0} into the configuration.\nAre you sure?
 
 DuplicateSignalSystemName = Cannot add because "{0}" already exists. To replace an existing Signal Head, delete it first.
 GrapevineSkippingCreation = Skipping creation of Grapevine signal head because "{0}" does not start with 'GH'.

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -212,7 +212,7 @@ WarningSystemNameAsUser = System Name "{0}" has already been used as a User Name
 WarningNoTurnout = Could not provide "{0}" - "{1}".
 AddNoTurnout = Cannot add Signal Head because could not provide "{0}" - "{1}".
 WarningEdit = Please finish editing "{0}" before editing "{1}".
-WarnExcessBeans = You are about to add {0} {1} Objects into the configuration\nAre you sure?
+WarnExcessBeans = You are about to add {1} {0} into the configuration\nAre you sure?
 
 DuplicateSignalSystemName = Cannot add because "{0}" already exists. To replace an existing Signal Head, delete it first.
 GrapevineSkippingCreation = Skipping creation of Grapevine signal head because "{0}" does not start with 'GH'.

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_ca.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_ca.properties
@@ -207,7 +207,7 @@ WarningSystemNameAsUser = El Nom de Sistema "{0}" ja s'ha usat com a Nom d'Usuar
 WarningNoTurnout = No es pot proporcionar "{0}" - "{1}".
 AddNoTurnout = No es pot afegir Senyal perqu\u00e8 no es pot proporcionar "{0}" - "{1}".
 WarningEdit = Siusplau acaba d'editar "{0}" abans d'editar "{1}".
-WarnExcessBeans = Est\u00e0s apunt d'afegir {0} {1} Objectes a la configuraci\u00f3\nEst\u00e0s segur?
+WarnExcessBeans = Est\u00e0s apunt d'afegir {1} {0} a la configuraci\u00f3\nEst\u00e0s segur?
 
 DuplicateSignalSystemName = No es pot afegir perqu\u00e8 "{0}" ja existeix. Per canviar un senyal existent, primer elimina'l.
 GrapevineSkippingCreation = No s'ha creat el Senya\u00f1 Grapevine perqu\u00e8 "{0}" no comen\u00e7a per 'GH'.

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_cs.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_cs.properties
@@ -209,7 +209,7 @@ WarningSystemNameAsUser = U\u017eivatelsk\u00fd n\u00e1zev " {0} " je ji\u017e p
 WarningNoTurnout = Nemohu poskytnout " {0} " - " {1} ".
 AddNoTurnout = Nemohu p\u0159idat n\u00e1v\u011bstn\u00ed \u0161t\u00edt proto\u017ee nemohu poskytnout " {0} " - " {1} ".
 WarningEdit = Pros\u00edm dokon\u010dete \u00fapravy " {0} " p\u0159ed \u00fapravou " {1} ".
-WarnExcessBeans = Chyst\u00e1te se p\u0159idat {0} {1} objekty do konfigurace\nJste si jist\u00fd?
+WarnExcessBeans = Chyst\u00e1te se p\u0159idat {1} {0} do konfigurace\nJste si jist\u00fd?
 
 DuplicateSignalSystemName = Nemohu p\u0159idat " {0} " proto\u017ee u\u017e existuje. Pro nahrazen\u00ed ji\u017e existuj\u00edc\u00edho n\u00e1v\u011bstn\u00edho \u0161t\u00edtu jej nejd\u0159\u00edve vyma\u017ete.
 GrapevineSkippingCreation = Vynech\u00e1v\u00e1m vytvo\u0159en\u00ed Grapevine n\u00e1v\u011bstn\u00edho \u0161t\u00edtu proto\u017ee " {0} " neza\u010d\u00edn\u00e1 na GH.

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_da.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_da.properties
@@ -210,7 +210,7 @@ WarningSystemNameAsUser = Bruger Navn " {0} " er allerede blevet brugt som et Br
 WarningNoTurnout = Could not provide " {0} " - " {1} ".
 AddNoTurnout = Cannot add Signal Head because could not provide " {0} " - " {1} ".
 WarningEdit = Please finish editing " {0} " before editing " {1} ".
-WarnExcessBeans = You are about to add {0} {1} Objects into the configuration\nAre you sure?
+WarnExcessBeans = You are about to add {1} {0} into the configuration\nAre you sure?
 
 DuplicateSignalSystemName = Cannot add because " {0} " already exists. To replace an existing Signal Head, delete it first.
 GrapevineSkippingCreation = Skipping creation of Grapevine signal head because " {0} " does not start with GH.

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_de.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_de.properties
@@ -427,7 +427,7 @@ VetoDeleteBean={0} {1} kann nicht gel\u00f6scht werden.\n{2}
 #UpdateToUserNameTitle=Verweisungen \u00fcbersetzen nach NutzerName
 #UpdateToUserName=Wollen Sie alle Verweisungen nach {0}\nvon SystemName "{2}" auf NutzerName "{1}" \u00fcbersetzen?"
 UpdateToSystemNameTitle=Alle Verwendungen \u00fcbersetzen nach SystemName
-WarnExcessBeans=Sie werden {0} {1} Objekte die Konfiguration hinzuf\u00fcgen\nWeitermachen?
+WarnExcessBeans=Sie werden {1} {0} die Konfiguration hinzuf\u00fcgen\nWeitermachen?
 UpdateToSystemName=Willst du alle Verweisungen nach {0}\n von NutzerName "{2}" auf SystemName "{1}" \u00fcbersetzen?"
 UpdateComplete=NutzerName wurde verzogen. Um sicher zu sein dass alle \u00c4nderungen durchgefuhrt werden, speichere Ihres Gleisstellbild und starte JMRI neu
 

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_fr.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_fr.properties
@@ -202,7 +202,7 @@ WarningSystemNameAsUser = Nom Utilisateur " {0}" a d\u00e9j\u00e0 \u00e9t\u00e9 
 WarningNoTurnout = Impossible de fournir "{0} " - " {1}" .
 AddNoTurnout = Impossible d'ajouter t\u00eate de signal parce qu'il ne pouvait fournir "{0} " - " {1}".
 WarningEdit = Veuillez finir l'\u00e9dition " {0} " avant l'\u00e9dition " {1} ".
-WarnExcessBeans = Vous \u00eates sur le point d'ajouter {0} {1} objets dans la configuration.\nEn \u00eates-vous s\u00fbr?
+WarnExcessBeans = Vous \u00eates sur le point d'ajouter {1} {0} dans la configuration.\nEn \u00eates-vous s\u00fbr?
 
 DuplicateSignalSystemName = Impossible d'ajouter parce que que " {0} " existe d\u00e9j\u00e0. Pour remplacer une t\u00eate signal existante, d'abord la supprimer.
 GrapevineSkippingCreation = Sauter cr\u00e9ation de t\u00eate signal Grapevine parce que "{0 }" ne commence pas par GH .

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_it.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_it.properties
@@ -198,7 +198,7 @@ WarningSystemNameAsUser = Il Nome Utente " {0} " \u00e8 stato gi\u00e0 usato com
 WarningNoTurnout = Impossibile fornire " {0} " - " {1} ".
 AddNoTurnout = Impossibile aggiungere la Vela del segnale perch\u00e9 non in grado di fornire " {0} " - " {1} ".
 WarningEdit = Si prega di terminare le modifiche "{0}" prima di modificare " {1} ".
-WarnExcessBeans = Stai per aggiungere {0} {1} oggetti nella configurazione\nSei sicuro?
+WarnExcessBeans = Stai per aggiungere {1} {0} nella configurazione\nSei sicuro?
 
 DuplicateSignalSystemName = Impossibile aggiungere perch\u00e8 "{0}" esiste gi\u00e0. Per sostituire una Vela di segnale esistente, eliminarlo prima.
 GrapevineSkippingCreation = Saltata la creazione del segnale Grapevine perch\u00e8 "{0}" non inizia con GH.

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle_nl.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle_nl.properties
@@ -214,7 +214,7 @@ WarningSystemNameAsUser = Systeemnaam "{0}" is al in gebruik als Gebruikersnaam.
 WarningNoTurnout = Kan "{0}" niet aanmaken - "{1}".
 AddNoTurnout = Kan Seinschild niet aanmaken omdat "{0}" niet beschikbaar is - "{1}".
 WarningEdit = Voltooi configuratie "{0}" voordat "{1}" bewerkt wordt.
-WarnExcessBeans = Je staat op het punt om {0} items toe te voegen.\nIs dat correct?
+WarnExcessBeans = Je staat op het punt om {1} {0} toe te voegen.\nIs dat correct?
 
 DuplicateSignalSystemName = Cannot add because "{0}" already exists. To replace an existing Signal Head, delete it first.
 GrapevineSkippingCreation = Skipping creation of Grapevine signal head because "{0}" does not start with 'GH'.

--- a/java/src/jmri/jmrit/beantable/BlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/BlockTableAction.java
@@ -792,7 +792,7 @@ public class BlockTableAction extends AbstractTableAction {
         }
         if (NumberOfBlocks >= 65) { // limited by JSpinnerModel to 100
             if (JOptionPane.showConfirmDialog(addFrame,
-                    Bundle.getMessage("WarnExcessBeans", NumberOfBlocks),
+                    Bundle.getMessage("WarnExcessBeans", Bundle.getMessage("Blocks"), NumberOfBlocks),
                     Bundle.getMessage("WarningTitle"),
                     JOptionPane.YES_NO_OPTION) == 1) {
                 return;

--- a/java/src/jmri/jmrit/beantable/MemoryTableAction.java
+++ b/java/src/jmri/jmrit/beantable/MemoryTableAction.java
@@ -215,7 +215,7 @@ public class MemoryTableAction extends AbstractTableAction {
 
         if (numberOfMemory >= 65) { // limited by JSpinnerModel to 100
             if (JOptionPane.showConfirmDialog(addFrame,
-                    Bundle.getMessage("WarnExcessBeans", numberOfMemory),
+                    Bundle.getMessage("WarnExcessBeans", Bundle.getMessage("Memories"), numberOfMemory),
                     Bundle.getMessage("WarningTitle"),
                     JOptionPane.YES_NO_OPTION) == 1) {
                 return;

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -283,7 +283,7 @@ public class ReporterTableAction extends AbstractTableAction {
         }
         if (numberOfReporters >= 65) { // limited by JSpinnerModel to 100
             if (JOptionPane.showConfirmDialog(addFrame,
-                    Bundle.getMessage("WarnExcessBeans", numberOfReporters),
+                    Bundle.getMessage("WarnExcessBeans", Bundle.getMessage("Reporters"), numberOfReporters),
                     Bundle.getMessage("WarningTitle"),
                     JOptionPane.YES_NO_OPTION) == 1) {
                 return;

--- a/java/src/jmri/jmrit/beantable/SensorTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SensorTableAction.java
@@ -170,7 +170,7 @@ public class SensorTableAction extends AbstractTableAction {
         }
         if (numberOfSensors >= 65) { // limited by JSpinnerModel to 100
             if (JOptionPane.showConfirmDialog(addFrame,
-                    Bundle.getMessage("WarnExcessBeans", numberOfSensors),
+                    Bundle.getMessage("WarnExcessBeans", Bundle.getMessage("Sensors"), numberOfSensors),
                     Bundle.getMessage("WarningTitle"),
                     JOptionPane.YES_NO_OPTION) == 1) {
                 return;

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -1465,7 +1465,7 @@ public class TurnoutTableAction extends AbstractTableAction {
         }
         if (numberOfTurnouts >= 65) { // limited by JSpinnerModel to 100
             if (JOptionPane.showConfirmDialog(addFrame,
-                    Bundle.getMessage("WarnExcessBeans", numberOfTurnouts),
+                    Bundle.getMessage("WarnExcessBeans", Bundle.getMessage("Turnouts"), numberOfTurnouts),
                     Bundle.getMessage("WarningTitle"),
                     JOptionPane.YES_NO_OPTION) == 1) {
                 return;

--- a/java/src/jmri/jmrit/beantable/sensor/AddSensorPanel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/AddSensorPanel.java
@@ -160,7 +160,7 @@ public class AddSensorPanel extends jmri.util.swing.JmriPanel {
         }
         if (numberOfSensors >= 65) { // limited by JSpinnerModel to 100
             if (JOptionPane.showConfirmDialog(null,
-                    Bundle.getMessage("WarnExcessBeans", numberOfSensors),
+                    Bundle.getMessage("WarnExcessBeans", Bundle.getMessage("Sensors"), numberOfSensors),
                     Bundle.getMessage("WarningTitle"),
                     JOptionPane.YES_NO_OPTION) == 1) {
                 return;


### PR DESCRIPTION
If you bulk-add lots of Turnouts, Sensors, etc you get a warning that (a) contained a {1}, indicating that it wasn't matched to the code and (b) was too generic.  This PR improves that by using the {1} to include the object type, and improves the language.  

No other changes.
