### PR TITLE
Quit on uncaught Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ session.log
 # private / per-user configuration files
 /nbproject/private
 /web/app/nbproject/private
+/scripts/config-portable/nbproject/private
 /.idea/workspace.xml
 local.properties
 /test

--- a/java/src/jmri/util/exceptionhandler/Bundle.java
+++ b/java/src/jmri/util/exceptionhandler/Bundle.java
@@ -1,0 +1,98 @@
+package jmri.util.exceptionhandler;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Locale;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@CheckReturnValue
+@SuppressFBWarnings(value = "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS", justification = "Desired pattern is repeated class names with package-level access to members")
+
+@net.jcip.annotations.Immutable
+
+/**
+ * Provides standard access for resource bundles in a package.
+ *
+ * Convention is to provide a subclass of this name in each package, working off
+ * the local resource bundle name.
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ * @since 3.3.1
+ */
+public class Bundle extends jmri.Bundle {
+
+    @Nullable
+    private static final String name = "jmri.util.exceptionhandler.Bundle"; // NOI18N
+
+    //
+    // below here is boilerplate to be copied exactly
+    //
+    /**
+     * Provides a translated string for a given key from the package resource
+     * bundle or parent.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @param key Bundle key to be translated
+     * @return Internationalized text
+     */
+    static String getMessage(String key) {
+        return b.handleGetMessage(key);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key from the
+     * package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param key  Bundle key to be translated
+     * @param subs One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(String key, Object... subs) {
+        return b.handleGetMessage(key, subs);
+    }
+
+    /**
+     * Merges user data with a translated string for a given key in a given
+     * locale from the package resource bundle or parent.
+     * <p>
+     * Uses the transformation conventions of the Java MessageFormat utility.
+     * <p>
+     * Note that this is intentionally package-local access.
+     *
+     * @see java.text.MessageFormat
+     * @param locale The locale to be used
+     * @param key    Bundle key to be translated
+     * @param subs   One or more objects to be inserted into the message
+     * @return Internationalized text
+     */
+    static String getMessage(Locale locale, String key, Object... subs) {
+        return b.handleGetMessage(locale, key, subs);
+    }
+
+    private final static Bundle b = new Bundle();
+
+    @Override
+    @Nullable
+    protected String bundleName() {
+        return name;
+    }
+
+    @Override
+    protected jmri.Bundle getBundle() {
+        return b;
+    }
+
+    @Override
+    protected String retry(Locale locale, String key) {
+        return super.getBundle().handleGetMessage(locale, key);
+    }
+
+}

--- a/java/src/jmri/util/exceptionhandler/Bundle.java
+++ b/java/src/jmri/util/exceptionhandler/Bundle.java
@@ -21,7 +21,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * @author Bob Jacobsen Copyright (C) 2012
  * @since 3.3.1
  */
-public class Bundle extends jmri.Bundle {
+public class Bundle extends jmri.util.Bundle {
 
     @Nullable
     private static final String name = "jmri.util.exceptionhandler.Bundle"; // NOI18N

--- a/java/src/jmri/util/exceptionhandler/Bundle.properties
+++ b/java/src/jmri/util/exceptionhandler/Bundle.properties
@@ -1,0 +1,4 @@
+#Message displayed by UncaughtExceptionHandler on Errors
+UnrecoverableErrorMessage=<html>Unrecoverable error encountered.<br>This application will quit.<br><br><pre>{0}
+#Title of message displaed by UncaughtExceptionHandler on Errors
+UnrecoverableErrorTitle=Unrecoverable Error Encountered

--- a/java/src/jmri/util/exceptionhandler/UncaughtExceptionHandler.java
+++ b/java/src/jmri/util/exceptionhandler/UncaughtExceptionHandler.java
@@ -1,7 +1,9 @@
 package jmri.util.exceptionhandler;
 
+import java.awt.GraphicsEnvironment;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import javax.swing.JOptionPane;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +29,16 @@ public class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler
         }
 
         log.error("Uncaught Exception caught by jmri.util.exceptionhandler.UncaughtExceptionHandler", e);
+
+        if (e instanceof Error) {
+            if (!GraphicsEnvironment.isHeadless()) {
+                JOptionPane.showMessageDialog(null,
+                        Bundle.getMessage("UnrecoverableErrorMessage", generateStackTrace(e)),
+                        Bundle.getMessage("UnrecoverableErrorTitle"),
+                        JOptionPane.ERROR_MESSAGE);
+            }
+            System.exit(126);
+        }
     }
 
     static protected String generateStackTrace(Throwable e) {

--- a/java/test/jmri/util/exceptionhandler/BundleTest.java
+++ b/java/test/jmri/util/exceptionhandler/BundleTest.java
@@ -1,0 +1,46 @@
+package jmri.util.exceptionhandler;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the Bundle class
+ *
+ * @author Bob Jacobsen Copyright (C) 2012
+ */
+public class BundleTest {
+
+    @Test
+    public void testGoodKeysMessage() {
+        Assert.assertEquals("Help", Bundle.getMessage("HELP"));
+        Assert.assertEquals("Turnout", Bundle.getMessage("BeanNameTurnout"));
+    }
+
+    @Test
+    public void testBadKeyMessage() {
+        try {
+            Bundle.getMessage("FFFFFTTTTTTT");
+        } catch (java.util.MissingResourceException e) {
+            return;
+        } // OK
+        Assert.fail("No exception thrown");
+    }
+
+    @Test
+    public void testGoodKeysMessageArg() {
+        Assert.assertEquals("Help", Bundle.getMessage("HELP", "foo"));
+        Assert.assertEquals("Turnout", Bundle.getMessage("BeanNameTurnout", "foo"));
+        Assert.assertEquals("About Test", Bundle.getMessage("TitleAbout", "Test"));
+    }
+
+    @Test
+    public void testBadKeyMessageArg() {
+        try {
+            Bundle.getMessage("FFFFFTTTTTTT", "foo");
+        } catch (java.util.MissingResourceException e) {
+            return;
+        } // OK
+        Assert.fail("No exception thrown");
+    }
+
+}

--- a/java/test/jmri/util/exceptionhandler/PackageTest.java
+++ b/java/test/jmri/util/exceptionhandler/PackageTest.java
@@ -1,5 +1,6 @@
 package jmri.util.exceptionhandler;
 
+import junit.framework.JUnit4TestAdapter;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -26,6 +27,7 @@ public class PackageTest extends TestCase {
     public static Test suite() {
         TestSuite suite = new TestSuite("jmri.util.exceptionhandler.PackageTest");   // no tests in this class itself
 
+        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
         suite.addTest(UncaughtExceptionHandlerTest.suite());
 
         return suite;

--- a/java/test/jmri/util/exceptionhandler/UncaughtExceptionHandlerTest.java
+++ b/java/test/jmri/util/exceptionhandler/UncaughtExceptionHandlerTest.java
@@ -4,6 +4,8 @@ import jmri.util.JUnitAppender;
 import jmri.util.SwingTestCase;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.junit.After;
+import org.junit.Before;
 
 /**
  * Tests for the jmri.util.UncaughtExceptionHandler class.
@@ -41,7 +43,9 @@ public class UncaughtExceptionHandlerTest extends SwingTestCase {
         } catch (java.lang.reflect.InvocationTargetException e) {
             caught = true;
         }
-        jmri.util.JUnitUtil.waitFor(()->{return caught;}, "threw exception");
+        jmri.util.JUnitUtil.waitFor(() -> {
+            return caught;
+        }, "threw exception");
         // emits no logging, as the UncaughtExceptionHandlerTest handler isn't invoked
     }
 
@@ -62,17 +66,18 @@ public class UncaughtExceptionHandlerTest extends SwingTestCase {
         return suite;
     }
 
-    // The minimal setup for log4J
+    @Before
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         apps.tests.Log4JFixture.setUp();
         this.defaultExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler());
         super.setUp();
     }
 
+    @After
     @Override
-    protected void tearDown() throws Exception {
+    public void tearDown() throws Exception {
         super.tearDown();
         Thread.setDefaultUncaughtExceptionHandler(this.defaultExceptionHandler);
         apps.tests.Log4JFixture.tearDown();

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <slf4j.version>1.7.21</slf4j.version>
         <jackson.version>2.8.5</jackson.version>
         <jogamp.version>2.3.2</jogamp.version>
+        <openlcb.version>0.7.14</openlcb.version>
         <!-- test environment -->
         <jmri.path.program>${basedir}</jmri.path.program>
         <jmri.prefsdir>${basedir}/temp</jmri.prefsdir>
@@ -478,11 +479,11 @@
                         <link>http://users.frii.com/jarvi/rxtx/doc/</link>
                         <link>http://www.jdom.org/docs/apidocs/</link>
                         <link>http://javacsv.sourceforge.net/</link>
-                        <link>http://static.javadoc.io/com.fasterxml.jackson.core/jackson-databind/2.8.5/</link>
+                        <link>http://static.javadoc.io/com.fasterxml.jackson.core/jackson-databind/${jackson.version}/</link>
                         <link>http://logging.apache.org/log4j/1.2/apidocs/</link>
                         <link>http://download.java.net/media/java3d/javadoc/1.3.2/</link>
                         <link>https://jogamp.org/deployment/jogamp-next/javadoc/joal/javadoc/</link>
-                        <link>https://static.javadoc.io/org.openlcb/openlcb/0.7.12/</link>
+                        <link>https://static.javadoc.io/org.openlcb/openlcb/${openlcb.version}/</link>
                         <link>https://commons.apache.org/proper/commons-lang/javadocs/api-release/</link>
                     </links>
                 </configuration>
@@ -767,7 +768,7 @@
         <dependency>
             <groupId>org.openlcb</groupId>
             <artifactId>openlcb</artifactId>
-            <version>0.7.14</version>
+            <version>${openlcb.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.ntb</groupId>


### PR DESCRIPTION
Quit on an Error if it reaches the UncaughtExceptionHandler after displaying a message (if in GUI). It may be desirable to provide specific error messages when encountered. Note that there remains a classpath-related error that can cause a JMRI application to hang during start that this still does not catch, but that needs to caught in the main method (it is a missing or incorrect log4j jar).