### PR TITLE
AbstractAutomaton waitChange() NPE fix

### DIFF
--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -849,6 +849,8 @@ public class AbstractAutomaton implements Runnable {
             }
             if (prompt != null) {
                 log.trace("waitChange continues from {}", prompt.getSource());
+            } else {
+                log.trace("waitChange continues")
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt(); // retain if needed later


### PR DESCRIPTION
ArrayBlockingQueue poll() returns null if the list is empty. Don't call getSource() on prompt if it's null.