### PR TITLE
RFID help clarification [ci skip]

### DIFF
--- a/help/en/html/hardware/rfid/index.shtml
+++ b/help/en/html/hardware/rfid/index.shtml
@@ -39,7 +39,7 @@
       <ul>
         <li>CORE-ID / ID-Innovations - since version 2.11.4</li>
 
-        <li>Olimex - since v 3.9.2</li>
+        <li>Olimex MOD-RFID1456 13.56 MHz reader - since v 3.9.2</li>
 
         <li>Parallax - since v 3.9.2</li>
       </ul>


### PR DESCRIPTION
Clarifies RFID hardware help file: Olimex protocol supports 13.56MHz readers only.