### PR TITLE
Restore LocoNet (RMI) Server version inter-operation

### DIFF
--- a/java/src/jmri/jmrix/loconet/LocoNetException.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetException.java
@@ -8,7 +8,9 @@ import jmri.JmriException;
  * @author Bob Jacobsen Copyright (C) 2001
   */
 public class LocoNetException extends JmriException {
-
+    // serialVersionUID used by jmrix.loconet.locormi, please do not remove
+    private static final long serialVersionUID = -7412254026659440390L;
+    
     public LocoNetException(String m) {
         super(m);
     }

--- a/java/src/jmri/jmrix/loconet/LocoNetMessage.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetMessage.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class LocoNetMessage implements Serializable {
+    // Serializable, serialVersionUID used by jmrix.loconet.locormi, please do not remove
+    static final long serialVersionUID = -7904918731667071828L;
 
     /**
      * Create a new object, representing a specific-length message.

--- a/java/src/jmri/jmrix/loconet/LocoNetMessageException.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetMessageException.java
@@ -8,7 +8,9 @@ import jmri.JmriException;
  * @author Bob Jacobsen Copyright (C) 2001, 2008
   */
 public class LocoNetMessageException extends JmriException {
-
+    // serialVersionUID used by jmrix.loconet.locormi, please do not remove
+    private static final long serialVersionUID = -6472332226397111753L;
+    
     public LocoNetMessageException(String s) {
         super(s);
     }

--- a/java/src/jmri/jmrix/loconet/locormi/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/locormi/ConnectionConfig.java
@@ -82,7 +82,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
 
     @Override
     protected void setInstance() {
-        log.error("Unexpected call to setInstance", new Exception());
+        log.warn("Unexpected call to setInstance, multi-replica capability not yet present");
     }
 
     String manufacturerName = jmri.jmrix.loconet.LnConnectionTypeList.DIGITRAX;


### PR DESCRIPTION
See #3597 for background

Restores serialVersionUID values for several classes. Also clarifies (and makes less intrusive) a warning about the LocoNet (RMI) Server code not (yet) being migrated to allow multiple connections of the same type.