### PR TITLE
Fix problem at 4.9.2 startup with out of memory

### DIFF
--- a/java/src/jmri/jmrit/decoderdefn/DecoderIndexFile.java
+++ b/java/src/jmri/jmrit/decoderdefn/DecoderIndexFile.java
@@ -254,6 +254,7 @@ public class DecoderIndexFile extends XmlFile {
         if (masterFile == null) {
             return false;
         }
+        log.debug("checking for master file at {}", masterFile);
         Element masterRoot = masterXmlFile.rootFromURL(masterFile);
         if (masterRoot.getChild("decoderIndex") != null) {
             if (masterRoot.getChild("decoderIndex").getAttribute("version") != null) {
@@ -269,6 +270,7 @@ public class DecoderIndexFile extends XmlFile {
         // the master is found, we still do the right thing (nothing).
         String userVersion = null;
         DecoderIndexFile userXmlFile = new DecoderIndexFile();
+        log.debug("checking for user file at {}", defaultDecoderIndexFilename());
         Element userRoot = userXmlFile.rootFromName(defaultDecoderIndexFilename());
         if (userRoot.getChild("decoderIndex") != null) {
             if (userRoot.getChild("decoderIndex").getAttribute("version") != null) {
@@ -281,10 +283,7 @@ public class DecoderIndexFile extends XmlFile {
         }
 
         // force the update, with the version number located earlier is available
-        if (masterVersion != null) {
-            InstanceManager.getDefault(DecoderIndexFile.class).fileVersion = Integer.parseInt(masterVersion);
-        }
-
+        log.debug("forcing update of decoder index due to {} and {}", masterVersion, userVersion);
         forceCreationOfNewIndex();
         // and force it to be used
         return true;
@@ -314,9 +313,8 @@ public class DecoderIndexFile extends XmlFile {
             {
                 log.error("Failed to delete old index file");
             }
-            // force read from distributed file
+            // force read from distributed file on next access
             resetInstance();
-            InstanceManager.getDefault(DecoderIndexFile.class);
         }
 
         // create an array of file names from decoders dir in preferences, count entries


### PR DESCRIPTION
remove internal references to DecoderIndexFile object being created via InstanceManager to avoid instantiation loop

Closes #3929 