### PR TITLE
Remove java warnings

### DIFF
--- a/java/src/jmri/jmrit/display/controlPanelEditor/PortalIcon.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/PortalIcon.java
@@ -202,7 +202,7 @@ public class PortalIcon extends PositionableIcon implements java.beans.PropertyC
                         setStatus(FROM_ARROW);
                         break;
                     default:
-                        log.warn("Unhandled portal value: {}", ((Integer)e.getNewValue()) );
+                        log.warn("Unhandled portal value: {}", e.getNewValue() );
                 }
             } else if ("UserName".equals(e.getPropertyName())) {
                 setName((String) e.getNewValue());

--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/DrawFrame.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/DrawFrame.java
@@ -458,7 +458,6 @@ public abstract class DrawFrame extends jmri.util.JmriJFrame {
         _shape.drawHandles();
         _shape.updateSize();
         _shape.getEditor().getTargetPanel().repaint();
-;
     }
 
     // these 2 methods update the JTextfields when mouse moves handles

--- a/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
@@ -135,9 +135,9 @@ public class SwitchboardEditor extends Editor {
             Bundle.getMessage("Keys"),
             Bundle.getMessage("Symbols")
     };
-    private JComboBox switchShapeList;
+    private JComboBox<String> switchShapeList;
     private List<String> beanManuPrefixes = new ArrayList<String>();
-    private JComboBox beanManuNames;
+    private JComboBox<String> beanManuNames;
 
     // toolbar (from LE)
     private JPanel floatEditHelpPanel = null;
@@ -257,7 +257,7 @@ public class SwitchboardEditor extends Editor {
         log.debug("beanTypeChar set to [{}]", beanTypeChar);
         JLabel beanManuTitle = new JLabel(Bundle.getMessage("MakeLabel", Bundle.getMessage("ConnectionLabel")));
         beanSetupPane.add(beanManuTitle);
-        beanManuNames = new JComboBox();
+        beanManuNames = new JComboBox<>();
         if (getManager(beanTypeChar) instanceof jmri.managers.AbstractProxyManager) { // from abstractTableTabAction
             jmri.managers.AbstractProxyManager proxy = (jmri.managers.AbstractProxyManager) getManager(beanTypeChar);
             List<jmri.Manager> managerList = proxy.getManagerList();
@@ -286,7 +286,7 @@ public class SwitchboardEditor extends Editor {
         switchShapePane.setLayout(new FlowLayout(FlowLayout.TRAILING));
         JLabel switchShapeTitle = new JLabel(Bundle.getMessage("MakeLabel", Bundle.getMessage("SwitchShape")));
         switchShapePane.add(switchShapeTitle);
-        switchShapeList = new JComboBox(switchShapeStrings);
+        switchShapeList = new JComboBox<>(switchShapeStrings);
         switchShapeList.setSelectedIndex(0); // select Button in comboBox
         switchShapeList.setActionCommand(SWITCHTYPE_COMMAND);
         switchShapeList.addActionListener(this);
@@ -418,7 +418,7 @@ public class SwitchboardEditor extends Editor {
         int _currentState;
         String _manu = manuPrefix; // cannot use All group as in Tables
         String _insert = "";
-        if (_manu.startsWith("M")) { _insert = "+"; }; // create CANbus.MERG On event
+        if (_manu.startsWith("M")) { _insert = "+"; } // create CANbus.MERG On event
         for (int i = rangeMin; i <= rangeMax; i++) {
             switch (beanType) {
                 case 0:
@@ -1829,7 +1829,7 @@ public class SwitchboardEditor extends Editor {
      * @return bean connection prefix
      */
     public String getSwitchManu() {
-        return (String) this.beanManuPrefixes.get(beanManuNames.getSelectedIndex());
+        return this.beanManuPrefixes.get(beanManuNames.getSelectedIndex());
     }
 
     /**
@@ -2148,19 +2148,19 @@ public class SwitchboardEditor extends Editor {
     private long _clickTime;
 
     @Override
-    public void mousePressed(MouseEvent event) {};
+    public void mousePressed(MouseEvent event) {}
 
     @Override
-    public void mouseReleased(MouseEvent event) {};
+    public void mouseReleased(MouseEvent event) {}
 
     @Override
-    public void mouseClicked(MouseEvent event) {};
+    public void mouseClicked(MouseEvent event) {}
 
     @Override
-    public void mouseDragged(MouseEvent event) {};
+    public void mouseDragged(MouseEvent event) {}
 
     @Override
-    public void mouseMoved(MouseEvent event) {};
+    public void mouseMoved(MouseEvent event) {}
 
     @Override
     public void mouseEntered(MouseEvent event) {
@@ -2288,7 +2288,7 @@ public class SwitchboardEditor extends Editor {
                     default:
                         image = image1; // off, also for connected & unknown
                         break;
-                };
+                }
                 this.repaint();
             }
         }
@@ -2368,7 +2368,7 @@ public class SwitchboardEditor extends Editor {
      */
     @Override
     protected void copyItem(Positionable p) {
-    };
+    }
 
     /**
      * Set an object's location when it is created.

--- a/java/src/jmri/jmrit/jython/InputWindow.java
+++ b/java/src/jmri/jmrit/jython/InputWindow.java
@@ -108,7 +108,7 @@ public class InputWindow extends JPanel {
         });
         languages = new JComboBox<>(names.toArray(new String[names.size()]));
         if (pref.getComboBoxLastSelection(languageSelection) != null) {
-            languages.setSelectedItem((String) pref.getComboBoxLastSelection(languageSelection));
+            languages.setSelectedItem(pref.getComboBoxLastSelection(languageSelection));
         }
 
         JPanel p = new JPanel();

--- a/java/src/jmri/jmrit/operations/trains/timetable/TrainScheduleManager.java
+++ b/java/src/jmri/jmrit/operations/trains/timetable/TrainScheduleManager.java
@@ -39,7 +39,7 @@ public class TrainScheduleManager implements java.beans.PropertyChangeListener {
     private int _id = 0;
 
     public static synchronized TrainScheduleManager instance() {
-        TrainScheduleManager instance = jmri.InstanceManager.getNullableDefault(TrainScheduleManager.class);;
+        TrainScheduleManager instance = jmri.InstanceManager.getNullableDefault(TrainScheduleManager.class);
         if (instance == null) {
             log.debug("TrainScheduleManager creating instance");
             // create and load

--- a/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
+++ b/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
@@ -241,7 +241,7 @@ public class RosterSpeedProfile {
 
         entry = speeds.lowerEntry(lowStep);
         while (entry != null && lower<=0.0f) {
-            lowStep = entry.getKey();;
+            lowStep = entry.getKey();
             float value = entry.getValue().getForwardSpeed();
             if (value > 0.0f) {
                 lower = value;

--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfileTable.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfileTable.java
@@ -162,7 +162,7 @@ public class SpeedProfileTable extends jmri.util.JmriJFrame {
             default:
                 str = "track";
         }
-        description.setText(Bundle.getMessage("rosterId", Bundle.getMessage(str), rosterId));;
+        description.setText(Bundle.getMessage("rosterId", Bundle.getMessage(str), rosterId));
         model.fireTableDataChanged();
     }
 

--- a/java/src/jmri/jmrit/signalling/SignallingPanel.java
+++ b/java/src/jmri/jmrit/signalling/SignallingPanel.java
@@ -2002,7 +2002,7 @@ public class SignallingPanel extends jmri.util.swing.JmriPanel {
                 case STATE_COLUMN:
                     if ((String) type != null) {
                         //convertRowIndexToModel(row) not needed
-                        log.debug("setValueAt (rowConverted={}; value={})", r, (String) type);
+                        log.debug("setValueAt (rowConverted={}; value={})", r, type);
                         signalMastList.get(r).setSetToState((String) type);
                         fireTableRowsUpdated(r, r);
                     }

--- a/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
@@ -1036,7 +1036,7 @@ class Steam1Sound extends EngineSound {
                 // Regular queueing. Whole sound clip goes to the queue. Low notches.
                 _sound.queueBuffer(b);
                 log.debug("chuff or coast buffer queued. Interval: {}", interval);
-                setWait((int) ((sbl - SLEEP_INTERVAL * 4) / SLEEP_INTERVAL));
+                setWait( ((sbl - SLEEP_INTERVAL * 4) / SLEEP_INTERVAL));
                 if (getWait() < 3) {
                     setWait(0);
                 } else {
@@ -1050,7 +1050,7 @@ class Steam1Sound extends EngineSound {
                 if (interval > (SLEEP_INTERVAL + 10)) {
                     log.debug("need to cut sound clip from {} to length {}", 
                             (int)SoundBite.calcLength(b), interval); 
-                    setWait((int) ((interval - SLEEP_INTERVAL * 8) / SLEEP_INTERVAL));
+                    setWait( ((interval - SLEEP_INTERVAL * 8) / SLEEP_INTERVAL));
                     if (getWait() < 4) {
                         setWait(0);
                     }
@@ -1110,7 +1110,7 @@ class Steam1Sound extends EngineSound {
                         k, _sound.getSource().numQueuedBuffers());
                 // Create a buffer to queue rest of the filling time. Ignore small sound bites.
                 if (imrest > (SLEEP_INTERVAL + 10)) {
-                    setWait((int) ((imrest - SLEEP_INTERVAL * 4) / SLEEP_INTERVAL));
+                    setWait( ((imrest - SLEEP_INTERVAL * 4) / SLEEP_INTERVAL));
                     if (getWait() < 3) {
                         setWait(0);
                     }

--- a/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
@@ -283,7 +283,7 @@ public class CMRISystemConnectionMemo extends SystemConnectionMemo {
             log.error("illegal system prefix in CMRI system name: " + systemName);
             return false;
         }
-        ;
+
         if (systemName.charAt(offset) != type) {
             log.error("illegal type character in CMRI system name: " + systemName);
             return false;

--- a/java/src/jmri/jmrix/dccpp/swing/DCCppTableModel.java
+++ b/java/src/jmri/jmrix/dccpp/swing/DCCppTableModel.java
@@ -46,7 +46,7 @@ public abstract class DCCppTableModel extends AbstractTableModel {
             }
         }
         return(false);
-    };
+    }
     
     public boolean isNewRow(int row) {
         //return((boolean) isNew.elementAt(row));

--- a/java/src/jmri/util/swing/GuiUtilBase.java
+++ b/java/src/jmri/util/swing/GuiUtilBase.java
@@ -42,8 +42,8 @@ public class GuiUtilBase {
         //This bit does not size very well, but it works for now.
         if (child.getChild("option") != null) {
             child.getChildren("option").stream().forEach((item) -> {
-                String setting = ((Element) item).getAttribute("setting").getValue();
-                String setMethod = ((Element) item).getText();
+                String setting = item.getAttribute("setting").getValue();
+                String setMethod = item.getText();
                 parameters.put(setMethod, setting);
             });
         }

--- a/java/src/jmri/util/swing/JTreeUtil.java
+++ b/java/src/jmri/util/swing/JTreeUtil.java
@@ -43,7 +43,7 @@ public class JTreeUtil extends GuiUtilBase {
         node.setUserObject(actionFromNode(main, wi, context));
 
         main.getChildren("node").stream().forEach((child) -> {
-            node.add(treeFromElement((Element) child, wi, context));
+            node.add(treeFromElement(child, wi, context));
         });
         return node;
     }

--- a/java/src/jmri/web/server/WebServer.java
+++ b/java/src/jmri/web/server/WebServer.java
@@ -56,7 +56,7 @@ public final class WebServer implements LifeCycle, LifeCycle.Listener {
 
     private static enum Registration {
         DENIAL, REDIRECTION, RESOURCE, SERVLET
-    };
+    }
     private final Server server;
     private ZeroConfService zeroConfService = null;
     private WebServerPreferences preferences = null;

--- a/java/test/jmri/jmrit/logix/OBlockTest.java
+++ b/java/test/jmri/jmrit/logix/OBlockTest.java
@@ -154,7 +154,7 @@ public class OBlockTest {
     @Test
     public void testAddPortal() {
         OBlock b = blkMgr.createNewOBlock("OB0", "");
-        PortalManager portalMgr = InstanceManager.getDefault(PortalManager.class);;
+        PortalManager portalMgr = InstanceManager.getDefault(PortalManager.class);
         Portal p = portalMgr.providePortal("foop");
         b.addPortal(p);
         Assert.assertEquals("No portals", 0, b.getPortals().size());

--- a/java/test/jmri/jmrit/operations/trains/TrainIconTest.java
+++ b/java/test/jmri/jmrit/operations/trains/TrainIconTest.java
@@ -70,6 +70,6 @@ public class TrainIconTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(TrainIconTest.class.getName());
+    // private final static Logger log = LoggerFactory.getLogger(TrainIconTest.class.getName());
 
 }

--- a/java/test/jmri/jmrit/roster/RosterTest.java
+++ b/java/test/jmri/jmrit/roster/RosterTest.java
@@ -382,8 +382,8 @@ public class RosterTest {
         rp.setSpeed(1000, 500, 5000);
         rp.setSpeed(500, 250, 2500);
         Assert.assertEquals(1.0,rp.getThrottleSetting(500,true),0.0);
-        Assert.assertEquals(0.5,rp.getThrottleSetting(250,true),0.0);;
-        Assert.assertEquals(0.25,rp.getThrottleSetting(125,true),0.0);;
+        Assert.assertEquals(0.5,rp.getThrottleSetting(250,true),0.0);
+        Assert.assertEquals(0.25,rp.getThrottleSetting(125,true),0.0);
     }
 
    @Test
@@ -393,8 +393,8 @@ public class RosterTest {
         rp.setSpeed(1000, 500, 5000);
         rp.setSpeed(500, 250, 2500);
         Assert.assertEquals(1.0,rp.getThrottleSetting(5000,false),0.0);
-        Assert.assertEquals(0.5,rp.getThrottleSetting(2500,false),0.0);;
-        Assert.assertEquals(0.25,rp.getThrottleSetting(1250,false),0.0);;
+        Assert.assertEquals(0.5,rp.getThrottleSetting(2500,false),0.0);
+        Assert.assertEquals(0.25,rp.getThrottleSetting(1250,false),0.0);
     }
 
     public Roster createTestRoster() throws IOException, FileNotFoundException {

--- a/java/test/jmri/jmrit/symbolicprog/EnumVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/EnumVariableValueTest.java
@@ -87,24 +87,24 @@ public class EnumVariableValueTest extends AbstractVariableValueTestBase {
         Component val1 = variable.getCommonRep();
         // now get rep, check
         JComboBox<?> rep1 = (JComboBox<?>) variable.getNewRep("");
-        Assert.assertEquals("initial rep ", "5", (String) rep1.getSelectedItem());
+        Assert.assertEquals("initial rep ", "5", rep1.getSelectedItem());
 
         // update via value
         setValue(variable, "2");
 
         // check again with existing reference
         Assert.assertEquals("same value object ", val1, variable.getCommonRep());
-        Assert.assertEquals("1 saved rep ", "2", (String) rep1.getSelectedItem());
+        Assert.assertEquals("1 saved rep ", "2", rep1.getSelectedItem());
         // pick up new references and check
         checkValue(variable, "1 new value ", "2");
-        Assert.assertEquals("1 new rep ", "2", (String) ((JComboBox<?>) variable.getNewRep("")).getSelectedItem());
+        Assert.assertEquals("1 new rep ", "2", ((JComboBox<?>) variable.getNewRep("")).getSelectedItem());
 
         // update via rep
         rep1.setSelectedItem("9");
 
         // check again with existing references
         Assert.assertEquals("2 saved value ", "9", ((JComboBox<?>) val1).getSelectedItem());
-        Assert.assertEquals("2 saved rep ", "9", (String) rep1.getSelectedItem());
+        Assert.assertEquals("2 saved rep ", "9", rep1.getSelectedItem());
         // pick up new references and check
         checkValue(variable, "2 new value ", "9");
         Assert.assertEquals("2 new rep ", "9", ((JComboBox<?>) variable.getNewRep("")).getSelectedItem());

--- a/java/test/jmri/jmrit/ussctc/RouteLockTest.java
+++ b/java/test/jmri/jmrit/ussctc/RouteLockTest.java
@@ -59,7 +59,6 @@ public class RouteLockTest {
         
         SignalHead s = new jmri.implementation.VirtualSignalHead("IH1");
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
-        NamedBeanHandle<SignalHead> h = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle("IH1", s);
         
         s.setState(SignalHead.YELLOW);
 
@@ -74,7 +73,6 @@ public class RouteLockTest {
         
         SignalHead s = new jmri.implementation.VirtualSignalHead("IH1");
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
-        NamedBeanHandle<SignalHead> h = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle("IH1", s);
         
         s.setState(SignalHead.YELLOW);
 
@@ -110,7 +108,6 @@ public class RouteLockTest {
     public void testBeanSettingMatch() throws JmriException {
         SignalHead s = new jmri.implementation.VirtualSignalHead("IH1");
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
-        NamedBeanHandle<SignalHead> h = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle("IH1", s);
 
         Turnout t = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
         t.setCommandedState(Turnout.CLOSED);
@@ -126,7 +123,6 @@ public class RouteLockTest {
     public void testBeanSettingoMatch() throws JmriException {
         SignalHead s = new jmri.implementation.VirtualSignalHead("IH1");
         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
-        NamedBeanHandle<SignalHead> h = InstanceManager.getDefault(NamedBeanHandleManager.class).getNamedBeanHandle("IH1", s);
 
         Turnout t = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
         t.setCommandedState(Turnout.CLOSED);

--- a/java/test/jmri/jmrix/AbstractMRNodeTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/AbstractMRNodeTrafficControllerTest.java
@@ -30,7 +30,7 @@ public class AbstractMRNodeTrafficControllerTest extends AbstractMRTrafficContro
         JUnitUtil.resetInstanceManager();
         tc = new AbstractMRNodeTrafficController(){
            @Override
-           protected void setInstance() {};
+           protected void setInstance() {}
            @Override
            protected void forwardMessage(AbstractMRListener client, AbstractMRMessage m){
            }

--- a/java/test/jmri/jmrix/AbstractMRTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/AbstractMRTrafficControllerTest.java
@@ -59,7 +59,7 @@ public class AbstractMRTrafficControllerTest {
         JUnitUtil.resetInstanceManager();
         tc = new AbstractMRTrafficController(){
            @Override
-           protected void setInstance() {};
+           protected void setInstance() {}
            @Override
            protected void forwardMessage(AbstractMRListener client, AbstractMRMessage m){
            }

--- a/java/test/jmri/jmrix/AbstractMonFrameTest.java
+++ b/java/test/jmri/jmrix/AbstractMonFrameTest.java
@@ -23,7 +23,7 @@ public class AbstractMonFrameTest {
            @Override
            public String title(){
               return "test";
-           };
+           }
            @Override
            public void init(){
            }

--- a/java/test/jmri/jmrix/AbstractMonPaneTest.java
+++ b/java/test/jmri/jmrix/AbstractMonPaneTest.java
@@ -20,7 +20,7 @@ public class AbstractMonPaneTest {
            @Override
            public String getTitle(){
               return "test";
-           };
+           }
            @Override
            public void init(){
            }

--- a/java/test/jmri/jmrix/can/AbstractCanTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/AbstractCanTrafficControllerTest.java
@@ -20,7 +20,7 @@ public class AbstractCanTrafficControllerTest extends jmri.jmrix.AbstractMRTraff
         JUnitUtil.resetInstanceManager();
         tc = new AbstractCanTrafficController(){
            @Override
-           protected void setInstance() {};
+           protected void setInstance() {}
            @Override
            protected void forwardMessage(AbstractMRListener client, AbstractMRMessage m){
            }

--- a/java/test/jmri/jmrix/lenz/XNetReplyTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetReplyTest.java
@@ -139,7 +139,7 @@ public class XNetReplyTest {
     public void testSkipPrefix(){
        XNetReply m=new XNetReply("63 14 01 04 72");
        // skip prefix currently always returns -1, there is no prefix.
-       Assert.assertEquals("skipPrefix return value",-1,(long)m.skipPrefix(0));
+       Assert.assertEquals("skipPrefix return value",-1, m.skipPrefix(0));
     }
 
 

--- a/java/test/jmri/jmrix/lenz/XNetSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetSystemConnectionMemoTest.java
@@ -48,7 +48,7 @@ public class XNetSystemConnectionMemoTest extends TestCase {
           @Override
           public int getCommandStationType(){
               return(0x10); // MultiMaus
-          };
+          }
         });
 
         XNetSystemConnectionMemo t = new XNetSystemConnectionMemo();
@@ -63,7 +63,7 @@ public class XNetSystemConnectionMemoTest extends TestCase {
           @Override
           public int getCommandStationType(){
               return(0x00); // LZV100
-          };
+          }
         });
 
         XNetSystemConnectionMemo t = new XNetSystemConnectionMemo();

--- a/java/test/jmri/util/MathUtilTest.java
+++ b/java/test/jmri/util/MathUtilTest.java
@@ -172,7 +172,7 @@ public class MathUtilTest extends TestCase {
         for (double a = -3.0 * limits; a < +3.0 * limits; a += limits / 10.0) {
             double t = a;
             while (t >= +limits) {t -= limits;}
-            while (t < 0.0) {t += limits;};
+            while (t < 0.0) {t += limits;}
             double c = MathUtil.normalizeAngleDEG(a);
             Assert.assertEquals(t, c, tolerance);
             passed = (math.fabs(t - c) <= tolerance);
@@ -221,7 +221,7 @@ public class MathUtilTest extends TestCase {
                 double t = a - b;
                 while (t >= theMax) {t -= theRange;}
                 while (t < theMin) {t += theRange;}
-                if (t < 0.0) { t = -t;};
+                if (t < 0.0) { t = -t;}
                 double c = MathUtil.absDiffAngleDEG(a, b);
                 Assert.assertEquals(t, c, tolerance);
                 passed = (math.fabs(t - c) <= tolerance);
@@ -244,8 +244,8 @@ public class MathUtilTest extends TestCase {
             for (double b = -3.3 * limits; b < +3.3 * limits; b += limits / 15.0) {
                 for (double c = -3.3 * limits; c < +3.3 * limits; c += limits / 15.0) {
                     double t = a;
-                    if (t < b) {t = b;};
-                    if (t > c) {t = c;};
+                    if (t < b) {t = b;}
+                    if (t > c) {t = c;}
                     double d = MathUtil.pin(a, b, c);
                     Assert.assertEquals(t, d, tolerance);
                     passed = (math.fabs(t - d) <= tolerance);

--- a/java/test/jmri/util/swing/JmriNamedPaneActionTest.java
+++ b/java/test/jmri/util/swing/JmriNamedPaneActionTest.java
@@ -33,6 +33,6 @@ public class JmriNamedPaneActionTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JmriNamedPaneActionTest.class.getName());
+    // private final static Logger log = LoggerFactory.getLogger(JmriNamedPaneActionTest.class.getName());
 
 }


### PR DESCRIPTION
Fix some simple warnings from Jenkins:
- Extra semicolons
- Extra casts
- a few unneeded variables (lots of those left)