### PR TITLE
Add option to start DCC++ TCP server at startup

### DIFF
--- a/java/src/apps/ActionListBundle.properties
+++ b/java/src/apps/ActionListBundle.properties
@@ -82,6 +82,9 @@ jmri.jmrix.libusb.UsbViewAction = Open USB Device Viewer
 # web items
 jmri.web.server.WebServerAction = Start Web Server
 
+# DCC++ TCP Server
+jmri.jmrix.dccpp.dccppovertcp.ServerAction = Start DCC++ TCP Server
+
 jmri.jmrit.MemoryFrameAction = Open Memory Monitor
 
 # services


### PR DESCRIPTION
This allows the DCC++ TCP server to be started from JmriFaceless