### PR TITLE
Fix warn message caused by 128step being default without being explic…

### DIFF
--- a/java/src/jmri/jmrit/dispatcher/AutoTurnouts.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoTurnouts.java
@@ -140,7 +140,7 @@ public class AutoTurnouts {
             curBlock = entryPt.getBlock();
             prevBlock = entryPt.getFromBlock();
             curBlockSeqNum = s.getBlockSequenceNumber(curBlock);
-        } else if (s.containsBlock(at.getStartBlock())) {
+        } else if ( !at.isAllocationReversed() && s.containsBlock(at.getStartBlock())) {
             curBlock = at.getStartBlock();
             curBlockSeqNum = s.getBlockSequenceNumber(curBlock);
             //Get the previous block so that we can set the turnouts in the current block correctly.
@@ -148,6 +148,15 @@ public class AutoTurnouts {
                 prevBlock = s.getBlockBySequenceNumber(curBlockSeqNum - 1);
             } else if (direction == Section.REVERSE) {
                 prevBlock = s.getBlockBySequenceNumber(curBlockSeqNum + 1);
+            }
+        } else if (at.isAllocationReversed() && s.containsBlock(at.getEndBlock())) {
+            curBlock = at.getEndBlock();
+            curBlockSeqNum = s.getBlockSequenceNumber(curBlock);
+            //Get the previous block so that we can set the turnouts in the current block correctly.
+            if (direction == Section.REVERSE) {
+                prevBlock = s.getBlockBySequenceNumber(curBlockSeqNum + 1);
+            } else if (direction == Section.FORWARD) {
+                prevBlock = s.getBlockBySequenceNumber(curBlockSeqNum - 1);
             }
         } else {
 

--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -162,6 +162,8 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
                 return (int) ((fSpeed * 28) * 4) + 12;
             case DccThrottle.SpeedStepMode14:
                 return (int) ((fSpeed * 14) * 8) + 8;
+            case DccThrottle.SpeedStepMode128:
+                return speed;
             default:
                 log.warn("Unhandled speed step: {}", this.getSpeedStepMode());
                 break;


### PR DESCRIPTION
Fix warn message caused by 128 step being default without being explicitly tested for.
Fix There and Back under SSL when looking for adjoining section/block