### PR TITLE
Firmware download fixes

### DIFF
--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -249,3 +249,6 @@ Copyright = Copyright \u00a9 {0} JMRI Community
 PullResistanceUp = Pullup Resistor Enabled
 PullResistanceDown = Pulldown Resistor Enabled
 PullResistanceOff = No Pullup/Pulldown.
+
+# Specifically for AbstractLoaderPane 
+StatusFileNotFound = File Not Found

--- a/java/src/jmri/jmrit/MemoryContents.java
+++ b/java/src/jmri/jmrit/MemoryContents.java
@@ -135,7 +135,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * @author Bob Jacobsen Copyright (C) 2005, 2008
- * @author B. Milhaupt Copyright (C) 2014
+ * @author B. Milhaupt Copyright (C) 2014, 2017
  */
 public class MemoryContents {
 

--- a/java/src/jmri/jmrit/MemoryContents.java
+++ b/java/src/jmri/jmrit/MemoryContents.java
@@ -210,7 +210,7 @@ public class MemoryContents {
         hasData = false;
         curExtLinAddr = 0;
         curExtSegAddr = 0;
-        ArrayList<String> keyValComments = new ArrayList<String>(1);
+        keyValComments = new ArrayList<String>(1);
     }
 
     private boolean isPageInitialized(int page) {
@@ -395,6 +395,9 @@ public class MemoryContents {
         } catch (IOException ex) {
             throw new FileNotFoundException(ex.toString());
         }
+        
+        this.clear();   // Ensure that the information storage is clear of any 
+                        // previous contents
         currentPage = 0;
         loadOffsetFieldType = LoadOffsetFieldType.UNDEFINED;
         boolean foundDataRecords = false;
@@ -667,7 +670,7 @@ public class MemoryContents {
                     } else if (recordType == RECTYP_EOF_RECORD) {
                         if ((extractRecLen(line) != 0)
                                 || (extractLoadOffset(line) != 0)) {
-                            String message = "Illegal EOF record form in line "
+                            String message = "Illegal EOF record form in line " // NOI18N
                                     + lineNum;
                             log.error(message);
                             throw new MemoryFileRecordContentException(message);
@@ -1456,7 +1459,7 @@ public class MemoryContents {
      */
     @Override
     public String toString() {
-        StringBuffer retval = new StringBuffer("Pages occupied: ");
+        StringBuffer retval = new StringBuffer("Pages occupied: "); // NOI18N
         for (int page=0; page<PAGES; page++) {
             if (isPageInitialized(page)) {
                 retval.append(page);
@@ -1481,7 +1484,7 @@ public class MemoryContents {
         hasData = false;
         curExtLinAddr = 0;
         curExtSegAddr = 0;
-        ArrayList<String> keyValComments = new ArrayList<String>(1);
+        keyValComments = new ArrayList<String>(1);
         for (int i = 0 ; i < pageArray.length; ++i) {
             pageArray[i] = null;
         }

--- a/java/src/jmri/jmrit/MemoryContents.java
+++ b/java/src/jmri/jmrit/MemoryContents.java
@@ -210,6 +210,7 @@ public class MemoryContents {
         hasData = false;
         curExtLinAddr = 0;
         curExtSegAddr = 0;
+        ArrayList<String> keyValComments = new ArrayList<String>(1);
     }
 
     private boolean isPageInitialized(int page) {
@@ -1301,7 +1302,7 @@ public class MemoryContents {
                 line.substring(CHARS_IN_RECORD_MARK + CHARS_IN_RECORD_LENGTH,
                         CHARS_IN_RECORD_MARK + CHARS_IN_RECORD_LENGTH + charsInAddress()), 16);
     }
-
+    
     /**
      * Generalized class from which detailed exceptions are derived.
      */
@@ -1463,6 +1464,28 @@ public class MemoryContents {
             }
         }
         return new String(retval);
+    }
+
+    /**
+     * Clear out an imported Firmware File.
+     * 
+     * This may be used, when the instantiating object has evaluated the contents of 
+     * a firmware file and found it to be inappropriate for updating to a device, 
+     * to clear out the firmware image so that there is no chance that it can be
+     * updated to the device.
+     * 
+     */
+    public void clear() {
+        log.info("Clearing a MemoryContents object by program request.");
+        currentPage = -1;
+        hasData = false;
+        curExtLinAddr = 0;
+        curExtSegAddr = 0;
+        ArrayList<String> keyValComments = new ArrayList<String>(1);
+        for (int i = 0 ; i < pageArray.length; ++i) {
+            pageArray[i] = null;
+        }
+        
     }
 
     private final static Logger log = LoggerFactory.getLogger(MemoryContents.class.getName());

--- a/java/src/jmri/jmrix/AbstractLoaderPane.java
+++ b/java/src/jmri/jmrix/AbstractLoaderPane.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * display in the status line of the pane.
  *
  * @author Bob Jacobsen Copyright (C) 2005, 2015
- * @author B. Milhaupt Copyright (C) 2013, 2014
+ * @author B. Milhaupt Copyright (C) 2013, 2014, 2017
  */
 public abstract class AbstractLoaderPane extends jmri.util.swing.JmriPanel
         implements ActionListener {

--- a/java/src/jmri/jmrix/AbstractLoaderPane.java
+++ b/java/src/jmri/jmrix/AbstractLoaderPane.java
@@ -49,6 +49,7 @@ public abstract class AbstractLoaderPane extends jmri.util.swing.JmriPanel
     // GUI member declarations
     JLabel inputFileName = new JLabel("");
 
+    protected JButton selectButton;
     protected JButton loadButton;
     protected JButton verifyButton;  // protected so subclass can set invisible
     protected JButton abortButton;
@@ -102,7 +103,7 @@ public abstract class AbstractLoaderPane extends jmri.util.swing.JmriPanel
 
             JPanel p = new JPanel();
             p.setLayout(new FlowLayout());
-            JButton selectButton = new JButton(Bundle.getMessage("ButtonSelect"));
+            selectButton = new JButton(Bundle.getMessage("ButtonSelect"));
             selectButton.addActionListener((ActionEvent e) -> {
                 inputContent = new MemoryContents();
                 setDefaultFieldValues();
@@ -352,6 +353,7 @@ public abstract class AbstractLoaderPane extends jmri.util.swing.JmriPanel
         verifyButton.setToolTipText(Bundle.getMessage("TipDisabledDownload"));
         abortButton.setEnabled(true);
         abortButton.setToolTipText(Bundle.getMessage("TipAbortEnabled"));
+        selectButton.setEnabled(false);
     }
 
     protected void doVerify() {
@@ -362,6 +364,7 @@ public abstract class AbstractLoaderPane extends jmri.util.swing.JmriPanel
         verifyButton.setToolTipText(Bundle.getMessage("TipDisabledDownload"));
         abortButton.setEnabled(true);
         abortButton.setToolTipText(Bundle.getMessage("TipAbortEnabled"));
+        selectButton.setEnabled(false);
     }
 
     /**
@@ -392,6 +395,7 @@ public abstract class AbstractLoaderPane extends jmri.util.swing.JmriPanel
         verifyButton.setToolTipText(Bundle.getMessage("TipVerifyEnabled"));
         abortButton.setEnabled(false);
         abortButton.setToolTipText(Bundle.getMessage("TipAbortDisabled"));
+        selectButton.setEnabled(true);
     }
 
     /**
@@ -414,6 +418,8 @@ public abstract class AbstractLoaderPane extends jmri.util.swing.JmriPanel
         verifyButton.setToolTipText(Bundle.getMessage("TipVerifyDisabled"));
         abortButton.setEnabled(false);
         abortButton.setToolTipText(Bundle.getMessage("TipAbortDisabled"));
+        selectButton.setEnabled(true);
+
     }
 
     // boolean used to abort the threaded operation
@@ -493,6 +499,11 @@ public abstract class AbstractLoaderPane extends jmri.util.swing.JmriPanel
         } else {
             disableDownloadVerifyButtons();
         }
+    }
+    
+    public void clearInputFileName() {
+        inputFileName.setText("");
+        inputFileName.setToolTipText("");
     }
 
     @Override

--- a/java/src/jmri/jmrix/loconet/downloader/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/downloader/Bundle.properties
@@ -1,7 +1,7 @@
 # Bundle.properties
 #
 # Copyright 2005 Bob Jacobsen
-#
+# Copyright 2017 B. Milhaupt
 #
 # Default properties for the jmri.jmrix.loconet.downloader GUI elements
 

--- a/java/src/jmri/jmrix/loconet/downloader/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/downloader/Bundle.properties
@@ -18,6 +18,7 @@ LabelSoftware = Software Version Number:
 LabelDelay = Delay (msec):
 LabelEEStart = Start of EEPROM addresses (hex):
 LabelChunkSize = Chunk Size:
+LabelEraseBlockSize = Erase Block Size:
 
 BoxTitleFirmwareFileProperties = Firmware File Properties
 
@@ -34,4 +35,7 @@ ButtonCheckHardwareGreater  = Accept later hardware versions
 ButtonCheckSoftwareNo       = Don't check software version
 ButtonCheckSoftwareLess     = Only overwrite earlier software versions
 
-
+ErrorInvalidOptionInFile    = Invalid "{1}" parameter value "{0}" in file.
+ErrorTitle                  = Invalid Parameter
+ErrorInvalidParameter       = Parameter value is out of range
+ErrorInvalidEraseBlkSize    = <html>Invalid "{1}" parameter value "{0}" in file.<p>This tool cannot be used to update a device where the firmware file specifies a value greater than 128.<p>Updating any such device using this tool will likely make the device unusable!</html>

--- a/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
@@ -497,7 +497,9 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
                 this.disableDownloadVerifyButtons();
                 // clear out the firmware image to ensure that the user won't 
                 // write it to the device
-                inputContent = new MemoryContents(); 
+                inputContent.clear();
+                setDefaultFieldValues();
+                clearInputFileName();        
             }
         }
     }

--- a/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
@@ -801,6 +801,7 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
             totalmsgs = 0;
             sentmsgs = 0;
             location = location & 0x00FFFFF8;  // mask off bits to be multiple of 8
+            log.info("delayVal = "+delayval);
             do {
                 location = location + 8;
                 totalmsgs++;
@@ -913,6 +914,7 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
                         tdelay = delayval + 4 + 14;
                     }                        
                     // do the actual wait
+                    log.info("doWait "+tdelay);
                     wait(tdelay);
                 }
             } catch (InterruptedException e) {
@@ -934,9 +936,10 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
                     if (address >= eestartval) {
                         tdelay = (delayval + 50 + 14) * multiplier;
                     } else {
-                        tdelay = (delayval + 4 + 14) * multiplier;
+                        tdelay = (delayval) * multiplier;
                     }                        
                     // do the actual wait
+                    log.info("doLongWait "+tdelay);
                     wait(tdelay);
                 }
             } catch (InterruptedException e) {

--- a/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
@@ -56,11 +56,12 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
     }
 
     /** This gets invoked early. We don't want it to do anything, so 
-     * ew just fail to pass it up. Instead, we wait for the later call of
+     * we just fail to pass it up. Instead, we wait for the later call of
      * initComponents(LocoNetSystemConnectionMemo memo)
+
      */
     @Override
-    public void initComponents() throws Exception {
+    public void initComponents(){
     }
         
     @Override
@@ -71,6 +72,10 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
 
     /**
      * LnPanelInterface implementation creates standard form of title
+     * 
+     * @param menuTitle is a string containing the name of the tool
+     * @return a new string containing the connection's UserName plus the name 
+     *          of the tool
      */
     public String getTitle(String menuTitle) { return jmri.jmrix.loconet.swing.LnPanel.getTitleHelper(memo, menuTitle); }
 
@@ -451,10 +456,11 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
                 this.setOptionsRadiobuttons(text);
             } catch (NumberFormatException ex) {
                 JOptionPane.showMessageDialog(this,
-                        Bundle.getMessage("ErrorInvalidOptionInFile", text, "Options"), 
+                        Bundle.getMessage("ErrorInvalidOptionInFile", text, "Options"), // NOI18N
                         Bundle.getMessage("ErrorTitle"),
                         JOptionPane.ERROR_MESSAGE);
                 this.disableDownloadVerifyButtons();
+                log.warn("Invalid dmf file 'Options' value {0}",text);
                 return;
             }
         }
@@ -498,14 +504,15 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
 
     /**
      * Add filter(s) for possible types to the input file chooser.
+     * @param chooser - a JFileChooser to which the filter is to be added
      */
     @Override
     protected void addChooserFilters(JFileChooser chooser) {
             javax.swing.filechooser.FileNameExtensionFilter filter
                     = new javax.swing.filechooser.FileNameExtensionFilter(
-                            Bundle.getMessage("FileFilterLabel",
-                                    "*.dfm, *.hex"), // NOI18N // NOI18N
-                            "dmf", "hex");   // NOI18N // NOI18N
+                            Bundle.getMessage("FileFilterLabel", // NOI18N
+                                    "*.dfm, *.hex"), // NOI18N
+                            "dmf", "hex");   // NOI18N
 
             chooser.addChoosableFileFilter(
                     new javax.swing.filechooser.FileNameExtensionFilter(
@@ -871,6 +878,7 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
 
         /**
          * Send a command to resume at another address
+         * @param location to be written next
          */
         void setAddr(int location) {
             sendOne(PXCT2SENDADDRESS,
@@ -884,6 +892,8 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
          * Wait the specified time.
          *
          * 16*10/16.44 = 14 msec is the time it takes to send the message.
+         * @param address to be sent next, for computing the delay before 
+         *          sending the next message
          */
         void doWait(int address) {
             try {
@@ -915,6 +925,7 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
 
         /**
          * Update the GUI for progress
+         * @param value is the percentage of "doneness" to be displayed
          */
         void updateGUI(final int value) {
             javax.swing.SwingUtilities.invokeLater(new Runnable() {

--- a/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
@@ -801,7 +801,6 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
             totalmsgs = 0;
             sentmsgs = 0;
             location = location & 0x00FFFFF8;  // mask off bits to be multiple of 8
-            log.info("delayVal = "+delayval);
             do {
                 location = location + 8;
                 totalmsgs++;
@@ -914,7 +913,6 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
                         tdelay = delayval + 4 + 14;
                     }                        
                     // do the actual wait
-                    log.info("doWait "+tdelay);
                     wait(tdelay);
                 }
             } catch (InterruptedException e) {
@@ -939,7 +937,6 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
                         tdelay = (delayval) * multiplier;
                     }                        
                     // do the actual wait
-                    log.info("doLongWait "+tdelay);
                     wait(tdelay);
                 }
             } catch (InterruptedException e) {

--- a/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * display in the status line of the pane.
  *
  * @author Bob Jacobsen Copyright (C) 2005, 2015
- * @author B. Milhaupt Copyright (C) 2013, 2014
+ * @author B. Milhaupt Copyright (C) 2013, 2014, 2017
   */
 public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
         implements ActionListener, jmri.jmrix.loconet.swing.LnPanelInterface {


### PR DESCRIPTION
- LocoNet firmware downloader prevents read of firmware file where "! Prog Blk Size" values greater than 128 or less than 64 (default = 64).  Displays a dialog box error in this case.

- LocoNet firmware downloader has better (slower) timings for better compatibility - especially for UR92.

- MemoryContents now implements a clear() method to clear out any previous contents.

- AbstractLoaderPane now uses memoryContents.clear() method; now disables the file "select" button during active download or verify operations so user cannot change files "mid-stream".

- various javadocs, i18n, findbugs fixes
