### PR TITLE
I18N for functionlabels & soundlabels.

### DIFF
--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -31,6 +31,7 @@ import jmri.jmrit.symbolicprog.CvTableModel;
 import jmri.jmrit.symbolicprog.VariableTableModel;
 import jmri.util.FileUtil;
 import jmri.util.davidflanagan.HardcopyWriter;
+import jmri.util.jdom.LocaleSelector;
 import org.jdom2.Attribute;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -796,7 +797,10 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
             for (Element fn : l) {
                 int num = Integer.parseInt(fn.getAttribute("num").getValue());
                 String lock = fn.getAttribute("lockable").getValue();
-                String val = fn.getText();
+                String val = LocaleSelector.getAttribute(fn,"text");
+                if (val == null){
+                    val = fn.getText();
+                }
                 if ((this.getFunctionLabel(num) == null) || (source.equalsIgnoreCase("model"))) {
                     this.setFunctionLabel(num, val);
                     this.setFunctionLockable(num, lock.equals("true"));
@@ -861,7 +865,10 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
             List<Element> l = e3.getChildren(RosterEntry.SOUND_LABEL);
             for (Element fn : l) {
                 int num = Integer.parseInt(fn.getAttribute("num").getValue());
-                String val = fn.getText();
+                String val = LocaleSelector.getAttribute(fn,"text");
+                if (val == null){
+                    val = fn.getText();
+                }
                 if ((this.getSoundLabel(num) == null) || (source.equalsIgnoreCase("model"))) {
                     this.setSoundLabel(num, val);
                 }

--- a/xml/schema/decoder.xsd
+++ b/xml/schema/decoder.xsd
@@ -491,13 +491,18 @@
   <xs:complexType name="functionlabelsType">
     <xs:sequence>
       <xs:element name="functionlabel" minOccurs="0" maxOccurs="unbounded">
-        <xs:complexType>
-          <xs:simpleContent>
-            <xs:extension base="xs:string">
-              <xs:attribute name="num" type="xs:string"/>
-              <xs:attribute name="lockable" type="xs:string"/>
-            </xs:extension>
-          </xs:simpleContent>
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element name="text" minOccurs="0" maxOccurs="unbounded" >
+              <xs:unique name="UniqueFunctionText1">
+                <xs:annotation><xs:documentation>Insist that there's only one text per language</xs:documentation></xs:annotation>
+                <xs:selector xpath="text"/>
+                <xs:field xpath="@xml:lang"/>
+              </xs:unique>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="num" type="xs:string"/>
+          <xs:attribute name="lockable" type="xs:string"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>
@@ -506,12 +511,17 @@
   <xs:complexType name="soundlabelsType">
     <xs:sequence>
       <xs:element name="soundlabel" minOccurs="0" maxOccurs="unbounded">
-        <xs:complexType>
-          <xs:simpleContent>
-            <xs:extension base="xs:string">
-              <xs:attribute name="num" type="xs:string"/>
-            </xs:extension>
-          </xs:simpleContent>
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element name="text" minOccurs="0" maxOccurs="unbounded" >
+              <xs:unique name="UniqueSoundText1">
+                <xs:annotation><xs:documentation>Insist that there's only one text per language</xs:documentation></xs:annotation>
+                <xs:selector xpath="text"/>
+                <xs:field xpath="@xml:lang"/>
+              </xs:unique>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="num" type="xs:string"/>
         </xs:complexType>
       </xs:element>
     </xs:sequence>


### PR DESCRIPTION
Provide I18N for the load-once default `functionlabel` and `soundlabel` elements in a decoder definition, as per request from @Klb4ever.

The `functionlabel` and soundlabel `elements` now support localisable `<text>` elements. 