### PR TITLE
Update NetBeans per-file compilation targets

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -534,12 +534,14 @@
 
     <macrodef name="java-compile">
         <attribute name="javac.source"/>
+        <attribute name="javac.includes" default=""/>
         <attribute name="javac.target" default="${target}"/>
         <attribute name="javac.deprecation" default="${deprecation}"/>
         <attribute name="javac.classpath" default="compile.class.path"/>
         <sequential>
             <mkdir dir="@{javac.target}"/> <!-- ensure destdir exists -->
             <javac compiler="modern"
+                   includes="@{javac.includes}"
                    srcdir="@{javac.source}"
                    destdir="@{javac.target}"
                    source="${source_version}"

--- a/nbproject/ide-file-targets.xml
+++ b/nbproject/ide-file-targets.xml
@@ -1,41 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project basedir="../java" name="JMRI-IDE">
+<project basedir=".." name="JMRI-IDE">
+    <import file="../build.xml"/>
     <!-- TODO: edit the following target according to your needs -->
-    <!-- (more info: http://www.netbeans.org/kb/55/freeform-config.html#compilesingle) -->
-    <target name="compile-selected-files-in-jmri">
+    <!-- (more info: http://www.netbeans.org/kb/articles/freeform-config.html#compilesingle) -->
+    <target name="compile-selected-files-in-jmri" depends="runtime-library-selection">
         <fail unless="files">Must set property 'files'</fail>
-        <!-- TODO decide on and define some value for ${build.classes.dir} -->
-        <mkdir dir="classes"/>
-        <javac destdir="classes" includeantruntime="false" includes="${files}" source="1.8" srcdir="src/jmri">
-            <classpath path="tmp;lib/ch.ntb.usb.jar;lib/xercesImpl.jar;lib/gluegen-rt.jar;lib/javacsv.jar;lib/jdom-2.0.5.jar;lib/jdom.jar;lib/jhall.jar;lib/jinput.jar;lib/jmdns.jar;lib/joal.jar;lib/openlcb.jar;lib/jlfgr-1_0.jar;lib/junit.jar;lib/jython-standalone-2.7.0.jar;lib/log4j-1.2.17.jar;lib/jna-4.2.2.jar;lib/purejavacomm-1.0.1.jar;lib/servlet.jar;lib/vecmath-1.5.2.jar;lib/mailapi.jar;lib/smtp.jar;lib/jfcunit.jar;lib/jakarta-regexp-1.5.jar;lib/ExternalLinkContentViewerUI.jar;lib/annotations.jar;lib/jsr305.jar;lib/WinRegistry-4.4.jar"/>
-        </javac>
+        <java-compile javac.source="${source}" javac.includes="${files}"/>
     </target>
     <!-- TODO: edit the following target according to your needs -->
     <!-- (more info: http://www.netbeans.org/kb/articles/freeform-config.html#compilesingle) -->
-    <target name="compile-selected-files-in-src">
+    <target name="compile-selected-files-in-src" depends="runtime-library-selection">
         <fail unless="files">Must set property 'files'</fail>
-        <mkdir dir="classes"/>
-        <javac destdir="classes" includes="${files}" source="1.8" srcdir="src">
-            <classpath path="tmp;lib/ch.ntb.usb.jar;lib/xercesImpl.jar;lib/gluegen-rt.jar;lib/javacsv.jar;lib/jdom-2.0.5.jar;lib/jdom.jar;lib/jhall.jar;lib/jinput.jar;lib/jmdns.jar;lib/joal.jar;lib/openlcb.jar;lib/jlfgr-1_0.jar;lib/junit.jar;lib/jython-standalone-2.7.0.jar;lib/log4j-1.2.17.jar;lib/jna-4.2.2.jar;lib/purejavacomm-1.0.1.jar;lib/servlet.jar;lib/vecmath-1.5.2.jar;lib/mailapi.jar;lib/smtp.jar;lib/jfcunit.jar;lib/jakarta-regexp-1.5.jar;lib/ExternalLinkContentViewerUI.jar;lib/annotations.jar;lib/jsr305.jar;lib/WinRegistry-4.4.jar"/>
-        </javac>
+        <java-compile javac.source="${source}" javac.includes="${files}"/>
     </target>
     <!-- TODO: edit the following target according to your needs -->
     <!-- (more info: http://www.netbeans.org/kb/articles/freeform-config.html#compilesingle) -->
     <target name="compile-selected-files-in-test">
         <fail unless="files">Must set property 'files'</fail>
-        <mkdir dir="classes"/>
-        <javac destdir="classes" includes="${files}" source="1.8" srcdir="test">
-            <classpath path="tmp;classes;lib/junit.jar;lib/ch.ntb.usb.jar;lib/xercesImpl.jar;lib/gluegen-rt.jar;lib/jakarta-regexp-1.5.jar;lib/javacsv.jar;lib/jdom-2.0.5.jar;lib/jdom.jar;lib/jfcunit.jar;lib/jhall.jar;lib/jinput.jar;lib/jmdns.jar;lib/joal.jar;lib/openlcb.jar;lib/jlfgr-1_0.jar;lib/junit.jar;lib/jython-standalone-2.7.0.jar;lib/log4j-1.2.17.jar;lib/mailapi.jar;lib/jython-standalone-2.7.0.jar;lib/jna-4.2.2.jar;lib/purejavacomm-1.0.1.jar;lib/servlet.jar;lib/vecmath-1.5.2.jar;lib/annotations.jar;lib/jsr305.jar;lib/WinRegistry-4.4.jar"/>
-        </javac>
+        <java-compile javac.source="${test}" javac.target="${testtarget}" javac.classpath="test.class.path" javac.includes="${files}"/>
     </target>
     <!-- TODO: edit the following target according to your needs -->
     <!-- (more info: http://www.netbeans.org/kb/articles/freeform-config.html#compilesingle) -->
     <target name="compile-selected-files-in-tmp">
         <fail unless="files">Must set property 'files'</fail>
-        <!-- TODO decide on and define some value for ${build.classes.dir} -->
-        <mkdir dir="${build.classes.dir}"/>
-        <javac destdir="${build.classes.dir}" includes="${files}" source="1.8" srcdir="java/tmp">
-            <classpath path="tmp;lib/ch.ntb.usb.jar;lib/xercesImpl.jar;lib/gluegen-rt.jar;lib/javacsv.jar;lib/jdom-2.0.5.jar;lib/jdom.jar;lib/jhall.jar;lib/jinput.jar;lib/jmdns.jar;lib/joal.jar;lib/openlcb.jar;lib/jlfgr-1_0.jar;lib/junit.jar;lib/jython-standalone-2.7.0.jar;lib/log4j-1.2.17.jar;lib/jna-4.2.2.jar;lib/purejavacomm-1.0.1.jar;lib/servlet.jar;lib/vecmath-1.5.2.jar;lib/mailapi.jar;lib/smtp.jar;lib/jfcunit.jar;lib/jakarta-regexp-1.5.jar;lib/ExternalLinkContentViewerUI.jar;lib/annotations.jar;lib/jsr305.jar;lib/WinRegistry-4.4.jar"/>
-        </javac>
+        <java-compile javac.source="${genjavasrcdir}" javac.includes="${files}"/>
     </target>
 </project>


### PR DESCRIPTION
Update the NetBeans per-file compilation targets to use the java-compile macro in build.xml so the updated targets do not get stale class paths. Also add ability to specify the files to compile to the java-compile macro.