### PR TITLE
More Java warnings work

### DIFF
--- a/java/src/jmri/TransitManager.java
+++ b/java/src/jmri/TransitManager.java
@@ -31,7 +31,7 @@ import jmri.managers.AbstractManager;
  *
  * @author Dave Duchamp Copyright (C) 2008, 2011
  */
-public class TransitManager extends AbstractManager implements PropertyChangeListener, InstanceManagerAutoDefault {
+public class TransitManager extends AbstractManager<Transit> implements PropertyChangeListener, InstanceManagerAutoDefault {
 
     public TransitManager() {
         super();

--- a/java/src/jmri/jmrit/logix/OBlockManager.java
+++ b/java/src/jmri/jmrit/logix/OBlockManager.java
@@ -28,7 +28,7 @@ import jmri.managers.AbstractManager;
  * @author Bob Jacobsen Copyright (C) 2006
  * @author Pete Cressman Copyright (C) 2009
  */
-public class OBlockManager extends AbstractManager
+public class OBlockManager extends AbstractManager<OBlock>
         implements java.beans.PropertyChangeListener, jmri.InstanceManagerAutoDefault {
 
     public OBlockManager() {

--- a/java/src/jmri/jmrit/logix/WarrantManager.java
+++ b/java/src/jmri/jmrit/logix/WarrantManager.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Pete Cressman Copyright (C) 2009
  */
-public class WarrantManager extends AbstractManager
+public class WarrantManager extends AbstractManager<Warrant>
         implements java.beans.PropertyChangeListener, jmri.InstanceManagerAutoDefault {
     
     private HashMap<String, RosterSpeedProfile> _mergeProfiles;

--- a/java/src/jmri/managers/AbstractAudioManager.java
+++ b/java/src/jmri/managers/AbstractAudioManager.java
@@ -59,21 +59,21 @@ public abstract class AbstractAudioManager extends AbstractManager<Audio>
 
     @Override
     public Audio getBySystemName(String key) {
-        //return (Audio)_tsys.get(key);
-        Audio rv = (Audio) _tsys.get(key);
+        //return _tsys.get(key);
+        Audio rv =  _tsys.get(key);
         if (rv == null) {
-            rv = (Audio) _tsys.get(key.toUpperCase());
+            rv = _tsys.get(key.toUpperCase());
         }
         return (rv);
     }
 
     @Override
     public Audio getByUserName(String key) {
-        //return key==null?null:(Audio)_tuser.get(key);
+        //return key==null?null:_tuser.get(key);
         if (key == null) {
             return (null);
         }
-        Audio rv = (Audio) _tuser.get(key);
+        Audio rv = _tuser.get(key);
         if (rv == null) {
             rv = this.getBySystemName(key);
         }

--- a/java/src/jmri/managers/AbstractLightManager.java
+++ b/java/src/jmri/managers/AbstractLightManager.java
@@ -77,7 +77,7 @@ public abstract class AbstractLightManager extends AbstractManager<Light>
      */
     @Override
     public Light getBySystemName(String name) {
-        return (Light) _tsys.get(name);
+        return _tsys.get(name);
     }
 
     /**
@@ -85,7 +85,7 @@ public abstract class AbstractLightManager extends AbstractManager<Light>
      */
     @Override
     public Light getByUserName(String key) {
-        return (Light) _tuser.get(key);
+        return _tuser.get(key);
     }
 
     /**

--- a/java/src/jmri/managers/AbstractMemoryManager.java
+++ b/java/src/jmri/managers/AbstractMemoryManager.java
@@ -51,12 +51,12 @@ public abstract class AbstractMemoryManager extends AbstractManager<Memory>
 
     @Override
     public Memory getBySystemName(String name) {
-        return (Memory) _tsys.get(name);
+        return _tsys.get(name);
     }
 
     @Override
     public Memory getByUserName(String key) {
-        return (Memory) _tuser.get(key);
+        return _tuser.get(key);
     }
 
     @Override

--- a/java/src/jmri/managers/AbstractReporterManager.java
+++ b/java/src/jmri/managers/AbstractReporterManager.java
@@ -49,12 +49,12 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
 
     @Override
     public Reporter getBySystemName(String name) {
-        return (Reporter) _tsys.get(name);
+        return _tsys.get(name);
     }
 
     @Override
     public Reporter getByUserName(String key) {
-        return (Reporter) _tuser.get(key);
+        return _tuser.get(key);
     }
 
     @Override

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -70,7 +70,7 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
             key = makeSystemName(key);
         }
         String name = normalizeSystemName(key);
-        return (Sensor) _tsys.get(name);
+        return _tsys.get(name);
     }
 
     @Override
@@ -80,7 +80,7 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
 
     @Override
     public Sensor getByUserName(String key) {
-        return (Sensor) _tuser.get(key);
+        return _tuser.get(key);
     }
 
     @Override
@@ -267,7 +267,7 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
         sensorDebounceGoingActive = timer;
         Enumeration<String> en = _tsys.keys();
         while (en.hasMoreElements()) {
-            Sensor sen = (Sensor) _tsys.get(en.nextElement());
+            Sensor sen = _tsys.get(en.nextElement());
             if (sen.getUseDefaultTimerSettings()) {
                 sen.setSensorDebounceGoingActiveTimer(timer);
             }
@@ -282,7 +282,7 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
         sensorDebounceGoingInActive = timer;
         Enumeration<String> en = _tsys.keys();
         while (en.hasMoreElements()) {
-            Sensor sen = (Sensor) _tsys.get(en.nextElement());
+            Sensor sen = _tsys.get(en.nextElement());
             if (sen.getUseDefaultTimerSettings()) {
                 sen.setSensorDebounceGoingInActiveTimer(timer);
             }

--- a/java/src/jmri/managers/AbstractSignalHeadManager.java
+++ b/java/src/jmri/managers/AbstractSignalHeadManager.java
@@ -54,12 +54,12 @@ public class AbstractSignalHeadManager extends AbstractManager<SignalHead>
 
     @Override
     public SignalHead getBySystemName(String name) {
-        return (SignalHead) _tsys.get(name);
+        return _tsys.get(name);
     }
 
     @Override
     public SignalHead getByUserName(String key) {
-        return (SignalHead) _tuser.get(key);
+        return _tuser.get(key);
     }
 
     @Override

--- a/java/src/jmri/managers/AbstractTurnoutManager.java
+++ b/java/src/jmri/managers/AbstractTurnoutManager.java
@@ -59,12 +59,12 @@ public abstract class AbstractTurnoutManager extends AbstractManager<Turnout>
 
     @Override
     public Turnout getBySystemName(String name) {
-        return (Turnout) _tsys.get(name);
+        return _tsys.get(name);
     }
 
     @Override
     public Turnout getByUserName(String key) {
-        return (Turnout) _tuser.get(key);
+        return _tuser.get(key);
     }
 
     @Override

--- a/java/src/jmri/managers/DefaultIdTagManager.java
+++ b/java/src/jmri/managers/DefaultIdTagManager.java
@@ -144,7 +144,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag>
         if (!initialised && !loading) {
             init();
         }
-        return (IdTag) _tsys.get(name);
+        return _tsys.get(name);
     }
 
     @Override
@@ -152,7 +152,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag>
         if (!initialised && !loading) {
             init();
         }
-        return (IdTag) _tuser.get(key);
+        return _tuser.get(key);
     }
 
     @Override
@@ -284,7 +284,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag>
         // First create a list of all tags seen by specified reporter
         // and record the time most recently seen
         for (IdTag n : _tsys.values()) {
-            IdTag t = (IdTag) n;
+            IdTag t = n;
             if (t.getWhereLastSeen() == reporter) {
                 out.add(t);
                 if (t.getWhenLastSeen().after(lastWhenLastSeen)) {

--- a/java/src/jmri/managers/DefaultLogixManager.java
+++ b/java/src/jmri/managers/DefaultLogixManager.java
@@ -185,12 +185,12 @@ public class DefaultLogixManager extends AbstractManager<Logix>
 
     @Override
     public Logix getBySystemName(String name) {
-        return (Logix) _tsys.get(name);
+        return _tsys.get(name);
     }
 
     @Override
     public Logix getByUserName(String key) {
-        return (Logix) _tuser.get(key);
+        return _tuser.get(key);
     }
 
     /**

--- a/java/src/jmri/managers/DefaultRouteManager.java
+++ b/java/src/jmri/managers/DefaultRouteManager.java
@@ -111,12 +111,12 @@ public class DefaultRouteManager extends AbstractManager<Route>
 
     @Override
     public Route getBySystemName(String name) {
-        return (Route) _tsys.get(name);
+        return _tsys.get(name);
     }
 
     @Override
     public Route getByUserName(String key) {
-        return (Route) _tuser.get(key);
+        return _tuser.get(key);
     }
 
     static DefaultRouteManager _instance = null;

--- a/java/src/jmri/managers/DefaultSignalGroupManager.java
+++ b/java/src/jmri/managers/DefaultSignalGroupManager.java
@@ -57,12 +57,12 @@ public class DefaultSignalGroupManager extends AbstractManager<SignalGroup>
 
     @Override
     public SignalGroup getBySystemName(String key) {
-        return (SignalGroup) _tsys.get(key);
+        return _tsys.get(key);
     }
 
     @Override
     public SignalGroup getByUserName(String key) {
-        return (SignalGroup) _tuser.get(key);
+        return _tuser.get(key);
     }
 
     @Override

--- a/java/src/jmri/managers/DefaultSignalMastManager.java
+++ b/java/src/jmri/managers/DefaultSignalMastManager.java
@@ -83,12 +83,12 @@ public class DefaultSignalMastManager extends AbstractManager<SignalMast>
 
     @Override
     public SignalMast getBySystemName(String key) {
-        return (SignalMast) _tsys.get(key);
+        return _tsys.get(key);
     }
 
     @Override
     public SignalMast getByUserName(String key) {
-        return (SignalMast) _tuser.get(key);
+        return _tuser.get(key);
     }
 
     @Override

--- a/java/src/jmri/managers/DefaultSignalSystemManager.java
+++ b/java/src/jmri/managers/DefaultSignalSystemManager.java
@@ -72,12 +72,12 @@ public class DefaultSignalSystemManager extends AbstractManager<SignalSystem>
 
     @Override
     public SignalSystem getBySystemName(String key) {
-        return (SignalSystem) _tsys.get(key);
+        return _tsys.get(key);
     }
 
     @Override
     public SignalSystem getByUserName(String key) {
-        return (SignalSystem) _tuser.get(key);
+        return _tuser.get(key);
     }
 
     void load() {

--- a/java/src/jmri/managers/ProxyLightManager.java
+++ b/java/src/jmri/managers/ProxyLightManager.java
@@ -34,7 +34,7 @@ public class ProxyLightManager extends AbstractProxyManager<Light>
      */
     @Override
     public Light getLight(String name) {
-        return (Light) super.getNamedBean(name);
+        return super.getNamedBean(name);
     }
 
     @Override
@@ -52,7 +52,7 @@ public class ProxyLightManager extends AbstractProxyManager<Light>
      */
     @Override
     public Light provideLight(String name) throws IllegalArgumentException {
-        return (Light) super.provideNamedBean(name);
+        return super.provideNamedBean(name);
     }
 
     /**
@@ -63,7 +63,7 @@ public class ProxyLightManager extends AbstractProxyManager<Light>
      */
     @Override
     public Light getBySystemName(String systemName) {
-        return (Light) super.getBeanBySystemName(systemName);
+        return super.getBeanBySystemName(systemName);
     }
 
     /**
@@ -74,7 +74,7 @@ public class ProxyLightManager extends AbstractProxyManager<Light>
      */
     @Override
     public Light getByUserName(String userName) {
-        return (Light) super.getBeanByUserName(userName);
+        return super.getBeanByUserName(userName);
     }
 
     /**
@@ -107,7 +107,7 @@ public class ProxyLightManager extends AbstractProxyManager<Light>
      */
     @Override
     public Light newLight(String systemName, String userName) {
-        return (Light) newNamedBean(systemName, userName);
+        return newNamedBean(systemName, userName);
     }
 
     /**

--- a/java/src/jmri/managers/ProxyReporterManager.java
+++ b/java/src/jmri/managers/ProxyReporterManager.java
@@ -32,7 +32,7 @@ public class ProxyReporterManager extends AbstractProxyManager<Reporter> impleme
      */
     @Override
     public Reporter getReporter(String name) {
-        return (Reporter) super.getNamedBean(name);
+        return super.getNamedBean(name);
     }
 
     @Override
@@ -42,7 +42,7 @@ public class ProxyReporterManager extends AbstractProxyManager<Reporter> impleme
 
     @Override
     public Reporter provideReporter(String sName) throws IllegalArgumentException {
-        return (Reporter) super.provideNamedBean(sName);
+        return super.provideNamedBean(sName);
     }
 
     /**
@@ -53,7 +53,7 @@ public class ProxyReporterManager extends AbstractProxyManager<Reporter> impleme
      */
     @Override
     public Reporter getBySystemName(String sName) {
-        return (Reporter) super.getBeanBySystemName(sName);
+        return super.getBeanBySystemName(sName);
     }
 
     /**
@@ -64,7 +64,7 @@ public class ProxyReporterManager extends AbstractProxyManager<Reporter> impleme
      */
     @Override
     public Reporter getByUserName(String userName) {
-        return (Reporter) super.getBeanByUserName(userName);
+        return super.getBeanByUserName(userName);
     }
 
     @Override
@@ -109,7 +109,7 @@ public class ProxyReporterManager extends AbstractProxyManager<Reporter> impleme
      */
     @Override
     public Reporter newReporter(String systemName, String userName) {
-        return (Reporter) newNamedBean(systemName, userName);
+        return newNamedBean(systemName, userName);
     }
 
     @Override

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -30,7 +30,7 @@ public class ProxySensorManager extends AbstractProxyManager<Sensor>
      */
     @Override
     public Sensor getSensor(String name) {
-        return (Sensor) super.getNamedBean(name);
+        return super.getNamedBean(name);
     }
 
     @Override
@@ -41,7 +41,7 @@ public class ProxySensorManager extends AbstractProxyManager<Sensor>
 
     @Override
     public Sensor provideSensor(String sName) throws IllegalArgumentException {
-        return (Sensor) super.provideNamedBean(sName);
+        return super.provideNamedBean(sName);
     }
 
     /**
@@ -52,7 +52,7 @@ public class ProxySensorManager extends AbstractProxyManager<Sensor>
      */
     @Override
     public Sensor getBySystemName(String sName) {
-        return (Sensor) super.getBeanBySystemName(sName);
+        return super.getBeanBySystemName(sName);
     }
 
     /**
@@ -63,7 +63,7 @@ public class ProxySensorManager extends AbstractProxyManager<Sensor>
      */
     @Override
     public Sensor getByUserName(String userName) {
-        return (Sensor) super.getBeanByUserName(userName);
+        return super.getBeanByUserName(userName);
     }
 
     /**
@@ -96,7 +96,7 @@ public class ProxySensorManager extends AbstractProxyManager<Sensor>
      */
     @Override
     public Sensor newSensor(String systemName, String userName) {
-        return (Sensor) newNamedBean(systemName, userName);
+        return newNamedBean(systemName, userName);
     }
 
     // null implementation to satisfy the SensorManager interface

--- a/java/src/jmri/managers/ProxyTurnoutManager.java
+++ b/java/src/jmri/managers/ProxyTurnoutManager.java
@@ -43,7 +43,7 @@ public class ProxyTurnoutManager extends AbstractProxyManager<Turnout> implement
      */
     @Override
     public Turnout getTurnout(String name) {
-        return (Turnout) super.getNamedBean(name);
+        return super.getNamedBean(name);
     }
 
     @Override
@@ -53,7 +53,7 @@ public class ProxyTurnoutManager extends AbstractProxyManager<Turnout> implement
 
     @Override
     public Turnout provideTurnout(String name) throws IllegalArgumentException {
-        return (Turnout) super.provideNamedBean(name);
+        return super.provideNamedBean(name);
     }
 
     /**
@@ -64,7 +64,7 @@ public class ProxyTurnoutManager extends AbstractProxyManager<Turnout> implement
      */
     @Override
     public Turnout getBySystemName(String systemName) {
-        return (Turnout) super.getBeanBySystemName(systemName);
+        return super.getBeanBySystemName(systemName);
     }
 
     /**
@@ -75,7 +75,7 @@ public class ProxyTurnoutManager extends AbstractProxyManager<Turnout> implement
      */
     @Override
     public Turnout getByUserName(String userName) {
-        return (Turnout) super.getBeanByUserName(userName);
+        return super.getBeanByUserName(userName);
     }
 
     /**
@@ -108,7 +108,7 @@ public class ProxyTurnoutManager extends AbstractProxyManager<Turnout> implement
      */
     @Override
     public Turnout newTurnout(String systemName, String userName) {
-        return (Turnout) newNamedBean(systemName, userName);
+        return newNamedBean(systemName, userName);
     }
 
     /**

--- a/java/test/jmri/EntryPointTest.java
+++ b/java/test/jmri/EntryPointTest.java
@@ -33,6 +33,6 @@ public class EntryPointTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EntryPointTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(EntryPointTest.class);
 
 }

--- a/java/test/jmri/configurexml/ClassMigrationManagerTest.java
+++ b/java/test/jmri/configurexml/ClassMigrationManagerTest.java
@@ -31,6 +31,6 @@ public class ClassMigrationManagerTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ClassMigrationManagerTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ClassMigrationManagerTest.class);
 
 }

--- a/java/test/jmri/configurexml/DefaultClassMigrationTest.java
+++ b/java/test/jmri/configurexml/DefaultClassMigrationTest.java
@@ -31,6 +31,6 @@ public class DefaultClassMigrationTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DefaultClassMigrationTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DefaultClassMigrationTest.class);
 
 }

--- a/java/test/jmri/configurexml/ErrorMemoTest.java
+++ b/java/test/jmri/configurexml/ErrorMemoTest.java
@@ -31,6 +31,6 @@ public class ErrorMemoTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ErrorMemoTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ErrorMemoTest.class);
 
 }

--- a/java/test/jmri/implementation/AbstractInstanceInitializerTest.java
+++ b/java/test/jmri/implementation/AbstractInstanceInitializerTest.java
@@ -31,6 +31,6 @@ public class AbstractInstanceInitializerTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AbstractInstanceInitializerTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(AbstractInstanceInitializerTest.class);
 
 }

--- a/java/test/jmri/implementation/SignalHeadSignalMastTest.java
+++ b/java/test/jmri/implementation/SignalHeadSignalMastTest.java
@@ -244,5 +244,5 @@ public class SignalHeadSignalMastTest {
         JUnitUtil.resetInstanceManager();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SignalHeadSignalMastTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SignalHeadSignalMastTest.class);
 }

--- a/java/test/jmri/jmrit/audio/swing/AudioBufferFrameTest.java
+++ b/java/test/jmri/jmrit/audio/swing/AudioBufferFrameTest.java
@@ -38,6 +38,6 @@ public class AudioBufferFrameTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AudioBufferFrameTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(AudioBufferFrameTest.class);
 
 }

--- a/java/test/jmri/jmrit/audio/swing/AudioListenerFrameTest.java
+++ b/java/test/jmri/jmrit/audio/swing/AudioListenerFrameTest.java
@@ -38,6 +38,6 @@ public class AudioListenerFrameTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AudioListenerFrameTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(AudioListenerFrameTest.class);
 
 }

--- a/java/test/jmri/jmrit/audio/swing/AudioSourceFrameTest.java
+++ b/java/test/jmri/jmrit/audio/swing/AudioSourceFrameTest.java
@@ -38,6 +38,6 @@ public class AudioSourceFrameTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AudioSourceFrameTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(AudioSourceFrameTest.class);
 
 }

--- a/java/test/jmri/jmrit/beantable/AddNewBeanPanelTest.java
+++ b/java/test/jmri/jmrit/beantable/AddNewBeanPanelTest.java
@@ -46,6 +46,6 @@ public class AddNewBeanPanelTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AddNewBeanPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(AddNewBeanPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/beantable/AddNewDevicePanelTest.java
+++ b/java/test/jmri/jmrit/beantable/AddNewDevicePanelTest.java
@@ -48,6 +48,6 @@ public class AddNewDevicePanelTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AddNewDevicePanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(AddNewDevicePanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/beantable/AddNewHardwareDevicePanelTest.java
+++ b/java/test/jmri/jmrit/beantable/AddNewHardwareDevicePanelTest.java
@@ -54,6 +54,6 @@ public class AddNewHardwareDevicePanelTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AddNewHardwareDevicePanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(AddNewHardwareDevicePanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/beantable/AudioTableFrameTest.java
+++ b/java/test/jmri/jmrit/beantable/AudioTableFrameTest.java
@@ -37,6 +37,6 @@ public class AudioTableFrameTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AudioTableFrameTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(AudioTableFrameTest.class);
 
 }

--- a/java/test/jmri/jmrit/beantable/AudioTablePanelTest.java
+++ b/java/test/jmri/jmrit/beantable/AudioTablePanelTest.java
@@ -38,6 +38,6 @@ public class AudioTablePanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AudioTablePanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(AudioTablePanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/beantable/beanedit/BeanEditItemTest.java
+++ b/java/test/jmri/jmrit/beantable/beanedit/BeanEditItemTest.java
@@ -32,6 +32,6 @@ public class BeanEditItemTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(BeanEditItemTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(BeanEditItemTest.class);
 
 }

--- a/java/test/jmri/jmrit/beantable/oblock/DnDJTableTest.java
+++ b/java/test/jmri/jmrit/beantable/oblock/DnDJTableTest.java
@@ -37,6 +37,6 @@ public class DnDJTableTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DnDJTableTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DnDJTableTest.class);
 
 }

--- a/java/test/jmri/jmrit/catalog/CatalogTreeLeafTest.java
+++ b/java/test/jmri/jmrit/catalog/CatalogTreeLeafTest.java
@@ -31,6 +31,6 @@ public class CatalogTreeLeafTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(CatalogTreeLeafTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(CatalogTreeLeafTest.class);
 
 }

--- a/java/test/jmri/jmrit/catalog/DragJLabelTest.java
+++ b/java/test/jmri/jmrit/catalog/DragJLabelTest.java
@@ -35,6 +35,6 @@ public class DragJLabelTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DragJLabelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DragJLabelTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/MultiIconEditorTest.java
+++ b/java/test/jmri/jmrit/display/MultiIconEditorTest.java
@@ -35,5 +35,5 @@ public class MultiIconEditorTest {
     public void tearDown() throws Exception {
         JUnitUtil.tearDown();
     }
-    private final static Logger log = LoggerFactory.getLogger(MultiIconEditorTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(MultiIconEditorTest.class);
 }

--- a/java/test/jmri/jmrit/display/PositionablePopupUtilTest.java
+++ b/java/test/jmri/jmrit/display/PositionablePopupUtilTest.java
@@ -37,6 +37,6 @@ public class PositionablePopupUtilTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PositionablePopupUtilTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(PositionablePopupUtilTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/PositionablePropertiesUtilTest.java
+++ b/java/test/jmri/jmrit/display/PositionablePropertiesUtilTest.java
@@ -36,6 +36,6 @@ public class PositionablePropertiesUtilTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PositionablePropertiesUtilTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(PositionablePropertiesUtilTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitFrameTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitFrameTest.java
@@ -40,6 +40,6 @@ public class EditCircuitFrameTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EditCircuitFrameTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(EditCircuitFrameTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitPathsTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitPathsTest.java
@@ -40,6 +40,6 @@ public class EditCircuitPathsTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EditCircuitPathsTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(EditCircuitPathsTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalDirectionTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalDirectionTest.java
@@ -40,6 +40,6 @@ public class EditPortalDirectionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EditPortalDirectionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(EditPortalDirectionTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalFrameTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditPortalFrameTest.java
@@ -40,6 +40,6 @@ public class EditPortalFrameTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EditPortalFrameTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(EditPortalFrameTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawCircleTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawCircleTest.java
@@ -40,6 +40,6 @@ public class DrawCircleTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DrawCircleTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DrawCircleTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawEllipseTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawEllipseTest.java
@@ -40,6 +40,6 @@ public class DrawEllipseTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DrawEllipseTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DrawEllipseTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawPolygonTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawPolygonTest.java
@@ -40,6 +40,6 @@ public class DrawPolygonTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DrawPolygonTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DrawPolygonTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawRectangleTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawRectangleTest.java
@@ -40,6 +40,6 @@ public class DrawRectangleTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DrawRectangleTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DrawRectangleTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawRoundRectTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/DrawRoundRectTest.java
@@ -40,6 +40,6 @@ public class DrawRoundRectTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DrawRoundRectTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DrawRoundRectTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/BlockValueFileTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/BlockValueFileTest.java
@@ -31,5 +31,5 @@ public class BlockValueFileTest {
     public void tearDown() throws Exception {
         JUnitUtil.tearDown();
     }
-    private final static Logger log = LoggerFactory.getLogger(BlockValueFileTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(BlockValueFileTest.class);
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutBlockConnectivityToolsTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutBlockConnectivityToolsTest.java
@@ -31,5 +31,5 @@ public class LayoutBlockConnectivityToolsTest {
     public void tearDown() throws Exception {
         JUnitUtil.tearDown();
     }
-    private final static Logger log = LoggerFactory.getLogger(LayoutBlockConnectivityToolsTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LayoutBlockConnectivityToolsTest.class);
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutBlockManagerTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutBlockManagerTest.java
@@ -31,5 +31,5 @@ public class LayoutBlockManagerTest {
     public void tearDown() throws Exception {
         JUnitUtil.tearDown();
     }
-    private final static Logger log = LoggerFactory.getLogger(LayoutEditorActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LayoutEditorActionTest.class);
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutBlockTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutBlockTest.java
@@ -31,5 +31,5 @@ public class LayoutBlockTest {
     public void tearDown() throws Exception {
         JUnitUtil.tearDown();
     }
-    private final static Logger log = LoggerFactory.getLogger(LayoutBlockTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LayoutBlockTest.class);
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutConnectivityTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutConnectivityTest.java
@@ -33,5 +33,5 @@ public class LayoutConnectivityTest {
     public void tearDown() throws Exception {
         JUnitUtil.tearDown();
     }
-    private final static Logger log = LoggerFactory.getLogger(LayoutConnectivityTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LayoutConnectivityTest.class);
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorActionTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorActionTest.java
@@ -37,5 +37,5 @@ public class LayoutEditorActionTest {
     public void tearDown() throws Exception {
         JUnitUtil.tearDown();
     }
-    private final static Logger log = LoggerFactory.getLogger(LayoutEditorActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LayoutEditorActionTest.class);
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -717,5 +717,5 @@ public class LayoutEditorTest {
     }
 
     //initialize logging
-    private final static Logger log = LoggerFactory.getLogger(LayoutEditorTest.class.getName());
+    // private final static Logger log = LoggerFactory.getLogger(LayoutEditorTest.class.getName());
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutTurnoutTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutTurnoutTest.java
@@ -802,5 +802,5 @@ public class LayoutTurnoutTest {
         // reset the instance manager.
         JUnitUtil.tearDown();
     }
-    private final static Logger log = LoggerFactory.getLogger(LayoutSlipTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LayoutSlipTest.class);
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/MultiIconEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/MultiIconEditorTest.java
@@ -35,5 +35,5 @@ public class MultiIconEditorTest {
     public void tearDown() throws Exception {
         JUnitUtil.tearDown();
     }
-    private final static Logger log = LoggerFactory.getLogger(MultiIconEditorTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(MultiIconEditorTest.class);
 }

--- a/java/test/jmri/jmrit/display/palette/DecoratorPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/DecoratorPanelTest.java
@@ -36,6 +36,6 @@ public class DecoratorPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DecoratorPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DecoratorPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/DetectionPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/DetectionPanelTest.java
@@ -44,6 +44,6 @@ public class DetectionPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DetectionPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DetectionPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/DropJLabelTest.java
+++ b/java/test/jmri/jmrit/display/palette/DropJLabelTest.java
@@ -50,6 +50,6 @@ public class DropJLabelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DropJLabelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DropJLabelTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/IconDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/IconDialogTest.java
@@ -46,6 +46,6 @@ public class IconDialogTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(IconDialogTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(IconDialogTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/IndicatorTOIconDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/IndicatorTOIconDialogTest.java
@@ -47,6 +47,6 @@ public class IndicatorTOIconDialogTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(IndicatorTOIconDialogTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(IndicatorTOIconDialogTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/IndicatorTOItemPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/IndicatorTOItemPanelTest.java
@@ -42,6 +42,6 @@ public class IndicatorTOItemPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(IndicatorTOItemPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(IndicatorTOItemPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/ItemDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/ItemDialogTest.java
@@ -35,6 +35,6 @@ public class ItemDialogTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ItemDialogTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ItemDialogTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/MemoryItemPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/MemoryItemPanelTest.java
@@ -46,6 +46,6 @@ public class MemoryItemPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(MemoryItemPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(MemoryItemPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/MultiSensorIconDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/MultiSensorIconDialogTest.java
@@ -45,6 +45,6 @@ public class MultiSensorIconDialogTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(MultiSensorIconDialogTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(MultiSensorIconDialogTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/MultiSensorItemPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/MultiSensorItemPanelTest.java
@@ -41,6 +41,6 @@ public class MultiSensorItemPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(MultiSensorItemPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(MultiSensorItemPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/ReporterItemPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/ReporterItemPanelTest.java
@@ -41,6 +41,6 @@ public class ReporterItemPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ReporterItemPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ReporterItemPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/SignalHeadItemPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/SignalHeadItemPanelTest.java
@@ -41,6 +41,6 @@ public class SignalHeadItemPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SignalHeadItemPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SignalHeadItemPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/SignalMastItemPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/SignalMastItemPanelTest.java
@@ -41,6 +41,6 @@ public class SignalMastItemPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SignalMastItemPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SignalMastItemPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/palette/TableItemPanelTest.java
+++ b/java/test/jmri/jmrit/display/palette/TableItemPanelTest.java
@@ -42,6 +42,6 @@ public class TableItemPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(TableItemPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(TableItemPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorActionTest.java
+++ b/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorActionTest.java
@@ -31,6 +31,6 @@ public class SwitchboardEditorActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SwitchboardEditorActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SwitchboardEditorActionTest.class);
 
 }

--- a/java/test/jmri/jmrit/logix/FunctionPanelTest.java
+++ b/java/test/jmri/jmrit/logix/FunctionPanelTest.java
@@ -39,6 +39,6 @@ public class FunctionPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(FunctionPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(FunctionPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/logix/SpeedProfilePanelTest.java
+++ b/java/test/jmri/jmrit/logix/SpeedProfilePanelTest.java
@@ -35,6 +35,6 @@ public class SpeedProfilePanelTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SpeedProfilePanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SpeedProfilePanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/logix/SpeedUtilTest.java
+++ b/java/test/jmri/jmrit/logix/SpeedUtilTest.java
@@ -36,6 +36,6 @@ public class SpeedUtilTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SpeedUtilTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SpeedUtilTest.class);
 
 }

--- a/java/test/jmri/jmrit/logix/WarrantShutdownTaskTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantShutdownTaskTest.java
@@ -34,6 +34,6 @@ public class WarrantShutdownTaskTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(WarrantShutdownTaskTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(WarrantShutdownTaskTest.class);
 
 }

--- a/java/test/jmri/jmrit/operations/trains/timetable/TrainScheduleTest.java
+++ b/java/test/jmri/jmrit/operations/trains/timetable/TrainScheduleTest.java
@@ -33,6 +33,6 @@ public class TrainScheduleTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(TrainScheduleTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(TrainScheduleTest.class);
 
 }

--- a/java/test/jmri/jmrit/picker/PickFrameTest.java
+++ b/java/test/jmri/jmrit/picker/PickFrameTest.java
@@ -35,6 +35,6 @@ public class PickFrameTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PickFrameTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(PickFrameTest.class);
 
 }

--- a/java/test/jmri/jmrit/picker/PickPanelTest.java
+++ b/java/test/jmri/jmrit/picker/PickPanelTest.java
@@ -44,6 +44,6 @@ public class PickPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PickPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(PickPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/picker/PickSinglePanelTest.java
+++ b/java/test/jmri/jmrit/picker/PickSinglePanelTest.java
@@ -36,6 +36,6 @@ public class PickSinglePanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PickSinglePanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(PickSinglePanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/progsupport/ProgModePaneTest.java
+++ b/java/test/jmri/jmrit/progsupport/ProgModePaneTest.java
@@ -31,6 +31,6 @@ public class ProgModePaneTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ProgModePaneTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ProgModePaneTest.class);
 
 }

--- a/java/test/jmri/jmrit/progsupport/ProgOpsModePaneTest.java
+++ b/java/test/jmri/jmrit/progsupport/ProgOpsModePaneTest.java
@@ -32,6 +32,6 @@ public class ProgOpsModePaneTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ProgOpsModePaneTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ProgOpsModePaneTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/CombinedLocoSelPaneTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CombinedLocoSelPaneTest.java
@@ -38,6 +38,6 @@ public class CombinedLocoSelPaneTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(CombinedLocoSelPaneTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(CombinedLocoSelPaneTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/CombinedLocoSelTreePaneTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CombinedLocoSelTreePaneTest.java
@@ -38,6 +38,6 @@ public class CombinedLocoSelTreePaneTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(CombinedLocoSelTreePaneTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(CombinedLocoSelTreePaneTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/ComboOffRadioButtonTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/ComboOffRadioButtonTest.java
@@ -71,6 +71,6 @@ public class ComboOffRadioButtonTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ComboOffRadioButtonTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ComboOffRadioButtonTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/ComboOnRadioButtonTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/ComboOnRadioButtonTest.java
@@ -71,6 +71,6 @@ public class ComboOnRadioButtonTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ComboOnRadioButtonTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ComboOnRadioButtonTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/CsvExportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CsvExportActionTest.java
@@ -40,6 +40,6 @@ public class CsvExportActionTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(CsvExportActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(CsvExportActionTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/CsvImportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CsvImportActionTest.java
@@ -39,6 +39,6 @@ public class CsvImportActionTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(CsvImportActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(CsvImportActionTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/CsvImporterTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CsvImporterTest.java
@@ -57,6 +57,6 @@ public class CsvImporterTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(CsvImporterTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(CsvImporterTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/DccAddressPanelTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/DccAddressPanelTest.java
@@ -39,6 +39,6 @@ public class DccAddressPanelTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DccAddressPanelTest.class.getName());
+    // private final static Logger log = LoggerFactory.getLogger(DccAddressPanelTest.class.getName());
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/DccAddressVarHandlerTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/DccAddressVarHandlerTest.java
@@ -67,6 +67,6 @@ public class DccAddressVarHandlerTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DccAddressVarHandlerTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DccAddressVarHandlerTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/FactoryResetActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/FactoryResetActionTest.java
@@ -42,6 +42,6 @@ public class FactoryResetActionTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(FactoryResetActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(FactoryResetActionTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/GenericImportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/GenericImportActionTest.java
@@ -40,6 +40,6 @@ public class GenericImportActionTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(GenericImportActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(GenericImportActionTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/KnownLocoSelPaneTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/KnownLocoSelPaneTest.java
@@ -46,6 +46,6 @@ public class KnownLocoSelPaneTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(KnownLocoSelPaneTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(KnownLocoSelPaneTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/LocoSelTreePaneTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/LocoSelTreePaneTest.java
@@ -38,6 +38,6 @@ public class LocoSelTreePaneTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LocoSelTreePaneTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LocoSelTreePaneTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/LokProgImportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/LokProgImportActionTest.java
@@ -40,6 +40,6 @@ public class LokProgImportActionTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LokProgImportActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LokProgImportActionTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/LokProgImporterTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/LokProgImporterTest.java
@@ -58,6 +58,6 @@ public class LokProgImporterTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LokProgImporterTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LokProgImporterTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/Pr1ExportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/Pr1ExportActionTest.java
@@ -40,6 +40,6 @@ public class Pr1ExportActionTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Pr1ExportActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(Pr1ExportActionTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/Pr1ImportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/Pr1ImportActionTest.java
@@ -40,6 +40,6 @@ public class Pr1ImportActionTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Pr1ImportActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(Pr1ImportActionTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/Pr1WinExportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/Pr1WinExportActionTest.java
@@ -40,6 +40,6 @@ public class Pr1WinExportActionTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Pr1WinExportActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(Pr1WinExportActionTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/PrintActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/PrintActionTest.java
@@ -48,6 +48,6 @@ public class PrintActionTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PrintActionTest.class.getName());
+    // private final static Logger log = LoggerFactory.getLogger(PrintActionTest.class.getName());
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/PrintCvActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/PrintCvActionTest.java
@@ -51,6 +51,6 @@ public class PrintCvActionTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PrintCvActionTest.class.getName());
+    // private final static Logger log = LoggerFactory.getLogger(PrintCvActionTest.class.getName());
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/QuantumCvMgrImportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/QuantumCvMgrImportActionTest.java
@@ -40,6 +40,6 @@ public class QuantumCvMgrImportActionTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(QuantumCvMgrImportActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(QuantumCvMgrImportActionTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/QuantumCvMgrImporterTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/QuantumCvMgrImporterTest.java
@@ -57,6 +57,6 @@ public class QuantumCvMgrImporterTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(QuantumCvMgrImporterTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(QuantumCvMgrImporterTest.class);
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/ResetTableModelTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/ResetTableModelTest.java
@@ -36,6 +36,6 @@ public class ResetTableModelTest {
         apps.tests.Log4JFixture.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ResetTableModelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ResetTableModelTest.class);
 
 }

--- a/java/test/jmri/jmrit/throttle/SpeedPanelTest.java
+++ b/java/test/jmri/jmrit/throttle/SpeedPanelTest.java
@@ -31,6 +31,6 @@ public class SpeedPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SpeedPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SpeedPanelTest.class);
 
 }

--- a/java/test/jmri/jmrit/turnoutoperations/CommonTurnoutOperationConfigTest.java
+++ b/java/test/jmri/jmrit/turnoutoperations/CommonTurnoutOperationConfigTest.java
@@ -32,6 +32,6 @@ public class CommonTurnoutOperationConfigTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(CommonTurnoutOperationConfigTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(CommonTurnoutOperationConfigTest.class);
 
 }

--- a/java/test/jmri/jmrit/turnoutoperations/NoFeedbackTurnoutOperationConfigTest.java
+++ b/java/test/jmri/jmrit/turnoutoperations/NoFeedbackTurnoutOperationConfigTest.java
@@ -32,6 +32,6 @@ public class NoFeedbackTurnoutOperationConfigTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(NoFeedbackTurnoutOperationConfigTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(NoFeedbackTurnoutOperationConfigTest.class);
 
 }

--- a/java/test/jmri/jmrit/turnoutoperations/RawTurnoutOperationConfigTest.java
+++ b/java/test/jmri/jmrit/turnoutoperations/RawTurnoutOperationConfigTest.java
@@ -32,6 +32,6 @@ public class RawTurnoutOperationConfigTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(RawTurnoutOperationConfigTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(RawTurnoutOperationConfigTest.class);
 
 }

--- a/java/test/jmri/jmrit/turnoutoperations/SensorTurnoutOperationConfigTest.java
+++ b/java/test/jmri/jmrit/turnoutoperations/SensorTurnoutOperationConfigTest.java
@@ -32,6 +32,6 @@ public class SensorTurnoutOperationConfigTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SensorTurnoutOperationConfigTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SensorTurnoutOperationConfigTest.class);
 
 }

--- a/java/test/jmri/jmrit/turnoutoperations/TurnoutOperationConfigTest.java
+++ b/java/test/jmri/jmrit/turnoutoperations/TurnoutOperationConfigTest.java
@@ -32,6 +32,6 @@ public class TurnoutOperationConfigTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(TurnoutOperationConfigTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(TurnoutOperationConfigTest.class);
 
 }

--- a/java/test/jmri/jmrit/turnoutoperations/TurnoutOperationFrameTest.java
+++ b/java/test/jmri/jmrit/turnoutoperations/TurnoutOperationFrameTest.java
@@ -36,6 +36,6 @@ public class TurnoutOperationFrameTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(TurnoutOperationFrameTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(TurnoutOperationFrameTest.class);
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/ConfigurableSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/ConfigurableSoundTest.java
@@ -31,6 +31,6 @@ public class ConfigurableSoundTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ConfigurableSoundTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ConfigurableSoundTest.class);
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/Diesel2SoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/Diesel2SoundTest.java
@@ -31,6 +31,6 @@ public class Diesel2SoundTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Diesel2SoundTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(Diesel2SoundTest.class);
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/Diesel3SoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/Diesel3SoundTest.java
@@ -31,6 +31,6 @@ public class Diesel3SoundTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Diesel3SoundTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(Diesel3SoundTest.class);
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/DieselSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/DieselSoundTest.java
@@ -31,6 +31,6 @@ public class DieselSoundTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DieselSoundTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DieselSoundTest.class);
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/EngineSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/EngineSoundTest.java
@@ -31,6 +31,6 @@ public class EngineSoundTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EngineSoundTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(EngineSoundTest.class);
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/Steam1SoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/Steam1SoundTest.java
@@ -31,6 +31,6 @@ public class Steam1SoundTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Steam1SoundTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(Steam1SoundTest.class);
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/SteamSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/SteamSoundTest.java
@@ -31,6 +31,6 @@ public class SteamSoundTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SteamSoundTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SteamSoundTest.class);
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/ThrottleTriggerTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/ThrottleTriggerTest.java
@@ -31,6 +31,6 @@ public class ThrottleTriggerTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ThrottleTriggerTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ThrottleTriggerTest.class);
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/VSDFileTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDFileTest.java
@@ -40,6 +40,6 @@ public class VSDFileTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(VSDFileTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(VSDFileTest.class);
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/VSDecoderCreationStartupActionFactoryTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDecoderCreationStartupActionFactoryTest.java
@@ -31,6 +31,6 @@ public class VSDecoderCreationStartupActionFactoryTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(VSDecoderCreationStartupActionFactoryTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(VSDecoderCreationStartupActionFactoryTest.class);
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/VSDecoderPaneTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDecoderPaneTest.java
@@ -36,6 +36,6 @@ public class VSDecoderPaneTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(VSDecoderPaneTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(VSDecoderPaneTest.class);
 
 }

--- a/java/test/jmri/jmrit/vsdecoder/swing/VSDOptionsDialogTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/swing/VSDOptionsDialogTest.java
@@ -36,6 +36,6 @@ public class VSDOptionsDialogTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(VSDOptionsDialogTest.class.getName());
+    // private final static Logger log = LoggerFactory.getLogger(VSDOptionsDialogTest.class.getName());
 
 }

--- a/java/test/jmri/jmrix/ActiveSystemFlagTest.java
+++ b/java/test/jmri/jmrix/ActiveSystemFlagTest.java
@@ -49,6 +49,6 @@ public class ActiveSystemFlagTest extends TestCase {
     }
 
     // protected access for subclass
-    private final static Logger log = LoggerFactory.getLogger(ActiveSystemFlagTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ActiveSystemFlagTest.class);
 
 }

--- a/java/test/jmri/jmrix/SystemConnectionMemoManagerTest.java
+++ b/java/test/jmri/jmrix/SystemConnectionMemoManagerTest.java
@@ -34,6 +34,6 @@ public class SystemConnectionMemoManagerTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SystemConnectionMemoManagerTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SystemConnectionMemoManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/can/swing/CanNamedPaneActionTest.java
+++ b/java/test/jmri/jmrix/can/swing/CanNamedPaneActionTest.java
@@ -46,6 +46,6 @@ public class CanNamedPaneActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(CanNamedPaneActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(CanNamedPaneActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/cmri/serial/nodeiolist/NodeIOListActionTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/nodeiolist/NodeIOListActionTest.java
@@ -38,6 +38,6 @@ public class NodeIOListActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(NodeIOListActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(NodeIOListActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/cmri/serial/serialmon/SerialFilterActionTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/serialmon/SerialFilterActionTest.java
@@ -32,6 +32,6 @@ public class SerialFilterActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialFilterActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SerialFilterActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/cmri/serial/serialmon/SerialFilterFrameTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/serialmon/SerialFilterFrameTest.java
@@ -34,6 +34,6 @@ public class SerialFilterFrameTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SerialFilterFrameTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SerialFilterFrameTest.class);
 
 }

--- a/java/test/jmri/jmrix/dcc4pc/Dcc4PcBoardManagerTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/Dcc4PcBoardManagerTest.java
@@ -39,6 +39,6 @@ public class Dcc4PcBoardManagerTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Dcc4PcBoardManagerTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(Dcc4PcBoardManagerTest.class);
 
 }

--- a/java/test/jmri/jmrix/dcc4pc/swing/Dcc4PcNamedPaneActionTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/swing/Dcc4PcNamedPaneActionTest.java
@@ -41,6 +41,6 @@ public class Dcc4PcNamedPaneActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Dcc4PcNamedPaneActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(Dcc4PcNamedPaneActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/ecos/swing/EcosNamedPaneActionTest.java
+++ b/java/test/jmri/jmrix/ecos/swing/EcosNamedPaneActionTest.java
@@ -37,6 +37,6 @@ public class EcosNamedPaneActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EcosNamedPaneActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(EcosNamedPaneActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/jinput/UsbNodeTest.java
+++ b/java/test/jmri/jmrix/jinput/UsbNodeTest.java
@@ -31,6 +31,6 @@ public class UsbNodeTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(UsbNodeTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(UsbNodeTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/ds64/Ds64TabbedPanelTest.java
+++ b/java/test/jmri/jmrix/loconet/ds64/Ds64TabbedPanelTest.java
@@ -31,6 +31,6 @@ public class Ds64TabbedPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Ds64TabbedPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(Ds64TabbedPanelTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/ds64/SimpleTurnoutStateEntryTest.java
+++ b/java/test/jmri/jmrix/loconet/ds64/SimpleTurnoutStateEntryTest.java
@@ -31,6 +31,6 @@ public class SimpleTurnoutStateEntryTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SimpleTurnoutStateEntryTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SimpleTurnoutStateEntryTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/ds64/SimpleTurnoutTest.java
+++ b/java/test/jmri/jmrix/loconet/ds64/SimpleTurnoutTest.java
@@ -31,6 +31,6 @@ public class SimpleTurnoutTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SimpleTurnoutTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SimpleTurnoutTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/lnsvf2/LnSv2MessageContentsTest.java
+++ b/java/test/jmri/jmrix/loconet/lnsvf2/LnSv2MessageContentsTest.java
@@ -33,6 +33,6 @@ public class LnSv2MessageContentsTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LnSv2MessageContentsTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LnSv2MessageContentsTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpPreferencesPanelTest.java
+++ b/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpPreferencesPanelTest.java
@@ -32,6 +32,6 @@ public class LnTcpPreferencesPanelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LnTcpPreferencesPanelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LnTcpPreferencesPanelTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpPreferencesTest.java
+++ b/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpPreferencesTest.java
@@ -31,6 +31,6 @@ public class LnTcpPreferencesTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LnTcpPreferencesTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LnTcpPreferencesTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpStartupActionFactoryTest.java
+++ b/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpStartupActionFactoryTest.java
@@ -31,6 +31,6 @@ public class LnTcpStartupActionFactoryTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LnTcpStartupActionFactoryTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LnTcpStartupActionFactoryTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/locostats/LocoBufferIIStatusTest.java
+++ b/java/test/jmri/jmrix/loconet/locostats/LocoBufferIIStatusTest.java
@@ -31,6 +31,6 @@ public class LocoBufferIIStatusTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LocoBufferIIStatusTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LocoBufferIIStatusTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/locostats/LocoStatsFuncTest.java
+++ b/java/test/jmri/jmrix/loconet/locostats/LocoStatsFuncTest.java
@@ -38,6 +38,6 @@ public class LocoStatsFuncTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LocoStatsFuncTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LocoStatsFuncTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/locostats/PR2StatusTest.java
+++ b/java/test/jmri/jmrix/loconet/locostats/PR2StatusTest.java
@@ -31,6 +31,6 @@ public class PR2StatusTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PR2StatusTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(PR2StatusTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/locostats/PR3MS100ModeStatusTest.java
+++ b/java/test/jmri/jmrix/loconet/locostats/PR3MS100ModeStatusTest.java
@@ -31,6 +31,6 @@ public class PR3MS100ModeStatusTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PR3MS100ModeStatusTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(PR3MS100ModeStatusTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/locostats/RawStatusTest.java
+++ b/java/test/jmri/jmrix/loconet/locostats/RawStatusTest.java
@@ -31,6 +31,6 @@ public class RawStatusTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(RawStatusTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(RawStatusTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/soundloader/EditorTableDataModelTest.java
+++ b/java/test/jmri/jmrix/loconet/soundloader/EditorTableDataModelTest.java
@@ -32,6 +32,6 @@ public class EditorTableDataModelTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(EditorTableDataModelTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(EditorTableDataModelTest.class);
 
 }

--- a/java/test/jmri/jmrix/loconet/swing/LnNamedPaneActionTest.java
+++ b/java/test/jmri/jmrix/loconet/swing/LnNamedPaneActionTest.java
@@ -43,6 +43,6 @@ public class LnNamedPaneActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(LnNamedPaneActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(LnNamedPaneActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/marklin/swing/MarklinNamedPaneActionTest.java
+++ b/java/test/jmri/jmrix/marklin/swing/MarklinNamedPaneActionTest.java
@@ -37,6 +37,6 @@ public class MarklinNamedPaneActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(MarklinNamedPaneActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(MarklinNamedPaneActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/mrc/swing/MrcNamedPaneActionTest.java
+++ b/java/test/jmri/jmrix/mrc/swing/MrcNamedPaneActionTest.java
@@ -42,6 +42,6 @@ public class MrcNamedPaneActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(MrcNamedPaneActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(MrcNamedPaneActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/nce/consist/NceConsistRosterMenuTest.java
+++ b/java/test/jmri/jmrix/nce/consist/NceConsistRosterMenuTest.java
@@ -36,6 +36,6 @@ public class NceConsistRosterMenuTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(NceConsistRosterMenuTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(NceConsistRosterMenuTest.class);
 
 }

--- a/java/test/jmri/jmrix/nce/consist/PrintNceConsistRosterActionTest.java
+++ b/java/test/jmri/jmrix/nce/consist/PrintNceConsistRosterActionTest.java
@@ -35,6 +35,6 @@ public class PrintNceConsistRosterActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PrintNceConsistRosterActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(PrintNceConsistRosterActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/nce/swing/NceNamedPaneActionTest.java
+++ b/java/test/jmri/jmrix/nce/swing/NceNamedPaneActionTest.java
@@ -44,6 +44,6 @@ public class NceNamedPaneActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(NceNamedPaneActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(NceNamedPaneActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/openlcb/swing/ClientActionsTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/ClientActionsTest.java
@@ -40,6 +40,6 @@ public class ClientActionsTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ClientActionsTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ClientActionsTest.class);
 
 }

--- a/java/test/jmri/jmrix/powerline/swing/PowerlineNamedPaneActionTest.java
+++ b/java/test/jmri/jmrix/powerline/swing/PowerlineNamedPaneActionTest.java
@@ -46,6 +46,6 @@ public class PowerlineNamedPaneActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PowerlineNamedPaneActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(PowerlineNamedPaneActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/rfid/swing/RfidNamedPaneActionTest.java
+++ b/java/test/jmri/jmrix/rfid/swing/RfidNamedPaneActionTest.java
@@ -41,6 +41,6 @@ public class RfidNamedPaneActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(RfidNamedPaneActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(RfidNamedPaneActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/swing/SystemConnectionComboBoxTest.java
+++ b/java/test/jmri/jmrix/swing/SystemConnectionComboBoxTest.java
@@ -34,6 +34,6 @@ public class SystemConnectionComboBoxTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(SystemConnectionComboBoxTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(SystemConnectionComboBoxTest.class);
 
 }

--- a/java/test/jmri/jmrix/tams/swing/TamsNamedPaneActionTest.java
+++ b/java/test/jmri/jmrix/tams/swing/TamsNamedPaneActionTest.java
@@ -38,6 +38,6 @@ public class TamsNamedPaneActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(TamsNamedPaneActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(TamsNamedPaneActionTest.class);
 
 }

--- a/java/test/jmri/jmrix/zimo/swing/Mx1NamedPaneActionTest.java
+++ b/java/test/jmri/jmrix/zimo/swing/Mx1NamedPaneActionTest.java
@@ -53,6 +53,6 @@ public class Mx1NamedPaneActionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Mx1NamedPaneActionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(Mx1NamedPaneActionTest.class);
 
 }

--- a/java/test/jmri/profile/AddProfileDialogTest.java
+++ b/java/test/jmri/profile/AddProfileDialogTest.java
@@ -37,6 +37,6 @@ public class AddProfileDialogTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(AddProfileDialogTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(AddProfileDialogTest.class);
 
 }

--- a/java/test/jmri/profile/ProfileManagerDialogTest.java
+++ b/java/test/jmri/profile/ProfileManagerDialogTest.java
@@ -39,6 +39,6 @@ public class ProfileManagerDialogTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ProfileManagerDialogTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ProfileManagerDialogTest.class);
 
 }

--- a/java/test/jmri/server/json/JsonClientHandlerTest.java
+++ b/java/test/jmri/server/json/JsonClientHandlerTest.java
@@ -40,6 +40,6 @@ public class JsonClientHandlerTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonClientHandlerTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonClientHandlerTest.class);
 
 }

--- a/java/test/jmri/server/json/JsonConnectionTest.java
+++ b/java/test/jmri/server/json/JsonConnectionTest.java
@@ -39,6 +39,6 @@ public class JsonConnectionTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonConnectionTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonConnectionTest.class);
 
 }

--- a/java/test/jmri/server/json/block/JsonBlockHttpServiceTest.java
+++ b/java/test/jmri/server/json/block/JsonBlockHttpServiceTest.java
@@ -33,6 +33,6 @@ public class JsonBlockHttpServiceTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonBlockHttpServiceTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonBlockHttpServiceTest.class);
 
 }

--- a/java/test/jmri/server/json/block/JsonBlockSocketServiceTest.java
+++ b/java/test/jmri/server/json/block/JsonBlockSocketServiceTest.java
@@ -40,6 +40,6 @@ public class JsonBlockSocketServiceTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonBlockSocketServiceTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonBlockSocketServiceTest.class);
 
 }

--- a/java/test/jmri/server/json/consist/JsonConsistHttpServiceTest.java
+++ b/java/test/jmri/server/json/consist/JsonConsistHttpServiceTest.java
@@ -33,6 +33,6 @@ public class JsonConsistHttpServiceTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonConsistHttpServiceTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonConsistHttpServiceTest.class);
 
 }

--- a/java/test/jmri/server/json/consist/JsonConsistSocketServiceTest.java
+++ b/java/test/jmri/server/json/consist/JsonConsistSocketServiceTest.java
@@ -40,6 +40,6 @@ public class JsonConsistSocketServiceTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonConsistSocketServiceTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonConsistSocketServiceTest.class);
 
 }

--- a/java/test/jmri/server/json/layoutblock/JsonLayoutBlockHttpServiceTest.java
+++ b/java/test/jmri/server/json/layoutblock/JsonLayoutBlockHttpServiceTest.java
@@ -33,6 +33,6 @@ public class JsonLayoutBlockHttpServiceTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonLayoutBlockHttpServiceTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonLayoutBlockHttpServiceTest.class);
 
 }

--- a/java/test/jmri/server/json/layoutblock/JsonLayoutBlockSocketServiceTest.java
+++ b/java/test/jmri/server/json/layoutblock/JsonLayoutBlockSocketServiceTest.java
@@ -40,6 +40,6 @@ public class JsonLayoutBlockSocketServiceTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonLayoutBlockSocketServiceTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonLayoutBlockSocketServiceTest.class);
 
 }

--- a/java/test/jmri/server/json/operations/JsonOperationsHttpServiceTest.java
+++ b/java/test/jmri/server/json/operations/JsonOperationsHttpServiceTest.java
@@ -33,6 +33,6 @@ public class JsonOperationsHttpServiceTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonOperationsHttpServiceTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonOperationsHttpServiceTest.class);
 
 }

--- a/java/test/jmri/server/json/operations/JsonUtilTest.java
+++ b/java/test/jmri/server/json/operations/JsonUtilTest.java
@@ -33,6 +33,6 @@ public class JsonUtilTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonUtilTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonUtilTest.class);
 
 }

--- a/java/test/jmri/server/json/throttle/JsonThrottleSocketServiceTest.java
+++ b/java/test/jmri/server/json/throttle/JsonThrottleSocketServiceTest.java
@@ -40,6 +40,6 @@ public class JsonThrottleSocketServiceTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonThrottleSocketServiceTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonThrottleSocketServiceTest.class);
 
 }

--- a/java/test/jmri/server/json/throttle/JsonThrottleTest.java
+++ b/java/test/jmri/server/json/throttle/JsonThrottleTest.java
@@ -48,6 +48,6 @@ public class JsonThrottleTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonThrottleTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonThrottleTest.class);
 
 }

--- a/java/test/jmri/server/json/time/JsonTimeHttpServiceTest.java
+++ b/java/test/jmri/server/json/time/JsonTimeHttpServiceTest.java
@@ -33,6 +33,6 @@ public class JsonTimeHttpServiceTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonTimeHttpServiceTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonTimeHttpServiceTest.class);
 
 }

--- a/java/test/jmri/server/json/time/JsonTimeSocketServiceTest.java
+++ b/java/test/jmri/server/json/time/JsonTimeSocketServiceTest.java
@@ -40,6 +40,6 @@ public class JsonTimeSocketServiceTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonTimeSocketServiceTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonTimeSocketServiceTest.class);
 
 }

--- a/java/test/jmri/server/web/app/JsonManifestTest.java
+++ b/java/test/jmri/server/web/app/JsonManifestTest.java
@@ -31,6 +31,6 @@ public class JsonManifestTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JsonManifestTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JsonManifestTest.class);
 
 }

--- a/java/test/jmri/server/web/app/WebAppManagerTest.java
+++ b/java/test/jmri/server/web/app/WebAppManagerTest.java
@@ -31,6 +31,6 @@ public class WebAppManagerTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(WebAppManagerTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(WebAppManagerTest.class);
 
 }

--- a/java/test/jmri/server/web/app/WebAppServletTest.java
+++ b/java/test/jmri/server/web/app/WebAppServletTest.java
@@ -31,6 +31,6 @@ public class WebAppServletTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(WebAppServletTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(WebAppServletTest.class);
 
 }

--- a/java/test/jmri/swing/DefaultListCellEditorTest.java
+++ b/java/test/jmri/swing/DefaultListCellEditorTest.java
@@ -46,6 +46,6 @@ public class DefaultListCellEditorTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(DefaultListCellEditorTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(DefaultListCellEditorTest.class);
 
 }

--- a/java/test/jmri/util/BusyGlassPaneTest.java
+++ b/java/test/jmri/util/BusyGlassPaneTest.java
@@ -45,6 +45,6 @@ public class BusyGlassPaneTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(BusyGlassPaneTest.class.getName());
+    // private final static Logger log = LoggerFactory.getLogger(BusyGlassPaneTest.class.getName());
 
 }

--- a/java/test/jmri/util/ExternalLinkContentViewerUITest.java
+++ b/java/test/jmri/util/ExternalLinkContentViewerUITest.java
@@ -34,6 +34,6 @@ public class ExternalLinkContentViewerUITest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ExternalLinkContentViewerUITest.class);
+    // private final static Logger log = LoggerFactory.getLogger(ExternalLinkContentViewerUITest.class);
 
 }

--- a/java/test/jmri/util/FileChooserFilterTest.java
+++ b/java/test/jmri/util/FileChooserFilterTest.java
@@ -30,6 +30,6 @@ public class FileChooserFilterTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(FileChooserFilterTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(FileChooserFilterTest.class);
 
 }

--- a/java/test/jmri/util/IterableEnumerationTest.java
+++ b/java/test/jmri/util/IterableEnumerationTest.java
@@ -47,6 +47,6 @@ public class IterableEnumerationTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(IterableEnumerationTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(IterableEnumerationTest.class);
 
 }

--- a/java/test/jmri/util/JTreeWithPopupTest.java
+++ b/java/test/jmri/util/JTreeWithPopupTest.java
@@ -32,6 +32,6 @@ public class JTreeWithPopupTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JTreeWithPopupTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JTreeWithPopupTest.class);
 
 }

--- a/java/test/jmri/util/MenuScrollerTest.java
+++ b/java/test/jmri/util/MenuScrollerTest.java
@@ -31,6 +31,6 @@ public class MenuScrollerTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(MenuScrollerTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(MenuScrollerTest.class);
 
 }

--- a/java/test/jmri/util/PipeListenerTest.java
+++ b/java/test/jmri/util/PipeListenerTest.java
@@ -49,6 +49,6 @@ public class PipeListenerTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PipeListenerTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(PipeListenerTest.class);
 
 }

--- a/java/test/jmri/util/PropertyChangeEventQueueTest.java
+++ b/java/test/jmri/util/PropertyChangeEventQueueTest.java
@@ -107,6 +107,6 @@ public class PropertyChangeEventQueueTest extends TestCase {
         super.tearDown();
     }
 
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PropertyChangeEventQueueTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PropertyChangeEventQueueTest.class);
 
 }

--- a/java/test/jmri/util/prefs/JmriUserInterfaceConfigurationProviderTest.java
+++ b/java/test/jmri/util/prefs/JmriUserInterfaceConfigurationProviderTest.java
@@ -33,6 +33,6 @@ public class JmriUserInterfaceConfigurationProviderTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JmriUserInterfaceConfigurationProviderTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JmriUserInterfaceConfigurationProviderTest.class);
 
 }

--- a/java/test/jmri/util/swing/BeanSelectCreatePanelTest.java
+++ b/java/test/jmri/util/swing/BeanSelectCreatePanelTest.java
@@ -34,6 +34,6 @@ public class BeanSelectCreatePanelTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(BeanSelectCreatePanelTest.class.getName());
+    // private final static Logger log = LoggerFactory.getLogger(BeanSelectCreatePanelTest.class.getName());
 
 }

--- a/java/test/jmri/util/swing/BusyDialogTest.java
+++ b/java/test/jmri/util/swing/BusyDialogTest.java
@@ -36,6 +36,6 @@ public class BusyDialogTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(BusyDialogTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(BusyDialogTest.class);
 
 }

--- a/java/test/jmri/util/swing/ValidatedTextFieldTest.java
+++ b/java/test/jmri/util/swing/ValidatedTextFieldTest.java
@@ -31,6 +31,6 @@ public class ValidatedTextFieldTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ValidatedTextFieldTest.class.getName());
+    // private final static Logger log = LoggerFactory.getLogger(ValidatedTextFieldTest.class.getName());
 
 }

--- a/java/test/jmri/util/swing/mdi/JmriJInternalFrameInterfaceTest.java
+++ b/java/test/jmri/util/swing/mdi/JmriJInternalFrameInterfaceTest.java
@@ -37,6 +37,6 @@ public class JmriJInternalFrameInterfaceTest {
         JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(JmriJInternalFrameInterfaceTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(JmriJInternalFrameInterfaceTest.class);
 
 }

--- a/java/test/jmri/util/swing/multipane/PanedInterfaceTest.java
+++ b/java/test/jmri/util/swing/multipane/PanedInterfaceTest.java
@@ -39,6 +39,6 @@ public class PanedInterfaceTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(PanedInterfaceTest.class.getName());
+    // private final static Logger log = LoggerFactory.getLogger(PanedInterfaceTest.class.getName());
 
 }

--- a/java/test/jmri/util/swing/multipane/ThreePaneTLRWindowTest.java
+++ b/java/test/jmri/util/swing/multipane/ThreePaneTLRWindowTest.java
@@ -37,6 +37,6 @@ public class ThreePaneTLRWindowTest {
         jmri.util.JUnitUtil.tearDown();
     }
 
-    private final static Logger log = LoggerFactory.getLogger(ThreePaneTLRWindowTest.class.getName());
+    // private final static Logger log = LoggerFactory.getLogger(ThreePaneTLRWindowTest.class.getName());
 
 }


### PR DESCRIPTION
- Proper generic type in a couple managers
- remove unnecessary casts from prior generic work
- comment out unused log variable in Test classes to reduce warnings