### PR TITLE
Allow Standalone LocoNet for LocoBuffer* connections

### DIFF
--- a/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
@@ -52,7 +52,7 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
      */
     public String[] getCommandStationListWithStandaloneLN() {
         String[] result = new String[commandStationNames.length + 1];
-        for (int i = 0 ; i < result.length; ++i) {
+        for (int i = 0 ; i < result.length-1; ++i) {
             result[i] = commandStationNames[i];
         }
         result[commandStationNames.length] = LnCommandStationType.COMMAND_STATION_STANDALONE.getName();

--- a/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Vector;
+import jmri.jmrix.loconet.LnCommandStationType;
 import jmri.jmrix.loconet.LnPacketizer;
 import jmri.jmrix.loconet.LnPortController;
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
@@ -36,10 +37,28 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
         option2Name = "CommandStation"; // NOI18N
         option3Name = "TurnoutHandle"; // NOI18N
         options.put(option1Name, new Option("Connection uses:", validOption1));
-        options.put(option2Name, new Option("Command station type:", commandStationNames, false));
+        options.put(option2Name, new Option("Command station type:", getCommandStationListWithStandaloneLN(), false));
         options.put(option3Name, new Option("Turnout command handling:", new String[]{"Normal", "Spread", "One Only", "Both"}));
     }
-
+    
+    /**
+     * Create a list of possible command stations and append "Standalone LocoNet"
+     * 
+     * Note: This is not suitable for use by any class which extends this class if
+     * the hardware interface is part of a command station.
+     * 
+     * @return String[] containing the array of command stations, plus "Standalone 
+     *          LocoNet"
+     */
+    public String[] getCommandStationListWithStandaloneLN() {
+        String[] result = new String[commandStationNames.length + 1];
+        for (int i = 0 ; i < result.length; ++i) {
+            result[i] = commandStationNames[i];
+        }
+        result[commandStationNames.length] = LnCommandStationType.COMMAND_STATION_STANDALONE.getName();
+        return result;
+    }
+    
     Vector<String> portNameVector = null;
     SerialPort activeSerialPort = null;
 
@@ -201,6 +220,8 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
      * this, as there seems to be no way to check the number of queued bytes and
      * buffer length. This might go false for short intervals, but it might also
      * stick off if something goes wrong.
+     * 
+     * @return an indication of whether the interface is accepting transmit messages.
      */
     @Override
     public boolean okToSend() {
@@ -263,6 +284,8 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
 
     /**
      * Local method to do specific configuration, overridden in class
+     * @param activeSerialPort is the serial port to be configured
+     * @throws gnu.io.UnsupportedCommOperationException
      */
     protected void setSerialPort(SerialPort activeSerialPort) throws gnu.io.UnsupportedCommOperationException {
         // find the baud rate value, configure comm options

--- a/java/src/jmri/jmrix/loconet/pr3/PR3Adapter.java
+++ b/java/src/jmri/jmrix/loconet/pr3/PR3Adapter.java
@@ -24,7 +24,11 @@ public class PR3Adapter extends LocoBufferAdapter {
     }
 
     /**
-     * Always use flow control, not considered a user-settable option
+     * Sets up the serial port characteristics.  Always uses flow control, which is
+     * not considered a user-settable option.  Sets the PR3 for the appropriate
+     * operating mode, based on the selected "command station type".
+     * 
+     * @param activeSerialPort - the port to be configured
      */
     @Override
     protected void setSerialPort(SerialPort activeSerialPort) throws gnu.io.UnsupportedCommOperationException {
@@ -126,6 +130,8 @@ public class PR3Adapter extends LocoBufferAdapter {
 
     /**
      * Get an array of valid baud rates.
+     * 
+     * @return String[] containing the single valid baud rate, "57,600".
      */
     @Override
     public String[] validBaudRates() {
@@ -135,6 +141,7 @@ public class PR3Adapter extends LocoBufferAdapter {
     /**
      * Get an array of valid baud rates as integers. This allows subclasses to
      * change the arrays of speeds.
+     * @return int[] containing the single valud baud rate, 57600.
      */
     @Override
     public int[] validBaudNumber() {
@@ -142,8 +149,14 @@ public class PR3Adapter extends LocoBufferAdapter {
     }
 
     // Option 1 does flow control, inherited from LocoBufferAdapter
+    
     /**
-     * The PR3 can be used in numerous modes, so handle that
+     * The PR3 can be used as a "Standalone Programmer", or with various LocoNet 
+     * command stations, or as an interface to a "Standalone LocoNet".  Provide those
+     * options.
+     * 
+     * @return an array of strings containing the various command station names and
+     *      name(s) of modes without command stations
      */
     public String[] commandStationOptions() {
         String[] retval = new String[commandStationNames.length + 2];


### PR DESCRIPTION
Adds "Standalone LocoNet" as an option for a connection's "command station" for LocoBuffer, LocoBuffer-USB, and LocoBufferII.  (PR3 already has "Standalone LocoNet".)

Fixes a few missing JavaDocs items.