### PR TITLE
Threading updates

### DIFF
--- a/default.lcf
+++ b/default.lcf
@@ -3,6 +3,11 @@
 # If making changes here that should be included in the distribution
 # please also update the file for distribution at 'scripts/default.lcf'
 
+# JMRI itself uses Log4J et al for logging.  Some of the components
+# that JMRI uses, however, use other approaches.  
+#    purejavacomm:  Uses a "purejavacomm.loglevel" system property not controlled here,
+#                   c.f.the build.xml file for how we handle it when running under Ant.
+
 # #############################################################
 #  Log4J configuration
 # #############################################################

--- a/help/en/html/doc/Technical/NetBeans.shtml
+++ b/help/en/html/doc/Technical/NetBeans.shtml
@@ -203,21 +203,20 @@
 
       <h3><a id="setup" name="setup"></a>Checking out code</h3>
 
-      <ul>
-        <li>In NetBeans, under the "Team" menu, select Git, then
-        Clone Repository. Enter the
-        https://github.com/JMRI/JMRI.git repository URL from the
-        <a href="https://github.com/JMRI/JMRI">JMRI GitHub page</a>
-        on the NetBeans form under "Repository URL". We recommend
-        that you also enter your GitHub user name and password on
-        the form, so we can attribute your contributions to you
-        later. Click "Next". Make sure that the "master*" box is
-        checked to pull down the main version of the code. Click
-        "Next", and then click "Finish".
+      In NetBeans, under the "Team" menu, select Git, then
+      Clone Repository. Enter the
+      https://github.com/JMRI/JMRI.git repository URL from the
+      <a href="https://github.com/JMRI/JMRI">JMRI GitHub page</a>
+      on the NetBeans form under "Repository URL". We recommend
+      that you also enter your GitHub user name and password on
+      the form, so we can attribute your contributions to you
+      later. Click "Next". Make sure that the "master*" box is
+      checked to pull down the main version of the code. Click
+      "Next", and then click "Finish".
 
-          <p>It'll take a long time to pull down a copy of the code
-          (note the progress bar in the lower right), but then
-          you're good to go.</p>
+      <p>It'll take a long time to pull down a copy of the code
+      (note the progress bar in the lower right), but then
+      you're good to go.</p>
 
           <h3>Local Commits</h3>When using Git, the "commit"
           operation is local to your computer. It doesn't make any
@@ -225,8 +224,9 @@
 
           <p>You're encouraged to commit often, so that your
           changes are safely stored away from your working
-          directory and that each small change is separately
-          recorded.</p>
+          directory. Having each small change separately
+          recorded can be incredibly helpful later on if you
+          have to track down where a problem was introduced.</p>
 
           <h3><a id="updating" name="updating"></a>Updating the
           code from Git</h3>
@@ -523,8 +523,7 @@
             you selected will contain the patches, along with an
             information header.</li>
           </ul><!--#include virtual="/Footer" -->
-        </li>
-      </ul>
+
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->
 </body>

--- a/help/en/html/doc/Technical/Threads.shtml
+++ b/help/en/html/doc/Technical/Threads.shtml
@@ -31,7 +31,9 @@
     <!--#include virtual="Sidebar" -->
 
     <div id="mainContent">
-      <h1>JMRI: Threading</h1>The vast majority of JMRI code (and
+      <h1>JMRI: Threading</h1>
+      
+      The vast majority of JMRI code (and
       programmers) don't have to worry about threading. Their code
       gets invoked, and invokes other code, and threading takes
       care of itself. This is particularly true of event-based
@@ -45,11 +47,14 @@
 
       <p>Note that this does <em>not</em> mean that other things
       can't be happening. For example, this script fragment:</p>
-      <pre>
-<code>
-    state = sensors.provideSensor("mySensor").getState()<br>    turnouts.provideTurnout("myTurnout").setState(THROWN)<br>    print state == sensors.provideSensor("mySensor").getState()<br></code>
-</pre>can print either true or false, because changing that turnout
-<em>can</em> change associated sensors instantaneously.
+
+<pre style="font-family: monospace;">
+    state = sensors.provideSensor("mySensor").getState()<br>
+    turnouts.provideTurnout("myTurnout").setState(THROWN)<br>
+    print state == sensors.provideSensor("mySensor").getState()<br>
+</pre>
+    can print either true or false, because changing that turnout
+    <em>can</em> change associated sensors instantaneously.
 
       <p>There are times when you might want to do something a bit
       more complex using an additional thread:</p>
@@ -63,9 +68,11 @@
 
         <li>You might be interfacing to some other existing code
         that uses threads.</li>
-      </ul>We would prefer that you handle the threading issues
-      that arise in that case via the <a href=
-      "http://jmri.org/JavaDoc/doc/jmri/util/ThreadingUtil.html">jmri.util.ThreadingUtil</a>
+      </ul>
+      
+      We would prefer that you handle the threading issues
+      that arise in that case via the 
+      <a href="http://jmri.org/JavaDoc/doc/jmri/util/ThreadingUtil.html">jmri.util.ThreadingUtil</a>
       class. ThreadingUtil provides utilities that make it easy to
       invoke needed functions on the right thread.
 
@@ -75,14 +82,17 @@
       separate thread. At the end, when it's time to set your new
       frame visible, you have to to that on the Swing (GUI) thread.
       Here's the code to do that:</p>
-      <pre>
-    frame = new JmriJFrame();  // frame declared as instance variable<br>    // spend a long time reading data and configuring the frame<br>    ThreadingUtil.runOnGUI( ()-&gt;{  frame.setVisible(); });<br>
-</pre>ThreadingUtil separates operations on the GUI (e.g. Java
-Swing) thread, and operations on the Layout (e.g. Sensors,
-Turnouts, etc) thread. There's no real difference now, but in the
-interest of perhaps someday needing to separate those, we've
-introduced the two versions now. Please try to pick the
-mostly-likely-right one when coding.
+<pre style="font-family: monospace;">
+    frame = new JmriJFrame();  // frame declared as instance variable<br>
+    // spend a long time reading data and configuring the frame<br>
+    ThreadingUtil.runOnGUI( ()-&gt;{  frame.setVisible(); });<br>
+</pre>
+        ThreadingUtil separates operations on the GUI (e.g. Java
+        Swing) thread, and operations on the Layout (e.g. Sensors,
+        Turnouts, etc) thread. There's no real difference now, but in the
+        interest of perhaps someday needing to separate those, we've
+        introduced the two versions now. Please try to pick the
+        mostly-likely-right one when coding.
 
       <p>(N.B.: You'll find lots of older cases that use explicitly
       use javax.swing.SwingUtilities.invokeLater(r) or
@@ -90,7 +100,63 @@ mostly-likely-right one when coding.
       migrated to the newer JMRI-specific methods as time is
       available to keep our code just a tiny bit cleaner and more
       flexible.) 
-      
+  
+<h3>Ending Threads</h3>
+
+    This is really about interrupt() and our use of it.
+    
+    <p>
+    Bottom line recommendation:  <em>Never</em> swallow <code>InterruptedException</code>!
+    If you call a method that throws it, your choices are (from best to worst):
+    <ol>
+    <li>InterruptedException means your operation has been interrupted:  Some other 
+        piece of code has <em>deliberately</em> asked your operation to end.
+        This is not an error, and shouldn't be treated as one.  If you can, 
+        terminate what the code is doing and return to normal operation.
+    <li>If you can't reliably terminate whatever is being done, perhaps because you're 
+        code is a low-level part, Just pass the InterruptedException up:  
+        Don't <code>catch</code> it, just have your method says that it
+        <code>throws InterruptedException</code>.
+    <li>Sometimes you can't change the signature of your method: Perhaps it's overriding a
+        Java definition by inheritance. Only if you can't terminate cleanly or pass it up,
+        you can mark the interrupt and continue:
+<pre style="font-family: monospace;">
+        try {
+            wait()
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+</pre>
+        This will let execution continue, as if you hadn't received the interrupt, but 
+        the <em>next</em> that execution hits a blocking call, that call will 
+        immediately get an interrupt too. Perhaps it can handle it better!
+    </ol>
+
+<h3>Other Items of Interest</h3>    
+
+    <p>
+    Using a 
+    <a href="https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/BlockingQueue.html">BlockingQueue</a>
+    from the 
+    <a href="https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/package-summary.html">java.util.concurrent</a>
+    package can remove the need to mess with thread synchronization and locking.
+    That can be a huge win!
+    
+    <p>
+    The 
+    <a href="https://github.com/JMRI/JMRI/tree/master/java/test/jmri/util/ThreadingDemoAndTest.java">java/test/jmri/util/ThreadingDemoAndTest.java</a>
+    file is an example of using threads for join, interrupt, etc.
+    It also includes a BlockingQueue example.
+    
+    <p>
+    The 
+    <a href="http://jmri.org/JavaDoc/doc/jmri/util/PropertyChangeEventQueueTest.html">jmri.util.PropertyChangeEventQueueTest</a>
+    can handle listening to lots of NamedBeans without possibly missing or overlapping some notifications.
+    The 
+    <a href="https://github.com/JMRI/JMRI/tree/master/java/test/jmri/util/ThreadingDemoAndTest.java">jmri.jmrit.automat.SigLet</a>
+    class is an example of using this.
+    
+    
 <h2>Debugging</h2>
 
 <h3>Getting a thread-dump</h3>
@@ -116,6 +182,8 @@ kill -s QUIT `ps | grep java | grep apps | awk '{print $1}'`<br>
     </ul>
 <li>If you're running under Netbeans or Eclipse, there are simple menu commands to do this.
 </ul>
+Note that if running under Ant or an IDE, you might get more than one dump:  The one
+you're looking for from JMRI, plus many one from Ant or the IDE itself.
 
     <!--#include virtual="/Footer" --></p>
     </div><!-- closes #mainContent-->

--- a/help/en/html/doc/Technical/Threads.shtml
+++ b/help/en/html/doc/Technical/Threads.shtml
@@ -131,6 +131,9 @@
         the <em>next</em> that execution hits a blocking call, that call will 
         immediately get an interrupt too. Perhaps it can handle it better!
     </ol>
+    
+    For more background, please read 
+    <a href="https://www.ibm.com/developerworks/library/j-jtp05236/index.html">this article</a>.
 
 <h3>Other Items of Interest</h3>    
 

--- a/java/src/jmri/Sensor.java
+++ b/java/src/jmri/Sensor.java
@@ -124,20 +124,36 @@ public interface Sensor extends NamedBean {
     /**
      * Use the timers specified in the {@link jmri.SensorManager} for the
      * debounce delay.
+     * @since 4.9.2 (replaces {@link #useDefaultTimerSettings(boolean)})
      *
      * @param flag true to set to current defaults if not previously true
      */
-    public void useDefaultTimerSettings(boolean flag);
+    public void setUseDefaultTimerSettings(boolean flag);
 
     /**
      * Does this sensor use the default timers values? (A remarkably unfortunate
      * name given the one above)
+     * @since 4.9.2 (replaces {@link #useDefaultTimerSettings()})
      *
      * @return true if using default debounce values from the
      *         {@link jmri.SensorManager}
      */
-    public boolean useDefaultTimerSettings();
+    public boolean getUseDefaultTimerSettings();
 
+    /**
+     * @deprecated Since JMRI 4.9.2, use {@link #setUseDefaultTimerSettings(boolean)}
+     * @param flag true to set to current defaults if not previously true
+     */
+    @Deprecated
+    public void useDefaultTimerSettings(boolean flag);
+    
+    /**
+     * @deprecated Since JMRI 4.9.2, use {@link #setUseDefaultTimerSettings(boolean)}
+     * @return true if using default debounce values from the
+     *         {@link jmri.SensorManager}
+     */
+    @Deprecated
+    public boolean useDefaultTimerSettings();
     /**
      * Some sensor boards also serve the function of being able to report back
      * train identities via such methods as RailCom. The setting and creation of

--- a/java/src/jmri/implementation/AbstractSensor.java
+++ b/java/src/jmri/implementation/AbstractSensor.java
@@ -78,7 +78,7 @@ public abstract class AbstractSensor extends AbstractNamedBean implements Sensor
     }
 
     @Override
-    public void useDefaultTimerSettings(boolean boo) {
+    public void setUseDefaultTimerSettings(boolean boo) {
         if (boo == useDefaultTimerSettings) {
             return;
         }
@@ -91,9 +91,22 @@ public abstract class AbstractSensor extends AbstractNamedBean implements Sensor
     }
 
     @Override
-    public boolean useDefaultTimerSettings() {
+    public boolean getUseDefaultTimerSettings() {
         return useDefaultTimerSettings;
     }
+    
+    @Override
+    @Deprecated
+    public void useDefaultTimerSettings(boolean boo) {
+        setUseDefaultTimerSettings(boo);
+    }
+    
+    @Override
+    @Deprecated
+    public boolean useDefaultTimerSettings() {
+        return getUseDefaultTimerSettings();
+    }
+    
 
     protected Thread thr;
     protected Runnable r;

--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -524,7 +524,7 @@ public class AbstractAutomaton implements Runnable {
 
             mSensors[i].addPropertyChangeListener(listeners[i] = (PropertyChangeEvent e) -> {
                 synchronized (self) {
-                    log.debug("notify waitSensorState[] of property change");
+                    log.trace("notify waitSensorState[] of property change");
                     self.notifyAll(); // should be only one thread waiting, but just in case
                 }
             });
@@ -569,7 +569,7 @@ public class AbstractAutomaton implements Runnable {
         PropertyChangeListener listener;
         warrant.addPropertyChangeListener(listener = (PropertyChangeEvent e) -> {
             synchronized (self) {
-                log.debug("notify waitWarrantRunState of property change");
+                log.trace("notify waitWarrantRunState of property change");
                 self.notifyAll(); // should be only one thread waiting, but just in case
             }
         });
@@ -611,7 +611,7 @@ public class AbstractAutomaton implements Runnable {
         PropertyChangeListener listener;
         warrant.addPropertyChangeListener(listener = (PropertyChangeEvent e) -> {
             synchronized (self) {
-                log.debug("notify waitWarrantBlock of property change");
+                log.trace("notify waitWarrantBlock of property change");
                 self.notifyAll(); // should be only one thread waiting, but just in case
             }
         });
@@ -668,7 +668,7 @@ public class AbstractAutomaton implements Runnable {
                 blockChanged = true;
             }
             synchronized (self) {
-                log.debug("notify waitWarrantBlockChange of property change");
+                log.trace("notify waitWarrantBlockChange of property change");
                 self.notifyAll(); // should be only one thread waiting, but just in case
             }
         });
@@ -713,7 +713,7 @@ public class AbstractAutomaton implements Runnable {
 
             mTurnouts[i].addPropertyChangeListener(listeners[i] = (PropertyChangeEvent e) -> {
                 synchronized (self) {
-                    log.debug("notify waitTurnoutConsistent[] of property change");
+                    log.trace("notify waitTurnoutConsistent[] of property change");
                     self.notifyAll(); // should be only one thread waiting, but just in case
                 }
             });
@@ -798,7 +798,7 @@ public class AbstractAutomaton implements Runnable {
         
         if (recreate) {
             // here, have to create a new state array
-            log.debug("recreate state array");
+            log.trace("recreate state array");
             tempState = new int[mInputs.length];
             for (i = 0 ; i < mInputs.length; i++) {
                 tempState[i] = mInputs[i].getState();
@@ -821,7 +821,7 @@ public class AbstractAutomaton implements Runnable {
 
         }
 
-        log.debug("waitChange[] listeners registered");
+        log.trace("waitChange[] listeners registered");
         
         // queue a check for whether there was a change while registering
         jmri.util.ThreadingUtil.runOnLayoutEventually(
@@ -829,7 +829,7 @@ public class AbstractAutomaton implements Runnable {
                 log.trace("start separate waitChange check");
                 for (int j = 0 ; j < mInputs.length; j++) {
                     if ( initialState[j] != mInputs[j].getState() ) {
-                        log.debug("notify that input {} changed when initial on-layout check was finally done", j);
+                        log.trace("notify that input {} changed when initial on-layout check was finally done", j);
                         waitChangeQueue.offer(new PropertyChangeEvent(mInputs[j], "State", initialState[j], mInputs[j].getState()));
                         break;
                     }
@@ -858,7 +858,7 @@ public class AbstractAutomaton implements Runnable {
         for (i = 0; i < mInputs.length; i++) {
             mInputs[i].removePropertyChangeListener(listeners[i]);
         }
-        log.debug("waitChange[] listeners removed");
+        log.trace("waitChange[] listeners removed");
         endWait();
     }
 
@@ -900,7 +900,7 @@ public class AbstractAutomaton implements Runnable {
      *
      * @param mSensors Array of sensors to watch
      */
-    public synchronized void waitSensorChange(Sensor[] mSensors) {
+    public void waitSensorChange(Sensor[] mSensors) {
         waitChange(mSensors);
     }
 

--- a/java/src/jmri/jmrit/automat/JythonSiglet.java
+++ b/java/src/jmri/jmrit/automat/JythonSiglet.java
@@ -39,7 +39,7 @@ public class JythonSiglet extends Siglet {
      * <LI>Run the python defineIO routine
      * </UL>
      * Initialization of the Python in the actual script file is deferred until
-     * the {@link #handle} method.
+     * the {@link #defineIO} method.
      */
     @Override
     public void defineIO() {

--- a/java/src/jmri/jmrit/automat/Siglet.java
+++ b/java/src/jmri/jmrit/automat/Siglet.java
@@ -83,7 +83,7 @@ abstract public class Siglet {
                         try {
                             PropertyChangeEvent pe = pq.take();
                             // _any_ event drives output
-                            log.trace("driving setOutput");
+                            log.trace("driving setOutput from {}", pe);
                             setOutput();
                         } catch (InterruptedException e) {
                             // done

--- a/java/src/jmri/jmrit/automat/Siglet.java
+++ b/java/src/jmri/jmrit/automat/Siglet.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import java.beans.PropertyChangeEvent;
 
 import jmri.NamedBean;
-import jmri.util.PropertyChangeEventQueue;
+import jmri.util.*;
 
 /**
  * A Siglet is a "an embedded signal automation", like an "applet" an embedded
@@ -84,7 +84,7 @@ abstract public class Siglet {
                             PropertyChangeEvent pe = pq.take();
                             // _any_ event drives output
                             log.trace("driving setOutput from {}", pe);
-                            setOutput();
+                            ThreadingUtil.runOnLayout( ()->{ setOutput(); } );
                         } catch (InterruptedException e) {
                             // done
                             log.trace("Siglet {} cleaning up due to interrupt", name);

--- a/java/src/jmri/jmrit/automat/Siglet.java
+++ b/java/src/jmri/jmrit/automat/Siglet.java
@@ -1,7 +1,10 @@
 package jmri.jmrit.automat;
 
 import java.util.Arrays;
+import java.beans.PropertyChangeEvent;
+
 import jmri.NamedBean;
+import jmri.util.PropertyChangeEventQueue;
 
 /**
  * A Siglet is a "an embedded signal automation", like an "applet" an embedded
@@ -9,27 +12,26 @@ import jmri.NamedBean;
  * <P>
  * Subclasses must load the inputs and outputs arrays during the defineIO
  * method. When any of these change, the Siglet must then recompute and apply
- * the output signal settings.
+ * the output signal settings via their implementation of the {@link #setOutput} method.
  * <P>
- * You can't assume that Siglets run in their own thread; they should not use
+ * Siglets may not run in their own thread; they should not use
  * wait() in any of it's various forms.
  * <P>
- * Do not assume that Siglets will always inherit from AbstractAutomaton; that
- * may be an implementation artifact.
+ * Siglet was separated from AbstractAutomaton in JMRI 4.9.2
  * <P>
  * Do not have any overlap between the items in the input and output lists; this
  * will cause a recursive invocation when the output changes.
  *
- * @author Bob Jacobsen Copyright (C) 2003
+ * @author Bob Jacobsen Copyright (C) 2003, 2017
  */
-public class Siglet extends AbstractAutomaton {
+abstract public class Siglet {
 
     public Siglet() {
-        super();
+        this.name = "";
     }
 
     public Siglet(String name) {
-        super(name);
+        this.name = name;
     }
 
     public NamedBean[] inputs;      // public for Jython subclass access
@@ -37,43 +39,88 @@ public class Siglet extends AbstractAutomaton {
 
     /**
      * User-provided routine to define the input and output objects to be
-     * handled.
+     * handled. Invoked during the Siglet {@link #start()} call.
      */
-    public void defineIO() {
-    }
+    abstract public void defineIO();
 
     /**
      * User-provided routine to compute new output state and apply it.
      */
-    public void setOutput() {
-    }
+    abstract public void setOutput();
 
-    /**
-     * Implements AbstractAutomaton method to initialise connections to the
-     * layout.
-     */
-    @Override
-    protected void init() {
-        defineIO();
+    final public String getName() {
+        return name;
     }
+    private String name;
+    final public void setName(String name) {
+        this.name = name;
+    }
+    
+    public void start() {
+        Thread previousThread = thread;
+        try {
+            if (previousThread !=null ) previousThread.join();
+        } catch (InterruptedException e) {
+            log.warn("Aborted start() due to interrupt");
+        }
+        if (thread != null) log.error("Found thread != null, which is an internal synchronization error for {}", name);
+        
+        defineIO(); // user method that will load inputs
+        if (inputs.length <= 0) {
+            log.error("Siglet start invoked, but defined no inputs");
+            return;
+        }
 
-    /**
-     * Implements AbstractAutomaton method to wait for state changes and
-     * respond.
-     */
-    @Override
-    protected boolean handle() {
-        // write down state to compare later for changes
-        waitChangePrecheck(inputs);
-        // update the result
+        pq = new PropertyChangeEventQueue(inputs);
         setOutput();
-        // wait for changes
-        waitChange(inputs);
-        // and repeat
-        return true;
+        
+        // run one cycle at start
+               
+        thread = new Thread(
+            new Runnable() {
+                public void run() {
+                    while (true) {
+                        try {
+                            PropertyChangeEvent pe = pq.take();
+                            // _any_ event drives output
+                            log.trace("driving setOutput");
+                            setOutput();
+                        } catch (InterruptedException e) {
+                            // done
+                            log.trace("Siglet {} cleaning up due to interrupt", name);
+                            pq.dispose();
+                            thread = null; // flag that this won't execute again
+                            return;
+                        }
+                    }
+                }
+            }
+        );
+        thread.setDaemon(true);
+        thread.setName(getName());
+        thread.start();
+    }
+    
+    /**
+     * Stop execution of the logic.
+     * <p>Note: completion not guaranteed when this returns, as the 
+     * internal operation may proceed for a short time.  It's safe
+     * to call "start" again without worrying about that.
+     */
+
+    public void stop() {
+        if (thread != null) thread.interrupt();
     }
 
+    /**
+     * Convenience method to copy in an array of NamedBeans
+     */
     public void setInputs(NamedBean[] in) {
         inputs = Arrays.copyOf(in, in.length);
     }
+
+    PropertyChangeEventQueue pq;
+    Thread thread;
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Siglet.class.getName());
+
 }

--- a/java/src/jmri/jmrit/beantable/beanedit/SensorDebounceEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/SensorDebounceEditAction.java
@@ -144,7 +144,7 @@ public class SensorDebounceEditAction extends BeanEditAction {
         timeVal = sensorDebounceInactiveField.getText();
         time = Integer.valueOf(timeVal).intValue();
         sen.setSensorDebounceGoingInActiveTimer(time);
-        sen.useDefaultTimerSettings(sensorDebounceGlobalCheck.isSelected());
+        sen.setUseDefaultTimerSettings(sensorDebounceGlobalCheck.isSelected());
     }
 
     protected void resetDebounceItems(ActionEvent e) {
@@ -154,8 +154,8 @@ public class SensorDebounceEditAction extends BeanEditAction {
         }
         enabled(true);
         Sensor sen = (Sensor) bean;
-        sensorDebounceGlobalCheck.setSelected(sen.useDefaultTimerSettings());
-        if (sen.useDefaultTimerSettings()) {
+        sensorDebounceGlobalCheck.setSelected(sen.getUseDefaultTimerSettings());
+        if (sen.getUseDefaultTimerSettings()) {
             sensorDebounceActiveField.setEnabled(false);
             sensorDebounceInactiveField.setEnabled(false);
         } else {

--- a/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/sensor/SensorTableDataModel.java
@@ -233,7 +233,7 @@ public class SensorTableDataModel extends BeanTableDataModel {
         }
         //Need to do something here to make it disable 
         if (col == ACTIVEDELAY || col == INACTIVEDELAY) {
-            if (sen.useDefaultTimerSettings()) {
+            if (sen.getUseDefaultTimerSettings()) {
                 return false;
             } else {
                 return true;
@@ -261,7 +261,7 @@ public class SensorTableDataModel extends BeanTableDataModel {
             boolean val = s.getInverted();
             return Boolean.valueOf(val);
         } else if (col == USEGLOBALDELAY) {
-            boolean val = s.useDefaultTimerSettings();
+            boolean val = s.getUseDefaultTimerSettings();
             return Boolean.valueOf(val);
         } else if (col == ACTIVEDELAY) {
             return s.getSensorDebounceGoingActiveTimer();
@@ -301,7 +301,7 @@ public class SensorTableDataModel extends BeanTableDataModel {
             s.setInverted(b);
         } else if (col == USEGLOBALDELAY) {
             boolean b = ((Boolean) value).booleanValue();
-            s.useDefaultTimerSettings(b);
+            s.setUseDefaultTimerSettings(b);
         } else if (col == ACTIVEDELAY) {
             String val = (String) value;
             long goingActive = Long.valueOf(val);

--- a/java/src/jmri/jmrit/blockboss/BlockBossLogic.java
+++ b/java/src/jmri/jmrit/blockboss/BlockBossLogic.java
@@ -1277,7 +1277,7 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             boolean found = false;
 
             if (nb instanceof SignalHead) {
-                if (getDrivenSignalNamedBean() != null && getDrivenSignalNamedBean().getBean().equals(nb)) {
+                if (getDrivenSignalNamedBean().getBean().equals(nb)) {
                     message.append("<br><b>This SSL will be deleted</b>");
                     throw new java.beans.PropertyVetoException(message.toString(), evt);
                 }
@@ -1335,7 +1335,7 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             }
         } else if ("DoDelete".equals(evt.getPropertyName())) { //IN18N
             if (nb instanceof SignalHead) {
-                if (getDrivenSignalNamedBean() != null && getDrivenSignalNamedBean().getBean().equals(nb)) {
+                if (getDrivenSignalNamedBean().getBean().equals(nb)) {
                     stop();
                     bblList.remove(this);
                 }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -922,9 +922,9 @@ public class LayoutBlock extends AbstractNamedBean implements java.beans.Propert
 
         if (getOccupancySensor() != null) {
             if (sensorDebounceGlobalCheck.isSelected()) {
-                getOccupancySensor().useDefaultTimerSettings(true);
+                getOccupancySensor().setUseDefaultTimerSettings(true);
             } else {
-                getOccupancySensor().useDefaultTimerSettings(false);
+                getOccupancySensor().setUseDefaultTimerSettings(false);
                 if (!sensorDebounceInactiveField.getText().trim().equals("")) {
                     getOccupancySensor().setSensorDebounceGoingInActiveTimer(Long.parseLong(sensorDebounceInactiveField.getText().trim()));
                 }

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -1673,6 +1673,10 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
      */
     class rosterPopupListener extends MouseAdapter {
 
+        // does clickTimer still actually do anything in this code?
+        // it looks like it just starts and stops, without
+        // invoking anything
+        
         javax.swing.Timer clickTimer = null;
 
         @Override

--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
@@ -896,19 +896,19 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
 
         SensorDetails(Sensor sen) {
             sensor = sen;
-            usingGlobal = sen.useDefaultTimerSettings();
+            usingGlobal = sen.getUseDefaultTimerSettings();
             activeDelay = sen.getSensorDebounceGoingActiveTimer();
             inactiveDelay = sen.getSensorDebounceGoingInActiveTimer();
         }
 
         void setupSensor() {
-            sensor.useDefaultTimerSettings(false);
+            sensor.setUseDefaultTimerSettings(false);
             sensor.setSensorDebounceGoingActiveTimer(0);
             sensor.setSensorDebounceGoingInActiveTimer(0);
         }
 
         void resetDetails() {
-            sensor.useDefaultTimerSettings(usingGlobal);
+            sensor.setUseDefaultTimerSettings(usingGlobal);
             sensor.setSensorDebounceGoingActiveTimer(activeDelay);
             sensor.setSensorDebounceGoingInActiveTimer(inactiveDelay);
         }

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -253,7 +253,7 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
         Enumeration<String> en = _tsys.keys();
         while (en.hasMoreElements()) {
             Sensor sen = (Sensor) _tsys.get(en.nextElement());
-            if (sen.useDefaultTimerSettings()) {
+            if (sen.getUseDefaultTimerSettings()) {
                 sen.setSensorDebounceGoingActiveTimer(timer);
             }
         }
@@ -268,7 +268,7 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
         Enumeration<String> en = _tsys.keys();
         while (en.hasMoreElements()) {
             Sensor sen = (Sensor) _tsys.get(en.nextElement());
-            if (sen.useDefaultTimerSettings()) {
+            if (sen.getUseDefaultTimerSettings()) {
                 sen.setSensorDebounceGoingInActiveTimer(timer);
             }
         }

--- a/java/src/jmri/managers/configurexml/AbstractSensorManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractSensorManagerConfigXML.java
@@ -70,7 +70,7 @@ public abstract class AbstractSensorManagerConfigXML extends AbstractNamedBeanMa
             storeCommon(s, elem);
 
             log.debug("store sensor " + sname);
-            if (s.useDefaultTimerSettings()) {
+            if (s.getUseDefaultTimerSettings()) {
                 elem.addContent(new Element("useGlobalDebounceTimer").addContent("yes"));
             } else {
                 if (s.getSensorDebounceGoingActiveTimer() > 0 || s.getSensorDebounceGoingInActiveTimer() > 0) {
@@ -214,7 +214,7 @@ public abstract class AbstractSensorManagerConfigXML extends AbstractNamedBeanMa
 
             if (sensorList.get(i).getChild("useGlobalDebounceTimer") != null) {
                 if (sensorList.get(i).getChild("useGlobalDebounceTimer").getText().equals("yes")) {
-                    s.useDefaultTimerSettings(true);
+                    s.setUseDefaultTimerSettings(true);
                 }
             }
             s.setInverted(inverted);

--- a/java/src/jmri/util/PropertyChangeEventQueue.java
+++ b/java/src/jmri/util/PropertyChangeEventQueue.java
@@ -1,0 +1,92 @@
+package jmri.util;
+
+import jmri.*;
+
+import java.beans.*;
+import java.util.*;
+import java.util.concurrent.*;
+import javax.annotation.*;
+import net.jcip.annotations.*;
+
+/**
+ * Gathers PropertyChangeEvents that might occur in overlapping threads
+ * and overlapping times, presenting them as requested.
+ * <p>
+ * Listeners are installed when the object is constructed.
+ * {@link #dispose()} detaches those listeners, after which the
+ * object should not be used.
+ * It is not an error to call {@link #dispose()} multiple times.
+ * <p>
+ * 
+ *
+ * @author Bob Jacobsen Copyright 2017
+ */
+@ThreadSafe
+public class PropertyChangeEventQueue {
+
+
+    /**
+     * @param collection Set of NamedBeans whose events should be handled. 
+     *          Keeps a copy of the contents, so future changes irrelevant.
+     */
+    public PropertyChangeEventQueue(@Nonnull Collection<NamedBean> collection) {
+        for (NamedBean item : collection) {
+            items.add(item);
+            item.addPropertyChangeListener(listener);
+        }
+        if (log.isTraceEnabled()) log.trace("Created {}", this.toString());
+    }
+
+    /**
+     * @param array Set of NamedBeans whose events should be handled
+     *          Keeps a copy of the contents, so future changes irrelevant.
+     */
+    public PropertyChangeEventQueue(@Nonnull NamedBean[] array) {
+        this(Arrays.asList(array));
+    }
+        
+    // Empty object makes no sense
+    private PropertyChangeEventQueue() {}
+    
+    final Collection<NamedBean> items = new ArrayList<>();
+    final static int MAX_SIZE = 100;
+    final BlockingQueue<PropertyChangeEvent> dq = new ArrayBlockingQueue<>(MAX_SIZE);
+    final PropertyChangeListener listener = new PropertyChangeListener() {
+        public void propertyChange(PropertyChangeEvent e) { 
+            log.trace(" handling event {}", e);
+            boolean success = false;
+            success = dq.offer(e); 
+            if (! success) log.error("Could not process event {} from {} in {}", e.getPropertyName(), e.getSource(), dq.toString());
+        }
+    };
+    
+    /**
+     * Dispose by dropping the listeners to all the specified {@link NamedBean}s.
+     * The object should not be used again after calling this. 
+     * It is not an error to call this multiple times.
+     */
+    public void dispose() {
+        if (log.isTraceEnabled()) log.trace("dispose() {}", items.toString());
+    }
+    
+    public PropertyChangeEvent take() throws InterruptedException {
+        return dq.take();
+    }
+    
+    public PropertyChangeEvent poll(long timeout, TimeUnit unit) throws InterruptedException {
+        return dq.poll(timeout, unit);
+    }
+    
+    public String toString() {
+        StringBuffer b = new StringBuffer("PropertyChangeEventQueue for");
+        boolean first;
+        for (NamedBean bean : items) {
+            b.append(" (\"");
+            b.append(bean.getDisplayName());
+            b.append("\")");
+        }
+        return new String(b);
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PropertyChangeEventQueue.class.getName());
+}

--- a/java/src/jmri/util/PropertyChangeEventQueue.java
+++ b/java/src/jmri/util/PropertyChangeEventQueue.java
@@ -10,14 +10,15 @@ import net.jcip.annotations.*;
 
 /**
  * Gathers PropertyChangeEvents that might occur in overlapping threads
- * and overlapping times, presenting them as requested.
+ * and at overlapping times, presenting them as requested.
  * <p>
  * Listeners are installed when the object is constructed.
  * {@link #dispose()} detaches those listeners, after which the
  * object should not be used.
  * It is not an error to call {@link #dispose()} multiple times.
  * <p>
- * 
+ * Although this could be more generic than NamedBean, there's 
+ * no single interface that specifies "can call addPropertyChangeListener(..)".
  *
  * @author Bob Jacobsen Copyright 2017
  */
@@ -67,6 +68,9 @@ public class PropertyChangeEventQueue {
      */
     public void dispose() {
         if (log.isTraceEnabled()) log.trace("dispose() {}", items.toString());
+        for (NamedBean bean : items) {
+            bean.removePropertyChangeListener(listener);
+        }
     }
     
     public PropertyChangeEvent take() throws InterruptedException {

--- a/java/src/jmri/util/ThreadingUtil.java
+++ b/java/src/jmri/util/ThreadingUtil.java
@@ -32,7 +32,7 @@ public class ThreadingUtil {
      * <p>
      * Typical uses:
      * <p>
-     * {@code ThreadingUtil.runOnLayout( ()->{ sensor.setState(value); } );}
+     * {@code ThreadingUtil.runOnLayout( ()->{ sensor.setState(value); } );   }
      *
      * @param ta What to run, usually as a lambda expression
      */
@@ -48,7 +48,7 @@ public class ThreadingUtil {
      * <p>
      * Typical uses:
      * <p>
-     * {@code ThreadingUtil.runOnLayoutEventually( ()->{ sensor.setState(value); } );}
+     * {@code ThreadingUtil.runOnLayoutEventually( ()->{ sensor.setState(value); } );   }
      *
      * @param ta What to run, usually as a lambda expression
      */
@@ -64,7 +64,7 @@ public class ThreadingUtil {
      * <p>
      * Typical uses:
      * <p>
-     * {@code ThreadingUtil.runOnLayoutEventually( ()->{ sensor.setState(value); }, 1000 );}
+     * {@code ThreadingUtil.runOnLayoutEventually( ()->{ sensor.setState(value); }, 1000 );   }
      *
      * @param ta What to run, usually as a lambda expression
      * @param delay interval in milliseconds
@@ -87,7 +87,7 @@ public class ThreadingUtil {
      * <p>
      * Typical uses:
      * <p>
-     * {@code ThreadingUtil.runOnGUI( ()->{ mine.setVisible(); } );}
+     * {@code ThreadingUtil.runOnGUI( ()->{ mine.setVisible(); } );   }
      *
      * @param ta What to run, usually as a lambda expression
      */
@@ -117,7 +117,7 @@ public class ThreadingUtil {
      * <p>
      * Typical uses:
      * <p>
-     * {@code ThreadingUtil.runOnGUIEventually( ()->{ mine.setVisible(); } );}
+     * {@code ThreadingUtil.runOnGUIEventually( ()->{ mine.setVisible(); } );   }
      *
      * @param ta What to run, usually as a lambda expression
      */
@@ -134,7 +134,7 @@ public class ThreadingUtil {
      * <p>
      * Typical uses:
      * <p>
-     * {@code ThreadingUtil.runOnGUIEventually( ()->{ mine.setVisible(); }, 1000 );}
+     * {@code ThreadingUtil.runOnGUIEventually( ()->{ mine.setVisible(); }, 1000 );   }
      *
      * @param ta What to run, usually as a lambda expression
      * @param delay interval in milliseconds

--- a/java/src/jmri/util/ThreadingUtil.java
+++ b/java/src/jmri/util/ThreadingUtil.java
@@ -158,6 +158,33 @@ public class ThreadingUtil {
     static public boolean isGUIThread() {
         return SwingUtilities.isEventDispatchThread();
     }
+    
+    /** 
+     * Check whether a specific thread is running (or able to run) 
+     * right now.
+     * @return true is the specified thread is or could be running right now
+     */
+     static public boolean canThreadRun(Thread t) {
+        Thread.State s = t.getState();
+        return s.equals(Thread.State.RUNNABLE);
+     }
 
+    /** 
+     * Check whether a specific thread is currently waiting.
+     * <p>
+     * Note: This includes both waiting due to an explicit wait() call, and 
+     *  due to being blocked attempting to synchronize.
+     * <p>
+     * Note: {@link #canThreadRun(Thread)} and {@link #isThreadWaiting(Thread)}
+     *  should never simultanously be true, but it might look that way due to 
+     *  sampling delays when checking on another thread.
+     * 
+     * @return true is the specified thread is or could be running right now
+     */
+     static public boolean isThreadWaiting(Thread t) {
+        Thread.State s = t.getState();
+        return s.equals(Thread.State.BLOCKED) || s.equals(Thread.State.WAITING) || s.equals(Thread.State.TIMED_WAITING);
+     }
+     
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ThreadingUtil.class.getName());
 }

--- a/java/test/jmri/implementation/AbstractSensorTest.java
+++ b/java/test/jmri/implementation/AbstractSensorTest.java
@@ -106,9 +106,9 @@ public /*abstract*/ class AbstractSensorTest extends TestCase {
         t.setSensorDebounceGoingInActiveTimer(31L);
         Assert.assertEquals("timer", 31L, t.getSensorDebounceGoingInActiveTimer());
         
-        Assert.assertEquals("initial default", false, t.useDefaultTimerSettings());
-        t.useDefaultTimerSettings(true);
-        Assert.assertEquals("initial default", true, t.useDefaultTimerSettings());
+        Assert.assertEquals("initial default", false, t.getUseDefaultTimerSettings());
+        t.setUseDefaultTimerSettings(true);
+        Assert.assertEquals("initial default", true, t.getUseDefaultTimerSettings());
                 
     }
 

--- a/java/test/jmri/jmrit/automat/AbstractAutomatonTest.java
+++ b/java/test/jmri/jmrit/automat/AbstractAutomatonTest.java
@@ -21,8 +21,8 @@ public class AbstractAutomatonTest {
     Sensor sensor2;
     Sensor sensor3;
     Sensor sensor4;
-    boolean done;
-    boolean running;
+    volatile boolean done;
+    volatile boolean running;
     
     @Test
     public void testCTor() {
@@ -88,6 +88,33 @@ public class AbstractAutomatonTest {
         Assert.assertTrue("didn't complete handle", ! done);
     }
     
+    @Test
+    public void testWaitSensorChange() throws JmriException {
+        log.debug("start testWaitChange");
+        // more of a test of infrastructure
+        done = false;
+        sensor1 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS1");
+        sensor2 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS2");
+        sensor3 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS3");
+        sensor4 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS4");
+        AbstractAutomaton a = new AbstractAutomaton(){
+            public boolean handle() {
+                waitSensorChange(new Sensor[]{sensor1, sensor2, sensor3, sensor4});
+                done = true;
+                return false; // done
+            }
+        };
+        
+        log.debug("before start test automat testWaitChange");
+        a.start();
+        JUnitUtil.waitFor(()->{return a.isWaiting();}, "waiting");
+        
+        log.debug("after start test automat, before change sensor");
+        sensor2.setKnownState(Sensor.ACTIVE);
+        
+        log.debug("after change sensor, before waitFor");
+        JUnitUtil.waitFor(()->{return done;}, "done");
+    }
 
 
     @Test

--- a/java/test/jmri/jmrit/automat/SigletTest.java
+++ b/java/test/jmri/jmrit/automat/SigletTest.java
@@ -37,11 +37,12 @@ public class SigletTest {
         t.start();
         
         JUnitUtil.waitFor( ()->{ return defined; }, "defineIO run"); 
-        Assert.assertFalse(output);
+        Assert.assertTrue(output); // first cycle included
 
+        output = false;
         is1.setState(Sensor.ACTIVE);
         
-        JUnitUtil.waitFor( ()->{ return output; }, "setOutput run"); 
+        JUnitUtil.waitFor( ()->{ return output; }, "setOutput run again"); 
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrit/automat/SigletTest.java
+++ b/java/test/jmri/jmrit/automat/SigletTest.java
@@ -1,5 +1,8 @@
 package jmri.jmrit.automat;
 
+import jmri.*;
+import jmri.util.*;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -15,16 +18,47 @@ import org.slf4j.LoggerFactory;
 public class SigletTest {
 
     @Test
-    public void testCTor() {
-        Siglet t = new Siglet();
+    public void testBasics() throws JmriException {
+        Siglet t = new Siglet() {
+            public void defineIO() {
+                defined = true;
+                setInputs(new NamedBean[]{is1, is2});
+            }
+            public void setOutput() {
+                output = true;
+            }
+        };
         Assert.assertNotNull("exists",t);
+        
+        t.setName("foo");
+        Assert.assertEquals("foo", t.getName());
+        
+        Assert.assertFalse(defined);
+        t.start();
+        
+        JUnitUtil.waitFor( ()->{ return defined; }, "defineIO run"); 
+        Assert.assertFalse(output);
+
+        is1.setState(Sensor.ACTIVE);
+        
+        JUnitUtil.waitFor( ()->{ return output; }, "setOutput run"); 
     }
 
     // The minimal setup for log4J
+    Sensor is1;
+    Sensor is2;
+    volatile boolean defined;
+    volatile boolean output;
+
     @Before
     public void setUp() {
         apps.tests.Log4JFixture.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
+        JUnitUtil.initInternalSensorManager();
+        is1 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS1");
+        is2 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS2");
+        defined = false;
+        output = false;
     }
 
     @After

--- a/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
+++ b/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
@@ -21,25 +21,25 @@ public class BlockBossLogicTest extends TestCase {
         JUnitUtil.setBeanState(sig, appearance);
         JUnitUtil.waitFor(()->{return appearance == sig.getAppearance();}, "setAndWait "+sig.getSystemName()+": "+appearance);
     }
-    
+
+    protected void startLogic(BlockBossLogic b) {
+        p.start();
+        //JUnitUtil.waitFor(()->{return p.isWaiting();}, "logic running");
+    }
+
+    protected void stopLogic() {
+        if (p!=null) {
+            p.stop();
+            //JUnitUtil.waitFor(()->{return !p.isRunning();}, "logic stopped");
+            p=null;
+        }
+    }
+
     BlockBossLogic p;
     void setupSimpleBlock() {
         p = new BlockBossLogic("IH1");
         p.setMode(BlockBossLogic.SINGLEBLOCK);
         p.setWatchedSignal1("IH2", false);
-    }
-
-    protected void startLogic(BlockBossLogic b) {
-        p.start();
-        JUnitUtil.waitFor(()->{return p.isWaiting();}, "logic running");
-    }
-        
-    protected void stopLogic() {
-        if (p!=null) {
-            p.stop();
-            JUnitUtil.waitFor(()->{return !p.isRunning();}, "logic stopped");
-            p=null;
-        }
     }
     
     // test creation
@@ -162,8 +162,11 @@ public class BlockBossLogicTest extends TestCase {
     }
 
     // if no next signal, next signal considered green
-    public void testSimpleBlockNoNext() {
+    public void testSimpleBlockNoNext() throws jmri.JmriException {
+        s1.setState(Sensor.INACTIVE);
+        
         p = new BlockBossLogic("IH1");
+        p.setSensor1("1");
         p.setMode(BlockBossLogic.SINGLEBLOCK);
         startLogic(p);
 
@@ -171,9 +174,12 @@ public class BlockBossLogicTest extends TestCase {
     }
 
     // if no next signal, next signal is considered green
-    public void testSimpleBlockNoNextLimited() {
+    public void testSimpleBlockNoNextLimited() throws jmri.JmriException {
+        s1.setState(Sensor.INACTIVE);
+        
         p = new BlockBossLogic("IH1");
         p.setMode(BlockBossLogic.SINGLEBLOCK);
+        p.setSensor1("1");
         p.setLimitSpeed1(true);
 
         startLogic(p);

--- a/java/test/jmri/jmrix/lenz/li100/LI100XNetProgrammerTest.java
+++ b/java/test/jmri/jmrix/lenz/li100/LI100XNetProgrammerTest.java
@@ -78,9 +78,8 @@ public class LI100XNetProgrammerTest extends TestCase {
         mr3.setElement(2, 0x60);
         t.sendTestMessage(mr3);
 
-        jmri.util.JUnitUtil.releaseThread(this);
-
         //failure in this test occurs with the next line.
+        jmri.util.JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;},"Receive Called not set");
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
         Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
     }
@@ -139,9 +138,8 @@ public class LI100XNetProgrammerTest extends TestCase {
         mr3.setElement(2, 0x60);
         t.sendTestMessage(mr3);
 
-        jmri.util.JUnitUtil.releaseThread(this);
-
         //failure in this test occurs with the next line.
+        jmri.util.JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;},"Receive Called not set");
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
         Assert.assertEquals("Register mode received value", 12, l.getRcvdValue());
 
@@ -198,9 +196,8 @@ public class LI100XNetProgrammerTest extends TestCase {
         mr3.setElement(2, 0x60);
         t.sendTestMessage(mr3);
 
-        jmri.util.JUnitUtil.releaseThread(this);
-
         //failure in this test occurs with the next line.
+        jmri.util.JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;},"Receive Called not set");
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
         Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
 
@@ -259,9 +256,8 @@ public class LI100XNetProgrammerTest extends TestCase {
         mr3.setElement(2, 0x60);
         t.sendTestMessage(mr3);
 
-        jmri.util.JUnitUtil.releaseThread(this);
-
         //failure in this test occurs with the next line.
+        jmri.util.JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;},"Receive Called not set");
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
         Assert.assertEquals("Register mode received value", 34, l.getRcvdValue());
     }
@@ -318,9 +314,8 @@ public class LI100XNetProgrammerTest extends TestCase {
         mr3.setElement(2, 0x60);
         t.sendTestMessage(mr3);
 
-        jmri.util.JUnitUtil.releaseThread(this);
-
         //failure in this test occurs with the next line.
+        jmri.util.JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;},"Receive Called not set");
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
         Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
     }
@@ -379,9 +374,8 @@ public class LI100XNetProgrammerTest extends TestCase {
         mr3.setElement(2, 0x60);
         t.sendTestMessage(mr3);
 
-        jmri.util.JUnitUtil.releaseThread(this);
-
         //failure in this test occurs with the next line.
+        jmri.util.JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;},"Receive Called not set");
         Assert.assertFalse("Receive Called by Programmer", l.getRcvdInvoked() == 0);
         Assert.assertEquals("Direct mode received value", 34, l.getRcvdValue());
 

--- a/java/test/jmri/jmrix/loconet/SlotManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/SlotManagerTest.java
@@ -2,6 +2,8 @@ package jmri.jmrix.loconet;
 
 import jmri.ProgListener;
 import jmri.managers.DefaultProgrammerManager;
+import jmri.util.*;
+
 import org.junit.Assert;
 import junit.framework.Test;
 import junit.framework.TestCase;
@@ -207,15 +209,16 @@ public class SlotManagerTest extends TestCase {
         startedLongTimer = false;
 
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(()->{return startedLongTimer;},"startedLongTimer not set");
         Assert.assertEquals("post-LACK status", -999, status);
         Assert.assertTrue("started long timer", startedLongTimer);
         Assert.assertFalse("didn't start short timer", startedShortTimer);
         
         // read received back (DCS240 sequence)
+        value = 0;
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x2B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1C, 0x23, 0x7F, 0x7F, 0x3B}));
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(()->{return value == 35;},"value == 35 not set");
         log.debug("checking..");
         Assert.assertEquals("reply status", 0, status);
         Assert.assertEquals("reply value", 35, value);
@@ -315,16 +318,17 @@ public class SlotManagerTest extends TestCase {
         startedShortTimer = false;
         startedLongTimer = false;
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(()->{return startedShortTimer;},"startedShortTimer not set");
         Assert.assertEquals("post-LACK status", -999, status);
         Assert.assertTrue("started short timer", startedShortTimer);
         Assert.assertFalse("didn't start long timer", startedLongTimer);
         
         // read received back (DCS240 sequence)
+        value = -15;
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1E, 0x10, 0x7F, 0x7F, 0x4A}));
         Assert.assertEquals("no immediate reply", -999, status);
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(()->{return value == -1;},"value == -1 not set");
         log.debug("checking..");
         Assert.assertEquals("reply status", 0, status);
         Assert.assertEquals("reply value", -1, value);
@@ -359,7 +363,7 @@ public class SlotManagerTest extends TestCase {
         startedLongTimer = false;
 
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(()->{return startedShortTimer;},"startedShortTimer not set");
         Assert.assertEquals("post-LACK status", -999, status);
         Assert.assertTrue("started short timer", startedShortTimer);
         Assert.assertFalse("didn't start long timer", startedLongTimer);
@@ -367,6 +371,7 @@ public class SlotManagerTest extends TestCase {
         // CS check received back (DCS240 sequence)
         log.debug("send CS check back");
         slotmanager.message(new LocoNetMessage(new int[]{0xBB, 0x7F, 0x00, 0x3B}));
+        // not clear what to wait for here; status doesn't change
         jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
         Assert.assertEquals("post-CS-check status", -999, status);
         
@@ -374,6 +379,7 @@ public class SlotManagerTest extends TestCase {
         log.debug("send E7 reply back");
         slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1E, 0x10, 0x7F, 0x7F, 0x4A}));
         Assert.assertEquals("no immediate reply", -999, status);
+        // not clear what to wait for here; content doesn't change
         jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
         log.debug("checking..");
         Assert.assertEquals("reply status", 0, status);
@@ -446,7 +452,7 @@ public class SlotManagerTest extends TestCase {
         startedShortTimer = false;
         startedLongTimer = false;        
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(()->{return startedShortTimer;},"startedShortTimer not set");
         Assert.assertEquals("post-LACK status", -999, status);
         Assert.assertTrue("started short timer", startedShortTimer);
         Assert.assertFalse("didn't start long timer", startedLongTimer);
@@ -473,7 +479,7 @@ public class SlotManagerTest extends TestCase {
         startedShortTimer = false;
         startedLongTimer = false;        
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(()->{return startedShortTimer;},"startedShortTimer not set");
         Assert.assertEquals("post-LACK status", -999, status);
         Assert.assertTrue("started short timer", startedShortTimer);
         Assert.assertFalse("didn't start long timer", startedLongTimer);
@@ -499,7 +505,7 @@ public class SlotManagerTest extends TestCase {
         startedShortTimer = false;
         startedLongTimer = false;        
         slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
-        jmri.util.JUnitUtil.releaseThread(this, releaseTestDelay);
+        JUnitUtil.waitFor(()->{return startedShortTimer;},"startedShortTimer not set");
         Assert.assertEquals("post-LACK status", -999, status);
         Assert.assertTrue("started short timer", startedShortTimer);
         Assert.assertFalse("didn't start long timer", startedLongTimer);

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -115,7 +115,9 @@ public class JUnitUtil {
      *
      * @param self  currently ignored
      * @param delay milliseconds to wait
+     * @deprecated 4.9.1 Use the various waitFor routines instead
      */
+    @Deprecated
     public static void releaseThread(Object self, int delay) {
         if (javax.swing.SwingUtilities.isEventDispatchThread()) {
             log.error("Cannot use releaseThread on Swing thread", new Exception());

--- a/java/test/jmri/util/PackageTest.java
+++ b/java/test/jmri/util/PackageTest.java
@@ -36,6 +36,7 @@ public class PackageTest extends TestCase {
         suite.addTest(PreferNumericComparatorTest.suite());
         suite.addTest(StringUtilTest.suite());
         suite.addTest(ThreadingUtilTest.suite());
+        suite.addTest(ThreadingDemoAndTest.suite());
         suite.addTest(I18NTest.suite());
         suite.addTest(AlphanumComparatorTest.suite());
         suite.addTest(ColorUtilTest.suite());

--- a/java/test/jmri/util/PackageTest.java
+++ b/java/test/jmri/util/PackageTest.java
@@ -48,6 +48,7 @@ public class PackageTest extends TestCase {
         suite.addTest(jmri.util.swing.PackageTest.suite());
 
         suite.addTest(jmri.util.WaitHandlerTest.suite());
+        suite.addTest(jmri.util.PropertyChangeEventQueueTest.suite());
         suite.addTest(jmri.util.zeroconf.PackageTest.suite());
         suite.addTest(jmri.util.DateUtilTest.suite());
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.prefs.PackageTest.class));

--- a/java/test/jmri/util/PropertyChangeEventQueueTest.java
+++ b/java/test/jmri/util/PropertyChangeEventQueueTest.java
@@ -1,0 +1,99 @@
+package jmri.util;
+
+import java.util.*;
+import java.beans.*;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+import jmri.*;
+
+/**
+ * Tests for the jmri.util.PropertyChangeEventQueue class.
+ *
+ * @author	Bob Jacobsen Copyright 2017
+ */
+public class PropertyChangeEventQueueTest extends TestCase {
+
+    public void testArraySingleListen() throws jmri.JmriException, InterruptedException {        
+        PropertyChangeEventQueue pq = new PropertyChangeEventQueue(new NamedBean[]{is1, is2});
+        
+        is1.setState(Sensor.ACTIVE);
+        
+        // may have to wait, but done automatically
+        PropertyChangeEvent e = pq.take();
+        Assert.assertEquals(is1, e.getSource());
+        Assert.assertEquals("KnownState", e.getPropertyName());
+        Assert.assertEquals(Sensor.ACTIVE, e.getNewValue());
+
+        // test no more
+        PropertyChangeEvent another = pq.poll(100, TimeUnit.MILLISECONDS);
+        Assert.assertTrue(another == null);
+    }
+    
+    public void testListSingleListen() throws jmri.JmriException, InterruptedException {
+        PropertyChangeEventQueue pq = new PropertyChangeEventQueue(Arrays.asList(new NamedBean[]{is1, is2}));
+        
+        is1.setState(Sensor.ACTIVE);
+        
+        // may have to wait, but done automatically
+        PropertyChangeEvent e = pq.take();
+        Assert.assertEquals(is1, e.getSource());
+        Assert.assertEquals("KnownState", e.getPropertyName());
+        Assert.assertEquals(Sensor.ACTIVE, e.getNewValue());
+        
+        // test no more
+        PropertyChangeEvent another = pq.poll(100, TimeUnit.MILLISECONDS);
+        Assert.assertTrue(another == null);
+    }
+
+    public void testToString() throws jmri.JmriException {
+        PropertyChangeEventQueue pq = new PropertyChangeEventQueue(new NamedBean[]{is1, is2});
+
+        Assert.assertEquals("PropertyChangeEventQueue for (\"IS1\") (\"IS2\")", pq.toString());
+    }
+    
+    // from here down is testing infrastructure
+    public PropertyChangeEventQueueTest(String s) {
+        super(s);
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {"-noloading", PropertyChangeEventQueueTest.class.getName()};
+        junit.textui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        TestSuite suite = new TestSuite(PropertyChangeEventQueueTest.class);
+        return suite;
+    }
+
+    Sensor is1;
+    Sensor is2;
+    volatile boolean flag1;
+
+    // The minimal setup for log4J
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.resetInstanceManager();
+        JUnitUtil.initInternalSensorManager();
+        is1 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS1");
+        is2 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS2");
+        flag1 = false;
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PropertyChangeEventQueueTest.class.getName());
+
+}

--- a/java/test/jmri/util/PropertyChangeEventQueueTest.java
+++ b/java/test/jmri/util/PropertyChangeEventQueueTest.java
@@ -55,6 +55,21 @@ public class PropertyChangeEventQueueTest extends TestCase {
         Assert.assertEquals("PropertyChangeEventQueue for (\"IS1\") (\"IS2\")", pq.toString());
     }
     
+    public void testDispose() throws jmri.JmriException, InterruptedException {
+        PropertyChangeEventQueue pq = new PropertyChangeEventQueue(Arrays.asList(new NamedBean[]{is1, is2}));
+    
+        int start = is1.getNumPropertyChangeListeners(); // there can be internal listeners
+        Assert.assertTrue(start >= 1);
+        
+        pq.dispose();
+        
+        Assert.assertEquals(start-1, is1.getNumPropertyChangeListeners());
+
+        pq.dispose();  // check not an error
+        
+        Assert.assertEquals(start-1, is1.getNumPropertyChangeListeners());        
+    }
+
     // from here down is testing infrastructure
     public PropertyChangeEventQueueTest(String s) {
         super(s);

--- a/java/test/jmri/util/ThreadingDemoAndTest.java
+++ b/java/test/jmri/util/ThreadingDemoAndTest.java
@@ -1,0 +1,260 @@
+package jmri.util;
+
+import org.junit.Assert;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * This class serves as a demonstration of some good
+ * threading practices in JMRI, and also as a run-time test of them.
+ * <p>
+ * It's in the java/test package tree because it's not 
+ * something we intend to ship to users.
+ * <p?
+ * For information on threading in JMRI, see the
+ * <href="http://jmri.org/help/en/html/doc/Technical/Threads.shtml">Threading doc page</a>.
+ * See also the {@link ThreadingUtil} and {@lnk WaitHandler} classes along with the 
+ * examples in their associated JUnit test classes:
+ * {@link ThreadingUtilTest} and {@lnk WaitHandlerTest}.
+ *
+ * @author	Bob Jacobsen Copyright 2017
+ */
+public class ThreadingDemoAndTest extends TestCase {
+
+    volatile boolean flagInterrupted1 = false;
+    volatile boolean flagInterrupted2 = false;
+    volatile boolean flagInterrupted3 = false;
+
+    /** 
+     * Show the basic life-cycle of a thread
+     * <ul>
+     *    <li>being created, 
+     *    <li>being started, 
+     *    <li>waiting on a lock on an object,
+     *    <li>being woken up, and 
+     *    <li>terminating.
+     * </ul>
+     * Plus the synchronization needed around the wait and wake-up calls
+     */
+    public void testThreadingLifeCycle() {
+        final Object lock = new Object();  // this object is the lock for the wait and notify
+        final Thread t = new Thread() {
+            public void run()  {
+                try {
+                    synchronized(lock) {
+                        lock.wait();
+                    }
+                } catch (InterruptedException e) {
+                }
+            }
+        };
+        t.setName("testThreadingLifeCycle");
+        t.setDaemon(true);
+        
+        // confirm our understanding of the life cycle
+        Assert.assertTrue(t.getState().equals(Thread.State.NEW));
+        
+        t.start();
+        JUnitUtil.waitFor( ()->{ return ThreadingUtil.isThreadWaiting(t); }, "Got to wait state");
+        
+        synchronized(lock) {
+            lock.notifyAll();
+        }
+        JUnitUtil.waitFor( ()->{ return t.getState().equals(Thread.State.TERMINATED); }, "Got to terminated state");        
+    }
+
+    /**
+     * How one thread t2 can "join" on the ending of another thread t1
+     */
+    public void testThreadingJoinCycle() {
+        final Object lock = new Object();
+        final Thread t1 = new Thread() {
+            public void run()  {
+                try {
+                    synchronized(lock) {
+                        lock.wait();
+                    }
+                } catch (InterruptedException e) {
+                }
+            }
+        };
+        t1.setName("testThreadingLifeCycle 1");
+        t1.setDaemon(true);
+        
+        final Thread t2 = new Thread() {
+            public void run()  {
+                try {
+                    t1.join();
+                } catch (InterruptedException e) {
+                }
+            }
+        };
+        t2.setName("testThreadingLifeCycle 2");
+        t2.setDaemon(true);
+        
+        // confirm our understanding of the life cycle
+        Assert.assertTrue(t1.getState().equals(Thread.State.NEW));
+        Assert.assertTrue(t2.getState().equals(Thread.State.NEW));
+        
+        t1.start();
+        t2.start();
+        
+        JUnitUtil.waitFor( ()->{ return ThreadingUtil.isThreadWaiting(t1); }, "Got 1 to wait state");
+        JUnitUtil.waitFor( ()->{ return ThreadingUtil.isThreadWaiting(t2); }, "Got 2 to wait state");
+        
+        synchronized(lock) {
+            lock.notifyAll();
+        }
+        
+        JUnitUtil.waitFor( ()->{ return t1.getState().equals(Thread.State.TERMINATED); }, "Got 1 to terminated state");        
+        JUnitUtil.waitFor( ()->{ return t2.getState().equals(Thread.State.TERMINATED); }, "Got 2 to terminated state");        
+    }
+    
+
+    /**
+     * Interrupting a thread ends the current wait, but 
+     * doesn't kill the thread; it can go on to wait more.
+     */
+    public void testInterruptAndContinue() {
+        flagInterrupted1 = false;  // set true when we get to the first wait
+        flagInterrupted2 = false;  // set true when we get to the second wait
+
+        final Object lock = new Object();
+        final Thread t1 = new Thread() {
+            public void run()  {
+                try {
+                    synchronized(lock) {
+                        lock.wait();
+                    }
+                } catch (InterruptedException e) {
+                    flagInterrupted1 = true;
+                    // we're just going to continue to another wait
+                }
+                try {
+                    synchronized(lock) {
+                        lock.wait();
+                    }
+                } catch (InterruptedException e) {
+                    flagInterrupted2 = true;
+                    // we're just going to continue and terminate
+                }
+                
+            }
+        };
+        t1.setName("testInterruptAndContinue");
+        t1.setDaemon(true);
+                
+        // confirm our understanding of the life cycle
+        Assert.assertTrue(t1.getState().equals(Thread.State.NEW));
+        
+        t1.start();
+        
+        JUnitUtil.waitFor( ()->{ return ThreadingUtil.isThreadWaiting(t1); }, "Got to wait state");
+        
+        t1.interrupt(); // end 1st wait
+
+        JUnitUtil.waitFor( ()->{ return flagInterrupted1; }, "handled first interrupt");
+        JUnitUtil.waitFor( ()->{ return ThreadingUtil.isThreadWaiting(t1); }, "and went to second wait");
+
+        t1.interrupt(); // end 2nd wait
+        
+        JUnitUtil.waitFor( ()->{ return flagInterrupted2; }, "handled second interrupt");
+        JUnitUtil.waitFor( ()->{ return t1.getState().equals(Thread.State.TERMINATED); }, "Got 1 to terminated state");        
+    }
+
+    /**
+     * Interrupting a thread that restores the interrupted status also kills the next wait
+     */
+    public void testThreadReassertsInterrupt() {
+        flagInterrupted1 = false;  // set true when we leave the first wait
+        flagInterrupted2 = false;  // set true when we leave the second wait
+        flagInterrupted3 = false;  // set true when we leave the third wait
+
+        final Object lock = new Object();
+        final Thread t1 = new Thread() {
+            public void run()  {
+                try {
+                    synchronized(lock) {
+                        lock.wait();
+                    }
+                } catch (InterruptedException e) {
+                    flagInterrupted1 = true;
+                    Thread.currentThread().interrupt();
+                    // restored the status for the next wait
+                }
+                try {
+                    synchronized(lock) {
+                        lock.wait();
+                    }
+                } catch (InterruptedException e) {
+                    flagInterrupted2 = true;
+                }
+                try {
+                    synchronized(lock) {
+                        lock.wait();
+                    }
+                } catch (InterruptedException e) {
+                    flagInterrupted3 = true;
+                    // we're just going to continue and terminate
+                }
+                
+            }
+        };
+        t1.setName("testThreadReassertsInterrupt");
+        t1.setDaemon(true);
+                
+        // confirm our understanding of the life cycle
+        Assert.assertTrue(t1.getState().equals(Thread.State.NEW));
+        
+        t1.start();
+        
+        JUnitUtil.waitFor( ()->{ return ThreadingUtil.isThreadWaiting(t1); }, "Got to wait state");
+        
+        t1.interrupt(); // end 1st wait
+
+        JUnitUtil.waitFor( ()->{ return flagInterrupted1; }, "handled first interrupt");
+        JUnitUtil.waitFor( ()->{ return flagInterrupted2; }, "continued to second interrupt handler");
+        
+        // it ran to the 2nd, but waited there because that consumed the interrupt
+        JUnitUtil.waitFor( ()->{ return ThreadingUtil.isThreadWaiting(t1); }, "at third wait");        
+        Assert.assertTrue(! flagInterrupted3); 
+
+        t1.interrupt(); // end 3rd wait
+        
+        JUnitUtil.waitFor( ()->{ return flagInterrupted3; }, "continued to third interrupt handler");
+        JUnitUtil.waitFor( ()->{ return t1.getState().equals(Thread.State.TERMINATED); }, "continued off the end to terminated state");        
+    }
+
+
+    // from here down is testing infrastructure
+    public ThreadingDemoAndTest(String s) {
+        super(s);
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {"-noloading", ThreadingDemoAndTest.class.getName()};
+        junit.textui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        TestSuite suite = new TestSuite(ThreadingDemoAndTest.class);
+        return suite;
+    }
+
+    // The minimal setup for log4J
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        apps.tests.Log4JFixture.setUp();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        apps.tests.Log4JFixture.tearDown();
+        super.tearDown();
+    }
+
+}

--- a/java/test/jmri/util/ThreadingUtilTest.java
+++ b/java/test/jmri/util/ThreadingUtilTest.java
@@ -98,6 +98,9 @@ public class ThreadingUtilTest extends TestCase {
         JUnitUtil.waitFor( ()->{ return done; }, "Delayed oepration complete");
     }
 
+    /**
+     * Show how to query state of _current_ thread
+     */
     public void testSelfState() {
     
         // To run the tests, this thread has to be running, not waiting

--- a/java/test/jmri/util/ThreadingUtilTest.java
+++ b/java/test/jmri/util/ThreadingUtilTest.java
@@ -98,6 +98,12 @@ public class ThreadingUtilTest extends TestCase {
         JUnitUtil.waitFor( ()->{ return done; }, "Delayed oepration complete");
     }
 
+    public void testSelfState() {
+    
+        // To run the tests, this thread has to be running, not waiting
+        Assert.assertTrue(ThreadingUtil.canThreadRun(Thread.currentThread()));
+        Assert.assertFalse(ThreadingUtil.isThreadWaiting(Thread.currentThread()));
+    }
 
     // from here down is testing infrastructure
     public ThreadingUtilTest(String s) {

--- a/java/test/jmri/util/WaitHandlerTest.java
+++ b/java/test/jmri/util/WaitHandlerTest.java
@@ -56,23 +56,11 @@ public class WaitHandlerTest extends TestCase {
         };
         t.start();
 
-        for (int i = 1; i < TEST_DELAY; i++) {
-            // wait on flag 1 for start
-            if (flag1) {
-                break;
-            }
-            JUnitUtil.releaseThread(this, 1);
-        }
+        JUnitUtil.waitFor(()->{return flag1;},"flag1 not set");
 
         Assert.assertTrue("started", flag1);
 
-        for (int i = 1; i < TEST_DELAY; i++) {
-            // wait on flag 2 for end
-            if (flag2) {
-                break;
-            }
-            JUnitUtil.releaseThread(this, 1);
-        }
+        JUnitUtil.waitFor(()->{return flag2;},"flag2 not set");
 
         Assert.assertTrue("ended", flag2);
         Assert.assertTrue("run time long enough", THREAD_DELAY <= endTime - startTime);
@@ -93,13 +81,7 @@ public class WaitHandlerTest extends TestCase {
         };
         t.start();
 
-        for (int i = 1; i < TEST_DELAY; i++) {
-            // wait on flag 1 for start
-            if (flag1) {
-                break;
-            }
-            JUnitUtil.releaseThread(this, 1);
-        }
+        JUnitUtil.waitFor(()->{return flag1;},"flag1 not set");
 
         Assert.assertTrue("started", flag1);
 
@@ -108,13 +90,7 @@ public class WaitHandlerTest extends TestCase {
         t.interrupt();
         Assert.assertTrue("notify early enough", THREAD_DELAY > Calendar.getInstance().getTimeInMillis() - startTime);
 
-        for (int i = 1; i < TEST_DELAY; i++) {
-            // wait on flag 2 for end
-            if (flag2) {
-                break;
-            }
-            JUnitUtil.releaseThread(this, 1);
-        }
+        JUnitUtil.waitFor(()->{return flag2;},"flag2 not set");
 
         Assert.assertTrue("ended", flag2);
         Assert.assertTrue("ended early", THREAD_DELAY >= endTime - startTime);
@@ -140,13 +116,7 @@ public class WaitHandlerTest extends TestCase {
         };
         t.start();
 
-        for (int i = 1; i < TEST_DELAY; i++) {
-            // wait on flag 1 for start
-            if (flag1) {
-                break;
-            }
-            JUnitUtil.releaseThread(this, 1);
-        }
+        JUnitUtil.waitFor(()->{return flag1;},"flag1 not set");
 
         Assert.assertTrue("started", flag1);
 
@@ -158,13 +128,7 @@ public class WaitHandlerTest extends TestCase {
             t.notify();
         }
 
-        for (int i = 1; i < TEST_DELAY; i++) {
-            // wait on flag 2 for end
-            if (flag2) {
-                break;
-            }
-            JUnitUtil.releaseThread(this, 1);
-        }
+        JUnitUtil.waitFor(()->{return flag2;},"flag2 not set");
 
         Assert.assertTrue("ended", flag2);
 
@@ -191,13 +155,7 @@ public class WaitHandlerTest extends TestCase {
         };
         t.start();
 
-        for (int i = 1; i < TEST_DELAY; i++) {
-            // wait on flag 1 for start
-            if (flag1) {
-                break;
-            }
-            JUnitUtil.releaseThread(this, 1);
-        }
+        JUnitUtil.waitFor(()->{return flag1;},"flag1 not set");
         Assert.assertTrue("started", flag1);
         Assert.assertTrue("still running", !flag2);
 
@@ -207,14 +165,7 @@ public class WaitHandlerTest extends TestCase {
             Assert.assertTrue("notify early enough", THREAD_DELAY >= Calendar.getInstance().getTimeInMillis() - startTime);
         }
 
-        for (int i = 1; i < TEST_DELAY; i++) {
-            // wait on flag 2 for end
-            if (flag2) {
-                break;
-            }
-            JUnitUtil.releaseThread(this, 1);
-        }
-
+        JUnitUtil.waitFor(()->{return flag2;},"flag2 not set");
         Assert.assertTrue("ended", flag2);
 
         if (THREAD_DELAY <= endTime - startTime) {

--- a/jython/test/AutomatonStopTest.py
+++ b/jython/test/AutomatonStopTest.py
@@ -1,0 +1,50 @@
+# Test that a simple Python automaton can be stopped cleanly
+#
+# Author: Bob Jacobsen, copyright 2017
+# Part of the JMRI distribution
+
+import java
+import jmri
+
+class AutomatonStopTest(jmri.jmrit.automat.AbstractAutomaton) :
+	
+	# init() is called exactly once at the beginning to do
+	# any necessary configuration.
+	def init(self):
+		return
+	
+	# sample subroutine
+	def mycode(self) :
+		# wait for some time
+		self.waitMsec(1000)
+		return
+	
+	# handle() is called repeatedly until it returns false.
+	#
+	# Modify this to do your calculation.
+	def handle(self):
+		# do the work
+		self.mycode()
+		# and continue around again forever
+		return 1	# to continue
+	
+# end of class definition
+
+# create one of these
+a = AutomatonStopTest()
+
+# set the name, as a example of configuring it
+name = "AutomatonStopTest test thread"
+a.setName(name)
+
+# start it running
+a.start()
+
+# tell it to stop
+jmri.jmrit.automat.AutomatSummary.instance().get(name).stop()
+
+# confirm that it has stopped (might have to wait a here?)
+for t in java.lang.Thread.getAllStackTraces().keySet() :
+    if (t.getName() == name) :
+        if (t.getState() != java.lang.Thread.State.TERMINATED) : raise AssertionError('thread did not TERMINATE')
+ 


### PR DESCRIPTION
- new sample file
- create new `PropertyListenerBlockingQueue` for reliable, atomic listening to a group of NamedBeans
- switching Siglet to PLBQ to remove the (admittedly tiny) window to miss a layout change
- more tests
- threading documentation cleanup, update (which needs improvement)
- some Findbugs cleanup
- fix two execrable member names encountered during the work
- fix formatting on NetBeans page