### PR TITLE
Fix of dup keys

### DIFF
--- a/java/src/jmri/jmrix/JmrixBundle_it.properties
+++ b/java/src/jmri/jmrix/JmrixBundle_it.properties
@@ -114,6 +114,5 @@ ManagerDefaultSelector.AllInternal=All defaults are assigned to an internal conn
 DefaultStatusText=Pronto
 
 # Lenz XpressNet/Roco Z21 shared config items
-DefaultStatusText       = Pronto
 ButtonResetDefaults     = Reset ai Defaults di Fabbrica
 UseDefaultValue         = default

--- a/java/src/jmri/jmrix/JmrixBundle_nl.properties
+++ b/java/src/jmri/jmrix/JmrixBundle_nl.properties
@@ -239,14 +239,6 @@ SoftwareVersionLabel    = Software-versie:
 ApplicationVersionLabel = Applicatie-versie
 ProtocolVersionLabel    = Protocol-versie:
 
-MonitorXTitle           = {0} Gegevensmonitor
-ErrorConvertNumberX     = Kan {0} niet omzetten in een geldig Hardware-adres
-WarningAddressAsNumber  = Hardware-adres invoeren als geheel getal
-WarningPortRangeXY      = Poort-nummer van {0} tot {1} invoeren
-WarningModuleAddress    = Hardware-adres invoeren als "Module-nummer:Poort-nummer"
-#Error message displayed on start if internal connection has all defaults.
-ManagerDefaultSelector.AllInternal=All defaults are assigned to an internal connection.
-
 UseDefaultValue         = Gebruik standaardwaarde
 ButtonResetDefaults     = Standaardwaardes
 


### PR DESCRIPTION
Seems somehow a duplicate block was in the JmriBundle_nl file and one
line dup in the JmrixBundle_it file.