### PR TITLE
Prevent NPE in tables tools.

### DIFF
--- a/java/src/jmri/jmrit/beantable/ListedTableFrame.java
+++ b/java/src/jmri/jmrit/beantable/ListedTableFrame.java
@@ -304,7 +304,7 @@ public class ListedTableFrame extends BeanTableFrame {
         try {
             return Integer.parseInt(InstanceManager.getDefault(UserPreferencesManager.class)
                     .getProperty(ListedTableFrame.class.getName(), "dividerLocation").toString());
-        } catch (NumberFormatException ex) {
+        } catch (NullPointerException | NumberFormatException ex) {
             // ignore, this means the divider location has never been saved
             return 0;
         }


### PR DESCRIPTION
Fixes #4049.
An unset preference can be null, so catch that while also catching the declared NumberFormatException since the result in either case is the same.