### PR TITLE
Add ourAspect entries

### DIFF
--- a/xml/signals/SPTCO-1930/appearance-DW-2-head.xml
+++ b/xml/signals/SPTCO-1930/appearance-DW-2-head.xml
@@ -114,22 +114,27 @@
     <aspectMapping>
       <advancedAspect>Diverging Clear</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
     <aspectMapping>
       <advancedAspect>Diverging Approach</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
     <aspectMapping>
       <advancedAspect>Branch Clear</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
     <aspectMapping>
       <advancedAspect>Branch Approach</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
     <aspectMapping>
       <advancedAspect>Branch Diverging</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
   </aspectMappings>
 </appearancetable>

--- a/xml/signals/SPTCO-1930/appearance-SL-2-head.xml
+++ b/xml/signals/SPTCO-1930/appearance-SL-2-head.xml
@@ -114,22 +114,27 @@
     <aspectMapping>
       <advancedAspect>Diverging Clear</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
     <aspectMapping>
       <advancedAspect>Diverging Approach</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
     <aspectMapping>
       <advancedAspect>Branch Clear</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
     <aspectMapping>
       <advancedAspect>Branch Approach</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
     <aspectMapping>
       <advancedAspect>Branch Diverging</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
   </aspectMappings>
 </appearancetable>  

--- a/xml/signals/SPTCO-1930/appearance-SL-3-head.xml
+++ b/xml/signals/SPTCO-1930/appearance-SL-3-head.xml
@@ -174,14 +174,17 @@
     <aspectMapping>
       <advancedAspect>Branch Clear</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
     <aspectMapping>
       <advancedAspect>Branch Approach</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
     <aspectMapping>
       <advancedAspect>Branch Diverging</advancedAspect>
       <ourAspect>Clear</ourAspect>
+      <ourAspect>Diverging Clear</ourAspect>
     </aspectMapping>
   </aspectMappings>
 </appearancetable>  


### PR DESCRIPTION
The multi-head masts were defaulting to Clear when the next signal on a diverging route was displaying a diverging aspect.