### PR TITLE
Sample script to empty file history

### DIFF
--- a/jython/ClearFileHistory.py
+++ b/jython/ClearFileHistory.py
@@ -1,0 +1,8 @@
+###############################################################
+#   Clears <File History> area before you save Panel XML file #
+#   Gerald Wolfson   9/2017                                   #
+###############################################################
+import jmri
+
+jmri.InstanceManager.getDefault(jmri.jmrit.revhistory.FileHistory).purge(0)
+print("The <File History> section has been cleared")

--- a/jython/test/ClearFileHistoryTest.py
+++ b/jython/test/ClearFileHistoryTest.py
@@ -1,0 +1,8 @@
+# Test the ClearFileHistory.py script
+import jmri
+jmri.InstanceManager.getDefault(jmri.jmrit.revhistory.FileHistory).addOperation("Test", "", jmri.jmrit.revhistory.FileHistory())  # ensure at least one level
+
+execfile("jython/ClearFileHistory.py")
+
+# check that history is empty
+if (jmri.InstanceManager.getDefault(jmri.jmrit.revhistory.FileHistory).getList()[0].history != None) : raise AssertionError('History not empty')


### PR DESCRIPTION
Same script from Gerald Wolfson @wolfsonga  to empty the file history before writing out an XML file.

Includes test file.