### PR TITLE
Delay initialization of the UserPreferencesManager.

### DIFF
--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -32,20 +32,26 @@ import org.slf4j.LoggerFactory;
  * {@link InstanceManager#getNullableDefault} method instead.
  * <p>
  * Multiple items can be held, and are retrieved as a list with
- * {@link    InstanceManager#getList}.
+ * {@link InstanceManager#getList}.
  * <p>
  * If a specific item is needed, e.g. one that has been constructed via a
  * complex process during startup, it should be installed with
  * {@link InstanceManager#store}.
  * <p>
- * If it's OK for the InstanceManager to create an object on first request, have
- * that object's class implement the {@link InstanceManagerAutoDefault} flag
- * interface. The InstanceManager will then construct a default object via the
- * no-argument constructor when one is first requested.
+ * If it is desirable for the InstanceManager to create an object on first
+ * request, have that object's class implement the
+ * {@link InstanceManagerAutoDefault} flag interface. The InstanceManager will
+ * then construct a default object via the no-argument constructor when one is
+ * first requested.
  * <p>
  * For initialization of more complex default objects, see the
  * {@link InstanceInitializer} mechanism and its default implementation in
  * {@link jmri.managers.DefaultInstanceInitializer}.
+ * <p>
+ * Implement the {@link InstanceManagerAutoInitialize} interface when default
+ * objects need to be initialized after the default instance has been
+ * constructed and registered with the InstanceManager. This will allow
+ * references to the default instance during initialization to work as expected.
  * <hr>
  * This file is part of JMRI.
  * <P>
@@ -218,6 +224,7 @@ public final class InstanceManager {
                 try {
                     T obj = (T) type.getConstructor((Class[]) null).newInstance((Object[]) null);
                     l.add(obj);
+                    // obj has been added, now initialize it if needed
                     if (obj instanceof InstanceManagerAutoInitialize) {
                         ((InstanceManagerAutoInitialize) obj).initialize();
                     }
@@ -236,6 +243,7 @@ public final class InstanceManager {
                     T obj = (T) getDefault().initializers.get(type).getDefault(type);
                     log.debug("      initializer created default of {}", type.getName());
                     l.add(obj);
+                    // obj has been added, now initialize it if needed
                     if (obj instanceof InstanceManagerAutoInitialize) {
                         ((InstanceManagerAutoInitialize) obj).initialize();
                     }

--- a/java/src/jmri/managers/JmriUserPreferencesManager.java
+++ b/java/src/jmri/managers/JmriUserPreferencesManager.java
@@ -25,6 +25,7 @@ import javax.swing.SortOrder;
 import jmri.ConfigureManager;
 import jmri.InstanceInitializer;
 import jmri.InstanceManager;
+import jmri.InstanceManagerAutoInitialize;
 import jmri.JmriException;
 import jmri.UserPreferencesManager;
 import jmri.beans.Bean;
@@ -57,7 +58,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Randall Wood (C) 2016
  */
-public class JmriUserPreferencesManager extends Bean implements UserPreferencesManager {
+public class JmriUserPreferencesManager extends Bean implements UserPreferencesManager, InstanceManagerAutoInitialize {
 
     public final static String SAVE_ALLOWED = "saveAllowed";
 
@@ -1218,6 +1219,11 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
         });
     }
 
+    @Override
+    public void initialize() {
+        this.readUserPreferences();
+    }
+
     /**
      * Holds details about the specific class.
      */
@@ -1449,9 +1455,7 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
         @Override
         public <T> Object getDefault(Class<T> type) throws IllegalArgumentException {
             if (type.equals(UserPreferencesManager.class)) {
-                JmriUserPreferencesManager instance = new JmriUserPreferencesManager();
-                instance.readUserPreferences();
-                return instance;
+                return new JmriUserPreferencesManager();
             }
             return super.getDefault(type);
         }


### PR DESCRIPTION
Allow the InstanceManager to initialize the default instance of the UserPreferencesManager after it has created the default instance.

Fixes #3999.

The problem here was that, in the absence of per-profile/per-computer stored user preferences, and in the presence of the older-style per-profile/all-computers stored user preferences, creating and initializing the default instance before registering it was causing the infinite looping. The solution was to implement the InstanceManagerAutoInitialize interface for JmriUserPreferencesManager and to move its initialization into the initialize method(). This allows the InstanceManager to register and create the default and then initialize it.