### PR TITLE
Layout Editor schema update for XtrkCad

### DIFF
--- a/xml/schema/types/layouteditor.xsd
+++ b/xml/schema/types/layouteditor.xsd
@@ -68,7 +68,7 @@
       <xs:attribute name="windowheight" type="xs:integer" use="required" />
       <xs:attribute name="windowwidth" type="xs:integer" use="required" />
       <xs:attribute name="panelheight" type="xs:integer"/>
-      <xs:attribute name="panelwidth" type="xs:integer" use="required" />
+      <xs:attribute name="panelwidth" type="xs:integer />
       <xs:attribute name="height" type="xs:integer" >
         <xs:annotation><xs:documentation>Deprecated since JMRI 2.2</xs:documentation></xs:annotation>
       </xs:attribute>

--- a/xml/schema/types/layouteditor.xsd
+++ b/xml/schema/types/layouteditor.xsd
@@ -68,7 +68,7 @@
       <xs:attribute name="windowheight" type="xs:integer" use="required" />
       <xs:attribute name="windowwidth" type="xs:integer" use="required" />
       <xs:attribute name="panelheight" type="xs:integer"/>
-      <xs:attribute name="panelwidth" type="xs:integer />
+      <xs:attribute name="panelwidth" type="xs:integer" />
       <xs:attribute name="height" type="xs:integer" >
         <xs:annotation><xs:documentation>Deprecated since JMRI 2.2</xs:documentation></xs:annotation>
       </xs:attribute>


### PR DESCRIPTION
Make panelWidth attribute in LayoutEditor schema (LayoutEditorType) not required.  The code doesn't seem to require it, and XtrkCadReader-emitted files don't contain it.