### PR TITLE
Restore LocoRMI tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
                         <!-- ignore until #3340 is merged -->
                         <exclude>jmri.jmrix.nce.**.Nce*</exclude>
                         <!-- ignore until #3492 is resolved -->
-                        <exclude>jmri.jmrix.loconet.locormi.LnMessage*Test</exclude>
+                        <exclude>%regex[jmri.jmrix.loconet.locormi.LnMessage[Client|Server]Test]</exclude>
                         <!-- ignore until #2601 is resolved -->
                         <exclude>jmri.jmrit.decoderdefn.DuplicateTest</exclude>
                         <!-- ignore to avoid duplicate test runs -->


### PR DESCRIPTION
Restore LocoRMI tests disabled in #3487.

The initial commit reduces the size of the exclusion, but the target for this PR is to completely remove the exclusion.