### PR TITLE
Update sensor schema to handle properties

### DIFF
--- a/java/src/jmri/managers/configurexml/AbstractSensorManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractSensorManagerConfigXML.java
@@ -65,6 +65,10 @@ public abstract class AbstractSensorManagerConfigXML extends AbstractNamedBeanMa
             Element elem = new Element("sensor")
                     .setAttribute("inverted", inverted);
             elem.addContent(new Element("systemName").addContent(sname));
+
+            // store common part
+            storeCommon(s, elem);
+
             log.debug("store sensor " + sname);
             if (s.useDefaultTimerSettings()) {
                 elem.addContent(new Element("useGlobalDebounceTimer").addContent("yes"));
@@ -80,9 +84,6 @@ public abstract class AbstractSensorManagerConfigXML extends AbstractNamedBeanMa
                // store the sensor's value for pull resistance.
                elem.addContent(new Element("pullResistance").addContent(s.getPullResistance().getShortName()));
             }
-
-            // store common part
-            storeCommon(s, elem);
 
             sensors.addContent(elem);
 

--- a/java/test/jmri/configurexml/valid/DCCppSensorTurnoutLight.xml
+++ b/java/test/jmri/configurexml/valid/DCCppSensorTurnoutLight.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-2-9-6.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-2-9-6.xsd">
+  <jmriversion>
+    <major>4</major>
+    <minor>9</minor>
+    <test>1</test>
+    <modifier>ish</modifier>
+  </jmriversion>
+  <sensors class="jmri.jmrix.dccpp.configurexml.DCCppSensorManagerXml">
+    <sensor inverted="false">
+      <systemName>DCCPPS0</systemName>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS1</systemName>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">4</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS2</systemName>
+    </sensor>
+  </sensors>
+  <turnouts class="jmri.jmrix.dccpp.configurexml.DCCppTurnoutManagerXml">
+    <operations automate="false">
+      <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
+      <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
+      <operation name="Sensor" class="jmri.configurexml.turnoutoperations.SensorTurnoutOperationXml" interval="300" maxtries="3" />
+    </operations>
+    <defaultclosedspeed>Normal</defaultclosedspeed>
+    <defaultthrownspeed>Restricted</defaultthrownspeed>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>DCCPPT1</systemName>
+    </turnout>
+  </turnouts>
+  <lights class="jmri.jmrix.dccpp.configurexml.DCCppLightManagerXml">
+    <light minIntensity="0.0" maxIntensity="1.0" transitionTime="0.0">
+      <systemName>DCCPPL3</systemName>
+    </light>
+  </lights>
+  <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
+  <signalgroups class="jmri.managers.configurexml.DefaultSignalGroupManagerXml" />
+  <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
+  <warrants class="jmri.jmrit.logix.configurexml.WarrantManagerXml" />
+  <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
+    <logicDelay>500</logicDelay>
+  </signalmastlogics>
+  <filehistory>
+    <operation>
+      <type>app</type>
+      <date>Sat Jul 01 10:08:04 PDT 2017</date>
+      <filename>JMRI program</filename>
+    </operation>
+    <operation>
+      <type>Store</type>
+      <date>Sat Jul 01 10:10:47 PDT 2017</date>
+      <filename />
+    </operation>
+  </filehistory>
+  <!--Written by JMRI version 4.9.1ish+jake+20170701T1705Z+R5c211008cb on Sat Jul 01 10:10:47 PDT 2017-->
+</layout-config>

--- a/java/test/jmri/configurexml/valid/DCCppSensors.xml
+++ b/java/test/jmri/configurexml/valid/DCCppSensors.xml
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-2-9-6.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-2-9-6.xsd">
+  <jmriversion>
+    <major>4</major>
+    <minor>7</minor>
+    <test>6</test>
+    <modifier />
+  </jmriversion>
+  <sensors class="jmri.jmrix.dccpp.configurexml.DCCppSensorManagerXml">
+    <sensor inverted="false">
+      <systemName>DCCPPS256</systemName>
+      <debounceTimers>
+        <goingActive>1</goingActive>
+        <goingInActive>1</goingInActive>
+      </debounceTimers>
+      <userName>dec0</userName>
+      <comment>siding track</comment>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">29</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS257</systemName>
+      <userName>dec1</userName>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">27</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS258</systemName>
+      <userName>dec2</userName>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">25</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS259</systemName>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">23</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS384</systemName>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">45</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS385</systemName>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">43</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS386</systemName>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">41</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS387</systemName>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">39</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS388</systemName>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">37</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS389</systemName>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">35</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS390</systemName>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">33</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+    <sensor inverted="false">
+      <systemName>DCCPPS391</systemName>
+      <properties>
+        <property>
+          <key>Pin</key>
+          <value class="java.lang.Integer">31</value>
+        </property>
+        <property>
+          <key>Pullup</key>
+          <value class="java.lang.Boolean">true</value>
+        </property>
+      </properties>
+    </sensor>
+  </sensors>
+  <turnouts class="jmri.jmrix.dccpp.configurexml.DCCppTurnoutManagerXml">
+    <operations automate="false">
+      <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
+      <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
+      <operation name="Sensor" class="jmri.configurexml.turnoutoperations.SensorTurnoutOperationXml" interval="300" maxtries="3" />
+    </operations>
+    <defaultclosedspeed>Normal</defaultclosedspeed>
+    <defaultthrownspeed>Restricted</defaultthrownspeed>
+    <turnout feedback="BSTURNOUT" inverted="false" automate="Off">
+      <systemName>DCCPPT0</systemName>
+      <userName>siding-0-1</userName>
+    </turnout>
+    <turnout feedback="BSTURNOUT" inverted="false" automate="Off">
+      <systemName>DCCPPT1</systemName>
+      <userName>siding-2</userName>
+    </turnout>
+    <turnout feedback="BSTURNOUT" inverted="false" automate="Off">
+      <systemName>DCCPPT128</systemName>
+      <userName>decoupler 0</userName>
+    </turnout>
+    <turnout feedback="BSTURNOUT" inverted="false" automate="Off">
+      <systemName>DCCPPT129</systemName>
+      <userName>decoupler 1</userName>
+    </turnout>
+    <turnout feedback="BSTURNOUT" inverted="false" automate="Off">
+      <systemName>DCCPPT130</systemName>
+      <userName>decoupler 2</userName>
+    </turnout>
+    <turnout feedback="BSTURNOUT" inverted="false" automate="Off">
+      <systemName>DCCPPT2</systemName>
+      <userName>locomotives</userName>
+    </turnout>
+    <turnout feedback="BSTURNOUT" inverted="false" automate="Off">
+      <systemName>DCCPPT3</systemName>
+      <userName>crossover</userName>
+    </turnout>
+    <turnout feedback="BSTURNOUT" inverted="false" automate="Off">
+      <systemName>DCCPPT4</systemName>
+      <userName>shunters</userName>
+    </turnout>
+  </turnouts>
+  <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
+  <signalgroups class="jmri.managers.configurexml.DefaultSignalGroupManagerXml" />
+  <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
+  <warrants class="jmri.jmrit.logix.configurexml.WarrantManagerXml" />
+  <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
+    <logicDelay>500</logicDelay>
+  </signalmastlogics>
+  <logixs class="jmri.managers.configurexml.DefaultLogixManagerXml">
+    <logix userName="System Logix" enabled="yes">
+      <systemName>SYS</systemName>
+      <userName>System Logix</userName>
+    </logix>
+  </logixs>
+  <filehistory>
+    <operation>
+      <type>app</type>
+      <date>Tue Jun 27 15:22:35 BST 2017</date>
+      <filename>JMRI program</filename>
+    </operation>
+    <operation>
+      <type>Load OK</type>
+      <date>Tue Jun 27 15:22:41 BST 2017</date>
+      <filename>/dcs/dap/.jmri/GreenField/June21-1.xml</filename>
+      <filehistory>
+        <operation>
+          <type>app</type>
+          <date>Wed Jun 21 17:31:30 BST 2017</date>
+          <filename>JMRI program</filename>
+        </operation>
+        <operation>
+          <type>Load OK</type>
+          <date>Wed Jun 21 17:31:36 BST 2017</date>
+          <filename>/dcs/dap/.jmri/GreenField/June21-1.xml</filename>
+          <filehistory>
+            <operation>
+              <type>app</type>
+              <date>Wed Jun 21 17:03:42 BST 2017</date>
+              <filename>JMRI program</filename>
+            </operation>
+            <operation>
+              <type>Load OK</type>
+              <date>Wed Jun 21 17:03:47 BST 2017</date>
+              <filename>/dcs/dap/.jmri/GreenField/June21-1.xml</filename>
+              <filehistory>
+                <operation>
+                  <type>app</type>
+                  <date>Wed Jun 21 16:10:58 BST 2017</date>
+                  <filename>JMRI program</filename>
+                </operation>
+                <operation>
+                  <type>Load OK</type>
+                  <date>Wed Jun 21 16:11:02 BST 2017</date>
+                  <filename>/dcs/dap/.jmri/GreenField/June21-1.xml</filename>
+                  <filehistory>
+                    <operation>
+                      <type>app</type>
+                      <date>Wed Jun 21 16:09:38 BST 2017</date>
+                      <filename>JMRI program</filename>
+                    </operation>
+                    <operation>
+                      <type>Load OK</type>
+                      <date>Wed Jun 21 16:09:43 BST 2017</date>
+                      <filename>/dcs/dap/.jmri/GreenField/June21-1.xml</filename>
+                      <filehistory>
+                        <operation>
+                          <type>app</type>
+                          <date>Wed Jun 21 16:03:41 BST 2017</date>
+                          <filename>JMRI program</filename>
+                        </operation>
+                        <operation>
+                          <type>Load OK</type>
+                          <date>Wed Jun 21 16:03:46 BST 2017</date>
+                          <filename>/dcs/dap/.jmri/GreenField/June21-1.xml</filename>
+                        </operation>
+                        <operation>
+                          <type>Store</type>
+                          <date>Wed Jun 21 16:07:01 BST 2017</date>
+                          <filename />
+                        </operation>
+                      </filehistory>
+                    </operation>
+                    <operation>
+                      <type>Store</type>
+                      <date>Wed Jun 21 16:10:23 BST 2017</date>
+                      <filename />
+                    </operation>
+                  </filehistory>
+                </operation>
+                <operation>
+                  <type>Store</type>
+                  <date>Wed Jun 21 17:01:07 BST 2017</date>
+                  <filename />
+                </operation>
+              </filehistory>
+            </operation>
+            <operation>
+              <type>Store</type>
+              <date>Wed Jun 21 17:05:23 BST 2017</date>
+              <filename />
+            </operation>
+          </filehistory>
+        </operation>
+        <operation>
+          <type>Store</type>
+          <date>Wed Jun 21 17:33:26 BST 2017</date>
+          <filename />
+        </operation>
+      </filehistory>
+    </operation>
+    <operation>
+      <type>Store</type>
+      <date>Tue Jun 27 15:31:26 BST 2017</date>
+      <filename />
+    </operation>
+  </filehistory>
+  <!--Written by JMRI version 4.7.6+R570b2bc on Tue Jun 27 15:31:26 BST 2017-->
+</layout-config>
+
+<!-- neodl1.grp.bf1.yahoo.com Sat Jul  1 17:14:41 UTC 2017 -->

--- a/xml/schema/types/sensors-2-9-6.xsd
+++ b/xml/schema/types/sensors-2-9-6.xsd
@@ -53,9 +53,50 @@
         <xs:element name="sensor" minOccurs="0" maxOccurs="unbounded">
           <xs:complexType>
             <xs:all>
+              <!-- The following is really ugly duplication caused by not being able to , and should be fixed by
+                     1) Moving to XML Schema 1.1
+                     2) Then converting the "sequence" element in NamedBeanType into an "all" element
+                     3) Then having this "sensor" element extend from NamedBeanType
+                    The problem is that (a) XML Schema 1.0 "all" elements can't be extended, but
+                    (b) we want to insert something _inside_ the order of elements in NamedBeanType.
+                    So we recreate those here.  (The code in SensorManager has had the order fixed in 4.7.7
+                    but old files still exist)
+                    -->
               <xs:element name="systemName" type="systemNameType" minOccurs="1" maxOccurs="1"/>
               <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
               <xs:element name="comment" type="commentType" minOccurs="0" maxOccurs="1" />
+              <xs:element name="properties" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="property" minOccurs="1" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="key" minOccurs="1" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:simpleContent>
+                                <xs:extension base="xs:string">
+                                  <xs:attribute name="class" type="classType" use="optional" />
+                                </xs:extension>
+                              </xs:simpleContent>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="value" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:simpleContent>
+                                <xs:extension base="xs:string">
+                                  <xs:attribute name="class" type="classType" use="required" />
+                                </xs:extension>
+                              </xs:simpleContent>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <!-- end of ugly duplication -->
+
               <xs:element name="useGlobalDebounceTimer" type="yesNoType" minOccurs="0" maxOccurs="1" />
               <xs:element name="debounceTimers" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
@@ -66,6 +107,7 @@
                 </xs:complexType>
               </xs:element>
               <xs:element name="pullResistance" type="xs:string" minOccurs="0" maxOccurs="1" />
+
             </xs:all>
             <xs:attribute name="systemName" type="systemNameType">
                 <xs:annotation><xs:documentation>Deprecated 2.9.6 in favor of separate element</xs:documentation></xs:annotation>


### PR DESCRIPTION
This is patch to allow sensor elements to include properties, which fixes #3695.  

See also #3701 for a long term fix.