### PR TITLE
Fix Cbus EventTable print (preview) NPE (for JMRI 4.7.8)

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTableDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTableDataModel.java
@@ -456,14 +456,14 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
         String columnString = "";
         String lineString = "";
         String spaces;
-        StringBuffer buf = new StringBuffer();
+        // StringBuffer buf = new StringBuffer();
         // loop through each column
         boolean complete = false;
         while (!complete) {
             complete = true;
             for (int i = 0; i < columnStrings.length; i++) {
                 // create a base string the width of the column
-                //spaces = "";
+                StringBuffer buf = new StringBuffer();
                 for (int j = 0; j < columnWidth[i]; j++) {
                     //spaces = spaces + " ";
                     buf.append(" ");

--- a/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePane.java
@@ -2,6 +2,7 @@ package jmri.jmrix.can.cbus.swing.eventtable;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.awt.FlowLayout;
+import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -123,6 +124,7 @@ public class CbusEventTablePane extends jmri.jmrix.can.swing.CanPanel {
     @Override
     public List<JMenu> getMenus() {
         List<JMenu> menuList = new ArrayList<JMenu>();
+        Frame mFrame = new Frame();
 
         ResourceBundle rb = ResourceBundle.getBundle("apps.AppsBundle");
         JMenu fileMenu = new JMenu(Bundle.getMessage("MenuFile"));
@@ -156,7 +158,7 @@ public class CbusEventTablePane extends jmri.jmrix.can.swing.CanPanel {
             public void actionPerformed(ActionEvent e) {
                 HardcopyWriter writer = null;
                 try {
-                    writer = new HardcopyWriter(getWindowInterface().getFrame(), getTitle(), 10, .8, .5, .5, .5, false);
+                    writer = new HardcopyWriter(mFrame, getTitle(), 10, .8, .5, .5, .5, false);
                 } catch (HardcopyWriter.PrintCanceledException ex) {
                     //log.debug("Print cancelled");
                     return;
@@ -172,7 +174,7 @@ public class CbusEventTablePane extends jmri.jmrix.can.swing.CanPanel {
             public void actionPerformed(ActionEvent e) {
                 HardcopyWriter writer = null;
                 try {
-                    writer = new HardcopyWriter(getWindowInterface().getFrame(), getTitle(), 10, .8, .5, .5, .5, true);
+                    writer = new HardcopyWriter(mFrame, getTitle(), 10, .8, .5, .5, .5, true);
                 } catch (HardcopyWriter.PrintCanceledException ex) {
                     //log.debug("Print cancelled");
                     return;


### PR DESCRIPTION
Also in an upcoming PR for master. Note this method is not checked as part of any CI test, and may have failed since 4.4
Added a simple fix to get a neat printout.