### PR TITLE
Ensure a Profile is in place for tests

### DIFF
--- a/java/test/jmri/util/zeroconf/ZeroConfServiceTest.java
+++ b/java/test/jmri/util/zeroconf/ZeroConfServiceTest.java
@@ -34,6 +34,7 @@ public class ZeroConfServiceTest {
     @Before
     public void setUp() throws Exception {
         Log4JFixture.setUp();
+        JUnitUtil.resetProfileManager();
     }
 
     @After


### PR DESCRIPTION
The ZeroConfService requires that the WebServerPreferences default instance be usable and that requires a Profile be set, so provide one.