### PR TITLE
Fix a bug in the loadAtStartup function of DispatcherFrame.java.

### DIFF
--- a/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
@@ -135,9 +135,9 @@ public class DispatcherFrame extends jmri.util.JmriJFrame {
                         log.debug("initializing block paths early"); //TODO: figure out how to prevent the "regular" init
                         InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class).initializeLayoutBlockPaths();
                     }
-
-                    ActiveTrain at = createActiveTrain(info.getTransitName(), info.getTrainName(), tSource,
-                            startBlock, startBlockSeq, destinationBlock, destinationBlockSeq,
+                    
+                    ActiveTrain at = createActiveTrain(info.getTransitName().split("\\(")[0], info.getTrainName(), tSource,
+                            startBlock.split("\\(")[0], startBlockSeq, destinationBlock.split("\\(")[0], destinationBlockSeq,
                             info.getAutoRun(), info.getDCCAddress(), info.getPriority(),
                             info.getResetWhenDone(), info.getReverseAtEnd(), info.getAllocateAllTheWay(), true, null);
                     if (at != null) {


### PR DESCRIPTION
If a user name is defined for the transit or starting block or destination block, the validation process fails. The validation code expects either the system name or the user name, but not both. The createActiveTrain method is using a concatenated string of both, causing the validation failure.