### PR TITLE
Set the maxmemmory parameter on appveyor JUnit task

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1340,7 +1340,7 @@
     <target name="ci-test-appveyor" depends="tests, runtime-library-selection" description="run ci-test using Appveyor">
         <!-- identical to ci-test target except test output is different -->
         <jacoco:coverage destfile="jacoco.exec" excludes="org.slf4j.*">
-        <junit haltonerror="false" haltonfailure="false" printsummary="yes" showoutput="yes" fork="yes" dir="." errorProperty="test.failed" failureProperty="test.failed">
+        <junit haltonerror="false" haltonfailure="false" printsummary="yes" showoutput="yes" fork="yes" maxmemory="2048m" dir="." errorProperty="test.failed" failureProperty="test.failed">
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -841,6 +841,12 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      */
     @Override
     public void dispose() {
+        if (!ThreadingUtil.isGUIThread()){
+            // recursive call to dispose, but put it on the GUI thread
+            ThreadingUtil.runOnGUI( () -> { dispose(); } );
+            // and then return.
+            return;
+        }
         InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(p -> {
             if (reuseFrameSavedPosition) {
                 p.setWindowLocation(windowFrameRef, this.getLocation());

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -841,8 +841,6 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      */
     @Override
     public void dispose() {
-        if (!jmri.util.ThreadingUtil.isGUIThread()) 
-              log.error("operations while not on GUI thread", new Exception("Traceback"));
         InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(p -> {
             if (reuseFrameSavedPosition) {
                 p.setWindowLocation(windowFrameRef, this.getLocation());

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -841,12 +841,6 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      */
     @Override
     public void dispose() {
-        if (!ThreadingUtil.isGUIThread()){
-            // recursive call to dispose, but put it on the GUI thread
-            ThreadingUtil.runOnGUI( () -> { dispose(); } );
-            // and then return.
-            return;
-        }
         InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(p -> {
             if (reuseFrameSavedPosition) {
                 p.setWindowLocation(windowFrameRef, this.getLocation());

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -841,6 +841,8 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      */
     @Override
     public void dispose() {
+        if (!jmri.util.ThreadingUtil.isGUIThread()) 
+              log.error("operations while not on GUI thread", new Exception("Traceback"));
         InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(p -> {
             if (reuseFrameSavedPosition) {
                 p.setWindowLocation(windowFrameRef, this.getLocation());


### PR DESCRIPTION
As discussed in #3986 ( and per https://ant.apache.org/manual/Tasks/junit.html )

This probably sets the memory limit higher than necessary.