### PR TITLE
Update CTC tools; new script-based tools

### DIFF
--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -150,7 +150,7 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
     }
 
     /**
-     * Add a protected newKnownState() for use by implementations.
+     * Add a newKnownState() for use by implementations.
      * <P>
      * Use this to update internal information when a state change is detected
      * <em>outside</em> the Turnout object, e.g. via feedback from sensors on
@@ -166,11 +166,12 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
      * going to THROWN or CLOSED, because there may be others listening to
      * network state.
      * <P>
-     * Not intended for general use, e.g. for users to set the KnownState.
+     * This method is intended for general use, e.g. for users to set the KnownState,
+     * so it doesn't appear in the Turnout interface.
      *
      * @param s New state value
      */
-    protected void newKnownState(int s) {
+    public void newKnownState(int s) {
         if (_knownState != s) {
             int oldState = _knownState;
             _knownState = s;

--- a/java/src/jmri/jmrit/ussctc/CodeLine.java
+++ b/java/src/jmri/jmrit/ussctc/CodeLine.java
@@ -104,7 +104,7 @@ public class CodeLine {
     void startSendCode(Station station) {
         final Station s = station;
         log.debug("CodeLine startSendCode - Tell hardware to start sending code");
-        logMemory.setValue("Sending Code");
+        logMemory.setValue("Sending Code: Station "+station.getName());
         hStartTO.getBean().setCommandedState(Turnout.THROWN);
         new Timer().schedule(new TimerTask() { // turn that off
             @Override
@@ -150,7 +150,7 @@ public class CodeLine {
         station.indicationStart();
     
         log.debug("Tell hardware to start sending indication");
-        logMemory.setValue("Receiving Indication");
+        logMemory.setValue("Receiving Indication: Station "+station.getName());
         hStartTO.getBean().setCommandedState(Turnout.THROWN);
         new Timer().schedule(new TimerTask() { // turn that off
             @Override

--- a/java/src/jmri/jmrit/ussctc/CodeLine.java
+++ b/java/src/jmri/jmrit/ussctc/CodeLine.java
@@ -31,6 +31,10 @@ public class CodeLine {
     public CodeLine(String startTO, String output1TO, String output2TO, String output3TO, String output4TO) {
         NamedBeanHandleManager hm = InstanceManager.getDefault(NamedBeanHandleManager.class);
         TurnoutManager tm = InstanceManager.getDefault(TurnoutManager.class);
+
+        logMemory = InstanceManager.getDefault(MemoryManager.class).provideMemory(
+                        Constants.commonNamePrefix+"CODELINE"+Constants.commonNameSuffix+"LOG");
+        log.debug("log memory name is {}", logMemory.getSystemName());
         
         hStartTO = hm.getNamedBeanHandle(startTO, tm.provideTurnout(startTO));
 
@@ -39,6 +43,8 @@ public class CodeLine {
         hOutput3TO = hm.getNamedBeanHandle(output3TO, tm.provideTurnout(output3TO));
         hOutput4TO = hm.getNamedBeanHandle(output4TO, tm.provideTurnout(output4TO));
     }
+
+    Memory logMemory = null;
 
     NamedBeanHandle<Turnout> hStartTO;
 
@@ -77,6 +83,7 @@ public class CodeLine {
             return;
         }
         active = false;
+        logMemory.setValue("");
         log.debug("CodeLine goes inactive");
     }
     
@@ -97,6 +104,7 @@ public class CodeLine {
     void startSendCode(Station station) {
         final Station s = station;
         log.debug("CodeLine startSendCode - Tell hardware to start sending code");
+        logMemory.setValue("Sending Code");
         hStartTO.getBean().setCommandedState(Turnout.THROWN);
         new Timer().schedule(new TimerTask() { // turn that off
             @Override
@@ -142,6 +150,7 @@ public class CodeLine {
         station.indicationStart();
     
         log.debug("Tell hardware to start sending indication");
+        logMemory.setValue("Receiving Indication");
         hStartTO.getBean().setCommandedState(Turnout.THROWN);
         new Timer().schedule(new TimerTask() { // turn that off
             @Override

--- a/java/src/jmri/jmrit/ussctc/CodeLine.java
+++ b/java/src/jmri/jmrit/ussctc/CodeLine.java
@@ -50,9 +50,53 @@ public class CodeLine {
     public static int START_PULSE_LENGTH = 500; // mSec
     public static int CODE_SEND_DELAY = 2500; // mSec
     
-    void requestSendCode(Station station) {
+    volatile Deque<Station> codeQueue = new ArrayDeque<>();
+    volatile Deque<Station> indicationQueue = new ArrayDeque<>();
+    
+    volatile boolean active = false;
+    
+    synchronized void endAndCheckNext() {
+        if (!active) log.error("endAndCheckNext with active false", new Exception("traceback"));
+        active = false;
+        checkForWork();
+    }
+    
+    synchronized void checkForWork() {
+        log.debug("checkForWork with active == {}", active);
+        if (active) return;
+        active = true;
+        Station station;
+        station = indicationQueue.pollFirst();
+        if (station != null) {
+            startSendIndication(station);
+            return;
+        }
+        station = codeQueue.pollFirst();
+        if (station != null) {
+            startSendCode(station);
+            return;
+        }
+        active = false;
+        log.debug("CodeLine goes inactive");
+    }
+    
+    /**
+     * Request processing of an indication from the field
+     */
+    synchronized void requestSendCode(Station station) {
+        log.debug("requestSendCode queued");
+        // remove if present
+        while (codeQueue.contains(station)) {
+            codeQueue.remove(station);
+            log.debug("     removed previous request");
+        }
+        codeQueue.addLast(station);
+        checkForWork();
+    }
+
+    void startSendCode(Station station) {
         final Station s = station;
-        log.debug("CodeLine requestSendCode - Tell hardware to start sending code");
+        log.debug("CodeLine startSendCode - Tell hardware to start sending code");
         hStartTO.getBean().setCommandedState(Turnout.THROWN);
         new Timer().schedule(new TimerTask() { // turn that off
             @Override
@@ -68,6 +112,9 @@ public class CodeLine {
             public void run() {
                 jmri.util.ThreadingUtil.runOnGUI( ()->{
                     s.codeValueDelivered();
+                    // and see if anything else needs to be done
+                    log.debug("end of codeValueDelivered");
+                    endAndCheckNext();
                 } );
             }
         }, CODE_SEND_DELAY);
@@ -76,11 +123,22 @@ public class CodeLine {
     /**
      * Request processing of an indication from the field
      */
-    void requestIndicationStart(Station station) {
+    synchronized void requestIndicationStart(Station station) {
+        log.debug("requestIndicationStart queued");
+        // remove if present
+        while (indicationQueue.contains(station)) {
+            indicationQueue.remove(station);
+            log.debug("     removed previous request");
+        }
+        indicationQueue.addLast(station);
+        checkForWork();
+    }
+    
+    void startSendIndication(Station station) {
         final Station s = station;
-        log.debug("CodeLine requestIndicationStart - process indication from field");
+        log.debug("CodeLine startSendIndication - process indication from field");
 
-        // light code light
+        // light code light and gather values
         station.indicationStart();
     
         log.debug("Tell hardware to start sending indication");
@@ -98,7 +156,11 @@ public class CodeLine {
             @Override
             public void run() {
                 jmri.util.ThreadingUtil.runOnGUI( ()->{
+                    log.debug("hardware delay done, receiving indication");
                     s.indicationComplete();
+                    log.debug("end of indicationComplete");
+                    // and see if anything else needs to be done
+                    endAndCheckNext();
                 } );
             }
         }, CODE_SEND_DELAY);

--- a/java/src/jmri/jmrit/ussctc/RouteLock.java
+++ b/java/src/jmri/jmrit/ussctc/RouteLock.java
@@ -58,7 +58,7 @@ public class RouteLock implements Lock {
     }
 
     /**
-     * @param array User or system name of a SignalHead that covers this route
+     * @param head User or system name of a SignalHead that covers this route
      */
     public RouteLock(String head) {
         this(new String[]{head});

--- a/java/src/jmri/jmrit/ussctc/RouteLock.java
+++ b/java/src/jmri/jmrit/ussctc/RouteLock.java
@@ -11,29 +11,74 @@ import java.util.*;
  */
 public class RouteLock implements Lock {
 
+    /**
+     * @param list SignalHeads that cover this route
+     */
     public RouteLock(List<NamedBeanHandle<SignalHead>> list) {
         this.list = list;
+        this.beans = null;
     }
     
+    /**
+     * @param list SignalHeads that cover this route
+     * @param beans Defines the specific route
+     */
+    public RouteLock(List<NamedBeanHandle<SignalHead>> list, List<BeanSetting> beans) {
+        this.list = list;
+        this.beans = beans;
+    }
+    
+    /**
+     * @param array User or system names of SignalHeads that cover this route
+     */
     public RouteLock(String[] array) {
         NamedBeanHandleManager hm = InstanceManager.getDefault(NamedBeanHandleManager.class);
         SignalHeadManager sm = InstanceManager.getDefault(SignalHeadManager.class);
 
         list = new ArrayList<>();
         for (String s : array) list.add(hm.getNamedBeanHandle(s, sm.getSignalHead(s)));
+        
+        this.beans = null;
     }
 
+    /**
+     * @param array User or system names of SignalHeads that cover this route
+     * @param beans Defines the specific route
+     */
+    public RouteLock(String[] array, BeanSetting[] beans) {
+        NamedBeanHandleManager hm = InstanceManager.getDefault(NamedBeanHandleManager.class);
+        SignalHeadManager sm = InstanceManager.getDefault(SignalHeadManager.class);
+
+        list = new ArrayList<>();
+        for (String s : array) list.add(hm.getNamedBeanHandle(s, sm.getSignalHead(s)));
+        
+        this.beans = new ArrayList<>();
+        for (BeanSetting bean : beans) this.beans.add(bean);
+        
+    }
+
+    /**
+     * @param array User or system name of a SignalHead that covers this route
+     */
     public RouteLock(String head) {
         this(new String[]{head});
     }
 
     List<NamedBeanHandle<SignalHead>> list; 
+    List<BeanSetting> beans;
     
     /**
      * Test the lock conditions
      * @return True if lock is clear and operation permitted
      */
     public boolean isLockClear() {
+        // if this route isn't in effect, then permitted
+        if (beans != null) {
+            for (BeanSetting bean : beans) {
+                if ( ! bean.check()) return true;
+            }
+        }
+        
         for (NamedBeanHandle<SignalHead> handle : list) {
             if (handle.getBean().getState() != SignalHead.RED) return false;
         }

--- a/java/src/jmri/jmrit/ussctc/SignalHeadSection.java
+++ b/java/src/jmri/jmrit/ussctc/SignalHeadSection.java
@@ -121,6 +121,8 @@ public class SignalHeadSection implements Section<CodeGroupThreeBits, CodeGroupT
 
     boolean timeRunning = false;
     
+    public boolean isRunningTime() { return timeRunning; }
+    
     Station station;
     
     /**

--- a/java/src/jmri/jmrit/ussctc/SignalHeadSection.java
+++ b/java/src/jmri/jmrit/ussctc/SignalHeadSection.java
@@ -173,7 +173,7 @@ public class SignalHeadSection implements Section<CodeGroupThreeBits, CodeGroupT
                 (int)timeMemory.getValue());
             
             log.debug("starting to run time");
-            logMemory.setValue("Running time");
+            logMemory.setValue("Running time: Station "+station.getName());
         }
     
         // Set the indicators based on current and requested state

--- a/java/src/jmri/jmrit/ussctc/SignalHeadSection.java
+++ b/java/src/jmri/jmrit/ussctc/SignalHeadSection.java
@@ -125,6 +125,21 @@ public class SignalHeadSection implements Section<CodeGroupThreeBits, CodeGroupT
     
     Station station;
     
+    List<Lock> locks;
+    public void addLocks(List<Lock> locks) { this.locks = locks; }
+
+    protected boolean checkLockPermitted() {
+        boolean permitted = true;
+        if (locks != null) {
+            for (Lock lock : locks) {
+                if ( ! lock.isLockClear()) permitted = false;
+            }
+        }
+        log.debug(" Lock check found permitted = {}", permitted);
+        return permitted;
+    }
+    
+    
     /**
      * Start of sending code operation:
      * <ul>
@@ -216,7 +231,15 @@ public class SignalHeadSection implements Section<CodeGroupThreeBits, CodeGroupT
         // following signal change won't drive an _immediate_ indication cycle.
         // Also, always go via stop...
         CodeGroupThreeBits  currentIndication = getCurrentIndication();
-        if (value == CODE_LEFT) {
+        if (! checkLockPermitted() ) {
+            // lock sets stop
+            lastIndication = CODE_STOP;
+            setListHeldState(hRightHeads, true);
+            setListHeldState(hLeftHeads, true);
+            log.debug("Layout signals set LEFT");
+            lastIndication = CODE_LEFT;
+            setListHeldState(hLeftHeads, false);
+        } else if (value == CODE_LEFT) {
             lastIndication = CODE_STOP;
             setListHeldState(hRightHeads, true);
             setListHeldState(hLeftHeads, true);

--- a/java/src/jmri/jmrit/ussctc/Station.java
+++ b/java/src/jmri/jmrit/ussctc/Station.java
@@ -127,13 +127,14 @@ public class Station {
      */
     public void indicationComplete() {
         log.debug("Station - start indicationComplete");
-        // clear the code light
-        button.indicationComplete();
         
         // tell each section
         for (int i = 0; i < sections.size(); i++) {
             sections.get(i).indicationComplete(indicationValues.get(i));
         }
+        // clear the code light
+        button.indicationComplete();
+
         log.debug("Station - end indicationComplete");
     }
 

--- a/java/src/jmri/jmrit/ussctc/Station.java
+++ b/java/src/jmri/jmrit/ussctc/Station.java
@@ -27,13 +27,15 @@ import java.util.*;
  */
 public class Station {
 
-    public Station(CodeLine codeline, CodeButton button) {
+    public Station(String name, CodeLine codeline, CodeButton button) {
+        this.name = name;
         this.codeline = codeline;
         this.button = button;
         
         button.addStation(this);  // register with Codebutton
     }
     
+    String name;
     CodeLine codeline;
     CodeButton button;
     
@@ -50,6 +52,13 @@ public class Station {
      * Provide access to CodeLine to which this Station is attached.
      */
     CodeLine getCodeLine() { return codeline; }
+    
+    /**
+     * Provide access this Station's name
+     */
+    String getName() { return name; }
+    
+    public String toString() { return "Station "+name; }
     
     /**
      * Tell the Sections to start a code-send operation (from machine to field).

--- a/java/src/jmri/jmrit/ussctc/TimeLock.java
+++ b/java/src/jmri/jmrit/ussctc/TimeLock.java
@@ -1,0 +1,82 @@
+package jmri.jmrit.ussctc;
+
+import jmri.*;
+
+import java.util.*;
+
+/**
+ * Lock if any of the SignalHeadSections controlling traffic are running time.
+ *
+ * @author Bob Jacobsen Copyright (C) 2007, 2017
+ */
+public class TimeLock implements Lock {
+
+    /**
+     * @param list SignalHeadSections that cover this route
+     */
+    public TimeLock(List<SignalHeadSection> list) {
+        this.list = list;
+        this.beans = null;
+    }
+    
+    /**
+     * @param list SignalHeadSections that cover this route
+     * @param beans Defines the specific route
+     */
+    public TimeLock(List<SignalHeadSection> list, List<BeanSetting> beans) {
+        this.list = list;
+        this.beans = beans;
+    }
+    
+    /**
+     * @param array SignalHeadSections that cover this route
+     * @param beans Defines the specific route
+     */
+    public TimeLock(SignalHeadSection[] array, BeanSetting[] beans) {
+        list = new ArrayList<>();
+        for (SignalHeadSection s : array) list.add(s);
+        
+        this.beans = new ArrayList<>();
+        for (BeanSetting bean : beans) this.beans.add(bean);
+        
+    }
+
+    /**
+     * @param array SignalHeadSections that cover this route
+     */
+    public TimeLock(SignalHeadSection[] array) {
+        list = new ArrayList<>();
+        for (SignalHeadSection s : array) list.add(s);
+        
+        this.beans = null;   
+    }
+
+    /**
+     * @param head SignalHeadSection that covers this route
+     */
+    public TimeLock(SignalHeadSection head) {
+        this(new SignalHeadSection[]{head});
+    }
+
+    List<SignalHeadSection> list; 
+    List<BeanSetting> beans;
+    
+    /**
+     * Test the lock conditions
+     * @return True if lock is clear and operation permitted
+     */
+    public boolean isLockClear() {
+        // if this route isn't in effect, then permitted
+        if (beans != null) {
+            for (BeanSetting bean : beans) {
+                if ( ! bean.check()) return true;
+            }
+        }
+        
+        for (SignalHeadSection section : list) {
+            if (section.isRunningTime()) return false;
+        }
+        return true;
+    }
+    
+}

--- a/java/src/jmri/jmrit/ussctc/VetoedBell.java
+++ b/java/src/jmri/jmrit/ussctc/VetoedBell.java
@@ -1,0 +1,29 @@
+package jmri.jmrit.ussctc;
+
+import jmri.*;
+
+/**
+ * Derive a CTC machine bell via a Turnout output.
+ *
+ * @author Bob Jacobsen Copyright (C) 2007, 2017
+ */
+public class VetoedBell implements Bell {
+
+    public VetoedBell(String veto, Bell bell) {
+        NamedBeanHandleManager hm = InstanceManager.getDefault(NamedBeanHandleManager.class);
+        SensorManager tm = InstanceManager.getDefault(SensorManager.class);
+        
+        hVeto = hm.getNamedBeanHandle(veto, tm.provideSensor(veto));
+        this.bell = bell;
+    }
+
+    NamedBeanHandle<Sensor> hVeto;
+    Bell bell;
+        
+    public void ring() {
+        if (hVeto.getBean().getKnownState() != Sensor.ACTIVE) {
+            bell.ring();
+        }
+    }
+
+}

--- a/java/test/jmri/jmrit/ussctc/MaintainerCallSectionTest.java
+++ b/java/test/jmri/jmrit/ussctc/MaintainerCallSectionTest.java
@@ -79,7 +79,7 @@ public class MaintainerCallSectionTest {
         codeline = new CodeLine("Code Sequencer Start", "IT101", "IT102", "IT103", "IT104");
         
         requestIndicationStart = false;
-        station = new Station(codeline, new CodeButton("IS221", "IS222")) {
+        station = new Station("test", codeline, new CodeButton("IS221", "IS222")) {
             public void requestIndicationStart() {
                 requestIndicationStart = true;
             }

--- a/java/test/jmri/jmrit/ussctc/PackageDemo.java
+++ b/java/test/jmri/jmrit/ussctc/PackageDemo.java
@@ -50,7 +50,7 @@ public class PackageDemo {
         CodeLine line = new CodeLine("Code Sequencer Start", "IT101", "IT102", "IT103", "IT104");
 
         CodeButton button = new CodeButton("Sec1 Code", "Sec1 Code");
-        Station station = new Station(line, button);
+        Station station = new Station("1", line, button);
 
         TurnoutSection turnout = new TurnoutSection("Sec 1 Layout TO", "Sec1 TO 1 N", "Sec1 TO 1 R", "Sec1 TO 1 N", "Sec1 TO 1 R", station);
         station.add(turnout);

--- a/java/test/jmri/jmrit/ussctc/PackageTest.java
+++ b/java/test/jmri/jmrit/ussctc/PackageTest.java
@@ -45,6 +45,7 @@ public class PackageTest extends TestCase {
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.CodeLineTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.CodeButtonTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.PhysicalBellTest.class));
+        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.VetoedBellTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.MaintainerCallSectionTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.TrackCircuitSectionTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.TurnoutSectionTest.class));

--- a/java/test/jmri/jmrit/ussctc/PackageTest.java
+++ b/java/test/jmri/jmrit/ussctc/PackageTest.java
@@ -41,6 +41,7 @@ public class PackageTest extends TestCase {
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.CombinedLockTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.OccupancyLockTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.RouteLockTest.class));
+        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.TimeLockTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.StationTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.CodeLineTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.CodeButtonTest.class));

--- a/java/test/jmri/jmrit/ussctc/RouteLockTest.java
+++ b/java/test/jmri/jmrit/ussctc/RouteLockTest.java
@@ -106,7 +106,44 @@ public class RouteLockTest {
         
         Assert.assertTrue( ! lock.isLockClear());
     }
-       
+ 
+    @Test
+    public void testBeanSettingMatch() throws JmriException {
+        ArrayList<NamedBeanHandle<SignalHead>> list = new ArrayList<>();
+        
+        SignalHead s = new jmri.implementation.VirtualSignalHead("IH1");
+        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
+        NamedBeanHandle<SignalHead> h = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle("IH1", s);
+
+        Turnout t = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
+        t.setCommandedState(Turnout.CLOSED);
+        
+        s.setState(SignalHead.YELLOW);
+        BeanSetting b = new BeanSetting(t, Turnout.CLOSED);
+        RouteLock lock = new RouteLock(new String[]{"IH1"}, new BeanSetting[]{b});
+        
+        Assert.assertTrue( ! lock.isLockClear());
+    }
+
+    @Test
+    public void testBeanSettingoMatch() throws JmriException {
+        ArrayList<NamedBeanHandle<SignalHead>> list = new ArrayList<>();
+        
+        SignalHead s = new jmri.implementation.VirtualSignalHead("IH1");
+        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
+        NamedBeanHandle<SignalHead> h = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle("IH1", s);
+
+        Turnout t = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
+        t.setCommandedState(Turnout.CLOSED);
+        
+        s.setState(SignalHead.YELLOW);
+        BeanSetting b = new BeanSetting(t, Turnout.THROWN);
+        RouteLock lock = new RouteLock(new String[]{"IH1"}, new BeanSetting[]{b});
+        
+        Assert.assertTrue( lock.isLockClear());
+    }
+
+      
     // The minimal setup for log4J
     @Before
     public void setUp() {

--- a/java/test/jmri/jmrit/ussctc/RouteLockTest.java
+++ b/java/test/jmri/jmrit/ussctc/RouteLockTest.java
@@ -56,7 +56,6 @@ public class RouteLockTest {
 
     @Test
     public void testOneFailStringArrayCtor() throws JmriException {
-        ArrayList<NamedBeanHandle<SignalHead>> list = new ArrayList<>();
         
         SignalHead s = new jmri.implementation.VirtualSignalHead("IH1");
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
@@ -109,8 +108,6 @@ public class RouteLockTest {
  
     @Test
     public void testBeanSettingMatch() throws JmriException {
-        ArrayList<NamedBeanHandle<SignalHead>> list = new ArrayList<>();
-        
         SignalHead s = new jmri.implementation.VirtualSignalHead("IH1");
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
         NamedBeanHandle<SignalHead> h = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle("IH1", s);
@@ -127,8 +124,6 @@ public class RouteLockTest {
 
     @Test
     public void testBeanSettingoMatch() throws JmriException {
-        ArrayList<NamedBeanHandle<SignalHead>> list = new ArrayList<>();
-        
         SignalHead s = new jmri.implementation.VirtualSignalHead("IH1");
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
         NamedBeanHandle<SignalHead> h = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle("IH1", s);

--- a/java/test/jmri/jmrit/ussctc/SignalHeadSectionTest.java
+++ b/java/test/jmri/jmrit/ussctc/SignalHeadSectionTest.java
@@ -37,7 +37,7 @@ public class SignalHeadSectionTest {
         codeline = new CodeLine("Code Sequencer Start", "IT101", "IT102", "IT103", "IT104");
         
         requestIndicationStart = false;
-        station = new Station(codeline, new CodeButton("IS221", "IS222")) {
+        station = new Station("test", codeline, new CodeButton("IS221", "IS222")) {
             public void requestIndicationStart() {
                 requestIndicationStart = true;
             }

--- a/java/test/jmri/jmrit/ussctc/StationTest.java
+++ b/java/test/jmri/jmrit/ussctc/StationTest.java
@@ -13,13 +13,16 @@ public class StationTest {
 
     @Test
     public void testConstruction() {
-        Station s = new Station(codeline, button);
+        Station s = new Station("test", codeline, button);
         s.add(new TurnoutSection());
+        
+        Assert.assertEquals("test", s.getName());        
+        Assert.assertEquals("Station "+s.getName(), s.toString());        
     }
 
     @Test
     public void testSendCode() {
-        Station s = new Station(codeline, button);
+        Station s = new Station("tests", codeline, button);
         s.add(new Section<CodeGroupTwoBits, CodeGroupTwoBits>(){
             public CodeGroupTwoBits  codeSendStart() { countCodeSend++; return CodeGroupTwoBits.Double00; }
             public void codeValueDelivered(CodeGroupTwoBits value) { }
@@ -36,7 +39,7 @@ public class StationTest {
 
     @Test
     public void testSendCodeSendAndImplementMultiSection() {
-        Station s = new Station(codeline, button);
+        Station s = new Station("test", codeline, button);
         s.add(new Section<CodeGroupTwoBits, CodeGroupTwoBits>(){
             public CodeGroupTwoBits  codeSendStart() { countCodeSend++; return CodeGroupTwoBits.Double10; }
             public void codeValueDelivered(CodeGroupTwoBits value) { 

--- a/java/test/jmri/jmrit/ussctc/TimeLockTest.java
+++ b/java/test/jmri/jmrit/ussctc/TimeLockTest.java
@@ -1,0 +1,139 @@
+package jmri.jmrit.ussctc;
+
+import org.junit.*;
+
+import jmri.*;
+
+import java.util.*;
+
+/**
+ * Tests for TimeLock class in the jmri.jmrit.ussctc package
+ *
+ * @author	Bob Jacobsen Copyright 2007
+  */
+public class TimeLockTest {
+
+    @Test
+    public void testEmpty() {
+        ArrayList<SignalHeadSection> list = new ArrayList<>();
+        
+        TimeLock lock = new TimeLock(list);
+        
+        Assert.assertTrue(lock.isLockClear());
+    }
+
+    @Test
+    public void testOneInListPass() throws JmriException {
+        ArrayList<SignalHeadSection> list = new ArrayList<>();
+        
+        SignalHeadSection s = new SignalHeadSection() {
+            public boolean isRunningTime() { return false;}
+        };
+        list.add(s);
+ 
+        TimeLock lock = new TimeLock(list);
+        
+        Assert.assertTrue(lock.isLockClear());
+    }
+
+    @Test
+    public void testOneFailActive() throws JmriException {
+        ArrayList<SignalHeadSection> list = new ArrayList<>();
+        
+        SignalHeadSection s = new SignalHeadSection() {
+            public boolean isRunningTime() { return true;}
+        };
+        list.add(s);
+ 
+        TimeLock lock = new TimeLock(list);
+        
+        Assert.assertTrue( ! lock.isLockClear());
+    }
+
+    @Test
+    public void testOneFailStringArrayCtor() throws JmriException {
+        SignalHeadSection s = new SignalHeadSection() {
+            public boolean isRunningTime() { return true;}
+        };
+
+        TimeLock lock = new TimeLock(new SignalHeadSection[]{s});
+        
+        Assert.assertTrue( ! lock.isLockClear());
+    }
+
+    @Test
+    public void testOneFailSingleCtor() throws JmriException {
+        SignalHeadSection s = new SignalHeadSection() {
+            public boolean isRunningTime() { return true;}
+        };
+
+        TimeLock lock = new TimeLock(s);
+        
+        Assert.assertTrue( ! lock.isLockClear());
+    }
+
+    @Test
+    public void testSecondFailActive() throws JmriException {
+        ArrayList<SignalHeadSection> list = new ArrayList<>();
+        
+        SignalHeadSection s = new SignalHeadSection() {
+            public boolean isRunningTime() { return false;}
+        };     
+        list.add(s);
+
+        s = new SignalHeadSection() {
+            public boolean isRunningTime() { return true;}
+        };    
+        list.add(s);
+
+        TimeLock lock = new TimeLock(list);
+        
+        Assert.assertTrue( ! lock.isLockClear());
+    }
+ 
+    @Test
+    public void testBeanSettingMatch() throws JmriException {
+        SignalHeadSection s = new SignalHeadSection() {
+            public boolean isRunningTime() { return true;}
+        };  
+
+        Turnout t = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
+        t.setCommandedState(Turnout.CLOSED);
+        
+        BeanSetting b = new BeanSetting(t, Turnout.CLOSED);
+        TimeLock lock = new TimeLock(new SignalHeadSection[]{s}, new BeanSetting[]{b});
+        
+        Assert.assertTrue( ! lock.isLockClear());
+    }
+
+    @Test
+    public void testBeanSettingoMatch() throws JmriException {
+        SignalHeadSection s = new SignalHeadSection() {
+            public boolean isRunningTime() { return true;}
+        };
+
+        Turnout t = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
+        t.setCommandedState(Turnout.CLOSED);
+        
+        BeanSetting b = new BeanSetting(t, Turnout.THROWN);
+        TimeLock lock = new TimeLock(new SignalHeadSection[]{s}, new BeanSetting[]{b});
+        
+        Assert.assertTrue( lock.isLockClear());
+    }
+
+      
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.resetInstanceManager();
+        jmri.util.JUnitUtil.initConfigureManager();
+    }
+
+    @After
+    public void tearDown() {
+        jmri.util.JUnitUtil.resetInstanceManager();
+        apps.tests.Log4JFixture.tearDown();
+    }
+
+}

--- a/java/test/jmri/jmrit/ussctc/TrackCircuitSectionTest.java
+++ b/java/test/jmri/jmrit/ussctc/TrackCircuitSectionTest.java
@@ -103,7 +103,7 @@ public class TrackCircuitSectionTest {
         codeline = new CodeLine("Code Sequencer Start", "IT101", "IT102", "IT103", "IT104");
         
         requestIndicationStart = false;
-        station = new Station(codeline, new CodeButton("IS221", "IS222")) {
+        station = new Station("test", codeline, new CodeButton("IS221", "IS222")) {
             public void requestIndicationStart() {
                 requestIndicationStart = true;
             }

--- a/java/test/jmri/jmrit/ussctc/TurnoutSectionTest.java
+++ b/java/test/jmri/jmrit/ussctc/TurnoutSectionTest.java
@@ -215,7 +215,7 @@ public class TurnoutSectionTest {
         codeline = new CodeLine("Code Sequencer Start", "IT101", "IT102", "IT103", "IT104");
         
         requestIndicationStart = false;
-        station = new Station(codeline, new CodeButton("IS221", "IS222")) {
+        station = new Station("test", codeline, new CodeButton("IS221", "IS222")) {
             public void requestIndicationStart() {
                 requestIndicationStart = true;
             }

--- a/java/test/jmri/jmrit/ussctc/VetoedBellTest.java
+++ b/java/test/jmri/jmrit/ussctc/VetoedBellTest.java
@@ -1,0 +1,76 @@
+package jmri.jmrit.ussctc;
+
+import org.junit.*;
+
+import jmri.*;
+import jmri.util.*;
+
+/**
+ * Tests for VetoedBell class in the jmri.jmrit.ussctc package
+ *
+ * @author	Bob Jacobsen Copyright 2007
+  */
+public class VetoedBellTest {
+
+    @Test
+    public void testConstruction() {
+        new VetoedBell("veto Sensor", new PhysicalBell("Bell output"));
+    }
+ 
+    @Test 
+    public void testBellStrokeAllowed() throws JmriException {
+        rung = false;
+        Bell bell = new Bell(){
+            public void ring() {
+                rung = true;
+            }
+        };
+        veto.setState(Sensor.INACTIVE);
+        
+        Bell vbell = new VetoedBell("veto Sensor", bell);
+        vbell.ring();
+        
+        Assert.assertTrue(rung);
+    }
+    
+    @Test 
+    public void testBellStrokeNotAllowed() throws JmriException  {
+        rung = false;
+        Bell bell = new Bell(){
+            public void ring() {
+                rung = true;
+            }
+        };
+        veto.setState(Sensor.ACTIVE);
+        
+        Bell vbell = new VetoedBell("veto Sensor", bell);
+        vbell.ring();
+        
+        Assert.assertTrue(!rung);
+    }
+    
+    boolean rung;
+    Sensor veto;
+    Turnout bellTurnout;
+    
+    // The minimal setup for log4J
+    @org.junit.Before
+    public void setUp() {
+        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.resetInstanceManager();
+        JUnitUtil.initConfigureManager();
+        JUnitUtil.initInternalTurnoutManager();
+        JUnitUtil.initShutDownManager();
+        JUnitUtil.resetProfileManager();
+        
+        veto = InstanceManager.getDefault(SensorManager.class).provideSensor("IS1"); veto.setUserName("veto Sensor");
+        bellTurnout = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1"); bellTurnout.setUserName("Bell output");
+    }
+
+    @org.junit.After
+    public void tearDown() {
+        jmri.util.JUnitUtil.resetInstanceManager();
+        apps.tests.Log4JFixture.tearDown();
+    }
+
+}

--- a/jython/CombineSensors.py
+++ b/jython/CombineSensors.py
@@ -1,0 +1,62 @@
+# Make a master sensor follow a set of follower sensor
+# *) Changes to the known state of the followers map to the known state of the master,
+#       following the rules (first applied wins)
+#          Any UNKNOWN -> UNKNOWN
+#          Any INCONSISTENT -> INCONSISTENT
+#          Any ACTIVE -> ACTIVE
+#          All INACTIVE -> INACTIVE
+#          Otherwise, INCONSISTENT
+# *) changes to the known state of the master does nothing
+#
+# This is hard to do properly in Logix due to limited access to states
+# and events (can't tell which change happened due to what)
+#
+# Author: Bob Jacobsen, copyright 2017
+# Part of the JMRI distribution
+
+import jmri
+import java
+
+# Define the listener. 
+class CombineSensors(java.beans.PropertyChangeListener):
+  def set(self, masterName, followerList) :
+    self.master = sensors.getSensor(masterName)
+    self.followers = followerList
+    # force event to set the initial state
+    self.propertyChange(java.beans.PropertyChangeEvent(sensors.getSensor(followerList[0]), "KnownState", 0, 0))
+    # set up listeners
+    self.master.addPropertyChangeListener(self)
+    for follower in self.followers :
+        sensors.getSensor(follower).addPropertyChangeListener(self)
+    return
+  def propertyChange(self, event):
+    # print "Receive change of", event.propertyName, "from", self.master.describeState(event.oldValue), "to", self.master.describeState(event.newValue), "in", event.source.userName
+    if (event.source != self.master and event.propertyName == "KnownState" ): 
+        # do the KnownState rules
+        for follower in self.followers :
+            if (sensors.getSensor(follower).getKnownState() == UNKNOWN) : 
+                self.master.setKnownState(UNKNOWN)
+                return
+        for follower in self.followers :
+            if (sensors.getSensor(follower).getKnownState() == INCONSISTENT) : 
+                self.master.setKnownState(INCONSISTENT)
+                return
+        for follower in self.followers :
+            if (sensors.getSensor(follower).getKnownState() == ACTIVE) : 
+                self.master.setKnownState(ACTIVE)
+                return
+        inactive = True
+        for follower in self.followers :
+            if (sensors.getSensor(follower).getKnownState() != INACTIVE) : 
+                inactive = False
+        if (inactive) :
+            self.master.setKnownState(INACTIVE)
+            return
+        self.master.setKnownState(INCONSISTENT)
+    return
+
+# Example of use - add lines like the following 
+# that includes system or user names for the master turnout and 
+# the array of followers. These must already exist.
+# CombineTurnouts().set("IT100",["IT101", "IT102"])
+ 

--- a/jython/CombineSensors.py
+++ b/jython/CombineSensors.py
@@ -56,7 +56,7 @@ class CombineSensors(java.beans.PropertyChangeListener):
     return
 
 # Example of use - add lines like the following 
-# that includes system or user names for the master turnout and 
+# that includes system or user names for the master sensor and 
 # the array of followers. These must already exist.
-# CombineTurnouts().set("IT100",["IT101", "IT102"])
+# CombineSensors().set("IS100",["IS101", "IS102"])
  

--- a/jython/CombineTurnouts.py
+++ b/jython/CombineTurnouts.py
@@ -1,0 +1,71 @@
+# Make a set of turnouts follow a single one
+# *) Changes to commanded state of the master are copied to the followers
+# *) Changes to the known state of the followers map to the known state of the master,
+#       following the rules (first applied wins)
+#          Any UNKNOWN -> UNKNOWN
+#          Any INCONSISTENT -> INCONSISTENT
+#          All THROWN -> THROWN
+#          All CLOSED -> CLOSED
+#          Otherwise, INCONSISTENT
+#
+# This is hard to do properly in Logix due to limited access to states
+# and events (can't tell which change happened due to what)
+#
+# Author: Bob Jacobsen, copyright 2017
+# Part of the JMRI distribution
+
+import jmri
+import java
+
+# Define the listener. 
+class CombineTurnouts(java.beans.PropertyChangeListener):
+  def set(self, masterName, followerList) :
+    self.master = turnouts.getTurnout(masterName)
+    self.followers = followerList
+    # force set the initial state
+    for follower in self.followers :
+        turnouts.getTurnout(follower).setCommandedState(self.master.getCommandedState())
+    # set up listeners
+    self.master.addPropertyChangeListener(self)
+    for follower in self.followers :
+        turnouts.getTurnout(follower).addPropertyChangeListener(self)
+    return
+  def propertyChange(self, event):
+    # print "Receive change of", event.propertyName, "from", self.master.describeState(event.oldValue), "to", self.master.describeState(event.newValue), "in", event.source.userName
+    # if a change to master commanded state
+    if (event.source == self.master and event.propertyName == "CommandedState" ) :
+        for follower in self.followers :
+            if (self.master.getCommandedState() != turnouts.getTurnout(follower).getCommandedState()) : 
+                turnouts.getTurnout(follower).setCommandedState(self.master.getCommandedState())
+    elif (event.source != self.master and event.propertyName == "KnownState" ): 
+        # otherwise, do the KnownState rules
+        for follower in self.followers :
+            if (turnouts.getTurnout(follower).getKnownState() == UNKNOWN) : 
+                self.master.newKnownState(UNKNOWN)
+                return
+        for follower in self.followers :
+            if (turnouts.getTurnout(follower).getKnownState() == INCONSISTENT) : 
+                self.master.newKnownState(INCONSISTENT)
+                return
+        OK = True
+        for follower in self.followers :
+            if (turnouts.getTurnout(follower).getKnownState() != CLOSED) : 
+                OK = False
+        if (OK) :
+            self.master.newKnownState(CLOSED)
+            return
+        OK = True
+        for follower in self.followers :
+            if (turnouts.getTurnout(follower).getKnownState() != THROWN) : 
+                OK = False
+        if (OK) :
+            self.master.newKnownState(THROWN)
+            return
+        self.master.newKnownState(INCONSISTENT)
+    return
+
+# Example of use - add lines like the following 
+# that includes system or user names for the master turnout and 
+# the array of followers. These must already exist.
+# CombineTurnouts().set("IT100",["IT101", "IT102"])
+ 

--- a/jython/ctc/TwoColumnMachine.py
+++ b/jython/ctc/TwoColumnMachine.py
@@ -58,7 +58,7 @@ codeline = CodeLine("Code Sequencer Start", "IT101", "IT102", "IT103", "IT104")
 # Set up Station 1 - stations are numbered 1, 2, 3 etc. 
 # Station 1 is levers 1 and 2
 
-station = Station(codeline, CodeButton("Sta 1 Code", "Sta 1 Code"))
+station = Station("1", codeline, CodeButton("Sta 1 Code", "Sta 1 Code"))
 
 turnout = TurnoutSection("Sta 1 Layout TO", "Sta 1 TO 1 N", "Sta 1 TO 1 R", "Sta 1 TO 1 N", "Sta 1 TO 1 R", station)
 station.add(turnout)
@@ -68,7 +68,7 @@ station.add(TrackCircuitSection("TC Sta 1 OS", "Sta 1 OS TC", station))
 
 # Set up Station 2 - levers 3 and 4
 
-station = Station(codeline, CodeButton("Sta 2 Code", "Sta 2 Code"))
+station = Station("2", codeline, CodeButton("Sta 2 Code", "Sta 2 Code"))
 
 station.add(TurnoutSection("Sta 2 Layout TO", "Sta 2 TO 3 N", "Sta 2 TO 3 R", "Sta 2 TO 3 N", "Sta 2 TO 3 R", station))   
 station.add(TrackCircuitSection("TC Main", "Sta 2 Main TC", station))

--- a/jython/test/CombineSensorsTest.py
+++ b/jython/test/CombineSensorsTest.py
@@ -1,0 +1,48 @@
+# Test the CombineSensors.py script
+import jmri
+
+follower1 = sensors.provideSensor("IS101")
+follower1.setUserName("follower1")
+follower2 = sensors.provideSensor("IS102")
+follower2.setUserName("follower2")
+
+master = sensors.provideSensor("IS10000")
+master.setUserName("master")
+master.setKnownState(INACTIVE)
+
+# confirm test implementation
+follower1.setKnownState(INCONSISTENT)
+if (follower1.getKnownState() != INCONSISTENT) : raise AssertionError('follower1 known state not changed')
+
+# prep initial state for tests
+follower1.setKnownState(ACTIVE)
+follower2.setKnownState(ACTIVE)
+
+# start actual test
+
+execfile("jython/CombineSensors.py")
+
+CombineSensors().set("IS10000",["IS101", "IS102"])
+
+if (master.getKnownState() != ACTIVE) : raise AssertionError('Initial state not set into master')
+
+follower1.setKnownState(INCONSISTENT)
+if (master.getKnownState() != INCONSISTENT) : raise AssertionError('master didnt follow follower1 INCONSISTENT')
+
+follower1.setKnownState(ACTIVE)
+if (master.getKnownState() != ACTIVE) : raise AssertionError('master didnt follow follower1 ACTIVE after INCONSISTENT')
+
+follower1.setKnownState(INACTIVE)
+follower2.setKnownState(INACTIVE)
+if (master.getKnownState() != INACTIVE) : raise AssertionError('master didnt follow INACTIVE, INACTIVE')
+
+follower2.setKnownState(UNKNOWN)
+if (master.getKnownState() != UNKNOWN) : raise AssertionError('master didnt follow follower2 UNKNOWN')
+
+follower1.setKnownState(ACTIVE)
+follower2.setKnownState(ACTIVE)
+if (master.getKnownState() != ACTIVE) : raise AssertionError('master didnt follow ACTIVE, ACTIVE')
+
+follower1.setKnownState(ACTIVE)
+follower2.setKnownState(INACTIVE)
+if (master.getKnownState() != INCONSISTENT) : raise AssertionError('master didnt follow ACTIVE, INACTIVE')

--- a/jython/test/CombineSensorsTest.py
+++ b/jython/test/CombineSensorsTest.py
@@ -39,10 +39,10 @@ if (master.getKnownState() != INACTIVE) : raise AssertionError('master didnt fol
 follower2.setKnownState(UNKNOWN)
 if (master.getKnownState() != UNKNOWN) : raise AssertionError('master didnt follow follower2 UNKNOWN')
 
-follower1.setKnownState(ACTIVE)
+follower1.setKnownState(INACTIVE)
 follower2.setKnownState(ACTIVE)
-if (master.getKnownState() != ACTIVE) : raise AssertionError('master didnt follow ACTIVE, ACTIVE')
+if (master.getKnownState() != ACTIVE) : raise AssertionError('master didnt follow INACTIVE, ACTIVE')
 
 follower1.setKnownState(ACTIVE)
 follower2.setKnownState(INACTIVE)
-if (master.getKnownState() != INCONSISTENT) : raise AssertionError('master didnt follow ACTIVE, INACTIVE')
+if (master.getKnownState() != ACTIVE) : raise AssertionError('master didnt follow ACTIVE, INACTIVE')

--- a/jython/test/CombineTurnoutsTest.py
+++ b/jython/test/CombineTurnoutsTest.py
@@ -1,0 +1,72 @@
+# Test the CombineTurnouts.py script
+import jmri
+
+# create special turnouts that can have their KnownState directly changed
+class TestTurnout(jmri.implementation.AbstractTurnout) :
+    def forwardCommandChangeToLayout(self, s) :
+        return
+    def turnoutPushbuttonLockout(self, b) : 
+        return 
+    def setTestKnownState(self, state) :
+        self.newKnownState(state)
+
+follower1 = TestTurnout("IT101")
+follower1.setUserName("follower1")
+jmri.InstanceManager.getDefault(jmri.TurnoutManager).register(follower1)
+follower2 = TestTurnout("IT102")
+follower2.setUserName("follower2")
+jmri.InstanceManager.getDefault(jmri.TurnoutManager).register(follower2)
+
+master = turnouts.provideTurnout("IT10000")
+master.setUserName("master")
+master.setCommandedState(THROWN)
+
+# confirm test implementation
+follower1.setTestKnownState(INCONSISTENT)
+if (follower1.getKnownState() != INCONSISTENT) : raise AssertionError('follower1 known state not changed')
+
+# prep initial state for tests
+follower1.setCommandedState(CLOSED)
+follower2.setCommandedState(CLOSED)
+
+# start actual test
+
+execfile("jython/CombineTurnouts.py")
+
+CombineTurnouts().set("IT10000",["IT101", "IT102"])
+
+if (follower1.getCommandedState() != THROWN) : raise AssertionError('Initial state not set into follower1')
+if (follower2.getCommandedState() != THROWN) : raise AssertionError('Initial state not set into follower2')
+
+master.setCommandedState(CLOSED)
+if (follower1.getCommandedState() != CLOSED) : raise AssertionError('follower1 didnt follow CLOSED')
+if (follower2.getCommandedState() != CLOSED) : raise AssertionError('follower2 didnt follow CLOSED')
+
+master.setCommandedState(THROWN)
+if (follower1.getCommandedState() != THROWN) : raise AssertionError('follower1 didnt follow THROWN')
+if (follower2.getCommandedState() != THROWN) : raise AssertionError('follower2 didnt follow THROWN')
+
+master.setCommandedState(CLOSED)
+if (follower1.getCommandedState() != CLOSED) : raise AssertionError('follower1 didnt follow 2nd CLOSED')
+if (follower2.getCommandedState() != CLOSED) : raise AssertionError('follower2 didnt follow 2nd CLOSED')
+
+follower1.setTestKnownState(INCONSISTENT)
+if (master.getKnownState() != INCONSISTENT) : raise AssertionError('master didnt follow follower1 INCONSISTENT')
+
+follower1.setTestKnownState(CLOSED)
+if (master.getKnownState() != CLOSED) : raise AssertionError('master didnt follow follower1 CLOSED after INCONSISTENT')
+
+follower1.setTestKnownState(THROWN)
+follower2.setTestKnownState(THROWN)
+if (master.getKnownState() != THROWN) : raise AssertionError('master didnt follow THROWN, THROWN')
+
+follower2.setTestKnownState(UNKNOWN)
+if (master.getKnownState() != UNKNOWN) : raise AssertionError('master didnt follow follower2 UNKNOWN')
+
+follower1.setTestKnownState(CLOSED)
+follower2.setTestKnownState(CLOSED)
+if (master.getKnownState() != CLOSED) : raise AssertionError('master didnt follow CLOSED, CLOSED')
+
+follower1.setTestKnownState(CLOSED)
+follower2.setTestKnownState(THROWN)
+if (master.getKnownState() != INCONSISTENT) : raise AssertionError('master didnt follow CLOSED, THROWN')


### PR DESCRIPTION
- Improve the CTC tools introduced in #3690 based on initial user feedback
- Improved example

- Add two new script-based tools [CombineTurnouts](http://jmri.org/jython/CombineTurnouts.py) and [CombineSensors](http://jmri.org/jython/CombineSensors.py) for mapping a single Turnout or Sensor onto multiple pieces of hardware. Includes test routines which can serve as further examples.