### PR TITLE
Make PositionableShape abstract

### DIFF
--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/PositionablePolygon.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/PositionablePolygon.java
@@ -302,5 +302,16 @@ public class PositionablePolygon extends PositionableShape {
         }
     }
 
+    @Override
+    protected void invalidateShape() {
+        // do nothing to prevent PositionableShape from invalidating this path
+    }
+
+    @Override
+    protected Shape makeShape() {
+        // return an empty shape so it can be appended to
+        return new GeneralPath(GeneralPath.WIND_EVEN_ODD);
+    }
+
     private final static Logger log = LoggerFactory.getLogger(PositionablePolygon.class);
 }

--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/PositionableShape.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/PositionableShape.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Pete Cressman Copyright (c) 2012
  */
-public class PositionableShape extends PositionableJComponent implements PropertyChangeListener {
+public abstract class PositionableShape extends PositionableJComponent implements PropertyChangeListener {
 
     private Shape _shape;
     protected Color _lineColor = Color.black;
@@ -81,6 +81,7 @@ public class PositionableShape extends PositionableJComponent implements Propert
         _shape = s;
     }
 
+    @Nonnull
     protected Shape getShape() {
         if (_shape == null) {
             _shape = makeShape();
@@ -122,18 +123,11 @@ public class PositionableShape extends PositionableJComponent implements Propert
 
     /**
      * Create the shape returned by {@link #getShape()}.
-     * <p>
-     * This should be abstract, but {@link #deepClone()} requires this class not
-     * be abstract, and we never want to accept a null return value from this
-     * method, so the default implementation throws an uncaught exception
-     * instead.
      *
      * @return the created shape
      */
     @Nonnull
-    protected Shape makeShape() {
-        throw new UnsupportedOperationException("Must be overridden by an implementing class.");
-    }
+    protected abstract Shape makeShape();
 
     /**
      * Force the shape to be regenerated next time it is needed.
@@ -251,10 +245,7 @@ public class PositionableShape extends PositionableJComponent implements Propert
     }
 
     @Override
-    public Positionable deepClone() {
-        PositionableShape pos = new PositionableShape(_editor);
-        return finishClone(pos);
-    }
+    public abstract Positionable deepClone();
 
     protected Positionable finishClone(PositionableShape pos) {
         pos._lineWidth = _lineWidth;

--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/configurexml/PositionableShapeXml.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/configurexml/PositionableShapeXml.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 import jmri.NamedBeanHandle;
 import jmri.Sensor;
 import jmri.configurexml.AbstractXmlAdapter;
-import jmri.jmrit.display.Editor;
 import jmri.jmrit.display.ToolTip;
 import jmri.jmrit.display.controlPanelEditor.shape.PositionableShape;
 import org.jdom2.Attribute;
@@ -18,7 +17,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Pete Cressman Copyright (c) 2012
  */
-public class PositionableShapeXml extends AbstractXmlAdapter {
+public abstract class PositionableShapeXml extends AbstractXmlAdapter {
 
     public PositionableShapeXml() {
     }
@@ -102,23 +101,6 @@ public class PositionableShapeXml extends AbstractXmlAdapter {
     public boolean load(Element shared, Element perNode) {
         log.error("Invalid method called");
         return false;
-    }
-
-    /**
-     * Create a PositionableShape, then add to a target JLayeredPane
-     *
-     * @param element Top level Element to unpack.
-     * @param o       Editor as an Object
-     */
-    @Override
-    public void load(Element element, Object o) {
-        // create the objects
-        Editor ed = (Editor) o;
-        PositionableShape ps = new PositionableShape(ed);
-
-        ed.putItem(ps);
-        // load individual item's option settings after editor has set its global settings
-        loadCommonAttributes(ps, Editor.MARKERS, element);
     }
 
     public void loadCommonAttributes(PositionableShape ps, int defaultLevel, Element element) {

--- a/java/src/jmri/jmrit/operations/automation/actions/RunSwitchListChangesAction.java
+++ b/java/src/jmri/jmrit/operations/automation/actions/RunSwitchListChangesAction.java
@@ -41,7 +41,9 @@ public class RunSwitchListChangesAction extends Action {
      * there's new work for that location.
      * <p>
      * common code see RunSwitchListAction.java
-     * @param isChanged if set true only locations with changes will get a custom switch list.
+     *
+     * @param isChanged if set true only locations with changes will get a
+     *                  custom switch list.
      */
     @SuppressFBWarnings(
             value = {"UC_USELESS_CONDITION", "RpC_REPEATED_CONDITIONAL_TEST"},
@@ -75,14 +77,14 @@ public class RunSwitchListChangesAction extends Action {
             if (!InstanceManager.getDefault(TrainCustomSwitchList.class).checkProcessReady()) {
                 log.warn(
                         "Timeout waiting for excel switch list program to complete previous operation, timeout value: {} seconds",
-                        Control.excelWaitTime);                
+                        Control.excelWaitTime);
             }
             if (InstanceManager.getDefault(TrainCustomSwitchList.class).doesCommonFileExist()) {
                 log.warn("Switch List CSV common file exists!");
             }
             for (Location location : InstanceManager.getDefault(LocationManager.class).getLocationsByNameList()) {
-                if (location.isSwitchListEnabled() &&
-                        (!isChanged || (isChanged && location.getStatus().equals(Location.MODIFIED)))) {
+                if (location.isSwitchListEnabled()
+                        && (!isChanged || (isChanged && location.getStatus().equals(Location.MODIFIED)))) {
                     // also build the regular switch lists so they can be used
                     if (!Setup.isSwitchListRealTime()) {
                         trainSwitchLists.buildSwitchList(location);
@@ -116,7 +118,7 @@ public class RunSwitchListChangesAction extends Action {
 
     @Override
     public void cancelAction() {
-        // no cancel for this action     
+        // no cancel for this action
     }
 
     private final static Logger log = LoggerFactory.getLogger(RunSwitchListChangesAction.class);

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/PositionableShapeTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/PositionableShapeTest.java
@@ -1,7 +1,9 @@
 package jmri.jmrit.display.controlPanelEditor.shape;
 
 import java.awt.GraphicsEnvironment;
+import java.awt.Shape;
 import jmri.jmrit.display.EditorScaffold;
+import jmri.jmrit.display.Positionable;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -11,15 +13,27 @@ import org.junit.Test;
 
 /**
  *
- * @author Paul Bender Copyright (C) 2017	
+ * @author Paul Bender Copyright (C) 2017
  */
 public class PositionableShapeTest {
 
     @Test
     public void testCTor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        PositionableShape t = new PositionableShape(new EditorScaffold());
-        Assert.assertNotNull("exists",t);
+        PositionableShape t = new PositionableShape(new EditorScaffold()) {
+            @Override
+            protected Shape makeShape() {
+                // bogus body, not used in tests
+                return null;
+            }
+
+            @Override
+            public Positionable deepClone() {
+                // bogus body, not used in tests
+                return null;
+            }
+        };
+        Assert.assertNotNull("exists", t);
     }
 
     // The minimal setup for log4J
@@ -34,5 +48,4 @@ public class PositionableShapeTest {
     }
 
     // private final static Logger log = LoggerFactory.getLogger(PositionableShapeTest.class);
-
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/configurexml/PositionableShapeXmlTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/configurexml/PositionableShapeXmlTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.display.controlPanelEditor.shape.configurexml;
 
 import jmri.util.JUnitUtil;
+import org.jdom2.Element;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -8,16 +9,21 @@ import org.junit.Test;
 
 /**
  * PositionableShapeXmlTest.java
- *
+ * <p>
  * Description: tests for the PositionableShapeXml class
  *
- * @author   Paul Bender  Copyright (C) 2016
+ * @author Paul Bender Copyright (C) 2016
  */
 public class PositionableShapeXmlTest {
 
     @Test
-    public void testCtor(){
-      Assert.assertNotNull("PositionableShapeXml constructor",new PositionableShapeXml());
+    public void testCtor() {
+        Assert.assertNotNull("PositionableShapeXml constructor", new PositionableShapeXml() {
+            @Override
+            public void load(Element e, Object o) throws Exception {
+                // do nothing
+            }
+        });
     }
 
     // The minimal setup for log4J
@@ -32,4 +38,3 @@ public class PositionableShapeXmlTest {
     }
 
 }
-


### PR DESCRIPTION
Make PositionableShape and methods that must be overridden abstract so that implementing classes need to override those methods.
Implement a missing implementation of PositionableShape.makeShape().
Fixes #4059