### PR TITLE
Fix name for Hornby TTS A4 4-6-2

### DIFF
--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <!--Written by JMRI version 4.7.4ish+heap+20170520T1036Z+R02a6d02 on Sat May 20 20:38:08 AEST 2017 $Id$-->
-  <decoderIndex version="812">
+  <!--Written by JMRI version 4.7.4ish+heap+20170525T0953Z+R506cab5 on Thu May 25 19:53:15 AEST 2017 $Id$-->
+  <decoderIndex version="814">
     <mfgList nmraListDate="2015-03-06" updated="2015-03-25" lastadd="107,124,126,128,134">
       <manufacturer mfg="NMRA" mfgID="999" />
       <manufacturer mfg="A-Train Electronics" mfgID="137" />
@@ -7003,7 +7003,13 @@
           <output name="Rear Light" label="Ye" maxcurrent="0.1A" />
           <output name="Aux" label="Gr" maxcurrent="0.1A" />
         </model>
-        <model model="Hornby TTS A4 4-6-0" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="135">
+        <model model="Hornby TTS A4 4-6-0" show="no" replacementModel="Hornby TTS A4 4-6-2" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="135">
+          <versionCV lowVersionID="2" highVersionID="120" />
+          <output name="Headlight" label="Wh" maxcurrent="0.1A" />
+          <output name="Rear Light" label="Ye" maxcurrent="0.1A" />
+          <output name="Aux" label="Gr" maxcurrent="0.1A" />
+        </model>
+        <model model="Hornby TTS A4 4-6-2" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="135">
           <versionCV lowVersionID="2" highVersionID="120" />
           <output name="Headlight" label="Wh" maxcurrent="0.1A" />
           <output name="Rear Light" label="Ye" maxcurrent="0.1A" />

--- a/xml/decoders/HornbyTTS.xml
+++ b/xml/decoders/HornbyTTS.xml
@@ -13,6 +13,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+    <version author="Dave Heap" version="1.4" lastUpdated="23170520"/>
     <version author="Dave Heap" version="1.3" lastUpdated="20170520"/>
     <version author="Nigel Cliffe" version="1.1" lastUpdated="20150121"/>
     <version author="Nigel Cliffe" version="1" lastUpdated="20141001"/>
@@ -34,6 +35,7 @@
                 A4 Mallard & Gadwall = 135
     -->
     <!--  Version 1.3 - update to differentiate between 2P & 9F, based on a composite productID of CV159(low) & CV158(high). 	-->
+    <!--  Version 1.4 - update to replace "Hornby TTS A4 4-6-0" with "Hornby TTS A4 4-6-2" (typo). 	-->
 
     <decoder>
         <family name="Hornby TTS Sound Decoder" mfg="Hornby" comment="">
@@ -85,7 +87,13 @@
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
             </model>
-            <model model="Hornby TTS A4 4-6-0" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="135">
+            <model model="Hornby TTS A4 4-6-0" show="no" replacementModel="Hornby TTS A4 4-6-2" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="135">
+                <versionCV lowVersionID="2" highVersionID="120"/>
+                <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
+                <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
+                <output name="Aux" label="Gr" maxcurrent="0.1A"/>
+            </model>
+            <model model="Hornby TTS A4 4-6-2" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="135">
                 <versionCV lowVersionID="2" highVersionID="120"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>


### PR DESCRIPTION
Replacement model for incorrectly named "Hornby TTS A4 4-6-0".