### PR TITLE
Allow script access to monitor text area

### DIFF
--- a/java/src/jmri/jmrix/AbstractMonFrame.java
+++ b/java/src/jmri/jmrix/AbstractMonFrame.java
@@ -409,6 +409,14 @@ public abstract class AbstractMonFrame extends JmriJFrame {
         return linesBuffer.toString();
     }
 
+    /** 
+     * Get access to the main text area. This is intended
+     * for use in e.g. scripting to extend the behavior of the window.
+     */
+    public final synchronized JTextArea getTextArea() {
+        return monTextPane;
+    }
+    
     /**
      * Method to position caret at end of JTextArea ta when scroll true.
      *

--- a/java/src/jmri/jmrix/AbstractMonPane.java
+++ b/java/src/jmri/jmrix/AbstractMonPane.java
@@ -628,6 +628,14 @@ public abstract class AbstractMonPane extends JmriPanel {
         return monTextPane.getText();
     }
 
+    /** 
+     * Get access to the main text area. This is intended
+     * for use in e.g. scripting to extend the behavior of the window.
+     */
+    public final synchronized JTextArea getTextArea() {
+        return monTextPane;
+    }
+
     public synchronized String getFilterText() {
         return filterField.getText();
     }


### PR DESCRIPTION
Provides a new `getTextArea()` method to allow scripts access to the display area in protocol-monitor windows.  This follows from a JMRIusers discussion.