### PR TITLE
Ignore the ProcessSerialNumber argument

### DIFF
--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -109,6 +109,8 @@ function parse_args() {
             # ignore and do not pass the settingsdir argument
             --settingsdir) shift ;;
             --settingsdir=*) ;;
+            # ignore and do not pass a ProcessSerialNumber argument (from the open command on macOS)
+            -psn_*) ;;
             # everything after this is to be passed to JMRI
             --) ARGS="${ARGS} $@" ; break ;;
             # pass anything else on to JMRI


### PR DESCRIPTION
The ```open``` command on macOS adds a ProcessSerialNumber argument (```-psn_#_########```) as the last argument when running a JMRI bundled application (this may also occur if the application is launched directly from a DMG while double clicking it in the Finder). This ignores that argument so JMRI app does not attempt to interpret it as an alternate configuration name.