### PR TITLE
recursively call dispose in jmri.util.JmriJFrame if not run on the GUI thread

### DIFF
--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -841,6 +841,12 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      */
     @Override
     public void dispose() {
+        if (!ThreadingUtil.isGUIThread()){
+            // recursive call to dispose, but put it on the GUI thread
+            ThreadingUtil.runOnGUI( () -> { dispose(); } );
+            // and then return.
+            return;
+        }
         InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(p -> {
             if (reuseFrameSavedPosition) {
                 p.setWindowLocation(windowFrameRef, this.getLocation());

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -841,8 +841,6 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      */
     @Override
     public void dispose() {
-        if (!jmri.util.ThreadingUtil.isGUIThread()) 
-              log.error("operations while not on GUI thread", new Exception("Traceback"));
         InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(p -> {
             if (reuseFrameSavedPosition) {
                 p.setWindowLocation(windowFrameRef, this.getLocation());

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -841,6 +841,8 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      */
     @Override
     public void dispose() {
+        if (!jmri.util.ThreadingUtil.isGUIThread()) 
+              log.error("operations while not on GUI thread", new Exception("Traceback"));
         InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(p -> {
             if (reuseFrameSavedPosition) {
                 p.setWindowLocation(windowFrameRef, this.getLocation());


### PR DESCRIPTION
Per @rhwood's suggestion in PR #3984 relative to issue #3986