### PR TITLE
AbstractAutomaton waitChange() NPE fix (mark II)

### DIFF
--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -849,6 +849,8 @@ public class AbstractAutomaton implements Runnable {
             }
             if (prompt != null) {
                 log.trace("waitChange continues from {}", prompt.getSource());
+            } else {
+                log.trace("waitChange continues")
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt(); // retain if needed later

--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -850,7 +850,7 @@ public class AbstractAutomaton implements Runnable {
             if (prompt != null) {
                 log.trace("waitChange continues from {}", prompt.getSource());
             } else {
-                log.trace("waitChange continues")
+                log.trace("waitChange continues");
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt(); // retain if needed later


### PR DESCRIPTION
waitChangeQueue.poll() sometimes returns null. Dont call getSource() on prompt if it's null.