### PR TITLE
Suppress use of RenderingHints.VALUE_INTERPOLATION_BICUBIC

### DIFF
--- a/java/src/jmri/jmrit/catalog/NamedIcon.java
+++ b/java/src/jmri/jmrit/catalog/NamedIcon.java
@@ -336,7 +336,7 @@ public class NamedIcon extends ImageIcon {
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
                 RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-//         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+//         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,   // Turned off due to poor performance, see Issue #3850 and PR #3855 for background
 //                 RenderingHints.VALUE_INTERPOLATION_BICUBIC);
         g2d.drawImage(getImage(), t, comp);
         setImage(bufIm);

--- a/java/src/jmri/jmrit/catalog/NamedIcon.java
+++ b/java/src/jmri/jmrit/catalog/NamedIcon.java
@@ -336,8 +336,8 @@ public class NamedIcon extends ImageIcon {
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
                 RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-                RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+//         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+//                 RenderingHints.VALUE_INTERPOLATION_BICUBIC);
         g2d.drawImage(getImage(), t, comp);
         setImage(bufIm);
         g2d.dispose();

--- a/java/src/jmri/jmrit/display/PositionableLabel.java
+++ b/java/src/jmri/jmrit/display/PositionableLabel.java
@@ -822,7 +822,7 @@ public class PositionableLabel extends JLabel implements Positionable {
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
                 RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-//         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+//         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,   // Turned off due to poor performance, see Issue #3850 and PR #3855 for background
 //                 RenderingHints.VALUE_INTERPOLATION_BICUBIC);
 
         if (_popupUtil != null) {
@@ -908,7 +908,7 @@ public class PositionableLabel extends JLabel implements Positionable {
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
                 RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-//         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+//         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,   // Turned off due to poor performance, see Issue #3850 and PR #3855 for background
 //                 RenderingHints.VALUE_INTERPOLATION_BICUBIC);
 
         if (_popupUtil != null) {
@@ -1037,7 +1037,7 @@ public class PositionableLabel extends JLabel implements Positionable {
                         RenderingHints.VALUE_ANTIALIAS_ON);
                 g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
                         RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-//                 g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+//                 g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,   // Turned off due to poor performance, see Issue #3850 and PR #3855 for background
 //                         RenderingHints.VALUE_INTERPOLATION_BICUBIC);
             }
 

--- a/java/src/jmri/jmrit/display/PositionableLabel.java
+++ b/java/src/jmri/jmrit/display/PositionableLabel.java
@@ -822,8 +822,8 @@ public class PositionableLabel extends JLabel implements Positionable {
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
                 RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-                RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+//         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+//                 RenderingHints.VALUE_INTERPOLATION_BICUBIC);
 
         if (_popupUtil != null) {
             if (_popupUtil.hasBackground()) {
@@ -908,8 +908,8 @@ public class PositionableLabel extends JLabel implements Positionable {
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
                 RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-                RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+//         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+//                 RenderingHints.VALUE_INTERPOLATION_BICUBIC);
 
         if (_popupUtil != null) {
             if (_popupUtil.hasBackground()) {
@@ -1037,8 +1037,8 @@ public class PositionableLabel extends JLabel implements Positionable {
                         RenderingHints.VALUE_ANTIALIAS_ON);
                 g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
                         RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-                g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-                        RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+//                 g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+//                         RenderingHints.VALUE_INTERPOLATION_BICUBIC);
             }
 
             switch (_popupUtil.getOrientation()) {

--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/PositionableShape.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/PositionableShape.java
@@ -180,8 +180,8 @@ public class PositionableShape extends PositionableJComponent
                     RenderingHints.VALUE_ANTIALIAS_ON);
             g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
                     RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-            g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-                    RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+//             g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+//                     RenderingHints.VALUE_INTERPOLATION_BICUBIC);
         }
 
         g2d.setClip(null);

--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/PositionableShape.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/PositionableShape.java
@@ -180,7 +180,7 @@ public class PositionableShape extends PositionableJComponent
                     RenderingHints.VALUE_ANTIALIAS_ON);
             g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION,
                     RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-//             g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+//             g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,  // Turned off due to poor performance, see Issue #3850 and PR #3855 for background
 //                     RenderingHints.VALUE_INTERPOLATION_BICUBIC);
         }
 


### PR DESCRIPTION
See Issue #3850 for background. 

This fixes the performance hit on macOS of using RenderingHints.VALUE_INTERPOLATION_BICUBIC by suppressing it in all places where it was used.  This may be an overshoot:
- The test case only exercised the case near line 1000 in PositionableLabel; the others may or may not have an effect in other cases
- A similar-appearing performance problem was seen on Windows, but I don't know for sure this is the cause.

If we can get a better understanding of what's causing the extreme performance hit, perhaps we can target this a bit more tightly.  Or maybe provide a start-up option that lets somebody manually turn this on if their hardware can benefit from it?