### PR TITLE
Tests for Issue 3995

### DIFF
--- a/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
@@ -97,6 +97,19 @@ public class LnOpsModeProgrammerTest extends TestCase {
         Assert.assertEquals(0x01, m.getElement(14));
     }
     
+     public void testSOps16001Read() throws ProgrammerException {
+        LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(sm, memo, 16001, true);
+        
+        lnopsmodeprogrammer.readCV("2",pl);
+        
+        // should have written and not returned
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+
+        Assert.assertEquals("message", "[EF 0E 7C 2F 00 7D 01 00 00 01 00 7F 7F 00]", lnis.outbound.toString());
+                
+     }
+
       public void testSv1Write() throws ProgrammerException {
         LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(sm, memo, 1, true);
         

--- a/java/test/jmri/jmrix/loconet/locomon/LlnmonTest.java
+++ b/java/test/jmri/jmrix/loconet/locomon/LlnmonTest.java
@@ -1446,6 +1446,11 @@ public class LlnmonTest extends TestCase {
         assertEquals("OpsModeProg test 3", "Byte Read on Main Track (Ops Mode): Decoder address 5155: CV18.\n",
                 f.displayMessage(l));
 
+        l = new LocoNetMessage(new int[] {0xEf, 0x0E, 0x7c, 0x2F, 0, 0x7D, 0x01, 0x00, 0x02, 0x01, 0x7F, 0x7F, 0x7F, 0x4D}); //!!
+        assertEquals("Bit mode direct read test 16001",
+                "Programming Track Request: Read Byte in OP's Mode variable  CV2 of Loco 16001 value 255 (0xff, 11111111).\n",
+                f.displayMessage(l));
+
         l = new LocoNetMessage(new int[] {0xB4, 0x6F, 0x7F, 0x5B});
         assertEquals("OpsModeProg test 4",
                 "LONG_ACK: Function not implemented, no reply will follow.\n",


### PR DESCRIPTION
Add two tests for LocoNet ops mode access to address 16001, see Issue #3995.

One is not passing (but will when the presentation error highlighted in #3995 is fixed), so this is originally marked WIP.