### PR TITLE
fix loconet monitor address display

### DIFF
--- a/java/src/jmri/jmrix/loconet/locomon/Llnmon.java
+++ b/java/src/jmri/jmrix/loconet/locomon/Llnmon.java
@@ -219,33 +219,88 @@ public class Llnmon {
      *      representation of the loco address, if appropriate
      */
     private static String convertToMixed(int addressLow, int addressHigh) {
-
         // if we have a 2 digit decoder address, proceed accordingly
-        String isShortAddress = "";
-        if (addressHigh == 0x7d) {
-            isShortAddress = Bundle.getMessage("LN_MSG_HELPER_IS_SHORT_ADDRESS");
-            addressHigh = 0;
-        }
-        if ((addressHigh == 0) | (addressHigh == 0x7f)) {
-            if (addressLow >= 120) {
-                return Bundle.getMessage("LN_MSG_LOCO_ADDRESS_HELPER_MIXED_ADDRESS",
-                        String.valueOf(addressLow), isShortAddress, "(c" +     // NOI18N
-                        String.valueOf(addressLow - 120) + ")");    // NOI18N
-            } else if (addressLow >= 110) {
-                return Bundle.getMessage("LN_MSG_LOCO_ADDRESS_HELPER_MIXED_ADDRESS",
-                        String.valueOf(addressLow), isShortAddress, "(b" +     // NOI18N
-                        String.valueOf(addressLow - 110) + ")");    // NOI18N
-            } else if (addressLow >= 100) {
-               return  Bundle.getMessage("LN_MSG_LOCO_ADDRESS_HELPER_MIXED_ADDRESS",
-                        String.valueOf(addressLow), isShortAddress, "(a" +     // NOI18N
-                        String.valueOf(addressLow - 100) + ")");    // NOI18N
-            } else {
-               return  Bundle.getMessage("LN_MSG_LOCO_ADDRESS_HELPER_UNMIXED_ADDRESS",
-                        String.valueOf(addressLow), isShortAddress);
-            }
-        } else {
-            // return the full 4 digit address
-            return String.valueOf(LOCO_ADR(addressHigh, addressLow));
+        switch (addressHigh) {
+            case 0x7d:
+                log.warn("addressLow / 10 = "+ Integer.toString(addressLow / 10));
+                switch (addressLow) {
+                    case 100: case 101: case 102: case 103: case 104: case 105:
+                    case 106: case 107: case 108: case 109:
+                        // N (short, alternately 'An') (or long address NN)
+                        return Bundle.getMessage("LN_MSG_HELPER_IS_ALTERNATE_SHORT_AND_LONG_ADDRESS_Ax", 
+                                addressLow, 
+                                addressLow-100, 
+                                String.valueOf(LOCO_ADR(addressHigh, addressLow)));
+                                // Note: .toString intentionally used here to remove the "internationalized"
+                                // presentation of integers, which, in US English, adds a "," between 
+                                // the thousands digit and the hundreds digit.  This comma is undesired 
+                                // in this application.
+                    case 110: case 111: case 112: case 113: case 114: case 115:
+                    case 116: case 117: case 118: case 119:
+                        // N (short, alternately 'Bn') (or long address NN)
+                        return Bundle.getMessage("LN_MSG_HELPER_IS_ALTERNATE_SHORT_AND_LONG_ADDRESS_Bx", 
+                                addressLow, 
+                                addressLow-110, 
+                                String.valueOf(LOCO_ADR(addressHigh, addressLow)));
+                                // Note: .toString intentionally used here to remove the "internationalized"
+                                // presentation of integers, which, in US English, adds a "," between 
+                                // the thousands digit and the hundreds digit.  This comma is undesired 
+                                // in this application.
+                    case 120: case 121: case 122: case 123: case 124: case 125:
+                    case 126: case 127:
+                        // N (short, alternately 'Cn') (or long address NN)
+                        return Bundle.getMessage("LN_MSG_HELPER_IS_ALTERNATE_SHORT_AND_LONG_ADDRESS_Cx", 
+                                addressLow, 
+                                addressLow-120, 
+                                String.valueOf(LOCO_ADR(addressHigh, addressLow)));
+                                // Note: .toString intentionally used here to remove the "internationalized"
+                                // presentation of integers, which, in US English, adds a "," between 
+                                // the thousands digit and the hundreds digit.  This comma is undesired 
+                                // in this application.
+                    default:
+                        // N (short) (or long address NN)
+                        return Bundle.getMessage("LN_MSG_HELPER_IS_SHORT_AND_LONG_ADDRESS", 
+                                addressLow, 
+                                String.valueOf(LOCO_ADR(addressHigh, addressLow)));
+                                // Note: .toString intentionally used here to remove the "internationalized"
+                                // presentation of integers, which, in US English, adds a "," between 
+                                // the thousands digit and the hundreds digit.  This comma is undesired 
+                                // in this application.
+                }
+                
+            case 0x00:
+            case 0x7f:
+                switch (addressLow) {
+                    case 100: case 101: case 102: case 103: case 104: case 105:
+                    case 106: case 107: case 108: case 109:
+                        // N (short, alternately 'An')
+                        return Bundle.getMessage("LN_MSG_HELPER_IS_ALTERNATE_SHORT_ADDRESS_Ax", 
+                                addressLow, 
+                                addressLow-100);
+                    case 110: case 111: case 112: case 113: case 114: case 115:
+                    case 116: case 117: case 118: case 119:
+                        // N (short, alternately 'Bn')
+                        return Bundle.getMessage("LN_MSG_HELPER_IS_ALTERNATE_SHORT_ADDRESS_Bx", 
+                                addressLow, 
+                                addressLow-110);
+                    case 120: case 121: case 122: case 123: case 124: case 125:
+                    case 126: case 127:
+                        // N (short, alternately 'Cn')
+                        return Bundle.getMessage("LN_MSG_HELPER_IS_ALTERNATE_SHORT_ADDRESS_Cx", 
+                                addressLow, 
+                                addressLow-120);
+                    default:
+                        // N (short)                        
+                        return Bundle.getMessage("LN_MSG_HELPER_IS_SHORT_ADDRESS", 
+                                addressLow);
+                }
+            default:
+                // return the full 4 digit address
+                return String.valueOf(LOCO_ADR(addressHigh, addressLow));
+                // Note: .toString intentionally used here to remove the "internationalized"
+                // presentation of integers, which, in US English, adds a "," between 
+                // the thousands digit and the hundreds digit.  This comma is undesired 
+                // in this application.
         }
     } // end of private static String convertToMixed(int addressLow, int addressHigh)
 

--- a/java/src/jmri/jmrix/loconet/locomon/Llnmon.java
+++ b/java/src/jmri/jmrix/loconet/locomon/Llnmon.java
@@ -167,7 +167,7 @@ public class Llnmon {
             return Bundle.getMessage("LN_MSG_LOCOIO_HELPER_FIRMWARE_REV_DOTTED_ONE_DIGIT", val);
         } else if ((val >= 10) && (val < 100)) {
             return Bundle.getMessage("LN_MSG_LOCOIO_HELPER_FIRMWARE_REV_DOTTED_TWO_DIGITS",
-                    new Integer(val/10), val%10);   // the integer is boxed in order to prevent display as a floating point value
+                    Integer.valueOf(val/10), val%10);   // the integer is boxed in order to prevent display as a floating point value
         } else if ((val >= 100) && (val < 1000)) {
             int hundreds = val/100;
             int tens = (val - (hundreds * 100)) / 10;

--- a/java/src/jmri/jmrix/loconet/locomon/Llnmon.properties
+++ b/java/src/jmri/jmrix/loconet/locomon/Llnmon.properties
@@ -11,30 +11,34 @@ LN_MSG_GPOFF = Set Global (Track) Power to 'OFF'.\n
 LN_MSG_IDLE = Set Global (Track) Power to 'Force Idle, Broadcast Emergency STOP'.\n
 LN_MSG_MASTER_BUSY = Master is busy.\n
 
-# Note: in LN_MSG_REQ_SLOT_FOR_ADDR and in LN_MSG_REQ_EXP_SLOT_FOR_ADDR, the following
+# Note: in LN_MSG_REQ_SLOT_FOR_ADDR ,LN_MSG_HELPER_IS_SHORT_AND_LONG_ADDRESS, 
+# and in LN_MSG_HELPER_IS_SHORT_ADDRESS, the following
 # string replacements will be used:
 #   {0} is replaced with the integer value representing the locomotive address
+#   {1} (where applicable) is replaced with the integer value representing the 
+#       long locomotive address (14-bit) 
 LN_MSG_REQ_SLOT_FOR_ADDR = Request slot for loco address {0}.\n
+LN_MSG_HELPER_IS_SHORT_AND_LONG_ADDRESS = {0} (short) (or long address {1})
+LN_MSG_HELPER_IS_SHORT_ADDRESS = {0} (short)
 
-LN_MSG_HELPER_IS_SHORT_ADDRESS = (short)
-
-# in LN_MSG_LOCO_ADDRESS_HELPER_MIXED_ADDRESS, the following parameter substitutions
-# will be made:
-#   {0} the locomotive address, represented as a decimal integer
-#   {1} an empty string if the address is a "long" DCC address, or
-#       LN_MSG_HELPER_IS_SHORT_ADDRESS if the address is a "short" DCC address,
-#       as appropriate.
-#   {2} the "mixed-mode" representation of the address, such as "(a0)" for 100,
-#       "(b7)" for 117, or "(c3)" for 123.
-LN_MSG_LOCO_ADDRESS_HELPER_MIXED_ADDRESS = {0}{1} {2}
-
-# in LN_MSG_LOCO_ADDRESS_HELPER_UNMIXED_ADDRESS, the following parameter substitutions
-# will be made:
-#   {0} the locomotive address, represented as a decimal integer
-#   {1} an empty string if the address is a "long" DCC address, or
-#       LN_MSG_HELPER_IS_SHORT_ADDRESS if the address is a "short" DCC address,
-#       as appropriate.
-LN_MSG_LOCO_ADDRESS_HELPER_UNMIXED_ADDRESS = {0}{1}
+# Note: in LN_MSG_HELPER_IS_ALTERNATE_SHORT_AND_LONG_ADDRESS_Ax,
+# LN_MSG_HELPER_IS_ALTERNATE_SHORT_AND_LONG_ADDRESS_Bx, 
+# LN_MSG_HELPER_IS_ALTERNATE_SHORT_AND_LONG_ADDRESS_Cx, 
+# LN_MSG_HELPER_IS_ALTERNATE_SHORT_ADDRESS_Ax,
+# LN_MSG_HELPER_IS_ALTERNATE_SHORT_ADDRESS_Bx, and in 
+# LN_MSG_HELPER_IS_ALTERNATE_SHORT_ADDRESS_Cx, the address is displayed as a
+# "Short" address and a "Mixed" address, and sometimes a "Long" address.
+# The following string replacements will be used:
+#   {0} is replaced with the integer value representing the locomotive address
+#   {1} is replaced with the integer remainder of the short locomotive address 
+#       minus the hex "sixteens" digit, as appropriate for the key.
+#   {2} (where applicable) is replaced with the long locomotive address (14-bit)
+LN_MSG_HELPER_IS_ALTERNATE_SHORT_AND_LONG_ADDRESS_Ax = {0} (short, or "A{1}") (or long address {2})
+LN_MSG_HELPER_IS_ALTERNATE_SHORT_AND_LONG_ADDRESS_Bx = {0} (short, or "B{1}") (or long address {2})
+LN_MSG_HELPER_IS_ALTERNATE_SHORT_AND_LONG_ADDRESS_Cx = {0} (short, or "C{1}") (or long address {2})
+LN_MSG_HELPER_IS_ALTERNATE_SHORT_ADDRESS_Ax = {0} (short, or "A{1}")
+LN_MSG_HELPER_IS_ALTERNATE_SHORT_ADDRESS_Bx = {0} (short, or "B{1}")
+LN_MSG_HELPER_IS_ALTERNATE_SHORT_ADDRESS_Cx = {0} (short, or "C{1}")
 
 # Note: in LN_MSG_REQ_SWITCH, the following string replacements will be used:
 #   {0} is replaced with the turnout 'system name', such as 'LT51'

--- a/java/src/jmri/jmrix/loconet/locomon/LocoMonPane.java
+++ b/java/src/jmri/jmrix/loconet/locomon/LocoMonPane.java
@@ -70,7 +70,7 @@ public class LocoMonPane extends jmri.jmrix.AbstractMonPane implements LocoNetLi
     }
 
     @Override
-    public void initComponents(LocoNetSystemConnectionMemo memo) {
+    public synchronized void initComponents(LocoNetSystemConnectionMemo memo) {
         this.memo = memo;
         // connect to the LnTrafficController
         if (memo.getLnTrafficController() == null) {

--- a/java/test/jmri/jmrix/loconet/locomon/LlnmonTest.java
+++ b/java/test/jmri/jmrix/loconet/locomon/LlnmonTest.java
@@ -37,7 +37,7 @@ public class LlnmonTest extends TestCase {
         assertEquals(" in B", "Transponder address 1056 present at LR163 () (BDL16x Board ID 11 RX4 zone B).\n", f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xD0, 0x21, 0x24, 0x7d, 0x70, 0x04});
-        assertEquals(" in C", "Transponder address 112(short) (b2) present at LR165 () (BDL16x Board ID 11 RX4 zone C).\n", f.displayMessage(l));
+        assertEquals(" in C", "Transponder address 112 (short, or \"B2\") (or long address 16112) present at LR165 () (BDL16x Board ID 11 RX4 zone C).\n", f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xD0, 0x21, 0x26, 0x08, 0x20, 0x04});
         assertEquals(" in D", "Transponder address 1056 present at LR167 () (BDL16x Board ID 11 RX4 zone D).\n", f.displayMessage(l));
@@ -58,31 +58,31 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xD0, 0x20, 0x2E, 0x7d, 0x01, 0x04});
         assertEquals("another in H",
-                "Transponder address 1(short) present at LR47 () (BDL16x Board ID 3 RX4 zone H).\n",
+                "Transponder address 1 (short) (or long address 16001) present at LR47 () (BDL16x Board ID 3 RX4 zone H).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x40, 0x7D, 0x03, 0x00, 0x00, 0x00, 0x2D});
-        assertEquals("find loco 3(short)",
-                "Transponding Find query for loco address 3(short).\n",
+        assertEquals("find loco 3 (short)",
+                "Transponding Find query for loco address 3 (short) (or long address 16003).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x7D, 0x03, 0x00, 0x12, 0x00, 0x7F});
         assertEquals(" in H",
-                "Transponder Find report: address 3(short) present at LR19 (BDL16x Board 2 RX4 zone B).\n",
+                "Transponder Find report: address 3 (short) (or long address 16003) present at LR19 (BDL16x Board 2 RX4 zone B).\n",
                 f.displayMessage(l));
 
         LnReporter r = (LnReporter) lnrm.provideReporter("LR19");
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x7D, 0x03, 0x00, 0x14, 0x00, 0x7F});
         assertEquals("Transponding no reporter user name",
-                "Transponder Find report: address 3(short) present at LR21 (BDL16x Board 2 RX4 zone C).\n",
+                "Transponder Find report: address 3 (short) (or long address 16003) present at LR21 (BDL16x Board 2 RX4 zone C).\n",
                 f.displayMessage(l));
 
         r.setUserName("AUserName");
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x7D, 0x03, 0x00, 0x12, 0x00, 0x7F});
         assertEquals("Transponding in B, with reporter user name",
-                "Transponder Find report: address 3(short) present at LR19 (AUserName) (BDL16x Board 2 RX4 zone B).\n",
+                "Transponder Find report: address 3 (short) (or long address 16003) present at LR19 (AUserName) (BDL16x Board 2 RX4 zone B).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x01, 0x7D, 0x03, 0x00, 0x12, 0x00, 0x7F});
@@ -92,12 +92,12 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x40, 0x00, 0x04, 0x00, 0x00, 0x00, 0x2D});
         assertEquals("find loco 4 (long)",
-                "Transponding Find query for loco address 4.\n",
+                "Transponding Find query for loco address 4 (short).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x00, 0x04, 0x00, 0x16, 0x00, 0x7F});
         assertEquals(" in D",
-                "Transponder Find report: address 4 present at LR23 (BDL16x Board 2 RX4 zone D).\n",
+                "Transponder Find report: address 4 (short) present at LR23 (BDL16x Board 2 RX4 zone D).\n",
                 f.displayMessage(l));
 
         assertNotNull("reporter Got Created", lnrm.getBySystemName("LR23"));
@@ -105,7 +105,7 @@ public class LlnmonTest extends TestCase {
         assertNull("reporter is Not Yet Created", lnrm.getBySystemName("LR25"));
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x00, 0x04, 0x00, 0x18, 0x00, 0x7F});
         assertEquals(" in D",
-                "Transponder Find report: address 4 present at LR25 (BDL16x Board 2 RX4 zone E).\n",
+                "Transponder Find report: address 4 (short) present at LR25 (BDL16x Board 2 RX4 zone E).\n",
                 f.displayMessage(l));
         assertNotNull("reporter Created", lnrm.getBySystemName("LR25"));
         ((LnReporter) lnrm.getBySystemName("LR25")).setUserName("Friendly name E");
@@ -121,37 +121,37 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x00, 0x04, 0x00, 0x18, 0x00, 0x7F});
         assertEquals(" in D",
-                "Transponder Find report: address 4 present at LR25 (Friendly name E) (BDL16x Board 2 RX4 zone E).\n",
+                "Transponder Find report: address 4 (short) present at LR25 (Friendly name E) (BDL16x Board 2 RX4 zone E).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x00, 0x04, 0x00, 0x14, 0x00, 0x7F});
         assertEquals(" in D",
-                "Transponder Find report: address 4 present at LR21 (Friendly Name C) (BDL16x Board 2 RX4 zone C).\n",
+                "Transponder Find report: address 4 (short) present at LR21 (Friendly Name C) (BDL16x Board 2 RX4 zone C).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x00, 0x04, 0x00, 0x12, 0x00, 0x7F});
         assertEquals(" in D",
-                "Transponder Find report: address 4 present at LR19 (Friendly Name B) (BDL16x Board 2 RX4 zone B).\n",
+                "Transponder Find report: address 4 (short) present at LR19 (Friendly Name B) (BDL16x Board 2 RX4 zone B).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x00, 0x04, 0x00, 0x10, 0x00, 0x7F});
         assertEquals(" in D",
-                "Transponder Find report: address 4 present at LR17 (Friendly Name A) (BDL16x Board 2 RX4 zone A).\n",
+                "Transponder Find report: address 4 (short) present at LR17 (Friendly Name A) (BDL16x Board 2 RX4 zone A).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x00, 0x04, 0x00, 0x1A, 0x00, 0x7F});
         assertEquals(" in D",
-                "Transponder Find report: address 4 present at LR27 (Friendly Name F) (BDL16x Board 2 RX4 zone F).\n",
+                "Transponder Find report: address 4 (short) present at LR27 (Friendly Name F) (BDL16x Board 2 RX4 zone F).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x00, 0x04, 0x00, 0x1C, 0x00, 0x7F});
         assertEquals(" in D",
-                "Transponder Find report: address 4 present at LR29 (Friendly Name G) (BDL16x Board 2 RX4 zone G).\n",
+                "Transponder Find report: address 4 (short) present at LR29 (Friendly Name G) (BDL16x Board 2 RX4 zone G).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x00, 0x04, 0x00, 0x1E, 0x00, 0x7F});
         assertEquals(" in D",
-                "Transponder Find report: address 4 present at LR31 (Friendly Name H) (BDL16x Board 2 RX4 zone H).\n",
+                "Transponder Find report: address 4 (short) present at LR31 (Friendly Name H) (BDL16x Board 2 RX4 zone H).\n",
                 f.displayMessage(l));
 
     }
@@ -1448,7 +1448,7 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xEf, 0x0E, 0x7c, 0x2F, 0, 0x7D, 0x01, 0x00, 0x02, 0x01, 0x7F, 0x7F, 0x7F, 0x4D}); //!!
         assertEquals("Bit mode direct read test 16001",
-                "Programming Track Request: Read Byte in OP's Mode variable  CV2 of Loco 16001 value 255 (0xff, 11111111).\n",
+                "Byte Read on Main Track (Ops Mode): Decoder address 1 (short) (or long address 16001): CV2.\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xB4, 0x6F, 0x7F, 0x5B});
@@ -1513,12 +1513,12 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xEF, 0x0E, 0x7C, 0x2F, 0x00, 0x00, 0x01, 0x00, 0x00, 0x65, 0x23, 0x33, 0x44, 0x02});
         assertEquals("OpsModeProg test 17",
-                "Byte Read on Main Track (Ops Mode): Decoder address 1: CV102.\n",
+                "Byte Read on Main Track (Ops Mode): Decoder address 1 (short): CV102.\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7C, 0x2F, 0x10, 0x00, 0x01, 0x00, 0x02, 0x7f, 0x00, 0x33, 0x44, 0x6F});
         assertEquals("OpsModeProg test 19",
-                "Programming Response: Byte Read on Main Track (Ops Mode) Was successful via RX4/BDL16x: Decoder address 1: CV128 value 128 (0x80, 10000000b).\n",
+                "Programming Response: Byte Read on Main Track (Ops Mode) Was successful via RX4/BDL16x: Decoder address 1 (short): CV128 value 128 (0x80, 10000000b).\n",
                 f.displayMessage(l));
 
         /*
@@ -1743,7 +1743,7 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xEf, 0x0E, 0x7c, 0x64, 0, 0x00, 0x02, 0x00, 0x01, 0x00, 0x09, 0, 0, 0x6F});
         assertEquals("Bit mode direct write test 2",
-                "Byte Write (No feedback) on Main Track: Decoder address 2: CV129 value 9 (0x09, 00001001b).\n",
+                "Byte Write (No feedback) on Main Track: Decoder address 2 (short): CV129 value 9 (0x09, 00001001b).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x64, 0, 0x04, 0x08, 0x00, 0x01, 0x00, 0x09, 0, 0, 0x6F});
@@ -1763,7 +1763,7 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x24, 0, 0x7d, 0x03, 0x00, 0x02, 0x01, 0x08, 0, 0, 0x6F});
         assertEquals("Bit mode direct test 5",
-                "Programming Response: Byte Read (No feedback) on Main Track (Ops Mode) Was Successful: Decoder address 3(short): CV2 value 136 (0x88, 10001000b).\n",
+                "Programming Response: Byte Read (No feedback) on Main Track (Ops Mode) Was Successful: Decoder address 3 (short) (or long address 16003): CV2 value 136 (0x88, 10001000b).\n",
                 f.displayMessage(l));
 
         /*
@@ -1778,7 +1778,7 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xEf, 0x0E, 0x7c, 0x6C, 0, 0x00, 0x02, 0x00, 0x01, 0x00, 0x09, 0, 0, 0x6F});
         assertEquals("Bit mode direct write test 2",
-                "Byte Write on Main Track (Ops Mode): Decoder address 2: CV129 value 9 (0x09, 00001001b).\n",
+                "Byte Write on Main Track (Ops Mode): Decoder address 2 (short): CV129 value 9 (0x09, 00001001b).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x6C, 0, 0x04, 0x08, 0x00, 0x01, 0x00, 0x09, 0, 0, 0x6F});
@@ -1798,7 +1798,7 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x2C, 0, 0x7d, 0x03, 0x00, 0x02, 0x01, 0x08, 0, 0, 0x6F});
         assertEquals("Bit mode direct test 5",
-                "Programming Response: Byte Read on Main Track (Ops Mode) Was Successful: Decoder address 3(short): CV2 value 136 (0x88, 10001000b).\n",
+                "Programming Response: Byte Read on Main Track (Ops Mode) Was Successful: Decoder address 3 (short) (or long address 16003): CV2 value 136 (0x88, 10001000b).\n",
                 f.displayMessage(l));
 
         /*
@@ -1813,7 +1813,7 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xEf, 0x0E, 0x7c, 0x44, 0, 0x00, 0x02, 0x00, 0x01, 0x00, 0x09, 0, 0, 0x6F});
         assertEquals("Bit mode direct write test 2",
-                "Bit Write (No feedback) on Main Track (Ops Mode): Decoder address 2: CV129 value 9 (0x09, 00001001b).\n",
+                "Bit Write (No feedback) on Main Track (Ops Mode): Decoder address 2 (short): CV129 value 9 (0x09, 00001001b).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x44, 0, 0x04, 0x08, 0x00, 0x01, 0x00, 0x09, 0, 0, 0x6F});
@@ -1833,7 +1833,7 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x04, 0, 0x7d, 0x03, 0x00, 0x02, 0x01, 0x08, 0, 0, 0x6F});
         assertEquals("Bit mode direct test 5",
-                "Programming Response: Bit Read (No feedback) on Main Track (Ops Mode) Was Successful: Decoder address 3(short): CV2 value 136 (0x88, 10001000b).\n",
+                "Programming Response: Bit Read (No feedback) on Main Track (Ops Mode) Was Successful: Decoder address 3 (short) (or long address 16003): CV2 value 136 (0x88, 10001000b).\n",
                 f.displayMessage(l));
 
         /*
@@ -1848,7 +1848,7 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xEf, 0x0E, 0x7c, 0x4c, 0, 0x00, 0x02, 0x00, 0x01, 0x00, 0x09, 0, 0, 0x6F});
         assertEquals("Bit mode direct write test 2",
-                "Bit Write on Main Track (Ops Mode): Decoder address 2: CV129 value 9 (0x09, 00001001b).\n",
+                "Bit Write on Main Track (Ops Mode): Decoder address 2 (short): CV129 value 9 (0x09, 00001001b).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x4c, 0, 0x04, 0x08, 0x00, 0x01, 0x00, 0x09, 0, 0, 0x6F});
@@ -1868,7 +1868,7 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x0c, 0, 0x7d, 0x03, 0x00, 0x02, 0x01, 0x08, 0, 0, 0x6F});
         assertEquals("Bit mode direct test 5",
-                "Programming Response: Bit Read on Main Track (Ops Mode) Was Successful: Decoder address 3(short): CV2 value 136 (0x88, 10001000b).\n",
+                "Programming Response: Bit Read on Main Track (Ops Mode) Was Successful: Decoder address 3 (short) (or long address 16003): CV2 value 136 (0x88, 10001000b).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x4c, 1, 0x04, 0x08, 0x00, 0x01, 0x00, 0x09, 0, 0, 0x6F});
@@ -1893,22 +1893,22 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x0c, 0x01, 0x7d, 0x03, 0x00, 0x02, 0x01, 0x08, 0, 0, 0x6F});
         assertEquals("Bit mode direct test 5",
-                "Programming Response: Bit Read on Main Track (Ops Mode) Failed, Service Mode programming track empty: Decoder address 3(short): CV2 value 136 (0x88, 10001000b).\n",
+                "Programming Response: Bit Read on Main Track (Ops Mode) Failed, Service Mode programming track empty: Decoder address 3 (short) (or long address 16003): CV2 value 136 (0x88, 10001000b).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x0c, 0x02, 0x7d, 0x03, 0x00, 0x02, 0x01, 0x08, 0, 0, 0x6F});
         assertEquals("Bit mode direct test 5",
-                "Programming Response: Bit Read on Main Track (Ops Mode) Failed, No Write Acknowledge from decoder: Decoder address 3(short): CV2 value 136 (0x88, 10001000b).\n",
+                "Programming Response: Bit Read on Main Track (Ops Mode) Failed, No Write Acknowledge from decoder: Decoder address 3 (short) (or long address 16003): CV2 value 136 (0x88, 10001000b).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x0c, 0x04, 0x7d, 0x03, 0x00, 0x02, 0x01, 0x08, 0, 0, 0x6F});
         assertEquals("Bit mode direct test 5",
-                "Programming Response: Bit Read on Main Track (Ops Mode) Failed, Read Compare Acknowledge not detected: Decoder address 3(short): CV2 value 136 (0x88, 10001000b).\n",
+                "Programming Response: Bit Read on Main Track (Ops Mode) Failed, Read Compare Acknowledge not detected: Decoder address 3 (short) (or long address 16003): CV2 value 136 (0x88, 10001000b).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x7c, 0x0c, 0x08, 0x7d, 0x03, 0x00, 0x02, 0x01, 0x08, 0, 0, 0x6F});
         assertEquals("Bit mode direct test 5",
-                "Programming Response: Bit Read on Main Track (Ops Mode) Failed, User Aborted: Decoder address 3(short): CV2 value 136 (0x88, 10001000b).\n",
+                "Programming Response: Bit Read on Main Track (Ops Mode) Failed, User Aborted: Decoder address 3 (short) (or long address 16003): CV2 value 136 (0x88, 10001000b).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xEf, 0x0E, 0x7c, 0x41, 0, 0x01, 0x00, 0x00, 0x00, 0x01, 0x59, 0, 0, 0x6F});
@@ -2059,12 +2059,12 @@ public class LlnmonTest extends TestCase {
         LocoNetMessage l;
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x40, 0x7D, 0x03, 0x00, 0x00, 0x00, 0x2D});
         assertEquals(" basic Transponding Test 01",
-                "Transponding Find query for loco address 3(short).\n",
+                "Transponding Find query for loco address 3 (short) (or long address 16003).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xD0, 0x20, 0x12, 0x7D, 0x03, 0x63});
         assertEquals(" basic Transponding Test 02",
-                "Transponder address 3(short) present at LR19 () (BDL16x Board ID 2 RX4 zone B).\n",
+                "Transponder address 3 (short) (or long address 16003) present at LR19 () (BDL16x Board ID 2 RX4 zone B).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xB2, 0x0B, 0x70, 0x36});
@@ -2079,12 +2079,12 @@ public class LlnmonTest extends TestCase {
 
        l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x00, 0x7D, 0x03, 0x00, 0x12, 0x00, 0x7F});
         assertEquals(" basic Transponding Test 05",
-                "Transponder Find report: address 3(short) present at LR19 (BDL16x Board 2 RX4 zone B).\n",
+                "Transponder Find report: address 3 (short) (or long address 16003) present at LR19 (BDL16x Board 2 RX4 zone B).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xD0, 0x00, 0x12, 0x7D, 0x03, 0x43});
         assertEquals(" basic Transponding Test 06",
-                "Transponder address 3(short) absent at LR19 () (BDL16x Board ID 2 RX4 zone B).\n",
+                "Transponder address 3 (short) (or long address 16003) absent at LR19 () (BDL16x Board ID 2 RX4 zone B).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xB2, 0x0B, 0x60, 0x26});
@@ -2094,7 +2094,7 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x40, 0x00, 0x01, 0x00, 0x00, 0x00, 0x2D});
         assertEquals(" basic Transponding Test 08",
-                "Transponding Find query for loco address 1.\n",
+                "Transponding Find query for loco address 1 (short).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x40, 0x02, 0x01, 0x00, 0x00, 0x00, 0x2D});
@@ -2104,22 +2104,22 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xE5, 0x09, 0x40, 0x00, 0x71, 0x00, 0x00, 0x00, 0x2D});
         assertEquals(" basic Transponding Test 10",
-                "Transponding Find query for loco address 113 (b3).\n",
+                "Transponding Find query for loco address 113 (short, or \"B3\").\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xD0, 0x20, 0x12, 0x00, 0x03, 0x63});
         assertEquals(" basic Transponding Test 11",
-                "Transponder address 3 present at LR19 () (BDL16x Board ID 2 RX4 zone B).\n",
+                "Transponder address 3 (short) present at LR19 () (BDL16x Board ID 2 RX4 zone B).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xD0, 0x20, 0x15, 0x00, 0x03, 0x63});
         assertEquals(" basic Transponding Test 12",
-                "Transponder address 3 present at LR22 () (BDL16x Board ID 2 RX4 zone (Unknown 5)).\n",
+                "Transponder address 3 (short) present at LR22 () (BDL16x Board ID 2 RX4 zone (Unknown 5)).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xD0, 0x00, 0x15, 0x00, 0x03, 0x63});
         assertEquals(" basic Transponding Test 12",
-                "Transponder address 3 absent at LR22 () (BDL16x Board ID 2 RX4 zone (Unknown 5)).\n",
+                "Transponder address 3 (short) absent at LR22 () (BDL16x Board ID 2 RX4 zone (Unknown 5)).\n",
                 f.displayMessage(l));
 
     }
@@ -4424,7 +4424,7 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xE5, 0x10, 0x7f, 0x05, 0x00, 0x0, 0x30, 0x30, 0x30, 0x30, 0x70, 0x30, 0x30, 0x30, 0x30, 0x00});
         assertEquals("Throttle message 1",
-                "Send Throttle Text Message to Throttle 5 with message 00000000.\n",
+                "Send Throttle Text Message to Throttle 5 (short) with message 00000000.\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE5, 0x10, 0x7f, 0x00, 0x22, 0x0, 0x31, 0x32, 0x30, 0x30, 0x70, 0x30, 0x30, 0x30, 0x30, 0x00});
@@ -4505,7 +4505,7 @@ public class LlnmonTest extends TestCase {
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x40, 0x00, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x51}  );
         assertEquals(" Slot test 2",
                 "Report of slot 64 information:\n"
-                +"\tLoco 0 is Not Consisted, Free, operating in 28 SS mode, and is moving Forward at speed 0,\n"
+                +"\tLoco 0 (short) is Not Consisted, Free, operating in 28 SS mode, and is moving Forward at speed 0,\n"
                 +"\tF0=Off, F1=Off, F2=Off, F3=Off, F4=Off, F5=Off, F6=Off, F7=Off, F8=Off\n"
                 + "\tMaster supports LocoNet 1.1; Track Status: Off/Running; Programming Track Status: Available; STAT2=0x00, ThrottleID=0x00 0x00 (0).\n",
                 f.displayMessage(l));
@@ -4585,7 +4585,7 @@ public class LlnmonTest extends TestCase {
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xBF, 0x00, 0x00, 0x40} );
-        assertEquals(" Slot test 18", "Request slot for loco address 0.\n", f.displayMessage(l));
+        assertEquals(" Slot test 18", "Request slot for loco address 0 (short).\n", f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0x81, 0x7E} );
         assertEquals(" Slot test 19", "Master is busy.\n", f.displayMessage(l));
@@ -4601,7 +4601,7 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x02, 0x03, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10} );
         assertEquals(" Slot test 23", "Report of slot 2 information:\n"
-                +"\tLoco 0 is Not Consisted, Free, operating in 128 SS mode, and is moving Forward at speed 0,\n"
+                +"\tLoco 0 (short) is Not Consisted, Free, operating in 128 SS mode, and is moving Forward at speed 0,\n"
                 +"\tF0=Off, F1=Off, F2=Off, F3=Off, F4=Off, F5=Off, F6=Off, F7=Off, F8=Off\n"
                 +"\tMaster supports LocoNet 1.1; Track Status: On/Running; Programming Track Status: Available; STAT2=0x00, ThrottleID=0x00 0x00 (0).\n",
                 f.displayMessage(l));
@@ -4868,10 +4868,10 @@ public class LlnmonTest extends TestCase {
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xBF, 0x7d, 0x04, 0x40} );
-        assertEquals(" Slot test 79", "Request slot for loco address 4(short).\n", f.displayMessage(l));
+        assertEquals(" Slot test 79", "Request slot for loco address 4 (short) (or long address 16004).\n", f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xBF, 0x00, 0x70, 0x40} );
-        assertEquals(" Slot test 80", "Request slot for loco address 112 (b2).\n", f.displayMessage(l));
+        assertEquals(" Slot test 80", "Request slot for loco address 112 (short, or \"B2\").\n", f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xA2, 0x25, 0x07, 0x7E});
         assertEquals(" Slot test 81",
@@ -5082,14 +5082,14 @@ public class LlnmonTest extends TestCase {
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x01, 0x03, 0x31, 0x00, 0x00, 0x07, 0x00, 0x7d, 0x00, 0x20, 0x30, 0x03} );
         assertEquals(" Slot test 13", "Report of slot 1 information:\n"
-                +"\tLoco 49(short) is Not Consisted, Free, operating in 128 SS mode, and is moving Forward at speed 0,\n"
+                +"\tLoco 49 (short) (or long address 16049) is Not Consisted, Free, operating in 128 SS mode, and is moving Forward at speed 0,\n"
                 +"\tF0=Off, F1=Off, F2=Off, F3=Off, F4=Off, F5=Off, F6=Off, F7=Off, F8=Off\n"
                 +"\tMaster supports LocoNet 1.1; Track Status: On/Running; Programming Track Status: Available; STAT2=0x00, ThrottleID=0x30 0x20 (6176).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE7, 0x0E, 0x01, 0x03, 0x31, 0x00, 0x00, 0x07, 0x00, 0x7F, 0x00, 0x20, 0x30, 0x03} );
         assertEquals(" Slot test 13", "Report of slot 1 information:\n"
-                +"\tLoco 49 (via an Alias) is Not Consisted, Free, operating in 128 SS mode, and is moving Forward at speed 0,\n"
+                +"\tLoco 49 (short) (via an Alias) is Not Consisted, Free, operating in 128 SS mode, and is moving Forward at speed 0,\n"
                 +"\tF0=Off, F1=Off, F2=Off, F3=Off, F4=Off, F5=Off, F6=Off, F7=Off, F8=Off\n"
                 +"\tMaster supports LocoNet 1.1; Track Status: On/Running; Programming Track Status: Available; STAT2=0x00, ThrottleID=0x30 0x20 (6176).\n",
                 f.displayMessage(l));
@@ -5131,39 +5131,39 @@ public class LlnmonTest extends TestCase {
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE6, 0x10, 0x00, 0x02, 0x01, 0x00, 0x0f, 0x00, 0x01, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} );
-        assertEquals("aliasing 09", "Report Alias pair 1: 128 is an alias for 8; 0 is an alias for 0.\n",
+        assertEquals("aliasing 09", "Report Alias pair 1: 128 is an alias for 8; 0 (short) is an alias for 0.\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE6, 0x10, 0x00, 0x02, 0x02, 0x00, 0x0f, 0x00, 0x02, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} );
-        assertEquals("aliasing 10", "Report Alias pair 2: 256 is an alias for 9; 0 is an alias for 0.\n",
+        assertEquals("aliasing 10", "Report Alias pair 2: 256 is an alias for 9; 0 (short) is an alias for 0.\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE6, 0x10, 0x00, 0x02, 0x03, 0x00, 0x0f, 0x00, 0x04, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} );
-        assertEquals("aliasing 11", "Report Alias pair 3: 512 is an alias for 10; 0 is an alias for 0.\n",
+        assertEquals("aliasing 11", "Report Alias pair 3: 512 is an alias for 10; 0 (short) is an alias for 0.\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE6, 0x10, 0x00, 0x02, 0x04, 0x00, 0x0f, 0x00, 0x08, 0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} );
-        assertEquals("aliasing 12", "Report Alias pair 4: 1024 is an alias for 11; 0 is an alias for 0.\n",
+        assertEquals("aliasing 12", "Report Alias pair 4: 1024 is an alias for 11; 0 (short) is an alias for 0.\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE6, 0x10, 0x00, 0x02, 0x05, 0x00, 0x0f, 0x00, 0x10, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} );
-        assertEquals("aliasing 13", "Report Alias pair 5: 2048 is an alias for 12; 0 is an alias for 0.\n",
+        assertEquals("aliasing 13", "Report Alias pair 5: 2048 is an alias for 12; 0 (short) is an alias for 0.\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE6, 0x10, 0x00, 0x02, 0x06, 0x00, 0x0f, 0x00, 0x20, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} );
-        assertEquals("aliasing 14", "Report Alias pair 6: 4096 is an alias for 13; 0 is an alias for 0.\n",
+        assertEquals("aliasing 14", "Report Alias pair 6: 4096 is an alias for 13; 0 (short) is an alias for 0.\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE6, 0x10, 0x00, 0x02, 0x07, 0x00, 0x0f, 0x00, 0x40, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} );
-        assertEquals("aliasing 15", "Report Alias pair 7: 8192 is an alias for 14; 0 is an alias for 0.\n",
+        assertEquals("aliasing 15", "Report Alias pair 7: 8192 is an alias for 14; 0 (short) is an alias for 0.\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE6, 0x10, 0x00, 0x02, 0x08, 0x00, 0x0f, 0x01, 0x01, 0x0f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} );
-        assertEquals("aliasing 16", "Report Alias pair 8: 129 is an alias for 15; 0 is an alias for 0.\n",
+        assertEquals("aliasing 16", "Report Alias pair 8: 129 is an alias for 15; 0 (short) is an alias for 0.\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE6, 0x10, 0x00, 0x02, 0x09, 0x00, 0x0f, 0x7f, 0x01, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} );
-        assertEquals("aliasing 17", "Report Alias pair 9: 255 is an alias for 16; 0 is an alias for 0.\n",
+        assertEquals("aliasing 17", "Report Alias pair 9: 255 is an alias for 16; 0 (short) is an alias for 0.\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xE6, 0x10, 0x00, 0x02, 0x00, 0x00, 0x0f, 0x7f, 0x01, 0x10, 0x00, 0x0A, 0x01, 0x20, 0x00, 0x00} );
@@ -5192,63 +5192,63 @@ public class LlnmonTest extends TestCase {
         LocoNetMessage l;
 
         l = new LocoNetMessage(new int[] {0xbf, 0x00, 0x01, 0x7f});
-        assertEquals("convert To Mixed 1", "Request slot for loco address 1.\n",
+        assertEquals("convert To Mixed 1", "Request slot for loco address 1 (short).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x7d, 0x01, 0x7f});
-        assertEquals("convert To Mixed 2", "Request slot for loco address 1(short).\n",
+        assertEquals("convert To Mixed 2", "Request slot for loco address 1 (short) (or long address 16001).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x7F, 0x01, 0x7f});
-        assertEquals("convert To Mixed 3", "Request slot for loco address 1.\n",
+        assertEquals("convert To Mixed 3", "Request slot for loco address 1 (short).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x00, 99, 0x7f});
-        assertEquals("convert To Mixed 4", "Request slot for loco address 99.\n",
+        assertEquals("convert To Mixed 4", "Request slot for loco address 99 (short).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x7d, 99, 0x7f});
-        assertEquals("convert To Mixed 5", "Request slot for loco address 99(short).\n",
+        assertEquals("convert To Mixed 5", "Request slot for loco address 99 (short) (or long address 16099).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x7f, 99, 0x7f});
-        assertEquals("convert To Mixed 6", "Request slot for loco address 99.\n",
+        assertEquals("convert To Mixed 6", "Request slot for loco address 99 (short).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x00, 100, 0x7f});
-        assertEquals("convert To Mixed 7", "Request slot for loco address 100 (a0).\n",
+        assertEquals("convert To Mixed 7", "Request slot for loco address 100 (short, or \"A0\").\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x7d, 100, 0x7f});
-        assertEquals("convert To Mixed 8", "Request slot for loco address 100(short) (a0).\n",
+        assertEquals("convert To Mixed 8", "Request slot for loco address 100 (short, or \"A0\") (or long address 16100).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x7f, 109, 0x7f});
-        assertEquals("convert To Mixed 9", "Request slot for loco address 109 (a9).\n",
+        assertEquals("convert To Mixed 9", "Request slot for loco address 109 (short, or \"A9\").\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x00, 111, 0x7f});
-        assertEquals("convert To Mixed 10", "Request slot for loco address 111 (b1).\n",
+        assertEquals("convert To Mixed 10", "Request slot for loco address 111 (short, or \"B1\").\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x7d, 111, 0x7f});
-        assertEquals("convert To Mixed 11", "Request slot for loco address 111(short) (b1).\n",
+        assertEquals("convert To Mixed 11", "Request slot for loco address 111 (short, or \"B1\") (or long address 16111).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x7f, 114, 0x7f});
-        assertEquals("convert To Mixed 12", "Request slot for loco address 114 (b4).\n",
+        assertEquals("convert To Mixed 12", "Request slot for loco address 114 (short, or \"B4\").\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x00, 122, 0x7f});
-        assertEquals("convert To Mixed 13", "Request slot for loco address 122 (c2).\n",
+        assertEquals("convert To Mixed 13", "Request slot for loco address 122 (short, or \"C2\").\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x7d, 122, 0x7f});
-        assertEquals("convert To Mixed 14", "Request slot for loco address 122(short) (c2).\n",
+        assertEquals("convert To Mixed 14", "Request slot for loco address 122 (short, or \"C2\") (or long address 16122).\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x7f, 123, 0x7f});
-        assertEquals("convert To Mixed 15", "Request slot for loco address 123 (c3).\n",
+        assertEquals("convert To Mixed 15", "Request slot for loco address 123 (short, or \"C3\").\n",
                 f.displayMessage(l));
 
         l = new LocoNetMessage(new int[] {0xbf, 0x01, 14, 0x7f});


### PR DESCRIPTION
Changes the display of locomotive addresses in LocoNet monitor to include alternate addressing type interpretations of LocoNet data.

Addresses issue #3995 and includes modified form of PR #4020 (instead of PR #4020).