### PR TITLE
Be tolerant of throttle layout configs which don't have speedpanel element

### DIFF
--- a/java/src/jmri/jmrit/throttle/ThrottleFrame.java
+++ b/java/src/jmri/jmrit/throttle/ThrottleFrame.java
@@ -794,9 +794,11 @@ public class ThrottleFrame extends JDesktopPane implements ComponentListener, Ad
             ((javax.swing.plaf.basic.BasicInternalFrameUI) addressPanel.getUI()).getNorthPane().setPreferredSize(new Dimension(0, bSize));
         }
         Element speedPanelElement = e.getChild("SpeedPanel");
-        speedPanel.setXml(speedPanelElement);
-        if (((javax.swing.plaf.basic.BasicInternalFrameUI) controlPanel.getUI()).getNorthPane() != null) {
-            ((javax.swing.plaf.basic.BasicInternalFrameUI) addressPanel.getUI()).getNorthPane().setPreferredSize(new Dimension(0, bSize));
+        if (speedPanelElement != null) { // older throttle configs may not have this element
+            speedPanel.setXml(speedPanelElement);
+            if (((javax.swing.plaf.basic.BasicInternalFrameUI) controlPanel.getUI()).getNorthPane() != null) {
+                ((javax.swing.plaf.basic.BasicInternalFrameUI) addressPanel.getUI()).getNorthPane().setPreferredSize(new Dimension(0, bSize));
+            }
         }
 
         List<Element> jinsts = e.getChildren("Jynstrument");


### PR DESCRIPTION
Speedpanels seem to have been introduced between 4.4 and 4.8. Using a default throttle config from 4.4 causes an NPE in 4.8. If a user loads a throttle layout from the startup menu this NPE is caught and trhe preferences dialog is opened automatically but this is not useful in this case.

The NPE is otherwise harmless and does not affect operation. This PR juist skips dealing with the speedpanel config if it's missing, avoiding the error message on startup.