### PR TITLE
Update ConfigureXml support for reading older files with different class names

### DIFF
--- a/java/src/jmri/configurexml/ClassMigration.properties
+++ b/java/src/jmri/configurexml/ClassMigration.properties
@@ -26,3 +26,10 @@ jmri.configurexml.GuiLafConfigPaneXml               = jmri.managers.configurexml
 jmri.configurexml.LsDecSignalHeadXml                = jmri.managers.configurexml.LsDecSignalHeadXml
 jmri.configurexml.TripleTurnoutSignalHeadXml        = jmri.managers.configurexml.TripleTurnoutSignalHeadXml
 jmri.configurexml.VirtualSignalHeadXml              = jmri.managers.configurexml.VirtualSignalHeadXml
+
+jmri.jmrit.display.configurexml.LayoutEditorXml     = jmri.jmrit.display.layoutEditor.configurexml.LayoutEditorXml
+
+jmri.jmrit.display.configurexml.ControlPanelEditorXml  = jmri.jmrit.display.layoutEditor.controlPanelEditor.ControlPanelEditorXml
+
+jmri.jmrit.display.configurexml.PanelEditorXml      = jmri.jmrit.display.layoutEditor.panelEditor.PanelEditorXml
+


### PR DESCRIPTION
Add migration support for three editors moved to subpackages:

```
jmri.jmrit.display.configurexml.LayoutEditorXml     = jmri.jmrit.display.layoutEditor.configurexml.LayoutEditorXml

jmri.jmrit.display.configurexml.ControlPanelEditorXml  = jmri.jmrit.display.layoutEditor.controlPanelEditor.ControlPanelEditorXml

jmri.jmrit.display.configurexml.PanelEditorXml      = jmri.jmrit.display.layoutEditor.panelEditor.PanelEditorXml
```
