### PR TITLE
Improve turnout locking GUI

### DIFF
--- a/java/src/jmri/Turnout.java
+++ b/java/src/jmri/Turnout.java
@@ -418,15 +418,27 @@ public interface Turnout extends NamedBean {
     public void enableLockOperation(int turnoutLockout, boolean locked);
 
     /**
-     * Determine if turnout can be locked. A turnout can be locked to prevent it
+     * Determine if turnout can be locked as currently configured. A turnout can be locked to prevent it
      * being thrown from a cab or push button on the layout if supported by the
      * protocol.
      *
-     * @param turnoutLockout the type of lock
+     * @param turnoutLockout the type of lock, one of CABLOCKOUT, PUSHBUTTONLOCKOUT
+     * or BOTH = CABLOCKOUT | PUSHBUTTONLOCKOUT
      * @return true if turnout is locked using specified lock method; false
      *         otherwise
      */
     public boolean canLock(int turnoutLockout);
+
+    /**
+     * Provide the possible locking modes for a turnout.  
+     * These may require additional configuration, e.g. 
+     * setting of a decoder definition for PUSHBUTTONLOCKOUT,
+     * before {@link #canLock(int)} will return true.
+     *
+     * @return One of 0 for none, CABLOCKOUT, PUSHBUTTONLOCKOUT
+     * or CABLOCKOUT | PUSHBUTTONLOCKOUT for both
+     */
+    public int getPossibleLockModes();
 
     /**
      * Lock a turnout. A turnout can be locked to prevent it being thrown from a
@@ -455,13 +467,13 @@ public interface Turnout extends NamedBean {
     /**
      * Get a human readable representation of the decoder types.
      *
-     * @return a list of known stationary decoders
+     * @return a list of known stationary decoders that can be specified for locking
      */
     @Nonnull
     public String[] getValidDecoderNames();
 
     /**
-     * Get a human readable representation of the decoder type for this turnout.
+     * Get a human readable representation of the locking decoder type for this turnout.
      *
      * @return the name of the decoder type
      */
@@ -469,7 +481,7 @@ public interface Turnout extends NamedBean {
     public String getDecoderName();
 
     /**
-     * Set a human readable representation of the decoder type for this turnout.
+     * Set a human readable representation of the locking decoder type for this turnout.
      *
      * @param decoderName the name of the decoder type
      */

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -455,6 +455,20 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
 
     protected boolean _enablePushButtonLockout = false;
 
+    /**
+     * This implementation by itself doesn't provide locking support.
+     * Override this in subclasses that do. 
+     *
+     * @return One of 0 for none
+     */
+    public int getPossibleLockModes() { return 0; }
+
+    /**
+     * This implementation by itself doesn't provide locking support.
+     * Override this in subclasses that do. 
+     *
+     * @return false for not supported
+     */
     @Override
     public boolean canLock(int turnoutLockout) {
         return false;

--- a/java/src/jmri/jmrit/beantable/beanedit/BeanEditBundle.properties
+++ b/java/src/jmri/jmrit/beantable/beanedit/BeanEditBundle.properties
@@ -59,6 +59,7 @@ ThrownSpeed = Thrown Speed
 ThrownSpeedToolTip = The maximum Speed that a train is permited to run when the turnout is set thrown
 
 LockToolTip = The turnout lock feature allows you to selectively disable accessory (turnouts) commands from cabs and/or locally-wired pushbuttons.\nThe lock can be set (locked) or unset (unlocked) from a checkbox in the Turnout Table, from a Route or Logix, or from scripts.
+LockModeUnavailable = The turnout lock feature is not available for this type of turnout.
 LockMode = Lock Mode
 LockModeToolTip = Select lock type to be used
 LockModeDecoder = Accessory Decoder

--- a/java/src/jmri/jmrix/nce/NceTurnout.java
+++ b/java/src/jmri/jmrix/nce/NceTurnout.java
@@ -168,6 +168,12 @@ public class NceTurnout extends AbstractTurnout {
     public boolean canInvert() {
         return true;
     }
+    /**
+     * NCE turnouts can provide both modes when properly configured
+     *
+     * @return Both cab and pushbutton (decoder) modes
+     */
+    public int getPossibleLockModes() { return CABLOCKOUT | PUSHBUTTONLOCKOUT ; }
 
     /**
      * NCE turnouts support two types of lockouts, pushbutton and cab. Cab

--- a/java/test/jmri/jmrix/nce/NceTurnoutTest.java
+++ b/java/test/jmri/jmrix/nce/NceTurnoutTest.java
@@ -1,8 +1,11 @@
 package jmri.jmrix.nce;
 
 import jmri.implementation.AbstractTurnoutTestBase;
+import jmri.Turnout;
+
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests for the jmri.jmrix.nce.NceTurnout class
@@ -25,6 +28,41 @@ public class NceTurnoutTest extends AbstractTurnoutTestBase {
     @Override
     public int numListeners() {
         return tcis.numListeners();
+    }
+
+    @Test
+    public void testLockCoding() {
+        Assert.assertTrue(Turnout.CABLOCKOUT != Turnout.PUSHBUTTONLOCKOUT);
+        // test for proper bit coding, needed because CABLOCKOUT | PUSHBUTTONLOCKOUT is used for "both"
+        Assert.assertTrue( (Turnout.CABLOCKOUT & Turnout.PUSHBUTTONLOCKOUT) == 0);
+    }
+
+    @Test
+    public void testCanLockModes() {
+        // prepare an interface
+        tcis = new NceTrafficControlScaffold() {
+            public int getUsbSystem() { return NceTrafficController.USB_SYSTEM_NONE; }
+        };
+
+        Turnout t1 = new NceTurnout(tcis, "NT", 4);
+        
+        // by default, none
+        Assert.assertTrue( ! t1.canLock(Turnout.PUSHBUTTONLOCKOUT));
+        Assert.assertTrue( ! t1.canLock(Turnout.CABLOCKOUT));
+        Assert.assertTrue( ! t1.canLock(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT));
+        
+        t1.setFeedbackMode(Turnout.MONITORING);
+
+        // with MONITORING, just CABLOCKOUT
+        Assert.assertTrue( ! t1.canLock(Turnout.PUSHBUTTONLOCKOUT));
+        Assert.assertTrue( t1.canLock(Turnout.CABLOCKOUT));
+        Assert.assertTrue( t1.canLock(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT));
+        
+        // add a decoder
+        t1.setDecoderName(t1.getValidDecoderNames()[1]);  // [0] is the "unknown" NONE entry
+        Assert.assertTrue( t1.canLock(Turnout.PUSHBUTTONLOCKOUT));
+        Assert.assertTrue( t1.canLock(Turnout.CABLOCKOUT));
+        Assert.assertTrue( t1.canLock(Turnout.CABLOCKOUT | Turnout.PUSHBUTTONLOCKOUT));
     }
 
     @Override


### PR DESCRIPTION
Improve the locking elements of the Turnout Table (and lock edit tab) to make it clearer to the user whether the particular turnout being configured supports turnout locking or not.

With this PR, the "lock mode" column only shows modes available for selection. For most turnouts, perhaps all other than specific NCE ones, that's "None".  The "lock decoder" column only shows available choices; this is also "None" in most cases.  The "Lock" tab on the editor window will show an explanatory message when the turnout doesn't have lock modes available.

As part of this, add a method to the Turnout interface to make a clear distinction between "what locking modes can be configured" and "what lock modes are available in the current configuration".

