### PR TITLE
URL-encode roster entry Ids in URL paths

### DIFF
--- a/java/src/jmri/server/json/Bundle.properties
+++ b/java/src/jmri/server/json/Bundle.properties
@@ -21,3 +21,5 @@ ErrorMissingData=Data portion of JSON message missing.
 ErrorProcessingJSON=Unable to process JSON message with error: {0}.
 ErrorUnsupportedOperation=Unsupported operation attempted: {0}.
 ErrorMissingAttribute=Data attribute {0} is required.
+#Error message when URLEncoding fails for a property.
+ErrorUnencodable={2} property of {0} named {1} cannot be encoded in UTF-8

--- a/java/src/jmri/server/json/Bundle_ca.properties
+++ b/java/src/jmri/server/json/Bundle_ca.properties
@@ -23,3 +23,5 @@ ErrorMissingData=Falta porci\u00f3 d'informaci\u00f3 de missatge JSON.
 ErrorProcessingJSON=Impossible de processar el missatge JSON amb error: {0}.
 ErrorUnsupportedOperation=Intent d'operaci\u00f3 no soportada: {0}.
 ErrorMissingAttribute=Es requereix l'atribut {0} d'informaci\u00f3.
+#Error message when URLEncoding fails for a property.
+ErrorUnencodable={2} property of {0} named {1} cannot be encoded in UTF-8

--- a/java/src/jmri/server/json/Bundle_de.properties
+++ b/java/src/jmri/server/json/Bundle_de.properties
@@ -23,3 +23,5 @@ ErrorMissingData=Datateil fehlt in JSON Nachricht.
 ErrorProcessingJSON=Kann JSON Nachricht nicht lesen; Fehlermeldung: {0}.
 ErrorUnsupportedOperation=Nicht-unterst\u00fctzte Arbeit gefragt: {0}.
 ErrorMissingAttribute= Data-attribut {0} fehlt.
+#Error message when URLEncoding fails for a property.
+ErrorUnencodable={2} property of {0} named {1} cannot be encoded in UTF-8

--- a/java/src/jmri/server/json/Bundle_nl.properties
+++ b/java/src/jmri/server/json/Bundle_nl.properties
@@ -23,3 +23,5 @@ ErrorMissingData=Datadeel van JSON bericht ontbreekt.
 ErrorProcessingJSON=Kan JSON bericht niet verwerken; fout: {0}.
 ErrorUnsupportedOperation=Niet-ondersteunde bewerking gevraagd: {0}.
 ErrorMissingAttribute= Vereist data-attribuut {0} ontbreekt.
+#Error message when URLEncoding fails for a property.
+ErrorUnencodable={2} property of {0} named {1} cannot be encoded in UTF-8

--- a/java/src/jmri/server/json/roster/JsonRosterSocketService.java
+++ b/java/src/jmri/server/json/roster/JsonRosterSocketService.java
@@ -29,8 +29,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Listen for changes in the roster and notify subscribed clients of changes
- *   to the roster, including roster groups
+ * Listen for changes in the roster and notify subscribed clients of changes to
+ * the roster, including roster groups
  *
  * @author Randall Wood Copyright (C) 2014, 2016
  */
@@ -115,20 +115,24 @@ public class JsonRosterSocketService extends JsonSocketService {
         @Override
         public void propertyChange(PropertyChangeEvent evt) {
             try {
-                if (evt.getPropertyName().equals(RosterEntry.ID)) {
-                    // send old roster entry and new roster entry to client as roster changes
-                    ObjectNode root = connection.getObjectMapper().createObjectNode().put(TYPE, JsonRoster.ROSTER);
-                    ObjectNode data = root.putObject(DATA);
-                    RosterEntry old = new RosterEntry((RosterEntry) evt.getSource(), (String) evt.getOldValue());
-                    data.put(ADD, service.getRosterEntry(connection.getLocale(), (RosterEntry) evt.getSource()));
-                    data.put(REMOVE, service.getRosterEntry(connection.getLocale(), old));
-                    log.debug("Sending add and remove rosterEntry for {} ({} => {})", evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
-                    connection.sendMessage(root);
-                } else if (!evt.getPropertyName().equals(RosterEntry.DATE_UPDATED)
-                        && !evt.getPropertyName().equals(RosterEntry.FILENAME)
-                        && !evt.getPropertyName().equals(RosterEntry.COMMENT)) {  //don't send comment changes
-                    log.debug("Sending updated rosterEntry for {} ({} => {})", evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
-                    connection.sendMessage(service.getRosterEntry(connection.getLocale(), (RosterEntry) evt.getSource()));
+                try {
+                    if (evt.getPropertyName().equals(RosterEntry.ID)) {
+                        // send old roster entry and new roster entry to client as roster changes
+                        ObjectNode root = connection.getObjectMapper().createObjectNode().put(TYPE, JsonRoster.ROSTER);
+                        ObjectNode data = root.putObject(DATA);
+                        RosterEntry old = new RosterEntry((RosterEntry) evt.getSource(), (String) evt.getOldValue());
+                        data.set(ADD, service.getRosterEntry(connection.getLocale(), (RosterEntry) evt.getSource()));
+                        data.set(REMOVE, service.getRosterEntry(connection.getLocale(), old));
+                        log.debug("Sending add and remove rosterEntry for {} ({} => {})", evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
+                        connection.sendMessage(root);
+                    } else if (!evt.getPropertyName().equals(RosterEntry.DATE_UPDATED)
+                            && !evt.getPropertyName().equals(RosterEntry.FILENAME)
+                            && !evt.getPropertyName().equals(RosterEntry.COMMENT)) {  //don't send comment changes
+                        log.debug("Sending updated rosterEntry for {} ({} => {})", evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
+                        connection.sendMessage(service.getRosterEntry(connection.getLocale(), (RosterEntry) evt.getSource()));
+                    }
+                } catch (JsonException ex) {
+                    connection.sendMessage(ex.getJsonMessage());
                 }
             } catch (IOException ex) {
                 onClose();
@@ -142,19 +146,23 @@ public class JsonRosterSocketService extends JsonSocketService {
         public void propertyChange(PropertyChangeEvent evt) {
             ObjectNode root = connection.getObjectMapper().createObjectNode().put(TYPE, JsonRoster.ROSTER);
             try {
-                if (evt.getPropertyName().equals(Roster.ADD)) {
-                    root.putObject(DATA).put(ADD, service.getRosterEntry(connection.getLocale(), (RosterEntry) evt.getNewValue()));
-                    ((PropertyChangeProvider) evt.getNewValue()).addPropertyChangeListener(rosterEntryListener);
-                    connection.sendMessage(root);
-                } else if (evt.getPropertyName().equals(Roster.REMOVE)) {
-                    root.putObject(DATA).put(REMOVE, service.getRosterEntry(connection.getLocale(), (RosterEntry) evt.getOldValue()));
-                    connection.sendMessage(root);
-                } else if (!evt.getPropertyName().equals(Roster.SAVED)
-                        && !evt.getPropertyName().equals(Roster.ROSTER_GROUP_ADDED)
-                                && !evt.getPropertyName().equals(Roster.ROSTER_GROUP_REMOVED)
-                                && ! evt.getPropertyName().equals(Roster.ROSTER_GROUP_RENAMED)) {
-                    // catch all events other than SAVED, and group stuff (handled elsewhere)
-                    connection.sendMessage(service.getRoster(connection.getLocale(), root));
+                try {
+                    if (evt.getPropertyName().equals(Roster.ADD)) {
+                        root.putObject(DATA).put(ADD, service.getRosterEntry(connection.getLocale(), (RosterEntry) evt.getNewValue()));
+                        ((PropertyChangeProvider) evt.getNewValue()).addPropertyChangeListener(rosterEntryListener);
+                        connection.sendMessage(root);
+                    } else if (evt.getPropertyName().equals(Roster.REMOVE)) {
+                        root.putObject(DATA).put(REMOVE, service.getRosterEntry(connection.getLocale(), (RosterEntry) evt.getOldValue()));
+                        connection.sendMessage(root);
+                    } else if (!evt.getPropertyName().equals(Roster.SAVED)
+                            && !evt.getPropertyName().equals(Roster.ROSTER_GROUP_ADDED)
+                            && !evt.getPropertyName().equals(Roster.ROSTER_GROUP_REMOVED)
+                            && !evt.getPropertyName().equals(Roster.ROSTER_GROUP_RENAMED)) {
+                        // catch all events other than SAVED, and group stuff (handled elsewhere)
+                        connection.sendMessage(service.getRoster(connection.getLocale(), root));
+                    }
+                } catch (JsonException ex) {
+                    connection.sendMessage(ex.getJsonMessage());
                 }
             } catch (IOException ex) {
                 onClose();
@@ -176,8 +184,8 @@ public class JsonRosterSocketService extends JsonSocketService {
                     } catch (JsonException ex) {
                         connection.sendMessage(ex.getJsonMessage());
                     }
-                //handle event names of format "attributeUpdated:RosterGroup:GROUPNAME"
-                } else if (evt.getPropertyName().startsWith(RosterEntry.ATTRIBUTE_UPDATED)) {  
+                    //handle event names of format "attributeUpdated:RosterGroup:GROUPNAME"
+                } else if (evt.getPropertyName().startsWith(RosterEntry.ATTRIBUTE_UPDATED)) {
                     String attrName = evt.getPropertyName().substring(RosterEntry.ATTRIBUTE_UPDATED.length());
                     if (attrName.startsWith(Roster.ROSTER_GROUP_PREFIX)) {
                         String groupName = attrName.substring(Roster.ROSTER_GROUP_PREFIX.length());
@@ -191,7 +199,7 @@ public class JsonRosterSocketService extends JsonSocketService {
                             }
                         }
                     }
-                //handle attribute deleted, old value is of form "RosterGroup:GROUPNAME"     
+                    //handle attribute deleted, old value is of form "RosterGroup:GROUPNAME"
                 } else if (evt.getPropertyName().startsWith(RosterEntry.ATTRIBUTE_DELETED)) {
                     if (((String) evt.getOldValue()).startsWith(Roster.ROSTER_GROUP_PREFIX)) {
                         String groupName = ((String) evt.getOldValue()).substring(Roster.ROSTER_GROUP_PREFIX.length());
@@ -205,7 +213,7 @@ public class JsonRosterSocketService extends JsonSocketService {
                             }
                         }
                     }
-                    
+
                 }
 
             } catch (IOException ex) {

--- a/java/src/jmri/util/StringUtil.java
+++ b/java/src/jmri/util/StringUtil.java
@@ -1,5 +1,9 @@
 package jmri.util;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import javax.annotation.CheckForNull;
@@ -458,29 +462,40 @@ public class StringUtil {
     }
 
     /**
-     * Return String after replacing various special characters with their
-     * "escaped" counterpart, to facilitate use with web servers.
+     * Replace various special characters with their "escaped" counterpart in
+     * UTF-8 character encoding, to facilitate use with web servers.
      *
      * @param s String to escape
      * @return String with escaped values
+     * @throws java.io.UnsupportedEncodingException if unable to escape in UTF-8
+     * @deprecated since 4.9.1; use
+     * {@link java.net.URLEncoder#encode(java.lang.String, java.lang.String)}
+     * directly
      */
     @CheckReturnValue
     @Nonnull
-    static public String escapeString(@Nonnull String s) {
-        return s.replaceAll(" ", "%20").replaceAll("#", "%23").replaceAll("&", "%26").replaceAll("'", "%27").replaceAll("\"", "%22").replaceAll("<", "%3C").replaceAll(">", "%3E");
+    @Deprecated
+    static public String escapeString(@Nonnull String s) throws UnsupportedEncodingException {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8.toString());
     }
 
     /**
-     * Return String after replacing various escaped character with their
+     * Replace various escaped character in UTF-8 character encoding with their
      * "regular" counterpart, to facilitate use with web servers.
      *
      * @param s String to unescape
      * @return String with escaped values replaced with regular values
+     * @throws java.io.UnsupportedEncodingException if unable to unescape from
+     *                                              UTF-8
+     * @deprecated since 4.9.1; use
+     * {@link java.net.URLDecoder#decode(java.lang.String, java.lang.String)}
+     * directly
      */
     @CheckReturnValue
     @Nonnull
-    static public String unescapeString(@Nonnull String s) {
-        return s.replaceAll("%20", " ").replaceAll("%23", "#").replaceAll("%26", "&").replaceAll("%27", "'").replaceAll("%22", "\"").replaceAll("%3C", "<").replaceAll("%3E", ">");
+    @Deprecated
+    static public String unescapeString(@Nonnull String s) throws UnsupportedEncodingException {
+        return URLDecoder.decode(s, StandardCharsets.UTF_8.toString());
     }
 
     /**

--- a/java/src/jmri/web/servlet/ServletUtil.java
+++ b/java/src/jmri/web/servlet/ServletUtil.java
@@ -3,6 +3,7 @@ package jmri.web.servlet;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Locale;
 import javax.servlet.http.HttpServletResponse;
@@ -17,7 +18,7 @@ import jmri.web.server.WebServerPreferences;
  */
 public class ServletUtil {
 
-    public static final String UTF8 = "UTF-8"; // NOI18N
+    public static final String UTF8 = StandardCharsets.UTF_8.toString(); // NOI18N
     // media types
     public static final String APPLICATION_JAVASCRIPT = "application/javascript"; // NOI18N
     public static final String APPLICATION_JSON = "application/json"; // NOI18N

--- a/java/src/jmri/web/servlet/frameimage/JmriJFrameServlet.java
+++ b/java/src/jmri/web/servlet/frameimage/JmriJFrameServlet.java
@@ -2,6 +2,7 @@ package jmri.web.servlet.frameimage;
 
 import static jmri.server.json.JSON.NAME;
 import static jmri.server.json.JSON.URL;
+import static jmri.web.servlet.ServletUtil.UTF8;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -13,6 +14,9 @@ import java.awt.event.MouseListener;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Date;
@@ -35,9 +39,9 @@ import javax.swing.JRadioButton;
 import jmri.jmrit.display.Editor;
 import jmri.jmrit.display.Positionable;
 import jmri.server.json.JSON;
+import jmri.server.json.JsonException;
 import jmri.server.json.util.JsonUtilHttpService;
 import jmri.util.JmriJFrame;
-import jmri.util.StringUtil;
 import jmri.web.server.WebServerPreferences;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -287,7 +291,7 @@ public class JmriJFrameServlet extends HttpServlet {
         // 6 is ajax preference
         // 7 is protect
         Object[] args = new String[]{"localhost", // NOI18N
-            StringUtil.escapeString(frame.getTitle()),
+            URLEncoder.encode(frame.getTitle(), UTF8),
             (click ? clickRetryTime : noclickRetryTime),
             noclickRetryTime,
             Boolean.toString(plain),
@@ -349,7 +353,7 @@ public class JmriJFrameServlet extends HttpServlet {
             ArrayNode root = mapper.createArrayNode();
             HashSet<JFrame> frames = new HashSet<>();
             JsonUtilHttpService service = new JsonUtilHttpService(new ObjectMapper());
-            JmriJFrame.getFrameList().stream().forEach((frame) -> {
+            for (JmriJFrame frame : JmriJFrame.getFrameList()) {
                 if (usePanels && frame instanceof Editor) {
                     ObjectNode node = service.getPanel(request.getLocale(), (Editor) frame, JSON.XML);
                     if (node != null) {
@@ -364,14 +368,20 @@ public class JmriJFrameServlet extends HttpServlet {
                             && !frames.contains(frame)
                             && frame.isVisible()) {
                         ObjectNode node = mapper.createObjectNode();
-                        node.put(NAME, title);
-                        node.put(URL, "/frame/" + StringUtil.escapeString(title) + ".html"); // NOI18N
-                        node.put("png", "/frame/" + StringUtil.escapeString(title) + ".png"); // NOI18N
-                        root.add(node);
-                        frames.add(frame);
+                        try {
+                            node.put(NAME, title);
+                            node.put(URL, "/frame/" + URLEncoder.encode(title, UTF8) + ".html"); // NOI18N
+                            node.put("png", "/frame/" + URLEncoder.encode(title, UTF8) + ".png"); // NOI18N
+                            root.add(node);
+                            frames.add(frame);
+                        } catch (UnsupportedEncodingException ex) {
+                            JsonException je = new JsonException(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Unable to encode panel title \"" + title + "\"");
+                            response.sendError(je.getCode(), mapper.writeValueAsString(je.getJsonMessage()));
+                            return;
+                        }
                     }
                 }
-            });
+            }
             response.getWriter().write(mapper.writeValueAsString(root));
         } else {
             response.getWriter().append(Bundle.getMessage(request.getLocale(), "FrameDocType")); // NOI18N
@@ -382,7 +392,7 @@ public class JmriJFrameServlet extends HttpServlet {
                 String title = frame.getTitle();
                 //don't add to list if blank or disallowed
                 if (!title.isEmpty() && frame.getAllowInFrameServlet() && !disallowedFrames.contains(title) && frame.isVisible()) {
-                    String link = "/frame/" + StringUtil.escapeString(title) + ".html"; // NOI18N
+                    String link = "/frame/" + URLEncoder.encode(title, UTF8) + ".html"; // NOI18N
                     //format a table row for each valid window (frame)
                     response.getWriter().append("<tr><td><a href='" + link + "'>"); // NOI18N
                     response.getWriter().append(title);
@@ -390,7 +400,7 @@ public class JmriJFrameServlet extends HttpServlet {
                     response.getWriter().append("<td><a href='");
                     response.getWriter().append(link);
                     response.getWriter().append("'><img src='"); // NOI18N
-                    response.getWriter().append("/frame/" + StringUtil.escapeString(title) + ".png"); // NOI18N
+                    response.getWriter().append("/frame/" + URLEncoder.encode(title, UTF8) + ".png"); // NOI18N
                     response.getWriter().append("'></a></td></tr>\n"); // NOI18N
                 }
             }
@@ -400,7 +410,7 @@ public class JmriJFrameServlet extends HttpServlet {
     }
 
     // Requests for frames are always /frame/<name>.html or /frame/<name>.png
-    private String getFrameName(String URI) {
+    private String getFrameName(String URI) throws UnsupportedEncodingException {
         if (!URI.contains(".")) { // NOI18N
             return null;
         } else {
@@ -409,7 +419,7 @@ public class JmriJFrameServlet extends HttpServlet {
             String name = URI.substring(URI.lastIndexOf("/"), stop); // NOI18N
             // URI contains a leading / at this point
             name = name.substring(1, name.lastIndexOf(".")); // NOI18N
-            name = StringUtil.unescapeString(name); //undo escaped characters
+            name = URLDecoder.decode(name, UTF8); //undo escaped characters
             log.debug("Frame name is {}", name); // NOI18N
             return name;
         }

--- a/java/src/jmri/web/servlet/json/Bundle.properties
+++ b/java/src/jmri/web/servlet/json/Bundle.properties
@@ -6,3 +6,5 @@ JsonTitle=Json Console
 # providing relative path to translated Roster.html
 # (for example) Roster.html=web/servlet/json/Json_it.html
 Json.html=web/servlet/json/Json.html
+#Error message passed to client when requesting an object type not handled by the JSON server
+ErrorUnknownType=Object Type \\"{0}\\" is unknown

--- a/java/src/jmri/web/servlet/json/Bundle_ca.properties
+++ b/java/src/jmri/web/servlet/json/Bundle_ca.properties
@@ -9,3 +9,5 @@ JsonTitle=Consola Json
 # providing relative path to translated Roster.html
 # (for example) Roster.html=web/servlet/json/Json_it.html
 Json.html=web/servlet/json/Json.html
+#Error message passed to client when requesting an object type not handled by the JSON server
+ErrorUnknownType=Object Type \\"{0}\\" is unknown

--- a/java/src/jmri/web/servlet/json/Bundle_cs.properties
+++ b/java/src/jmri/web/servlet/json/Bundle_cs.properties
@@ -9,3 +9,5 @@ JsonTitle=Json konsole
 # providing relative path to translated Roster.html
 # (for example) Roster.html=web/servlet/json/Json_it.html
 Json.html=web/servlet/json/Json_cs.html
+#Error message passed to client when requesting an object type not handled by the JSON server
+ErrorUnknownType=Object Type \\"{0}\\" is unknown

--- a/java/src/jmri/web/servlet/json/Bundle_da.properties
+++ b/java/src/jmri/web/servlet/json/Bundle_da.properties
@@ -6,3 +6,5 @@ JsonTitle=Json Console
 # providing relative path to translated Roster.html
 # (for example) Roster.html=web/servlet/json/Json_it.html
 Json.html=web/servlet/json/Json.html
+#Error message passed to client when requesting an object type not handled by the JSON server
+ErrorUnknownType=Object Type \\"{0}\\" is unknown

--- a/java/src/jmri/web/servlet/json/Bundle_de.properties
+++ b/java/src/jmri/web/servlet/json/Bundle_de.properties
@@ -6,3 +6,5 @@ JsonTitle=JSON Console
 # providing relative path to translated Roster.html
 # (for example) Roster.html=web/servlet/json/Json_it.html
 Json.html=web/servlet/json/Json_de.html
+#Error message passed to client when requesting an object type not handled by the JSON server
+ErrorUnknownType=Object Type \\"{0}\\" is unknown

--- a/java/src/jmri/web/servlet/json/Bundle_nl.properties
+++ b/java/src/jmri/web/servlet/json/Bundle_nl.properties
@@ -6,3 +6,5 @@ JsonTitle=JSON Console
 # providing relative path to translated Roster.html
 # (for example) Roster.html=web/servlet/json/Json_it.html
 Json.html=web/servlet/json/Json_nl.html
+#Error message passed to client when requesting an object type not handled by the JSON server
+ErrorUnknownType=Object Type \\"{0}\\" is unknown

--- a/java/src/jmri/web/servlet/json/JsonServlet.java
+++ b/java/src/jmri/web/servlet/json/JsonServlet.java
@@ -8,6 +8,7 @@ import static jmri.server.json.JsonException.CODE;
 import static jmri.server.json.operations.JsonOperations.LOCATION;
 import static jmri.server.json.power.JsonPowerServiceFactory.POWER;
 import static jmri.web.servlet.ServletUtil.APPLICATION_JSON;
+import static jmri.web.servlet.ServletUtil.UTF8;
 import static jmri.web.servlet.ServletUtil.UTF8_APPLICATION_JSON;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -16,7 +17,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -131,15 +131,15 @@ public class JsonServlet extends WebSocketServlet {
             return;
         }
 
-        String[] rest = request.getPathInfo().split("/"); // NOI18N
-        String type = (rest.length > 1) ? rest[1] : null;
+        String[] rest = request.getRequestURI().substring(request.getContextPath().length()).split("/"); // NOI18N
+        String type = (rest.length > 1) ? URLDecoder.decode(rest[1], UTF8) : null;
         if (type != null) {
             response.setContentType(UTF8_APPLICATION_JSON);
-            ServletUtil.getInstance().setNonCachingHeaders(response);
-            final String name = (rest.length > 2) ? URLDecoder.decode(rest[2], StandardCharsets.UTF_8.name()) : null;
+            ServletUtil.getDefault().setNonCachingHeaders(response);
+            final String name = (rest.length > 2) ? URLDecoder.decode(rest[2], UTF8) : null;
             ObjectNode parameters = this.mapper.createObjectNode();
             for (Map.Entry<String, String[]> entry : request.getParameterMap().entrySet()) {
-                parameters.put(entry.getKey(), URLDecoder.decode(entry.getValue()[0], "UTF-8"));
+                parameters.put(entry.getKey(), URLDecoder.decode(entry.getValue()[0], UTF8));
             }
             JsonNode reply = null;
             try {
@@ -235,11 +235,11 @@ public class JsonServlet extends WebSocketServlet {
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(UTF8_APPLICATION_JSON);
         response.setHeader("Connection", "Keep-Alive"); // NOI18N
-        ServletUtil.getInstance().setNonCachingHeaders(response);
+        ServletUtil.getDefault().setNonCachingHeaders(response);
 
-        String[] rest = request.getPathInfo().split("/"); // NOI18N
-        String type = (rest.length > 1) ? rest[1] : null;
-        String name = (rest.length > 2) ? rest[2] : null;
+        String[] rest = request.getRequestURI().substring(request.getContextPath().length()).split("/"); // NOI18N
+        String type = (rest.length > 1) ? URLDecoder.decode(rest[1], UTF8) : null;
+        String name = (rest.length > 2) ? URLDecoder.decode(rest[2], UTF8) : null;
         JsonNode data;
         JsonNode reply = null;
         try {
@@ -322,11 +322,11 @@ public class JsonServlet extends WebSocketServlet {
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(UTF8_APPLICATION_JSON);
         response.setHeader("Connection", "Keep-Alive"); // NOI18N
-        ServletUtil.getInstance().setNonCachingHeaders(response);
+        ServletUtil.getDefault().setNonCachingHeaders(response);
 
-        String[] rest = request.getPathInfo().split("/"); // NOI18N
-        String type = (rest.length > 1) ? rest[1] : null;
-        String name = (rest.length > 2) ? rest[2] : null;
+        String[] rest = request.getRequestURI().substring(request.getContextPath().length()).split("/"); // NOI18N
+        String type = (rest.length > 1) ? URLDecoder.decode(rest[1], UTF8) : null;
+        String name = (rest.length > 2) ? URLDecoder.decode(rest[2], UTF8) : null;
         JsonNode data;
         JsonNode reply = null;
         try {
@@ -399,11 +399,11 @@ public class JsonServlet extends WebSocketServlet {
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType(UTF8_APPLICATION_JSON);
         response.setHeader("Connection", "Keep-Alive"); // NOI18N
-        ServletUtil.getInstance().setNonCachingHeaders(response);
+        ServletUtil.getDefault().setNonCachingHeaders(response);
 
-        String[] rest = request.getPathInfo().split("/"); // NOI18N
-        String type = (rest.length > 1) ? rest[1] : null;
-        String name = (rest.length > 2) ? rest[2] : null;
+        String[] rest = request.getRequestURI().substring(request.getContextPath().length()).split("/"); // NOI18N
+        String type = (rest.length > 1) ? URLDecoder.decode(rest[1], UTF8) : null;
+        String name = (rest.length > 2) ? URLDecoder.decode(rest[2], UTF8) : null;
         JsonNode reply = mapper.createObjectNode();
         try {
             if (type != null) {

--- a/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
@@ -12,6 +12,8 @@ import java.awt.Frame;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import javax.annotation.CheckForNull;
 import javax.imageio.ImageIO;
 import javax.servlet.ServletException;
@@ -23,7 +25,6 @@ import jmri.jmrit.display.Editor;
 import jmri.server.json.JSON;
 import jmri.server.json.util.JsonUtilHttpService;
 import jmri.util.FileUtil;
-import jmri.util.StringUtil;
 import jmri.web.server.WebServer;
 import jmri.web.servlet.ServletUtil;
 import org.jdom2.Attribute;
@@ -87,9 +88,9 @@ abstract class AbstractPanelServlet extends HttpServlet {
             return;
         }
         if (request.getParameter(JSON.NAME) != null) {
-            String panelName = StringUtil.unescapeString(request.getParameter(JSON.NAME));
+            String panelName = URLDecoder.decode(request.getParameter(JSON.NAME), UTF8);
             if (getEditor(panelName) != null) {
-                response.sendRedirect("/panel/" + StringUtil.escapeString(panelName)); // NOI18N
+                response.sendRedirect("/panel/" + URLEncoder.encode(panelName, UTF8)); // NOI18N
             } else {
                 response.sendRedirect("/panel/"); // NOI18N
             }
@@ -97,7 +98,7 @@ abstract class AbstractPanelServlet extends HttpServlet {
             listPanels(request, response);
         } else {
             String[] path = request.getRequestURI().split("/"); // NOI18N
-            String panelName = StringUtil.unescapeString(path[path.length - 1]);
+            String panelName = URLDecoder.decode(path[path.length - 1], UTF8);
             if ("png".equals(request.getParameter("format"))) {
                 BufferedImage panel = getPanelImage(panelName);
                 if (panel == null) {

--- a/java/src/jmri/web/servlet/roster/RosterServlet.java
+++ b/java/src/jmri/web/servlet/roster/RosterServlet.java
@@ -429,9 +429,9 @@ public class RosterServlet extends HttpServlet {
                     this.doImage(request, response, FileUtil.getFile(re.getFunctionSelectedImage(function)));
                 }
             } else if (type.equals("file")) {
-                ServletUtil.getInstance().writeFile(response, new File(Roster.getDefault().getRosterLocation(), "roster" + File.separator + re.getFileName()), ServletUtil.UTF8_APPLICATION_XML); // NOI18N
+                ServletUtil.getDefault().writeFile(response, new File(Roster.getDefault().getRosterLocation(), "roster" + File.separator + re.getFileName()), ServletUtil.UTF8_APPLICATION_XML); // NOI18N
             } else if (type.equals("throttle")) {
-                ServletUtil.getInstance().writeFile(response, new File(FileUtil.getUserFilesPath(), "throttle" + File.separator + id + ".xml"), ServletUtil.UTF8_APPLICATION_XML); // NOI18N
+                ServletUtil.getDefault().writeFile(response, new File(FileUtil.getUserFilesPath(), "throttle" + File.separator + id + ".xml"), ServletUtil.UTF8_APPLICATION_XML); // NOI18N
             } else {
                 // don't know what to do
                 response.sendError(HttpServletResponse.SC_BAD_REQUEST);
@@ -457,7 +457,7 @@ public class RosterServlet extends HttpServlet {
      * @throws java.io.IOException if communications is cut with client
      */
     protected void doRoster(HttpServletRequest request, HttpServletResponse response, JsonNode filter) throws IOException {
-        ServletUtil.getInstance().setNonCachingHeaders(response);
+        ServletUtil.getDefault().setNonCachingHeaders(response);
         log.debug("Getting roster with filter {}", filter);
         String group = (!filter.path(GROUP).isMissingNode()) ? filter.path(GROUP).asText() : null;
         log.debug("Group {} was in filter", group);
@@ -544,12 +544,12 @@ public class RosterServlet extends HttpServlet {
                         FileUtil.readURL(FileUtil.findURL(Bundle.getMessage(request.getLocale(), "Roster.html"))),
                         String.format(request.getLocale(),
                                 Bundle.getMessage(request.getLocale(), "HtmlTitle"),
-                                ServletUtil.getInstance().getRailroadName(false),
+                                ServletUtil.getDefault().getRailroadName(false),
                                 Bundle.getMessage(request.getLocale(), "RosterTitle")
                         ),
-                        ServletUtil.getInstance().getNavBar(request.getLocale(), request.getContextPath()),
-                        ServletUtil.getInstance().getRailroadName(false),
-                        ServletUtil.getInstance().getFooter(request.getLocale(), request.getContextPath()),
+                        ServletUtil.getDefault().getNavBar(request.getLocale(), request.getContextPath()),
+                        ServletUtil.getDefault().getRailroadName(false),
+                        ServletUtil.getDefault().getFooter(request.getLocale(), request.getContextPath()),
                         group
                 ));
                 break;

--- a/java/src/jmri/web/servlet/roster/RosterServlet.java
+++ b/java/src/jmri/web/servlet/roster/RosterServlet.java
@@ -390,7 +390,6 @@ public class RosterServlet extends HttpServlet {
             }
             idOffset = 2;
         }
-        log.error("Processing roster entry \"{}\" from \"{}\"", pathInfo[idOffset], request.getRequestURI());
         String id = URLDecoder.decode(pathInfo[idOffset], UTF8);
         if (pathInfo.length > (1 + idOffset)) {
             type = pathInfo[pathInfo.length - 1];

--- a/java/test/jmri/server/json/roster/JsonRosterHttpServiceTest.java
+++ b/java/test/jmri/server/json/roster/JsonRosterHttpServiceTest.java
@@ -117,9 +117,12 @@ public class JsonRosterHttpServiceTest {
 
     /**
      * Test of getRoster method, of class JsonRosterHttpService.
+     *
+     * @throws jmri.server.json.JsonException if unable to URL-encode roster
+     *                                        entry Ids
      */
     @Test
-    public void testGetRoster() {
+    public void testGetRoster() throws JsonException {
         JsonRosterHttpService instance = new JsonRosterHttpService(this.objectMapper);
         // no group name - check only size - it should contain all entries in Roster
         Assert.assertEquals(Roster.getDefault().numEntries(),
@@ -155,9 +158,12 @@ public class JsonRosterHttpServiceTest {
 
     /**
      * Test of getRosterEntry method, of class JsonRosterHttpService.
+     *
+     * @throws jmri.server.json.JsonException if unable to URL-encode roster
+     *                                        entry Id
      */
     @Test
-    public void testGetRosterEntry_Locale_RosterEntry() {
+    public void testGetRosterEntry_Locale_RosterEntry() throws JsonException {
         RosterEntry entry = Roster.getDefault().getEntryForId(TEST_ENTRY1);
         Assert.assertNotNull(entry);
         JsonRosterHttpService instance = new JsonRosterHttpService(this.objectMapper);

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <!-- dependency versions (its easier to include version in dependency
         but if multiple dependencies are linked, use a property for single
         dependency source) -->
-        <jetty.version>9.2.21.v20170120</jetty.version>
+        <jetty.version>9.3.9.v20160517</jetty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <jackson.version>2.8.5</jackson.version>
         <jogamp.version>2.3.2</jogamp.version>


### PR DESCRIPTION
- URL-encode roster entry Ids in URL paths and only in URL paths.
- Accept URL-encoded roster entry Ids in request paths in the Roster servlet.
- Accept URL-encoded types and object Ids in request paths in the JSON servlet.