### PR TITLE
Minor ConfigXml Update

### DIFF
--- a/java/src/jmri/configurexml/ConfigXmlManager.java
+++ b/java/src/jmri/configurexml/ConfigXmlManager.java
@@ -80,10 +80,10 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
     }
 
     /**
-     * Handles classes that have moved to a new package or been superceded.
+     * Handles ConfigureXml classes that have moved to a new package or been superceded.
      *
-     * @param name name of the moved or superceded class
-     * @return name of the class in newer package or of superseding class
+     * @param name name of the moved or superceded ConfigureXml class
+     * @return name of the ConfigureXml class in newer package or of superseding class
      */
     static public String currentClassName(String name) {
         if (!classMigrationBundle.containsKey(name)) {

--- a/java/src/jmri/jmrit/XmlFile.java
+++ b/java/src/jmri/jmrit/XmlFile.java
@@ -625,8 +625,7 @@ public abstract class XmlFile {
      */
     static public void addDefaultInfo(Element root) {
         String content = "Written by JMRI version " + jmri.Version.name()
-                + " on " + (new Date()).toString()
-                + " $Id$";
+                + " on " + (new Date()).toString();
         Comment comment = new Comment(content);
         root.addContent(comment);
     }


### PR DESCRIPTION
- ConfigureXml was storing a $Id tag into files, apparently left over from CVS days.  Removed.
- Fixed a confusing (at least to me) JavaDoc comment