### PR TITLE
Prevent NPE getting selected item.

### DIFF
--- a/java/src/jmri/jmrit/roster/swing/RosterGroupComboBox.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterGroupComboBox.java
@@ -142,6 +142,7 @@ public class RosterGroupComboBox extends JComboBox<String> implements RosterGrou
 
     @Override
     public String getSelectedItem() {
-        return super.getSelectedItem().toString();
+        Object item = super.getSelectedItem();
+        return item != null ? item.toString() : null;
     }
 }


### PR DESCRIPTION
A recent change to prevent the need to cast the result of getSelectedItem introduced a potential NPE. This fixes that.