### PR TITLE
Centralize flowcontrol setting

### DIFF
--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -96,7 +96,7 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
         serialPort.setRTS(rts);
         serialPort.setDTR(dtr);
         try {
-            serialPort.setFlowControlMode(flow);
+            if (flow!=purejavacomm.SerialPort.FLOWCONTROL_NONE) serialPort.setFlowControlMode(flow);
         } catch (purejavacomm.UnsupportedCommOperationException e) {
             log.warn("Could not set flow control, ignoring");
         }

--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -85,6 +85,35 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
     }
 
     /**
+     * Set the control leads and flow control.
+     * This handles any necessary ordering.
+     * @param serialPort
+     * @param flow flow control mode from (@link purejavacomm.SerialPort} 
+     * @param rts Set RTS active if true
+     * @param dtr set DTR active if true
+     */
+    protected void configureLeadsAndFlowControl(purejavacomm.SerialPort serialPort, int flow, boolean rts, boolean dtr) {
+        serialPort.setRTS(rts);
+        serialPort.setDTR(dtr);
+        try {
+            serialPort.setFlowControlMode(flow);
+        } catch (purejavacomm.UnsupportedCommOperationException e) {
+            log.warn("Could not set flow control, ignoring");
+        }
+        if (flow!=purejavacomm.SerialPort.FLOWCONTROL_RTSCTS_OUT) serialPort.setRTS(rts);  // not connected in some serial ports and adapters
+        serialPort.setDTR(dtr); 
+    }
+
+    /** 
+     * Sets the flow control, while also setting RTS and DTR to active.
+     * @param serialPort
+     * @param flow flow control mode from (@link purejavacomm.SerialPort} 
+     */
+    protected void configureLeadsAndFlowControl(purejavacomm.SerialPort serialPort, int flow) {
+        configureLeadsAndFlowControl(serialPort, flow, true, true);
+    }
+    
+    /**
      * Set the baud rate. This records it for later.
      */
     @Override

--- a/java/src/jmri/jmrix/acela/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/acela/serialdriver/SerialDriverAdapter.java
@@ -58,12 +58,8 @@ public class SerialDriverAdapter extends AcelaPortController implements jmri.jmr
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
 
             // set timeout
             // activeSerialPort.enableReceiveTimeout(1000);
@@ -92,7 +88,7 @@ public class SerialDriverAdapter extends AcelaPortController implements jmri.jmr
 
         } catch (NoSuchPortException p) {
             return handlePortNotFound(p, portName, log);
-        } catch (UnsupportedCommOperationException | IOException ex) {
+        } catch (IOException ex) {
             log.error("Unexpected exception while opening port " + portName + " trace follows: " + ex);
             ex.printStackTrace();
             return "Unexpected error while opening port " + portName + ": " + ex;

--- a/java/src/jmri/jmrix/bachrus/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/bachrus/serialdriver/SerialDriverAdapter.java
@@ -64,13 +64,11 @@ public class SerialDriverAdapter extends SpeedoPortController implements jmri.jm
             }
 
             // set RTS high, DTR high
-            activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
             //AJB: Removed Jan 2010 - 
             //Setting flow control mode to zero kills comms - SPROG doesn't send data
             //Concern is that will disabling this affect other SPROGs? Serial ones? 
-            //activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
 
             // set timeout
             // activeSerialPort.enableReceiveTimeout(1000);

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/GcSerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/GcSerialDriverAdapter.java
@@ -60,12 +60,8 @@ public class GcSerialDriverAdapter extends GcPortController implements jmri.jmri
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
             activeSerialPort.enableReceiveTimeout(50);  // 50 mSec timeout before sending chars
 
             // set timeout

--- a/java/src/jmri/jmrix/can/adapters/lawicell/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/lawicell/SerialDriverAdapter.java
@@ -60,12 +60,8 @@ public class SerialDriverAdapter extends PortController implements jmri.jmrix.Se
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
             activeSerialPort.enableReceiveTimeout(50);  // 50 mSec timeout before sending chars
 
             // set timeout

--- a/java/src/jmri/jmrix/cmri/serial/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/cmri/serial/serialdriver/SerialDriverAdapter.java
@@ -237,13 +237,9 @@ public class SerialDriverAdapter extends SerialPortAdapter implements jmri.jmrix
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_2, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     @Override

--- a/java/src/jmri/jmrix/dcc4pc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/dcc4pc/serialdriver/SerialDriverAdapter.java
@@ -50,7 +50,7 @@ public class SerialDriverAdapter extends Dcc4PcPortController implements jmri.jm
             }
             try {
                 activeSerialPort.setSerialPortParams(115200, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
-                activeSerialPort.setFlowControlMode(SerialPort.FLOWCONTROL_NONE);
+                configureLeadsAndFlowControl(activeSerialPort, SerialPort.FLOWCONTROL_NONE);
             } catch (UnsupportedCommOperationException e) {
                 log.error("Cannot set serial parameters on port " + portName + ": " + e.getMessage());
             }

--- a/java/src/jmri/jmrix/dccpp/serial/DCCppAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/serial/DCCppAdapter.java
@@ -286,17 +286,9 @@ public class DCCppAdapter extends DCCppSerialPortController implements jmri.jmri
                                        SerialPort.STOPBITS_1,
                                        SerialPort.PARITY_NONE);
         
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-        
         // find and configure flow control
-        //int flow = SerialPort.FLOWCONTROL_RTSCTS_OUT; // default, but also deftaul for getOptionState(option1Name)
         int flow = SerialPort.FLOWCONTROL_NONE;
-        //        if (!getOptionState(option1Name).equals(validOption1[0])) {
-        //            flow = SerialPort.FLOWCONTROL_NONE;
-        //        }
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
         //if (getOptionState(option2Name).equals(validOption2[0]))
         //    checkBuffer = true;
     }

--- a/java/src/jmri/jmrix/direct/serial/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/direct/serial/SerialDriverAdapter.java
@@ -80,12 +80,8 @@ public class SerialDriverAdapter extends PortController implements jmri.jmrix.Se
                 }
             }
 
-            // set RTS high, DTR low in case power is needed
-            activeSerialPort.setRTS(true);          // not connected in some serial ports and adapters
-            activeSerialPort.setDTR(false);         // pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
 
             // activeSerialPort.enableReceiveTimeout(1000);
             log.debug("Serial timeout was observed as: " + activeSerialPort.getReceiveTimeout()

--- a/java/src/jmri/jmrix/easydcc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/easydcc/serialdriver/SerialDriverAdapter.java
@@ -54,12 +54,8 @@ public class SerialDriverAdapter extends EasyDccPortController implements jmri.j
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
 
             // set timeout
             // activeSerialPort.enableReceiveTimeout(1000);
@@ -88,7 +84,7 @@ public class SerialDriverAdapter extends EasyDccPortController implements jmri.j
 
         } catch (NoSuchPortException p) {
             return handlePortNotFound(p, portName, log);
-        } catch (UnsupportedCommOperationException | IOException ex) {
+        } catch (IOException ex) {
             log.error("Unexpected exception while opening port " + portName + " trace follows: " + ex);
             ex.printStackTrace();
             return "Unexpected error while opening port " + portName + ": " + ex;

--- a/java/src/jmri/jmrix/grapevine/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/grapevine/serialdriver/SerialDriverAdapter.java
@@ -235,13 +235,9 @@ public class SerialDriverAdapter extends SerialPortController implements jmri.jm
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_2, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     @Override

--- a/java/src/jmri/jmrix/ieee802154/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/ieee802154/serialdriver/SerialDriverAdapter.java
@@ -229,13 +229,9 @@ public class SerialDriverAdapter extends IEEE802154PortController implements jmr
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     @Override

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeAdapter.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeAdapter.java
@@ -162,13 +162,9 @@ public class XBeeAdapter extends jmri.jmrix.ieee802154.serialdriver.SerialDriver
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        //activeSerialPort.setRTS(true);          // not connected in some serial ports and adapters
-        //activeSerialPort.setDTR(true);          // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
         
 
         if (log.isDebugEnabled()) {

--- a/java/src/jmri/jmrix/lenz/hornbyelite/EliteAdapter.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/EliteAdapter.java
@@ -252,10 +252,6 @@ public class EliteAdapter extends XNetSerialPortController implements jmri.jmrix
                 SerialPort.STOPBITS_1,
                 SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = 0;  // no flow control is first in the elite setup,
         // since it doesn't seem to work with flow
@@ -263,7 +259,8 @@ public class EliteAdapter extends XNetSerialPortController implements jmri.jmrix
         if (!getOptionState(option1Name).equals(validOption1[0])) {
             flow = SerialPort.FLOWCONTROL_RTSCTS_OUT;
         }
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
+
         /*if (!getOptionState(option2Name).equals(validOption2[0]))
          CheckBuffer = false;*/
     }

--- a/java/src/jmri/jmrix/lenz/li100/LI100Adapter.java
+++ b/java/src/jmri/jmrix/lenz/li100/LI100Adapter.java
@@ -245,16 +245,13 @@ public class LI100Adapter extends XNetSerialPortController implements jmri.jmrix
                 SerialPort.STOPBITS_1,
                 SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_RTSCTS_OUT; // default, but also deftaul for getOptionState(option1Name)
         if (!getOptionState(option1Name).equals(validOption1[0])) {
             flow = 0;
         }
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
+
         /*if (getOptionState(option2Name).equals(validOption2[0]))
          checkBuffer = true;*/
     }

--- a/java/src/jmri/jmrix/lenz/li100f/LI100fAdapter.java
+++ b/java/src/jmri/jmrix/lenz/li100f/LI100fAdapter.java
@@ -247,16 +247,13 @@ public class LI100fAdapter extends XNetSerialPortController implements jmri.jmri
                 SerialPort.STOPBITS_1,
                 SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_RTSCTS_OUT; // default, but also deftaul for getOptionState(option1Name)
         if (!getOptionState(option1Name).equals(validOption1[0])) {
             flow = 0;
         }
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
+
         /*if (getOptionState(option2Name).equals(validOption2[0]))
          checkBuffer = true;*/
     }

--- a/java/src/jmri/jmrix/lenz/li101/LI101Adapter.java
+++ b/java/src/jmri/jmrix/lenz/li101/LI101Adapter.java
@@ -245,16 +245,14 @@ public class LI101Adapter extends XNetSerialPortController implements jmri.jmrix
                 SerialPort.STOPBITS_1,
                 SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_RTSCTS_OUT; // default, but also deftaul for getOptionState(option1Name)
         if (!getOptionState(option1Name).equals(validOption1[0])) {
             flow = 0;
         }
-        activeSerialPort.setFlowControlMode(flow);
+
+        configureLeadsAndFlowControl(activeSerialPort, flow);
+
         /*if (getOptionState(option2Name).equals(validOption2[0]))
          checkBuffer = true;*/
     }

--- a/java/src/jmri/jmrix/lenz/liusb/LIUSBAdapter.java
+++ b/java/src/jmri/jmrix/lenz/liusb/LIUSBAdapter.java
@@ -247,16 +247,14 @@ public class LIUSBAdapter extends XNetSerialPortController implements jmri.jmrix
                 SerialPort.STOPBITS_1,
                 SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_RTSCTS_OUT; // default, but also deftaul for getOptionState(option1Name)
         if (!getOptionState(option1Name).equals(validOption1[0])) {
             flow = 0;
         }
-        activeSerialPort.setFlowControlMode(flow);
+
+        configureLeadsAndFlowControl(activeSerialPort, flow);
+
         //if (getOptionState(option2Name).equals(validOption2[0]))
         //    checkBuffer = true;
     }

--- a/java/src/jmri/jmrix/lenz/ztc640/ZTC640Adapter.java
+++ b/java/src/jmri/jmrix/lenz/ztc640/ZTC640Adapter.java
@@ -244,16 +244,14 @@ public class ZTC640Adapter extends XNetSerialPortController implements jmri.jmri
                 SerialPort.STOPBITS_1,
                 SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = 0; // default, but also deftaul for getOptionState(option1Name)
         if (!getOptionState(option1Name).equals(validOption1[0])) {
             flow = SerialPort.FLOWCONTROL_RTSCTS_OUT;
         }
-        activeSerialPort.setFlowControlMode(flow);
+
+        configureLeadsAndFlowControl(activeSerialPort, flow);
+
         /* if (getOptionState(option2Name).equals(validOption2[0]))
          setCheckBuffer(true);*/
     }

--- a/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
@@ -295,16 +295,13 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in Mac DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_RTSCTS_OUT; // default, but also defaults in selectedOption1
         if (getOptionState(option1Name).equals(validOption1[1])) {
             flow = SerialPort.FLOWCONTROL_NONE;
         }
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
+        
         log.debug("Found flow control " + activeSerialPort.getFlowControlMode() // NOI18N
                 + " RTSCTS_OUT=" + SerialPort.FLOWCONTROL_RTSCTS_OUT // NOI18N
                 + " RTSCTS_IN= " + SerialPort.FLOWCONTROL_RTSCTS_IN); // NOI18N

--- a/java/src/jmri/jmrix/loconet/locobufferusb/LocoBufferUsbAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobufferusb/LocoBufferUsbAdapter.java
@@ -34,14 +34,10 @@ public class LocoBufferUsbAdapter extends LocoBufferAdapter {
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in Mac DIN8; on main connector, this is DTR
-
         // configure flow control to always on
         int flow = SerialPort.FLOWCONTROL_RTSCTS_OUT;
-        activeSerialPort.setFlowControlMode(flow);
-        activeSerialPort.setRTS(true);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
+
         log.debug("Found flow control " + activeSerialPort.getFlowControlMode()
                 + " RTSCTS_OUT=" + SerialPort.FLOWCONTROL_RTSCTS_OUT
                 + " RTSCTS_IN= " + SerialPort.FLOWCONTROL_RTSCTS_IN);

--- a/java/src/jmri/jmrix/loconet/ms100/MS100Adapter.java
+++ b/java/src/jmri/jmrix/loconet/ms100/MS100Adapter.java
@@ -88,12 +88,9 @@ public class MS100Adapter extends LnPortController implements jmri.jmrix.SerialP
                 }
             }
 
-            // set RTS high, DTR low to power the MS100
-            activeSerialPort.setRTS(true);          // not connected in some serial ports and adapters
-            activeSerialPort.setDTR(false);         // pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            // set RTS high, DTR low to power the MS100
+            configureLeadsAndFlowControl(activeSerialPort, 0, true, false);
 
             // set timeout
             try {
@@ -116,7 +113,7 @@ public class MS100Adapter extends LnPortController implements jmri.jmrix.SerialP
 
         } catch (NoSuchPortException p) {
             return handlePortNotFound(p, portName, log);
-        } catch (UnsupportedCommOperationException | IOException ex) {
+        } catch (IOException ex) {
             log.error("Unexpected exception while opening port " + portName + " trace follows: " + ex);
             ex.printStackTrace();
             return "Unexpected error while opening port " + portName + ": " + ex;

--- a/java/src/jmri/jmrix/loconet/pr2/PR2Adapter.java
+++ b/java/src/jmri/jmrix/loconet/pr2/PR2Adapter.java
@@ -36,16 +36,12 @@ public class PR2Adapter extends LocoBufferAdapter {
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in Mac DIN8; on main connector, this is DTR
-
         // configure flow control from option
         int flow = SerialPort.FLOWCONTROL_RTSCTS_OUT;
         if (getOptionState(option1Name).equals(validOption1[1])) {
             flow = SerialPort.FLOWCONTROL_NONE;
         }
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
         log.debug("Found flow control " + activeSerialPort.getFlowControlMode() // NOI18N
                 + " RTSCTS_OUT=" + SerialPort.FLOWCONTROL_RTSCTS_OUT // NOI18N
                 + " RTSCTS_IN= " + SerialPort.FLOWCONTROL_RTSCTS_IN); // NOI18N

--- a/java/src/jmri/jmrix/loconet/pr3/PR3Adapter.java
+++ b/java/src/jmri/jmrix/loconet/pr3/PR3Adapter.java
@@ -43,16 +43,13 @@ public class PR3Adapter extends LocoBufferAdapter {
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in Mac DIN8; on main connector, this is DTR
-
         // configure flow control to always on
         int flow = SerialPort.FLOWCONTROL_RTSCTS_OUT;
         if (getOptionState(option1Name).equals(validOption1[1])) {
             flow = SerialPort.FLOWCONTROL_NONE;
         }
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
+
         log.debug("Found flow control " + activeSerialPort.getFlowControlMode() // NOI18N
                 + " RTSCTS_OUT=" + SerialPort.FLOWCONTROL_RTSCTS_OUT // NOI18N
                 + " RTSCTS_IN= " + SerialPort.FLOWCONTROL_RTSCTS_IN); // NOI18N

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockAdapter.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockAdapter.java
@@ -89,7 +89,8 @@ public class UhlenbrockAdapter extends LocoBufferAdapter {
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        activeSerialPort.setFlowControlMode(SerialPort.FLOWCONTROL_NONE);
+        configureLeadsAndFlowControl(activeSerialPort, SerialPort.FLOWCONTROL_NONE);
+
         log.info("Found flow control " + activeSerialPort.getFlowControlMode()
                 + " RTSCTS_OUT=" + SerialPort.FLOWCONTROL_RTSCTS_OUT
                 + " RTSCTS_IN= " + SerialPort.FLOWCONTROL_RTSCTS_IN);

--- a/java/src/jmri/jmrix/maple/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/maple/serialdriver/SerialDriverAdapter.java
@@ -243,13 +243,9 @@ public class SerialDriverAdapter extends SerialPortController implements jmri.jm
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_2, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     @Override

--- a/java/src/jmri/jmrix/mrc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/mrc/serialdriver/SerialDriverAdapter.java
@@ -55,12 +55,8 @@ public class SerialDriverAdapter extends MrcPortController implements jmri.jmrix
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();//IN18N
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
 
             // set timeout
             // activeSerialPort.enableReceiveTimeout(1000);
@@ -89,7 +85,7 @@ public class SerialDriverAdapter extends MrcPortController implements jmri.jmrix
 
         } catch (NoSuchPortException p) {
             return handlePortNotFound(p, portName, log);
-        } catch (UnsupportedCommOperationException | IOException ex) {
+        } catch (IOException ex) {
             log.error("Unexpected exception while opening port " + portName + " trace follows: " + ex);//IN18N
             ex.printStackTrace();
             return "Unexpected error while opening port " + portName + ": " + ex;//IN18N

--- a/java/src/jmri/jmrix/nce/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/nce/serialdriver/SerialDriverAdapter.java
@@ -66,12 +66,8 @@ public class SerialDriverAdapter extends NcePortController implements jmri.jmrix
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
             activeSerialPort.enableReceiveTimeout(50);  // 50 mSec timeout before sending chars
 
             // set timeout

--- a/java/src/jmri/jmrix/nce/usbdriver/UsbDriverAdapter.java
+++ b/java/src/jmri/jmrix/nce/usbdriver/UsbDriverAdapter.java
@@ -71,12 +71,8 @@ public class UsbDriverAdapter extends NcePortController {
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
             activeSerialPort.enableReceiveTimeout(50);  // 50 mSec timeout before sending chars
 
             // set timeout

--- a/java/src/jmri/jmrix/oaktree/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/oaktree/serialdriver/SerialDriverAdapter.java
@@ -243,13 +243,9 @@ public class SerialDriverAdapter extends SerialPortController implements jmri.jm
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_2, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     @Override

--- a/java/src/jmri/jmrix/powerline/cm11/SpecificDriverAdapter.java
+++ b/java/src/jmri/jmrix/powerline/cm11/SpecificDriverAdapter.java
@@ -242,13 +242,9 @@ public class SpecificDriverAdapter extends SerialPortController implements jmri.
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     protected String[] validSpeeds = new String[]{"(automatic)"};

--- a/java/src/jmri/jmrix/powerline/cp290/SpecificDriverAdapter.java
+++ b/java/src/jmri/jmrix/powerline/cp290/SpecificDriverAdapter.java
@@ -242,13 +242,9 @@ public class SpecificDriverAdapter extends SerialPortController implements jmri.
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     protected String[] validSpeeds = new String[]{"(automatic)"};

--- a/java/src/jmri/jmrix/powerline/insteon2412s/SpecificDriverAdapter.java
+++ b/java/src/jmri/jmrix/powerline/insteon2412s/SpecificDriverAdapter.java
@@ -242,13 +242,9 @@ public class SpecificDriverAdapter extends SerialPortController implements jmri.
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     protected String[] validSpeeds = new String[]{"(automatic)"};

--- a/java/src/jmri/jmrix/powerline/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/powerline/serialdriver/SerialDriverAdapter.java
@@ -277,13 +277,10 @@ public class SerialDriverAdapter extends SerialPortController implements jmri.jm
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
+        // set RTS high, DTR high
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     @Override

--- a/java/src/jmri/jmrix/qsi/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/qsi/serialdriver/SerialDriverAdapter.java
@@ -56,12 +56,8 @@ public class SerialDriverAdapter extends QsiPortController implements jmri.jmrix
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);		// not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);		// pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
 
             // set timeout
             // activeSerialPort.enableReceiveTimeout(1000);
@@ -90,7 +86,7 @@ public class SerialDriverAdapter extends QsiPortController implements jmri.jmrix
 
         } catch (NoSuchPortException p) {
             return handlePortNotFound(p, portName, log);
-        } catch (UnsupportedCommOperationException | IOException ex) {
+        } catch (IOException ex) {
             log.error("Unexpected exception while opening port " + portName + " trace follows: " + ex);
             ex.printStackTrace();
             return "Unexpected error while opening port " + portName + ": " + ex;

--- a/java/src/jmri/jmrix/rfid/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/rfid/serialdriver/SerialDriverAdapter.java
@@ -349,10 +349,6 @@ public class SerialDriverAdapter extends RfidPortController implements jmri.jmri
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);          // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);          // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
         if (getOptionState(option1Name).equals("MERG Concentrator")) {
@@ -360,8 +356,7 @@ public class SerialDriverAdapter extends RfidPortController implements jmri.jmri
             log.debug("Set hardware flow control for Concentrator");
             flow = SerialPort.FLOWCONTROL_RTSCTS_OUT;
         }
-        activeSerialPort.setFlowControlMode(flow);
-        activeSerialPort.setRTS(true);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     @Override

--- a/java/src/jmri/jmrix/rps/serial/SerialAdapter.java
+++ b/java/src/jmri/jmrix/rps/serial/SerialAdapter.java
@@ -68,12 +68,8 @@ public class SerialAdapter extends jmri.jmrix.AbstractSerialPortController imple
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);		// not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);		// pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
 
             // set timeout
             log.debug("Serial timeout was observed as: " + activeSerialPort.getReceiveTimeout()
@@ -105,7 +101,7 @@ public class SerialAdapter extends jmri.jmrix.AbstractSerialPortController imple
 
         } catch (NoSuchPortException p) {
             return handlePortNotFound(p, portName, log);
-        } catch (UnsupportedCommOperationException | IOException ex) {
+        } catch (IOException ex) {
             log.error("Unexpected exception while opening port " + portName + " trace follows: " + ex);
             ex.printStackTrace();
             return "Unexpected error while opening port " + portName + ": " + ex;

--- a/java/src/jmri/jmrix/secsi/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/secsi/serialdriver/SerialDriverAdapter.java
@@ -243,13 +243,9 @@ public class SerialDriverAdapter extends SerialPortController implements jmri.jm
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_2, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);		// not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);		// pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     @Override

--- a/java/src/jmri/jmrix/serialsensor/SerialSensorAdapter.java
+++ b/java/src/jmri/jmrix/serialsensor/SerialSensorAdapter.java
@@ -67,12 +67,9 @@ public class SerialSensorAdapter extends AbstractSerialPortController
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);		// not connected in some serial ports and adapters
-            activeSerialPort.setDTR(false);		// pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            // set RTS active low, DTR inactive high
+            configureLeadsAndFlowControl(activeSerialPort, 0, true, false);
 
             // set timeout
             // activeSerialPort.enableReceiveTimeout(1000);
@@ -140,9 +137,6 @@ public class SerialSensorAdapter extends AbstractSerialPortController
         } catch (NoSuchPortException ex1) {
             log.error("No such port " + portName, ex1);
             return "No such port " + portName + ": " + ex1;
-        } catch (UnsupportedCommOperationException ex2) {
-            log.error("Exception to operation on port " + portName, ex2);
-            return "Exception to operation on port " + portName + ": " + ex2;
         } catch (TooManyListenersException ex3) {
             log.error("Too Many Listeners on port " + portName, ex3);
             return "Too Many Listeners on port " + portName + ": " + ex3;

--- a/java/src/jmri/jmrix/tams/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/tams/serialdriver/SerialDriverAdapter.java
@@ -62,11 +62,7 @@ public class SerialDriverAdapter extends TamsPortController implements jmri.jmri
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);        // not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);        // pin 1 in DIN8; on main connector, this is DTR
-
-            activeSerialPort.setFlowControlMode(SerialPort.FLOWCONTROL_RTSCTS_IN | SerialPort.FLOWCONTROL_RTSCTS_OUT);//added by Jan
+            configureLeadsAndFlowControl(activeSerialPort, SerialPort.FLOWCONTROL_RTSCTS_IN | SerialPort.FLOWCONTROL_RTSCTS_OUT);
 
             // set timeout
             try {
@@ -102,7 +98,7 @@ public class SerialDriverAdapter extends TamsPortController implements jmri.jmri
 
         } catch (NoSuchPortException p) {
             return handlePortNotFound(p, portName, log);
-        } catch (UnsupportedCommOperationException | IOException ex) {
+        } catch (IOException ex) {
             log.error("Unexpected exception while opening port " + portName + " trace follows: " + ex);
             ex.printStackTrace();
             return "Unexpected error while opening port " + portName + ": " + ex;

--- a/java/src/jmri/jmrix/tmcc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/tmcc/serialdriver/SerialDriverAdapter.java
@@ -228,13 +228,9 @@ public class SerialDriverAdapter extends SerialPortController implements jmri.jm
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8,
                 SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);		// not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);		// pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_NONE; // default
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     @Override

--- a/java/src/jmri/jmrix/wangrow/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/wangrow/serialdriver/SerialDriverAdapter.java
@@ -59,12 +59,8 @@ public class SerialDriverAdapter extends NcePortController implements jmri.jmrix
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);		// not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);		// pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
             activeSerialPort.enableReceiveTimeout(50);  // 50 mSec timeout before sending chars
 
             // set timeout

--- a/java/src/jmri/jmrix/xpa/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/xpa/serialdriver/SerialDriverAdapter.java
@@ -61,12 +61,8 @@ public class SerialDriverAdapter extends XpaPortController implements jmri.jmrix
                 return "Cannot set serial parameters on port " + portName + ": " + e.getMessage();
             }
 
-            // set RTS high, DTR high
-            activeSerialPort.setRTS(true);		// not connected in some serial ports and adapters
-            activeSerialPort.setDTR(true);		// pin 1 in DIN8; on main connector, this is DTR
-
             // disable flow control; hardware lines used for signaling, XON/XOFF might appear in data
-            activeSerialPort.setFlowControlMode(0);
+            configureLeadsAndFlowControl(activeSerialPort, 0);
 
             // set timeout
             // activeSerialPort.enableReceiveTimeout(1000);
@@ -95,7 +91,7 @@ public class SerialDriverAdapter extends XpaPortController implements jmri.jmrix
 
         } catch (NoSuchPortException p) {
             return handlePortNotFound(p, portName, log);
-        } catch (UnsupportedCommOperationException | IOException ex) {
+        } catch (IOException ex) {
             log.error("Unexpected exception while opening port " + portName + " trace follows: " + ex);
             ex.printStackTrace();
             return "IO Exception while opening port " + portName + ": " + ex;

--- a/java/src/jmri/jmrix/zimo/mx1/Mx1Adapter.java
+++ b/java/src/jmri/jmrix/zimo/mx1/Mx1Adapter.java
@@ -237,16 +237,12 @@ public class Mx1Adapter extends Mx1PortController implements jmri.jmrix.SerialPo
         }
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);		// not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);		// pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_RTSCTS_OUT; // default, but also defaults in selectedOption1
         if (getOptionState(option1Name).equals(validOption1[1])) {
             flow = 0;
         }
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     @Override

--- a/java/src/jmri/jmrix/zimo/mxulf/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/zimo/mxulf/SerialDriverAdapter.java
@@ -245,16 +245,12 @@ public class SerialDriverAdapter extends Mx1PortController implements jmri.jmrix
         }
         activeSerialPort.setSerialPortParams(baud, SerialPort.DATABITS_8, SerialPort.STOPBITS_1, SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);		// not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);		// pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = SerialPort.FLOWCONTROL_RTSCTS_OUT | SerialPort.FLOWCONTROL_RTSCTS_IN; // default, but also defaults in selectedOption1
         if (getOptionState(option1Name).equals(validOption1[1])) {
             flow = 0;
         }
-        activeSerialPort.setFlowControlMode(flow);
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     @Override

--- a/java/src/jmri/jmrix/ztc/ztc611/ZTC611Adapter.java
+++ b/java/src/jmri/jmrix/ztc/ztc611/ZTC611Adapter.java
@@ -249,18 +249,12 @@ public class ZTC611Adapter extends XNetSerialPortController implements jmri.jmri
                 SerialPort.STOPBITS_1,
                 SerialPort.PARITY_NONE);
 
-        // set RTS high, DTR high - done early, so flow control can be configured after
-        activeSerialPort.setRTS(true);  // not connected in some serial ports and adapters
-        activeSerialPort.setDTR(true);  // pin 1 in DIN8; on main connector, this is DTR
-
         // find and configure flow control
         int flow = 0; // default, but also deftaul for getOptionState(option1Name)
         if (!getOptionState(option1Name).equals(validOption1[0])) {
             flow = SerialPort.FLOWCONTROL_RTSCTS_OUT;
         }
-        activeSerialPort.setFlowControlMode(flow);
-        /* if (getOptionState(option2Name).equals(validOption2[0]))
-         setCheckBuffer(true);*/
+        configureLeadsAndFlowControl(activeSerialPort, flow);
     }
 
     @Override


### PR DESCRIPTION
refactor setting RTS, DTR and flow control into a single routine to make it easier to (try to) deal with order issues in PJC.