### PR TITLE
Prevent potential duplicate user names

### DIFF
--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -310,7 +310,7 @@ public class LightTableAction extends AbstractTableAction {
 
             @Override
             public NamedBean getByUserName(String name) {
-                return lightManager.getByUserName(name);
+                return InstanceManager.getDefault(LightManager.class).getByUserName(name);
             }
 
             @Override

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -557,7 +557,7 @@ public class TurnoutTableAction extends AbstractTableAction {
 
             @Override
             public NamedBean getByUserName(String name) {
-                return turnManager.getByUserName(name);
+                return InstanceManager.getDefault(TurnoutManager.class).getByUserName(name);
             }
 
             @Override

--- a/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
@@ -131,7 +131,7 @@ public class SensorTableDataModel extends BeanTableDataModel {
 
     @Override
     protected NamedBean getByUserName(String name) {
-        return senManager.getByUserName(name);
+        return InstanceManager.getDefault(SensorManager.class).getByUserName(name);
     }
 
     @Override


### PR DESCRIPTION
The turnout, sensor and light tables can have multiple tabs based on
the number of connections.  Except for the All tab, these tabs have a
manager with a subset of the objects.  The Rename process was using the
tab specific manager instead of the global manager to check for
duplicate user names.