### PR TITLE
Avoid ERROR message in C/MRI Turnout test

### DIFF
--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
@@ -23,7 +23,8 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
         memo = new jmri.jmrix.cmri.CMRISystemConnectionMemo();
         memo.setTrafficController(tcis);
         n = new SerialNode(0, SerialNode.SMINI,tcis);
-        t = new SerialTurnout("CT4", "t4",memo);
+
+        t = memo.getTurnoutManager().provideTurnout("4");
         Assert.assertNotNull("exists", n);
     }
 

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
@@ -3,6 +3,7 @@ package jmri.jmrix.cmri.serial;
 import jmri.implementation.AbstractTurnoutTestBase;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests for the jmri.jmrix.cmri.serial.SerialTurnout class
@@ -15,6 +16,11 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
     private SerialTrafficControlScaffold tcis = null;
     private SerialNode n = null;
 
+    @Test
+    public void testCtor() {
+        new SerialTurnout("5", "to5", memo);
+    }
+    
     @Override
     @Before
     public void setUp() {


### PR DESCRIPTION
Create turnout w proper call to avoid ERROR message