### PR TITLE
Test for Java 9 on macOS correctly

### DIFF
--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -300,8 +300,9 @@ if [ -z "${JAVA_HOME}" ] ; then
         JAVA_HOME="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home"
         if [ -x "${JAVA_HOME}/bin/java" ] ; then
             JAVACMD="${JAVA_HOME}/bin/java"
-            # Test if java is present and version 1.8 or 1.9
-            if [[ ! "$( "${JAVACMD}" -version 2>&1 )" =~ 1.[89] ]] ; then
+            # Test if java is present and version 1.8 or 9
+            java_version="$( "${JAVACMD}" -version 2>&1 | grep version )"
+            if [[ ! "${java_version}" =~ \"1.8 && ! "${java_version}" =~ \"9 ]] ; then
                 JAVA_HOME=""
             fi
         else


### PR DESCRIPTION
Java 9 uses the version "X..." instead of the previous Java pattern of "1.X..." so test for that correctly. (Prior testing for Java 9 was done using a JDK instead of a JRE, so this was missed in that earlier testing.)