### PR TITLE
Normalize NamedBeans user names

### DIFF
--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -83,6 +83,13 @@ public interface NamedBean {
     @CheckForNull
     public String getUserName();
 
+    /**
+     * Set the user name, normalizing it if needed.
+     *
+     * @param s the new user name
+     * @throws jmri.NamedBean.BadUserNameException if the user name can not be
+     *                                             normalized
+     */
     public void setUserName(@CheckForNull String s) throws BadUserNameException;
 
     /**
@@ -320,7 +327,8 @@ public interface NamedBean {
      * @param inputName User name to be normalized
      * @throws BadUserNameException If the inputName can't be converted to
      *                              normalized form
-     * @return A user name in standard normalized form
+     * @return A user name in standard normalized form or null if inputName was
+     *         null
      */
     @CheckReturnValue
     @CheckForNull

--- a/java/src/jmri/implementation/AbstractIdTag.java
+++ b/java/src/jmri/implementation/AbstractIdTag.java
@@ -59,7 +59,8 @@ public abstract class AbstractIdTag extends AbstractNamedBean implements IdTag {
 
     @Override
     public String toString() {
-        return (mUserName == null || mUserName.length() == 0) ? getTagID() : mUserName;
+        String userName = getUserName();
+        return (userName == null || userName.isEmpty()) ? getTagID() : userName;
     }
 
     @Override

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -37,7 +37,7 @@ public abstract class AbstractNamedBean implements NamedBean {
      *                                               normalized
      * @throws jmri.NamedBean.BadSystemNameException if the system name is null
      */
-    protected AbstractNamedBean(@Nonnull String sys, @Nullable String user) throws NamedBean.BadUserNameException {
+    protected AbstractNamedBean(@Nonnull String sys, @Nullable String user) throws NamedBean.BadUserNameException, NamedBean.BadSystemNameException {
         if (sys == null) {
             throw new NamedBean.BadSystemNameException();
         }

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -5,6 +5,8 @@ import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
 import java.util.HashMap;
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.OverridingMethodsMustInvokeSuper;
 import jmri.NamedBean;
 
@@ -18,21 +20,27 @@ import jmri.NamedBean;
 public abstract class AbstractNamedBean implements NamedBean {
 
     /**
-     * simple constructor
+     * Simple constructor.
      *
-     * @param sys the system name for this bean
+     * @param sys the system name for this bean; must not be null
      */
-    protected AbstractNamedBean(String sys) {
+    protected AbstractNamedBean(@Nonnull String sys) {
         this(sys, null);
     }
 
     /**
-     * designated constructor
+     * Designated constructor.
      *
-     * @param sys  the system name for this bean
-     * @param user the user name for this bean
+     * @param sys  the system name for this bean; must not be null
+     * @param user the user name for this bean; can be null
+     * @throws jmri.NamedBean.BadUserNameException   if the user name cannot be
+     *                                               normalized
+     * @throws jmri.NamedBean.BadSystemNameException if the system name is null
      */
-    protected AbstractNamedBean(String sys, String user) throws NamedBean.BadUserNameException {
+    protected AbstractNamedBean(@Nonnull String sys, @Nullable String user) throws NamedBean.BadUserNameException {
+        if (sys == null) {
+            throw new NamedBean.BadSystemNameException();
+        }
         mSystemName = sys;
         // normalize the user name or refuse construction if unable to
         AbstractNamedBean.this.setUserName(user);
@@ -274,26 +282,28 @@ public abstract class AbstractNamedBean implements NamedBean {
     }
 
     /**
-     * compare for equality
-     * @param o the object to compare us to
-     * @return true if we are equal to the object
+     * {@inheritDoc}
+     * <p>
+     * This implementation tests that the results of
+     * {@link jmri.NamedBean#getSystemName()} and
+     * {@link jmri.NamedBean#getUserName()} are equal for this and obj.
+     *
+     * @param obj the reference object with which to compare.
+     * @return {@code true} if this object is the same as the obj argument;
+     *         {@code false} otherwise.
      */
     @Override
-    public boolean equals(Object o) {
-        boolean result = super.equals(o);
-        if (!result && (o != null) && o instanceof AbstractNamedBean) {
-            AbstractNamedBean b = (AbstractNamedBean) o;
-            if (this == b) {
-                result = true;
-            } else {
-                String bSystemName = b.getSystemName();
-                if ((mSystemName != null) && (bSystemName != null)
-                        && mSystemName.equals(bSystemName)) {
-                    String bUserName = b.getUserName();
-                    if ((mUserName != null) && (bUserName != null)
-                            && mUserName.equals(bUserName)) {
-                        result = true;
-                    }
+    public boolean equals(Object obj) {
+        // test the obj == this
+        boolean result = super.equals(obj);
+
+        if (!result && (obj != null) && obj instanceof AbstractNamedBean) {
+            AbstractNamedBean b = (AbstractNamedBean) obj;
+            if (this.getSystemName().equals(b.getSystemName())) {
+                String bUserName = b.getUserName();
+                if ((mUserName != null) && (bUserName != null)
+                        && mUserName.equals(bUserName)) {
+                    result = true;
                 }
             }
         }
@@ -302,6 +312,7 @@ public abstract class AbstractNamedBean implements NamedBean {
 
     /**
      * calculate our hash code
+     *
      * @return our hash code
      */
     @Override

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -19,6 +19,12 @@ import jmri.NamedBean;
  */
 public abstract class AbstractNamedBean implements NamedBean {
 
+    // force changes through setUserName() to ensure rules are applied
+    // as a side effect require reads through getUserName()
+    private String mUserName;
+    // final so does not need to be private to protect against changes
+    protected final String mSystemName;
+
     /**
      * Simple constructor.
      *
@@ -43,6 +49,8 @@ public abstract class AbstractNamedBean implements NamedBean {
         }
         mSystemName = sys;
         // normalize the user name or refuse construction if unable to
+        // use this form to prevent subclass from overriding setUserName
+        // during construction
         AbstractNamedBean.this.setUserName(user);
     }
 
@@ -206,9 +214,6 @@ public abstract class AbstractNamedBean implements NamedBean {
         mUserName = NamedBean.normalizeUserName(s);
         firePropertyChange("UserName", old, mUserName);
     }
-
-    protected String mUserName = null;
-    protected String mSystemName = null;
 
     @OverridingMethodsMustInvokeSuper
     protected void firePropertyChange(String p, Object old, Object n) {

--- a/java/src/jmri/implementation/DefaultIdTag.java
+++ b/java/src/jmri/implementation/DefaultIdTag.java
@@ -84,9 +84,9 @@ public class DefaultIdTag extends AbstractIdTag {
         Element e = new Element("idtag"); //NOI18N
         // e.setAttribute("systemName", this.mSystemName); // not needed from 2.11.1
         e.addContent(new Element("systemName").addContent(this.mSystemName)); //NOI18N
-        if (this.mUserName != null && this.mUserName.length() > 0) {
-            // e.setAttribute("userName", this.mUserName); // not needed from 2.11.1
-            e.addContent(new Element("userName").addContent(this.mUserName)); //NOI18N
+        if (this.getUserName() != null && this.getUserName().length() > 0) {
+            // e.setAttribute("userName", this.getUserName()); // not needed from 2.11.1
+            e.addContent(new Element("userName").addContent(this.getUserName())); //NOI18N
         }
         if (this.getComment() != null && this.getComment().length() > 0) {
             e.addContent(new Element("comment").addContent(this.getComment())); //NOI18N

--- a/java/src/jmri/implementation/DefaultSignalGroup.java
+++ b/java/src/jmri/implementation/DefaultSignalGroup.java
@@ -14,7 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A Conditional type to provide Signal Groups (n Signal Heads w/Conditionals for a main Mast).
+ * A Conditional type to provide Signal Groups (n Signal Heads w/Conditionals
+ * for a main Mast).
  *
  * @see jmri.SignalGroup SignalGroup
  * @author Pete Cressman Copyright (C) 2009
@@ -26,7 +27,7 @@ public class DefaultSignalGroup extends AbstractNamedBean implements jmri.Signal
      * Constructor for SignalGroup instance.
      *
      * @param systemName suggested system name
-     * @param userName provided user name
+     * @param userName   provided user name
      */
     public DefaultSignalGroup(String systemName, String userName) {
         super(systemName, userName);
@@ -83,7 +84,7 @@ public class DefaultSignalGroup extends AbstractNamedBean implements jmri.Signal
             getSignalMast().removePropertyChangeListener(mSignalMastListener);
         }
         _signalMast = InstanceManager.getDefault(NamedBeanHandleManager.class)
-                        .getNamedBeanHandle(mastName, signalMast);
+                .getNamedBeanHandle(mastName, signalMast);
         getSignalMast().addPropertyChangeListener(mSignalMastListener = new java.beans.PropertyChangeListener() {
             @Override
             public void propertyChange(java.beans.PropertyChangeEvent e) {
@@ -173,14 +174,14 @@ public class DefaultSignalGroup extends AbstractNamedBean implements jmri.Signal
             log.warn("did not find a SignalHead named " + pName);
         } else {
             addSignalHead(InstanceManager.getDefault(NamedBeanHandleManager.class)
-                            .getNamedBeanHandle(pName, mHead));
+                    .getNamedBeanHandle(pName, mHead));
         }
     }
 
     @Override
     public void addSignalHead(SignalHead signalHead) {
-        addSignalHead(InstanceManager.getDefault(NamedBeanHandleManager.class) 
-                        .getNamedBeanHandle(signalHead.getDisplayName(), signalHead));
+        addSignalHead(InstanceManager.getDefault(NamedBeanHandleManager.class)
+                .getNamedBeanHandle(signalHead.getDisplayName(), signalHead));
     }
 
     protected PropertyChangeListener mSignalMastListener = null;
@@ -531,8 +532,9 @@ public class DefaultSignalGroup extends AbstractNamedBean implements jmri.Signal
 
         /**
          * Set whether the sensors and turnouts should be treated as separate
-         * calculations (OR) or as one (AND), when determining if the Signal Head in this item
-         * should be On or Off.
+         * calculations (OR) or as one (AND), when determining if the Signal
+         * Head in this item should be On or Off.
+         *
          * @param boo Provide true for AND, false for OR
          */
         public void setSensorTurnoutOper(boolean boo) {
@@ -748,39 +750,6 @@ public class DefaultSignalGroup extends AbstractNamedBean implements jmri.Signal
     public void setState(int state) {
 
     }
-
-    /**
-     * Number of current listeners. May return -1 if the information is not
-     * available for some reason.
-     */
-    @Override
-    public synchronized int getNumPropertyChangeListeners() {
-        return pcs.getPropertyChangeListeners().length;
-    }
-
-    @Override
-    public synchronized java.beans.PropertyChangeListener[] getPropertyChangeListeners() {
-        return pcs.getPropertyChangeListeners();
-    }
-
-    @Override
-    protected void firePropertyChange(String p, Object old, Object n) {
-        if (pcs != null) {
-            pcs.firePropertyChange(p, old, n);
-        }
-    }
-
-    @Override
-    public synchronized void addPropertyChangeListener(java.beans.PropertyChangeListener l) {
-        pcs.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public synchronized void removePropertyChangeListener(java.beans.PropertyChangeListener l) {
-        pcs.removePropertyChangeListener(l);
-    }
-
-    java.beans.PropertyChangeSupport pcs = new java.beans.PropertyChangeSupport(this);
 
     private final static Logger log = LoggerFactory.getLogger(DefaultSignalGroup.class.getName());
 }

--- a/java/src/jmri/implementation/DefaultSignalMastLogic.java
+++ b/java/src/jmri/implementation/DefaultSignalMastLogic.java
@@ -1227,40 +1227,6 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
             firePropertyChange("turnouts", null, this.destination);
         }
 
-        /*void setTurnoutThroats(Hashtable<Turnout, Boolean> turnouts){
-         if(this.turnoutThroats!=null){
-         Enumeration<Turnout> keys = this.turnouts.keys();
-         while ( keys.hasMoreElements() )
-         {
-         Turnout key = keys.nextElement();
-         key.removePropertyChangeListener(propertyTurnoutListener);
-         }
-         }
-         destMastInit = false;
-         if(turnouts==null){
-         this.turnoutThroats = new Hashtable<Turnout, Boolean>(0);
-         } else {
-         this.turnoutThroats=turnouts;
-         }
-         firePropertyChange("turnouts", null, this.destination);
-         }*/
- /*void setAutoTurnoutThroats(Hashtable<Turnout, Boolean> turnouts){
-         if(this.turnoutThroats!=null){
-         Enumeration<Turnout> keys = this.turnouts.keys();
-         while ( keys.hasMoreElements() )
-         {
-         Turnout key = keys.nextElement();
-         key.removePropertyChangeListener(propertyTurnoutListener);
-         }
-         }
-         destMastInit = false;
-         if(turnouts==null){
-         this.autoTurnoutThroats = new Hashtable<Turnout, Boolean>(0);
-         } else {
-         this.autoTurnoutThroats=turnouts;
-         }
-         firePropertyChange("turnouts", null, this.destination);
-         }*/
         void setAutoTurnouts(Hashtable<Turnout, Integer> turnouts) {
             log.debug("{} called setAutoTurnouts with {}", destination.getDisplayName(), (turnouts != null ? "" + turnouts.size() + " turnouts in hash table" : "null hash table reference"));
             if (this.autoTurnouts != null) {
@@ -1747,8 +1713,7 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
         /**
          * Check the details of this source-destination signal mast logic pair.
          * Steps through every sensor, turnout etc. before setting the SML
-         * Aspect on the source mast via
-         * {
+         * Aspect on the source mast via {
          *
          * @see #setSignalAppearance } and {
          * @see #setMastAppearance }

--- a/java/src/jmri/implementation/DefaultSignalMastLogic.java
+++ b/java/src/jmri/implementation/DefaultSignalMastLogic.java
@@ -71,7 +71,6 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
     }
 
     // Most of the following methods will inherit Javadoc from jmri.SignalMastLogic.java
-
     @Override
     public void setFacingBlock(LayoutBlock facing) {
         facingBlock = facing;
@@ -797,8 +796,7 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
     }
 
     /**
-     * Evaluate the destination signal mast Aspect and set ours
-     * accordingly.
+     * Evaluate the destination signal mast Aspect and set ours accordingly.
      */
     void setMastAppearance() {
         synchronized (this) {
@@ -1032,7 +1030,8 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
     }
 
     /**
-     * Class to store SML properties for a destination mast paired with this source mast.
+     * Class to store SML properties for a destination mast paired with this
+     * source mast.
      */
     private class DestinationMast {
 
@@ -1245,7 +1244,7 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
          }
          firePropertyChange("turnouts", null, this.destination);
          }*/
-        /*void setAutoTurnoutThroats(Hashtable<Turnout, Boolean> turnouts){
+ /*void setAutoTurnoutThroats(Hashtable<Turnout, Boolean> turnouts){
          if(this.turnoutThroats!=null){
          Enumeration<Turnout> keys = this.turnouts.keys();
          while ( keys.hasMoreElements() )
@@ -1262,7 +1261,6 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
          }
          firePropertyChange("turnouts", null, this.destination);
          }*/
-
         void setAutoTurnouts(Hashtable<Turnout, Integer> turnouts) {
             log.debug("{} called setAutoTurnouts with {}", destination.getDisplayName(), (turnouts != null ? "" + turnouts.size() + " turnouts in hash table" : "null hash table reference"));
             if (this.autoTurnouts != null) {
@@ -1360,7 +1358,8 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
         /**
          *
          * @param newAutoMasts Hashtable of signal masts and set to Aspects
-         * @param overwrite When true, replace an existing autoMasts list in the SML
+         * @param overwrite    When true, replace an existing autoMasts list in
+         *                     the SML
          */
         void setAutoMasts(Hashtable<SignalMast, String> newAutoMasts, boolean overwrite) {
             if (log.isDebugEnabled()) {
@@ -1695,7 +1694,6 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
         }
 
         // the following 2 methods are not supplied in the implementation
-
         boolean inWait = false;
 
         /*
@@ -1748,8 +1746,12 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
 
         /**
          * Check the details of this source-destination signal mast logic pair.
-         * Steps through every sensor, turnout etc. before setting the SML Aspect on the source mast via
-         * {@see #setSignalAppearance } and {@see #setMastAppearance }
+         * Steps through every sensor, turnout etc. before setting the SML
+         * Aspect on the source mast via
+         * {
+         *
+         * @see #setSignalAppearance } and {
+         * @see #setMastAppearance }
          */
         void checkStateDetails() {
             turnoutThrown = false;
@@ -1921,8 +1923,8 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
         }
 
         /**
-         * Set up this source-destination signal mast logic pair.
-         * Steps through every list defined on the source mast.
+         * Set up this source-destination signal mast logic pair. Steps through
+         * every list defined on the source mast.
          */
         void initialise() {
             if ((destMastInit) || (disposed)) {
@@ -2237,7 +2239,8 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
         }
 
         /**
-         * From a list of Layout Blocks search for included Turnouts and their set to state
+         * From a list of Layout Blocks search for included Turnouts and their
+         * set to state
          *
          * @param lblks List of Layout Blocks
          * @return a list of block - turnout state pairs
@@ -2328,11 +2331,13 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
 
         /**
          * Generate auto signalmast for a given SML. Looks through all the other
-         * logics to see if there are any blocks that are in common and thus will
-         * add the other signal mast protecting that block.
+         * logics to see if there are any blocks that are in common and thus
+         * will add the other signal mast protecting that block.
          *
-         * @param sml       The Signal Mast Logic for which to set up autoSignalMasts
-         * @param overwrite When true, replace an existing autoMasts list in the SML
+         * @param sml       The Signal Mast Logic for which to set up
+         *                  autoSignalMasts
+         * @param overwrite When true, replace an existing autoMasts list in the
+         *                  SML
          */
         void setupAutoSignalMast(jmri.SignalMastLogic sml, boolean overwrite) {
             if (!allowAutoSignalMastGeneration) {
@@ -2376,7 +2381,8 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
         }
 
         /**
-         * Add a certain Signal Mast to the list of AutoSignalMasts for this SML.
+         * Add a certain Signal Mast to the list of AutoSignalMasts for this
+         * SML.
          *
          * @param mast The Signal Mast to be added
          */
@@ -2397,7 +2403,8 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
         }
 
         /**
-         * Remove a certain Signal Mast from the list of AutoSignalMasts for this SML.
+         * Remove a certain Signal Mast from the list of AutoSignalMasts for
+         * this SML.
          *
          * @param mast The Signal Mast to be removed
          */
@@ -2435,8 +2442,8 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
         }
 
         /**
-         * Remove references from this Destination Mast and clear lists,
-         * so that it can eventually be garbage-collected.
+         * Remove references from this Destination Mast and clear lists, so that
+         * it can eventually be garbage-collected.
          */
         void dispose() {
             if (thr != null) {
@@ -2795,28 +2802,6 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
         }
     };
 
-    java.beans.PropertyChangeSupport pcs = new java.beans.PropertyChangeSupport(this);
-
-    @Override
-    public synchronized void addPropertyChangeListener(java.beans.PropertyChangeListener l) {
-        pcs.addPropertyChangeListener(l);
-    }
-
-    @Override
-    public synchronized void removePropertyChangeListener(java.beans.PropertyChangeListener l) {
-        pcs.removePropertyChangeListener(l);
-    }
-
-    @Override
-    public synchronized int getNumPropertyChangeListeners() {
-        return pcs.getPropertyChangeListeners().length;
-    }
-
-    protected void firePropertyChange(String p, Object old, Object n) {
-        pcs.firePropertyChange(p, old, n);
-    }
-
-
     //@todo need to think how we deal with auto generated lists based upon the layout editor.
     @Override
     public void vetoableChange(java.beans.PropertyChangeEvent evt) throws java.beans.PropertyVetoException {
@@ -2924,8 +2909,12 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
      *
      * @return Always zero
      */
-    public int getState() { return 0; }
-    public void setState(int i) { }
+    public int getState() {
+        return 0;
+    }
+
+    public void setState(int i) {
+    }
 
     private final static Logger log = LoggerFactory.getLogger(DefaultSignalMastLogic.class.getName());
 }

--- a/java/src/jmri/jmrit/catalog/AbstractCatalogTree.java
+++ b/java/src/jmri/jmrit/catalog/AbstractCatalogTree.java
@@ -8,6 +8,7 @@ import java.util.Hashtable;
 import javax.annotation.CheckReturnValue;
 import javax.swing.tree.DefaultTreeModel;
 import jmri.CatalogTree;
+import jmri.NamedBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,8 +227,8 @@ public abstract class AbstractCatalogTree extends DefaultTreeModel implements Ca
     @Override
     public void setUserName(String s) {
         String old = mUserName;
-        mUserName = s;
-        firePropertyChange("UserName", old, s);
+        mUserName = NamedBean.normalizeUserName(s);
+        firePropertyChange("UserName", old, mUserName);
     }
 
     protected void firePropertyChange(String p, Object old, Object n) {
@@ -249,9 +250,12 @@ public abstract class AbstractCatalogTree extends DefaultTreeModel implements Ca
     @CheckReturnValue
     public String describeState(int state) {
         switch (state) {
-            case UNKNOWN: return Bundle.getMessage("BeanStateUnknowng");
-            case INCONSISTENT: return Bundle.getMessage("BeanStateInconsistent");
-            default: return Bundle.getMessage("BeanStateUnexpected", state);
+            case UNKNOWN:
+                return Bundle.getMessage("BeanStateUnknowng");
+            case INCONSISTENT:
+                return Bundle.getMessage("BeanStateInconsistent");
+            default:
+                return Bundle.getMessage("BeanStateUnexpected", state);
         }
     }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -3131,12 +3131,9 @@ public class LayoutBlock extends AbstractNamedBean implements java.beans.Propert
     @Override
     public synchronized void addPropertyChangeListener(java.beans.PropertyChangeListener l) {
         if (l == this) {
-            if (enableAddRouteLogging) {
-                log.info("adding ourselves as a listener for some strange reason! Skipping");
-            }
+            log.debug("adding ourselves as a listener for some strange reason! Skipping");
             return;
         }
-
         super.addPropertyChangeListener(l);
     }
 

--- a/java/src/jmri/jmrit/signalling/entryexit/DestinationPoints.java
+++ b/java/src/jmri/jmrit/signalling/entryexit/DestinationPoints.java
@@ -42,10 +42,9 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
     int entryExitType = EntryExitPairs.SETUPTURNOUTSONLY;//SETUPSIGNALMASTLOGIC;
     boolean enabled = true;
     boolean activeEntryExit = false;
-    ArrayList<LayoutBlock> routeDetails = new ArrayList<LayoutBlock>();
+    ArrayList<LayoutBlock> routeDetails = new ArrayList<>();
     LayoutBlock destination;
     boolean disposed = false;
-    String uniqueId = null;
 
     transient EntryExitPairs manager = jmri.InstanceManager.getDefault(jmri.jmrit.signalling.EntryExitPairs.class);
 
@@ -66,15 +65,9 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
     transient Source src = null;
 
     DestinationPoints(PointDetails point, String id, Source src) {
-        super(id);
+        super(id != null ? id : UUID.randomUUID().toString());
         this.src = src;
         this.point = point;
-        if (id == null) {
-            uniqueId = UUID.randomUUID().toString();
-            mSystemName = uniqueId;
-        } else {
-            uniqueId = id;
-        }
         mUserName = (src.getPoint().getDisplayName() + " to " + this.point.getDisplayName());
 
         propertyBlockListener = new PropertyChangeListener() {
@@ -91,7 +84,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
     }
 
     String getUniqueId() {
-        return uniqueId;
+        return getSystemName();
     }
 
     public PointDetails getDestPoint() {
@@ -167,7 +160,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
 
             if (now == Block.OCCUPIED) {
                 LayoutBlock lBlock = InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class).getLayoutBlock(blk);
-                //If the block was previously active or inactive then we will 
+                //If the block was previously active or inactive then we will
                 //reset the useExtraColor, but not if it was previously unknown or inconsistent.
                 lBlock.setUseExtraColor(false);
                 blk.removePropertyChangeListener(propertyBlockListener); //was this
@@ -941,7 +934,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
                 for (LayoutBlock srcProLBlock : src.getSourceProtecting()) {
                     protectLBlock = srcProLBlock;
                     if (!reverseDirection) {
-                        //We have a problem, the destination point is already setup with a route, therefore we would need to 
+                        //We have a problem, the destination point is already setup with a route, therefore we would need to
                         //check some how that a route hasn't been set to it.
                         destinationLBlock = getFacing();
                         ArrayList<LayoutBlock> blocks = new ArrayList<LayoutBlock>();

--- a/java/src/jmri/jmrit/signalling/entryexit/DestinationPoints.java
+++ b/java/src/jmri/jmrit/signalling/entryexit/DestinationPoints.java
@@ -68,7 +68,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
         super(id != null ? id : UUID.randomUUID().toString());
         this.src = src;
         this.point = point;
-        mUserName = (src.getPoint().getDisplayName() + " to " + this.point.getDisplayName());
+        setUserName(src.getPoint().getDisplayName() + " to " + this.point.getDisplayName());
 
         propertyBlockListener = new PropertyChangeListener() {
             @Override
@@ -80,7 +80,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
 
     @Override
     public String getDisplayName() {
-        return mUserName;
+        return getUserName();
     }
 
     String getUniqueId() {
@@ -154,7 +154,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
         Block blk = (Block) e.getSource();
         if (e.getPropertyName().equals("state")) {  // NOI18N
             if (log.isDebugEnabled()) {
-                log.debug(mUserName + "  We have a change of state on the block " + blk.getDisplayName());  // NOI18N
+                log.debug(getUserName() + "  We have a change of state on the block " + blk.getDisplayName());  // NOI18N
             }
             int now = ((Integer) e.getNewValue()).intValue();
 
@@ -752,15 +752,15 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
         if (cancelClear == EntryExitPairs.CLEARROUTE) {
             if (routeDetails.size() == 0) {
                 if (log.isDebugEnabled()) {
-                    log.debug(mUserName + "  all blocks have automatically been cleared down");  // NOI18N
+                    log.debug(getUserName() + "  all blocks have automatically been cleared down");  // NOI18N
                 }
             } else {
                 if (log.isDebugEnabled()) {
-                    log.debug(mUserName + "  No blocks were cleared down " + routeDetails.size());  // NOI18N
+                    log.debug(getUserName() + "  No blocks were cleared down " + routeDetails.size());  // NOI18N
                 }
                 try {
                     if (log.isDebugEnabled()) {
-                        log.debug(mUserName + "  set first block as active so that we can manually clear this down " + routeDetails.get(0).getBlock().getUserName());  // NOI18N
+                        log.debug(getUserName() + "  set first block as active so that we can manually clear this down " + routeDetails.get(0).getBlock().getUserName());  // NOI18N
                     }
                     if (routeDetails.get(0).getOccupancySensor() != null) {
                         routeDetails.get(0).getOccupancySensor().setState(Sensor.ACTIVE);
@@ -779,7 +779,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
                     log.error("error in clear route A " + e);  // NOI18N
                 }
                 if (log.isDebugEnabled()) {
-                    log.debug(mUserName + "  Going to clear routeDetails down " + routeDetails.size());  // NOI18N
+                    log.debug(getUserName() + "  Going to clear routeDetails down " + routeDetails.size());  // NOI18N
                     for (int i = 0; i < routeDetails.size(); i++) {
                         log.debug("Block at " + i + " " + routeDetails.get(i).getDisplayName());
                     }
@@ -789,7 +789,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
                     //Should we just be usrc.pdating the block status and not the sensor
                     for (int i = 1; i < routeDetails.size() - 1; i++) {
                         if (log.isDebugEnabled()) {
-                            log.debug(mUserName + " in loop Set active " + routeDetails.get(i).getDisplayName() + " " + routeDetails.get(i).getBlock().getSystemName());  // NOI18N
+                            log.debug(getUserName() + " in loop Set active " + routeDetails.get(i).getDisplayName() + " " + routeDetails.get(i).getBlock().getSystemName());  // NOI18N
                         }
                         try {
                             if (routeDetails.get(i).getOccupancySensor() != null) {
@@ -799,7 +799,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
                             }
 
                             if (log.isDebugEnabled()) {
-                                log.debug(mUserName + " in loop Set inactive " + routeDetails.get(i - 1).getDisplayName() + " " + routeDetails.get(i - 1).getBlock().getSystemName());  // NOI18N
+                                log.debug(getUserName() + " in loop Set inactive " + routeDetails.get(i - 1).getDisplayName() + " " + routeDetails.get(i - 1).getBlock().getSystemName());  // NOI18N
                             }
                             if (routeDetails.get(i - 1).getOccupancySensor() != null) {
                                 routeDetails.get(i - 1).getOccupancySensor().setState(Sensor.INACTIVE);
@@ -815,7 +815,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
                     }
                     try {
                         if (log.isDebugEnabled()) {
-                            log.debug(mUserName + " out of loop Set active " + routeDetails.get(routeDetails.size() - 1).getDisplayName() + " " + routeDetails.get(routeDetails.size() - 1).getBlock().getSystemName());  // NOI18N
+                            log.debug(getUserName() + " out of loop Set active " + routeDetails.get(routeDetails.size() - 1).getDisplayName() + " " + routeDetails.get(routeDetails.size() - 1).getBlock().getSystemName());  // NOI18N
                         }
                         //Get the last block an set it active.
                         if (routeDetails.get(routeDetails.size() - 1).getOccupancySensor() != null) {
@@ -824,7 +824,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
                             routeDetails.get(routeDetails.size() - 1).getBlock().goingActive();
                         }
                         if (log.isDebugEnabled()) {
-                            log.debug(mUserName + " out of loop Set inactive " + routeDetails.get(routeDetails.size() - 2).getUserName() + " " + routeDetails.get(routeDetails.size() - 2).getBlock().getSystemName());  // NOI18N
+                            log.debug(getUserName() + " out of loop Set inactive " + routeDetails.get(routeDetails.size() - 2).getUserName() + " " + routeDetails.get(routeDetails.size() - 2).getBlock().getSystemName());  // NOI18N
                         }
                         if (routeDetails.get(routeDetails.size() - 2).getOccupancySensor() != null) {
                             routeDetails.get(routeDetails.size() - 2).getOccupancySensor().setState(Sensor.INACTIVE);
@@ -867,18 +867,18 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
 
     synchronized void activeBean(boolean reverseDirection, boolean showMessage) {
         if (activeEntryExit) {
-            // log.debug(mUserName + "  Our route is active so this would go for a clear down but we need to check that the we can clear it down" + activeEndPoint);
+            // log.debug(getUserName() + "  Our route is active so this would go for a clear down but we need to check that the we can clear it down" + activeEndPoint);
             if (!isEnabled()) {
                 log.debug("A disabled entry exit has been called will bomb out");  // NOI18N
                 return;
             }
-            log.debug(mUserName + "  We have a valid match on our end point so we can clear down");  // NOI18N
+            log.debug(getUserName() + "  We have a valid match on our end point so we can clear down");  // NOI18N
             //setRouteTo(false);
             //src.pd.setRouteFrom(false);
             setRoute(false);
         } else {
             if (isRouteToPointSet()) {
-                log.debug(mUserName + "  route to this point is set therefore can not set another to it " /*+ destPoint.src.getPoint().getID()*/);  // NOI18N
+                log.debug(getUserName() + "  route to this point is set therefore can not set another to it " /*+ destPoint.src.getPoint().getID()*/);  // NOI18N
                 if (showMessage && !manager.isRouteStacked(this, false)) {
                     handleNoCurrentRoute(reverseDirection, "Route already set to the destination point");  // NOI18N
                 }
@@ -1055,7 +1055,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
                     //No valid paths found so will quit
                     if (pathList.get(0).getListOfBlocks().isEmpty()) {
                         if (showMessage) {
-                            log.error(mUserName + " " + pathList.get(0).getErrorMessage());
+                            log.error(getUserName() + " " + pathList.get(0).getErrorMessage());
                             //Considered normal if not a valid through path
                             handleNoCurrentRoute(reverseDirection, pathList.get(0).getErrorMessage());
                             src.pd.setNXButtonState(EntryExitPairs.NXBUTTONINACTIVE);

--- a/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
@@ -50,11 +50,11 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
             clockSensor.setKnownState(Sensor.ACTIVE);
             clockSensor.addPropertyChangeListener(
                     new PropertyChangeListener() {
-                        @Override
-                        public void propertyChange(PropertyChangeEvent e) {
-                            clockSensorChanged();
-                        }
-                    });
+                @Override
+                public void propertyChange(PropertyChangeEvent e) {
+                    clockSensorChanged();
+                }
+            });
         } catch (jmri.JmriException e) {
             log.warn("Exception setting ISCLOCKRUNNING sensor ACTIVE: " + e);
         }
@@ -110,10 +110,9 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
      * @param i java.time.Instant
      */
     @Override
-    public void setTime(Instant i){
-       setTime(Date.from(i));
+    public void setTime(Instant i) {
+        setTime(Date.from(i));
     }
-
 
     @Override
     public void userSetTime(Date d) {
@@ -216,7 +215,7 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
 
     @Override
     public void userSetRate(double factor) {
-        // this call is used when user changes fast clock rate either in Setup Fast Clock or via a ClockControl  
+        // this call is used when user changes fast clock rate either in Setup Fast Clock or via a ClockControl
         // implementation
         if (factor < 0.1 || factor > 100) {
             log.error("rate of " + factor + " is out of reasonable range, set to 1");
@@ -481,13 +480,6 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
         return (!notInitialized);
     }
 
-    PropertyChangeSupport pcs = new PropertyChangeSupport(this);
-
-    @Override
-    protected void firePropertyChange(String p, Object old, Object n) {
-        pcs.firePropertyChange(p, old, n);
-    }
-
     /**
      * Handle a change in the clock running sensor
      */
@@ -505,26 +497,6 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
             }
             setRun(false);
         }
-    }
-
-    /**
-     * Request a call-back when the bound Rate or Run property changes.
-     * <P>
-     * Not yet implemented.
-     */
-    @Override
-    public synchronized void addPropertyChangeListener(PropertyChangeListener l) {
-        pcs.addPropertyChangeListener(l);
-    }
-
-    /**
-     * Remove a request for a call-back when a bound property changes.
-     * <P>
-     * Not yet implemented.
-     */
-    @Override
-    public synchronized void removePropertyChangeListener(PropertyChangeListener l) {
-        pcs.removePropertyChangeListener(l);
     }
 
     /**

--- a/java/src/jmri/jmrix/acela/AcelaLight.java
+++ b/java/src/jmri/jmrix/acela/AcelaLight.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * AcelaLight.java
- *
+ * <p>
  * Implementation of the Light Object for Acela
  * <P>
  * Based in part on SerialTurnout.java
@@ -24,8 +24,11 @@ public class AcelaLight extends AbstractLight {
      * Create a Light object, with only system name.
      * <P>
      * 'systemName' was previously validated in AcelaLightManager
+     *
+     * @param systemName the system name for this Light
+     * @param memo       the memo for the system connection
      */
-    public AcelaLight(String systemName,AcelaSystemConnectionMemo memo) {
+    public AcelaLight(String systemName, AcelaSystemConnectionMemo memo) {
         super(systemName);
         _memo = memo;
         initializeLight(systemName);
@@ -35,8 +38,12 @@ public class AcelaLight extends AbstractLight {
      * Create a Light object, with both system and user names.
      * <P>
      * 'systemName' was previously validated in AcelaLightManager
+     *
+     * @param systemName the system name for this Light
+     * @param userName   the user name for this Light
+     * @param memo       the memo for the system connection
      */
-    public AcelaLight(String systemName, String userName,AcelaSystemConnectionMemo memo) {
+    public AcelaLight(String systemName, String userName, AcelaSystemConnectionMemo memo) {
         super(systemName, userName);
         _memo = memo;
         initializeLight(systemName);
@@ -48,12 +55,10 @@ public class AcelaLight extends AbstractLight {
      * AbstractLight.java
      */
     private void initializeLight(String systemName) {
-        // Save system name
-        mSystemName = systemName;
         // Extract the Bit from the name
         mBit = AcelaAddress.getBitFromSystemName(systemName);
         // Set initial state
-        AcelaNode mNode = AcelaAddress.getNodeFromSystemName(mSystemName,_memo);
+        AcelaNode mNode = AcelaAddress.getNodeFromSystemName(mSystemName, _memo);
 
         if (mNode != null) {
             int initstate;
@@ -71,16 +76,7 @@ public class AcelaLight extends AbstractLight {
     /**
      * System dependent instance variables
      */
-    String mSystemName = "";     // system name 
     int mBit = -1;                // global address from 0
-
-    /**
-     * Return the current state of this Light
-     */
-    @Override
-    public int getState() {
-        return mState;
-    }
 
     /**
      * Set the current state of this Light This routine requests the hardware to
@@ -90,15 +86,19 @@ public class AcelaLight extends AbstractLight {
      */
     @Override
     public void setState(int newState) {
-        AcelaNode mNode = AcelaAddress.getNodeFromSystemName(mSystemName,_memo);
+        AcelaNode mNode = AcelaAddress.getNodeFromSystemName(mSystemName, _memo);
 
         if (mNode != null) {
-            if (newState == ON) {
-                mNode.setOutputBit(mBit, true);
-            } else if (newState == OFF) {
-                mNode.setOutputBit(mBit, false);
-            } else {
-                log.warn("illegal state requested for Light: " + getSystemName());
+            switch (newState) {
+                case ON:
+                    mNode.setOutputBit(mBit, true);
+                    break;
+                case OFF:
+                    mNode.setOutputBit(mBit, false);
+                    break;
+                default:
+                    log.warn("illegal state requested for Light: {}", getSystemName());
+                    break;
             }
         }
 
@@ -107,7 +107,7 @@ public class AcelaLight extends AbstractLight {
             mState = newState;
 
             // notify listeners, if any
-            firePropertyChange("KnownState", Integer.valueOf(oldState), Integer.valueOf(newState));
+            firePropertyChange("KnownState", oldState, newState);
         }
     }
 

--- a/java/src/jmri/jmrix/acela/AcelaTurnout.java
+++ b/java/src/jmri/jmrix/acela/AcelaTurnout.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * AcelaLight.java
- *
+ * <p>
  * Implementation of the Light Object for Acela
  * <P>
  * Based in part on SerialTurnout.java
@@ -20,12 +20,14 @@ import org.slf4j.LoggerFactory;
 public class AcelaTurnout extends AbstractTurnout {
 
     private AcelaSystemConnectionMemo _memo = null;
-    private String prefix = null;
 
     /**
      * Create a Light object, with only system name.
      * <P>
      * 'systemName' was previously validated in AcelaLightManager
+     *
+     * @param systemName the system name for this Turnout
+     * @param memo       the memo for the system connection
      */
     public AcelaTurnout(String systemName, AcelaSystemConnectionMemo memo) {
         super(systemName);
@@ -37,11 +39,14 @@ public class AcelaTurnout extends AbstractTurnout {
      * Create a Light object, with both system and user names.
      * <P>
      * 'systemName' was previously validated in AcelaLightManager
+     *
+     * @param systemName the system name for this Turnout
+     * @param userName   the user name for this Turnout
+     * @param memo       the memo for the system connection
      */
     public AcelaTurnout(String systemName, String userName, AcelaSystemConnectionMemo memo) {
         super(systemName, userName);
         _memo = memo;
-        prefix = _memo.getSystemPrefix() + "T";
         initializeTurnout(systemName);
     }
 
@@ -51,67 +56,20 @@ public class AcelaTurnout extends AbstractTurnout {
      * AbstractLight.java
      */
     private void initializeTurnout(String systemName) {
-        // Save system name
-        mSystemName = systemName;
-
         // Extract the Bit from the name
         mBit = AcelaAddress.getBitFromSystemName(systemName);
 
         // Set initial state
-//        setState( OFF );
         setState(UNKNOWN);
         // Set defaults for all other instance variables
-/*
-         setControlType( NO_CONTROL );
-         setControlSensor( null );
-         setControlSensorSense(Sensor.ACTIVE);
-         setFastClockControlSchedule( 0,0,0,0 );
-         setControlTurnout( null );
-         setControlTurnoutState( Turnout.CLOSED );
-         */
     }
 
     /**
      * System dependent instance variables
      */
-    String mSystemName = "";     // system name 
-//    protected int mState = OFF;  // current state of this light
     protected int mState = UNKNOWN;  // current state of this turnout
     int mBit = -1;                // global address from 0
 
-    /**
-     * Return the current state of this Light
-     */
-//  public int getState() { return mState; }
-    /**
-     * Set the current state of this Light This routine requests the hardware to
-     * change. If this is really a change in state of this bit (tested in
-     * AcelaNode), a Transmit packet will be sent before this Node is next
-     * polled.
-     */
-    /*
-     public void setState(int newState) {
-     AcelaNode mNode = AcelaAddress.getNodeFromSystemName(mSystemName,_memo);
-
-     if (mNode!=null) {
-     if (newState==ON) {
-     mNode.setOutputBit(mBit,true);
-     } else if (newState==OFF) {
-     mNode.setOutputBit(mBit,false);
-     } else {
-     log.warn("illegal state requested for Turnout: "+getSystemName());
-     }
-     }
- 
-     if (newState!=mState) {
-     int oldState = mState;
-     mState = newState;
-            
-     // notify listeners, if any
-     firePropertyChange("KnownState", Integer.valueOf(oldState), Integer.valueOf(newState));
-     }
-     }
-     */
     // Handle a request to change state by sending a turnout command
     @Override
     protected void forwardCommandChangeToLayout(int s) {
@@ -119,8 +77,7 @@ public class AcelaTurnout extends AbstractTurnout {
             // first look for the double case, which we can't handle
             if ((s & Turnout.THROWN) != 0) {
                 // this is the disaster case!
-                log.error("Cannot command both CLOSED and THROWN " + s);
-                return;
+                log.error("Cannot command both CLOSED and THROWN {}", s);
             } else {
                 // send a CLOSED command
                 sendMessage(true ^ getInverted());
@@ -132,22 +89,17 @@ public class AcelaTurnout extends AbstractTurnout {
     }
 
     /**
-     * Send a message to the layout to lock or unlock the turnout pushbuttons if
-     * true, pushbutton lockout enabled
+     * Send a message to the layout to lock or unlock the turnout push buttons.
+     * <p>
+     * This implementation does nothing, as Acela turnouts do not support
+     * lockout.
+     *
+     * @param pushButtonLockout true to lockout turnout push buttons; false
+     *                          otherwise
      */
     @Override
     protected void turnoutPushbuttonLockout(boolean pushButtonLockout) {
         // Acela turnouts do not currently support lockout
-/*
-         if (log.isDebugEnabled())
-         log.debug("Send command to "
-         + (pushButtonLockout ? "Lock" : "Unlock")
-         + " Pushbutton NT" + _number);
-  
-         byte[] bl = PushbuttonPacket.pushbuttonPkt(prefix, _number, pushButtonLockout);
-         AcelaMessage m = AcelaMessage.sendPacketMessage(bl);
-        _memo.getTrafficController().sendAcelaMessage(m, null);
-         */
     }
 
     // Acela turnouts do support inversion
@@ -181,17 +133,19 @@ public class AcelaTurnout extends AbstractTurnout {
             newState = adjustStateForInversion(THROWN);
         }
 
-        AcelaNode mNode = AcelaAddress.getNodeFromSystemName(mSystemName,_memo);
+        AcelaNode mNode = AcelaAddress.getNodeFromSystemName(mSystemName, _memo);
 
         if (mNode != null) {
-//            if (newState==ON) {
-            if (newState == THROWN) {
-                mNode.setOutputBit(mBit, true);
-//            } else if (newState==OFF) {
-            } else if (newState == CLOSED) {
-                mNode.setOutputBit(mBit, false);
-            } else {
-                log.warn("illegal state requested for Turnout: " + getSystemName());
+            switch (newState) {
+                case THROWN:
+                    mNode.setOutputBit(mBit, true);
+                    break;
+                case CLOSED:
+                    mNode.setOutputBit(mBit, false);
+                    break;
+                default:
+                    log.warn("illegal state requested for Turnout: {}", getSystemName());
+                    break;
             }
         }
 
@@ -200,7 +154,7 @@ public class AcelaTurnout extends AbstractTurnout {
             mState = newState;
 
             // notify listeners, if any
-            firePropertyChange("KnownState", Integer.valueOf(oldState), Integer.valueOf(newState));
+            firePropertyChange("KnownState", oldState, newState);
         }
     }
 

--- a/java/src/jmri/jmrix/dccpp/DCCppLight.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppLight.java
@@ -6,9 +6,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * DCCppLight.java
- *
- * Implementation of the Light Object for DCC++ NOTE: This is a
- * simplification of the DCCppTurnout class.
+ * <p>
+ * Implementation of the Light Object for DCC++ NOTE: This is a simplification
+ * of the DCCppTurnout class.
  * <P>
  * Based in part on SerialLight.java
  *
@@ -24,6 +24,10 @@ public class DCCppLight extends AbstractLight implements DCCppListener {
      * Create a Light object, with only system name.
      * <P>
      * 'systemName' was previously validated in DCCppLightManager
+     *
+     * @param tc         the traffic controller for the connection
+     * @param lm         the managing LightManager for this Light
+     * @param systemName the system name for this Light
      */
     public DCCppLight(DCCppTrafficController tc, DCCppLightManager lm, String systemName) {
         super(systemName);
@@ -37,6 +41,11 @@ public class DCCppLight extends AbstractLight implements DCCppListener {
      * Create a Light object, with both system and user names.
      * <P>
      * 'systemName' was previously validated in DCCppLightManager
+     *
+     * @param tc         the traffic controller for the connection
+     * @param lm         the managing LightManager for this Light
+     * @param systemName the system name for this Light
+     * @param userName   the user name for this Light
      */
     public DCCppLight(DCCppTrafficController tc, DCCppLightManager lm, String systemName, String userName) {
         super(systemName, userName);
@@ -59,8 +68,6 @@ public class DCCppLight extends AbstractLight implements DCCppListener {
      *  Initilize the light object's parameters
      */
     private synchronized void initializeLight(String systemName) {
-        // Save system name
-        mSystemName = systemName;
         // Extract the Bit from the name
         mAddress = lm.getBitFromSystemName(systemName);
         // Set initial state
@@ -78,7 +85,6 @@ public class DCCppLight extends AbstractLight implements DCCppListener {
     /**
      * System dependent instance variables
      */
-    String mSystemName = "";     // system name 
     //protected int mState = OFF;  // current state of this light
     //private int mOldState =mState; // save the old state
     int mAddress = 0;            // accessory output address
@@ -90,14 +96,6 @@ public class DCCppLight extends AbstractLight implements DCCppListener {
     //private int InternalState = IDLE;
 
     /**
-     * Return the current state of this Light
-     */
-    @Override
-    synchronized public int getState() {
-        return mState;
-    }
-
-    /**
      * Set the current state of this Light This routine requests the hardware to
      * change.
      */
@@ -105,31 +103,31 @@ public class DCCppLight extends AbstractLight implements DCCppListener {
     synchronized public void setState(int newState) {
         if (newState != ON && newState != OFF) {
             // Unsuported state
-            log.warn("Unsupported state " + newState + " requested for light " + mSystemName);
+            log.warn("Unsupported state {} requested for light {}", newState, mSystemName);
             return;
         }
 
- log.debug("Light Set State: mstate = {} newstate = {}", mState, newState);
+        log.debug("Light Set State: mstate = {} newstate = {}", mState, newState);
 
         // get the right packet
- if (mAddress > 0) {
-     boolean state = (newState == jmri.Light.ON);
-     DCCppMessage msg = DCCppMessage.makeAccessoryDecoderMsg(mAddress, state);
-     //InternalState = COMMANDSENT;
-     tc.sendDCCppMessage(msg, this);
+        if (mAddress > 0) {
+            boolean state = (newState == jmri.Light.ON);
+            DCCppMessage msg = DCCppMessage.makeAccessoryDecoderMsg(mAddress, state);
+            //InternalState = COMMANDSENT;
+            tc.sendDCCppMessage(msg, this);
 
-     if (newState != mState) {
-  int oldState = mState;
-  mState = newState;
-  // notify listeners, if any
-  firePropertyChange("KnownState", Integer.valueOf(oldState), Integer.valueOf(newState));
-     }
- }
+            if (newState != mState) {
+                int oldState = mState;
+                mState = newState;
+                // notify listeners, if any
+                firePropertyChange("KnownState", oldState, newState);
+            }
+        }
     }
 
     /*
      *  Handle an incoming message from the DCC++ Base Station
-     *  NOTE: We aren't registered as a listener, so This is only triggered 
+     *  NOTE: We aren't registered as a listener, so This is only triggered
      *  when we send out a message
      */
     @Override
@@ -137,7 +135,7 @@ public class DCCppLight extends AbstractLight implements DCCppListener {
         if (log.isDebugEnabled()) {
             log.debug("recieved message: " + l);
         }
- // We don't expect a reply, so we don't do anything with replies.
+        // We don't expect a reply, so we don't do anything with replies.
     }
 
     // listen for the messages to the LI100/LI101
@@ -155,5 +153,3 @@ public class DCCppLight extends AbstractLight implements DCCppListener {
 
     private final static Logger log = LoggerFactory.getLogger(DCCppLight.class.getName());
 }
-
-

--- a/java/src/jmri/jmrix/dccpp/DCCppLight.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppLight.java
@@ -103,7 +103,7 @@ public class DCCppLight extends AbstractLight implements DCCppListener {
     synchronized public void setState(int newState) {
         if (newState != ON && newState != OFF) {
             // Unsuported state
-            log.warn("Unsupported state {} requested for light {}", newState, mSystemName);
+            log.warn("Unsupported state {} requested for light {}", newState, getSystemName());
             return;
         }
 

--- a/java/src/jmri/jmrix/lenz/XNetLight.java
+++ b/java/src/jmri/jmrix/lenz/XNetLight.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of the Light Object for XpressNet.
+ * <p>
  * NOTE: This is a simplification of the XNetTurnout class.
  * <p>
  * Based in part on SerialLight.java
@@ -13,6 +14,7 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2008-2010
  */
 public class XNetLight extends AbstractLight implements XNetListener {
+
     private XNetTrafficController tc = null;
     private XNetLightManager lm = null;
 
@@ -20,6 +22,10 @@ public class XNetLight extends AbstractLight implements XNetListener {
      * Create a Light object, with only system name.
      * <P>
      * 'systemName' was previously validated in LnLightManager
+     *
+     * @param tc         the traffic controller for the connection
+     * @param lm         the managing LightManager for this Light
+     * @param systemName the system name for this Light
      */
     public XNetLight(XNetTrafficController tc, XNetLightManager lm, String systemName) {
         super(systemName);
@@ -33,6 +39,11 @@ public class XNetLight extends AbstractLight implements XNetListener {
      * Create a Light object, with both system and user names.
      * <p>
      * 'systemName' was previously validated in XNetLightManager
+     *
+     * @param tc         the traffic controller for the connection
+     * @param lm         the managing LightManager for this Light
+     * @param systemName the system name for this Light
+     * @param userName   the user name for this Light
      */
     public XNetLight(XNetTrafficController tc, XNetLightManager lm, String systemName, String userName) {
         super(systemName, userName);
@@ -55,8 +66,6 @@ public class XNetLight extends AbstractLight implements XNetListener {
      * Initilize the light object's parameters.
      */
     private synchronized void initializeLight(String systemName) {
-        // Save system name
-        mSystemName = systemName;
         // Extract the Bit from the name
         mAddress = lm.getBitFromSystemName(systemName);
         // Set initial state
@@ -70,14 +79,13 @@ public class XNetLight extends AbstractLight implements XNetListener {
      * instance variables to default values.
      * Note: most instance variables are in AbstractLight.java
      */
-
     /**
      * System dependent instance variables
      */
     int mAddress = 0;            // accessory output address
 
     /**
-     *  Internal State Machine states.
+     * Internal State Machine states.
      */
     static final int OFFSENT = 1;
     static final int COMMANDSENT = 2;
@@ -85,22 +93,14 @@ public class XNetLight extends AbstractLight implements XNetListener {
     private int InternalState = IDLE;
 
     /**
-     * Return the current state of this Light
-     */
-    @Override
-    synchronized public int getState() {
-        return mState;
-    }
-
-    /**
-     * Set the current state of this Light.
-     * This routine requests the hardware to change.
+     * Set the current state of this Light. This routine requests the hardware
+     * to change.
      */
     @Override
     synchronized public void setState(int newState) {
         if (newState != ON && newState != OFF) {
             // Unsuported state
-            log.warn("Unsupported state " + newState + " requested for light " + mSystemName);
+            log.warn("Unsupported state {} requested for light {}", newState, mSystemName);
             return;
         }
 
@@ -116,67 +116,61 @@ public class XNetLight extends AbstractLight implements XNetListener {
             int oldState = mState;
             mState = newState;
             // notify listeners, if any
-            firePropertyChange("KnownState", Integer.valueOf(oldState), Integer.valueOf(newState));
+            firePropertyChange("KnownState", oldState, newState);
         }
         sendOffMessage();
     }
 
     /**
-     * Handle an incoming message from the XpressNet.
-     * NOTE: We aren't registered as a listener, so This is only triggered
-     * when we send out a message
+     * Handle an incoming message from the XpressNet. NOTE: We aren't registered
+     * as a listener, so this is only triggered when we send out a message.
+     *
+     * @param l the message to handle
      */
     @Override
     synchronized public void message(XNetReply l) {
         if (log.isDebugEnabled()) {
-            log.debug("received message: " + l);
+            log.debug("received message: {}", l);
         }
         if (InternalState == OFFSENT) {
             // If an OFF was sent, we want to check for Communications
             // errors before we try to do anything else.
             if (l.isCommErrorMessage()) {
                 /* this is a communications error */
-                log.error("Communications error occurred - message received was: "
-                        + l);
+                log.error("Communications error occurred - message received was: {}", l);
                 sendOffMessage();
-                return;
             } else if (l.isCSBusyMessage()) {
                 /* this is a communications error */
-                log.error("Command station busy - message received was: " + l);
+                log.error("Command station busy - message received was: {}", l);
                 sendOffMessage();
-                return;
             } else if (l.isOkMessage()) {
                 /* the command was successfully received */
-                synchronized (this) {
-                    //mOldState=mState;
-                    InternalState = IDLE;
-                }
-                return;
+                InternalState = IDLE;
             } else if (InternalState == COMMANDSENT) {
                 // If command was sent,, we want to check for Communications
                 // errors before we try to do anything else.
                 if (l.isCommErrorMessage()) {
                     /* this is a communications error */
-                    log.error("Communications error occurred - message received was: "
-                            + l);
+                    log.error("Communications error occurred - message received was: {}", l);
                     setState(mState);
                     return;
                 } else if (l.isCSBusyMessage()) {
                     /* this is a communications error */
-                    log.error("Command station busy - message received was: " + l);
+                    log.error("Command station busy - message received was: {}", l);
                     setState(mState);
                     return;
                 } else if (l.isOkMessage()) {
                     /* the command was successfully received */
                     sendOffMessage();
                 }
-                return;
             }
         }
     }
 
     /**
      * Listen for the messages to the LI100/LI101.
+     *
+     * @param l the expected message
      */
     @Override
     public void message(XNetMessage l) {
@@ -205,10 +199,7 @@ public class XNetLight extends AbstractLight implements XNetListener {
         tc.sendXNetMessage(msg, this);
 
         // Set the known state to the commanded state.
-        synchronized (this) {
-            //mOldState=mState; 
-            InternalState = OFFSENT;
-        }
+        InternalState = OFFSENT;
     }
 
     private final static Logger log = LoggerFactory.getLogger(XNetLight.class.getName());

--- a/java/src/jmri/jmrix/openlcb/OlcbSensor.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbSensor.java
@@ -95,7 +95,7 @@ public class OlcbSensor extends AbstractSensor {
      * @return user-visible string to represent this event.
      */
     private String getEventName(boolean isActive) {
-        String name = mUserName;
+        String name = getUserName();
         if (name == null) name = mSystemName;
         String msgName = isActive ? "SensorActiveEventName": "SensorInactiveEventName";
         return Bundle.getMessage(msgName, name);
@@ -162,7 +162,7 @@ public class OlcbSensor extends AbstractSensor {
             }
         }, ON_TIME);
     }
-    
+
     /*
      * since the events that drive a sensor can be whichever state a user
      * wants, the order of the event pair determines what is the 'active' state

--- a/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
@@ -18,14 +18,14 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2008, 2010, 2011
  */
- 
+
  /*
  * @startuml jmri/jmrix/openlcb/doc-files/OlcbTurnout-State-Diagram.png
  * CLOSED --> CLOSED: Event 1
  * THROWN --> CLOSED: Event 1
  * THROWN --> THROWN: Event 0
  * CLOSED --> THROWN: Event 0
- * [*] --> UNKNOWN 
+ * [*] --> UNKNOWN
  * UNKNOWN --> CLOSED: Event 1\nEvent 1 Produced msg with valid set\nEvent 1 Consumed msg with valid set
  * UNKNOWN --> THROWN: Event 0\nEvent 1 Produced msg with valid set\nEvent 0 Consumed msg with valid set
  * state INCONSISTENT
@@ -139,9 +139,9 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout {
      * @return user-visible string to represent this event.
      */
     private String getEventName(boolean isThrown) {
-        String name = mUserName;
+        String name = getUserName();
         if (name == null) name = mSystemName;
-        String msgName = isThrown ? "TurnoutThrownEventName": "TurnoutClosedEventName"; 
+        String msgName = isThrown ? "TurnoutThrownEventName": "TurnoutClosedEventName";
         return Bundle.getMessage(msgName, name);
     }
 
@@ -161,7 +161,7 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout {
             closedEventTableEntryHolder.getEntry().updateDescription(getEventName(false));
         }
     }
-    
+
     @Override
     public void setFeedbackMode(int mode) throws IllegalArgumentException {
         boolean recreate = (mode != _activeFeedbackType) && (pc != null);

--- a/java/test/jmri/jmrit/display/SensorIconWindowTest.java
+++ b/java/test/jmri/jmrit/display/SensorIconWindowTest.java
@@ -146,7 +146,9 @@ public class SensorIconWindowTest extends jmri.util.SwingTestCase {
                         location
                 ));
 
-        Assert.assertEquals("state after one click", Sensor.INACTIVE, sn.getState());
+        JUnitUtil.waitFor(() -> {
+            return sn.getState() == Sensor.INACTIVE;
+        }, "state after one click");
 
         // Click icon change state to inactive
         getHelper().enterClickAndLeave(new MouseEventData(this, icon));

--- a/java/test/jmri/jmrit/display/TurnoutIconWindowTest.java
+++ b/java/test/jmri/jmrit/display/TurnoutIconWindowTest.java
@@ -78,7 +78,7 @@ public class TurnoutIconWindowTest extends jmri.util.SwingTestCase {
                 location)
         );
 
-        // this will wait for WAITFOR_MAX_DELAY (15 seconds) max 
+        // this will wait for WAITFOR_MAX_DELAY (15 seconds) max
         // checking the condition every WAITFOR_DELAY_STEP (5 mSecs)
         // if it's still false after max wait it throws an assert.
         JUnitUtil.waitFor(() -> {

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorLoadAndStoreTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorLoadAndStoreTest.java
@@ -4,6 +4,8 @@ import static jmri.configurexml.LoadAndStoreTestBase.getFiles;
 
 import java.io.File;
 import jmri.configurexml.LoadAndStoreTestBase;
+import jmri.util.JUnitUtil;
+import org.junit.After;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -31,5 +33,14 @@ public class LayoutEditorLoadAndStoreTest extends LoadAndStoreTestBase {
 
     public LayoutEditorLoadAndStoreTest(File inFile, boolean inPass) {
         super(inFile, inPass, SaveType.User, true);
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        // since each file tested will open its own windows, just close any
+        // open windows since we can't accurately list them here
+        JUnitUtil.resetWindows(false, false);
+        super.tearDown();
     }
 }


### PR DESCRIPTION
- Restores normalization of NamedBeans user names accidentally removed earlier.
- Adds normalization of user names to NamedBeans that do not inherit from AbstractNamedBeans.
- Adds more commentary on normalization.
- Removes overridden PropertyChangeSupport instances and methods, since there is no value in endlessly reimplementing that.
- Enforces the contract in NamedBeans that the System Name be non-null.
- Tweaks a couple of tests.