### PR TITLE
Quick fix for Jenkins error

### DIFF
--- a/java/src/jmri/NamedBeanBundle_en_GB.properties
+++ b/java/src/jmri/NamedBeanBundle_en_GB.properties
@@ -11,4 +11,6 @@ MenuItemMinimize = Minimise
 
 BeanNameSignalSystem = Signalling System
 # running direction
-Forward = Forwards
+
+# Activating the next line (Uk english instead of US "forward") will cause jmri.jmrix.lenz.XNetMessageTest to fail on Jenkins
+# Forward = Forwards

--- a/java/src/jmri/NamedBeanBundle_en_GB.properties
+++ b/java/src/jmri/NamedBeanBundle_en_GB.properties
@@ -12,5 +12,5 @@ MenuItemMinimize = Minimise
 BeanNameSignalSystem = Signalling System
 # running direction
 
-# Activating the next line (Uk english instead of US "forward") will cause jmri.jmrix.lenz.XNetMessageTest to fail on Jenkins
+# Activating the next line (UK English "forwards" instead of US "forward") will cause jmri.jmrix.lenz.XNetMessageTest to fail on Jenkins
 # Forward = Forwards


### PR DESCRIPTION
Activating the ``Forward`` key in jmri.NamedBeanBundle_en_GB.properties (British english "Forwards" instead of US "Forward") will cause 6 errors in jmri.jmrix.lenz.XNetMessageTest on Jenkins.
Is Jenkins perhaps running on a GB Locale platform? No problem running ``alltest`` locally, so as a short term fix, deactivate this line. 
Sorry to have written "Uk english" in the props comment, can't correct that in the GitHub web editor.