### PR TITLE
Annotate JmriJFrame.dispose() as having to be invoked

### DIFF
--- a/help/en/html/doc/Technical/FindBugs.shtml
+++ b/help/en/html/doc/Technical/FindBugs.shtml
@@ -130,11 +130,6 @@ scanning through the code.
           - Used to annotate a method that, if overridden, must (or
           should) be invoke super in the overriding method.
           Examples of such methods include finalize() and clone().
-          The argument to the method indicates when the super
-          invocation should occur: at any time (ANYTIME), at the
-          beginning of the overriding method (FIRST), or at the end
-          of the overriding method (LAST), defaulting to any time,
-          e.g. <code>@OverrideMustInvoke(value=ANYTIME)</code>
 
           <p>Note this replaces the deprecated <a href=
           "http://findbugs.sourceforge.net/manual/annotations.html">

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -1,6 +1,7 @@
 package jmri.util;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Insets;
@@ -837,8 +838,9 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      * When window is finally destroyed, remove it from the list of windows.
      * <P>
      * Subclasses that over-ride this method must invoke this implementation
-     * with super.dispose()
+     * with super.dispose() right before returning.
      */
+    @OverridingMethodsMustInvokeSuper
     @Override
     public void dispose() {
         InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(p -> {


### PR DESCRIPTION
Annotate JmriJFrame.dispose() as having to be invoked by any subclass that reimplements it.

- Updating the documentation to cover the annotation we currently use, which doesn't take an argument
- During testing, discovered that our current version of FindBugs doesn't actually check this annotation in general (just in a couple cases, like `clone()` and `equals(..)`) 

