### PR TITLE
OpenLCB: sensor force update

### DIFF
--- a/java/src/jmri/jmrix/openlcb/OlcbSensor.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbSensor.java
@@ -140,12 +140,12 @@ public class OlcbSensor extends AbstractSensor {
     public void setKnownState(int s) throws jmri.JmriException {
         setOwnState(s);
         if (s == Sensor.ACTIVE) {
-            sensorListener.setFromOwner(true);
+            sensorListener.setFromOwnerWithForceNotify(true);
             if (addrInactive == null) {
                 setTimeout();
             }
         } else if (s == Sensor.INACTIVE) {
-            sensorListener.setFromOwner(false);
+            sensorListener.setFromOwnerWithForceNotify(false);
         }
     }
 

--- a/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
@@ -142,6 +142,13 @@ public class OlcbSensorTest extends TestCase {
         Assert.assertEquals(Sensor.INACTIVE, s.getKnownState());
         t.flush();
         Assert.assertTrue(new OlcbAddress("1.2.3.4.5.6.7.9").match(t.tc.rcvMessage));
+
+        // Repeat send
+        t.tc.rcvMessage = null;
+        s.setKnownState(Sensor.INACTIVE);
+        Assert.assertEquals(Sensor.INACTIVE, s.getKnownState());
+        t.flush();
+        Assert.assertTrue(new OlcbAddress("1.2.3.4.5.6.7.9").match(t.tc.rcvMessage));
     }
 
     public void testEventTable() {


### PR DESCRIPTION
Ensures that set of sensor state generates an outgoing bus message, even if the new state is the same as the previous. This is desired by advanced users in order to be able to write scripts that initialize the entire system to a known state.
Fixes https://github.com/openlcb/OpenLCB_Java/issues/92.



