### PR TITLE
Fix duplicate Entry/Exit managers / Layout blocks schema

### DIFF
--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -265,10 +265,6 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
             configOK = false;
         }
 
-        //Install Entry Exit Pairs Manager
-        //   Done after load config file so that connection-system-specific Managers are defined and usable
-        InstanceManager.store(new EntryExitPairs(), EntryExitPairs.class);
-
         // populate GUI
         log.debug("Start UI");
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));

--- a/java/src/jmri/jmrit/signalling/AddEntryExitPairPanel.java
+++ b/java/src/jmri/jmrit/signalling/AddEntryExitPairPanel.java
@@ -135,10 +135,14 @@ public class AddEntryExitPairPanel extends jmri.util.swing.JmriPanel {
 
     private void autoDiscovery() {
         if (!InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class).isAdvancedRoutingEnabled()) {
-            int response = JOptionPane.showConfirmDialog(null, Bundle.getMessage("EnableLayoutBlockRouting"));
+            int response = JOptionPane.showConfirmDialog(null,
+                    java.util.ResourceBundle.getBundle("jmri.jmrit.signalling.SignallingBundle")  // NOI18N
+                    .getString("EnableLayoutBlockRouting"));  // NOI18N
             if (response == 0) {
                 InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class).enableAdvancedRouting(true);
-                JOptionPane.showMessageDialog(null, Bundle.getMessage("LayoutBlockRoutingEnabled"));
+                JOptionPane.showMessageDialog(null,
+                        java.util.ResourceBundle.getBundle("jmri.jmrit.signalling.SignallingBundle")  // NOI18N
+                        .getString("LayoutBlockRoutingEnabled"));  // NOI18N
             }
         }
         entryExitFrame = new jmri.util.JmriJFrame("Discover Entry Exit Pairs", false, false);

--- a/java/src/jmri/jmrit/signalling/AddEntryExitPairPanel.java
+++ b/java/src/jmri/jmrit/signalling/AddEntryExitPairPanel.java
@@ -135,14 +135,10 @@ public class AddEntryExitPairPanel extends jmri.util.swing.JmriPanel {
 
     private void autoDiscovery() {
         if (!InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class).isAdvancedRoutingEnabled()) {
-            int response = JOptionPane.showConfirmDialog(null,
-                    java.util.ResourceBundle.getBundle("jmri.jmrit.signalling.SignallingBundle")  // NOI18N
-                    .getString("EnableLayoutBlockRouting"));  // NOI18N
+            int response = JOptionPane.showConfirmDialog(null, Bundle.getMessage("EnableLayoutBlockRouting"));
             if (response == 0) {
                 InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class).enableAdvancedRouting(true);
-                JOptionPane.showMessageDialog(null,
-                        java.util.ResourceBundle.getBundle("jmri.jmrit.signalling.SignallingBundle")  // NOI18N
-                        .getString("LayoutBlockRoutingEnabled"));  // NOI18N
+                JOptionPane.showMessageDialog(null, Bundle.getMessage("LayoutBlockRoutingEnabled"));
             }
         }
         entryExitFrame = new jmri.util.JmriJFrame("Discover Entry Exit Pairs", false, false);

--- a/xml/schema/types/layoutblocks-2-9-6.xsd
+++ b/xml/schema/types/layoutblocks-2-9-6.xsd
@@ -38,6 +38,7 @@
             <xs:sequence>
               <xs:element name="systemName" type="systemNameType" minOccurs="0" maxOccurs="1"/>
               <xs:element name="userName" type="userNameType" minOccurs="0" maxOccurs="1"/>
+              <xs:element name="metric" type="xs:integer" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
             <xs:attribute name="systemName" type="systemNameType">
                 <xs:annotation><xs:documentation>Deprecated 2.9.6 in favor of separate element</xs:documentation></xs:annotation>


### PR DESCRIPTION
Duplicate managers are being created.  The first one is created during panel XML loading.  The second is created at the end of startup processing.  The existing NX configuration is effectively hidden.

AddEntryExitPairPanel is using the wrong message bundle if "enable layout block routing" is required.

The layout blocks schema is missing the "metric" element.
