### PR TITLE
Include package-private methods in Javadoc tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,7 @@
                     <maxmemory>512m</maxmemory>
                     <overview>${basedir}/java/src/jmri/overview.html</overview>
                     <sourcepath>${basedir}/java/src:${project.build.directory}/generated-sources/javacc:${project.build.directory}/generated-sources/jjtree</sourcepath>
+                    <show>package</show>
                     <!-- remove -Xdoclint:-missing to get warnings about missing Javadoc tags -->
                     <!-- change from default 100 warnings -->
                     <additionalparam>-breakiterator -Xdoclint:all -Xdoclint:-missing -Xmaxwarns 2350</additionalparam>


### PR DESCRIPTION
This includes package-private methods in the Javadoc tests run on Travis CI to match the non-default inclusion of these methods in the JMRI Javadocs by Jenkins.