### PR TITLE
Add getPortableFilename to fix file pathnames

### DIFF
--- a/java/src/jmri/jmrit/beantable/LRouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LRouteTableAction.java
@@ -1354,7 +1354,7 @@ public class LRouteTableAction extends AbstractTableAction {
         // handle selection or cancel
         if (retVal == JFileChooser.APPROVE_OPTION) {
             try {
-                soundFile.setText(soundChooser.getSelectedFile().getCanonicalPath());
+                soundFile.setText(FileUtil.getPortableFilename(soundChooser.getSelectedFile().getCanonicalPath()));
             } catch (java.io.IOException e) {
                 log.error("exception setting sound file: " + e);
             }
@@ -1375,7 +1375,7 @@ public class LRouteTableAction extends AbstractTableAction {
         // handle selection or cancel
         if (retVal == JFileChooser.APPROVE_OPTION) {
             try {
-                scriptFile.setText(scriptChooser.getSelectedFile().getCanonicalPath());
+                scriptFile.setText(FileUtil.getPortableFilename(scriptChooser.getSelectedFile().getCanonicalPath()));
             } catch (java.io.IOException e) {
                 log.error("exception setting script file: " + e);
             }

--- a/java/src/jmri/jmrit/beantable/RouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableAction.java
@@ -1391,12 +1391,12 @@ public class RouteTableAction extends AbstractTableAction {
         String file = soundFile.getText();
         if (file.length() > 0) {
             actionList.add(new DefaultConditionalAction(Conditional.ACTION_OPTION_ON_CHANGE_TO_TRUE,
-                    Conditional.ACTION_RUN_SCRIPT, "", -1, file));
+                    Conditional.ACTION_PLAY_SOUND, "", -1, FileUtil.getPortableFilename(file)));
         }
         file = scriptFile.getText();
         if (file.length() > 0) {
             actionList.add(new DefaultConditionalAction(Conditional.ACTION_OPTION_ON_CHANGE_TO_TRUE,
-                    Conditional.ACTION_PLAY_SOUND, "", -1, file));
+                    Conditional.ACTION_RUN_SCRIPT, "", -1, FileUtil.getPortableFilename(file)));
         }
 
         ///// Construct 'AND' clause from 'VETO' controls ////////


### PR DESCRIPTION
LRouteTableAction was creating Logix conditionals with full path names for script and sound files. RouteTableAction “Export to Logix” was also using full path names for Logix conditionals.

For normal Route processing, the XML load and store handle the file name conversions.