### PR TITLE
Add unit tests for C/MRI name checking

### DIFF
--- a/java/src/jmri/jmrix/cmri/serial/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialSensorManager.java
@@ -44,7 +44,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
     }
 
     /**
-     * Return the C/MRI system letter
+     * {@inheritDoc}
      */
     @Override
     public String getSystemPrefix() {
@@ -151,11 +151,17 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean allowMultipleAdditions(String systemName) {
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String createSystemName(String curAddress, String prefix) throws JmriException {
         String tmpSName = "";
@@ -203,6 +209,9 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
     int bitNum = 0;
     int nAddress = 0;
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getNextValidAddress(String curAddress, String prefix) {
         //If the hardware address passed does not already exist then this can
@@ -241,9 +250,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
     }
 
     /**
-     * Public method to validate system name format.
-     *
-     * @return 'true' if system name has a valid format, else returns 'false'
+     * {@inheritDoc}
      */
     @Override
     public boolean validSystemNameFormat(String systemName) {
@@ -251,9 +258,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
     }
 
     /**
-     * Public method to normalize a system name.
-     *
-     * @return a normalized system name if system name has a valid format, else return "".
+     * {@inheritDoc}
      */
     @Override
     public String normalizeSystemName(String systemName) {
@@ -261,7 +266,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
     }
 
     /**
-     * Provide a manager-specific tooltip for the Add new item beantable pane.
+     * {@inheritDoc}
      */
     @Override
     public String getEntryToolTip() {

--- a/java/test/jmri/jmrix/cmri/CMRISystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/cmri/CMRISystemConnectionMemoTest.java
@@ -27,11 +27,21 @@ public class CMRISystemConnectionMemoTest {
         Assert.assertTrue(m.validSystemNameFormat("CS21",'S'));    
         Assert.assertTrue(m.validSystemNameFormat("CS2001",'S'));    
         Assert.assertTrue(m.validSystemNameFormat("CS21001",'S'));    
+        Assert.assertTrue(m.validSystemNameFormat("CS127001",'S'));    
+
+        Assert.assertTrue(m.validSystemNameFormat("CS999",'S'));    
+        Assert.assertTrue(m.validSystemNameFormat("CS2999",'S'));    
+        Assert.assertTrue(m.validSystemNameFormat("CS21999",'S'));    
+        Assert.assertTrue(m.validSystemNameFormat("CS127999",'S'));    
 
         Assert.assertTrue(m.validSystemNameFormat("CS21B1",'S'));    
         Assert.assertTrue(m.validSystemNameFormat("CS21B001",'S'));    
-        Assert.assertTrue(m.validSystemNameFormat("CS21B1001",'S'));    
+        Assert.assertTrue(m.validSystemNameFormat("CS21B1024",'S'));    
           
+        Assert.assertTrue(m.validSystemNameFormat("CS127B1",'S'));    
+        Assert.assertTrue(m.validSystemNameFormat("CS127B001",'S'));    
+        Assert.assertTrue(m.validSystemNameFormat("CS127B1024",'S'));    
+
         Assert.assertFalse(m.validSystemNameFormat("CSx",'S'));  
         jmri.util.JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CSx");
 

--- a/java/test/jmri/jmrix/cmri/CMRISystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/cmri/CMRISystemConnectionMemoTest.java
@@ -19,6 +19,25 @@ public class CMRISystemConnectionMemoTest {
         Assert.assertNotNull(m);
     }
 
+    @Test
+    public void testNormalizeSystemName() {
+        CMRISystemConnectionMemo m = new CMRISystemConnectionMemo();
+
+        Assert.assertTrue(m.validSystemNameFormat("CS2",'S'));    
+        Assert.assertTrue(m.validSystemNameFormat("CS21",'S'));    
+        Assert.assertTrue(m.validSystemNameFormat("CS2001",'S'));    
+        Assert.assertTrue(m.validSystemNameFormat("CS21001",'S'));    
+          
+        Assert.assertFalse(m.validSystemNameFormat("CSx",'S'));  
+        jmri.util.JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CSx");
+
+        Assert.assertFalse(m.validSystemNameFormat("CS2000",'S'));  
+        jmri.util.JUnitAppender.assertWarnMessage("bit number not in range 1 - 999 in CMRI system name: CS2000");
+
+        Assert.assertFalse(m.validSystemNameFormat("CS",'S'));  
+        jmri.util.JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CS");
+    }
+
     @Test public void systemPrefixTest() {
         CMRISystemConnectionMemo m = new CMRISystemConnectionMemo();
         Assert.assertEquals("Default System Prefix","C",m.getSystemPrefix());

--- a/java/test/jmri/jmrix/cmri/CMRISystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/cmri/CMRISystemConnectionMemoTest.java
@@ -20,13 +20,17 @@ public class CMRISystemConnectionMemoTest {
     }
 
     @Test
-    public void testNormalizeSystemName() {
+    public void testValidSystemNameFormat() {
         CMRISystemConnectionMemo m = new CMRISystemConnectionMemo();
 
         Assert.assertTrue(m.validSystemNameFormat("CS2",'S'));    
         Assert.assertTrue(m.validSystemNameFormat("CS21",'S'));    
         Assert.assertTrue(m.validSystemNameFormat("CS2001",'S'));    
         Assert.assertTrue(m.validSystemNameFormat("CS21001",'S'));    
+
+        Assert.assertTrue(m.validSystemNameFormat("CS21B1",'S'));    
+        Assert.assertTrue(m.validSystemNameFormat("CS21B001",'S'));    
+        Assert.assertTrue(m.validSystemNameFormat("CS21B1001",'S'));    
           
         Assert.assertFalse(m.validSystemNameFormat("CSx",'S'));  
         jmri.util.JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CSx");

--- a/java/test/jmri/jmrix/cmri/serial/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialSensorManagerTest.java
@@ -63,6 +63,23 @@ public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest
     }
 
     @Test
+    public void testValidSystemNameFormat() {
+        Assert.assertTrue(l.validSystemNameFormat("CS1"));
+        Assert.assertTrue(l.validSystemNameFormat("CS21"));
+        Assert.assertTrue(l.validSystemNameFormat("CS2001"));
+        Assert.assertTrue(l.validSystemNameFormat("CS21001"));
+
+        Assert.assertFalse(l.validSystemNameFormat("CSx"));
+        jmri.util.JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CSx");
+        
+        Assert.assertFalse(l.validSystemNameFormat("CS2000"));
+        jmri.util.JUnitAppender.assertWarnMessage("bit number not in range 1 - 999 in CMRI system name: CS2000");
+        
+        Assert.assertFalse(l.validSystemNameFormat("CS"));
+        jmri.util.JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CS");
+    }
+    
+    @Test
     public void testDefinitions() {
         Assert.assertEquals("Node definitions match", SerialSensorManager.SENSORSPERUA,
                 SerialNode.MAXSENSORS + 1);

--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -60,7 +60,7 @@ If you're attempting to perform this on MS Windows, refer to the MS Windows note
 
 - Update this note by (details in the update-HOWTO.sh comments; arguments when you run it should be last release, this release you're making, the next release; you may need to update):
 ```
-  ./scripts/update-HOWTO.sh 4.9.4 4.9.5 4.9.5
+  ./scripts/update-HOWTO.sh 4.9.4 4.9.5 4.9.6
 ```
 (and then manually update that line above to be last version release, this version being made today, next version to be made later; i.e. when starting to do *.4, the arguments are *.3 *.4 *.5)
 

--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -60,7 +60,7 @@ If you're attempting to perform this on MS Windows, refer to the MS Windows note
 
 - Update this note by (details in the update-HOWTO.sh comments; arguments when you run it should be last release, this release you're making, the next release; you may need to update):
 ```
-  ./scripts/update-HOWTO.sh 4.9.3 4.9.4 4.9.5
+  ./scripts/update-HOWTO.sh 4.9.4 4.9.5 4.9.5
 ```
 (and then manually update that line above to be last version release, this version being made today, next version to be made later; i.e. when starting to do *.4, the arguments are *.3 *.4 *.5)
 
@@ -167,13 +167,13 @@ We roll some general code maintenance items into the release process.  They can 
 ```    
         cd (local web copy)/releasenotes
         git pull 
-        cp jmri4.9.3.shtml jmri4.9.4.shtml
+        cp jmri4.9.4.shtml jmri4.9.5.shtml
         (edit the new release note accordingly)
             change numbers throughout
             move new warnings to old
             remove old-version change notes
-        git add jmri4.9.3.shtml
-        git commit -m"start new 4.9.4 release note" jmri4.9.4.shtml
+        git add jmri4.9.4.shtml
+        git commit -m"start new 4.9.5 release note" jmri4.9.5.shtml
         PR-and-merge (or direct push) and pull back.
         cd (local JMRI copy)
 ```
@@ -208,13 +208,13 @@ where the date at the end should be the date (and optionally time) of the last r
 - Put the following comment in the release GitHub item saying the branch exists, and all future changes should be documented in the new release note:
 
 ```
-The release-4.9.3 branch has been created. 
+The release-4.9.4 branch has been created. 
 
-From now on, please document your changes in the [jmri4.9.4.shtml](https://github.com/JMRI/website/blob/master/releasenotes/jmri4.9.4.shtml) release note file.
+From now on, please document your changes in the [jmri4.9.5.shtml](https://github.com/JMRI/website/blob/master/releasenotes/jmri4.9.5.shtml) release note file.
 
-Maintainers, please set the 4.9.4 milestone on pulls from now on, as that will be the next test release from the HEAD of the master branch.
+Maintainers, please set the 4.9.5 milestone on pulls from now on, as that will be the next test release from the HEAD of the master branch.
 
-Jenkins will be creating files shortly at the [CI server](http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.9.3/)
+Jenkins will be creating files shortly at the [CI server](http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.9.4/)
 ````
 
 ================================================================================
@@ -243,11 +243,11 @@ Jenkins will be creating files shortly at the [CI server](http://jmri.tagadab.co
 
 - Change the release note to point to the just-built files (in CI or where you put them), commit, wait (or force via ["Build Now"](http://jmri.tagadab.com/jenkins/job/Web%20Site/job/Website%20from%20JMRI%20GitHub%20website%20repository/) update). Confirm visible on web.
 
-- Announce the file set via email to jmri-developers@lists.sf.net with a subject line "First 4.9.3 files available":
+- Announce the file set via email to jmri-developers@lists.sf.net with a subject line "First 4.9.4 files available":
 
-First JMRI 4.9.3 files are available in the usual way at:
+First JMRI 4.9.4 files are available in the usual way at:
 
-http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.9.3
+http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.9.4
 
 Feedback appreciated. I would like to release this later today or tomorrow morning. 
 
@@ -258,7 +258,7 @@ Feedback appreciated. I would like to release this later today or tomorrow morni
 
 If anybody wants to add a change from here on in, they should
 
-- Ideally, start the work on either the release-4.9.3 branch (if working after that was started) or on a branch-from-master that's _before_ the release-4.9.3 branch was created.  That way, the change can be cleanly included in the release branch, and also directly onto master.
+- Ideally, start the work on either the release-4.9.4 branch (if working after that was started) or on a branch-from-master that's _before_ the release-4.9.4 branch was created.  That way, the change can be cleanly included in the release branch, and also directly onto master.
 
 - Commit their changes to that branch, and push as needed to get it to their GitHub fork.
 
@@ -266,7 +266,7 @@ If anybody wants to add a change from here on in, they should
 
    - One to master, as usual
    
-   - One to the release branch e.g. "release-4.9.3".  The comment on this PR should explain why this should be included instead of waiting for the next release.
+   - One to the release branch e.g. "release-4.9.4".  The comment on this PR should explain why this should be included instead of waiting for the next release.
    
    Merging the PR to the master makes those changes available on further developments forever; the one on the release, if accepted, includes the change and kicks off new runs of the various CI and build jobs.
 
@@ -274,7 +274,7 @@ If anybody wants to add a change from here on in, they should
 
 If somebody has merged their change into master (or it's branched from master later than the release tag), you have two choices:
 
-- Merge master into the release-4.9.3 branch.  This will bring _everything_ that's been merged in, so remember to update the version markers on those PRs.  Effectively, you've just started the release process later.  Note that the `release.properties` file will have the wrong minor number in it:  You'll have to edit and commit that to get the right number in the release.
+- Merge master into the release-4.9.4 branch.  This will bring _everything_ that's been merged in, so remember to update the version markers on those PRs.  Effectively, you've just started the release process later.  Note that the `release.properties` file will have the wrong minor number in it:  You'll have to edit and commit that to get the right number in the release.
 
 - `git cherrypick` just the changes you want.  Read the documentation on that command carefully and double check your work. If possible, check the contents of the release branch on the GitHub web site to make sure only the changes you wanted were included.
 
@@ -306,13 +306,13 @@ This step uploads the Linux, Mac OS X and Windows files to the SourceForge file 
 
 (replace "user" below with your SourceForge.net user name; must have SSH keys for SourceForge.net set up)
 
- - (The "./testrelease 4.9.3" local script on shell.sf.net does the following steps, except for the edit, of course)
+ - (The "./testrelease 4.9.4" local script on shell.sf.net does the following steps, except for the edit, of course)
 ```
     ssh user,jmri@shell.sf.net create
     ssh user,jmri@shell.sf.net
-    curl -o release.zip "http://jmri.tagadab.com/jenkins/job/Test%20Releases/job/4.9.3/ws/dist/release/*zip*/release.zip"
+    curl -o release.zip "http://jmri.tagadab.com/jenkins/job/Test%20Releases/job/4.9.4/ws/dist/release/*zip*/release.zip"
         (use the following instead if building on second Jenkins server)
-    curl -o release.zip "http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.9.3/ws/dist/release/*zip*/release.zip"
+    curl -o release.zip "http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.9.4/ws/dist/release/*zip*/release.zip"
     rm release/JMRI*
     unzip release.zip
     cd release
@@ -361,28 +361,28 @@ Note: Unlike releasing files to SourceForge, once a GitHub Release is created it
 
 - Fill out form:
 
-   - "tag version field" gets v4.9.3 (e.g. leading lower-case "v")
-   - @ branch: select the release-4.9.3 release branch
+   - "tag version field" gets v4.9.4 (e.g. leading lower-case "v")
+   - @ branch: select the release-4.9.4 release branch
 ```
-"Release title" field gets "Test/Prod Release 4.9.3"
+"Release title" field gets "Test/Prod Release 4.9.4"
 ```
    - Description content (the testrelease script above proposed this!):
 ```    
-[Release notes](http://jmri.org/releasenotes/jmri4.9.3.shtml)
+[Release notes](http://jmri.org/releasenotes/jmri4.9.4.shtml)
 
 Checksums:
 
 File | SHA256 checksum
 ---|---
-[JMRI.4.9.3.Rff24066.dmg](https://github.com/JMRI/JMRI/releases/download/v4.9.3/JMRI.4.9.3.Rff24066.dmg) | 61cc6eb66a6a7600376990e7181ae119fef33846824073f86483a18f5e7ad725
-[JMRI.4.9.3.Rff24066.exe](https://github.com/JMRI/JMRI/releases/download/v4.9.3/JMRI.4.9.3.Rff24066.exe) | 2b21fa42fd1979cc65450a9e8ed97c1274e1a6c5ac2f68955a130f33383e0f98
-[JMRI.4.9.3.Rff24066.tgz](https://github.com/JMRI/JMRI/releases/download/v4.9.3/JMRI.4.9.3.Rff24066.tgz) | 794fd80964d710aee2a962d2597b8a7e9329e238e16399a7f8cb6e64595b1c98
+[JMRI.4.9.4.Rff24066.dmg](https://github.com/JMRI/JMRI/releases/download/v4.9.4/JMRI.4.9.4.Rff24066.dmg) | 61cc6eb66a6a7600376990e7181ae119fef33846824073f86483a18f5e7ad725
+[JMRI.4.9.4.Rff24066.exe](https://github.com/JMRI/JMRI/releases/download/v4.9.4/JMRI.4.9.4.Rff24066.exe) | 2b21fa42fd1979cc65450a9e8ed97c1274e1a6c5ac2f68955a130f33383e0f98
+[JMRI.4.9.4.Rff24066.tgz](https://github.com/JMRI/JMRI/releases/download/v4.9.4/JMRI.4.9.4.Rff24066.tgz) | 794fd80964d710aee2a962d2597b8a7e9329e238e16399a7f8cb6e64595b1c98
 
 ```
 
 - Attach files by selecting them or dragging them in (you might have to have downloaded them above via e.g. a separate 
 ```
-curl -o release.zip "http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.9.3/lastSuccessfulBuild/artifact/dist/release/*zip*/release.zip"" 
+curl -o release.zip "http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.9.4/lastSuccessfulBuild/artifact/dist/release/*zip*/release.zip"" 
 ```
 and expansion; it's slow to upload from a typical home machine, though, so wish we had a way to cross-load from somewhere fast - if release.zip is still on SF.net, you can do
 ```
@@ -396,9 +396,9 @@ Note there's a little progress bar that has to go across & "Uploading your relea
 Alternatively, if you have shell access to the Jenkins server, you perhaps can upload directly from there, once the initial draft release has been created (this hasn't been tested):
 
 ```
-github-release upload -s {github_secret} -u JMRI -r JMRI -t v4.9.3 -n "JMRI.4.9.3+Rd144052.dmg" -f /var/lib/jenkins/jobs/TestReleases/jobs/4.9.3/workspace/dist/release/JMRI.4.9.3+Rd144052.dmg 
-github-release upload -s {github_secret} -u JMRI -r JMRI -t v4.9.3 -n "JMRI.4.9.3+Rd144052.exe" -f /var/lib/jenkins/jobs/TestReleases/jobs/4.7.5/workspace/dist/release/JMRI.4.9.3+Rd144052.exe 
-github-release upload -s {github_secret} -u JMRI -r JMRI -t v4.9.3 -n "JMRI.4.9.3+Rd144052.tgz" -f /var/lib/jenkins/jobs/TestReleases/jobs/4.7.5/workspace/dist/release/JMRI.4.9.3+Rd144052.tgz 
+github-release upload -s {github_secret} -u JMRI -r JMRI -t v4.9.4 -n "JMRI.4.9.4+Rd144052.dmg" -f /var/lib/jenkins/jobs/TestReleases/jobs/4.9.4/workspace/dist/release/JMRI.4.9.4+Rd144052.dmg 
+github-release upload -s {github_secret} -u JMRI -r JMRI -t v4.9.4 -n "JMRI.4.9.4+Rd144052.exe" -f /var/lib/jenkins/jobs/TestReleases/jobs/4.7.5/workspace/dist/release/JMRI.4.9.4+Rd144052.exe 
+github-release upload -s {github_secret} -u JMRI -r JMRI -t v4.9.4 -n "JMRI.4.9.4+Rd144052.tgz" -f /var/lib/jenkins/jobs/TestReleases/jobs/4.7.5/workspace/dist/release/JMRI.4.9.4+Rd144052.tgz 
 ```
     
 - Click "Publish Release"
@@ -416,7 +416,7 @@ git fetch
 git checkout master
 git pull
 git checkout -b temp-master
-git merge origin/release-4.9.3
+git merge origin/release-4.9.4
 ```
 
 Note that you're testing the merge of the release branch back onto master.  This should report "Already up-to-date.", i.e. no changes, with the possible exception of some auto-generated files:
@@ -448,11 +448,11 @@ git checkout -b (release-n.n.n+1)
 git push github
 ```
 
-- Create the next [GitHub Issue](https://github.com/JMRI/JMRI/issues) to hold discussion with conventional title "Create Test Release 4.9.4". Add the next release milestone (created above) to it. Typical text:
+- Create the next [GitHub Issue](https://github.com/JMRI/JMRI/issues) to hold discussion with conventional title "Create Test Release 4.9.5". Add the next release milestone (created above) to it. Typical text:
 
- This is the third release of the 4.9/4.10 cycle. It's intended to be released around September 8 2017 from HEAD of master.
+ This is the third release of the 4.9.5.10 cycle. It's intended to be released around September 8 2017 from HEAD of master.
 
-- Confirm that the tag for the current release (release-4.9.3) is in place, then manually delete the current release branch via the [GitHub UI](https://github.com/JMRI/JMRI/branches).
+- Confirm that the tag for the current release (release-4.9.4) is in place, then manually delete the current release branch via the [GitHub UI](https://github.com/JMRI/JMRI/branches).
 
 - Go to the GitHub PR and Issues [labels list](https://github.com/JMRI/JMRI/labels) and remove any "afterNextTestRelease" (and "afterNextProductionRelease" if appropriate) labels from done items
 
@@ -482,26 +482,26 @@ If you don't, a bunch of Windows users are likely to whine
 
 - Mail announcement to jmriusers@yahoogroups.com
 
-    Subject is "Test version 4.9.3 of JMRI/DecoderPro is available for download" or "JMRI 4.8 is available for download"
+    Subject is "Test version 4.9.4 of JMRI/DecoderPro is available for download" or "JMRI 4.8 is available for download"
 
     Content:
     
-Test version 4.9.3 of JMRI/DecoderPro is available for download.
+Test version 4.9.4 of JMRI/DecoderPro is available for download.
 
 This is the next in a series of test releases that will culminate in a production release, hopefully in December 2017.
 
 There have been a lot of updates in this version, so it should be considered experimental.
 
-If you use JMRI on Linux or Mac and are updating from JMRI 4.7.3 or earlier, there’s a necessary migration step. (Not needed on Windows) Please see the release note for details: <http://jmri.org/releasenotes/jmri4.9.3.shtml#migration>
+If you use JMRI on Linux or Mac and are updating from JMRI 4.7.3 or earlier, there’s a necessary migration step. (Not needed on Windows) Please see the release note for details: <http://jmri.org/releasenotes/jmri4.9.4.shtml#migration>
 
-For more information on the issues, new features and bug fixes in 4.9.3 please see the release note:
-<http://jmri.org/releasenotes/jmri4.9.3.shtml>
+For more information on the issues, new features and bug fixes in 4.9.4 please see the release note:
+<http://jmri.org/releasenotes/jmri4.9.4.shtml>
 
 Note that JMRI is made available under the GNU General Public License. For more information, please see our copyright and licensing page.
 <http://jmri.org/Copyright.html>
 
 The download links, along with lots of other information which we hope you'll read, can be found on the release note page:
-<http://jmri.org/releasenotes/jmri4.9.3.shtml>
+<http://jmri.org/releasenotes/jmri4.9.4.shtml>
 
 
 - If a production version, update the SF automatic download icon by selecting default in SF.net FRS (3 times)
@@ -554,7 +554,7 @@ If you're building locally:
 - Get the release in your local work directory
 
 ```
-    git checkout release-4.9.3
+    git checkout release-4.9.4
 ```
 
 - edit release.properties to say release.official=true (last line)


### PR DESCRIPTION
Added unit tests in `SerialSensorManagerTest` and `CMRISystemConnectionMemoTest` to document and ensure proper checking of system names.  No functional changes, these tests were already passing and failing as appropriate.

Also includes the updated release HOWTO from 4.9.4; just convenient to get into this PR.