### PR TITLE
CT Elektronik decoder definition fixes (for 4.7.6 branch)

### DIFF
--- a/xml/decoders/CT_Elektronik_DCX_V66_plus.xml
+++ b/xml/decoders/CT_Elektronik_DCX_V66_plus.xml
@@ -13,7 +13,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <version author="Nigel Cliffe" version="1.10" lastUpdated="2017/5/01"/>
+  <version author="Nigel Cliffe" version="1.11" lastUpdated="2017/6/16"/>
     
   <!-- previous version credit:                        -->
   <!--         <version author="peter.brandenburg@t-online.de"   -->
@@ -35,6 +35,9 @@
   <!--    added DCX76 series decoders -->
   <!-- Version 1.10, Nigel Cliffe, 2017/05/01 -->
   <!--    added DCX77 series decoders -->
+  <!--  Version 1.11, Nigel Cliffe, 2017/06/16 -->
+  <!--     re-instated meaningful labels on CV116 which were removed at some point in the past -->
+  
   <decoder>
     <family name="DCX Series (v.66 and higher)" mfg="CT Elektronik" lowVersionID="66" comment="DCX74, DCX75, with variants">
       <model model="DCX74D" numOuts="2" numFns="10" maxMotorCurrent="1.6 A" maxTotalCurrent="0.8 A">
@@ -946,17 +949,17 @@
       </variable>
       <variable CV="116" mask="XXXXXXXV" item="Switching 1" default="0">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label>Switching 1</label>
+        <label>Ignore accel (CV3) and decel (CV4)</label>
         <label xml:lang="de">CV3 und CV4 wird ausgeschaltet</label>
       </variable>
       <variable CV="116" mask="XXXXXXVX" default="0" item="Switching 2">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label>Switching 2</label>
+        <label>Half Speed Running</label>
         <label xml:lang="de">max. Geschwindigkeit wird vorwärts und rückwärts halbiert</label>
       </variable>
       <variable CV="116" mask="XXXXXVXX" default="0" item="Switching 3">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label>Switching 3</label>
+        <label>Reverse speed is 65% of forwards speed</label>
         <label xml:lang="de">rückwärts 65% der max. Geschw.keit (unabhängig vom Rang.)</label>
       </variable>
       <!--   Translations of extra features in CV116 from Tran documentation, note these are different, first SL75 and second DCX75..  -->
@@ -1645,16 +1648,16 @@
       <separator/>
       <display item="Switching 1"/>
       <display item="Switching 2"/>
+	  <label>
+        <text>  </text>
+      </label>
+      <label>
+        <text>  </text>
+      </label>
+      <label>
+        <text>Forward / Reverse speed option  </text>
+      </label>
       <display item="Switching 3"/>
-      <label>
-        <text>  </text>
-      </label>
-      <label>
-        <text>  </text>
-      </label>
-      <label>
-        <text>  </text>
-      </label>
       <label>
         <text>  </text>
       </label>

--- a/xml/decoders/CT_Elektronik_DCX_new2.xml
+++ b/xml/decoders/CT_Elektronik_DCX_new2.xml
@@ -13,11 +13,13 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <version author="ronald@wirkuhns.de" version="1.8" lastUpdated="2016/5/12"/>
-  <version author="ncliffe@btinternet.com" version="1.7" lastUpdated="2009/9/01"/>
-  <version author="ncliffe@btinternet.com" version="1.6" lastUpdated="2009/4/02"/>
-  <version author="ncliffe@btinternet.com" version="1.5" lastUpdated="2009/3/12"/>
-  <version author="peter.brandenburg@t-online.de" version="1" lastUpdated="2006/11/20"/>
+  <version author="Nigel Cliffe" version="1.9" lastUpdated="2017/6/16"/> -->
+
+  <!-- <version author="ronald@wirkuhns.de" version="1.8" lastUpdated="2016/5/12"/> -->
+  <!-- <version author="ncliffe@btinternet.com" version="1.7" lastUpdated="2009/9/01"/> -->
+  <!-- <version author="ncliffe@btinternet.com" version="1.6" lastUpdated="2009/4/02"/> -->
+  <!-- <version author="ncliffe@btinternet.com" version="1.5" lastUpdated="2009/3/12"/> -->
+  <!-- <version author="peter.brandenburg@t-online.de" version="1" lastUpdated="2006/11/20"/> -->
   <!-- version 1 - added CV's for new generation of decoders - Peter -->
   <!-- version 1.1 - added elements for "shunt speed" based on table supplied by CT -->
   <!--            Nigel Cliffe 2008/07/19; -->
@@ -51,6 +53,8 @@
   <!--    Subsequent changes to a few screens to move features to function map -->
   <!-- Version 1.8, Ronald Kuhn, 2016/05/12  -->
   <!--    translation to german  -->
+  <!-- Version 1.9, Nigel Cliffe, 2016/06/16 -->
+  <!--    Re-instated meaningful labels on CV116 which had been deleted in version 1.8  -->
   <decoder>
     <family name="DCX Series (v.27 and higher)" mfg="CT Elektronik" lowVersionID="27" highVersionID="59" comment="DCX74, DCX75, with variants">
       <model model="DCX74D" numOuts="2" numFns="10" maxMotorCurrent="1.6 A" maxTotalCurrent="0.8 A">
@@ -925,17 +929,17 @@
       </variable>
       <variable CV="116" mask="XXXXXXXV" item="Switching 1" default="0">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label>Switching 1</label>
+        <label>Ignore accel (CV3) and decel (CV4)</label>
         <label xml:lang="de">CV3 und CV4 wird ausgeschaltet</label>
       </variable>
       <variable CV="116" mask="XXXXXXVX" default="0" item="Switching 2">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label>Switching 2</label>
+        <label>Half speed</label>
         <label xml:lang="de">max. Geschwindigkeit wird vorwärts und rückwärts halbiert</label>
       </variable>
       <variable CV="116" mask="XXXXXVXX" default="0" item="Switching 3">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label>Switching 3</label>
+        <label>Reverse is 65% of forwards speed</label>
         <label xml:lang="de">rückwärts 65% der max. Geschw.keit (unabhängig vom Rang.)</label>
       </variable>
       <variable CV="117" default="0" item="F-Button Used For Dimming">
@@ -1614,16 +1618,17 @@
       <separator/>
       <display item="Switching 1"/>
       <display item="Switching 2"/>
-      <display item="Switching 3"/>
-      <label>
+       <label>
         <text>  </text>
       </label>
       <label>
         <text>  </text>
       </label>
       <label>
-        <text>  </text>
+        <text>Forward/Reverse speed ratio</text>
       </label>
+	  <display item="Switching 3"/>
+     
       <label>
         <text>  </text>
       </label>

--- a/xml/decoders/CT_Elektronik_DCX_new2.xml
+++ b/xml/decoders/CT_Elektronik_DCX_new2.xml
@@ -13,7 +13,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <version author="Nigel Cliffe" version="1.9" lastUpdated="2017/6/16"/> -->
+  <version author="Nigel Cliffe" version="1.9" lastUpdated="2017/6/16"/> 
 
   <!-- <version author="ronald@wirkuhns.de" version="1.8" lastUpdated="2016/5/12"/> -->
   <!-- <version author="ncliffe@btinternet.com" version="1.7" lastUpdated="2009/9/01"/> -->

--- a/xml/decoders/CT_Elektronik_Sound_SL_v100.xml
+++ b/xml/decoders/CT_Elektronik_Sound_SL_v100.xml
@@ -13,7 +13,9 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <version author="jclutterbuck2001@yahoo.co.uk" version="3.4" lastUpdated="2011/04/06"/>
+  <version author="nigel cliffe" version="3.5" lastUpdated="2017/06/15"/>
+  <!--  Re-instating meaningful labels to CV116 which were mysteriously changed somewhere without any documentation as to how that change happened  --> 
+  <!-- <version author="jclutterbuck2001@yahoo.co.uk" version="3.4" lastUpdated="2011/04/06"/>  -->
   <!--  v3.4: -->
   <!--  Split from old file - this one now applies to just SL75 & SL51 v100 onwards -->
   <!--  Major changes to Yard Mode and Uncoupling Panel CVs 55,56,58 & 151-152 all confirmed by testing (on v102 SL75) -->
@@ -2132,7 +2134,7 @@
             <choice>On</choice>
           </enumChoice>
         </enumVal>
-        <label>Switching 1</label>
+        <label>Ignore CV3 and CV4 accel/decel</label>
       </variable>
       <variable item="Switching 2" CV="116" mask="XXXXXXVX" default="0">
         <enumVal>
@@ -2143,7 +2145,7 @@
             <choice>On</choice>
           </enumChoice>
         </enumVal>
-        <label>Switching 2</label>
+        <label>Half speed running</label>
       </variable>
       <variable item="Switching 3" CV="116" mask="XXXXXVXX" default="0">
         <enumVal>
@@ -2154,7 +2156,7 @@
             <choice>On</choice>
           </enumChoice>
         </enumVal>
-        <label>Switching 3</label>
+        <label>Reverse 65% of forwards speed, (ignores "Yard" key)</label>
       </variable>
       <!-- CV116 = 8 brakes with diode 4-1 is active 
 CV116 = 16 brakes with Diode NOT richtungsabhangig 


### PR DESCRIPTION
Merges Nigel Cliffe's (@nigelcliffe) fix for Issue #3643 into the release 4.7.6 branch:

> I've noticed a fault probably caused by the language translations of the CT decoder files. The meaningful labels associated with CV116 where changed to less than useful terms. These files correct the most common decoders in use. (The whole CT stuff needs a tidy up, but not time to do that now).