### PR TITLE
Log launcher debugging statements

### DIFF
--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -75,7 +75,7 @@ function parse_args() {
             continue
         fi
         # note: set DEBUG=yes in environment to see at this point
-        [ -n "${DEBUG}" ] && echo "Parsing Arg: '${1}'"
+        [ -n "${DEBUG}" ] && echo "Parsing Arg: '${1}'" | tee -a ${launcher_log}
         case "${1}" in
             # append to classpath
             --cp:a) post_classpath="${post_classpath}:${2}" ; shift ;;
@@ -241,6 +241,11 @@ for opt in "$@"; do
     fi
 done
 
+# log to $settingsdir/log/launcher.log for debugging purposes
+launcher_log=${settingsdir}/log/launcher.log
+mkdir -p ${settingsdir}/log
+[ -f ${launcher_log} ] && rm -f ${launcher_log}
+
 # process arguments, stored arguments first, so CLI arguments can override
 
 # process default_options from the launcher configuration file
@@ -330,13 +335,13 @@ EOT
         JAVACMD=$( which java )
         JAVA_HOME="$( dirname ${JAVACMD} )/.."
     else
-        echo "Please install Java 1.8 per your operating system vendor's instructions."
+        echo "Please install Java 1.8 per your operating system vendor's instructions." | tee -a ${launcher_log}
         exit 1
     fi
 else
     JAVACMD="${JAVA_HOME}/bin/java"
     if [ ! -x "${JAVACMD}" ] ; then
-        echo "Unable to execute java using JAVA_HOME=\"${JAVA_HOME}\"."
+        echo "Unable to execute java using JAVA_HOME=\"${JAVA_HOME}\"." | tee -a ${launcher_log}
         exit 1
     fi
 fi
@@ -369,7 +374,7 @@ if [ -z "${JMRI_HOME}" ] ; then
 fi
 
 cd "${JMRI_HOME}"
-[ -n "${DEBUG}" ] && echo "PWD: '${PWD}'"
+[ -n "${DEBUG}" ] && echo "PWD: '${PWD}'" | tee -a ${launcher_log}
 
 
 # build library path
@@ -455,9 +460,9 @@ fi
 # remove any "\ " escaped spaces, since these are needed for bash, but not java
 CP="${CP//\\ / }"
 
-[ -n "${DEBUG}" ] && echo "CLASSPATH: '${CP}'"
+[ -n "${DEBUG}" ] && echo "CLASSPATH: '${CP}'" | tee -a ${launcher_log}
 
-[ -n "${DEBUG}" ] && echo "Java CMD: '${JAVACMD[@]}'"
+[ -n "${DEBUG}" ] && echo "Java CMD: '${JAVACMD[@]}'" | tee -a ${launcher_log}
 
 # configuration file name is 1st argument.
 # If not provided, build config file name dynamically
@@ -468,7 +473,7 @@ else
     APPNAME=$( basename "$0" )
 fi
 
-[ -n "${DEBUG}" ] && echo "APPNAME: '${APPNAME}'"
+[ -n "${DEBUG}" ] && echo "APPNAME: '${APPNAME}'" | tee -a ${launcher_log}
 
 # Process a config file name if passed as an option or when the application is
 # NOT the default one this script was built for and pass it as a Java property
@@ -478,7 +483,7 @@ if [ "$APPNAME" != "$DEFAULT_APP_NAME" -o -n "${CONFIGNAME}" ] ; then
         CONFIGNAME=$( echo $APPNAME | tr -d '[:space:]' | tr -d '=' )
     fi
     CONFIGFILE="-Dorg.jmri.Apps.configFilename=${CONFIGNAME}Config.xml"
-    [ -n "${DEBUG}" ] && echo "CONFIGFILE: '${CONFIGFILE}'"
+    [ -n "${DEBUG}" ] && echo "CONFIGFILE: '${CONFIGFILE}'" | tee -a ${launcher_log}
 fi
 
 # create the option string
@@ -505,6 +510,7 @@ OPTIONS="${OPTIONS} -Djava.library.path=.:$SYSLIBPATH:${LIBDIR}"
 
 # memory start and max limits
 OPTIONS="${OPTIONS} ${OS_OPTIONS-} ${jmri_xms} ${jmri_xmx}"
+[ -n "${DEBUG}" ] && echo "OPTIONS: '${OPTIONS}'" | tee -a ${launcher_log}
 
 # handle ports in --settings argument or JMRI_SERIAL_PORTS environment variable
 # but not if already in OPTIONS
@@ -517,7 +523,7 @@ declare -a DOCK_OPTIONS
 # Apple dock extensions to java get mangled by bash if included in ${OPTIONS}
 if [ "$OS" = "macosx" ] ; then
     DOCK_OPTIONS=(-Xdock:name="${APPNAME}" -Xdock:icon="${APPICON}")
-    [ -n "${DEBUG}" ] && echo "DOCK_OPTIONS: '${DOCK_OPTIONS[@]}'"
+    [ -n "${DEBUG}" ] && echo "DOCK_OPTIONS: '${DOCK_OPTIONS[@]}'" | tee -a ${launcher_log}
 fi
 
 
@@ -532,7 +538,7 @@ while [ "${EXIT_STATUS}" -eq "${RESTART_CODE}" ] ; do
     fi
 
     EXIT_STATUS=$?
-    [ -n "${DEBUG}" ] && echo Exit Status: "${EXIT_STATUS}"
+    [ -n "${DEBUG}" ] && echo Exit Status: "${EXIT_STATUS}" | tee -a ${launcher_log}
 done
 
 exit $EXIT_STATUS


### PR DESCRIPTION
Log debugging statements (if ```--debug``` is passed as an argument on the command line or added to default_arguments in jmri.conf or ```export DEBUG="yes"``` is called in the shell before launch) to the file at the JMRI portable path ```settings:log/launcher.log```