### PR TITLE
Add DELAYED Turnout feedback mode

### DIFF
--- a/help/en/html/doc/Technical/TurnoutFeedback.shtml
+++ b/help/en/html/doc/Technical/TurnoutFeedback.shtml
@@ -124,6 +124,14 @@
         When Sensor 2 is active, the turnout is known to be closed
         (normal).</dd>
 
+        <dt>DELAYED</dt>
+
+        <dd>When something tells the Turnout to change, 
+        it immediately starts the operation and goes to
+        the INCONSISTENT state to reflect that the points
+        are moving.  After a few seconds delay, the
+        operation completes and the final state is reported.</dd>
+
         <dt>MONITORING</dt>
 
         <dd>Default for LocoNet and XPressNet turnouts, and

--- a/help/en/manual/DecoderPro/Main_TurnoutControl.shtml
+++ b/help/en/manual/DecoderPro/Main_TurnoutControl.shtml
@@ -80,10 +80,15 @@
             &lt;thrown&gt; and &lt;closed&gt;</p>
 
             <p><strong>feedback mode:</strong> some of the
-            available feedback modes are: &lt;DIRECT&gt;, &lt;ONE
-            SENSOR&gt;, &lt;TWO SENSOR&gt;, and &lt;MONITORING&gt;.
+            available feedback modes are: &lt;DIRECT&gt;, &lt;DELAYED&gt;,
+            &lt;ONE SENSOR&gt;, &lt;TWO SENSOR&gt;, and &lt;MONITORING&gt;.
             A turnout using DIRECT mode does not have feedback from
-            the layout. ONE SENSOR use one sensor on the layout to
+            the layout. 
+            When a close or throw command is executed the JMRI program
+            assumes that the command always completes immediately. 
+            DELAYED simulates the turnout operation taking a few seconds
+            to complete.
+            ONE SENSOR use one sensor on the layout to
             provide feedback on he state of the turnout. TWO SENSOR
             uses two sensors for feedback, one for closed and one
             for thrown. MONITORING gets feedback from the system by

--- a/help/en/manual/DecoderPro3/dp3_Main_TurnoutControl.shtml
+++ b/help/en/manual/DecoderPro3/dp3_Main_TurnoutControl.shtml
@@ -80,10 +80,15 @@
             &lt;thrown&gt; and &lt;closed&gt;</p>
 
             <p><strong>feedback mode:</strong> some of the
-            available feedback modes are: &lt;DIRECT&gt;, &lt;ONE
-            SENSOR&gt;, &lt;TWO SENSOR&gt;, and &lt;MONITORING&gt;.
+            available feedback modes are: &lt;DIRECT&gt;, &lt;DELAYED&gt;,
+            &lt;ONE SENSOR&gt;, &lt;TWO SENSOR&gt;, and &lt;MONITORING&gt;.
             A turnout using DIRECT mode does not have feedback from
-            the layout. ONE SENSOR use one sensor on the layout to
+            the layout. 
+            When a close or throw command is executed the JMRI program
+            assumes that the command always completes immediately. 
+            DELAYED simulates the turnout operation taking a few seconds
+            to complete.
+            ONE SENSOR use one sensor on the layout to
             provide feedback on he state of the turnout. TWO SENSOR
             uses two sensors for feedback, one for closed and one
             for thrown. MONITORING gets feedback from the system by

--- a/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/TurnoutTable.shtml
@@ -354,6 +354,14 @@
         "Thrown". When Sensor 2 is "Active", the turnout is known
         to be "Closed" (normal).</dd>
 
+        <dt>DELAYED</dt>
+
+        <dd>When something tells the Turnout to change, 
+        it immediately starts the operation and goes to
+        the INCONSISTENT state to reflect that the points
+        are moving.  After a few seconds delay, the
+        operation completes and the final state is reported.</dd>
+
         <dt>MONITORING</dt>
 
         <dd>Default for LocoNet Turnouts (and probably XpressNet

--- a/help/en/package/jmri/jmrit/simpleturnoutctrl/SimpleTurnoutCtrl.shtml
+++ b/help/en/package/jmri/jmrit/simpleturnoutctrl/SimpleTurnoutCtrl.shtml
@@ -68,10 +68,13 @@
 
         <dd>Shows the turnout's feedback mode. Some of the
         available <a href="#Feedback">feedback</a> modes are:
-        DIRECT, ONE SENSOR, TWO SENSOR, and MONITORING. A turnout
+        DIRECT, DELAYED, ONE SENSOR, TWO SENSOR, and MONITORING. A turnout
         using DIRECT mode doesn't have feedback from the layout.
         When a close or throw command is executed the JMRI program
-        assumes that the command always completes. ONE SENSOR use
+        assumes that the command always completes immediately. 
+        DELAYED simulates the turnout operation taking a few seconds
+        to complete.
+        ONE SENSOR uses
         one sensor on the layout to provide feedback on the state
         of the turnout. TWO SENSOR uses two sensors for feedback,
         one for closed and one for thrown. MONITORING gets feedback

--- a/java/src/jmri/Turnout.java
+++ b/java/src/jmri/Turnout.java
@@ -137,6 +137,12 @@ public interface Turnout extends NamedBean {
     public static final int SIGNAL = 64;
 
     /**
+     * Constant representing "automatic delayed feedback" . This is DIRECT feedback
+     * with a fixed delay before the feedback (known state) takes effect.
+     */
+    public static final int DELAYED = 128;
+
+    /**
      * Constant representing turnout lockout cab commands
      */
     public static final int CABLOCKOUT = 1;

--- a/java/test/jmri/jmrix/dccpp/DCCppTurnoutTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppTurnoutTest.java
@@ -54,14 +54,14 @@ public class DCCppTurnoutTest extends jmri.implementation.AbstractTurnoutTestBas
         Assert.assertEquals(42, num);
         
         int[] vals = DCCppTurnout.getModeValues();
-        Assert.assertEquals(5, vals.length);
-        Assert.assertEquals(Turnout.MONITORING, vals[3]);
-        Assert.assertEquals(Turnout.EXACT, vals[4]);
+        Assert.assertEquals(6, vals.length);
+        Assert.assertEquals(Turnout.MONITORING, vals[4]);
+        Assert.assertEquals(Turnout.EXACT, vals[5]);
         
         String[] names = DCCppTurnout.getModeNames();
-        Assert.assertEquals(5, names.length);
-        Assert.assertEquals("BSTURNOUT", names[3]);
-        Assert.assertEquals("BSOUTPUT", names[4]);
+        Assert.assertEquals(6, names.length);
+        Assert.assertEquals("BSTURNOUT", names[4]);
+        Assert.assertEquals("BSOUTPUT", names[5]);
         // TODO: CHeck some othr stuff
         
         // Check a few basic things

--- a/jython/SetDefaultDelayedTurnoutDelay.py
+++ b/jython/SetDefaultDelayedTurnoutDelay.py
@@ -1,0 +1,14 @@
+# Change the delay for DELAYED Turnout feedback.
+#
+# Note the delay is for _all_ turnouts; there's no 
+# turnout-by-turnout operation currently.
+#
+# Author: Bob Jacobsen, copyright 2017
+# Part of the JMRI distribution
+
+import jmri
+
+# time is in milliseconds
+jmri.implementation.AbstractTurnout.DELAYED_FEEDBACK_INTERVAL = 10000
+
+

--- a/jython/test/SetDefaultDelayedTurnoutDelayTest.py
+++ b/jython/test/SetDefaultDelayedTurnoutDelayTest.py
@@ -1,0 +1,14 @@
+# Test the SetDefaultDelayedTurnoutDelayTest.py script
+
+import jmri
+
+# capture original value (also checks still accessible)
+original = jmri.implementation.AbstractTurnout.DELAYED_FEEDBACK_INTERVAL
+
+execfile("jython/SetDefaultDelayedTurnoutDelay.py")
+
+# check that it changed
+if (jmri.implementation.AbstractTurnout.DELAYED_FEEDBACK_INTERVAL == original) : raise AssertionError('Value not changed')
+
+# restore
+jmri.implementation.AbstractTurnout.DELAYED_FEEDBACK_INTERVAL = original


### PR DESCRIPTION
Add a new feedback mode to Turnouts: DELAYED

When this mode is selected and a Turnout's CommandedState is changed, the KnownState goes to INCONSISTENT for four seconds, then to the commanded state.  Overlapping operations will stay in INCONSISTENT until going to the last commanded state.  

The four second default can be changed via script; [jython/SetDefaultDelayedTurnoutDelay.py](http://jmri.org/jython/SetDefaultDelayedTurnoutDelay.py) shows how.