### PR TITLE
Restore backward read/write compatibility

### DIFF
--- a/java/src/jmri/configurexml/BlockManagerXml.java
+++ b/java/src/jmri/configurexml/BlockManagerXml.java
@@ -77,6 +77,11 @@ public class BlockManagerXml extends jmri.managers.configurexml.AbstractMemoryMa
                         } else {
                             Element elem = new Element("block");
                             elem.addContent(new Element("systemName").addContent(sname));
+                            
+                            // As a work-around for backward compatibility, store systemName as attribute.
+                            // Remove this in e.g. JMRI 4.11.1 and then update all the loadref comparison files
+                            elem.setAttribute("systemName", sname);
+                            
                             // the following null check is to catch a null pointer exception that sometimes was found to happen
                             String uname = b.getUserName();
                             if ((uname != null) && (!uname.equals(""))) {
@@ -112,6 +117,11 @@ public class BlockManagerXml extends jmri.managers.configurexml.AbstractMemoryMa
                         }
                         Element elem = new Element("block");
                         elem.addContent(new Element("systemName").addContent(sname));
+                            
+                        // As a work-around for backward compatibility, store systemName as attribute.
+                        // Remove this in e.g. JMRI 4.11.1 and then update all the loadref comparison files
+                        elem.setAttribute("systemName", sname);
+                            
                         if (log.isDebugEnabled()) {
                             log.debug("second store Block " + sname + ":" + uname);
                         }

--- a/java/src/jmri/configurexml/SectionManagerXml.java
+++ b/java/src/jmri/configurexml/SectionManagerXml.java
@@ -53,6 +53,11 @@ public class SectionManagerXml extends jmri.managers.configurexml.AbstractNamedB
                         Element elem = new Element("section");
                         elem.addContent(new Element("systemName").addContent(sname));
 
+                        // As a work-around for backward compatibility, store systemName and username as attribute.
+                        // Remove this in e.g. JMRI 4.11.1 and then update all the loadref comparison files
+                        elem.setAttribute("systemName", sname);
+                        if (x.getUserName()!=null && !x.getUserName().equals("")) elem.setAttribute("userName", x.getUserName());
+                            
                         // store common part
                         storeCommon(x, elem);
                         String txt = "userdefined";

--- a/java/src/jmri/configurexml/TransitManagerXml.java
+++ b/java/src/jmri/configurexml/TransitManagerXml.java
@@ -54,6 +54,11 @@ public class TransitManagerXml extends jmri.managers.configurexml.AbstractNamedB
                     Element elem = new Element("transit");
                     elem.addContent(new Element("systemName").addContent(sname));
 
+                    // As a work-around for backward compatibility, store systemName and username as attribute.
+                    // Remove this in e.g. JMRI 4.11.1 and then update all the loadref comparison files
+                    elem.setAttribute("systemName", sname);
+                    if (x.getUserName()!=null && !x.getUserName().equals("")) elem.setAttribute("userName", x.getUserName());
+                            
                     // store common part
                     storeCommon(x, elem);
 

--- a/java/src/jmri/managers/configurexml/DefaultConditionalManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultConditionalManagerXml.java
@@ -62,7 +62,13 @@ public class DefaultConditionalManagerXml extends jmri.managers.configurexml.Abs
                     log.error("Unable to save '{}' to the XML file", sname);
                     continue;
                 }
-                Element elem = new Element("conditional").setAttribute("systemName", sname);
+                Element elem = new Element("conditional");
+
+                // As a work-around for backward compatibility, store systemName and username as attribute.
+                // Remove this in e.g. JMRI 4.11.1 and then update all the loadref comparison files
+                elem.setAttribute("systemName", sname);
+                if (c.getUserName()!=null && !c.getUserName().equals("")) elem.setAttribute("userName", c.getUserName());
+
                 elem.addContent(new Element("systemName").addContent(sname));
 
                 // store common parts

--- a/java/src/jmri/managers/configurexml/DefaultLogixManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultLogixManagerXml.java
@@ -53,6 +53,10 @@ public class DefaultLogixManagerXml extends jmri.managers.configurexml.AbstractN
                 Element elem = new Element("logix");
                 elem.addContent(new Element("systemName").addContent(sname));
 
+                // As a work-around for backward compatibility, store systemName and username as attribute.
+                // Remove this in e.g. JMRI 4.11.1 and then update all the loadref comparison files
+                if (x.getUserName()!=null && !x.getUserName().equals("")) elem.setAttribute("userName", x.getUserName());
+
                 // store common part
                 storeCommon(x, elem);
 

--- a/java/src/jmri/managers/configurexml/DefaultRouteManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultRouteManagerXml.java
@@ -60,6 +60,10 @@ public class DefaultRouteManagerXml extends jmri.managers.configurexml.AbstractN
                 Element elem = new Element("route");
                 elem.addContent(new Element("systemName").addContent(sname));
 
+                // As a work-around for backward compatibility, store systemName and username as attribute.
+                // Remove this in e.g. JMRI 4.11.1 and then update all the loadref comparison files
+                if (r.getUserName()!=null && !r.getUserName().equals("")) elem.setAttribute("userName", r.getUserName());
+
                 // store common parts
                 storeCommon(r, elem);
 

--- a/java/test/jmri/configurexml/load/BlockManagerXmlTest-4.7.4.xml
+++ b/java/test/jmri/configurexml/load/BlockManagerXmlTest-4.7.4.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -298,55 +298,55 @@
   <signalgroups class="jmri.managers.configurexml.DefaultSignalGroupManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>blocknorthwest</userName>
     </block>
-    <block>
+    <block systemName="IB10">
       <systemName>IB10</systemName>
       <userName>blocksouthwest</userName>
     </block>
-    <block>
+    <block systemName="IB11">
       <systemName>IB11</systemName>
       <userName>blockwest</userName>
     </block>
-    <block>
+    <block systemName="IB12">
       <systemName>IB12</systemName>
       <userName>blockwestsiding</userName>
     </block>
-    <block>
+    <block systemName="IB2">
       <systemName>IB2</systemName>
       <userName>blocknorth</userName>
     </block>
-    <block>
+    <block systemName="IB3">
       <systemName>IB3</systemName>
       <userName>blocknorthsiding</userName>
     </block>
-    <block>
+    <block systemName="IB4">
       <systemName>IB4</systemName>
       <userName>blocknortheast</userName>
     </block>
-    <block>
+    <block systemName="IB5">
       <systemName>IB5</systemName>
       <userName>blockeast</userName>
     </block>
-    <block>
+    <block systemName="IB6">
       <systemName>IB6</systemName>
       <userName>blockeastsiding</userName>
     </block>
-    <block>
+    <block systemName="IB7">
       <systemName>IB7</systemName>
       <userName>blocksoutheast</userName>
     </block>
-    <block>
+    <block systemName="IB8">
       <systemName>IB8</systemName>
       <userName>blocksouth</userName>
     </block>
-    <block>
+    <block systemName="IB9">
       <systemName>IB9</systemName>
       <userName>blocksouthsiding</userName>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB1" length="0.0" curve="0">
       <systemName>IB1</systemName>
       <userName>blocknorthwest</userName>
       <permissive>no</permissive>
@@ -372,7 +372,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB10" length="0.0" curve="0">
       <systemName>IB10</systemName>
       <userName>blocksouthwest</userName>
       <permissive>no</permissive>
@@ -398,7 +398,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB11" length="0.0" curve="0">
       <systemName>IB11</systemName>
       <userName>blockwest</userName>
       <permissive>no</permissive>
@@ -414,7 +414,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB12" length="0.0" curve="0">
       <systemName>IB12</systemName>
       <userName>blockwestsiding</userName>
       <permissive>no</permissive>
@@ -430,7 +430,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB2" length="0.0" curve="0">
       <systemName>IB2</systemName>
       <userName>blocknorth</userName>
       <permissive>no</permissive>
@@ -446,7 +446,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB3" length="0.0" curve="0">
       <systemName>IB3</systemName>
       <userName>blocknorthsiding</userName>
       <permissive>no</permissive>
@@ -462,7 +462,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB4" length="0.0" curve="0">
       <systemName>IB4</systemName>
       <userName>blocknortheast</userName>
       <permissive>no</permissive>
@@ -488,7 +488,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB5" length="0.0" curve="0">
       <systemName>IB5</systemName>
       <userName>blockeast</userName>
       <permissive>no</permissive>
@@ -504,7 +504,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB6" length="0.0" curve="0">
       <systemName>IB6</systemName>
       <userName>blockeastsiding</userName>
       <permissive>no</permissive>
@@ -520,7 +520,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB7" length="0.0" curve="0">
       <systemName>IB7</systemName>
       <userName>blocksoutheast</userName>
       <permissive>no</permissive>
@@ -546,7 +546,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB8" length="0.0" curve="0">
       <systemName>IB8</systemName>
       <userName>blocksouth</userName>
       <permissive>no</permissive>
@@ -562,7 +562,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB9" length="0.0" curve="0">
       <systemName>IB9</systemName>
       <userName>blocksouthsiding</userName>
       <permissive>no</permissive>
@@ -581,7 +581,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <sections class="jmri.configurexml.SectionManagerXml">
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF1" rstopsensorname="ISSSTOPR1" fsensorname="ISSDIRF1" rsensorname="ISSDIRR1">
+    <section systemName="IY:AUTO:0001" userName="NorthWest" creationtype="userdefined" fstopsensorname="ISSSTOPF1" rstopsensorname="ISSSTOPR1" fsensorname="ISSDIRF1" rsensorname="ISSDIRR1">
       <systemName>IY:AUTO:0001</systemName>
       <userName>NorthWest</userName>
       <blockentry sName="IB1" order="0" />
@@ -590,21 +590,21 @@
       <entrypoint fromblock="IB2" toblock="IB1" direction="8" fixed="no" fromblockdirection="West" />
       <entrypoint fromblock="IB3" toblock="IB1" direction="8" fixed="no" fromblockdirection="West" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF2" rstopsensorname="ISSSTOPR2" fsensorname="ISSDIRF2" rsensorname="ISSDIRR2">
+    <section systemName="IY:AUTO:0002" userName="North" creationtype="userdefined" fstopsensorname="ISSSTOPF2" rstopsensorname="ISSSTOPR2" fsensorname="ISSDIRF2" rsensorname="ISSDIRR2">
       <systemName>IY:AUTO:0002</systemName>
       <userName>North</userName>
       <blockentry sName="IB2" order="0" />
       <entrypoint fromblock="IB1" toblock="IB2" direction="4" fixed="no" fromblockdirection="East" />
       <entrypoint fromblock="IB4" toblock="IB2" direction="8" fixed="no" fromblockdirection="West" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF3" rstopsensorname="ISSSTOPR3" fsensorname="ISSDIRF3" rsensorname="ISSDIRR3">
+    <section systemName="IY:AUTO:0003" userName="NorthSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF3" rstopsensorname="ISSSTOPR3" fsensorname="ISSDIRF3" rsensorname="ISSDIRR3">
       <systemName>IY:AUTO:0003</systemName>
       <userName>NorthSiding</userName>
       <blockentry sName="IB3" order="0" />
       <entrypoint fromblock="IB1" toblock="IB3" direction="4" fixed="no" fromblockdirection="East" />
       <entrypoint fromblock="IB4" toblock="IB3" direction="8" fixed="no" fromblockdirection="West" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF4" rstopsensorname="ISSSTOPR4" fsensorname="ISSDIRF4" rsensorname="ISSDIRR4">
+    <section systemName="IY:AUTO:0004" userName="NorthEast" creationtype="userdefined" fstopsensorname="ISSSTOPF4" rstopsensorname="ISSSTOPR4" fsensorname="ISSDIRF4" rsensorname="ISSDIRR4">
       <systemName>IY:AUTO:0004</systemName>
       <userName>NorthEast</userName>
       <blockentry sName="IB4" order="0" />
@@ -613,21 +613,21 @@
       <entrypoint fromblock="IB5" toblock="IB4" direction="8" fixed="no" fromblockdirection="North" />
       <entrypoint fromblock="IB6" toblock="IB4" direction="8" fixed="no" fromblockdirection="North" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF5" rstopsensorname="ISSSTOPR5" fsensorname="ISSDIRF5" rsensorname="ISSDIRR5">
+    <section systemName="IY:AUTO:0005" userName="East" creationtype="userdefined" fstopsensorname="ISSSTOPF5" rstopsensorname="ISSSTOPR5" fsensorname="ISSDIRF5" rsensorname="ISSDIRR5">
       <systemName>IY:AUTO:0005</systemName>
       <userName>East</userName>
       <blockentry sName="IB5" order="0" />
       <entrypoint fromblock="IB4" toblock="IB5" direction="4" fixed="no" fromblockdirection="South" />
       <entrypoint fromblock="IB7" toblock="IB5" direction="8" fixed="no" fromblockdirection="North" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF6" rstopsensorname="ISSSTOPR6" fsensorname="ISSDIRF6" rsensorname="ISSDIRR6">
+    <section systemName="IY:AUTO:0006" userName="EastSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF6" rstopsensorname="ISSSTOPR6" fsensorname="ISSDIRF6" rsensorname="ISSDIRR6">
       <systemName>IY:AUTO:0006</systemName>
       <userName>EastSiding</userName>
       <blockentry sName="IB6" order="0" />
       <entrypoint fromblock="IB4" toblock="IB6" direction="4" fixed="no" fromblockdirection="South" />
       <entrypoint fromblock="IB7" toblock="IB6" direction="8" fixed="no" fromblockdirection="North" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF7" rstopsensorname="ISSSTOPR7" fsensorname="ISSDIRF7" rsensorname="ISSDIRR7">
+    <section systemName="IY:AUTO:0007" userName="SouthEast" creationtype="userdefined" fstopsensorname="ISSSTOPF7" rstopsensorname="ISSSTOPR7" fsensorname="ISSDIRF7" rsensorname="ISSDIRR7">
       <systemName>IY:AUTO:0007</systemName>
       <userName>SouthEast</userName>
       <blockentry sName="IB7" order="0" />
@@ -636,21 +636,21 @@
       <entrypoint fromblock="IB8" toblock="IB7" direction="8" fixed="no" fromblockdirection="East" />
       <entrypoint fromblock="IB9" toblock="IB7" direction="8" fixed="no" fromblockdirection="East" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF8" rstopsensorname="ISSSTOPR8" fsensorname="ISSDIRF8" rsensorname="ISSDIRR8">
+    <section systemName="IY:AUTO:0008" userName="South" creationtype="userdefined" fstopsensorname="ISSSTOPF8" rstopsensorname="ISSSTOPR8" fsensorname="ISSDIRF8" rsensorname="ISSDIRR8">
       <systemName>IY:AUTO:0008</systemName>
       <userName>South</userName>
       <blockentry sName="IB8" order="0" />
       <entrypoint fromblock="IB7" toblock="IB8" direction="4" fixed="no" fromblockdirection="West" />
       <entrypoint fromblock="IB10" toblock="IB8" direction="8" fixed="no" fromblockdirection="East" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF9" rstopsensorname="ISSSTOPR9" fsensorname="ISSDIRF9" rsensorname="ISSDIRR9">
+    <section systemName="IY:AUTO:0009" userName="SouthSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF9" rstopsensorname="ISSSTOPR9" fsensorname="ISSDIRF9" rsensorname="ISSDIRR9">
       <systemName>IY:AUTO:0009</systemName>
       <userName>SouthSiding</userName>
       <blockentry sName="IB9" order="0" />
       <entrypoint fromblock="IB7" toblock="IB9" direction="4" fixed="no" fromblockdirection="West" />
       <entrypoint fromblock="IB10" toblock="IB9" direction="8" fixed="no" fromblockdirection="East" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF10" rstopsensorname="ISSSTOPR10" fsensorname="ISSDIRF10" rsensorname="ISSDIRR10">
+    <section systemName="IY:AUTO:0010" userName="SouthWest" creationtype="userdefined" fstopsensorname="ISSSTOPF10" rstopsensorname="ISSSTOPR10" fsensorname="ISSDIRF10" rsensorname="ISSDIRR10">
       <systemName>IY:AUTO:0010</systemName>
       <userName>SouthWest</userName>
       <blockentry sName="IB10" order="0" />
@@ -659,14 +659,14 @@
       <entrypoint fromblock="IB11" toblock="IB10" direction="8" fixed="no" fromblockdirection="South" />
       <entrypoint fromblock="IB12" toblock="IB10" direction="8" fixed="no" fromblockdirection="South" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF11" rstopsensorname="ISSSTOPR11" fsensorname="ISSDIRF11" rsensorname="ISSDIRR11">
+    <section systemName="IY:AUTO:0011" userName="West" creationtype="userdefined" fstopsensorname="ISSSTOPF11" rstopsensorname="ISSSTOPR11" fsensorname="ISSDIRF11" rsensorname="ISSDIRR11">
       <systemName>IY:AUTO:0011</systemName>
       <userName>West</userName>
       <blockentry sName="IB11" order="0" />
       <entrypoint fromblock="IB10" toblock="IB11" direction="4" fixed="no" fromblockdirection="North" />
       <entrypoint fromblock="IB1" toblock="IB11" direction="8" fixed="no" fromblockdirection="South" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF12" rstopsensorname="ISSSTOPR12" fsensorname="ISSDIRF12" rsensorname="ISSDIRR12">
+    <section systemName="IY:AUTO:0012" userName="WestSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF12" rstopsensorname="ISSSTOPR12" fsensorname="ISSDIRF12" rsensorname="ISSDIRR12">
       <systemName>IY:AUTO:0012</systemName>
       <userName>WestSiding</userName>
       <blockentry sName="IB12" order="0" />
@@ -679,5 +679,5 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 17 22:26:06 PDT 2016" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0556Z+R3cb853fe70 on Sun May 07 22:56:36 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:11:02 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/load/LoadFileTest-4.7.4.xml
+++ b/java/test/jmri/configurexml/load/LoadFileTest-4.7.4.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -117,20 +117,20 @@
   <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
     </block>
-    <block>
+    <block systemName="IB2">
       <systemName>IB2</systemName>
     </block>
-    <block length="25.4" curve="0">
+    <block systemName="IB1" length="25.4" curve="0">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
       <comment>Length 1</comment>
       <permissive>no</permissive>
     </block>
-    <block length="15.8" curve="0">
+    <block systemName="IB2" length="15.8" curve="0">
       <systemName>IB2</systemName>
       <comment>Length 900</comment>
       <permissive>yes</permissive>
@@ -138,7 +138,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <routes class="jmri.managers.configurexml.DefaultRouteManagerXml">
-    <route controlTurnout="IT101" controlTurnoutState="CLOSED">
+    <route userName="random route 1" controlTurnout="IT101" controlTurnoutState="CLOSED">
       <systemName>IR1</systemName>
       <userName>random route 1</userName>
       <routeOutputTurnout systemName="IT1" state="THROWN" />
@@ -155,7 +155,7 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
-    <logix enabled="yes">
+    <logix userName="Test logix" enabled="yes">
       <systemName>IX1</systemName>
       <userName>Test logix</userName>
       <logixConditional systemName="IX1C1" order="0" />
@@ -170,5 +170,5 @@
     </conditional>
   </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 05 23:42:04 PDT 2009" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0648Z+R90413022ff on Sun May 07 23:48:24 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:13:05 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/load/LoadFileTest277-4.7.4.xml
+++ b/java/test/jmri/configurexml/load/LoadFileTest277-4.7.4.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -114,11 +114,11 @@
   <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
     </block>
-    <block length="25.4" curve="0">
+    <block systemName="IB1" length="25.4" curve="0">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
       <comment>Length 1</comment>
@@ -127,7 +127,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <routes class="jmri.managers.configurexml.DefaultRouteManagerXml">
-    <route controlTurnout="IT101" controlTurnoutState="CLOSED">
+    <route userName="random route 1" controlTurnout="IT101" controlTurnoutState="CLOSED">
       <systemName>IR1</systemName>
       <userName>random route 1</userName>
       <routeOutputTurnout systemName="IT1" state="THROWN" />
@@ -144,7 +144,7 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
-    <logix enabled="yes">
+    <logix userName="Test logix" enabled="yes">
       <systemName>IX1</systemName>
       <userName>Test logix</userName>
       <logixConditional systemName="IX1C1" order="0" />
@@ -159,5 +159,5 @@
     </conditional>
   </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 05 23:42:04 PDT 2009" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0625Z+R3cb853fe70 on Sun May 07 23:25:31 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:21:33 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/load/LoadFileTest295-4.7.4.xml
+++ b/java/test/jmri/configurexml/load/LoadFileTest295-4.7.4.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -111,11 +111,11 @@
   <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
     </block>
-    <block length="25.4" curve="0">
+    <block systemName="IB1" length="25.4" curve="0">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
       <comment>Length 1</comment>
@@ -124,7 +124,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <routes class="jmri.managers.configurexml.DefaultRouteManagerXml">
-    <route controlTurnout="IT101" controlTurnoutState="CLOSED">
+    <route userName="random route 1" controlTurnout="IT101" controlTurnoutState="CLOSED">
       <systemName>IR1</systemName>
       <userName>random route 1</userName>
       <routeOutputTurnout systemName="IT1" state="THROWN" />
@@ -141,7 +141,7 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
-    <logix enabled="yes">
+    <logix userName="Test logix" enabled="yes">
       <systemName>IX1</systemName>
       <userName>Test logix</userName>
       <logixConditional systemName="IX1C1" order="0" />
@@ -156,5 +156,5 @@
     </conditional>
   </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 05 23:42:04 PDT 2009" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0639Z+R31e3f566ff on Sun May 07 23:39:47 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:16:15 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/load/PanelFileSchemaTest382-4.7.4.xml
+++ b/java/test/jmri/configurexml/load/PanelFileSchemaTest382-4.7.4.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -111,11 +111,11 @@
   <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
     </block>
-    <block length="25.4" curve="0">
+    <block systemName="IB1" length="25.4" curve="0">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
       <comment>Length 1</comment>
@@ -124,7 +124,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <routes class="jmri.managers.configurexml.DefaultRouteManagerXml">
-    <route controlTurnout="IT101" controlTurnoutState="CLOSED">
+    <route userName="random route 1" controlTurnout="IT101" controlTurnoutState="CLOSED">
       <systemName>IR1</systemName>
       <userName>random route 1</userName>
       <routeOutputTurnout systemName="IT1" state="THROWN" />
@@ -141,7 +141,7 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
-    <logix enabled="yes">
+    <logix userName="Test logix" enabled="yes">
       <systemName>IX1</systemName>
       <userName>Test logix</userName>
       <logixConditional systemName="IX1C1" order="0" />
@@ -156,5 +156,5 @@
     </conditional>
   </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 05 23:42:04 PDT 2009" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0613Z+R3cb853fe70 on Sun May 07 23:14:02 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:13:07 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/load/SectionManagerXmlTest-4.7.4.xml
+++ b/java/test/jmri/configurexml/load/SectionManagerXmlTest-4.7.4.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -298,55 +298,55 @@
   <signalgroups class="jmri.managers.configurexml.DefaultSignalGroupManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>blocknorthwest</userName>
     </block>
-    <block>
+    <block systemName="IB10">
       <systemName>IB10</systemName>
       <userName>blocksouthwest</userName>
     </block>
-    <block>
+    <block systemName="IB11">
       <systemName>IB11</systemName>
       <userName>blockwest</userName>
     </block>
-    <block>
+    <block systemName="IB12">
       <systemName>IB12</systemName>
       <userName>blockwestsiding</userName>
     </block>
-    <block>
+    <block systemName="IB2">
       <systemName>IB2</systemName>
       <userName>blocknorth</userName>
     </block>
-    <block>
+    <block systemName="IB3">
       <systemName>IB3</systemName>
       <userName>blocknorthsiding</userName>
     </block>
-    <block>
+    <block systemName="IB4">
       <systemName>IB4</systemName>
       <userName>blocknortheast</userName>
     </block>
-    <block>
+    <block systemName="IB5">
       <systemName>IB5</systemName>
       <userName>blockeast</userName>
     </block>
-    <block>
+    <block systemName="IB6">
       <systemName>IB6</systemName>
       <userName>blockeastsiding</userName>
     </block>
-    <block>
+    <block systemName="IB7">
       <systemName>IB7</systemName>
       <userName>blocksoutheast</userName>
     </block>
-    <block>
+    <block systemName="IB8">
       <systemName>IB8</systemName>
       <userName>blocksouth</userName>
     </block>
-    <block>
+    <block systemName="IB9">
       <systemName>IB9</systemName>
       <userName>blocksouthsiding</userName>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB1" length="0.0" curve="0">
       <systemName>IB1</systemName>
       <userName>blocknorthwest</userName>
       <permissive>no</permissive>
@@ -372,7 +372,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB10" length="0.0" curve="0">
       <systemName>IB10</systemName>
       <userName>blocksouthwest</userName>
       <permissive>no</permissive>
@@ -398,7 +398,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB11" length="0.0" curve="0">
       <systemName>IB11</systemName>
       <userName>blockwest</userName>
       <permissive>no</permissive>
@@ -414,7 +414,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB12" length="0.0" curve="0">
       <systemName>IB12</systemName>
       <userName>blockwestsiding</userName>
       <permissive>no</permissive>
@@ -430,7 +430,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB2" length="0.0" curve="0">
       <systemName>IB2</systemName>
       <userName>blocknorth</userName>
       <permissive>no</permissive>
@@ -446,7 +446,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB3" length="0.0" curve="0">
       <systemName>IB3</systemName>
       <userName>blocknorthsiding</userName>
       <permissive>no</permissive>
@@ -462,7 +462,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB4" length="0.0" curve="0">
       <systemName>IB4</systemName>
       <userName>blocknortheast</userName>
       <permissive>no</permissive>
@@ -488,7 +488,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB5" length="0.0" curve="0">
       <systemName>IB5</systemName>
       <userName>blockeast</userName>
       <permissive>no</permissive>
@@ -504,7 +504,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB6" length="0.0" curve="0">
       <systemName>IB6</systemName>
       <userName>blockeastsiding</userName>
       <permissive>no</permissive>
@@ -520,7 +520,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB7" length="0.0" curve="0">
       <systemName>IB7</systemName>
       <userName>blocksoutheast</userName>
       <permissive>no</permissive>
@@ -546,7 +546,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB8" length="0.0" curve="0">
       <systemName>IB8</systemName>
       <userName>blocksouth</userName>
       <permissive>no</permissive>
@@ -562,7 +562,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB9" length="0.0" curve="0">
       <systemName>IB9</systemName>
       <userName>blocksouthsiding</userName>
       <permissive>no</permissive>
@@ -581,7 +581,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <sections class="jmri.configurexml.SectionManagerXml">
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF1" rstopsensorname="ISSSTOPR1" fsensorname="ISSDIRF1" rsensorname="ISSDIRR1">
+    <section systemName="IY:AUTO:0001" userName="NorthWest" creationtype="userdefined" fstopsensorname="ISSSTOPF1" rstopsensorname="ISSSTOPR1" fsensorname="ISSDIRF1" rsensorname="ISSDIRR1">
       <systemName>IY:AUTO:0001</systemName>
       <userName>NorthWest</userName>
       <blockentry sName="IB1" order="0" />
@@ -590,21 +590,21 @@
       <entrypoint fromblock="IB2" toblock="IB1" direction="8" fixed="no" fromblockdirection="West" />
       <entrypoint fromblock="IB3" toblock="IB1" direction="8" fixed="no" fromblockdirection="West" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF2" rstopsensorname="ISSSTOPR2" fsensorname="ISSDIRF2" rsensorname="ISSDIRR2">
+    <section systemName="IY:AUTO:0002" userName="North" creationtype="userdefined" fstopsensorname="ISSSTOPF2" rstopsensorname="ISSSTOPR2" fsensorname="ISSDIRF2" rsensorname="ISSDIRR2">
       <systemName>IY:AUTO:0002</systemName>
       <userName>North</userName>
       <blockentry sName="IB2" order="0" />
       <entrypoint fromblock="IB1" toblock="IB2" direction="4" fixed="no" fromblockdirection="East" />
       <entrypoint fromblock="IB4" toblock="IB2" direction="8" fixed="no" fromblockdirection="West" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF3" rstopsensorname="ISSSTOPR3" fsensorname="ISSDIRF3" rsensorname="ISSDIRR3">
+    <section systemName="IY:AUTO:0003" userName="NorthSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF3" rstopsensorname="ISSSTOPR3" fsensorname="ISSDIRF3" rsensorname="ISSDIRR3">
       <systemName>IY:AUTO:0003</systemName>
       <userName>NorthSiding</userName>
       <blockentry sName="IB3" order="0" />
       <entrypoint fromblock="IB1" toblock="IB3" direction="4" fixed="no" fromblockdirection="East" />
       <entrypoint fromblock="IB4" toblock="IB3" direction="8" fixed="no" fromblockdirection="West" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF4" rstopsensorname="ISSSTOPR4" fsensorname="ISSDIRF4" rsensorname="ISSDIRR4">
+    <section systemName="IY:AUTO:0004" userName="NorthEast" creationtype="userdefined" fstopsensorname="ISSSTOPF4" rstopsensorname="ISSSTOPR4" fsensorname="ISSDIRF4" rsensorname="ISSDIRR4">
       <systemName>IY:AUTO:0004</systemName>
       <userName>NorthEast</userName>
       <blockentry sName="IB4" order="0" />
@@ -613,21 +613,21 @@
       <entrypoint fromblock="IB5" toblock="IB4" direction="8" fixed="no" fromblockdirection="North" />
       <entrypoint fromblock="IB6" toblock="IB4" direction="8" fixed="no" fromblockdirection="North" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF5" rstopsensorname="ISSSTOPR5" fsensorname="ISSDIRF5" rsensorname="ISSDIRR5">
+    <section systemName="IY:AUTO:0005" userName="East" creationtype="userdefined" fstopsensorname="ISSSTOPF5" rstopsensorname="ISSSTOPR5" fsensorname="ISSDIRF5" rsensorname="ISSDIRR5">
       <systemName>IY:AUTO:0005</systemName>
       <userName>East</userName>
       <blockentry sName="IB5" order="0" />
       <entrypoint fromblock="IB4" toblock="IB5" direction="4" fixed="no" fromblockdirection="South" />
       <entrypoint fromblock="IB7" toblock="IB5" direction="8" fixed="no" fromblockdirection="North" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF6" rstopsensorname="ISSSTOPR6" fsensorname="ISSDIRF6" rsensorname="ISSDIRR6">
+    <section systemName="IY:AUTO:0006" userName="EastSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF6" rstopsensorname="ISSSTOPR6" fsensorname="ISSDIRF6" rsensorname="ISSDIRR6">
       <systemName>IY:AUTO:0006</systemName>
       <userName>EastSiding</userName>
       <blockentry sName="IB6" order="0" />
       <entrypoint fromblock="IB4" toblock="IB6" direction="4" fixed="no" fromblockdirection="South" />
       <entrypoint fromblock="IB7" toblock="IB6" direction="8" fixed="no" fromblockdirection="North" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF7" rstopsensorname="ISSSTOPR7" fsensorname="ISSDIRF7" rsensorname="ISSDIRR7">
+    <section systemName="IY:AUTO:0007" userName="SouthEast" creationtype="userdefined" fstopsensorname="ISSSTOPF7" rstopsensorname="ISSSTOPR7" fsensorname="ISSDIRF7" rsensorname="ISSDIRR7">
       <systemName>IY:AUTO:0007</systemName>
       <userName>SouthEast</userName>
       <blockentry sName="IB7" order="0" />
@@ -636,21 +636,21 @@
       <entrypoint fromblock="IB8" toblock="IB7" direction="8" fixed="no" fromblockdirection="East" />
       <entrypoint fromblock="IB9" toblock="IB7" direction="8" fixed="no" fromblockdirection="East" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF8" rstopsensorname="ISSSTOPR8" fsensorname="ISSDIRF8" rsensorname="ISSDIRR8">
+    <section systemName="IY:AUTO:0008" userName="South" creationtype="userdefined" fstopsensorname="ISSSTOPF8" rstopsensorname="ISSSTOPR8" fsensorname="ISSDIRF8" rsensorname="ISSDIRR8">
       <systemName>IY:AUTO:0008</systemName>
       <userName>South</userName>
       <blockentry sName="IB8" order="0" />
       <entrypoint fromblock="IB7" toblock="IB8" direction="4" fixed="no" fromblockdirection="West" />
       <entrypoint fromblock="IB10" toblock="IB8" direction="8" fixed="no" fromblockdirection="East" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF9" rstopsensorname="ISSSTOPR9" fsensorname="ISSDIRF9" rsensorname="ISSDIRR9">
+    <section systemName="IY:AUTO:0009" userName="SouthSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF9" rstopsensorname="ISSSTOPR9" fsensorname="ISSDIRF9" rsensorname="ISSDIRR9">
       <systemName>IY:AUTO:0009</systemName>
       <userName>SouthSiding</userName>
       <blockentry sName="IB9" order="0" />
       <entrypoint fromblock="IB7" toblock="IB9" direction="4" fixed="no" fromblockdirection="West" />
       <entrypoint fromblock="IB10" toblock="IB9" direction="8" fixed="no" fromblockdirection="East" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF10" rstopsensorname="ISSSTOPR10" fsensorname="ISSDIRF10" rsensorname="ISSDIRR10">
+    <section systemName="IY:AUTO:0010" userName="SouthWest" creationtype="userdefined" fstopsensorname="ISSSTOPF10" rstopsensorname="ISSSTOPR10" fsensorname="ISSDIRF10" rsensorname="ISSDIRR10">
       <systemName>IY:AUTO:0010</systemName>
       <userName>SouthWest</userName>
       <blockentry sName="IB10" order="0" />
@@ -659,14 +659,14 @@
       <entrypoint fromblock="IB11" toblock="IB10" direction="8" fixed="no" fromblockdirection="South" />
       <entrypoint fromblock="IB12" toblock="IB10" direction="8" fixed="no" fromblockdirection="South" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF11" rstopsensorname="ISSSTOPR11" fsensorname="ISSDIRF11" rsensorname="ISSDIRR11">
+    <section systemName="IY:AUTO:0011" userName="West" creationtype="userdefined" fstopsensorname="ISSSTOPF11" rstopsensorname="ISSSTOPR11" fsensorname="ISSDIRF11" rsensorname="ISSDIRR11">
       <systemName>IY:AUTO:0011</systemName>
       <userName>West</userName>
       <blockentry sName="IB11" order="0" />
       <entrypoint fromblock="IB10" toblock="IB11" direction="4" fixed="no" fromblockdirection="North" />
       <entrypoint fromblock="IB1" toblock="IB11" direction="8" fixed="no" fromblockdirection="South" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF12" rstopsensorname="ISSSTOPR12" fsensorname="ISSDIRF12" rsensorname="ISSDIRR12">
+    <section systemName="IY:AUTO:0012" userName="WestSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF12" rstopsensorname="ISSSTOPR12" fsensorname="ISSDIRF12" rsensorname="ISSDIRR12">
       <systemName>IY:AUTO:0012</systemName>
       <userName>WestSiding</userName>
       <blockentry sName="IB12" order="0" />
@@ -675,7 +675,7 @@
     </section>
   </sections>
   <transits class="jmri.configurexml.TransitManagerXml">
-    <transit>
+    <transit systemName="IZ:AUTO:0001" userName="gocw1">
       <systemName>IZ:AUTO:0001</systemName>
       <userName>gocw1</userName>
       <transitsection sectionname="IY:AUTO:0003" sequence="1" direction="4" alternate="no" />
@@ -688,14 +688,14 @@
       <transitsection sectionname="IY:AUTO:0010" sequence="6" direction="4" alternate="no" />
       <transitsection sectionname="IY:AUTO:0012" sequence="7" direction="4" alternate="no" />
     </transit>
-    <transit>
+    <transit systemName="IZ:AUTO:0002" userName="gocw2">
       <systemName>IZ:AUTO:0002</systemName>
       <userName>gocw2</userName>
       <transitsection sectionname="IY:AUTO:0012" sequence="1" direction="4" alternate="no" />
       <transitsection sectionname="IY:AUTO:0001" sequence="2" direction="4" alternate="no" />
       <transitsection sectionname="IY:AUTO:0003" sequence="3" direction="4" alternate="no" />
     </transit>
-    <transit>
+    <transit systemName="IZ:AUTO:0003" userName="goccw1">
       <systemName>IZ:AUTO:0003</systemName>
       <userName>goccw1</userName>
       <transitsection sectionname="IY:AUTO:0009" sequence="1" direction="8" alternate="no" />
@@ -708,7 +708,7 @@
       <transitsection sectionname="IY:AUTO:0001" sequence="6" direction="8" alternate="no" />
       <transitsection sectionname="IY:AUTO:0011" sequence="7" direction="8" alternate="no" />
     </transit>
-    <transit>
+    <transit systemName="IZ:AUTO:0004" userName="goccw2">
       <systemName>IZ:AUTO:0004</systemName>
       <userName>goccw2</userName>
       <transitsection sectionname="IY:AUTO:0011" sequence="1" direction="8" alternate="no" />
@@ -721,5 +721,5 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 17 22:25:15 PDT 2016" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0636Z+R31e3f566ff on Sun May 07 23:36:39 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:16:16 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/loadref/BlockManagerXmlTest.xml
+++ b/java/test/jmri/configurexml/loadref/BlockManagerXmlTest.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -298,55 +298,55 @@
   <signalgroups class="jmri.managers.configurexml.DefaultSignalGroupManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>blocknorthwest</userName>
     </block>
-    <block>
+    <block systemName="IB10">
       <systemName>IB10</systemName>
       <userName>blocksouthwest</userName>
     </block>
-    <block>
+    <block systemName="IB11">
       <systemName>IB11</systemName>
       <userName>blockwest</userName>
     </block>
-    <block>
+    <block systemName="IB12">
       <systemName>IB12</systemName>
       <userName>blockwestsiding</userName>
     </block>
-    <block>
+    <block systemName="IB2">
       <systemName>IB2</systemName>
       <userName>blocknorth</userName>
     </block>
-    <block>
+    <block systemName="IB3">
       <systemName>IB3</systemName>
       <userName>blocknorthsiding</userName>
     </block>
-    <block>
+    <block systemName="IB4">
       <systemName>IB4</systemName>
       <userName>blocknortheast</userName>
     </block>
-    <block>
+    <block systemName="IB5">
       <systemName>IB5</systemName>
       <userName>blockeast</userName>
     </block>
-    <block>
+    <block systemName="IB6">
       <systemName>IB6</systemName>
       <userName>blockeastsiding</userName>
     </block>
-    <block>
+    <block systemName="IB7">
       <systemName>IB7</systemName>
       <userName>blocksoutheast</userName>
     </block>
-    <block>
+    <block systemName="IB8">
       <systemName>IB8</systemName>
       <userName>blocksouth</userName>
     </block>
-    <block>
+    <block systemName="IB9">
       <systemName>IB9</systemName>
       <userName>blocksouthsiding</userName>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB1" length="0.0" curve="0">
       <systemName>IB1</systemName>
       <userName>blocknorthwest</userName>
       <permissive>no</permissive>
@@ -372,7 +372,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB10" length="0.0" curve="0">
       <systemName>IB10</systemName>
       <userName>blocksouthwest</userName>
       <permissive>no</permissive>
@@ -398,7 +398,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB11" length="0.0" curve="0">
       <systemName>IB11</systemName>
       <userName>blockwest</userName>
       <permissive>no</permissive>
@@ -414,7 +414,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB12" length="0.0" curve="0">
       <systemName>IB12</systemName>
       <userName>blockwestsiding</userName>
       <permissive>no</permissive>
@@ -430,7 +430,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB2" length="0.0" curve="0">
       <systemName>IB2</systemName>
       <userName>blocknorth</userName>
       <permissive>no</permissive>
@@ -446,7 +446,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB3" length="0.0" curve="0">
       <systemName>IB3</systemName>
       <userName>blocknorthsiding</userName>
       <permissive>no</permissive>
@@ -462,7 +462,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB4" length="0.0" curve="0">
       <systemName>IB4</systemName>
       <userName>blocknortheast</userName>
       <permissive>no</permissive>
@@ -488,7 +488,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB5" length="0.0" curve="0">
       <systemName>IB5</systemName>
       <userName>blockeast</userName>
       <permissive>no</permissive>
@@ -504,7 +504,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB6" length="0.0" curve="0">
       <systemName>IB6</systemName>
       <userName>blockeastsiding</userName>
       <permissive>no</permissive>
@@ -520,7 +520,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB7" length="0.0" curve="0">
       <systemName>IB7</systemName>
       <userName>blocksoutheast</userName>
       <permissive>no</permissive>
@@ -546,7 +546,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB8" length="0.0" curve="0">
       <systemName>IB8</systemName>
       <userName>blocksouth</userName>
       <permissive>no</permissive>
@@ -562,7 +562,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB9" length="0.0" curve="0">
       <systemName>IB9</systemName>
       <userName>blocksouthsiding</userName>
       <permissive>no</permissive>
@@ -581,7 +581,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <sections class="jmri.configurexml.SectionManagerXml">
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF1" rstopsensorname="ISSSTOPR1" fsensorname="ISSDIRF1" rsensorname="ISSDIRR1">
+    <section systemName="IY:AUTO:0001" userName="NorthWest" creationtype="userdefined" fstopsensorname="ISSSTOPF1" rstopsensorname="ISSSTOPR1" fsensorname="ISSDIRF1" rsensorname="ISSDIRR1">
       <systemName>IY:AUTO:0001</systemName>
       <userName>NorthWest</userName>
       <blockentry sName="IB1" order="0" />
@@ -590,21 +590,21 @@
       <entrypoint fromblock="IB2" toblock="IB1" direction="8" fixed="no" fromblockdirection="West" />
       <entrypoint fromblock="IB3" toblock="IB1" direction="8" fixed="no" fromblockdirection="West" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF2" rstopsensorname="ISSSTOPR2" fsensorname="ISSDIRF2" rsensorname="ISSDIRR2">
+    <section systemName="IY:AUTO:0002" userName="North" creationtype="userdefined" fstopsensorname="ISSSTOPF2" rstopsensorname="ISSSTOPR2" fsensorname="ISSDIRF2" rsensorname="ISSDIRR2">
       <systemName>IY:AUTO:0002</systemName>
       <userName>North</userName>
       <blockentry sName="IB2" order="0" />
       <entrypoint fromblock="IB1" toblock="IB2" direction="4" fixed="no" fromblockdirection="East" />
       <entrypoint fromblock="IB4" toblock="IB2" direction="8" fixed="no" fromblockdirection="West" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF3" rstopsensorname="ISSSTOPR3" fsensorname="ISSDIRF3" rsensorname="ISSDIRR3">
+    <section systemName="IY:AUTO:0003" userName="NorthSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF3" rstopsensorname="ISSSTOPR3" fsensorname="ISSDIRF3" rsensorname="ISSDIRR3">
       <systemName>IY:AUTO:0003</systemName>
       <userName>NorthSiding</userName>
       <blockentry sName="IB3" order="0" />
       <entrypoint fromblock="IB1" toblock="IB3" direction="4" fixed="no" fromblockdirection="East" />
       <entrypoint fromblock="IB4" toblock="IB3" direction="8" fixed="no" fromblockdirection="West" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF4" rstopsensorname="ISSSTOPR4" fsensorname="ISSDIRF4" rsensorname="ISSDIRR4">
+    <section systemName="IY:AUTO:0004" userName="NorthEast" creationtype="userdefined" fstopsensorname="ISSSTOPF4" rstopsensorname="ISSSTOPR4" fsensorname="ISSDIRF4" rsensorname="ISSDIRR4">
       <systemName>IY:AUTO:0004</systemName>
       <userName>NorthEast</userName>
       <blockentry sName="IB4" order="0" />
@@ -613,21 +613,21 @@
       <entrypoint fromblock="IB5" toblock="IB4" direction="8" fixed="no" fromblockdirection="North" />
       <entrypoint fromblock="IB6" toblock="IB4" direction="8" fixed="no" fromblockdirection="North" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF5" rstopsensorname="ISSSTOPR5" fsensorname="ISSDIRF5" rsensorname="ISSDIRR5">
+    <section systemName="IY:AUTO:0005" userName="East" creationtype="userdefined" fstopsensorname="ISSSTOPF5" rstopsensorname="ISSSTOPR5" fsensorname="ISSDIRF5" rsensorname="ISSDIRR5">
       <systemName>IY:AUTO:0005</systemName>
       <userName>East</userName>
       <blockentry sName="IB5" order="0" />
       <entrypoint fromblock="IB4" toblock="IB5" direction="4" fixed="no" fromblockdirection="South" />
       <entrypoint fromblock="IB7" toblock="IB5" direction="8" fixed="no" fromblockdirection="North" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF6" rstopsensorname="ISSSTOPR6" fsensorname="ISSDIRF6" rsensorname="ISSDIRR6">
+    <section systemName="IY:AUTO:0006" userName="EastSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF6" rstopsensorname="ISSSTOPR6" fsensorname="ISSDIRF6" rsensorname="ISSDIRR6">
       <systemName>IY:AUTO:0006</systemName>
       <userName>EastSiding</userName>
       <blockentry sName="IB6" order="0" />
       <entrypoint fromblock="IB4" toblock="IB6" direction="4" fixed="no" fromblockdirection="South" />
       <entrypoint fromblock="IB7" toblock="IB6" direction="8" fixed="no" fromblockdirection="North" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF7" rstopsensorname="ISSSTOPR7" fsensorname="ISSDIRF7" rsensorname="ISSDIRR7">
+    <section systemName="IY:AUTO:0007" userName="SouthEast" creationtype="userdefined" fstopsensorname="ISSSTOPF7" rstopsensorname="ISSSTOPR7" fsensorname="ISSDIRF7" rsensorname="ISSDIRR7">
       <systemName>IY:AUTO:0007</systemName>
       <userName>SouthEast</userName>
       <blockentry sName="IB7" order="0" />
@@ -636,21 +636,21 @@
       <entrypoint fromblock="IB8" toblock="IB7" direction="8" fixed="no" fromblockdirection="East" />
       <entrypoint fromblock="IB9" toblock="IB7" direction="8" fixed="no" fromblockdirection="East" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF8" rstopsensorname="ISSSTOPR8" fsensorname="ISSDIRF8" rsensorname="ISSDIRR8">
+    <section systemName="IY:AUTO:0008" userName="South" creationtype="userdefined" fstopsensorname="ISSSTOPF8" rstopsensorname="ISSSTOPR8" fsensorname="ISSDIRF8" rsensorname="ISSDIRR8">
       <systemName>IY:AUTO:0008</systemName>
       <userName>South</userName>
       <blockentry sName="IB8" order="0" />
       <entrypoint fromblock="IB7" toblock="IB8" direction="4" fixed="no" fromblockdirection="West" />
       <entrypoint fromblock="IB10" toblock="IB8" direction="8" fixed="no" fromblockdirection="East" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF9" rstopsensorname="ISSSTOPR9" fsensorname="ISSDIRF9" rsensorname="ISSDIRR9">
+    <section systemName="IY:AUTO:0009" userName="SouthSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF9" rstopsensorname="ISSSTOPR9" fsensorname="ISSDIRF9" rsensorname="ISSDIRR9">
       <systemName>IY:AUTO:0009</systemName>
       <userName>SouthSiding</userName>
       <blockentry sName="IB9" order="0" />
       <entrypoint fromblock="IB7" toblock="IB9" direction="4" fixed="no" fromblockdirection="West" />
       <entrypoint fromblock="IB10" toblock="IB9" direction="8" fixed="no" fromblockdirection="East" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF10" rstopsensorname="ISSSTOPR10" fsensorname="ISSDIRF10" rsensorname="ISSDIRR10">
+    <section systemName="IY:AUTO:0010" userName="SouthWest" creationtype="userdefined" fstopsensorname="ISSSTOPF10" rstopsensorname="ISSSTOPR10" fsensorname="ISSDIRF10" rsensorname="ISSDIRR10">
       <systemName>IY:AUTO:0010</systemName>
       <userName>SouthWest</userName>
       <blockentry sName="IB10" order="0" />
@@ -659,14 +659,14 @@
       <entrypoint fromblock="IB11" toblock="IB10" direction="8" fixed="no" fromblockdirection="South" />
       <entrypoint fromblock="IB12" toblock="IB10" direction="8" fixed="no" fromblockdirection="South" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF11" rstopsensorname="ISSSTOPR11" fsensorname="ISSDIRF11" rsensorname="ISSDIRR11">
+    <section systemName="IY:AUTO:0011" userName="West" creationtype="userdefined" fstopsensorname="ISSSTOPF11" rstopsensorname="ISSSTOPR11" fsensorname="ISSDIRF11" rsensorname="ISSDIRR11">
       <systemName>IY:AUTO:0011</systemName>
       <userName>West</userName>
       <blockentry sName="IB11" order="0" />
       <entrypoint fromblock="IB10" toblock="IB11" direction="4" fixed="no" fromblockdirection="North" />
       <entrypoint fromblock="IB1" toblock="IB11" direction="8" fixed="no" fromblockdirection="South" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF12" rstopsensorname="ISSSTOPR12" fsensorname="ISSDIRF12" rsensorname="ISSDIRR12">
+    <section systemName="IY:AUTO:0012" userName="WestSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF12" rstopsensorname="ISSSTOPR12" fsensorname="ISSDIRF12" rsensorname="ISSDIRR12">
       <systemName>IY:AUTO:0012</systemName>
       <userName>WestSiding</userName>
       <blockentry sName="IB12" order="0" />
@@ -679,5 +679,5 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 17 22:26:06 PDT 2016" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0556Z+R3cb853fe70 on Sun May 07 22:56:36 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:20:39 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/loadref/LoadFileTest.xml
+++ b/java/test/jmri/configurexml/loadref/LoadFileTest.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -92,7 +92,7 @@
       <systemName>IM3</systemName>
       <userName>Memory 3</userName>
     </memory>
-    <memory value="12:05 PM">
+    <memory value="12:01 PM">
       <systemName>IMCURRENTTIME</systemName>
     </memory>
     <memory value="1.0">
@@ -117,20 +117,20 @@
   <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
     </block>
-    <block>
+    <block systemName="IB2">
       <systemName>IB2</systemName>
     </block>
-    <block length="25.4" curve="0">
+    <block systemName="IB1" length="25.4" curve="0">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
       <comment>Length 1</comment>
       <permissive>no</permissive>
     </block>
-    <block length="15.8" curve="0">
+    <block systemName="IB2" length="15.8" curve="0">
       <systemName>IB2</systemName>
       <comment>Length 900</comment>
       <permissive>yes</permissive>
@@ -138,7 +138,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <routes class="jmri.managers.configurexml.DefaultRouteManagerXml">
-    <route controlTurnout="IT101" controlTurnoutState="CLOSED">
+    <route userName="random route 1" controlTurnout="IT101" controlTurnoutState="CLOSED">
       <systemName>IR1</systemName>
       <userName>random route 1</userName>
       <routeOutputTurnout systemName="IT1" state="THROWN" />
@@ -155,7 +155,7 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
-    <logix enabled="yes">
+    <logix userName="Test logix" enabled="yes">
       <systemName>IX1</systemName>
       <userName>Test logix</userName>
       <logixConditional systemName="IX1C1" order="0" />
@@ -170,5 +170,5 @@
     </conditional>
   </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 05 23:42:04 PDT 2009" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0648Z+R90413022ff on Sun May 07 23:48:24 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:21:33 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/loadref/LoadFileTest277.xml
+++ b/java/test/jmri/configurexml/loadref/LoadFileTest277.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -114,11 +114,11 @@
   <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
     </block>
-    <block length="25.4" curve="0">
+    <block systemName="IB1" length="25.4" curve="0">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
       <comment>Length 1</comment>
@@ -127,7 +127,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <routes class="jmri.managers.configurexml.DefaultRouteManagerXml">
-    <route controlTurnout="IT101" controlTurnoutState="CLOSED">
+    <route userName="random route 1" controlTurnout="IT101" controlTurnoutState="CLOSED">
       <systemName>IR1</systemName>
       <userName>random route 1</userName>
       <routeOutputTurnout systemName="IT1" state="THROWN" />
@@ -144,7 +144,7 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
-    <logix enabled="yes">
+    <logix userName="Test logix" enabled="yes">
       <systemName>IX1</systemName>
       <userName>Test logix</userName>
       <logixConditional systemName="IX1C1" order="0" />
@@ -159,5 +159,5 @@
     </conditional>
   </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 05 23:42:04 PDT 2009" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0625Z+R3cb853fe70 on Sun May 07 23:25:31 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:21:33 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/loadref/LoadFileTest295.xml
+++ b/java/test/jmri/configurexml/loadref/LoadFileTest295.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -111,11 +111,11 @@
   <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
     </block>
-    <block length="25.4" curve="0">
+    <block systemName="IB1" length="25.4" curve="0">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
       <comment>Length 1</comment>
@@ -124,7 +124,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <routes class="jmri.managers.configurexml.DefaultRouteManagerXml">
-    <route controlTurnout="IT101" controlTurnoutState="CLOSED">
+    <route userName="random route 1" controlTurnout="IT101" controlTurnoutState="CLOSED">
       <systemName>IR1</systemName>
       <userName>random route 1</userName>
       <routeOutputTurnout systemName="IT1" state="THROWN" />
@@ -141,7 +141,7 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
-    <logix enabled="yes">
+    <logix userName="Test logix" enabled="yes">
       <systemName>IX1</systemName>
       <userName>Test logix</userName>
       <logixConditional systemName="IX1C1" order="0" />
@@ -156,5 +156,5 @@
     </conditional>
   </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 05 23:42:04 PDT 2009" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0639Z+R31e3f566ff on Sun May 07 23:39:47 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:13:06 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/loadref/PanelFileSchemaTest.xml
+++ b/java/test/jmri/configurexml/loadref/PanelFileSchemaTest.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -111,11 +111,11 @@
   <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
     </block>
-    <block length="25.4" curve="0">
+    <block systemName="IB1" length="25.4" curve="0">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
       <comment>Length 1</comment>
@@ -124,7 +124,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <routes class="jmri.managers.configurexml.DefaultRouteManagerXml">
-    <route controlTurnout="IT101" controlTurnoutState="CLOSED">
+    <route userName="random route 1" controlTurnout="IT101" controlTurnoutState="CLOSED">
       <systemName>IR1</systemName>
       <userName>random route 1</userName>
       <routeOutputTurnout systemName="IT1" state="THROWN" />
@@ -141,7 +141,7 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
-    <logix enabled="yes">
+    <logix userName="Test logix" enabled="yes">
       <systemName>IX1</systemName>
       <userName>Test logix</userName>
       <logixConditional systemName="IX1C1" order="0" />
@@ -156,5 +156,5 @@
     </conditional>
   </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 05 23:42:04 PDT 2009" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0646Z+R90413022ff on Sun May 07 23:46:59 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:16:15 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/loadref/PanelFileSchemaTest295.xml
+++ b/java/test/jmri/configurexml/loadref/PanelFileSchemaTest295.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -111,11 +111,11 @@
   <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
     </block>
-    <block length="25.4" curve="0">
+    <block systemName="IB1" length="25.4" curve="0">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
       <comment>Length 1</comment>
@@ -124,7 +124,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <routes class="jmri.managers.configurexml.DefaultRouteManagerXml">
-    <route controlTurnout="IT101" controlTurnoutState="CLOSED">
+    <route userName="random route 1" controlTurnout="IT101" controlTurnoutState="CLOSED">
       <systemName>IR1</systemName>
       <userName>random route 1</userName>
       <routeOutputTurnout systemName="IT1" state="THROWN" />
@@ -141,7 +141,7 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
-    <logix enabled="yes">
+    <logix userName="Test logix" enabled="yes">
       <systemName>IX1</systemName>
       <userName>Test logix</userName>
       <logixConditional systemName="IX1C1" order="0" />
@@ -156,5 +156,5 @@
     </conditional>
   </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 05 23:42:04 PDT 2009" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0638Z+R31e3f566ff on Sun May 07 23:38:16 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:16:16 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/loadref/PanelFileSchemaTest382.xml
+++ b/java/test/jmri/configurexml/loadref/PanelFileSchemaTest382.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -111,11 +111,11 @@
   <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
     </block>
-    <block length="25.4" curve="0">
+    <block systemName="IB1" length="25.4" curve="0">
       <systemName>IB1</systemName>
       <userName>Block 1</userName>
       <comment>Length 1</comment>
@@ -124,7 +124,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <routes class="jmri.managers.configurexml.DefaultRouteManagerXml">
-    <route controlTurnout="IT101" controlTurnoutState="CLOSED">
+    <route userName="random route 1" controlTurnout="IT101" controlTurnoutState="CLOSED">
       <systemName>IR1</systemName>
       <userName>random route 1</userName>
       <routeOutputTurnout systemName="IT1" state="THROWN" />
@@ -141,7 +141,7 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
-    <logix enabled="yes">
+    <logix userName="Test logix" enabled="yes">
       <systemName>IX1</systemName>
       <userName>Test logix</userName>
       <logixConditional systemName="IX1C1" order="0" />
@@ -156,5 +156,5 @@
     </conditional>
   </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 05 23:42:04 PDT 2009" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0613Z+R3cb853fe70 on Sun May 07 23:14:02 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:16:16 PDT 2017-->
 </layout-config>

--- a/java/test/jmri/configurexml/loadref/SectionManagerXmlTest.xml
+++ b/java/test/jmri/configurexml/loadref/SectionManagerXmlTest.xml
@@ -4,7 +4,7 @@
   <jmriversion>
     <major>4</major>
     <minor>7</minor>
-    <test>4</test>
+    <test>5</test>
     <modifier>ish</modifier>
   </jmriversion>
   <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
@@ -298,55 +298,55 @@
   <signalgroups class="jmri.managers.configurexml.DefaultSignalGroupManagerXml" />
   <blocks class="jmri.configurexml.BlockManagerXml">
     <defaultspeed>Normal</defaultspeed>
-    <block>
+    <block systemName="IB1">
       <systemName>IB1</systemName>
       <userName>blocknorthwest</userName>
     </block>
-    <block>
+    <block systemName="IB10">
       <systemName>IB10</systemName>
       <userName>blocksouthwest</userName>
     </block>
-    <block>
+    <block systemName="IB11">
       <systemName>IB11</systemName>
       <userName>blockwest</userName>
     </block>
-    <block>
+    <block systemName="IB12">
       <systemName>IB12</systemName>
       <userName>blockwestsiding</userName>
     </block>
-    <block>
+    <block systemName="IB2">
       <systemName>IB2</systemName>
       <userName>blocknorth</userName>
     </block>
-    <block>
+    <block systemName="IB3">
       <systemName>IB3</systemName>
       <userName>blocknorthsiding</userName>
     </block>
-    <block>
+    <block systemName="IB4">
       <systemName>IB4</systemName>
       <userName>blocknortheast</userName>
     </block>
-    <block>
+    <block systemName="IB5">
       <systemName>IB5</systemName>
       <userName>blockeast</userName>
     </block>
-    <block>
+    <block systemName="IB6">
       <systemName>IB6</systemName>
       <userName>blockeastsiding</userName>
     </block>
-    <block>
+    <block systemName="IB7">
       <systemName>IB7</systemName>
       <userName>blocksoutheast</userName>
     </block>
-    <block>
+    <block systemName="IB8">
       <systemName>IB8</systemName>
       <userName>blocksouth</userName>
     </block>
-    <block>
+    <block systemName="IB9">
       <systemName>IB9</systemName>
       <userName>blocksouthsiding</userName>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB1" length="0.0" curve="0">
       <systemName>IB1</systemName>
       <userName>blocknorthwest</userName>
       <permissive>no</permissive>
@@ -372,7 +372,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB10" length="0.0" curve="0">
       <systemName>IB10</systemName>
       <userName>blocksouthwest</userName>
       <permissive>no</permissive>
@@ -398,7 +398,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB11" length="0.0" curve="0">
       <systemName>IB11</systemName>
       <userName>blockwest</userName>
       <permissive>no</permissive>
@@ -414,7 +414,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB12" length="0.0" curve="0">
       <systemName>IB12</systemName>
       <userName>blockwestsiding</userName>
       <permissive>no</permissive>
@@ -430,7 +430,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB2" length="0.0" curve="0">
       <systemName>IB2</systemName>
       <userName>blocknorth</userName>
       <permissive>no</permissive>
@@ -446,7 +446,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB3" length="0.0" curve="0">
       <systemName>IB3</systemName>
       <userName>blocknorthsiding</userName>
       <permissive>no</permissive>
@@ -462,7 +462,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB4" length="0.0" curve="0">
       <systemName>IB4</systemName>
       <userName>blocknortheast</userName>
       <permissive>no</permissive>
@@ -488,7 +488,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB5" length="0.0" curve="0">
       <systemName>IB5</systemName>
       <userName>blockeast</userName>
       <permissive>no</permissive>
@@ -504,7 +504,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB6" length="0.0" curve="0">
       <systemName>IB6</systemName>
       <userName>blockeastsiding</userName>
       <permissive>no</permissive>
@@ -520,7 +520,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB7" length="0.0" curve="0">
       <systemName>IB7</systemName>
       <userName>blocksoutheast</userName>
       <permissive>no</permissive>
@@ -546,7 +546,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB8" length="0.0" curve="0">
       <systemName>IB8</systemName>
       <userName>blocksouth</userName>
       <permissive>no</permissive>
@@ -562,7 +562,7 @@
         </beansetting>
       </path>
     </block>
-    <block length="0.0" curve="0">
+    <block systemName="IB9" length="0.0" curve="0">
       <systemName>IB9</systemName>
       <userName>blocksouthsiding</userName>
       <permissive>no</permissive>
@@ -581,7 +581,7 @@
   </blocks>
   <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
   <sections class="jmri.configurexml.SectionManagerXml">
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF1" rstopsensorname="ISSSTOPR1" fsensorname="ISSDIRF1" rsensorname="ISSDIRR1">
+    <section systemName="IY:AUTO:0001" userName="NorthWest" creationtype="userdefined" fstopsensorname="ISSSTOPF1" rstopsensorname="ISSSTOPR1" fsensorname="ISSDIRF1" rsensorname="ISSDIRR1">
       <systemName>IY:AUTO:0001</systemName>
       <userName>NorthWest</userName>
       <blockentry sName="IB1" order="0" />
@@ -590,21 +590,21 @@
       <entrypoint fromblock="IB2" toblock="IB1" direction="8" fixed="no" fromblockdirection="West" />
       <entrypoint fromblock="IB3" toblock="IB1" direction="8" fixed="no" fromblockdirection="West" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF2" rstopsensorname="ISSSTOPR2" fsensorname="ISSDIRF2" rsensorname="ISSDIRR2">
+    <section systemName="IY:AUTO:0002" userName="North" creationtype="userdefined" fstopsensorname="ISSSTOPF2" rstopsensorname="ISSSTOPR2" fsensorname="ISSDIRF2" rsensorname="ISSDIRR2">
       <systemName>IY:AUTO:0002</systemName>
       <userName>North</userName>
       <blockentry sName="IB2" order="0" />
       <entrypoint fromblock="IB1" toblock="IB2" direction="4" fixed="no" fromblockdirection="East" />
       <entrypoint fromblock="IB4" toblock="IB2" direction="8" fixed="no" fromblockdirection="West" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF3" rstopsensorname="ISSSTOPR3" fsensorname="ISSDIRF3" rsensorname="ISSDIRR3">
+    <section systemName="IY:AUTO:0003" userName="NorthSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF3" rstopsensorname="ISSSTOPR3" fsensorname="ISSDIRF3" rsensorname="ISSDIRR3">
       <systemName>IY:AUTO:0003</systemName>
       <userName>NorthSiding</userName>
       <blockentry sName="IB3" order="0" />
       <entrypoint fromblock="IB1" toblock="IB3" direction="4" fixed="no" fromblockdirection="East" />
       <entrypoint fromblock="IB4" toblock="IB3" direction="8" fixed="no" fromblockdirection="West" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF4" rstopsensorname="ISSSTOPR4" fsensorname="ISSDIRF4" rsensorname="ISSDIRR4">
+    <section systemName="IY:AUTO:0004" userName="NorthEast" creationtype="userdefined" fstopsensorname="ISSSTOPF4" rstopsensorname="ISSSTOPR4" fsensorname="ISSDIRF4" rsensorname="ISSDIRR4">
       <systemName>IY:AUTO:0004</systemName>
       <userName>NorthEast</userName>
       <blockentry sName="IB4" order="0" />
@@ -613,21 +613,21 @@
       <entrypoint fromblock="IB5" toblock="IB4" direction="8" fixed="no" fromblockdirection="North" />
       <entrypoint fromblock="IB6" toblock="IB4" direction="8" fixed="no" fromblockdirection="North" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF5" rstopsensorname="ISSSTOPR5" fsensorname="ISSDIRF5" rsensorname="ISSDIRR5">
+    <section systemName="IY:AUTO:0005" userName="East" creationtype="userdefined" fstopsensorname="ISSSTOPF5" rstopsensorname="ISSSTOPR5" fsensorname="ISSDIRF5" rsensorname="ISSDIRR5">
       <systemName>IY:AUTO:0005</systemName>
       <userName>East</userName>
       <blockentry sName="IB5" order="0" />
       <entrypoint fromblock="IB4" toblock="IB5" direction="4" fixed="no" fromblockdirection="South" />
       <entrypoint fromblock="IB7" toblock="IB5" direction="8" fixed="no" fromblockdirection="North" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF6" rstopsensorname="ISSSTOPR6" fsensorname="ISSDIRF6" rsensorname="ISSDIRR6">
+    <section systemName="IY:AUTO:0006" userName="EastSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF6" rstopsensorname="ISSSTOPR6" fsensorname="ISSDIRF6" rsensorname="ISSDIRR6">
       <systemName>IY:AUTO:0006</systemName>
       <userName>EastSiding</userName>
       <blockentry sName="IB6" order="0" />
       <entrypoint fromblock="IB4" toblock="IB6" direction="4" fixed="no" fromblockdirection="South" />
       <entrypoint fromblock="IB7" toblock="IB6" direction="8" fixed="no" fromblockdirection="North" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF7" rstopsensorname="ISSSTOPR7" fsensorname="ISSDIRF7" rsensorname="ISSDIRR7">
+    <section systemName="IY:AUTO:0007" userName="SouthEast" creationtype="userdefined" fstopsensorname="ISSSTOPF7" rstopsensorname="ISSSTOPR7" fsensorname="ISSDIRF7" rsensorname="ISSDIRR7">
       <systemName>IY:AUTO:0007</systemName>
       <userName>SouthEast</userName>
       <blockentry sName="IB7" order="0" />
@@ -636,21 +636,21 @@
       <entrypoint fromblock="IB8" toblock="IB7" direction="8" fixed="no" fromblockdirection="East" />
       <entrypoint fromblock="IB9" toblock="IB7" direction="8" fixed="no" fromblockdirection="East" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF8" rstopsensorname="ISSSTOPR8" fsensorname="ISSDIRF8" rsensorname="ISSDIRR8">
+    <section systemName="IY:AUTO:0008" userName="South" creationtype="userdefined" fstopsensorname="ISSSTOPF8" rstopsensorname="ISSSTOPR8" fsensorname="ISSDIRF8" rsensorname="ISSDIRR8">
       <systemName>IY:AUTO:0008</systemName>
       <userName>South</userName>
       <blockentry sName="IB8" order="0" />
       <entrypoint fromblock="IB7" toblock="IB8" direction="4" fixed="no" fromblockdirection="West" />
       <entrypoint fromblock="IB10" toblock="IB8" direction="8" fixed="no" fromblockdirection="East" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF9" rstopsensorname="ISSSTOPR9" fsensorname="ISSDIRF9" rsensorname="ISSDIRR9">
+    <section systemName="IY:AUTO:0009" userName="SouthSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF9" rstopsensorname="ISSSTOPR9" fsensorname="ISSDIRF9" rsensorname="ISSDIRR9">
       <systemName>IY:AUTO:0009</systemName>
       <userName>SouthSiding</userName>
       <blockentry sName="IB9" order="0" />
       <entrypoint fromblock="IB7" toblock="IB9" direction="4" fixed="no" fromblockdirection="West" />
       <entrypoint fromblock="IB10" toblock="IB9" direction="8" fixed="no" fromblockdirection="East" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF10" rstopsensorname="ISSSTOPR10" fsensorname="ISSDIRF10" rsensorname="ISSDIRR10">
+    <section systemName="IY:AUTO:0010" userName="SouthWest" creationtype="userdefined" fstopsensorname="ISSSTOPF10" rstopsensorname="ISSSTOPR10" fsensorname="ISSDIRF10" rsensorname="ISSDIRR10">
       <systemName>IY:AUTO:0010</systemName>
       <userName>SouthWest</userName>
       <blockentry sName="IB10" order="0" />
@@ -659,14 +659,14 @@
       <entrypoint fromblock="IB11" toblock="IB10" direction="8" fixed="no" fromblockdirection="South" />
       <entrypoint fromblock="IB12" toblock="IB10" direction="8" fixed="no" fromblockdirection="South" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF11" rstopsensorname="ISSSTOPR11" fsensorname="ISSDIRF11" rsensorname="ISSDIRR11">
+    <section systemName="IY:AUTO:0011" userName="West" creationtype="userdefined" fstopsensorname="ISSSTOPF11" rstopsensorname="ISSSTOPR11" fsensorname="ISSDIRF11" rsensorname="ISSDIRR11">
       <systemName>IY:AUTO:0011</systemName>
       <userName>West</userName>
       <blockentry sName="IB11" order="0" />
       <entrypoint fromblock="IB10" toblock="IB11" direction="4" fixed="no" fromblockdirection="North" />
       <entrypoint fromblock="IB1" toblock="IB11" direction="8" fixed="no" fromblockdirection="South" />
     </section>
-    <section creationtype="userdefined" fstopsensorname="ISSSTOPF12" rstopsensorname="ISSSTOPR12" fsensorname="ISSDIRF12" rsensorname="ISSDIRR12">
+    <section systemName="IY:AUTO:0012" userName="WestSiding" creationtype="userdefined" fstopsensorname="ISSSTOPF12" rstopsensorname="ISSSTOPR12" fsensorname="ISSDIRF12" rsensorname="ISSDIRR12">
       <systemName>IY:AUTO:0012</systemName>
       <userName>WestSiding</userName>
       <blockentry sName="IB12" order="0" />
@@ -675,7 +675,7 @@
     </section>
   </sections>
   <transits class="jmri.configurexml.TransitManagerXml">
-    <transit>
+    <transit systemName="IZ:AUTO:0001" userName="gocw1">
       <systemName>IZ:AUTO:0001</systemName>
       <userName>gocw1</userName>
       <transitsection sectionname="IY:AUTO:0003" sequence="1" direction="4" alternate="no" />
@@ -688,14 +688,14 @@
       <transitsection sectionname="IY:AUTO:0010" sequence="6" direction="4" alternate="no" />
       <transitsection sectionname="IY:AUTO:0012" sequence="7" direction="4" alternate="no" />
     </transit>
-    <transit>
+    <transit systemName="IZ:AUTO:0002" userName="gocw2">
       <systemName>IZ:AUTO:0002</systemName>
       <userName>gocw2</userName>
       <transitsection sectionname="IY:AUTO:0012" sequence="1" direction="4" alternate="no" />
       <transitsection sectionname="IY:AUTO:0001" sequence="2" direction="4" alternate="no" />
       <transitsection sectionname="IY:AUTO:0003" sequence="3" direction="4" alternate="no" />
     </transit>
-    <transit>
+    <transit systemName="IZ:AUTO:0003" userName="goccw1">
       <systemName>IZ:AUTO:0003</systemName>
       <userName>goccw1</userName>
       <transitsection sectionname="IY:AUTO:0009" sequence="1" direction="8" alternate="no" />
@@ -708,7 +708,7 @@
       <transitsection sectionname="IY:AUTO:0001" sequence="6" direction="8" alternate="no" />
       <transitsection sectionname="IY:AUTO:0011" sequence="7" direction="8" alternate="no" />
     </transit>
-    <transit>
+    <transit systemName="IZ:AUTO:0004" userName="goccw2">
       <systemName>IZ:AUTO:0004</systemName>
       <userName>goccw2</userName>
       <transitsection sectionname="IY:AUTO:0011" sequence="1" direction="8" alternate="no" />
@@ -721,5 +721,5 @@
     <logicDelay>500</logicDelay>
   </signalmastlogics>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Jun 17 22:25:15 PDT 2016" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
-  <!--Written by JMRI version 4.7.4ish+jake+20170508T0636Z+R31e3f566ff on Sun May 07 23:36:39 PDT 2017 $Id$-->
+  <!--Written by JMRI version 4.7.5ish+jake+20170604T1810Z+Rcabd84d212 on Sun Jun 04 11:16:16 PDT 2017-->
 </layout-config>


### PR DESCRIPTION
This undoes part of #3477 to keep (or restore) backward compatibility of panel files.  See #3512 for background.

JMRI 4.7.5 will write the attribute(s) that earlier code (e.g. JMRI 4.2 - 4.6) was expecting instead of elements for certain data types.  Most of the #3477 migration, e.g. the most basic types, stays in place as the earlier JMRI versions were already properly reading the new format.

Sometime later, maybe JMRI 4.11.1, the read code for these attributes will have been around long enough and we can remove these attributes too.