### PR TITLE
Update test thread handling

### DIFF
--- a/java/test/jmri/configurexml/BlockManagerXmlTest.java
+++ b/java/test/jmri/configurexml/BlockManagerXmlTest.java
@@ -402,19 +402,15 @@ public class BlockManagerXmlTest extends TestCase {
         Assert.assertNotNull(m7);
 
         // allow listeners to process, but keep it quick by looking for desired result
-        for (int i = 0; i < 25; i++) {
-            JUnitUtil.releaseThread(this);
-            if (m1.getAspect().equals("Advance Approach")
+        JUnitUtil.waitFor(()->{
+                return (m1.getAspect().equals("Advance Approach")
                     && m2.getAspect().equals("Clear")
                     && m3.getAspect().equals("Clear")
                     && m4.getAspect().equals("Clear")
                     && m5.getAspect().equals("Approach")
                     && m6.getAspect().equals("Stop")
-                    && m7.getAspect().equals("Stop")) {
-                break;
-            }
-        }
-        JUnitUtil.releaseThread(this);
+                    && m7.getAspect().equals("Stop"));
+            },"Mast state ended as \""+m1.getAspect()+"\" \""+m2.getAspect()+"\" \""+m3.getAspect()+"\" \""+m4.getAspect()+"\" \""+m5.getAspect()+"\" \""+m6.getAspect()+"\" \""+m7.getAspect()+"\", desired state AA/C/C/C/A/S/S");
 
         // check for expected mast state 
         Assert.assertEquals("Signal 1", "Advance Approach", InstanceManager.getDefault(jmri.SignalMastManager.class).getSignalMast("IF$vsm:AAR-1946:SL-2-high-abs($0001)").getAspect());

--- a/java/test/jmri/jmrit/logix/NXFrameTest.java
+++ b/java/test/jmri/jmrit/logix/NXFrameTest.java
@@ -149,8 +149,11 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
                 Assert.fail("Unexpected Exception: " + e);
             }
         });
-        jmri.util.JUnitUtil.releaseThread(this);
-        Assert.assertEquals("Start Block Active", (OBlock.ALLOCATED | OBlock.OCCUPIED | OBlock.RUNNING), block.getState());
+
+        final OBlock testblock = block;
+        JUnitUtil.waitFor(() -> {
+            return testblock.getState() == (OBlock.ALLOCATED | OBlock.OCCUPIED | OBlock.RUNNING);
+        }, "Start Block Active");
 
         JUnitUtil.waitFor(() -> {
             return Bundle.getMessage("Halted", name, "0").equals(warrant.getRunningMessage());
@@ -253,7 +256,7 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
                         state == (OBlock.ALLOCATED | OBlock.RUNNING | OBlock.UNDETECTED);
             }, "Train occupies block "+i+" of "+route.length);
             flushAWT();
-            jmri.util.JUnitUtil.releaseThread(this);
+            jmri.util.JUnitUtil.releaseThread(this, 100);
 
             block = _OBlockMgr.getOBlock(route[i]);
             Sensor nextSensor;
@@ -267,7 +270,7 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
                         Assert.fail("Unexpected Exception: " + e);
                     }
                 });
-                jmri.util.JUnitUtil.releaseThread(this);
+                jmri.util.JUnitUtil.releaseThread(this, 100);
                 jmri.util.ThreadingUtil.runOnLayout(() -> {
                     try {
                         nextSensor.setState(Sensor.ACTIVE);
@@ -276,7 +279,7 @@ public class NXFrameTest extends jmri.util.SwingTestCase {
                     }
                 });
                 flushAWT();
-                jmri.util.JUnitUtil.releaseThread(this);
+                jmri.util.JUnitUtil.releaseThread(this, 100);
             } else {
                 nextSensor = null;
             }

--- a/java/test/jmri/jmrit/logix/WarrantTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantTest.java
@@ -195,21 +195,21 @@ public class WarrantTest {
             String m =  warrant.getRunningMessage();
             return m.endsWith("Cmd #2.");
         }, "Train starts to move after 2nd command");
-        jmri.util.JUnitUtil.releaseThread(this); // nothing specific to wait for...
+        jmri.util.JUnitUtil.releaseThread(this, 100); // What should we specifically waitFor?
 
         jmri.util.ThreadingUtil.runOnLayout( ()->{
             try {
                 sWest.setState(Sensor.ACTIVE);
             } catch (jmri.JmriException e) { Assert.fail("Unexpected Exception: "+e); }
         });
-        jmri.util.JUnitUtil.releaseThread(this);
+        jmri.util.JUnitUtil.releaseThread(this, 100); // What should we specifically waitFor?
 
         jmri.util.ThreadingUtil.runOnLayout( ()->{
             try {
                 sSouth.setState(Sensor.ACTIVE);
             } catch (jmri.JmriException e) { Assert.fail("Unexpected Exception: "+e); }
         });
-        jmri.util.JUnitUtil.releaseThread(this);
+        jmri.util.JUnitUtil.releaseThread(this, 100); // What should we specifically waitFor?
 
         // confirm one message logged
         jmri.util.JUnitAppender.assertWarnMessage("RosterSpeedProfile not found. Using default ThrottleFactor 0.75");

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -100,7 +100,9 @@ public class JUnitUtil {
      * use JFCUnit's flushAWT() and waitAtLeast(..)
      *
      * @param self currently ignored
+     * @deprecated 4.9.1 Use the various waitFor routines instead
      */
+    @Deprecated
     public static void releaseThread(Object self) {
         releaseThread(self, DEFAULT_RELEASETHREAD_DELAY);
     }


### PR DESCRIPTION
- deprecate releaseThread() in JUnitUtil in favor of waitFor style
- replace a few releaseThread() calls in tests