### PR TITLE
update throttle managers and throttle listeners to provide initial support for stealing throttles (on loconet).

### DIFF
--- a/java/src/jmri/ThrottleListener.java
+++ b/java/src/jmri/ThrottleListener.java
@@ -36,4 +36,12 @@ public interface ThrottleListener extends EventListener {
      */
     public void notifyFailedThrottleRequest(DccLocoAddress address, String reason);
 
+    /**
+     * Get notification that a throttle request requires is in use by another
+     * device, and a "steal" may be required.
+     *
+     * @param address DccLocoAddress of the throttle that needs to be stolen.
+     */
+    public void notifyStealThrottleRequired(DccLocoAddress address);
+
 }

--- a/java/src/jmri/ThrottleManager.java
+++ b/java/src/jmri/ThrottleManager.java
@@ -137,6 +137,53 @@ public interface ThrottleManager {
     public void cancelThrottleRequest(int address, boolean isLong, ThrottleListener l);
 
     /**
+     * Steal a requested throttle.
+     * <P>
+     * This is a convenience version of the call, which uses system-specific
+     * logic to tell whether the address is a short or long form.
+     *
+     * @param re desired Roster Entry
+     * @param l  ThrottleListener requesting the throttle steal occur.
+     * @param steal true if the request should continue, false otherwise.
+     * @since 4.9.2
+     */
+    public void stealThrottleRequest(BasicRosterEntry re, ThrottleListener l,boolean steal);
+
+    /**
+     * Steal a requested throttle.
+     * <P>
+     * This is a convenience version of the call, which uses system-specific
+     * logic to tell whether the address is a short or long form.
+     *
+     * @param address desired decoder address
+     * @param l  ThrottleListener requesting the throttle steal occur.
+     * @param steal true if the request should continue, false otherwise.
+     * @since 4.9.2
+     */
+    public void stealThrottleRequest(int address, ThrottleListener l,boolean steal);
+
+    /**
+     * Steal a requested throttle.
+     *
+     * @param address desired decoder address
+     * @param isLong  true if requesting a DCC long (extended) address
+     * @param l  ThrottleListener requesting the throttle steal occur.
+     * @param steal true if the request should continue, false otherwise.
+     * @since 4.9.2
+     */
+    public void stealThrottleRequest(int address, boolean isLong, ThrottleListener l,boolean steal);
+
+    /**
+     * Steal a requested throttle.
+     *
+     * @param address desired DccLocoAddress 
+     * @param l  ThrottleListener requesting the throttle steal occur.
+     * @param steal true if the request should continue, false otherwise.
+     * @since 4.9.2
+     */
+    public void stealThrottleRequest(DccLocoAddress address, ThrottleListener l,boolean steal);
+
+    /**
      * Test if the Dispatch Button should be enabled or not.
      *
      * @return true if dispatch is possible; false otherwise

--- a/java/src/jmri/jmris/AbstractThrottleServer.java
+++ b/java/src/jmri/jmris/AbstractThrottleServer.java
@@ -163,6 +163,12 @@ abstract public class AbstractThrottleServer implements ThrottleListener {
        }
     }
 
+    @Override
+    public void notifyStealThrottleRequired(DccLocoAddress address){
+        // this is an automatically stealing impelementation.
+        InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
+    }
+
 
     // internal class used to propagate back end throttle changes
     // to the clients.

--- a/java/src/jmri/jmris/json/JsonThrottle.java
+++ b/java/src/jmri/jmris/json/JsonThrottle.java
@@ -345,6 +345,12 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
             server.release(this);
         }
     }
+    
+    @Override
+    public void notifyStealThrottleRequired(DccLocoAddress address){
+        // this is an automatically stealing impelementation.
+        InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
+    }
 
     private void sendErrorMessage(int code, String message, JsonThrottleServer server) {
         try {

--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -965,6 +965,12 @@ public class AbstractAutomaton implements Runnable {
                     self.notifyAll(); // should be only one thread waiting, but just in case
                 }
             }
+
+            @Override
+            public void notifyStealThrottleRequired(jmri.DccLocoAddress address){
+                // this is an automatically stealing impelementation.
+                InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
+            }
         };
         boolean ok = InstanceManager.getDefault(ThrottleManager.class)
                 .requestThrottle(address, longAddress, throttleListener);
@@ -1028,6 +1034,12 @@ public class AbstractAutomaton implements Runnable {
                 synchronized (self) {
                     self.notifyAll(); // should be only one thread waiting, but just in case
                 }
+            }
+
+            @Override
+            public void notifyStealThrottleRequired(jmri.DccLocoAddress address){
+                // this is an automatically stealing impelementation.
+                InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
             }
         };
         boolean ok = InstanceManager.throttleManagerInstance()

--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -306,6 +306,12 @@ public class AutoActiveTrain implements ThrottleListener {
         log.error("Throttle request failed for " + address + " because " + reason);
     }
 
+    @Override
+    public void notifyStealThrottleRequired(jmri.DccLocoAddress address){
+        // this is an automatically stealing impelementation.
+        InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
+    }
+
     // more operational variables
     private ArrayList<AllocatedSection> _allocatedSectionList = new ArrayList<AllocatedSection>();
     private jmri.jmrit.display.layoutEditor.LayoutBlockManager _lbManager = null;

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -778,6 +778,12 @@ public class Warrant extends jmri.implementation.AbstractNamedBean
         abortWarrant( Bundle.getMessage("noThrottle", (reason +" "+ (address!=null?address.getNumber():getDisplayName()))));
         fireRunStatus("throttleFail", null, reason);
     }
+
+    @Override
+    public void notifyStealThrottleRequired(DccLocoAddress address){
+        // this is an automatically stealing impelementation.
+        InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
+    }
     
     protected void releaseThrottle(DccThrottle throttle) {
         if (throttle != null) {

--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
@@ -575,6 +575,12 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
         setButtonStates(true);
     }
 
+    @Override
+    public void notifyStealThrottleRequired(jmri.DccLocoAddress address){
+        // this is an automatically stealing impelementation.
+        InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
+    }
+
     PropertyChangeListener startListener = null;
     PropertyChangeListener finishListener = null;
     PropertyChangeListener middleListener = null;

--- a/java/src/jmri/jmrit/throttle/AddressPanel.java
+++ b/java/src/jmri/jmrit/throttle/AddressPanel.java
@@ -234,6 +234,12 @@ public class AddressPanel extends JInternalFrame implements ThrottleListener, Pr
         javax.swing.JOptionPane.showMessageDialog(null, reason, Bundle.getMessage("FailedSetupRequestTitle"), javax.swing.JOptionPane.WARNING_MESSAGE);
     }
 
+    @Override
+    public void notifyStealThrottleRequired(DccLocoAddress address){
+        int choice = javax.swing.JOptionPane.showConfirmDialog(this, Bundle.getMessage("StealQuestionText",address.toString()), Bundle.getMessage("StealRequestTitle"), javax.swing.JOptionPane.YES_NO_OPTION);
+        InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, choice == javax.swing.JOptionPane.YES_OPTION);
+    }
+
     /**
      * Get notification that a consist throttle has been found as we requested.
      *

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle.properties
@@ -136,6 +136,8 @@ Push_for_alternate_set_of_function_keys=Push for alternate set of function keys
 Feature_still_under_development =Feature still under development!
 
 FailedSetupRequestTitle = Failed to create Throttle
+StealQuestionText = Throttle {0} is in use by another device.  Steal?
+StealRequestTitle = Steal Throttle
 
 LayoutPowerOn = Layout Power On. Click to turn Off.
 LayoutPowerOff = Layout Power Off. Click to turn On.

--- a/java/src/jmri/jmrit/withrottle/ConsistFunctionController.java
+++ b/java/src/jmri/jmrit/withrottle/ConsistFunctionController.java
@@ -6,6 +6,7 @@ import jmri.ThrottleListener;
 import jmri.jmrit.roster.RosterEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import jmri.InstanceManager;
 
 /**
  *
@@ -47,6 +48,12 @@ public class ConsistFunctionController implements ThrottleListener {
     @Override
     public void notifyFailedThrottleRequest(DccLocoAddress address, String reason) {
         log.error("Throttle request failed for " + address + " because " + reason);
+    }
+
+    @Override
+    public void notifyStealThrottleRequired(DccLocoAddress address){
+        // this is an automatically stealing impelementation.
+        InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
     }
 
     public void dispose() {

--- a/java/src/jmri/jmrit/withrottle/ThrottleController.java
+++ b/java/src/jmri/jmrit/withrottle/ThrottleController.java
@@ -41,6 +41,7 @@ import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import jmri.InstanceManager;
 
 public class ThrottleController implements ThrottleListener, PropertyChangeListener {
 
@@ -206,6 +207,12 @@ public class ThrottleController implements ThrottleListener, PropertyChangeListe
     @Override
     public void notifyFailedThrottleRequest(DccLocoAddress address, String reason) {
         log.error("Throttle request failed for " + address + " because " + reason);
+    }
+
+    @Override
+    public void notifyStealThrottleRequired(DccLocoAddress address){
+        // this is an automatically stealing impelementation.
+        InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
     }
 
 

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -424,6 +424,12 @@ abstract public class AbstractThrottle implements DccThrottle {
                 @Override
                 public void notifyThrottleFound(DccThrottle t) {
                 }
+    
+                @Override
+                public void notifyStealThrottleRequired(DccLocoAddress address){
+                    // this is an automatically stealing impelementation.
+                    InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
+                }
             });
         }
     }

--- a/java/src/jmri/jmrix/AbstractThrottleManager.java
+++ b/java/src/jmri/jmrix/AbstractThrottleManager.java
@@ -346,6 +346,72 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
     }
 
     /**
+     * Steal a requested throttle.
+     * <P>
+     * This is a convenience version of the call, which uses system-specific
+     * logic to tell whether the address is a short or long form.
+     *
+     * @param re desired Roster Entry
+     * @param l  ThrottleListener requesting the throttle steal occur.
+     * @param steal true if the request should continue, false otherwise.
+     * @since 4.9.2
+     */
+    @Override
+    public void stealThrottleRequest(BasicRosterEntry re, ThrottleListener l,boolean steal){
+        stealThrottleRequest(re.getDccLocoAddress(), l,steal);
+    }
+
+    /**
+     * Steal a requested throttle.
+     * <P>
+     * This is a convenience version of the call, which uses system-specific
+     * logic to tell whether the address is a short or long form.
+     *
+     * @param address desired decoder address
+     * @param l  ThrottleListener requesting the throttle steal occur.
+     * @param steal true if the request should continue, false otherwise.
+     * @since 4.9.2
+     */
+    @Override
+    public void stealThrottleRequest(int address, ThrottleListener l,boolean steal){
+        boolean isLong = true;
+        if (canBeShortAddress(address)) {
+            isLong = false;
+        }
+        stealThrottleRequest(address, isLong, l,steal);
+    }
+
+    /**
+     * Steal a requested throttle.
+     *
+     * @param address desired decoder address
+     * @param isLong  true if requesting a DCC long (extended) address
+     * @param l  ThrottleListener requesting the throttle steal occur.
+     * @param steal true if the request should continue, false otherwise.
+     * @since 4.9.2
+     */
+    @Override
+    public void stealThrottleRequest(int address, boolean isLong, ThrottleListener l,boolean steal){
+        DccLocoAddress la = new DccLocoAddress(address, isLong);
+        stealThrottleRequest(la, l,steal);
+    }
+
+    /**
+     * Steal a requested throttle.
+     *
+     * @param address desired DccLocoAddress 
+     * @param l  ThrottleListener requesting the throttle steal occur.
+     * @param steal true if the request should continue, false otherwise.
+     * @since 4.9.2
+     */
+    @Override
+    public void stealThrottleRequest(DccLocoAddress address, ThrottleListener l,boolean steal){
+       // the default implementation does nothing.
+    }
+
+
+
+    /**
      * If the system-specific ThrottleManager has been unable to create the DCC
      * throttle then it needs to be removed from the throttleListeners,
      * otherwise any subsequent request for that address results in the address

--- a/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
@@ -1075,6 +1075,12 @@ public class SpeedoConsoleFrame extends JmriJFrame implements SpeedoListener,
     public void notifyFailedThrottleRequest(jmri.DccLocoAddress address, String reason) {
     }
 
+    @Override
+    public void notifyStealThrottleRequired(DccLocoAddress address){
+        // this is an automatically stealing impelementation.
+        InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
+    }
+
     javax.swing.Timer replyTimer = null;
     javax.swing.Timer displayTimer = null;
     javax.swing.Timer fastDisplayTimer = null;

--- a/java/src/jmri/jmrix/loconet/LocoNetConsist.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetConsist.java
@@ -474,6 +474,12 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
         consistRequestState = IDLESTATE;
     }
 
+    @Override
+    public void notifyStealThrottleRequired(DccLocoAddress address){
+        // this is an automatically stealing impelementation.
+        throttleManager.stealThrottleRequest(address, this, true);
+    }
+
     private final static Logger log = LoggerFactory.getLogger(LocoNetConsist.class.getName());
 
 }

--- a/java/src/jmri/jmrix/rps/RpsBlock.java
+++ b/java/src/jmri/jmrix/rps/RpsBlock.java
@@ -93,6 +93,12 @@ public class RpsBlock implements java.beans.PropertyChangeListener, jmri.Throttl
     public void notifyFailedThrottleRequest(DccLocoAddress address, String reason) {
     }
 
+    @Override
+    public void notifyStealThrottleRequired(DccLocoAddress address){
+        // this is an automatically stealing impelementation.
+        jmri.InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
+    }
+
     void updateCurrentThrottles() {
         List<Integer> l = sensor.getContents();
         if (l.size() == 0) {

--- a/java/src/jmri/jmrix/rps/Transmitter.java
+++ b/java/src/jmri/jmrix/rps/Transmitter.java
@@ -105,4 +105,10 @@ public class Transmitter implements ThrottleListener {
     @Override
     public void notifyFailedThrottleRequest(jmri.DccLocoAddress address, String reason) {
     }
+
+    @Override
+    public void notifyStealThrottleRequired(jmri.DccLocoAddress address){
+        // this is an automatically stealing impelementation.
+        InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
+    }
 }

--- a/java/src/jmri/server/json/throttle/JsonThrottle.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottle.java
@@ -371,6 +371,12 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
         }
     }
 
+    @Override
+    public void notifyStealThrottleRequired(DccLocoAddress address){
+        // this is an automatically stealing impelementation.
+        jmri.InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
+    }
+
     private void sendErrorMessage(JsonException message, JsonThrottleSocketService server) {
         try {
             server.getConnection().sendMessage(message.getJsonMessage());

--- a/java/test/jmri/managers/AbstractThrottleManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractThrottleManagerTestBase.java
@@ -31,6 +31,7 @@ public abstract class AbstractThrottleManagerTestBase {
 
     protected boolean throttleFoundResult = false;
     protected boolean throttleNotFoundResult = false;
+    protected boolean throttleStealResult = false;
 
     protected class ThrottleListen implements ThrottleListener {
 
@@ -44,12 +45,17 @@ public abstract class AbstractThrottleManagerTestBase {
              throttleNotFoundResult = true;
        }
 
+       @Override
+       public void notifyStealThrottleRequired(DccLocoAddress address){
+            throttleStealResult = true;
+       }
     }
 
     @After
     public void postTestReset(){
        throttleFoundResult = false;
        throttleNotFoundResult = false;
+       throttleStealResult = false;
     }
 
     // start of common tests


### PR DESCRIPTION
Partially addresses #2436 by providing infrastructure to make stealing possible.