### PR TITLE
Improve SystemName validation API

### DIFF
--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -111,12 +111,14 @@
       these "system names". JMRI code will map these to and from
       whatever information the hardware may need.</p>
 
-      <h2>System Name Format</h2>A system name is formed from a
+      <h2>System Name Format</h2>
+      
+      A system name is formed from a
       short prefix representing the hardware system, followed by a
-      single upper case letter indicating the type, followed by
-      system- and type-specific string identifying a specific
-      object. The string is meant to be related to the hardware
-      addressing, but is otherwise unconstrained.
+      single upper case letter indicating the type, followed by a
+      system- and type-specific suffix string identifying a specific
+      object. The suffix string is meant to be related to the hardware
+      addressing for the specific hardware system, but is otherwise unconstrained.
 
       <p>Examples:</p>
 
@@ -292,16 +294,17 @@
       </ul>
 
       <a name="systeminfo" id="systeminfo"></a>
-      <h3>System-specific info</h3>
+      <h3>System-specific suffix</h3>
       <p>"Internal" objects can also be addressed and manipulated,
         but they don't have a strict correspondence with some
         hardware on the layout. For example, if a signal head is
         implemented as three different outputs, LT1, LT2 and LT3, the
-        signal head object might be called IH3. <a name="special" id=
+        signal head object might be called IH3. 
+        <a name="special" id=
                 "special"></a></p>
 
       <p>Each different hardware system
-      can specify the "string" that follows the system and type
+      can specify the "suffix string" that follows the system and type
       letters. Generally, these are small numbers, but their exact
       meaning is very system-specific. For more information, please
         see the specific pages for</p>
@@ -329,12 +332,13 @@
         e.g, X10, Insteon</a></li>
       </ul>
 
-      <p>(If you find any missing or see ommissions in the following
+      <p>(If you find any missing or see omissions in the following
       summary, please <a href="getgitcode.shtml#propose">add
       a reference</a>)</p>
 
       <a name="entrysummary" id="entrysummary"></a>
       <h4>Adding an item to the table - Entry Format Summary</h4>
+      
       <p>When you add an item to one of the tables, many times you only
       have to enter the numbers and have JMRI construct
       the complete system name.<br>

--- a/java/src/jmri/LightManager.java
+++ b/java/src/jmri/LightManager.java
@@ -113,15 +113,6 @@ public interface LightManager extends Manager<Light> {
     public Light getBySystemName(@Nonnull String s);
 
     /**
-     * Test if parameter is a properly formatted system name.
-     *
-     * @param systemName the system name
-     * @return true if formatted correctly; false otherwise
-     */
-    @CheckReturnValue
-    public boolean validSystemNameFormat(@Nonnull String systemName);
-
-    /**
      * Test if parameter is a valid system name for current configuration.
      *
      * @param systemName the system name

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -66,6 +66,40 @@ public interface Manager<E extends NamedBean> {
     @Nonnull
     public String makeSystemName(@Nonnull String s);
 
+    /** 
+     * Code the validity (including just as a prefix)
+     * of a proposed name string.
+     * @since 4.9.5
+     */
+    enum NameValidity {
+        /**
+         * Indicates the name is valid as is, 
+         * and can also be a valid prefix for longer names
+         */
+        VALID,
+         /**
+          * Indicates name is not valid as-is, nor
+          * can it be made valid by adding more characters;
+          * just a bad start.
+          */
+        INVALID, 
+        /**
+         * Indicates that adding additional characters might (or might not)
+         * turn this into a valid name; it is not a valid name now.
+         */
+        VALID_AS_PREFIX_ONLY
+    }
+
+    /**
+     * Test if parameter is a properly formatted system name.
+     *
+     * @since 4.9.5, although similar methods existed previously in lower-level classes
+     * @param systemName the system name
+     * @return enum indicating current validity, which might be just as a prefix
+     */
+    @CheckReturnValue
+    public NameValidity validSystemNameFormat(@Nonnull String systemName);
+
     /**
      * Free resources when no longer used. Specifically, remove all references
      * to and from this object, so it can be garbage-collected.

--- a/java/src/jmri/ReporterManager.java
+++ b/java/src/jmri/ReporterManager.java
@@ -160,15 +160,6 @@ public interface ReporterManager extends Manager<Reporter> {
     public String getNextValidAddress(@Nonnull String curAddress, @Nonnull String prefix);
 
     /**
-     * Test if parameter is a properly formatted system name.
-     *
-     * @param systemName the system name
-     * @return true if formatted correctly; false otherwise
-     */
-    @CheckReturnValue
-    public boolean validSystemNameFormat(@Nonnull String systemName);
-
-    /**
      * Provide a manager-specific tooltip for the Add new item beantable pane.
      */
     public String getEntryToolTip();

--- a/java/src/jmri/SensorManager.java
+++ b/java/src/jmri/SensorManager.java
@@ -160,15 +160,6 @@ public interface SensorManager extends Manager<Sensor> {
     public boolean isPullResistanceConfigurable();
 
     /**
-     * Test if parameter is a properly formatted system name.
-     *
-     * @param systemName the system name
-     * @return true if formatted correctly; false otherwise
-     */
-    @CheckReturnValue
-    public boolean validSystemNameFormat(@Nonnull String systemName);
-
-    /**
      * Provide a manager-specific tooltip for the Add new item beantable pane.
      */
     public String getEntryToolTip();

--- a/java/src/jmri/TurnoutManager.java
+++ b/java/src/jmri/TurnoutManager.java
@@ -229,13 +229,14 @@ public interface TurnoutManager extends Manager<Turnout> {
     public boolean allowMultipleAdditions(@Nonnull String systemName);
 
     /**
-     * Test if parameter is a properly formatted system name.
+     * Test if parameter is a properly formatted hardware address
      *
      * @param systemName the system name
-     * @return true if formatted correctly; false otherwise
+     * @return enum indicating current validity, which might be just as a prefix
      */
-    @CheckReturnValue
-    public boolean validSystemNameFormat(@Nonnull String systemName);
+    //@CheckReturnValue
+    //public NameValidity validAddressFormat(@Nonnull String address);
+
 
     /**
      * Determine if the address supplied is valid and free, if not then it shall

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -894,7 +894,7 @@ public class LightTableAction extends AbstractTableAction {
             uName = null;   // a blank field means no user name
         }
         // Does System Name have a valid format
-        if (!InstanceManager.getDefault(LightManager.class).validSystemNameFormat(suName)) {
+        if (InstanceManager.getDefault(LightManager.class).validSystemNameFormat(suName) != Manager.NameValidity.VALID) {
             // Invalid System Name format
             log.warn("Invalid Light system name format entered: {}", suName);
             status1.setText(Bundle.getMessage("LightError3"));

--- a/java/src/jmri/jmrit/signalling/EntryExitPairs.java
+++ b/java/src/jmri/jmrit/signalling/EntryExitPairs.java
@@ -260,6 +260,17 @@ public class EntryExitPairs implements jmri.Manager<DestinationPoints>, jmri.Ins
     }
 
     /**
+     * {@inheritDoc}
+     * 
+     * @return always 'VALID' 
+     */
+    @Override
+    public NameValidity validSystemNameFormat(String systemName) {
+        return NameValidity.VALID;
+    }
+
+
+    /**
      * Enforces, and as a user convenience converts to, the standard form for a system name
      * for the NamedBeans handled by this manager.
      *

--- a/java/src/jmri/jmrix/acela/AcelaAddress.java
+++ b/java/src/jmri/jmrix/acela/AcelaAddress.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.acela;
 
+import jmri.Manager.NameValidity;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -131,27 +133,27 @@ public class AcelaAddress {
      *
      * @return 'true' if system name has a valid format, else return 'false'
      */
-    public static boolean validSystemNameFormat(String systemName, char type, String prefix) {
+    public static NameValidity validSystemNameFormat(String systemName, char type, String prefix) {
         // validate the system Name leader characters
         if (!(systemName.startsWith(prefix)) || (systemName.charAt(prefix.length()) != type )) {
             // here if an illegal format 
             log.debug("invalid character in header field of system name: " + systemName);
-            return (false);
+            return NameValidity.INVALID;
         }
         int num;
         try {
             num = Integer.valueOf(systemName.substring(prefix.length() + 1)).intValue();
         } catch (Exception e) {
             log.debug("invalid character in number field of system name: " + systemName);
-            return (false);
+            return NameValidity.INVALID;
         }
         if (num >= 0) {
             // This is a ALnnxxx address
         } else {
             log.debug("invalid Acela system name: " + systemName);
-            return (false);
+            return NameValidity.INVALID;
         }
-        return true;
+        return NameValidity.VALID;
     }
 
     /**
@@ -160,8 +162,8 @@ public class AcelaAddress {
      * @return 'true' if system name has a valid meaning in current
      * configuration, else return 'false'
      */
-    public static boolean validSystemNameConfig(String systemName, char type,AcelaSystemConnectionMemo memo) {
-        if (!validSystemNameFormat(systemName, type, memo.getSystemPrefix() )) {
+    public static boolean validSystemNameConfig(String systemName, char type, AcelaSystemConnectionMemo memo) {
+        if (validSystemNameFormat(systemName, type, memo.getSystemPrefix() ) != NameValidity.VALID) {
             // No point in trying if a valid system name format is not present
             return false;
         }
@@ -191,7 +193,7 @@ public class AcelaAddress {
 
     public static boolean validSystemNameConfig(String systemName, AcelaSystemConnectionMemo memo) {
         char type = systemName.charAt(1);
-        if (!validSystemNameFormat(systemName, type, memo.getSystemPrefix() )) {
+        if (validSystemNameFormat(systemName, type, memo.getSystemPrefix() ) != NameValidity.VALID) {
             // No point in trying if a valid system name format is not present
             return false;
         }
@@ -229,7 +231,7 @@ public class AcelaAddress {
      */
     public static String convertSystemNameToAlternate(String systemName) {
         // ensure that input system name has a valid format
-        if (!validSystemNameFormat(systemName, systemName.charAt(1),"A")) {
+        if (validSystemNameFormat(systemName, systemName.charAt(1),"A") != NameValidity.VALID) {
             // No point in trying if a valid system name format is not present
             return "";
         }
@@ -250,7 +252,7 @@ public class AcelaAddress {
      */
     public static String normalizeSystemName(String systemName) {
         // ensure that input system name has a valid format
-        if (!validSystemNameFormat(systemName, systemName.charAt(1),"A")) {
+        if (validSystemNameFormat(systemName, systemName.charAt(1),"A") != NameValidity.VALID) {
             // No point in normalizing if a valid system name format is not present
             return "";
         }

--- a/java/src/jmri/jmrix/acela/AcelaLightManager.java
+++ b/java/src/jmri/jmrix/acela/AcelaLightManager.java
@@ -2,6 +2,7 @@ package jmri.jmrix.acela;
 
 import jmri.Light;
 import jmri.managers.AbstractLightManager;
+import jmri.Manager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +61,7 @@ public class AcelaLightManager extends AbstractLightManager {
          }
          */
         // Validate the systemName
-        if (AcelaAddress.validSystemNameFormat(systemName, 'L', getSystemPrefix())) {
+        if (AcelaAddress.validSystemNameFormat(systemName, 'L', getSystemPrefix()) == NameValidity.VALID) {
             lgt = new AcelaLight(systemName, userName, _memo);
             if (!AcelaAddress.validSystemNameConfig(systemName, 'L', _memo)) {
                 log.warn("Light System Name does not refer to configured hardware: "
@@ -79,7 +80,7 @@ public class AcelaLightManager extends AbstractLightManager {
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (AcelaAddress.validSystemNameFormat(systemName, 'L', getSystemPrefix()));
     }
 

--- a/java/src/jmri/jmrix/acela/AcelaSensorManager.java
+++ b/java/src/jmri/jmrix/acela/AcelaSensorManager.java
@@ -103,7 +103,7 @@ public class AcelaSensorManager extends jmri.managers.AbstractSensorManager
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (AcelaAddress.validSystemNameFormat(systemName, 'S', getSystemPrefix()));
     }
 

--- a/java/src/jmri/jmrix/acela/AcelaTurnoutManager.java
+++ b/java/src/jmri/jmrix/acela/AcelaTurnoutManager.java
@@ -63,7 +63,7 @@ public class AcelaTurnoutManager extends AbstractTurnoutManager {
          */
 
         // Validate the systemName
-        if (AcelaAddress.validSystemNameFormat(systemName, 'T', getSystemPrefix())) {
+        if (AcelaAddress.validSystemNameFormat(systemName, 'T', getSystemPrefix()) == NameValidity.VALID) {
             trn = new AcelaTurnout(systemName, userName,_memo);
             if (!AcelaAddress.validSystemNameConfig(systemName, 'T',_memo)) {
                 log.warn("Turnout system Name does not refer to configured hardware: "
@@ -90,7 +90,7 @@ public class AcelaTurnoutManager extends AbstractTurnoutManager {
      *
      * @return 'true' if system name has a valid format, else return 'false'
      */
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (AcelaAddress.validSystemNameFormat(systemName, 'T', getSystemPrefix()));
     }
 

--- a/java/src/jmri/jmrix/can/cbus/CbusLightManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusLightManager.java
@@ -96,15 +96,15 @@ public class CbusLightManager extends AbstractLightManager {
     }
 
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         String addr = systemName.substring(getSystemPrefix().length() + 1); // get only the address part
         try {
             validateSystemNameFormat(addr);
         } catch (IllegalArgumentException e){
             log.debug("Warning: " + e.getMessage());
-            return false;
+            return NameValidity.INVALID;
         }
-        return true;
+        return NameValidity.VALID;
     }
 
     void validateSystemNameFormat(String address) throws IllegalArgumentException {

--- a/java/src/jmri/jmrix/can/cbus/CbusReporterManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusReporterManager.java
@@ -85,16 +85,16 @@ public class CbusReporterManager extends AbstractReporterManager implements
      * {@inheritDoc}
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         // name must be in the MSnnnnn format (M is user configurable); no + or ; or - for Reporter address
         try {
             // try to parse the string; success returns true
             Integer.valueOf(systemName.substring(getSystemPrefix().length() + 1, systemName.length()));
         } catch (NumberFormatException e) {
             log.debug("Warning: illegal character in number field of system name: {}", systemName);
-            return false;
+            return NameValidity.INVALID;
         }
-        return true;
+        return NameValidity.VALID;
     }
 
     /**

--- a/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
@@ -100,15 +100,15 @@ public class CbusSensorManager extends jmri.managers.AbstractSensorManager imple
     }
 
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         String addr = systemName.substring(getSystemPrefix().length() + 1); // get only the address part
         try {
             validateSystemNameFormat(addr);
         } catch (IllegalArgumentException e){
             log.debug("Warning: " + e.getMessage());
-            return false;
+            return NameValidity.INVALID;
         }
-        return true;
+        return NameValidity.VALID;
     }
 
     void validateSystemNameFormat(String address) throws IllegalArgumentException {

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnoutManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnoutManager.java
@@ -98,15 +98,15 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
     }
 
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         String addr = systemName.substring(getSystemPrefix().length() + 1); // get only the address part
         try {
             validateSystemNameFormat(addr);
         } catch (IllegalArgumentException e){
             log.debug("Warning: " + e.getMessage());
-            return false;
+            return NameValidity.INVALID;
         }
-        return true;
+        return NameValidity.VALID;
     }
 
     void validateSystemNameFormat(String address) throws IllegalArgumentException {

--- a/java/src/jmri/jmrix/cmri/serial/SerialLightManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialLightManager.java
@@ -24,7 +24,7 @@ public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Returns the system letter for CMRI.
+     * {@inheritDoc}
      */
     @Override
     public String getSystemPrefix() {
@@ -84,12 +84,10 @@ public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Public method to validate system name format.
-     *
-     * @return 'true' if system name has a valid format, else returns 'false'
+     * {@inheritDoc}
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return _memo.validSystemNameFormat(systemName, 'L');
     }
 
@@ -126,7 +124,7 @@ public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Provide a manager-specific tooltip for the Add new item beantable pane.
+     * {@inheritDoc}
      */
     @Override
     public String getEntryToolTip() {

--- a/java/src/jmri/jmrix/cmri/serial/SerialLightManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialLightManager.java
@@ -62,7 +62,7 @@ public class SerialLightManager extends AbstractLightManager {
             return (null);
         }
         // Validate the systemName
-        if (_memo.validSystemNameFormat(systemName, 'L')) {
+        if (_memo.validSystemNameFormat(systemName, 'L') == NameValidity.VALID) {
             lgt = new SerialLight(systemName, userName,_memo);
             if (!_memo.validSystemNameConfig(systemName, 'L',_memo.getTrafficController())) {
                 log.warn("Light system Name does not refer to configured hardware: "

--- a/java/src/jmri/jmrix/cmri/serial/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialSensorManager.java
@@ -52,8 +52,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
     }
 
     /**
-     * Create a new sensor if all checks are passed System name is normalized to
-     * ensure uniqueness.
+     * {@inheritDoc}
      */
     @Override
     public Sensor createNewSensor(String systemName, String userName) {
@@ -253,7 +252,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      * {@inheritDoc}
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return _memo.validSystemNameFormat(systemName, 'S');
     }
 

--- a/java/src/jmri/jmrix/cmri/serial/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialTurnoutManager.java
@@ -23,11 +23,17 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
        _memo = memo;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getSystemPrefix() {
         return _memo.getSystemPrefix();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Turnout createNewTurnout(String systemName, String userName) {
         // validate the system name, and normalize it
@@ -220,16 +226,25 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isNumControlBitsSupported(String systemName) {
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isControlTypeSupported(String systemName) {
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String createSystemName(String curAddress, String prefix) throws JmriException {
         int seperator = 0;
@@ -286,7 +301,7 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
     int nAddress = 0;
 
     /**
-     * Return the next valid free turnout hardware address.
+     * {@inheritDoc}
      */
     @Override
     public String getNextValidAddress(String curAddress, String prefix) throws JmriException {
@@ -336,19 +351,15 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
     }
 
     /**
-     * Public method to validate system name format.
-     *
-     * @return 'true' if system name has a valid format, else returns 'false'
+     * * {@inheritDoc}
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return _memo.validSystemNameFormat(systemName, 'T');
     }
 
     /**
-     * Public method to normalize a system name.
-     *
-     * @return a normalized system name if system name has a valid format, else return "".
+     * * {@inheritDoc}
      */
     @Override
     public String normalizeSystemName(String systemName) {
@@ -356,7 +367,7 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
     }
 
     /**
-     * Provide a manager-specific tooltip for the Add new item beantable pane.
+     * * {@inheritDoc}
      */
     @Override
     public String getEntryToolTip() {

--- a/java/src/jmri/jmrix/dccpp/DCCppLightManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppLightManager.java
@@ -90,8 +90,8 @@ public class DCCppLightManager extends AbstractLightManager {
      * name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return (getBitFromSystemName(systemName) != 0);
+    public NameValidity validSystemNameFormat(String systemName) {
+        return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
     /**

--- a/java/src/jmri/jmrix/dccpp/DCCppSensorManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppSensorManager.java
@@ -227,8 +227,8 @@ public class DCCppSensorManager extends jmri.managers.AbstractSensorManager impl
      * name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return (getBitFromSystemName(systemName) != 0);
+    public NameValidity validSystemNameFormat(String systemName) {
+        return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
     /**

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnoutManager.java
@@ -151,8 +151,8 @@ public class DCCppTurnoutManager extends jmri.managers.AbstractTurnoutManager im
      * name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return (getBitFromSystemName(systemName) != 0);
+    public NameValidity validSystemNameFormat(String systemName) {
+        return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
     /**

--- a/java/src/jmri/jmrix/grapevine/SerialLightManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialLightManager.java
@@ -43,7 +43,7 @@ public class SerialLightManager extends AbstractLightManager {
     public Light createNewLight(String systemName, String userName) {
         Light lgt = null;
         // Validate the systemName
-        if (SerialAddress.validSystemNameFormat(systemName, 'L')) {
+        if (SerialAddress.validSystemNameFormat(systemName, 'L') == NameValidity.VALID) {
             lgt = new SerialLight(systemName, userName);
             if (!SerialAddress.validSystemNameConfig(systemName, 'L')) {
                 log.warn("Light system Name does not refer to configured hardware: "
@@ -62,7 +62,7 @@ public class SerialLightManager extends AbstractLightManager {
      * else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'L'));
     }
 

--- a/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
@@ -124,7 +124,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      * else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'S'));
     }
 

--- a/java/src/jmri/jmrix/grapevine/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialTurnoutManager.java
@@ -154,7 +154,7 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
      * else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'T'));
     }
 

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeLightManager.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeLightManager.java
@@ -69,25 +69,25 @@ public class XBeeLightManager extends AbstractLightManager {
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         if (tc.getNodeFromName(addressFromSystemName(systemName)) == null
                 && tc.getNodeFromAddress(addressFromSystemName(systemName)) == null) {
             try {
                 if (tc.getNodeFromAddress(Integer.parseInt(addressFromSystemName(systemName))) == null) {
-                    return false;
+                    return NameValidity.INVALID;
                 } else {
                     return (pinFromSystemName(systemName) >= 0
-                            && pinFromSystemName(systemName) <= 7);
+                            && pinFromSystemName(systemName) <= 7) ? NameValidity.VALID : NameValidity.INVALID;
                 }
             } catch (java.lang.NumberFormatException nfe) {
                 // if there was a number format exception, we couldn't find the node.
                 log.error("Unable to convert " + systemName + " into the Xbee node and pin format of nn:xx");
-                return false;
+                return NameValidity.INVALID;
             }
 
         } else {
             return (pinFromSystemName(systemName) >= 0
-                    && pinFromSystemName(systemName) <= 7);
+                    && pinFromSystemName(systemName) <= 7) ? NameValidity.VALID : NameValidity.INVALID;
         }
     }
 

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeSensorManager.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeSensorManager.java
@@ -87,25 +87,25 @@ public class XBeeSensorManager extends jmri.managers.AbstractSensorManager imple
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         if (tc.getNodeFromName(addressFromSystemName(systemName)) == null
                 && tc.getNodeFromAddress(addressFromSystemName(systemName)) == null) {
             try {
                 if (tc.getNodeFromAddress(Integer.parseInt(addressFromSystemName(systemName))) == null) {
-                    return false;
+                    return NameValidity.INVALID;
                 } else {
                     return (pinFromSystemName(systemName) >= 0
-                            && pinFromSystemName(systemName) <= 7);
+                            && pinFromSystemName(systemName) <= 7) ? NameValidity.VALID : NameValidity.INVALID;
                 }
             } catch (java.lang.NumberFormatException nfe) {
                 // if there was a number format exception, we couldn't find the node.
                 log.debug("Unable to convert {} into the XBee node and pin format of nn:xx", systemName);
-                return false;
+                return NameValidity.INVALID;
             }
 
         } else {
             return (pinFromSystemName(systemName) >= 0
-                    && pinFromSystemName(systemName) <= 7);
+                    && pinFromSystemName(systemName) <= 7) ? NameValidity.VALID : NameValidity.INVALID;
         }
     }
 

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManager.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManager.java
@@ -78,24 +78,24 @@ public class XBeeTurnoutManager extends AbstractTurnoutManager {
      * @param systemName Xbee id format with pins to be checked
      * @return 'true' if system name has a valid format, else returns 'false'
      */
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         if (tc.getNodeFromName(addressFromSystemName(systemName)) == null
                 && tc.getNodeFromAddress(addressFromSystemName(systemName)) == null) {
             try {
                 if (tc.getNodeFromAddress(Integer.parseInt(addressFromSystemName(systemName))) == null) {
-                    return false;
+                    return NameValidity.INVALID;
                 } else {
                     return (pinFromSystemName(systemName) >= 0
                             && pinFromSystemName(systemName) <= 7
                             && (pin2FromSystemName(systemName) == -1
                             || (pin2FromSystemName(systemName) >= 0
-                            && pin2FromSystemName(systemName) <= 7)));
+                            && pin2FromSystemName(systemName) <= 7))) ? NameValidity.VALID : NameValidity.INVALID;
                 }
             } catch (java.lang.NumberFormatException nfe) {
                 // if there was a number format exception, we couldn't
                 // find the node.
                 log.error("Unable to convert " + systemName + " into the Xbee node and pin format of nn:xx");
-                return false;
+                return NameValidity.INVALID;
             }
 
         } else {
@@ -103,7 +103,7 @@ public class XBeeTurnoutManager extends AbstractTurnoutManager {
                     && pinFromSystemName(systemName) <= 7
                     && (pin2FromSystemName(systemName) == -1
                     || (pin2FromSystemName(systemName) >= 0
-                    && pin2FromSystemName(systemName) <= 7)));
+                    && pin2FromSystemName(systemName) <= 7))) ? NameValidity.VALID : NameValidity.INVALID;
         }
     }
 

--- a/java/src/jmri/jmrix/internal/InternalLightManager.java
+++ b/java/src/jmri/jmrix/internal/InternalLightManager.java
@@ -44,8 +44,8 @@ public class InternalLightManager extends jmri.managers.AbstractLightManager {
     }
 
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return true;
+    public NameValidity validSystemNameFormat(String systemName) {
+        return NameValidity.VALID;
     }
 
     @Override

--- a/java/src/jmri/jmrix/internal/InternalTurnoutManager.java
+++ b/java/src/jmri/jmrix/internal/InternalTurnoutManager.java
@@ -21,8 +21,8 @@ public class InternalTurnoutManager extends jmri.managers.InternalTurnoutManager
     }
 
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return true;
+    public NameValidity validSystemNameFormat(String systemName) {
+        return NameValidity.VALID;
     }
 
     /**

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientLightManager.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientLightManager.java
@@ -39,10 +39,10 @@ public class JMRIClientLightManager extends jmri.managers.AbstractLightManager {
      * name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return ((systemName.startsWith(prefix + "l")
                 || systemName.startsWith(prefix + "L"))
-                && Integer.valueOf(systemName.substring(prefix.length() + 1)).intValue() > 0);
+                && Integer.valueOf(systemName.substring(prefix.length() + 1)).intValue() > 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
     /**

--- a/java/src/jmri/jmrix/jmriclient/json/JsonClientLightManager.java
+++ b/java/src/jmri/jmrix/jmriclient/json/JsonClientLightManager.java
@@ -37,10 +37,10 @@ public class JsonClientLightManager extends AbstractLightManager implements Json
     }
 
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (systemName.startsWith(this.getSystemPrefix())
                 && systemName.substring(this.getSystemPrefix().length(), this.getSystemPrefix().length() + 1).equalsIgnoreCase("L")
-                && Integer.parseInt(systemName.substring(this.getSystemPrefix().length() + 1)) > 0);
+                && Integer.parseInt(systemName.substring(this.getSystemPrefix().length() + 1)) > 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
     @Override

--- a/java/src/jmri/jmrix/lenz/XNetLightManager.java
+++ b/java/src/jmri/jmrix/lenz/XNetLightManager.java
@@ -90,8 +90,8 @@ public class XNetLightManager extends AbstractLightManager {
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return (getBitFromSystemName(systemName) != 0);
+    public NameValidity validSystemNameFormat(String systemName) {
+        return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/LnLightManager.java
+++ b/java/src/jmri/jmrix/loconet/LnLightManager.java
@@ -87,8 +87,8 @@ public class LnLightManager extends AbstractLightManager {
      * name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return (getBitFromSystemName(systemName) != 0);
+    public NameValidity validSystemNameFormat(String systemName) {
+        return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID; 
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/LnReporterManager.java
+++ b/java/src/jmri/jmrix/loconet/LnReporterManager.java
@@ -92,8 +92,8 @@ public class LnReporterManager extends jmri.managers.AbstractReporterManager imp
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return (getBitFromSystemName(systemName) != 0);
+    public NameValidity validSystemNameFormat(String systemName) {
+        return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/LnSensorManager.java
+++ b/java/src/jmri/jmrix/loconet/LnSensorManager.java
@@ -210,8 +210,8 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return (getBitFromSystemName(systemName) != 0);
+    public NameValidity validSystemNameFormat(String systemName) {
+        return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
     @Override

--- a/java/src/jmri/jmrix/loconet/LnTurnoutManager.java
+++ b/java/src/jmri/jmrix/loconet/LnTurnoutManager.java
@@ -187,8 +187,8 @@ public class LnTurnoutManager extends jmri.managers.AbstractTurnoutManager imple
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return (getBitFromSystemName(systemName) != 0);
+    public NameValidity validSystemNameFormat(String systemName) {
+        return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
     /**

--- a/java/src/jmri/jmrix/maple/SerialAddress.java
+++ b/java/src/jmri/jmrix/maple/SerialAddress.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.maple;
 
+import jmri.Manager.NameValidity;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,13 +60,13 @@ public class SerialAddress {
      * @return 'true' if system name has a valid format,
      * else returns 'false'
      */
-    public static boolean validSystemNameFormat(String systemName, char type) {
+    public static NameValidity validSystemNameFormat(String systemName, char type) {
         // validate the system Name leader characters
         if ((systemName.charAt(0) != 'K') || (systemName.charAt(1) != type)) {
             // here if an illegal format 
             log.error("illegal character in header field of system name: "
                     + systemName);
-            return (false);
+            return NameValidity.INVALID;
         }
 
         // This is a KLxxxx (or KTxxxx or KSxxxx) address, make sure xxxx is OK
@@ -75,14 +77,14 @@ public class SerialAddress {
         } catch (Exception e) {
             log.error("illegal character in number field of system name: "
                     + systemName);
-            return false;
+            return NameValidity.INVALID;
         }
         // now check range
         if ((bitNum <= 0) || (type == 'S' && bitNum > 1000) || (bitNum > 8000)) {
             log.error("node address field out of range in system name - " + systemName);
-            return false;
+            return NameValidity.INVALID;
         }
-        return true;
+        return NameValidity.VALID;
     }
 
     /**
@@ -92,7 +94,7 @@ public class SerialAddress {
      * else returns 'false'
      */
     public static boolean validSystemNameConfig(String systemName, char type) {
-        if (!validSystemNameFormat(systemName, type)) {
+        if (validSystemNameFormat(systemName, type) != NameValidity.VALID) {
             // No point in trying if a valid system name format is not present
             return false;
         }
@@ -129,7 +131,7 @@ public class SerialAddress {
      */
     public static String normalizeSystemName(String systemName) {
         // ensure that input system name has a valid format
-        if (!validSystemNameFormat(systemName, systemName.charAt(1))) {
+        if (validSystemNameFormat(systemName, systemName.charAt(1)) != NameValidity.VALID) {
             // No point in normalizing if a valid system name format is not present
             return "";
         }

--- a/java/src/jmri/jmrix/maple/SerialLightManager.java
+++ b/java/src/jmri/jmrix/maple/SerialLightManager.java
@@ -22,7 +22,7 @@ public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Returns the system letter.
+     * {@inheritDoc}
      */
     @Override
     public String getSystemPrefix() {
@@ -30,12 +30,7 @@ public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Method to create a new Light based on the system name.
-     * Assumes calling method has
-     * checked that a Light with this system name does not already exist.
-     *
-     * @return null if the system name is not in a valid format or if the
-     * system name does not correspond to a configured digital output bit
+     * {@inheritDoc}
      */
     @Override
     public Light createNewLight(String systemName, String userName) {
@@ -83,18 +78,15 @@ public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Public method to validate system name format.
-     * @return 'true' if system name has a valid format, else returns 'false'
+     * {@inheritDoc}
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'L'));
     }
 
     /**
-     * Public method to validate system name for configuration returns 'true' if
-     * system name has a valid meaning in current configuration, else returns
-     * 'false'
+     * {@inheritDoc}
      */
     @Override
     public boolean validSystemNameConfig(String systemName) {
@@ -102,10 +94,7 @@ public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Public method to normalize a system name.
-     * <P>
-     * Returns a normalized system name if system name has a valid format, else
-     * returns "".
+     * {@inheritDoc}
      */
     @Override
     public String normalizeSystemName(String systemName) {
@@ -113,7 +102,7 @@ public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Provide a manager-specific tooltip for the Add new item beantable pane.
+     * {@inheritDoc}
      */
     @Override
     public String getEntryToolTip() {

--- a/java/src/jmri/jmrix/maple/SerialLightManager.java
+++ b/java/src/jmri/jmrix/maple/SerialLightManager.java
@@ -53,7 +53,7 @@ public class SerialLightManager extends AbstractLightManager {
             log.error("error when normalizing system name " + systemName);
             return null;
         }
-        if (SerialAddress.validSystemNameFormat(systemName, 'L')) {
+        if (SerialAddress.validSystemNameFormat(systemName, 'L') == NameValidity.VALID) {
             lgt = new SerialLight(sysName, userName);
             if (!SerialAddress.validSystemNameConfig(sysName, 'L')) {
                 log.warn("Light system Name '" + sysName + "' does not refer to configured hardware.");

--- a/java/src/jmri/jmrix/maple/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/maple/SerialSensorManager.java
@@ -96,7 +96,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'S'));
     }
 

--- a/java/src/jmri/jmrix/maple/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/maple/SerialTurnoutManager.java
@@ -85,7 +85,7 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'T'));
     }
 

--- a/java/src/jmri/jmrix/nce/NceLightManager.java
+++ b/java/src/jmri/jmrix/nce/NceLightManager.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.nce;
 
 import jmri.Light;
+import jmri.Manager;
 import jmri.managers.AbstractLightManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,8 +103,8 @@ public class NceLightManager extends AbstractLightManager {
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return (getBitFromSystemName(systemName) != 0);
+    public NameValidity validSystemNameFormat(String systemName) {
+        return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
     /**

--- a/java/src/jmri/jmrix/nce/NceSensorManager.java
+++ b/java/src/jmri/jmrix/nce/NceSensorManager.java
@@ -467,7 +467,7 @@ public class NceSensorManager extends jmri.managers.AbstractSensorManager
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         if (systemName.contains(":") && !systemName.endsWith(":")) { // prevent to try parsing too soon
             // If sensor address is presented in the AIU Cab Address:Pin Number On AIU format,
             // translate it into nnnn. Copied from createSystemName()
@@ -483,11 +483,11 @@ public class NceSensorManager extends jmri.managers.AbstractSensorManager
                 log.debug("Unable to convert " + curAddress + " into the cab and pin format of nn:xx");
                 jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class).
                         showErrorMessage(Bundle.getMessage("ErrorTitle"), Bundle.getMessage("ErrorConvertNumberX", curAddress), "" + ex, "", true, false);
-                return false;
+                return NameValidity.INVALID;
             }
             systemName = getSystemPrefix() + "S" + ((_aiucab - 1) * 16 + _pin - 1);
         }
-        return (getBitFromSystemName(systemName) != 0);
+        return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
     /**

--- a/java/src/jmri/jmrix/nce/NceTurnoutManager.java
+++ b/java/src/jmri/jmrix/nce/NceTurnoutManager.java
@@ -90,8 +90,8 @@ public class NceTurnoutManager extends jmri.managers.AbstractTurnoutManager impl
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return (getBitFromSystemName(systemName) != 0);
+    public NameValidity validSystemNameFormat(String systemName) {
+        return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID; 
     }
 
     /**

--- a/java/src/jmri/jmrix/oaktree/SerialAddress.java
+++ b/java/src/jmri/jmrix/oaktree/SerialAddress.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.oaktree;
 
+import jmri.Manager.NameValidity;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,13 +127,13 @@ public class SerialAddress {
      * @return 'true' if system name has a valid format, else returns 'false'
      * @param type Letter indicating device type expected
      */
-    public static boolean validSystemNameFormat(String systemName, char type) {
+    public static NameValidity validSystemNameFormat(String systemName, char type) {
         // validate the system Name leader characters
         if ((systemName.charAt(0) != 'O') || (systemName.charAt(1) != type)) {
             // here if an illegal format 
             log.error("illegal character in header field system name: "
                     + systemName);
-            return (false);
+            return NameValidity.INVALID;
         }
         // check for the presence of a 'B' to differentiate the two address formats
         String s = "";
@@ -152,24 +154,24 @@ public class SerialAddress {
             } catch (Exception e) {
                 log.error("illegal character in number field system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num < 1) || (num >= 256000)) {
                 log.error("number field out of range in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num - ((num / 1000) * 1000)) == 0) {
                 log.error("bit number not in range 1 - 999 in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
         } else {
             // This is a OLnnnBxxxx address - validate the node address field
             if (s.length() == 0) {
                 log.error("no node address before 'B' in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             int num;
             try {
@@ -177,12 +179,12 @@ public class SerialAddress {
             } catch (Exception e) {
                 log.error("illegal character in node address field of system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num < 0) || (num >= 128)) {
                 log.error("node address field out of range in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             // validate the bit number field
             try {
@@ -190,16 +192,16 @@ public class SerialAddress {
             } catch (Exception e) {
                 log.error("illegal character in bit number field of system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num < 1) || (num > 2048)) {
                 log.error("bit number field out of range in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
         }
 
-        return true;
+        return NameValidity.VALID;
     }
 
     /**
@@ -208,7 +210,7 @@ public class SerialAddress {
      * returns 'false'
      */
     public static boolean validSystemNameConfig(String systemName, char type) {
-        if (!validSystemNameFormat(systemName, type)) {
+        if (validSystemNameFormat(systemName, type) != NameValidity.VALID) {
             // No point in trying if a valid system name format is not present
             log.warn(systemName + " invalid; bad format");
             return false;
@@ -248,7 +250,7 @@ public class SerialAddress {
      */
     public static String convertSystemNameToAlternate(String systemName) {
         // ensure that input system name has a valid format
-        if (!validSystemNameFormat(systemName, systemName.charAt(1))) {
+        if (validSystemNameFormat(systemName, systemName.charAt(1)) != NameValidity.VALID) {
             // No point in trying if a valid system name format is not present
             return "";
         }
@@ -296,7 +298,7 @@ public class SerialAddress {
      */
     public static String normalizeSystemName(String systemName) {
         // ensure that input system name has a valid format
-        if (!validSystemNameFormat(systemName, systemName.charAt(1))) {
+        if (validSystemNameFormat(systemName, systemName.charAt(1)) != NameValidity.VALID) {
             // No point in normalizing if a valid system name format is not present
             return "";
         }

--- a/java/src/jmri/jmrix/oaktree/SerialLightManager.java
+++ b/java/src/jmri/jmrix/oaktree/SerialLightManager.java
@@ -39,7 +39,7 @@ public class SerialLightManager extends AbstractLightManager {
     public Light createNewLight(String systemName, String userName) {
         Light lgt = null;
         // Validate the systemName
-        if (SerialAddress.validSystemNameFormat(systemName, 'L')) {
+        if (SerialAddress.validSystemNameFormat(systemName, 'L') == NameValidity.VALID) {
             lgt = new SerialLight(systemName, userName);
             if (!SerialAddress.validSystemNameConfig(systemName, 'L')) {
                 log.warn("Light system Name does not refer to configured hardware: "
@@ -56,7 +56,7 @@ public class SerialLightManager extends AbstractLightManager {
      * name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'L'));
     }
 

--- a/java/src/jmri/jmrix/oaktree/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/oaktree/SerialSensorManager.java
@@ -98,7 +98,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      * name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'S'));
     }
 

--- a/java/src/jmri/jmrix/oaktree/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/oaktree/SerialTurnoutManager.java
@@ -58,7 +58,7 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
      * name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'T'));
     }
 

--- a/java/src/jmri/jmrix/powerline/SerialAddress.java
+++ b/java/src/jmri/jmrix/powerline/SerialAddress.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.powerline;
 
+import jmri.Manager.NameValidity;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -43,7 +45,7 @@ public class SerialAddress {
      * @return 'true' if system name has a valid format, else returns 'false'
      * @param type Letter indicating device type expected
      */
-    public boolean validSystemNameFormat(String systemName, char type) {
+    public NameValidity validSystemNameFormat(String systemName, char type) {
         // validate the system Name leader characters
         boolean aTest = aCodes.reset(systemName).matches();
         boolean hTest = hCodes.reset(systemName).matches();
@@ -51,14 +53,14 @@ public class SerialAddress {
         if ((!aTest) || (aCodes.group(2).charAt(0) != type)) {
             // here if an illegal format 
             log.error("illegal character in header field system name: " + systemName);
-            return (false);
+            return NameValidity.INVALID;
         }
         if (hTest && hCodes.groupCount() == 4) {
             // This is a PLaxx address - validate the house code and unit address fields
             if (hCodes.group(3).charAt(0) < minHouseCode || hCodes.group(3).charAt(0) > maxHouseCode) {
                 log.error("house code field out of range in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             int num;
             try {
@@ -66,14 +68,14 @@ public class SerialAddress {
             } catch (Exception e) {
                 log.error("illegal character in unit address field of system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num < 1) || (num > 16)) {
                 log.error("unit address field out of range in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
-            return (true);
+            return NameValidity.VALID;
         }
         
         assert aTest;
@@ -82,14 +84,14 @@ public class SerialAddress {
         if (!iTest) {
             // here if an illegal format
             log.error("address did not match any valid forms: " + systemName);
-            return (false);
+            return NameValidity.INVALID;
         } else {
             if (iCodes.groupCount() != 5) {
                 // here if an illegal format
                 log.error("invalid format - " + systemName);
-                return (false);
+                return NameValidity.INVALID;
             } else {
-                return (true);
+                return NameValidity.VALID;
             }
         }
     }
@@ -103,7 +105,7 @@ public class SerialAddress {
      * @return  true for valid names
      */
     public boolean validSystemNameConfig(String systemName, char type) {
-        if (!validSystemNameFormat(systemName, type)) {
+        if (validSystemNameFormat(systemName, type) != NameValidity.VALID) {
             // No point in trying if a valid system name format is not present
             log.warn(systemName + " invalid; bad format");
             return false;
@@ -121,7 +123,7 @@ public class SerialAddress {
      */
     public boolean isInsteon(String systemName) {
         // ensure that input system name has a valid format
-        if ((!aCodes.reset(systemName).matches()) || (!validSystemNameFormat(systemName, aCodes.group(2).charAt(0)))) {
+        if ((!aCodes.reset(systemName).matches()) || (validSystemNameFormat(systemName, aCodes.group(2).charAt(0)) != NameValidity.VALID)) {
             // No point in normalizing if a valid system name format is not present
             return false;
         } else {
@@ -160,7 +162,7 @@ public class SerialAddress {
         int hCount = hCodes.groupCount();
         boolean iMatch = iCodes.reset(systemName).matches();
         int iCount = iCodes.groupCount();
-        if (!aMatch || aCount != 2 || (!validSystemNameFormat(systemName, aCodes.group(2).charAt(0)))) {
+        if (!aMatch || aCount != 2 || (validSystemNameFormat(systemName, aCodes.group(2).charAt(0)) != NameValidity.VALID)) {
             // No point in normalizing if a valid system name format is not present
             return "";
         }
@@ -195,7 +197,7 @@ public class SerialAddress {
     public String houseCodeFromSystemName(String systemName) {
         String hCode = "";
         // ensure that input system name has a valid format
-        if ((!aCodes.reset(systemName).matches()) || (!validSystemNameFormat(systemName, aCodes.group(2).charAt(0)))) {
+        if ((!aCodes.reset(systemName).matches()) || (validSystemNameFormat(systemName, aCodes.group(2).charAt(0)) != NameValidity.VALID)) {
             // No point in normalizing if a valid system name format is not present
         } else {
             if (hCodes.reset(systemName).matches() && hCodes.groupCount() == 2) {
@@ -222,7 +224,7 @@ public class SerialAddress {
     public String deviceCodeFromSystemName(String systemName) {
         String dCode = "";
         // ensure that input system name has a valid format
-        if ((!aCodes.reset(systemName).matches()) || (!validSystemNameFormat(systemName, aCodes.group(2).charAt(0)))) {
+        if ((!aCodes.reset(systemName).matches()) || (validSystemNameFormat(systemName, aCodes.group(2).charAt(0)) != NameValidity.VALID)) {
             // No point in normalizing if a valid system name format is not present
         } else {
             if (hCodes.reset(systemName).matches()) {
@@ -258,7 +260,7 @@ public class SerialAddress {
     public int houseCodeAsValueFromSystemName(String systemName) {
         int hCode = -1;
         // ensure that input system name has a valid format
-        if ((!aCodes.reset(systemName).matches()) || (!validSystemNameFormat(systemName, aCodes.group(2).charAt(0)))) {
+        if ((!aCodes.reset(systemName).matches()) || (validSystemNameFormat(systemName, aCodes.group(2).charAt(0)) != NameValidity.VALID)) {
             // No point in normalizing if a valid system name format is not present
         } else {
             if (hCodes.reset(systemName).matches() && hCodes.groupCount() == 4) {
@@ -285,7 +287,7 @@ public class SerialAddress {
     public int deviceCodeAsValueFromSystemName(String systemName) {
         int dCode = -1;
         // ensure that input system name has a valid format
-        if ((!aCodes.reset(systemName).matches()) || (!validSystemNameFormat(systemName, aCodes.group(2).charAt(0)))) {
+        if ((!aCodes.reset(systemName).matches()) || (validSystemNameFormat(systemName, aCodes.group(2).charAt(0)) != NameValidity.VALID)) {
             // No point in normalizing if a valid system name format is not present
         } else {
             if (hCodes.reset(systemName).matches() && hCodes.groupCount() == 4) {
@@ -312,7 +314,7 @@ public class SerialAddress {
     public int idHighCodeAsValueFromSystemName(String systemName) {
         int dCode = -1;
         // ensure that input system name has a valid format
-        if (!iCodes.reset(systemName).matches() || !validSystemNameFormat(systemName, iCodes.group(2).charAt(0))) {
+        if (!iCodes.reset(systemName).matches() || validSystemNameFormat(systemName, iCodes.group(2).charAt(0)) != NameValidity.VALID) {
             // No point in normalizing if a valid system name format is not present
         } else {
             if (iCodes.groupCount() == 5) {
@@ -339,7 +341,7 @@ public class SerialAddress {
     public int idMiddleCodeAsValueFromSystemName(String systemName) {
         int dCode = -1;
         // ensure that input system name has a valid format
-        if (!iCodes.reset(systemName).matches() || !validSystemNameFormat(systemName, iCodes.group(2).charAt(0))) {
+        if (!iCodes.reset(systemName).matches() || validSystemNameFormat(systemName, iCodes.group(2).charAt(0)) != NameValidity.VALID) {
             // No point in normalizing if a valid system name format is not present
         } else {
             if (iCodes.groupCount() == 5) {
@@ -366,7 +368,7 @@ public class SerialAddress {
     public int idLowCodeAsValueFromSystemName(String systemName) {
         int dCode = -1;
         // ensure that input system name has a valid format
-        if (!iCodes.reset(systemName).matches() || !validSystemNameFormat(systemName, iCodes.group(2).charAt(0))) {
+        if (!iCodes.reset(systemName).matches() || validSystemNameFormat(systemName, iCodes.group(2).charAt(0)) != NameValidity.VALID) {
             // No point in normalizing if a valid system name format is not present
         } else {
             if (iCodes.groupCount() == 5) {

--- a/java/src/jmri/jmrix/powerline/SerialLightManager.java
+++ b/java/src/jmri/jmrix/powerline/SerialLightManager.java
@@ -46,7 +46,7 @@ abstract public class SerialLightManager extends AbstractLightManager {
     public Light createNewLight(String systemName, String userName) {
         Light lgt = null;
         // Validate the systemName
-        if (tc.getAdapterMemo().getSerialAddress().validSystemNameFormat(systemName, 'L')) {
+        if (tc.getAdapterMemo().getSerialAddress().validSystemNameFormat(systemName, 'L') == NameValidity.VALID) {
             lgt = createNewSpecificLight(systemName, userName);
             if (!tc.getAdapterMemo().getSerialAddress().validSystemNameConfig(systemName, 'L')) {
                 log.warn("Light system Name does not refer to configured hardware: "
@@ -71,7 +71,7 @@ abstract public class SerialLightManager extends AbstractLightManager {
      * name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (tc.getAdapterMemo().getSerialAddress().validSystemNameFormat(systemName, 'L'));
     }
 

--- a/java/src/jmri/jmrix/secsi/SerialAddress.java
+++ b/java/src/jmri/jmrix/secsi/SerialAddress.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.secsi;
 
+import jmri.Manager.NameValidity;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,13 +130,13 @@ public class SerialAddress {
      * @param type Letter indicating device type expected
      * @return 'true' if system name has a valid format, else returns 'false'
      */
-    public static boolean validSystemNameFormat(String systemName, char type) {
+    public static NameValidity validSystemNameFormat(String systemName, char type) {
         // validate the system Name leader characters
         if ((systemName.charAt(0) != 'V') || (systemName.charAt(1) != type)) {
             // here if an illegal format 
             log.error("illegal character in header field system name: "
                     + systemName);
-            return (false);
+            return NameValidity.INVALID;
         }
         // check for the presence of a 'B' to differentiate the two address formats
         String s = "";
@@ -155,24 +157,24 @@ public class SerialAddress {
             } catch (Exception e) {
                 log.error("illegal character in number field system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num < 1) || (num >= 128000)) {
                 log.error("number field out of range in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num - ((num / 1000) * 1000)) == 0) {
                 log.error("bit number not in range 1 - 999 in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
         } else {
             // This is a VLnnnBxxxx address - validate the node address field
             if (s.length() == 0) {
                 log.error("no node address before 'B' in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             int num;
             try {
@@ -180,12 +182,12 @@ public class SerialAddress {
             } catch (Exception e) {
                 log.error("illegal character in node address field of system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num < 0) || (num >= 128)) {
                 log.error("node address field out of range in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             // validate the bit number field
             try {
@@ -193,16 +195,16 @@ public class SerialAddress {
             } catch (Exception e) {
                 log.error("illegal character in bit number field of system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num < 1) || (num > 32)) {
                 log.error("bit number field out of range in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
         }
 
-        return true;
+        return NameValidity.VALID;
     }
 
     /**
@@ -212,7 +214,7 @@ public class SerialAddress {
      * returns 'false'
      */
     public static boolean validSystemNameConfig(String systemName, char type) {
-        if (!validSystemNameFormat(systemName, type)) {
+        if (validSystemNameFormat(systemName, type) != NameValidity.VALID) {
             // No point in trying if a valid system name format is not present
             log.warn(systemName + " invalid; bad format");
             return false;
@@ -253,7 +255,7 @@ public class SerialAddress {
      */
     public static String convertSystemNameToAlternate(String systemName) {
         // ensure that input system name has a valid format
-        if (!validSystemNameFormat(systemName, systemName.charAt(1))) {
+        if (validSystemNameFormat(systemName, systemName.charAt(1)) != NameValidity.VALID) {
             // No point in trying if a valid system name format is not present
             return "";
         }
@@ -301,7 +303,7 @@ public class SerialAddress {
      */
     public static String normalizeSystemName(String systemName) {
         // ensure that input system name has a valid format
-        if (!validSystemNameFormat(systemName, systemName.charAt(1))) {
+        if (validSystemNameFormat(systemName, systemName.charAt(1)) != NameValidity.VALID) {
             // No point in normalizing if a valid system name format is not present
             return "";
         }

--- a/java/src/jmri/jmrix/secsi/SerialLightManager.java
+++ b/java/src/jmri/jmrix/secsi/SerialLightManager.java
@@ -41,7 +41,7 @@ public class SerialLightManager extends AbstractLightManager {
     public Light createNewLight(String systemName, String userName) {
         Light lgt = null;
         // Validate the systemName
-        if (SerialAddress.validSystemNameFormat(systemName, 'L')) {
+        if (SerialAddress.validSystemNameFormat(systemName, 'L') == NameValidity.VALID) {
             lgt = new SerialLight(systemName, userName);
             if (!SerialAddress.validSystemNameConfig(systemName, 'L')) {
                 log.warn("Light system Name does not refer to configured hardware: "
@@ -58,7 +58,7 @@ public class SerialLightManager extends AbstractLightManager {
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'L'));
     }
 

--- a/java/src/jmri/jmrix/secsi/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/secsi/SerialSensorManager.java
@@ -103,7 +103,7 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'S'));
     }
 

--- a/java/src/jmri/jmrix/secsi/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/secsi/SerialTurnoutManager.java
@@ -58,7 +58,7 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
      * @return 'true' if system name has a valid format, else returns 'false'
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'T'));
     }
 

--- a/java/src/jmri/jmrix/tmcc/SerialAddress.java
+++ b/java/src/jmri/jmrix/tmcc/SerialAddress.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.tmcc;
 
+import jmri.Manager.NameValidity;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -132,13 +134,13 @@ public class SerialAddress {
      * @param type S, L, T for either sensor, light, turnout
      * @return 'true' if system name has a valid format, else returns 'false'
      */
-    public static boolean validSystemNameFormat(String systemName, char type) {
+    public static NameValidity validSystemNameFormat(String systemName, char type) {
         // validate the system Name leader characters
         if ((systemName.charAt(0) != 'T') || (systemName.charAt(1) != type)) {
             // here if an illegal format 
             log.error("illegal character in header field system name: "
                     + systemName);
-            return (false);
+            return NameValidity.INVALID;
         }
         // check for the presence of a 'B' to differentiate the two address formats
         String s = "";
@@ -159,24 +161,24 @@ public class SerialAddress {
             } catch (Exception e) {
                 log.error("illegal character in number field system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num < 1) || (num >= 128000)) {
                 log.warn("number field out of range in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num - ((num / 1000) * 1000)) == 0) {
                 log.warn("bit number not in range 1 - 999 in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
         } else {
             // This is a TTnnnBxxxx address - validate the node address field
             if (s.length() == 0) {
                 log.error("no node address before 'B' in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             int num;
             try {
@@ -184,12 +186,12 @@ public class SerialAddress {
             } catch (Exception e) {
                 log.warn("illegal character in node address field of system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num < 0) || (num >= 128)) {
                 log.warn("node address field out of range in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             // validate the bit number field
             try {
@@ -197,15 +199,15 @@ public class SerialAddress {
             } catch (Exception e) {
                 log.warn("illegal character in bit number field of system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
             if ((num < 1) || (num > 2048)) {
                 log.warn("bit number field out of range in system name: "
                         + systemName);
-                return (false);
+                return NameValidity.INVALID;
             }
         }
-        return true;
+        return NameValidity.VALID;
     }
 
     /**
@@ -217,7 +219,7 @@ public class SerialAddress {
      * @return true if valid name
      */
     public static boolean validSystemNameConfig(String systemName, char type) {
-        if (!validSystemNameFormat(systemName, type)) {
+        if (validSystemNameFormat(systemName, type) != NameValidity.VALID) {
             // No point in trying if a valid system name format is not present
             return false;
         }
@@ -236,7 +238,7 @@ public class SerialAddress {
      */
     public static String convertSystemNameToAlternate(String systemName) {
         // ensure that input system name has a valid format
-        if (!validSystemNameFormat(systemName, systemName.charAt(1))) {
+        if (validSystemNameFormat(systemName, systemName.charAt(1)) != NameValidity.VALID) {
             // No point in trying if a valid system name format is not present
             return "";
         }
@@ -286,7 +288,7 @@ public class SerialAddress {
      */
     public static String normalizeSystemName(String systemName) {
         // ensure that input system name has a valid format
-        if (!validSystemNameFormat(systemName, systemName.charAt(1))) {
+        if (validSystemNameFormat(systemName, systemName.charAt(1)) != NameValidity.VALID) {
             // No point in normalizing if a valid system name format is not present
             return "";
         }

--- a/java/src/jmri/jmrix/tmcc/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/tmcc/SerialTurnoutManager.java
@@ -181,7 +181,7 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
      *
      * @return 'true' if system name has a valid format, else return 'false'
      */
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         return (SerialAddress.validSystemNameFormat(systemName, 'T'));
     }
 

--- a/java/src/jmri/managers/AbstractLightManager.java
+++ b/java/src/jmri/managers/AbstractLightManager.java
@@ -120,7 +120,7 @@ public abstract class AbstractLightManager extends AbstractManager<Light>
                     + ";" + ((userName == null) ? "null" : userName));
         }
         // is system name in correct format?
-        if (!validSystemNameFormat(systemName)) {
+        if ( validSystemNameFormat(systemName) != NameValidity.VALID) {
             log.error("Invalid system name for newLight: " + systemName);
             throw new IllegalArgumentException("\""+systemName+"\" is invalid");
         }

--- a/java/src/jmri/managers/AbstractLightManager.java
+++ b/java/src/jmri/managers/AbstractLightManager.java
@@ -194,23 +194,7 @@ public abstract class AbstractLightManager extends AbstractManager<Light>
     }
 
     /**
-     * Validate system name format.
-     *
-     * @since 2.9.3
-     * @see jmri.jmrit.beantable.LightTableAction.CheckedTextField
-     * @param systemName proposed complete system name incl. prefix
-     * @return always 'true' to let undocumented connection system managers pass entry validation.
-     */
-    @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return true;
-    }
-
-    /**
      * Normalize the system name
-     * <P>
-     * This routine is used to ensure that each system name is uniquely linked
-     * to one C/MRI bit, by removing extra zeros inserted by the user.
      * <P>
      * If a system implementation has names that could be normalized, the
      * system-specific Light Manager should override this routine and supply a
@@ -225,7 +209,7 @@ public abstract class AbstractLightManager extends AbstractManager<Light>
      * Convert the system name to a normalized alternate name
      * <P>
      * This routine is to allow testing to ensure that two Lights with alternate
-     * names that refer to the same output bit are not created.
+     * names that refer to the same output bit are not created in systems with multiple name formats.
      * <P>
      * If a system implementation has alternate names, the system specific Light
      * Manager should override this routine and supply the alternate name.

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -433,6 +433,17 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
         return inputName;
     }
 
+    /**
+     * {@inheritDoc}
+     * 
+     * @return always 'VALID' to let undocumented connection system 
+     *         managers pass entry validation.
+     */
+    @Override
+    public NameValidity validSystemNameFormat(String systemName) {
+        return NameValidity.VALID;
+    }
+
     private final static Logger log = LoggerFactory.getLogger(AbstractManager.class);
 
 }

--- a/java/src/jmri/managers/AbstractReporterManager.java
+++ b/java/src/jmri/managers/AbstractReporterManager.java
@@ -125,19 +125,6 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
         return false;
     }
 
-    /**
-     * Validate system name format.
-     *
-     * @since 2.9.3
-     * @see jmri.jmrit.beantable.ReporterTableAction.CheckedTextField
-     * @param systemName proposed complete system name incl. prefix
-     * @return always 'true' to let undocumented connection system managers pass entry validation.
-     */
-    @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return true;
-    }
-
     @Override
     public String getNextValidAddress(String curAddress, String prefix) {
         //If the hardware address passed does not already exist then this can

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -187,19 +187,6 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
         return prefix + typeLetter() + curAddress;
     }
 
-    /**
-     * Validate system name format.
-     *
-     * @since 2.9.3
-     * @see jmri.jmrit.beantable.SensorTableAction.CheckedTextField
-     * @param systemName proposed complete system name incl. prefix
-     * @return always 'true' to let undocumented connection system managers pass entry validation.
-     */
-    @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return true;
-    }
-
     @Override
     public String getNextValidAddress(String curAddress, String prefix) {
         // If the hardware address passed does not already exist then this can

--- a/java/src/jmri/managers/AbstractTurnoutManager.java
+++ b/java/src/jmri/managers/AbstractTurnoutManager.java
@@ -237,20 +237,6 @@ public abstract class AbstractTurnoutManager extends AbstractManager<Turnout>
         return prefix + typeLetter() + curAddress;
     }
 
-    /**
-     * Validate system name format.
-     *
-     * @since 2.9.3
-     * @see jmri.jmrit.beantable.TurnoutTableAction.CheckedTextField
-     * @param systemName proposed complete system name incl. prefix
-     * @return always 'true' to let undocumented connection system 
-     *         managers pass entry validation.
-     */
-    @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return true;
-    }
-
     @Override
     public String getNextValidAddress(String curAddress, String prefix) throws JmriException {
         // If the hardware address passed does not already exist then this can

--- a/java/src/jmri/managers/DefaultSignalMastLogicManager.java
+++ b/java/src/jmri/managers/DefaultSignalMastLogicManager.java
@@ -267,6 +267,17 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
     }
 
     /**
+     * {@inheritDoc}
+     * 
+     * @return always 'VALID' 
+     */
+    @Override
+    public NameValidity validSystemNameFormat(String systemName) {
+        return NameValidity.VALID;
+    }
+
+
+    /**
      * Enforces, and as a user convenience converts to, the standard form for a system name
      * for the NamedBeans handled by this manager.
      *

--- a/java/src/jmri/managers/InternalLightManager.java
+++ b/java/src/jmri/managers/InternalLightManager.java
@@ -46,8 +46,8 @@ public class InternalLightManager extends AbstractLightManager {
     }
 
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return true;
+    public NameValidity validSystemNameFormat(String systemName) {
+        return NameValidity.VALID;
     }
 
     @Override

--- a/java/src/jmri/managers/InternalReporterManager.java
+++ b/java/src/jmri/managers/InternalReporterManager.java
@@ -41,8 +41,8 @@ public class InternalReporterManager extends AbstractReporterManager {
     }
 
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return true;
+    public NameValidity validSystemNameFormat(String systemName) {
+        return NameValidity.VALID;
     }
 
     @Override

--- a/java/src/jmri/managers/InternalSensorManager.java
+++ b/java/src/jmri/managers/InternalSensorManager.java
@@ -59,8 +59,8 @@ public class InternalSensorManager extends AbstractSensorManager {
     protected String prefix = "I";
 
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return true;
+    public NameValidity validSystemNameFormat(String systemName) {
+        return NameValidity.VALID;
     }
 
     @Override

--- a/java/src/jmri/managers/InternalTurnoutManager.java
+++ b/java/src/jmri/managers/InternalTurnoutManager.java
@@ -42,8 +42,8 @@ public class InternalTurnoutManager extends AbstractTurnoutManager {
     }
 
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return true;
+    public NameValidity validSystemNameFormat(String systemName) {
+        return NameValidity.VALID;
     }
 
     /**

--- a/java/src/jmri/managers/ProxyLightManager.java
+++ b/java/src/jmri/managers/ProxyLightManager.java
@@ -115,15 +115,15 @@ public class ProxyLightManager extends AbstractProxyManager<Light>
      * a system name.
      *
      * @return if a manager is found, return its determination of validity of
-     * system name format. Return false if no manager exists.
+     * system name format. Return INVALID if no manager exists.
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         int i = matchTentative(systemName);
         if (i >= 0) {
             return ((LightManager) getMgr(i)).validSystemNameFormat(systemName);
         }
-        return false;
+        return NameValidity.INVALID;
     }
 
     /**

--- a/java/src/jmri/managers/ProxyReporterManager.java
+++ b/java/src/jmri/managers/ProxyReporterManager.java
@@ -125,15 +125,15 @@ public class ProxyReporterManager extends AbstractProxyManager<Reporter> impleme
      * Validate system name format. Locate a system specfic ReporterManager based on a system name.
      *
      * @return if a manager is found, return its determination of validity of
-     * system name format. Return false if no manager exists.
+     * system name format. Return INVALID if no manager exists.
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         int i = matchTentative(systemName);
         if (i >= 0) {
             return ((ReporterManager) getMgr(i)).validSystemNameFormat(systemName);
         }
-        return false;
+        return NameValidity.INVALID;
     }
 
     @Override

--- a/java/src/jmri/managers/ProxySensorManager.java
+++ b/java/src/jmri/managers/ProxySensorManager.java
@@ -149,15 +149,15 @@ public class ProxySensorManager extends AbstractProxyManager<Sensor>
      * a system name.
      *
      * @return if a manager is found, return its determination of validity of
-     * system name format. Return false if no manager exists.
+     * system name format. Return INVALID if no manager exists.
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         int i = matchTentative(systemName);
         if (i >= 0) {
             return ((SensorManager) getMgr(i)).validSystemNameFormat(systemName);
         }
-        return false;
+        return NameValidity.INVALID;
     }
 
     /**

--- a/java/src/jmri/managers/ProxyTurnoutManager.java
+++ b/java/src/jmri/managers/ProxyTurnoutManager.java
@@ -236,15 +236,15 @@ public class ProxyTurnoutManager extends AbstractProxyManager<Turnout> implement
      * Validate system name format. Locate a system specfic TurnoutManager based on a system name.
      *
      * @return if a manager is found, return its determination of validity of
-     * system name format. Return false if no manager exists.
+     * system name format. Return INVALID if no manager exists.
      */
     @Override
-    public boolean validSystemNameFormat(String systemName) {
+    public NameValidity validSystemNameFormat(String systemName) {
         int i = matchTentative(systemName);
         if (i >= 0) {
             return ((TurnoutManager) getMgr(i)).validSystemNameFormat(systemName);
         }
-        return false;
+        return NameValidity.INVALID;
     }
 
     @Override

--- a/java/test/jmri/jmrix/acela/AcelaAddressTest.java
+++ b/java/test/jmri/jmrix/acela/AcelaAddressTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.acela;
 
+import jmri.Manager.NameValidity;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -16,6 +17,13 @@ public class AcelaAddressTest {
     public void testCTor() {
         AcelaAddress t = new AcelaAddress();
         Assert.assertNotNull("exists",t);
+    }
+
+    @Test
+    public void testValidateSystemNameFormat() {
+        Assert.assertTrue("valid format - AL2", NameValidity.VALID == AcelaAddress.validSystemNameFormat("AL2", 'L', "A"));
+        Assert.assertTrue("valid format - AT11", NameValidity.VALID == AcelaAddress.validSystemNameFormat("AT11", 'T', "A"));
+        Assert.assertTrue("valid format - AS2", NameValidity.VALID == AcelaAddress.validSystemNameFormat("AS2", 'S', "A"));
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/cmri/CMRISystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/cmri/CMRISystemConnectionMemoTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.cmri;
 
+import jmri.Manager.NameValidity;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -23,32 +25,32 @@ public class CMRISystemConnectionMemoTest {
     public void testValidSystemNameFormat() {
         CMRISystemConnectionMemo m = new CMRISystemConnectionMemo();
 
-        Assert.assertTrue(m.validSystemNameFormat("CS2",'S'));    
-        Assert.assertTrue(m.validSystemNameFormat("CS21",'S'));    
-        Assert.assertTrue(m.validSystemNameFormat("CS2001",'S'));    
-        Assert.assertTrue(m.validSystemNameFormat("CS21001",'S'));    
-        Assert.assertTrue(m.validSystemNameFormat("CS127001",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS2",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS21",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS2001",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS21001",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS127001",'S'));    
 
-        Assert.assertTrue(m.validSystemNameFormat("CS999",'S'));    
-        Assert.assertTrue(m.validSystemNameFormat("CS2999",'S'));    
-        Assert.assertTrue(m.validSystemNameFormat("CS21999",'S'));    
-        Assert.assertTrue(m.validSystemNameFormat("CS127999",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS999",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS2999",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS21999",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS127999",'S'));    
 
-        Assert.assertTrue(m.validSystemNameFormat("CS21B1",'S'));    
-        Assert.assertTrue(m.validSystemNameFormat("CS21B001",'S'));    
-        Assert.assertTrue(m.validSystemNameFormat("CS21B1024",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS21B1",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS21B001",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS21B1024",'S'));    
           
-        Assert.assertTrue(m.validSystemNameFormat("CS127B1",'S'));    
-        Assert.assertTrue(m.validSystemNameFormat("CS127B001",'S'));    
-        Assert.assertTrue(m.validSystemNameFormat("CS127B1024",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS127B1",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS127B001",'S'));    
+        Assert.assertEquals(NameValidity.VALID, m.validSystemNameFormat("CS127B1024",'S'));    
 
-        Assert.assertFalse(m.validSystemNameFormat("CSx",'S'));  
+        Assert.assertEquals(NameValidity.INVALID, m.validSystemNameFormat("CSx",'S'));  
         jmri.util.JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CSx");
 
-        Assert.assertFalse(m.validSystemNameFormat("CS2000",'S'));  
+        Assert.assertEquals(NameValidity.INVALID, m.validSystemNameFormat("CS2000",'S'));  
         jmri.util.JUnitAppender.assertWarnMessage("bit number not in range 1 - 999 in CMRI system name: CS2000");
 
-        Assert.assertFalse(m.validSystemNameFormat("CS",'S'));  
+        Assert.assertEquals(NameValidity.INVALID, m.validSystemNameFormat("CS",'S'));  
         jmri.util.JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CS");
     }
 

--- a/java/test/jmri/jmrix/cmri/serial/SerialAddressTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialAddressTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.cmri.serial;
 
+import jmri.Manager.NameValidity;
+
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import junit.framework.Test;
@@ -67,60 +69,60 @@ public class SerialAddressTest extends TestCase {
     }
 
     public void testValidateSystemNameFormat() {
-        Assert.assertTrue("valid format - CL2", memo.validSystemNameFormat("CL2", 'L'));
-        Assert.assertTrue("valid format - CL0B2", memo.validSystemNameFormat("CL0B2", 'L'));
+        Assert.assertTrue("valid format - CL2", NameValidity.VALID == memo.validSystemNameFormat("CL2", 'L'));
+        Assert.assertTrue("valid format - CL0B2", NameValidity.VALID == memo.validSystemNameFormat("CL0B2", 'L'));
 
-        Assert.assertTrue("invalid format - CL", !memo.validSystemNameFormat("CL", 'L'));
+        Assert.assertTrue("invalid format - CL", NameValidity.VALID != memo.validSystemNameFormat("CL", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CL");
 
-        Assert.assertTrue("invalid format - CLB2", !memo.validSystemNameFormat("CLB2", 'L'));
+        Assert.assertTrue("invalid format - CLB2", NameValidity.VALID != memo.validSystemNameFormat("CLB2", 'L'));
         JUnitAppender.assertWarnMessage("no node address before 'B' in CMRI system name: CLB2");
 
-        Assert.assertTrue("valid format - CL2005", memo.validSystemNameFormat("CL2005", 'L'));
-        Assert.assertTrue("valid format - CL2B5", memo.validSystemNameFormat("CL2B5", 'L'));
-        Assert.assertTrue("valid format - CT2005", memo.validSystemNameFormat("CT2005", 'T'));
-        Assert.assertTrue("valid format - CT2B5", memo.validSystemNameFormat("CT2B5", 'T'));
-        Assert.assertTrue("valid format - CS2005", memo.validSystemNameFormat("CS2005", 'S'));
-        Assert.assertTrue("valid format - CS2B5", memo.validSystemNameFormat("CS2B5", 'S'));
+        Assert.assertTrue("valid format - CL2005", NameValidity.VALID == memo.validSystemNameFormat("CL2005", 'L'));
+        Assert.assertTrue("valid format - CL2B5", NameValidity.VALID == memo.validSystemNameFormat("CL2B5", 'L'));
+        Assert.assertTrue("valid format - CT2005", NameValidity.VALID == memo.validSystemNameFormat("CT2005", 'T'));
+        Assert.assertTrue("valid format - CT2B5", NameValidity.VALID == memo.validSystemNameFormat("CT2B5", 'T'));
+        Assert.assertTrue("valid format - CS2005", NameValidity.VALID == memo.validSystemNameFormat("CS2005", 'S'));
+        Assert.assertTrue("valid format - CS2B5", NameValidity.VALID == memo.validSystemNameFormat("CS2B5", 'S'));
 
-        Assert.assertTrue("invalid format - CY2005", !memo.validSystemNameFormat("CY2005", 'L'));
+        Assert.assertTrue("invalid format - CY2005", NameValidity.VALID != memo.validSystemNameFormat("CY2005", 'L'));
         JUnitAppender.assertErrorMessage("illegal type character in CMRI system name: CY2005");
 
-        Assert.assertTrue("invalid format - CY2B5", !memo.validSystemNameFormat("CY2B5", 'L'));
+        Assert.assertTrue("invalid format - CY2B5", NameValidity.VALID != memo.validSystemNameFormat("CY2B5", 'L'));
         JUnitAppender.assertErrorMessage("illegal type character in CMRI system name: CY2B5");
 
-        Assert.assertTrue("valid format - CL22001", memo.validSystemNameFormat("CL22001", 'L'));
-        Assert.assertTrue("valid format - CL22B1", memo.validSystemNameFormat("CL22B1", 'L'));
+        Assert.assertTrue("valid format - CL22001", NameValidity.VALID == memo.validSystemNameFormat("CL22001", 'L'));
+        Assert.assertTrue("valid format - CL22B1", NameValidity.VALID == memo.validSystemNameFormat("CL22B1", 'L'));
 
-        Assert.assertTrue("invalid format - CL22000", !memo.validSystemNameFormat("CL22000", 'L'));
+        Assert.assertTrue("invalid format - CL22000", NameValidity.VALID != memo.validSystemNameFormat("CL22000", 'L'));
         JUnitAppender.assertWarnMessage("bit number not in range 1 - 999 in CMRI system name: CL22000");
 
-        Assert.assertTrue("invalid format - CL22B0", !memo.validSystemNameFormat("CL22B0", 'L'));
+        Assert.assertTrue("invalid format - CL22B0", NameValidity.VALID != memo.validSystemNameFormat("CL22B0", 'L'));
         JUnitAppender.assertWarnMessage("bit number field out of range in CMRI system name: CL22B0");
 
-        Assert.assertTrue("valid format - CL2999", memo.validSystemNameFormat("CL2999", 'L'));
-        Assert.assertTrue("valid format - CL2B2048", memo.validSystemNameFormat("CL2B2048", 'L'));
+        Assert.assertTrue("valid format - CL2999", NameValidity.VALID == memo.validSystemNameFormat("CL2999", 'L'));
+        Assert.assertTrue("valid format - CL2B2048", NameValidity.VALID == memo.validSystemNameFormat("CL2B2048", 'L'));
 
-        Assert.assertTrue("invalid format - CL2B2049", !memo.validSystemNameFormat("CL2B2049", 'L'));
+        Assert.assertTrue("invalid format - CL2B2049", NameValidity.VALID != memo.validSystemNameFormat("CL2B2049", 'L'));
         JUnitAppender.assertWarnMessage("bit number field out of range in CMRI system name: CL2B2049");
 
-        Assert.assertTrue("valid format - CL127999", memo.validSystemNameFormat("CL127999", 'L'));
+        Assert.assertTrue("valid format - CL127999", NameValidity.VALID == memo.validSystemNameFormat("CL127999", 'L'));
 
-        Assert.assertTrue("invalid format - CL128000", !memo.validSystemNameFormat("CL128000", 'L'));
+        Assert.assertTrue("invalid format - CL128000", NameValidity.VALID != memo.validSystemNameFormat("CL128000", 'L'));
         JUnitAppender.assertWarnMessage("number field out of range in CMRI system name: CL128000");
 
-        Assert.assertTrue("valid format - CL127B7", memo.validSystemNameFormat("CL127B7", 'L'));
+        Assert.assertTrue("valid format - CL127B7", NameValidity.VALID == memo.validSystemNameFormat("CL127B7", 'L'));
 
-        Assert.assertTrue("invalid format - CL128B7", !memo.validSystemNameFormat("CL128B7", 'L'));
+        Assert.assertTrue("invalid format - CL128B7", NameValidity.VALID != memo.validSystemNameFormat("CL128B7", 'L'));
         JUnitAppender.assertWarnMessage("node address field out of range in CMRI system name: CL128B7");
 
-        Assert.assertTrue("invalid format - CL2oo5", !memo.validSystemNameFormat("CL2oo5", 'L'));
+        Assert.assertTrue("invalid format - CL2oo5", NameValidity.VALID != memo.validSystemNameFormat("CL2oo5", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CL2oo5");
 
-        Assert.assertTrue("invalid format - CL2aB5", !memo.validSystemNameFormat("CL2aB5", 'L'));
+        Assert.assertTrue("invalid format - CL2aB5", NameValidity.VALID != memo.validSystemNameFormat("CL2aB5", 'L'));
         JUnitAppender.assertWarnMessage("illegal character in node address field of CMRI system name: CL2aB5");
 
-        Assert.assertTrue("invalid format - CL2B5x", !memo.validSystemNameFormat("CL2B5x", 'L'));
+        Assert.assertTrue("invalid format - CL2B5x", NameValidity.VALID != memo.validSystemNameFormat("CL2B5x", 'L'));
         JUnitAppender.assertWarnMessage("illegal character in bit number field of CMRI system name: CL2B5x");
     }
 

--- a/java/test/jmri/jmrix/cmri/serial/SerialAddressTwoSystemTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialAddressTwoSystemTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.cmri.serial;
 
+import jmri.Manager.NameValidity;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import junit.framework.Test;
@@ -93,60 +94,60 @@ public class SerialAddressTwoSystemTest extends TestCase {
     }
 
     public void testValidateSystemNameFormat() {
-        Assert.assertTrue("valid format - CL2", memo1.validSystemNameFormat("CL2", 'L'));
-        Assert.assertTrue("valid format - CL0B2", memo1.validSystemNameFormat("CL0B2", 'L'));
+        Assert.assertTrue("valid format - CL2", NameValidity.VALID == memo1.validSystemNameFormat("CL2", 'L'));
+        Assert.assertTrue("valid format - CL0B2", NameValidity.VALID == memo1.validSystemNameFormat("CL0B2", 'L'));
 
-        Assert.assertTrue("invalid format - CL", !memo1.validSystemNameFormat("CL", 'L'));
+        Assert.assertTrue("invalid format - CL", NameValidity.VALID != memo1.validSystemNameFormat("CL", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CL");
 
-        Assert.assertTrue("invalid format - CLB2", !memo1.validSystemNameFormat("CLB2", 'L'));
+        Assert.assertTrue("invalid format - CLB2", NameValidity.VALID != memo1.validSystemNameFormat("CLB2", 'L'));
         JUnitAppender.assertWarnMessage("no node address before 'B' in CMRI system name: CLB2");
 
-        Assert.assertTrue("valid format - CL2005", memo1.validSystemNameFormat("CL2005", 'L'));
-        Assert.assertTrue("valid format - CL2B5", memo1.validSystemNameFormat("CL2B5", 'L'));
-        Assert.assertTrue("valid format - CT2005", memo1.validSystemNameFormat("CT2005", 'T'));
-        Assert.assertTrue("valid format - CT2B5", memo1.validSystemNameFormat("CT2B5", 'T'));
-        Assert.assertTrue("valid format - CS2005", memo1.validSystemNameFormat("CS2005", 'S'));
-        Assert.assertTrue("valid format - CS2B5", memo1.validSystemNameFormat("CS2B5", 'S'));
+        Assert.assertTrue("valid format - CL2005", NameValidity.VALID == memo1.validSystemNameFormat("CL2005", 'L'));
+        Assert.assertTrue("valid format - CL2B5", NameValidity.VALID == memo1.validSystemNameFormat("CL2B5", 'L'));
+        Assert.assertTrue("valid format - CT2005", NameValidity.VALID == memo1.validSystemNameFormat("CT2005", 'T'));
+        Assert.assertTrue("valid format - CT2B5", NameValidity.VALID == memo1.validSystemNameFormat("CT2B5", 'T'));
+        Assert.assertTrue("valid format - CS2005", NameValidity.VALID == memo1.validSystemNameFormat("CS2005", 'S'));
+        Assert.assertTrue("valid format - CS2B5", NameValidity.VALID == memo1.validSystemNameFormat("CS2B5", 'S'));
 
-        Assert.assertTrue("invalid format - CY2005", !memo1.validSystemNameFormat("CY2005", 'L'));
+        Assert.assertTrue("invalid format - CY2005", NameValidity.VALID != memo1.validSystemNameFormat("CY2005", 'L'));
         JUnitAppender.assertErrorMessage("illegal type character in CMRI system name: CY2005");
 
-        Assert.assertTrue("invalid format - CY2B5", !memo1.validSystemNameFormat("CY2B5", 'L'));
+        Assert.assertTrue("invalid format - CY2B5", NameValidity.VALID != memo1.validSystemNameFormat("CY2B5", 'L'));
         JUnitAppender.assertErrorMessage("illegal type character in CMRI system name: CY2B5");
 
-        Assert.assertTrue("valid format - CL22001", memo1.validSystemNameFormat("CL22001", 'L'));
-        Assert.assertTrue("valid format - CL22B1", memo1.validSystemNameFormat("CL22B1", 'L'));
+        Assert.assertTrue("valid format - CL22001", NameValidity.VALID == memo1.validSystemNameFormat("CL22001", 'L'));
+        Assert.assertTrue("valid format - CL22B1", NameValidity.VALID == memo1.validSystemNameFormat("CL22B1", 'L'));
 
-        Assert.assertTrue("invalid format - CL22000", !memo1.validSystemNameFormat("CL22000", 'L'));
+        Assert.assertTrue("invalid format - CL22000", NameValidity.VALID != memo1.validSystemNameFormat("CL22000", 'L'));
         JUnitAppender.assertWarnMessage("bit number not in range 1 - 999 in CMRI system name: CL22000");
 
-        Assert.assertTrue("invalid format - CL22B0", !memo1.validSystemNameFormat("CL22B0", 'L'));
+        Assert.assertTrue("invalid format - CL22B0", NameValidity.VALID != memo1.validSystemNameFormat("CL22B0", 'L'));
         JUnitAppender.assertWarnMessage("bit number field out of range in CMRI system name: CL22B0");
 
-        Assert.assertTrue("valid format - CL2999", memo1.validSystemNameFormat("CL2999", 'L'));
-        Assert.assertTrue("valid format - CL2B2048", memo1.validSystemNameFormat("CL2B2048", 'L'));
+        Assert.assertTrue("valid format - CL2999", NameValidity.VALID == memo1.validSystemNameFormat("CL2999", 'L'));
+        Assert.assertTrue("valid format - CL2B2048", NameValidity.VALID == memo1.validSystemNameFormat("CL2B2048", 'L'));
 
-        Assert.assertTrue("invalid format - CL2B2049", !memo1.validSystemNameFormat("CL2B2049", 'L'));
+        Assert.assertTrue("invalid format - CL2B2049", NameValidity.VALID != memo1.validSystemNameFormat("CL2B2049", 'L'));
         JUnitAppender.assertWarnMessage("bit number field out of range in CMRI system name: CL2B2049");
 
-        Assert.assertTrue("valid format - CL127999", memo1.validSystemNameFormat("CL127999", 'L'));
+        Assert.assertTrue("valid format - CL127999", NameValidity.VALID == memo1.validSystemNameFormat("CL127999", 'L'));
 
-        Assert.assertTrue("invalid format - CL128000", !memo1.validSystemNameFormat("CL128000", 'L'));
+        Assert.assertTrue("invalid format - CL128000", NameValidity.VALID != memo1.validSystemNameFormat("CL128000", 'L'));
         JUnitAppender.assertWarnMessage("number field out of range in CMRI system name: CL128000");
 
-        Assert.assertTrue("valid format - CL127B7", memo1.validSystemNameFormat("CL127B7", 'L'));
+        Assert.assertTrue("valid format - CL127B7", NameValidity.VALID == memo1.validSystemNameFormat("CL127B7", 'L'));
 
-        Assert.assertTrue("invalid format - CL128B7", !memo1.validSystemNameFormat("CL128B7", 'L'));
+        Assert.assertTrue("invalid format - CL128B7", NameValidity.VALID != memo1.validSystemNameFormat("CL128B7", 'L'));
         JUnitAppender.assertWarnMessage("node address field out of range in CMRI system name: CL128B7");
 
-        Assert.assertTrue("invalid format - CL2oo5", !memo1.validSystemNameFormat("CL2oo5", 'L'));
+        Assert.assertTrue("invalid format - CL2oo5", NameValidity.VALID != memo1.validSystemNameFormat("CL2oo5", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CL2oo5");
 
-        Assert.assertTrue("invalid format - CL2aB5", !memo1.validSystemNameFormat("CL2aB5", 'L'));
+        Assert.assertTrue("invalid format - CL2aB5", NameValidity.VALID != memo1.validSystemNameFormat("CL2aB5", 'L'));
         JUnitAppender.assertWarnMessage("illegal character in node address field of CMRI system name: CL2aB5");
 
-        Assert.assertTrue("invalid format - CL2B5x", !memo1.validSystemNameFormat("CL2B5x", 'L'));
+        Assert.assertTrue("invalid format - CL2B5x", NameValidity.VALID != memo1.validSystemNameFormat("CL2B5x", 'L'));
         JUnitAppender.assertWarnMessage("illegal character in bit number field of CMRI system name: CL2B5x");
     }
 

--- a/java/test/jmri/jmrix/cmri/serial/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialSensorManagerTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.cmri.serial;
 
+import jmri.Manager.NameValidity;
 import jmri.Sensor;
 import jmri.util.JUnitUtil;
 import org.junit.After;
@@ -64,18 +65,18 @@ public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest
 
     @Test
     public void testValidSystemNameFormat() {
-        Assert.assertTrue(l.validSystemNameFormat("CS1"));
-        Assert.assertTrue(l.validSystemNameFormat("CS21"));
-        Assert.assertTrue(l.validSystemNameFormat("CS2001"));
-        Assert.assertTrue(l.validSystemNameFormat("CS21001"));
+        Assert.assertEquals(NameValidity.VALID, l.validSystemNameFormat("CS1"));
+        Assert.assertEquals(NameValidity.VALID, l.validSystemNameFormat("CS21"));
+        Assert.assertEquals(NameValidity.VALID, l.validSystemNameFormat("CS2001"));
+        Assert.assertEquals(NameValidity.VALID, l.validSystemNameFormat("CS21001"));
 
-        Assert.assertFalse(l.validSystemNameFormat("CSx"));
+        Assert.assertEquals(NameValidity.INVALID, l.validSystemNameFormat("CSx"));
         jmri.util.JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CSx");
         
-        Assert.assertFalse(l.validSystemNameFormat("CS2000"));
+        Assert.assertEquals(NameValidity.INVALID, l.validSystemNameFormat("CS2000"));
         jmri.util.JUnitAppender.assertWarnMessage("bit number not in range 1 - 999 in CMRI system name: CS2000");
         
-        Assert.assertFalse(l.validSystemNameFormat("CS"));
+        Assert.assertEquals(NameValidity.INVALID, l.validSystemNameFormat("CS"));
         jmri.util.JUnitAppender.assertErrorMessage("illegal character in number field of CMRI system name: CS");
     }
     

--- a/java/test/jmri/jmrix/grapevine/SerialAddressTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialAddressTest.java
@@ -155,7 +155,7 @@ public class SerialAddressTest extends TestCase {
     //////////////////////////////////////////////
     // service routine for testing validSystemNameFormat
     void checkValidSystemNameFormatName(String name, char letter, boolean OK) {
-        Assert.assertTrue((OK ? "" : "in") + "valid format - " + name, !SerialAddress.validSystemNameFormat(name, letter) ^ OK);
+        Assert.assertTrue((OK ? "" : "in") + "valid format - " + name, (SerialAddress.validSystemNameFormat(name, letter) != jmri.Manager.NameValidity.VALID) ^ OK);
     }
 
     public void testValidateSystemNameFormat() {

--- a/java/test/jmri/jmrix/maple/SerialAddressTest.java
+++ b/java/test/jmri/jmrix/maple/SerialAddressTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.maple;
 
+import jmri.Manager.NameValidity;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import junit.framework.Test;
@@ -51,30 +52,30 @@ public class SerialAddressTest extends TestCase {
     }
 
     public void testValidateSystemNameFormat() {
-        Assert.assertTrue("valid format - KL2", SerialAddress.validSystemNameFormat("KL2", 'L'));
+        Assert.assertTrue("valid format - KL2", NameValidity.VALID == SerialAddress.validSystemNameFormat("KL2", 'L'));
 
-        Assert.assertTrue("invalid format - KL", !SerialAddress.validSystemNameFormat("KL", 'L'));
+        Assert.assertTrue("invalid format - KL", NameValidity.VALID != SerialAddress.validSystemNameFormat("KL", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in number field of system name: KL");
 
-        Assert.assertTrue("valid format - KL2005", SerialAddress.validSystemNameFormat("KL2005", 'L'));
-        Assert.assertTrue("valid format - KT2005", SerialAddress.validSystemNameFormat("KT2005", 'T'));
-        Assert.assertTrue("valid format - KS205", SerialAddress.validSystemNameFormat("KS205", 'S'));
+        Assert.assertTrue("valid format - KL2005", NameValidity.VALID == SerialAddress.validSystemNameFormat("KL2005", 'L'));
+        Assert.assertTrue("valid format - KT2005", NameValidity.VALID == SerialAddress.validSystemNameFormat("KT2005", 'T'));
+        Assert.assertTrue("valid format - KS205", NameValidity.VALID == SerialAddress.validSystemNameFormat("KS205", 'S'));
 
-        Assert.assertTrue("invalid format - KY2005", !SerialAddress.validSystemNameFormat("KY2005", 'L'));
+        Assert.assertTrue("invalid format - KY2005", NameValidity.VALID != SerialAddress.validSystemNameFormat("KY2005", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in header field of system name: KY2005");
 
-        Assert.assertTrue("valid format - KL1", SerialAddress.validSystemNameFormat("KL1", 'L'));
-        Assert.assertTrue("valid format - KL1000", SerialAddress.validSystemNameFormat("KL1000", 'L'));
+        Assert.assertTrue("valid format - KL1", NameValidity.VALID == SerialAddress.validSystemNameFormat("KL1", 'L'));
+        Assert.assertTrue("valid format - KL1000", NameValidity.VALID == SerialAddress.validSystemNameFormat("KL1000", 'L'));
 
         // note: address format is invalid (out of range) as checked upon user input
-        Assert.assertTrue("invalid format - KL0", !SerialAddress.validSystemNameFormat("KL0", 'L'));
+        Assert.assertTrue("invalid format - KL0", NameValidity.VALID != SerialAddress.validSystemNameFormat("KL0", 'L'));
         JUnitAppender.assertErrorMessage("node address field out of range in system name - KL0");
 
-        Assert.assertTrue("valid format - KL2999", SerialAddress.validSystemNameFormat("KL2999", 'L'));
+        Assert.assertTrue("valid format - KL2999", NameValidity.VALID == SerialAddress.validSystemNameFormat("KL2999", 'L'));
 
-        Assert.assertTrue("valid format - KL7999", SerialAddress.validSystemNameFormat("KL7999", 'L'));
+        Assert.assertTrue("valid format - KL7999", NameValidity.VALID == SerialAddress.validSystemNameFormat("KL7999", 'L'));
 
-        Assert.assertTrue("invalid format - KL2oo5", !SerialAddress.validSystemNameFormat("KL2oo5", 'L'));
+        Assert.assertTrue("invalid format - KL2oo5", NameValidity.VALID != SerialAddress.validSystemNameFormat("KL2oo5", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in number field of system name: KL2oo5");
     }
 

--- a/java/test/jmri/jmrix/oaktree/SerialAddressTest.java
+++ b/java/test/jmri/jmrix/oaktree/SerialAddressTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.oaktree;
 
+import jmri.Manager.NameValidity;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import junit.framework.Test;
@@ -16,59 +17,59 @@ import org.junit.Assert;
 public class SerialAddressTest extends TestCase {
 
     public void testValidateSystemNameFormat() {
-        Assert.assertTrue("valid format - OL2", SerialAddress.validSystemNameFormat("OL2", 'L'));
-        Assert.assertTrue("valid format - OL0B2", SerialAddress.validSystemNameFormat("OL0B2", 'L'));
-        Assert.assertTrue("invalid format - OL", !SerialAddress.validSystemNameFormat("OL", 'L'));
+        Assert.assertTrue("valid format - OL2", NameValidity.VALID == SerialAddress.validSystemNameFormat("OL2", 'L'));
+        Assert.assertTrue("valid format - OL0B2", NameValidity.VALID == SerialAddress.validSystemNameFormat("OL0B2", 'L'));
+        Assert.assertTrue("invalid format - OL", NameValidity.VALID != SerialAddress.validSystemNameFormat("OL", 'L'));
 
-        Assert.assertTrue("invalid format - OLB2", !SerialAddress.validSystemNameFormat("OLB2", 'L'));
+        Assert.assertTrue("invalid format - OLB2", NameValidity.VALID != SerialAddress.validSystemNameFormat("OLB2", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in number field system name: OL");
         JUnitAppender.assertErrorMessage("no node address before 'B' in system name: OLB2");
 
-        Assert.assertTrue("valid format - OL2005", SerialAddress.validSystemNameFormat("OL2005", 'L'));
-        Assert.assertTrue("valid format - OL2B5", SerialAddress.validSystemNameFormat("OL2B5", 'L'));
-        Assert.assertTrue("valid format - OT2005", SerialAddress.validSystemNameFormat("OT2005", 'T'));
-        Assert.assertTrue("valid format - OT2B5", SerialAddress.validSystemNameFormat("OT2B5", 'T'));
-        Assert.assertTrue("valid format - OS2005", SerialAddress.validSystemNameFormat("OS2005", 'S'));
-        Assert.assertTrue("valid format - OS2B5", SerialAddress.validSystemNameFormat("OS2B5", 'S'));
+        Assert.assertTrue("valid format - OL2005", NameValidity.VALID == SerialAddress.validSystemNameFormat("OL2005", 'L'));
+        Assert.assertTrue("valid format - OL2B5", NameValidity.VALID == SerialAddress.validSystemNameFormat("OL2B5", 'L'));
+        Assert.assertTrue("valid format - OT2005", NameValidity.VALID == SerialAddress.validSystemNameFormat("OT2005", 'T'));
+        Assert.assertTrue("valid format - OT2B5", NameValidity.VALID == SerialAddress.validSystemNameFormat("OT2B5", 'T'));
+        Assert.assertTrue("valid format - OS2005", NameValidity.VALID == SerialAddress.validSystemNameFormat("OS2005", 'S'));
+        Assert.assertTrue("valid format - OS2B5", NameValidity.VALID == SerialAddress.validSystemNameFormat("OS2B5", 'S'));
 
-        Assert.assertTrue("invalid format - OY2005", !SerialAddress.validSystemNameFormat("OY2005", 'L'));
+        Assert.assertTrue("invalid format - OY2005", NameValidity.VALID != SerialAddress.validSystemNameFormat("OY2005", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in header field system name: OY2005");
 
-        Assert.assertTrue("invalid format - OY2B5", !SerialAddress.validSystemNameFormat("OY2B5", 'L'));
+        Assert.assertTrue("invalid format - OY2B5", NameValidity.VALID != SerialAddress.validSystemNameFormat("OY2B5", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in header field system name: OY2B5");
 
-        Assert.assertTrue("valid format - OL22001", SerialAddress.validSystemNameFormat("OL22001", 'L'));
-        Assert.assertTrue("valid format - OL22B1", SerialAddress.validSystemNameFormat("OL22B1", 'L'));
+        Assert.assertTrue("valid format - OL22001", NameValidity.VALID == SerialAddress.validSystemNameFormat("OL22001", 'L'));
+        Assert.assertTrue("valid format - OL22B1", NameValidity.VALID == SerialAddress.validSystemNameFormat("OL22B1", 'L'));
 
-        Assert.assertTrue("invalid format - OL22000", !SerialAddress.validSystemNameFormat("OL22000", 'L'));
+        Assert.assertTrue("invalid format - OL22000", NameValidity.VALID != SerialAddress.validSystemNameFormat("OL22000", 'L'));
         JUnitAppender.assertErrorMessage("bit number not in range 1 - 999 in system name: OL22000");
 
-        Assert.assertTrue("invalid format - OL22B0", !SerialAddress.validSystemNameFormat("OL22B0", 'L'));
+        Assert.assertTrue("invalid format - OL22B0", NameValidity.VALID != SerialAddress.validSystemNameFormat("OL22B0", 'L'));
         JUnitAppender.assertErrorMessage("bit number field out of range in system name: OL22B0");
 
-        Assert.assertTrue("valid format - OL2999", SerialAddress.validSystemNameFormat("OL2999", 'L'));
-        Assert.assertTrue("valid format - OL2B2048", SerialAddress.validSystemNameFormat("OL2B2048", 'L'));
+        Assert.assertTrue("valid format - OL2999", NameValidity.VALID == SerialAddress.validSystemNameFormat("OL2999", 'L'));
+        Assert.assertTrue("valid format - OL2B2048", NameValidity.VALID == SerialAddress.validSystemNameFormat("OL2B2048", 'L'));
 
-        Assert.assertTrue("invalid format - OL2B2049", !SerialAddress.validSystemNameFormat("OL2B2049", 'L'));
+        Assert.assertTrue("invalid format - OL2B2049", NameValidity.VALID != SerialAddress.validSystemNameFormat("OL2B2049", 'L'));
         JUnitAppender.assertErrorMessage("bit number field out of range in system name: OL2B2049");
 
-        Assert.assertTrue("valid format - OL127999", SerialAddress.validSystemNameFormat("OL127999", 'L'));
+        Assert.assertTrue("valid format - OL127999", NameValidity.VALID == SerialAddress.validSystemNameFormat("OL127999", 'L'));
 
-        Assert.assertTrue("invalid format - OL128000", !SerialAddress.validSystemNameFormat("OL128000", 'L'));
+        Assert.assertTrue("invalid format - OL128000", NameValidity.VALID != SerialAddress.validSystemNameFormat("OL128000", 'L'));
         JUnitAppender.assertErrorMessage("bit number not in range 1 - 999 in system name: OL128000");
 
-        Assert.assertTrue("valid format - OL127B7", SerialAddress.validSystemNameFormat("OL127B7", 'L'));
+        Assert.assertTrue("valid format - OL127B7", NameValidity.VALID == SerialAddress.validSystemNameFormat("OL127B7", 'L'));
 
-        Assert.assertTrue("invalid format - OL128B7", !SerialAddress.validSystemNameFormat("OL128B7", 'L'));
+        Assert.assertTrue("invalid format - OL128B7", NameValidity.VALID != SerialAddress.validSystemNameFormat("OL128B7", 'L'));
         JUnitAppender.assertErrorMessage("node address field out of range in system name: OL128B7");
 
-        Assert.assertTrue("invalid format - OL2oo5", !SerialAddress.validSystemNameFormat("OL2oo5", 'L'));
+        Assert.assertTrue("invalid format - OL2oo5", NameValidity.VALID != SerialAddress.validSystemNameFormat("OL2oo5", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in number field system name: OL2oo5");
 
-        Assert.assertTrue("invalid format - OL2aB5", !SerialAddress.validSystemNameFormat("OL2aB5", 'L'));
+        Assert.assertTrue("invalid format - OL2aB5", NameValidity.VALID != SerialAddress.validSystemNameFormat("OL2aB5", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in node address field of system name: OL2aB5");
 
-        Assert.assertTrue("invalid format - OL2B5x", !SerialAddress.validSystemNameFormat("OL2B5x", 'L'));
+        Assert.assertTrue("invalid format - OL2B5x", NameValidity.VALID != SerialAddress.validSystemNameFormat("OL2B5x", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in bit number field of system name: OL2B5x");
     }
 

--- a/java/test/jmri/jmrix/powerline/SerialAddressTest.java
+++ b/java/test/jmri/jmrix/powerline/SerialAddressTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.powerline;
 
+import jmri.Manager.NameValidity;
 import jmri.jmrix.powerline.simulator.SpecificSystemConnectionMemo;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
@@ -19,72 +20,72 @@ public class SerialAddressTest extends TestCase {
     SerialTrafficControlScaffold tc = null;
 
     public void testValidateSystemNameFormat() {
-        Assert.assertTrue("valid format - PLA1", tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PLA1", 'L'));
-        Assert.assertTrue("valid format - PLA16", tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PLA16", 'L'));
-        Assert.assertTrue("valid format - PLK3", tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PLK3", 'L'));
-        Assert.assertTrue("valid format - PTA1", tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PTA1", 'T'));
-        Assert.assertTrue("valid format - PTA16", tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PTA16", 'T'));
-        Assert.assertTrue("valid format - PTK3", tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PTK3", 'T'));
+        Assert.assertTrue("valid format - PLA1", NameValidity.VALID == tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PLA1", 'L'));
+        Assert.assertTrue("valid format - PLA16", NameValidity.VALID == tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PLA16", 'L'));
+        Assert.assertTrue("valid format - PLK3", NameValidity.VALID == tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PLK3", 'L'));
+        Assert.assertTrue("valid format - PTA1", NameValidity.VALID == tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PTA1", 'T'));
+        Assert.assertTrue("valid format - PTA16", NameValidity.VALID == tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PTA16", 'T'));
+        Assert.assertTrue("valid format - PTK3", NameValidity.VALID == tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PTK3", 'T'));
 
-        Assert.assertTrue("invalid format - PL2", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2", 'L'));
+        Assert.assertTrue("invalid format - PL2", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL2");
-        Assert.assertTrue("invalid format - PL0B2", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL0B2", 'L'));
+        Assert.assertTrue("invalid format - PL0B2", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL0B2", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL0B2");
-        Assert.assertTrue("invalid format - PL", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL", 'L'));
+        Assert.assertTrue("invalid format - PL", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL");
 
-        Assert.assertTrue("valid format - PLB2", tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PLB2", 'L'));
+        Assert.assertTrue("valid format - PLB2", NameValidity.VALID == tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PLB2", 'L'));
 
-        Assert.assertTrue("invalid format - PY2005", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PY2005", 'L'));
+        Assert.assertTrue("invalid format - PY2005", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PY2005", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in header field system name: PY2005");
 
-        Assert.assertTrue("invalid format - PY2B5", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PY2B5", 'L'));
+        Assert.assertTrue("invalid format - PY2B5", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PY2B5", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in header field system name: PY2B5");
 
-        Assert.assertTrue("invalid format - PL22001", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL22001", 'L'));
+        Assert.assertTrue("invalid format - PL22001", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL22001", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL22001");
-        Assert.assertTrue("invalid format - PL22B1", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL22B1", 'L'));
+        Assert.assertTrue("invalid format - PL22B1", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL22B1", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL22B1");
 
-        Assert.assertTrue("invalid format - PL22000", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL22000", 'L'));
+        Assert.assertTrue("invalid format - PL22000", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL22000", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL22000");
 
-        Assert.assertTrue("invalid format - PL22B0", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL22B0", 'L'));
+        Assert.assertTrue("invalid format - PL22B0", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL22B0", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL22B0");
 
-        Assert.assertTrue("invalid format - PL2999", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2999", 'L'));
+        Assert.assertTrue("invalid format - PL2999", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2999", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL2999");
-        Assert.assertTrue("invalid format - PL2B2048", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2B2048", 'L'));
+        Assert.assertTrue("invalid format - PL2B2048", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2B2048", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL2B2048");
 
-        Assert.assertTrue("invalid format - PL2B2049", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2B2049", 'L'));
+        Assert.assertTrue("invalid format - PL2B2049", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2B2049", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL2B2049");
 
-        Assert.assertTrue("invalid format - PL2B33", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2B33", 'L'));
+        Assert.assertTrue("invalid format - PL2B33", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2B33", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL2B33");
 
-        Assert.assertTrue("invalid format - PL127032", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL127032", 'L'));
+        Assert.assertTrue("invalid format - PL127032", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL127032", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL127032");
 
-        Assert.assertTrue("invalid format - PL127001", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL127001", 'L'));
+        Assert.assertTrue("invalid format - PL127001", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL127001", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL127001");
 
-        Assert.assertTrue("invalid format - PL127000", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL127000", 'L'));
+        Assert.assertTrue("invalid format - PL127000", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL127000", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL127000");
 
-        Assert.assertTrue("invalid format - PL127B7", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL127B7", 'L'));
+        Assert.assertTrue("invalid format - PL127B7", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL127B7", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL127B7");
 
-        Assert.assertTrue("invalid format - PL128B7", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL128B7", 'L'));
+        Assert.assertTrue("invalid format - PL128B7", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL128B7", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL128B7");
 
-        Assert.assertTrue("invalid format - PL2oo5", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2oo5", 'L'));
+        Assert.assertTrue("invalid format - PL2oo5", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2oo5", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL2oo5");
 
-        Assert.assertTrue("invalid format - PL2aB5", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2aB5", 'L'));
+        Assert.assertTrue("invalid format - PL2aB5", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2aB5", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL2aB5");
 
-        Assert.assertTrue("invalid format - PL2B5x", !tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2B5x", 'L'));
+        Assert.assertTrue("invalid format - PL2B5x", NameValidity.VALID != tc.getAdapterMemo().getSerialAddress().validSystemNameFormat("PL2B5x", 'L'));
         JUnitAppender.assertErrorMessage("address did not match any valid forms: PL2B5x");
     }
 

--- a/java/test/jmri/jmrix/secsi/SerialAddressTest.java
+++ b/java/test/jmri/jmrix/secsi/SerialAddressTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.secsi;
 
+import jmri.Manager.NameValidity;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import junit.framework.Test;
@@ -16,65 +17,65 @@ import org.junit.Assert;
 public class SerialAddressTest extends TestCase {
 
     public void testValidateSystemNameFormat() {
-        Assert.assertTrue("valid format - VL2", SerialAddress.validSystemNameFormat("VL2", 'L'));
-        Assert.assertTrue("valid format - VL0B2", SerialAddress.validSystemNameFormat("VL0B2", 'L'));
-        Assert.assertTrue("invalid format - VL", !SerialAddress.validSystemNameFormat("VL", 'L'));
+        Assert.assertTrue("valid format - VL2", NameValidity.VALID == SerialAddress.validSystemNameFormat("VL2", 'L'));
+        Assert.assertTrue("valid format - VL0B2", NameValidity.VALID == SerialAddress.validSystemNameFormat("VL0B2", 'L'));
+        Assert.assertTrue("invalid format - VL", NameValidity.VALID != SerialAddress.validSystemNameFormat("VL", 'L'));
 
-        Assert.assertTrue("invalid format - VLB2", !SerialAddress.validSystemNameFormat("VLB2", 'L'));
+        Assert.assertTrue("invalid format - VLB2", NameValidity.VALID != SerialAddress.validSystemNameFormat("VLB2", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in number field system name: VL");
         JUnitAppender.assertErrorMessage("no node address before 'B' in system name: VLB2");
 
-        Assert.assertTrue("valid format - VL2005", SerialAddress.validSystemNameFormat("VL2005", 'L'));
-        Assert.assertTrue("valid format - VL2B5", SerialAddress.validSystemNameFormat("VL2B5", 'L'));
-        Assert.assertTrue("valid format - VT2005", SerialAddress.validSystemNameFormat("VT2005", 'T'));
-        Assert.assertTrue("valid format - VT2B5", SerialAddress.validSystemNameFormat("VT2B5", 'T'));
-        Assert.assertTrue("valid format - VS2005", SerialAddress.validSystemNameFormat("VS2005", 'S'));
-        Assert.assertTrue("valid format - VS2B5", SerialAddress.validSystemNameFormat("VS2B5", 'S'));
+        Assert.assertTrue("valid format - VL2005", NameValidity.VALID == SerialAddress.validSystemNameFormat("VL2005", 'L'));
+        Assert.assertTrue("valid format - VL2B5", NameValidity.VALID == SerialAddress.validSystemNameFormat("VL2B5", 'L'));
+        Assert.assertTrue("valid format - VT2005", NameValidity.VALID == SerialAddress.validSystemNameFormat("VT2005", 'T'));
+        Assert.assertTrue("valid format - VT2B5", NameValidity.VALID == SerialAddress.validSystemNameFormat("VT2B5", 'T'));
+        Assert.assertTrue("valid format - VS2005", NameValidity.VALID == SerialAddress.validSystemNameFormat("VS2005", 'S'));
+        Assert.assertTrue("valid format - VS2B5", NameValidity.VALID == SerialAddress.validSystemNameFormat("VS2B5", 'S'));
 
-        Assert.assertTrue("invalid format - VY2005", !SerialAddress.validSystemNameFormat("VY2005", 'L'));
+        Assert.assertTrue("invalid format - VY2005", NameValidity.VALID != SerialAddress.validSystemNameFormat("VY2005", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in header field system name: VY2005");
 
-        Assert.assertTrue("invalid format - VY2B5", !SerialAddress.validSystemNameFormat("VY2B5", 'L'));
+        Assert.assertTrue("invalid format - VY2B5", NameValidity.VALID != SerialAddress.validSystemNameFormat("VY2B5", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in header field system name: VY2B5");
 
-        Assert.assertTrue("valid format - VL22001", SerialAddress.validSystemNameFormat("VL22001", 'L'));
-        Assert.assertTrue("valid format - VL22B1", SerialAddress.validSystemNameFormat("VL22B1", 'L'));
+        Assert.assertTrue("valid format - VL22001", NameValidity.VALID == SerialAddress.validSystemNameFormat("VL22001", 'L'));
+        Assert.assertTrue("valid format - VL22B1", NameValidity.VALID == SerialAddress.validSystemNameFormat("VL22B1", 'L'));
 
-        Assert.assertTrue("invalid format - VL22000", !SerialAddress.validSystemNameFormat("VL22000", 'L'));
+        Assert.assertTrue("invalid format - VL22000", NameValidity.VALID != SerialAddress.validSystemNameFormat("VL22000", 'L'));
         JUnitAppender.assertErrorMessage("bit number not in range 1 - 999 in system name: VL22000");
 
-        Assert.assertTrue("invalid format - VL22B0", !SerialAddress.validSystemNameFormat("VL22B0", 'L'));
+        Assert.assertTrue("invalid format - VL22B0", NameValidity.VALID != SerialAddress.validSystemNameFormat("VL22B0", 'L'));
         JUnitAppender.assertErrorMessage("bit number field out of range in system name: VL22B0");
 
-        Assert.assertTrue("valid format - VL2999", SerialAddress.validSystemNameFormat("VL2999", 'L'));
-        Assert.assertTrue("invalid format - VL2B2048", !SerialAddress.validSystemNameFormat("VL2B2048", 'L'));
+        Assert.assertTrue("valid format - VL2999", NameValidity.VALID == SerialAddress.validSystemNameFormat("VL2999", 'L'));
+        Assert.assertTrue("invalid format - VL2B2048", NameValidity.VALID != SerialAddress.validSystemNameFormat("VL2B2048", 'L'));
         JUnitAppender.assertErrorMessage("bit number field out of range in system name: VL2B2048");
 
-        Assert.assertTrue("invalid format - VL2B2049", !SerialAddress.validSystemNameFormat("VL2B2049", 'L'));
+        Assert.assertTrue("invalid format - VL2B2049", NameValidity.VALID != SerialAddress.validSystemNameFormat("VL2B2049", 'L'));
         JUnitAppender.assertErrorMessage("bit number field out of range in system name: VL2B2049");
 
-        Assert.assertTrue("invalid format - VL2B33", !SerialAddress.validSystemNameFormat("VL2B33", 'L'));
+        Assert.assertTrue("invalid format - VL2B33", NameValidity.VALID != SerialAddress.validSystemNameFormat("VL2B33", 'L'));
         JUnitAppender.assertErrorMessage("bit number field out of range in system name: VL2B33");
 
-        Assert.assertTrue("valid format - VL127032", SerialAddress.validSystemNameFormat("VL127032", 'L'));
+        Assert.assertTrue("valid format - VL127032", NameValidity.VALID == SerialAddress.validSystemNameFormat("VL127032", 'L'));
 
-        Assert.assertTrue("valid format - VL127001", SerialAddress.validSystemNameFormat("VL127001", 'L'));
+        Assert.assertTrue("valid format - VL127001", NameValidity.VALID == SerialAddress.validSystemNameFormat("VL127001", 'L'));
 
-        Assert.assertTrue("invalid format - VL127000", !SerialAddress.validSystemNameFormat("VL127000", 'L'));
+        Assert.assertTrue("invalid format - VL127000", NameValidity.VALID != SerialAddress.validSystemNameFormat("VL127000", 'L'));
         JUnitAppender.assertErrorMessage("bit number not in range 1 - 999 in system name: VL127000");
 
-        Assert.assertTrue("valid format - VL127B7", SerialAddress.validSystemNameFormat("VL127B7", 'L'));
+        Assert.assertTrue("valid format - VL127B7", NameValidity.VALID == SerialAddress.validSystemNameFormat("VL127B7", 'L'));
 
-        Assert.assertTrue("invalid format -VL128B7", !SerialAddress.validSystemNameFormat("VL128B7", 'L'));
+        Assert.assertTrue("invalid format -VL128B7", NameValidity.VALID != SerialAddress.validSystemNameFormat("VL128B7", 'L'));
         JUnitAppender.assertErrorMessage("node address field out of range in system name: VL128B7");
 
-        Assert.assertTrue("invalid format - VL2oo5", !SerialAddress.validSystemNameFormat("VL2oo5", 'L'));
+        Assert.assertTrue("invalid format - VL2oo5", NameValidity.VALID != SerialAddress.validSystemNameFormat("VL2oo5", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in number field system name: VL2oo5");
 
-        Assert.assertTrue("invalid format - VL2aB5", !SerialAddress.validSystemNameFormat("VL2aB5", 'L'));
+        Assert.assertTrue("invalid format - VL2aB5", NameValidity.VALID != SerialAddress.validSystemNameFormat("VL2aB5", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in node address field of system name: VL2aB5");
 
-        Assert.assertTrue("invalid format - VL2B5x", !SerialAddress.validSystemNameFormat("VL2B5x", 'L'));
+        Assert.assertTrue("invalid format - VL2B5x", NameValidity.VALID != SerialAddress.validSystemNameFormat("VL2B5x", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in bit number field of system name: VL2B5x");
     }
 

--- a/java/test/jmri/jmrix/tmcc/SerialAddressTest.java
+++ b/java/test/jmri/jmrix/tmcc/SerialAddressTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.tmcc;
 
+import jmri.Manager.NameValidity;
+
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import junit.framework.Test;
@@ -15,68 +17,68 @@ import org.junit.Assert;
 public class SerialAddressTest extends TestCase {
 
     public void testValidateSystemNameFormat() {
-        Assert.assertTrue("valid format - TL2", SerialAddress.validSystemNameFormat("TL2", 'L'));
+        Assert.assertTrue("valid format - TL2", NameValidity.VALID == SerialAddress.validSystemNameFormat("TL2", 'L'));
 
-        Assert.assertTrue("valid format - TL0B2", SerialAddress.validSystemNameFormat("TL0B2", 'L'));
+        Assert.assertTrue("valid format - TL0B2", NameValidity.VALID == SerialAddress.validSystemNameFormat("TL0B2", 'L'));
 
-        Assert.assertTrue("invalid format - TL", !SerialAddress.validSystemNameFormat("TL", 'L'));
+        Assert.assertTrue("invalid format - TL", NameValidity.VALID != SerialAddress.validSystemNameFormat("TL", 'L'));
 
-        Assert.assertTrue("invalid format - TLB2", !SerialAddress.validSystemNameFormat("TLB2", 'L'));
+        Assert.assertTrue("invalid format - TLB2", NameValidity.VALID != SerialAddress.validSystemNameFormat("TLB2", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in number field system name: TL");
         JUnitAppender.assertErrorMessage("no node address before 'B' in system name: TLB2");
 
-        Assert.assertTrue("valid format - TL2005", SerialAddress.validSystemNameFormat("TL2005", 'L'));
+        Assert.assertTrue("valid format - TL2005", NameValidity.VALID == SerialAddress.validSystemNameFormat("TL2005", 'L'));
 
-        Assert.assertTrue("valid format - TL2B5", SerialAddress.validSystemNameFormat("TL2B5", 'L'));
+        Assert.assertTrue("valid format - TL2B5", NameValidity.VALID == SerialAddress.validSystemNameFormat("TL2B5", 'L'));
 
-        Assert.assertTrue("valid format - TT2005", SerialAddress.validSystemNameFormat("TT2005", 'T'));
+        Assert.assertTrue("valid format - TT2005", NameValidity.VALID == SerialAddress.validSystemNameFormat("TT2005", 'T'));
 
-        Assert.assertTrue("valid format - TT2B5", SerialAddress.validSystemNameFormat("TT2B5", 'T'));
+        Assert.assertTrue("valid format - TT2B5", NameValidity.VALID == SerialAddress.validSystemNameFormat("TT2B5", 'T'));
 
-        Assert.assertTrue("valid format - TS2005", SerialAddress.validSystemNameFormat("TS2005", 'S'));
+        Assert.assertTrue("valid format - TS2005", NameValidity.VALID == SerialAddress.validSystemNameFormat("TS2005", 'S'));
 
-        Assert.assertTrue("valid format - TS2B5", SerialAddress.validSystemNameFormat("TS2B5", 'S'));
+        Assert.assertTrue("valid format - TS2B5", NameValidity.VALID == SerialAddress.validSystemNameFormat("TS2B5", 'S'));
 
-        Assert.assertTrue("invalid format - TY2005", !SerialAddress.validSystemNameFormat("TY2005", 'L'));
+        Assert.assertTrue("invalid format - TY2005", NameValidity.VALID != SerialAddress.validSystemNameFormat("TY2005", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in header field system name: TY2005");
 
-        Assert.assertTrue("invalid format - TY2B5", !SerialAddress.validSystemNameFormat("TY2B5", 'L'));
+        Assert.assertTrue("invalid format - TY2B5", NameValidity.VALID != SerialAddress.validSystemNameFormat("TY2B5", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in header field system name: TY2B5");
 
-        Assert.assertTrue("valid format - TL22001", SerialAddress.validSystemNameFormat("TL22001", 'L'));
+        Assert.assertTrue("valid format - TL22001", NameValidity.VALID == SerialAddress.validSystemNameFormat("TL22001", 'L'));
 
-        Assert.assertTrue("valid format - TL22B1", SerialAddress.validSystemNameFormat("TL22B1", 'L'));
+        Assert.assertTrue("valid format - TL22B1", NameValidity.VALID == SerialAddress.validSystemNameFormat("TL22B1", 'L'));
 
-        Assert.assertTrue("invalid format - TL22000", !SerialAddress.validSystemNameFormat("TL22000", 'L'));
+        Assert.assertTrue("invalid format - TL22000", NameValidity.VALID != SerialAddress.validSystemNameFormat("TL22000", 'L'));
         JUnitAppender.assertWarnMessage("bit number not in range 1 - 999 in system name: TL22000");
 
-        Assert.assertTrue("invalid format - TL22B0", !SerialAddress.validSystemNameFormat("TL22B0", 'L'));
+        Assert.assertTrue("invalid format - TL22B0", NameValidity.VALID != SerialAddress.validSystemNameFormat("TL22B0", 'L'));
         JUnitAppender.assertWarnMessage("bit number field out of range in system name: TL22B0");
 
-        Assert.assertTrue("valid format - TL2999", SerialAddress.validSystemNameFormat("TL2999", 'L'));
+        Assert.assertTrue("valid format - TL2999", NameValidity.VALID == SerialAddress.validSystemNameFormat("TL2999", 'L'));
 
-        Assert.assertTrue("valid format - TL2B2048", SerialAddress.validSystemNameFormat("TL2B2048", 'L'));
+        Assert.assertTrue("valid format - TL2B2048", NameValidity.VALID == SerialAddress.validSystemNameFormat("TL2B2048", 'L'));
 
-        Assert.assertTrue("invalid format - TL2B2049", !SerialAddress.validSystemNameFormat("TL2B2049", 'L'));
+        Assert.assertTrue("invalid format - TL2B2049", NameValidity.VALID != SerialAddress.validSystemNameFormat("TL2B2049", 'L'));
         JUnitAppender.assertWarnMessage("bit number field out of range in system name: TL2B2049");
 
-        Assert.assertTrue("valid format - TL127999", SerialAddress.validSystemNameFormat("TL127999", 'L'));
+        Assert.assertTrue("valid format - TL127999", NameValidity.VALID == SerialAddress.validSystemNameFormat("TL127999", 'L'));
 
-        Assert.assertTrue("invalid format - TL128000", !SerialAddress.validSystemNameFormat("TL128000", 'L'));
+        Assert.assertTrue("invalid format - TL128000", NameValidity.VALID != SerialAddress.validSystemNameFormat("TL128000", 'L'));
         JUnitAppender.assertWarnMessage("number field out of range in system name: TL128000");
 
-        Assert.assertTrue("valid format - TL127B7", SerialAddress.validSystemNameFormat("TL127B7", 'L'));
+        Assert.assertTrue("valid format - TL127B7", NameValidity.VALID == SerialAddress.validSystemNameFormat("TL127B7", 'L'));
 
-        Assert.assertTrue("invalid format - TL128B7", !SerialAddress.validSystemNameFormat("TL128B7", 'L'));
+        Assert.assertTrue("invalid format - TL128B7", NameValidity.VALID != SerialAddress.validSystemNameFormat("TL128B7", 'L'));
         JUnitAppender.assertWarnMessage("node address field out of range in system name: TL128B7");
 
-        Assert.assertTrue("invalid format - TL2oo5", !SerialAddress.validSystemNameFormat("TL2oo5", 'L'));
+        Assert.assertTrue("invalid format - TL2oo5", NameValidity.VALID != SerialAddress.validSystemNameFormat("TL2oo5", 'L'));
         JUnitAppender.assertErrorMessage("illegal character in number field system name: TL2oo5");
 
-        Assert.assertTrue("invalid format - TL2aB5", !SerialAddress.validSystemNameFormat("TL2aB5", 'L'));
+        Assert.assertTrue("invalid format - TL2aB5", NameValidity.VALID != SerialAddress.validSystemNameFormat("TL2aB5", 'L'));
         JUnitAppender.assertWarnMessage("illegal character in node address field of system name: TL2aB5");
 
-        Assert.assertTrue("invalid format - TL2B5x", !SerialAddress.validSystemNameFormat("TL2B5x", 'L'));
+        Assert.assertTrue("invalid format - TL2B5x", NameValidity.VALID != SerialAddress.validSystemNameFormat("TL2B5x", 'L'));
         JUnitAppender.assertWarnMessage("illegal character in bit number field of system name: TL2B5x");
     }
 

--- a/java/test/jmri/managers/TurnoutManagerScaffold.java
+++ b/java/test/jmri/managers/TurnoutManagerScaffold.java
@@ -141,8 +141,8 @@ public class TurnoutManagerScaffold implements TurnoutManager {
     }
 
     @Override
-    public boolean validSystemNameFormat(String systemName) {
-        return true;
+    public NameValidity validSystemNameFormat(String systemName) {
+        return NameValidity.VALID;
     }
 
     @Override


### PR DESCRIPTION
See Issue #4187 for background.

This PR puts the new `validSystemNameFormat` signature in place, so it now returns a `NameValidity` enum value.

The code that implements `validSystemNameFormat` was migrated, but not improved.  This means that 
- [ ] It only returns `VALID` or `INVALID` the same way it would have returned `true` or `false`; the algorithms have not been updated to detect that they've been asked to check a partial name which can be tagged as `VALID_AS_PREFIX_ONLY`.  That's a very system-specific thing that somebody else will have to eventually do.
- [ ] The logging of warnings and errors are still in place (mostly).  This needs to get refactored so they're no longer in `validSystemNameFormat` as warnings and errors, but rather become debug messages there; meanwhile, the e.g. `getTurnout(..)` and `provideTurnout(..)` messages that invoke them should log that an improper name was provided.  (This allows GUI code to intercept invalid names _before_ calling get or provide, leaving the normal user-level log completely clean)  I'll do this on a time-available basis over the next few days, either in this PR or another one.
