### PR TITLE
Use generics to avoid extensive unconfirmed casting

### DIFF
--- a/java/src/jmri/jmrit/operations/locations/YardmasterByTrackPanel.java
+++ b/java/src/jmri/jmrit/operations/locations/YardmasterByTrackPanel.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.operations.locations;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.text.MessageFormat;
@@ -38,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * Yardmaster frame by track. Shows work at one location listed by track.
  *
  * @author Dan Boudreau Copyright (C) 2015
- * 
+ *
  */
 public class YardmasterByTrackPanel extends CommonConductorYardmasterPanel {
 
@@ -181,7 +180,6 @@ public class YardmasterByTrackPanel extends CommonConductorYardmasterPanel {
         });
     }
 
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "CarManager only provides Car Objects")
     private void runUpdate() {
         log.debug("run update");
         removePropertyChangeListerners();
@@ -360,9 +358,9 @@ public class YardmasterByTrackPanel extends CommonConductorYardmasterPanel {
             }
             // now do car holds
             // we only need the cars on this track
-            List<RollingStock> rsList = carManager.getByTrainList();
+            List<Car> rsList = carManager.getByTrainList();
             List<Car> carList = new ArrayList<Car>();
-            for (RollingStock rs : rsList) {
+            for (Car rs : rsList) {
                 if (rs.getTrack() != _track || rs.getRouteLocation() != null)
                     continue;
                 carList.add((Car) rs);

--- a/java/src/jmri/jmrit/operations/locations/tools/LocationCopyFrame.java
+++ b/java/src/jmri/jmrit/operations/locations/tools/LocationCopyFrame.java
@@ -219,7 +219,7 @@ public class LocationCopyFrame extends OperationsFrame implements java.beans.Pro
         moveRollingStock(fromTrack, toTrack, InstanceManager.getDefault(EngineManager.class));
     }
 
-    private void moveRollingStock(Track fromTrack, Track toTrack, RollingStockManager manager) {
+    private void moveRollingStock(Track fromTrack, Track toTrack, RollingStockManager<? extends RollingStock> manager) {
         for (RollingStock rs : manager.getByIdList()) {
             if (rs.getTrack() == fromTrack) {
                 rs.setLocation(toTrack.getLocation(), toTrack, RollingStock.FORCE);

--- a/java/src/jmri/jmrit/operations/locations/tools/PrintLocationsAction.java
+++ b/java/src/jmri/jmrit/operations/locations/tools/PrintLocationsAction.java
@@ -20,7 +20,7 @@ import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.locations.Track;
 import jmri.jmrit.operations.locations.schedules.Schedule;
 import jmri.jmrit.operations.locations.schedules.ScheduleManager;
-import jmri.jmrit.operations.rollingstock.RollingStock;
+import jmri.jmrit.operations.rollingstock.cars.Car;
 import jmri.jmrit.operations.rollingstock.cars.CarManager;
 import jmri.jmrit.operations.rollingstock.cars.CarTypes;
 import jmri.jmrit.operations.rollingstock.engines.EngineTypes;
@@ -441,7 +441,7 @@ public class PrintLocationsAction extends AbstractAction {
     private void printAnalysisSelected() throws IOException {
         CarManager carManager = InstanceManager.getDefault(CarManager.class);
         List<Location> locations = manager.getLocationsByNameList();
-        List<RollingStock> cars = carManager.getByLocationList();
+        List<Car> cars = carManager.getByLocationList();
         String[] carTypes = InstanceManager.getDefault(CarTypes.class).getNames();
 
         String s = Bundle.getMessage("TrackAnalysis") + NEW_LINE;
@@ -452,7 +452,7 @@ public class PrintLocationsAction extends AbstractAction {
             // get the total length for a given car type
             int numberOfCars = 0;
             int totalTrackLength = 0;
-            for (RollingStock car : cars) {
+            for (Car car : cars) {
                 if (car.getTypeName().equals(type) && car.getLocation() != null) {
                     numberOfCars++;
                     totalTrackLength += car.getTotalLength();

--- a/java/src/jmri/jmrit/operations/locations/tools/TrackCopyFrame.java
+++ b/java/src/jmri/jmrit/operations/locations/tools/TrackCopyFrame.java
@@ -268,7 +268,7 @@ public class TrackCopyFrame extends OperationsFrame implements java.beans.Proper
         moveRollingStock(fromTrack, toTrack, InstanceManager.getDefault(EngineManager.class));
     }
 
-    private void moveRollingStock(Track fromTrack, Track toTrack, RollingStockManager manager) {
+    private void moveRollingStock(Track fromTrack, Track toTrack, RollingStockManager<? extends RollingStock> manager) {
         for (RollingStock rs : manager.getByIdList()) {
             if (rs.getTrack() == fromTrack) {
                 rs.setLocation(toTrack.getLocation(), toTrack, RollingStock.FORCE);

--- a/java/src/jmri/jmrit/operations/rollingstock/RollingStockGroup.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/RollingStockGroup.java
@@ -9,12 +9,13 @@ import org.slf4j.LoggerFactory;
  * A group of rolling stock that is managed as one unit.
  *
  * @author Daniel Boudreau Copyright (C) 2010, 2013
+ * @param <T> the type of RollingStock in this group
  */
-public class RollingStockGroup {
+public class RollingStockGroup<T extends RollingStock> {
 
     protected String _name = "";
-    protected RollingStock _lead = null;
-    protected List<RollingStock> _group = new ArrayList<RollingStock>();
+    protected T _lead = null;
+    protected List<T> _group = new ArrayList<>();
 
     public RollingStockGroup(String name) {
         _name = name;
@@ -30,7 +31,7 @@ public class RollingStockGroup {
         return _name;
     }
 
-    public void add(RollingStock rs) {
+    public void add(T rs) {
         if (_group.contains(rs)) {
             log.debug("rs ({}) already part of group ({})", rs.toString(), getName());
             return;
@@ -43,7 +44,7 @@ public class RollingStockGroup {
         firePropertyChange("grouplistLength", Integer.toString(oldSize), Integer.valueOf(_group.size())); // NOI18N
     }
 
-    public void delete(RollingStock rs) {
+    public void delete(T rs) {
         if (!_group.contains(rs)) {
             log.debug("rs ({}) not part of group ({})", rs.getId(), getName());
             return;
@@ -55,13 +56,13 @@ public class RollingStockGroup {
         firePropertyChange("grouplistLength", Integer.toString(oldSize), Integer.valueOf(_group.size())); // NOI18N
     }
 
-    public List<RollingStock> getGroup() {
+    public List<T> getGroup() {
         return _group;
     }
 
     public int getTotalLength() {
         int length = 0;
-        for (RollingStock rs : _group) {
+        for (T rs : _group) {
             length = length + rs.getTotalLength();
         }
         return length;
@@ -74,20 +75,20 @@ public class RollingStockGroup {
      */
     public int getAdjustedWeightTons() {
         int weightTons = 0;
-        for (RollingStock rs : _group) {
+        for (T rs : _group) {
             weightTons = weightTons + rs.getAdjustedWeightTons();
         }
         return weightTons;
     }
 
-    public boolean isLead(RollingStock rs) {
+    public boolean isLead(T rs) {
         if (rs == _lead) {
             return true;
         }
         return false;
     }
 
-    public RollingStock getLead() {
+    public T getLead() {
         return _lead;
     }
 
@@ -108,13 +109,13 @@ public class RollingStockGroup {
      *
      * @param rs lead for this group.
      */
-    public void setLead(RollingStock rs) {
+    public void setLead(T rs) {
         if (_group.contains(rs)) {
             _lead = rs;
         }
     }
 
-    public void removeLead(RollingStock rs) {
+    public void removeLead(T rs) {
         if (isLead(rs) && _group.size() > 0) {
             setLead(_group.get(0));
         }

--- a/java/src/jmri/jmrit/operations/rollingstock/RollingStockLogger.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/RollingStockLogger.java
@@ -19,6 +19,7 @@ import jmri.jmrit.XmlFile;
 import jmri.jmrit.operations.OperationsXml;
 import jmri.jmrit.operations.rollingstock.cars.Car;
 import jmri.jmrit.operations.rollingstock.cars.CarManager;
+import jmri.jmrit.operations.rollingstock.engines.Engine;
 import jmri.jmrit.operations.rollingstock.engines.EngineManager;
 import jmri.jmrit.operations.setup.Control;
 import jmri.jmrit.operations.setup.OperationsSetupXml;
@@ -330,8 +331,8 @@ public class RollingStockLogger extends XmlFile implements InstanceManagerAutoDe
         if (Setup.isCarLoggerEnabled() && !carLog) {
             log.debug("Rolling Stock Logger adding car listerners");
             carLog = true;
-            List<RollingStock> cars = InstanceManager.getDefault(CarManager.class).getList();
-            for (RollingStock car : cars) {
+            List<Car> cars = InstanceManager.getDefault(CarManager.class).getList();
+            for (Car car : cars) {
                 car.addPropertyChangeListener(this);
             }
             // listen for new rolling stock being added
@@ -343,8 +344,8 @@ public class RollingStockLogger extends XmlFile implements InstanceManagerAutoDe
         if (Setup.isEngineLoggerEnabled() && !engLog) {
             engLog = true;
             log.debug("Rolling Stock Logger adding engine listerners");
-            List<RollingStock> engines = InstanceManager.getDefault(EngineManager.class).getList();
-            for (RollingStock engine : engines) {
+            List<Engine> engines = InstanceManager.getDefault(EngineManager.class).getList();
+            for (Engine engine : engines) {
                 engine.addPropertyChangeListener(this);
             }
             // listen for new rolling stock being added
@@ -355,8 +356,8 @@ public class RollingStockLogger extends XmlFile implements InstanceManagerAutoDe
     private void removeCarListeners() {
         if (carLog) {
             log.debug("Rolling Stock Logger removing car listerners");
-            List<RollingStock> cars = InstanceManager.getDefault(CarManager.class).getList();
-            for (RollingStock car : cars) {
+            List<Car> cars = InstanceManager.getDefault(CarManager.class).getList();
+            for (Car car : cars) {
                 car.removePropertyChangeListener(this);
             }
             InstanceManager.getDefault(CarManager.class).removePropertyChangeListener(this);
@@ -367,8 +368,8 @@ public class RollingStockLogger extends XmlFile implements InstanceManagerAutoDe
     private void removeEngineListeners() {
         if (engLog) {
             log.debug("Rolling Stock Logger removing engine listerners");
-            List<RollingStock> engines = InstanceManager.getDefault(EngineManager.class).getList();
-            for (RollingStock engine : engines) {
+            List<Engine> engines = InstanceManager.getDefault(EngineManager.class).getList();
+            for (Engine engine : engines) {
                 engine.removePropertyChangeListener(this);
             }
             InstanceManager.getDefault(EngineManager.class).removePropertyChangeListener(this);

--- a/java/src/jmri/jmrit/operations/rollingstock/RollingStockManager.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/RollingStockManager.java
@@ -1,7 +1,6 @@
 package jmri.jmrit.operations.rollingstock;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
@@ -15,13 +14,14 @@ import org.slf4j.LoggerFactory;
  * Base class for rolling stock managers car and engine.
  *
  * @author Daniel Boudreau Copyright (C) 2010, 2011
+ * @param <T> the type of RollingStock managed by this manager
  */
-public class RollingStockManager {
+public class RollingStockManager<T extends RollingStock> {
 
     public static final String NONE = "";
 
     // RollingStock
-    protected Hashtable<String, RollingStock> _hashTable = new Hashtable<String, RollingStock>();
+    protected Hashtable<String, T> _hashTable = new Hashtable<>();
 
     public static final String LISTLENGTH_CHANGED_PROPERTY = "RollingStockListLength"; // NOI18N
 
@@ -43,22 +43,23 @@ public class RollingStockManager {
 
     /**
      * Get rolling stock by id
+     *
      * @param id The string id.
      *
      * @return requested RollingStock object or null if none exists
      */
-    public RollingStock getById(String id) {
+    public T getById(String id) {
         return _hashTable.get(id);
     }
 
     /**
      * Get rolling stock by road and number
      *
-     * @param road RollingStock road
+     * @param road   RollingStock road
      * @param number RollingStock number
      * @return requested RollingStock object or null if none exists
      */
-    public RollingStock getByRoadAndNumber(String road, String number) {
+    public T getByRoadAndNumber(String road, String number) {
         String id = RollingStock.createId(road, number);
         return getById(id);
     }
@@ -71,10 +72,10 @@ public class RollingStockManager {
      * @param road RollingStock road.
      * @return the first RollingStock found with the specified type and road.
      */
-    public RollingStock getByTypeAndRoad(String type, String road) {
+    public T getByTypeAndRoad(String type, String road) {
         Enumeration<String> en = _hashTable.keys();
         while (en.hasMoreElements()) {
-            RollingStock rs = getById(en.nextElement());
+            T rs = getById(en.nextElement());
             if (rs.getTypeName().equals(type) && rs.getRoadName().equals(road)) {
                 return rs;
             }
@@ -88,10 +89,10 @@ public class RollingStockManager {
      * @param rfid RollingStock's RFID.
      * @return the RollingStock with the specific RFID, or null if not found
      */
-    public RollingStock getByRfid(String rfid) {
+    public T getByRfid(String rfid) {
         Enumeration<String> en = _hashTable.keys();
         while (en.hasMoreElements()) {
-            RollingStock rs = getById(en.nextElement());
+            T rs = getById(en.nextElement());
             if (rs.getRfid().equals(rfid)) {
                 return rs;
             }
@@ -101,26 +102,28 @@ public class RollingStockManager {
 
     /**
      * Load RollingStock.
+     *
      * @param rs The RollingStock to load.
      */
-    public void register(RollingStock rs) {
-        Integer oldSize = Integer.valueOf(_hashTable.size());
+    public void register(T rs) {
+        int oldSize = _hashTable.size();
         _hashTable.put(rs.getId(), rs);
-        firePropertyChange(LISTLENGTH_CHANGED_PROPERTY, oldSize, Integer.valueOf(_hashTable.size()));
+        firePropertyChange(LISTLENGTH_CHANGED_PROPERTY, oldSize, _hashTable.size());
     }
 
     /**
      * Unload RollingStock.
+     *
      * @param rs The RollingStock to delete.
      */
-    public void deregister(RollingStock rs) {
+    public void deregister(T rs) {
         rs.dispose();
-        Integer oldSize = Integer.valueOf(_hashTable.size());
+        int oldSize = _hashTable.size();
         _hashTable.remove(rs.getId());
-        firePropertyChange(LISTLENGTH_CHANGED_PROPERTY, oldSize, Integer.valueOf(_hashTable.size()));
+        firePropertyChange(LISTLENGTH_CHANGED_PROPERTY, oldSize, _hashTable.size());
     }
 
-    public void changeId(RollingStock rs, String road, String number) {
+    public void changeId(T rs, String road, String number) {
         _hashTable.remove(rs.getId());
         rs._id = RollingStock.createId(road, number);
         register(rs);
@@ -130,20 +133,20 @@ public class RollingStockManager {
      * Remove all RollingStock from roster
      */
     public void deleteAll() {
-        Integer oldSize = Integer.valueOf(_hashTable.size());
+        int oldSize = _hashTable.size();
         Enumeration<String> en = _hashTable.keys();
         while (en.hasMoreElements()) {
-            RollingStock rs = getById(en.nextElement());
+            T rs = getById(en.nextElement());
             rs.dispose();
             _hashTable.remove(rs.getId());
         }
-        firePropertyChange(LISTLENGTH_CHANGED_PROPERTY, oldSize, Integer.valueOf(_hashTable.size()));
+        firePropertyChange(LISTLENGTH_CHANGED_PROPERTY, oldSize, _hashTable.size());
     }
 
     public void resetMoves() {
         Enumeration<String> en = _hashTable.keys();
         while (en.hasMoreElements()) {
-            RollingStock rs = getById(en.nextElement());
+            T rs = getById(en.nextElement());
             rs.setMoves(0);
         }
     }
@@ -153,13 +156,8 @@ public class RollingStockManager {
      *
      * @return list of RollingStock
      */
-    public List<RollingStock> getList() {
-        Enumeration<RollingStock> en = _hashTable.elements();
-        List<RollingStock> out = new ArrayList<RollingStock>();
-        while (en.hasMoreElements()) {
-            out.add(en.nextElement());
-        }
-        return out;
+    public List<T> getList() {
+        return new ArrayList<>(_hashTable.values());
     }
 
     /**
@@ -167,10 +165,10 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by id
      */
-    public List<RollingStock> getByIdList() {
+    public List<T> getByIdList() {
         Enumeration<String> en = _hashTable.keys();
         String[] arr = new String[_hashTable.size()];
-        List<RollingStock> out = new ArrayList<RollingStock>();
+        List<T> out = new ArrayList<>();
         int i = 0;
         while (en.hasMoreElements()) {
             arr[i] = en.nextElement();
@@ -188,7 +186,7 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by road name
      */
-    public List<RollingStock> getByRoadNameList() {
+    public List<T> getByRoadNameList() {
         return getByList(getByIdList(), BY_ROAD);
     }
 
@@ -202,15 +200,15 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by number
      */
-    public List<RollingStock> getByNumberList() {
+    public List<T> getByNumberList() {
         // first get by road list
-        List<RollingStock> sortIn = getByRoadNameList();
+        List<T> sortIn = getByRoadNameList();
         // now re-sort
-        List<RollingStock> out = new ArrayList<RollingStock>();
+        List<T> out = new ArrayList<>();
         int rsNumber = 0;
         int outRsNumber = 0;
 
-        for (RollingStock rs : sortIn) {
+        for (T rs : sortIn) {
             boolean rsAdded = false;
             try {
                 rsNumber = Integer.parseInt(rs.getNumber());
@@ -297,7 +295,7 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by RollingStock type
      */
-    public List<RollingStock> getByTypeList() {
+    public List<T> getByTypeList() {
         return getByList(getByRoadNameList(), BY_TYPE);
     }
 
@@ -307,10 +305,10 @@ public class RollingStockManager {
      * @param type type of rolling stock
      * @return list of RollingStock that are specific type
      */
-    public List<RollingStock> getByTypeList(String type) {
-        List<RollingStock> typeList = getByTypeList();
-        List<RollingStock> out = new ArrayList<RollingStock>();
-        for (RollingStock rs : typeList) {
+    public List<T> getByTypeList(String type) {
+        List<T> typeList = getByTypeList();
+        List<T> out = new ArrayList<>();
+        for (T rs : typeList) {
             if (rs.getTypeName().equals(type)) {
                 out.add(rs);
             }
@@ -323,7 +321,7 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by RollingStock color
      */
-    public List<RollingStock> getByColorList() {
+    public List<T> getByColorList() {
         return getByList(getByTypeList(), BY_COLOR);
     }
 
@@ -332,7 +330,7 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by RollingStock location
      */
-    public List<RollingStock> getByLocationList() {
+    public List<T> getByLocationList() {
         return getByList(getList(), BY_LOCATION);
     }
 
@@ -341,7 +339,7 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by RollingStock destination
      */
-    public List<RollingStock> getByDestinationList() {
+    public List<T> getByDestinationList() {
         return getByList(getByLocationList(), BY_DESTINATION);
     }
 
@@ -350,9 +348,9 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by trains
      */
-    public List<RollingStock> getByTrainList() {
-        List<RollingStock> byDest = getByList(getByIdList(), BY_DESTINATION);
-        List<RollingStock> byLoc = getByList(byDest, BY_LOCATION);
+    public List<T> getByTrainList() {
+        List<T> byDest = getByList(getByIdList(), BY_DESTINATION);
+        List<T> byLoc = getByList(byDest, BY_LOCATION);
         return getByList(byLoc, BY_TRAIN);
     }
 
@@ -361,7 +359,7 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by RollingStock moves
      */
-    public List<RollingStock> getByMovesList() {
+    public List<T> getByMovesList() {
         return getByList(getList(), BY_MOVES);
     }
 
@@ -370,7 +368,7 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by RollingStock built date
      */
-    public List<RollingStock> getByBuiltList() {
+    public List<T> getByBuiltList() {
         return getByList(getByIdList(), BY_BUILT);
     }
 
@@ -379,7 +377,7 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by RollingStock owner
      */
-    public List<RollingStock> getByOwnerList() {
+    public List<T> getByOwnerList() {
         return getByList(getByIdList(), BY_OWNER);
     }
 
@@ -388,7 +386,7 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by value
      */
-    public List<RollingStock> getByValueList() {
+    public List<T> getByValueList() {
         return getByList(getByIdList(), BY_VALUE);
     }
 
@@ -397,7 +395,7 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by RFIDs
      */
-    public List<RollingStock> getByRfidList() {
+    public List<T> getByRfidList() {
         return getByList(getByIdList(), BY_RFID);
     }
 
@@ -406,24 +404,23 @@ public class RollingStockManager {
      *
      * @return list of RollingStock ordered by last date
      */
-    public List<RollingStock> getByLastDateList() {
+    public List<T> getByLastDateList() {
         return getByList(getByIdList(), BY_LAST);
     }
 
     /**
      * Sort a specific list of rolling stock last date used
-     * 
+     *
      * @param inList list of rolling stock to sort.
      * @return list of RollingStock ordered by last date
      */
-    public List<RollingStock> getByLastDateList(List<RollingStock> inList) {
+    public List<T> getByLastDateList(List<T> inList) {
         return getByList(inList, BY_LAST);
     }
 
-    protected List<RollingStock> getByList(List<RollingStock> sortIn, int attribute) {
-        List<RollingStock> out = new ArrayList<RollingStock>();
-        sortIn.forEach(n -> out.add(n));
-        Collections.sort(out, getComparator(attribute));
+    protected List<T> getByList(List<T> sortIn, int attribute) {
+        List<T> out = new ArrayList<>(sortIn);
+        out.sort(getComparator(attribute));
         return out;
     }
 
@@ -433,9 +430,9 @@ public class RollingStockManager {
     protected static final int BY_ROAD = 1;
     protected static final int BY_TYPE = 2;
     protected static final int BY_COLOR = 3;
-    // BY_LOAD = 4 
+    // BY_LOAD = 4
     // BY_MODEL = 4
-    // BY_KERNEL = 5 
+    // BY_KERNEL = 5
     // BY_CONSIST = 5
     protected static final int BY_LOCATION = 6;
     protected static final int BY_DESTINATION = 7;
@@ -455,7 +452,7 @@ public class RollingStockManager {
     // BY_B_UNIT = 20
     // BY_HAZARD = 21
 
-    protected java.util.Comparator<RollingStock> getComparator(int attribute) {
+    protected java.util.Comparator<T> getComparator(int attribute) {
         switch (attribute) {
             case BY_NUMBER:
                 return (r1, r2) -> (r1.getNumber().compareToIgnoreCase(r2.getNumber()));
@@ -467,13 +464,13 @@ public class RollingStockManager {
                 return (r1, r2) -> (r1.getColor().compareToIgnoreCase(r2.getColor()));
             case BY_LOCATION:
                 return (r1, r2) -> (r1.getStatus() + r1.getLocationName() + r1.getTrackName())
-                        .compareToIgnoreCase(r2.getStatus() +
-                                r2.getLocationName() +
-                                r2.getTrackName());
+                        .compareToIgnoreCase(r2.getStatus()
+                                + r2.getLocationName()
+                                + r2.getTrackName());
             case BY_DESTINATION:
                 return (r1, r2) -> (r1.getDestinationName() + r1.getDestinationTrackName())
-                        .compareToIgnoreCase(r2.getDestinationName() +
-                                r2.getDestinationTrackName());
+                        .compareToIgnoreCase(r2.getDestinationName()
+                                + r2.getDestinationTrackName());
             case BY_TRAIN:
                 return (r1, r2) -> (r1.getTrainName().compareToIgnoreCase(r2.getTrainName()));
             case BY_MOVES:
@@ -492,8 +489,8 @@ public class RollingStockManager {
             case BY_BLOCKING:
                 return (r1, r2) -> (r1.getBlocking() - r2.getBlocking());
             default:
-                return (r1, r2) -> ((r1.getRoadName() + r1.getNumber()).compareToIgnoreCase(r2.getRoadName() +
-                        r2.getNumber()));
+                return (r1, r2) -> ((r1.getRoadName() + r1.getNumber()).compareToIgnoreCase(r2.getRoadName()
+                        + r2.getNumber()));
         }
     }
 
@@ -525,57 +522,60 @@ public class RollingStockManager {
 
     /**
      * Get a list of rolling stocks assigned to a train ordered by location
+     *
      * @param train The Train.
      *
      * @return List of RollingStock assigned to the train ordered by location
      */
-    public List<RollingStock> getByTrainList(Train train) {
-        // List<RollingStock> shuffle = shuffle(getList(train));
-        List<RollingStock> out = getByList(getList(train), BY_LOCATION);
-        return out;
+    public List<T> getByTrainList(Train train) {
+        return getByList(getList(train), BY_LOCATION);
     }
 
     /**
      * Returns a list (no order) of RollingStock in a train.
+     *
      * @param train The Train.
      *
      * @return list of RollingStock
      */
-    public List<RollingStock> getList(Train train) {
-        List<RollingStock> out = new ArrayList<RollingStock>();
-        _hashTable.forEach((key, rs) -> {
-            if (rs.getTrain() == train)
-                out.add(rs);
+    public List<T> getList(Train train) {
+        List<T> out = new ArrayList<>();
+        _hashTable.values().stream().filter((rs) -> {
+            return rs.getTrain() == train;
+        }).forEachOrdered((rs) -> {
+            out.add(rs);
         });
         return out;
     }
 
     /**
      * Returns a list (no order) of RollingStock at a location.
-     * 
+     *
      * @param location location to search for.
      * @return list of RollingStock
      */
-    public List<RollingStock> getList(Location location) {
-        List<RollingStock> out = new ArrayList<RollingStock>();
-        _hashTable.forEach((key, rs) -> {
-            if (rs.getLocation() == location)
-                out.add(rs);
+    public List<T> getList(Location location) {
+        List<T> out = new ArrayList<>();
+        _hashTable.values().stream().filter((rs) -> {
+            return rs.getLocation() == location;
+        }).forEachOrdered((rs) -> {
+            out.add(rs);
         });
         return out;
     }
 
     /**
      * Returns a list (no order) of RollingStock on a track.
-     * 
+     *
      * @param track Track to search for.
      * @return list of RollingStock
      */
-    public List<RollingStock> getList(Track track) {
-        List<RollingStock> out = new ArrayList<RollingStock>();
-        _hashTable.forEach((key, rs) -> {
-            if (rs.getTrack() == track)
-                out.add(rs);
+    public List<T> getList(Track track) {
+        List<T> out = new ArrayList<>();
+        _hashTable.values().stream().filter((rs) -> {
+            return rs.getTrack() == track;
+        }).forEachOrdered((rs) -> {
+            out.add(rs);
         });
         return out;
     }

--- a/java/src/jmri/jmrit/operations/rollingstock/RollingStockSetFrame.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/RollingStockSetFrame.java
@@ -34,8 +34,9 @@ import org.slf4j.LoggerFactory;
  * Frame for user to place RollingStock on the layout
  *
  * @author Dan Boudreau Copyright (C) 2010, 2011, 2012, 2013
+ * @param <T> the type of RollingStock supported by this frame
  */
-public class RollingStockSetFrame extends OperationsFrame implements java.beans.PropertyChangeListener {
+public class RollingStockSetFrame<T extends RollingStock> extends OperationsFrame implements java.beans.PropertyChangeListener {
 
     protected static final ResourceBundle rb = ResourceBundle
             .getBundle("jmri.jmrit.operations.rollingstock.cars.JmritOperationsCarsBundle");
@@ -45,7 +46,7 @@ public class RollingStockSetFrame extends OperationsFrame implements java.beans.
     protected LocationManager locationManager = InstanceManager.getDefault(LocationManager.class);
     protected TrainManager trainManager = InstanceManager.getDefault(TrainManager.class);
 
-    RollingStock _rs;
+    T _rs;
     protected boolean _disableComboBoxUpdate = false;
 
     // labels
@@ -253,7 +254,7 @@ public class RollingStockSetFrame extends OperationsFrame implements java.beans.
         setMinimumSize(new Dimension(Control.panelWidth500, Control.panelHeight500));
     }
 
-    public void load(RollingStock rs) {
+    public void load(T rs) {
         _rs = rs;
         textRoad.setText(_rs.getRoadName() + " " + _rs.getNumber());
         textType.setText(_rs.getTypeName());
@@ -307,7 +308,7 @@ public class RollingStockSetFrame extends OperationsFrame implements java.beans.
     RouteLocation rd;
 
     @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", justification = "GUI ease of use")
-    protected boolean change(RollingStock rs) {
+    protected boolean change(T rs) {
         log.debug("Change button action for rs ({})", rs.toString());
         // save the auto buttons
         autoTrackCheckBoxSelected = autoTrackCheckBox.isSelected();
@@ -442,7 +443,7 @@ public class RollingStockSetFrame extends OperationsFrame implements java.beans.
         return true;
     }
 
-    private boolean changeLocation(RollingStock rs) {
+    private boolean changeLocation(T rs) {
         if (!ignoreLocationCheckBox.isSelected()) {
             if (locationBox.getSelectedItem() == null) {
                 rs.setLocation(null, null);
@@ -485,7 +486,7 @@ public class RollingStockSetFrame extends OperationsFrame implements java.beans.
         return true;
     }
 
-    private void loadTrain(RollingStock rs) {
+    private void loadTrain(T rs) {
         if (!ignoreTrainCheckBox.isSelected()) {
             if (trainBox.getSelectedItem() == null) {
                 if (rs.getTrain() != null) {
@@ -504,7 +505,7 @@ public class RollingStockSetFrame extends OperationsFrame implements java.beans.
         }
     }
 
-    private boolean changeDestination(RollingStock rs) {
+    private boolean changeDestination(T rs) {
         if (!ignoreDestinationCheckBox.isSelected()) {
             if (destinationBox.getSelectedItem() == null) {
                 rs.setDestination(null, null);
@@ -524,7 +525,7 @@ public class RollingStockSetFrame extends OperationsFrame implements java.beans.
                 // determine is user changed the destination track and is part of train
                 if (destTrack != null && rs.getDestinationTrack() != destTrack && rs.getTrain() != null
                         && rs.getTrain().isBuilt() && rs.getRouteLocation() != null) {
-                    log.debug("Rolling stock ({}) has new track destination in built train ({})", 
+                    log.debug("Rolling stock ({}) has new track destination in built train ({})",
                             rs.toString(), rs.getTrainName());
                     rs.getTrain().setModified(true);
                 }
@@ -543,7 +544,7 @@ public class RollingStockSetFrame extends OperationsFrame implements java.beans.
         return true;
     }
 
-    protected void checkTrain(RollingStock rs) {
+    protected void checkTrain(T rs) {
         // determine if train is built and car is part of train or wants to be part of the train
         Train train = rs.getTrain();
         if (train != null && train.isBuilt()) {
@@ -583,7 +584,7 @@ public class RollingStockSetFrame extends OperationsFrame implements java.beans.
         }
     }
 
-    protected void setRouteLocationAndDestination(RollingStock rs, Train train, RouteLocation rl,
+    protected void setRouteLocationAndDestination(T rs, Train train, RouteLocation rl,
             RouteLocation rd) {
         if (rs.getRouteLocation() != null || rl != null) {
             train.setModified(true);
@@ -607,8 +608,8 @@ public class RollingStockSetFrame extends OperationsFrame implements java.beans.
         updateDestinationComboBoxes();
     }
 
-    protected boolean updateGroup(List<RollingStock> list) {
-        for (RollingStock rs : list) {
+    protected boolean updateGroup(List<T> list) {
+        for (T rs : list) {
             if (rs == _rs) {
                 continue;
             }

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/CarSetFrame.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/CarSetFrame.java
@@ -20,7 +20,6 @@ import jmri.jmrit.operations.OperationsXml;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.locations.Track;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.RollingStockSetFrame;
 import jmri.jmrit.operations.setup.Setup;
 import jmri.jmrit.operations.trains.Train;
@@ -32,7 +31,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dan Boudreau Copyright (C) 2008, 2010, 2011, 2013, 2014
  */
-public class CarSetFrame extends RollingStockSetFrame implements java.beans.PropertyChangeListener {
+public class CarSetFrame extends RollingStockSetFrame<Car> implements java.beans.PropertyChangeListener {
 
     protected static final ResourceBundle rb = ResourceBundle
             .getBundle("jmri.jmrit.operations.rollingstock.cars.JmritOperationsCarsBundle");
@@ -412,7 +411,7 @@ public class CarSetFrame extends RollingStockSetFrame implements java.beans.Prop
         checkTrain(car);
         // is this car part of a kernel?
         if (askKernelChange && car.getKernel() != null) {
-            List<RollingStock> list = car.getKernel().getGroup();
+            List<Car> list = car.getKernel().getGroup();
             if (list.size() > 1) {
                 if (JOptionPane.showConfirmDialog(this, MessageFormat.format(
                         Bundle.getMessage("carInKernel"), new Object[]{car.toString()}), MessageFormat
@@ -447,9 +446,8 @@ public class CarSetFrame extends RollingStockSetFrame implements java.beans.Prop
     }
 
     @Override
-    protected boolean updateGroup(List<RollingStock> list) {
-        for (RollingStock rs : list) {
-            Car car = (Car) rs;
+    protected boolean updateGroup(List<Car> list) {
+        for (Car car : list) {
             if (car == _car) {
                 continue;
             }

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/CarsTableFrame.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/CarsTableFrame.java
@@ -24,7 +24,6 @@ import jmri.jmrit.operations.OperationsFrame;
 import jmri.jmrit.operations.OperationsXml;
 import jmri.jmrit.operations.locations.schedules.ScheduleManager;
 import jmri.jmrit.operations.locations.tools.ModifyLocationsAction;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.setup.Control;
 import jmri.jmrit.operations.setup.Setup;
 import jmri.jmrit.operations.trains.tools.TrainsByCarTypeAction;
@@ -329,7 +328,7 @@ public class CarsTableFrame extends OperationsFrame implements TableModelListene
         }
     }
 
-    public List<RollingStock> getSortByList() {
+    public List<Car> getSortByList() {
         return carsTableModel.sysList;
     }
 

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/CarsTableModel.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/CarsTableModel.java
@@ -9,7 +9,6 @@ import javax.swing.JTable;
 import javax.swing.SwingUtilities;
 import javax.swing.table.TableCellEditor;
 import jmri.InstanceManager;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.engines.Engine;
 import jmri.jmrit.operations.setup.Control;
 import jmri.jmrit.operations.setup.Setup;
@@ -80,7 +79,7 @@ public class CarsTableModel extends javax.swing.table.AbstractTableModel impleme
 
     private int _sort = SORTBY_NUMBER;
 
-    List<RollingStock> sysList = null; // list of cars
+    List<Car> sysList = null; // list of cars
     boolean showAllCars = true; // when true show all cars
     String locationName = null; // only show cars with this location
     String trackName = null; // only show cars with this track
@@ -211,7 +210,7 @@ public class CarsTableModel extends javax.swing.table.AbstractTableModel impleme
     }
 
     public void resetCheckboxes() {
-        for (RollingStock car : sysList) {
+        for (Car car : sysList) {
             car.setSelected(false);
         }
     }
@@ -282,14 +281,14 @@ public class CarsTableModel extends javax.swing.table.AbstractTableModel impleme
         addPropertyChangeCars();
     }
 
-    public List<RollingStock> getSelectedCarList() {
+    public List<Car> getSelectedCarList() {
         return getCarList(_sort);
     }
 
     @SuppressFBWarnings(value = "DB_DUPLICATE_SWITCH_CLAUSES",
             justification = "default case is sort by number") // NOI18N
-    public List<RollingStock> getCarList(int sort) {
-        List<RollingStock> list;
+    public List<Car> getCarList(int sort) {
+        List<Car> list;
         switch (sort) {
             case SORTBY_NUMBER:
                 list = manager.getByNumberList();
@@ -355,7 +354,7 @@ public class CarsTableModel extends javax.swing.table.AbstractTableModel impleme
         return list;
     }
 
-    private void filterList(List<RollingStock> list) {
+    private void filterList(List<Car> list) {
         if (showAllCars) {
             return;
         }
@@ -722,13 +721,13 @@ public class CarsTableModel extends javax.swing.table.AbstractTableModel impleme
     }
 
     private void addPropertyChangeCars() {
-        for (RollingStock car : manager.getList()) {
+        for (Car car : manager.getList()) {
             car.addPropertyChangeListener(this);
         }
     }
 
     private void removePropertyChangeCars() {
-        for (RollingStock car : manager.getList()) {
+        for (Car car : manager.getList()) {
             car.removePropertyChangeListener(this);
         }
     }

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/DeleteCarRosterAction.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/DeleteCarRosterAction.java
@@ -6,7 +6,6 @@ import java.text.MessageFormat;
 import javax.swing.AbstractAction;
 import javax.swing.JOptionPane;
 import jmri.InstanceManager;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +42,7 @@ public class DeleteCarRosterAction extends AbstractAction {
             if (JOptionPane.showConfirmDialog(null, MessageFormat.format(Bundle.getMessage("carDeleteCarsTrack"),
                     new Object[]{_carsTableFrame.carsTableModel.trackName}),
                     Bundle.getMessage("carDeleteAll"), JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION) {
-                for (RollingStock car : _carsTableFrame.carsTableModel.getSelectedCarList()) {
+                for (Car car : _carsTableFrame.carsTableModel.getSelectedCarList()) {
                     InstanceManager.getDefault(CarManager.class).deregister(car);
                 }
             }

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/ExportCars.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/ExportCars.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.operations.rollingstock.cars;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -11,7 +10,6 @@ import java.text.MessageFormat;
 import java.util.List;
 import javax.swing.JOptionPane;
 import jmri.jmrit.XmlFile;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.setup.OperationsSetupXml;
 import jmri.jmrit.operations.setup.Setup;
 import org.slf4j.Logger;
@@ -28,9 +26,9 @@ public class ExportCars extends XmlFile {
     static final String ESC = "\""; // escape character NOI18N
     private String del = ","; // delimiter
 
-    List<RollingStock> _carList;
+    List<Car> _carList;
 
-    public ExportCars(List<RollingStock> carList) {
+    public ExportCars(List<Car> carList) {
         _carList = carList;
     }
 
@@ -64,8 +62,6 @@ public class ExportCars extends XmlFile {
         }
     }
 
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
-            justification = "CarManager only provides Car Objects")
     public void writeFile(String name) {
         log.debug("writeFile {}", name);
         // This is taken in large part from "Java and XML" page 368
@@ -134,8 +130,7 @@ public class ExportCars extends XmlFile {
         String extensions;
 
         // store car number, road, type, length, weight, color, owner, built date, location and track
-        for (RollingStock rs : _carList) {
-            Car car = (Car) rs;
+        for (Car car : _carList) {
             carType = car.getTypeName();
             if (carType.contains(del)) {
                 carType = ESC + car.getTypeName() + ESC;

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/Kernel.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/Kernel.java
@@ -1,9 +1,7 @@
 package jmri.jmrit.operations.rollingstock.cars;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.RollingStockGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,26 +11,21 @@ import org.slf4j.LoggerFactory;
  *
  * @author Daniel Boudreau Copyright (C) 2008, 2010
  */
-public class Kernel extends RollingStockGroup {
+public class Kernel extends RollingStockGroup<Car> {
 
     public Kernel(String name) {
         super(name);
         log.debug("New Kernel ({})", name);
     }
 
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "getGroup() only provides Car Objects")
     public List<Car> getCars() {
-        List<Car> cars = new ArrayList<Car>();
-        for (RollingStock rs : getGroup()) {
-            cars.add((Car) rs);
-        }
-        return cars;
+        return new ArrayList<>(getGroup());
     }
 
     @Override
     public void dispose() {
         while (getGroup().size() > 0) {
-            Car car = (Car) getGroup().get(0);
+            Car car = getGroup().get(0);
             if (car != null) {
                 car.setKernel(null);
             }

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/PrintCarRosterAction.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/PrintCarRosterAction.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.operations.rollingstock.cars;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.GridBagLayout;
@@ -19,7 +18,6 @@ import javax.swing.JScrollPane;
 import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsFrame;
 import jmri.jmrit.operations.locations.LocationManager;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.setup.Control;
 import jmri.jmrit.operations.setup.Setup;
 import jmri.util.davidflanagan.HardcopyWriter;
@@ -68,7 +66,6 @@ public class PrintCarRosterAction extends AbstractAction {
 
     int numberCharPerLine;
 
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "CarManager only provides Car Objects")
     private void printCars() {
 
         boolean landscape = false;
@@ -76,7 +73,7 @@ public class PrintCarRosterAction extends AbstractAction {
                 && manifestOrientationComboBox.getSelectedItem() == Setup.LANDSCAPE) {
             landscape = true;
         }
-        
+
         int fontSize = (int) fontSizeComboBox.getSelectedItem();
 
         // obtain a HardcopyWriter to do this
@@ -88,7 +85,7 @@ public class PrintCarRosterAction extends AbstractAction {
             log.debug("Print cancelled");
             return;
         }
-        
+
         numberCharPerLine = writer.getCharactersPerLine();
 
         // Loop through the Roster, printing as needed
@@ -117,9 +114,8 @@ public class PrintCarRosterAction extends AbstractAction {
         try {
             printTitleLine(writer);
             String previousLocation = null;
-            List<RollingStock> cars = panel.carsTableModel.getCarList(sortByComboBox.getSelectedIndex());
-            for (RollingStock rs : cars) {
-                Car car = (Car) rs;
+            List<Car> cars = panel.carsTableModel.getCarList(sortByComboBox.getSelectedIndex());
+            for (Car car : cars) {
                 if (printCarsWithLocation.isSelected() && car.getLocation() == null) {
                     continue; // car doesn't have a location skip
                 }
@@ -331,19 +327,19 @@ public class PrintCarRosterAction extends AbstractAction {
             JPanel pOrientation = new JPanel();
             pOrientation.setBorder(BorderFactory.createTitledBorder(Bundle.getMessage("BorderLayoutOrientation")));
             pOrientation.add(manifestOrientationComboBox);
-            
+
             manifestOrientationComboBox.addItem(Setup.PORTRAIT);
             manifestOrientationComboBox.addItem(Setup.LANDSCAPE);
-            
+
             JPanel pFontSize = new JPanel();
             pFontSize.setBorder(BorderFactory.createTitledBorder(Bundle.getMessage("BorderLayoutFontSize")));
             pFontSize.add(fontSizeComboBox);
-            
+
             // load font sizes 5 through 14
             for (int i = 5; i < 15; i++) {
                 fontSizeComboBox.addItem(i);
             }
-            
+
             fontSizeComboBox.setSelectedItem(Control.reportFontSize);
 
             JPanel pPanel = new JPanel();
@@ -447,7 +443,7 @@ public class PrintCarRosterAction extends AbstractAction {
             setVisible(false);
             pcr.printCars();
         }
-        
+
         @Override
         public void comboBoxActionPerformed(java.awt.event.ActionEvent ae) {
             if (sortByComboBox.getSelectedItem() != null && sortByComboBox.getSelectedItem().equals(panel.carsTableModel.getSortByName(panel.carsTableModel.SORTBY_LOCATION))) {

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/Consist.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/Consist.java
@@ -1,19 +1,17 @@
 package jmri.jmrit.operations.rollingstock.engines;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.RollingStockGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A consist is a group of engines that is managed as one engine
+ * A consist is a group of engines that is managed as one engine.
  *
  * @author Daniel Boudreau Copyright (C) 2008, 2010
  */
-public class Consist extends RollingStockGroup {
+public class Consist extends RollingStockGroup<Engine> {
 
     protected int _consistNumber = 0;
 
@@ -22,13 +20,8 @@ public class Consist extends RollingStockGroup {
         log.debug("New Consist ({})", name);
     }
 
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "getGroup() only provides Engine Objects")
     public List<Engine> getEngines() {
-        List<Engine> engines = new ArrayList<Engine>();
-        for (RollingStock rs : getGroup()) {
-            engines.add((Engine) rs);
-        }
-        return engines;
+        return new ArrayList<>(getGroup());
     }
 
     public int getConsistNumber() {
@@ -46,7 +39,7 @@ public class Consist extends RollingStockGroup {
     @Override
     public void dispose() {
         while (getGroup().size() > 0) {
-            Engine engine = (Engine) getGroup().get(0);
+            Engine engine = getGroup().get(0);
             if (engine != null) {
                 engine.setConsist(null);
             }

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/EngineAttributeEditFrame.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/EngineAttributeEditFrame.java
@@ -12,7 +12,6 @@ import javax.swing.JTextField;
 import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsFrame;
 import jmri.jmrit.operations.OperationsXml;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.cars.CarOwners;
 import jmri.jmrit.operations.rollingstock.cars.CarRoads;
 import jmri.jmrit.operations.setup.Control;
@@ -250,9 +249,8 @@ public class EngineAttributeEditFrame extends OperationsFrame implements java.be
     }
 
     private void replaceItem(String oldItem, String newItem) {
-        List<RollingStock> engines = engineManager.getList();
-        for (RollingStock rs : engines) {
-            Engine engine = (Engine) rs;
+        List<Engine> engines = engineManager.getList();
+        for (Engine engine : engines) {
             if (_comboboxName.equals(EngineEditFrame.MODEL)) {
                 // we need to copy the old model attributes, so find an engine.
                 if (engine.getModel().equals(oldItem)) {

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/EngineManager.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/EngineManager.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Daniel Boudreau Copyright (C) 2008
  */
-public class EngineManager extends RollingStockManager implements InstanceManagerAutoDefault, InstanceManagerAutoInitialize {
+public class EngineManager extends RollingStockManager<Engine> implements InstanceManagerAutoDefault, InstanceManagerAutoInitialize {
 
     protected Hashtable<String, Consist> _consistHashTable = new Hashtable<>(); // stores Consists by number
 
@@ -174,7 +174,7 @@ public class EngineManager extends RollingStockManager implements InstanceManage
      *
      * @return list of engines ordered by engine model
      */
-    public List<RollingStock> getByModelList() {
+    public List<Engine> getByModelList() {
         return getByList(getByRoadNameList(), BY_MODEL);
     }
 
@@ -183,11 +183,11 @@ public class EngineManager extends RollingStockManager implements InstanceManage
      *
      * @return list of engines ordered by engine consist
      */
-    public List<RollingStock> getByConsistList() {
+    public List<Engine> getByConsistList() {
         return getByList(getByRoadNameList(), BY_CONSIST);
     }
 
-    public List<RollingStock> getByHpList() {
+    public List<Engine> getByHpList() {
         return getByList(getByModelList(), BY_HP);
     }
 
@@ -198,14 +198,14 @@ public class EngineManager extends RollingStockManager implements InstanceManage
 
     // add engine options to sort comparator
     @Override
-    protected java.util.Comparator<RollingStock> getComparator(int attribute) {
+    protected java.util.Comparator<Engine> getComparator(int attribute) {
         switch (attribute) {
             case BY_MODEL:
-                return (e1, e2) -> (((Engine) e1).getModel().compareToIgnoreCase(((Engine) e2).getModel()));
+                return (e1, e2) -> (e1.getModel().compareToIgnoreCase(e2.getModel()));
             case BY_CONSIST:
-                return (e1, e2) -> (((Engine) e1).getConsistName().compareToIgnoreCase(((Engine) e2).getConsistName()));
+                return (e1, e2) -> (e1.getConsistName().compareToIgnoreCase(e2.getConsistName()));
             case BY_HP:
-                return (e1, e2) -> (((Engine) e1).getHpInteger() - ((Engine) e2).getHpInteger());
+                return (e1, e2) -> (e1.getHpInteger() - e2.getHpInteger());
             default:
                 return super.getComparator(attribute);
         }
@@ -240,15 +240,7 @@ public class EngineManager extends RollingStockManager implements InstanceManage
      * @return A list of sorted locos.
      */
     public List<Engine> getByTrainBlockingList(Train train) {
-        return castListToEngine(getByList(super.getByTrainList(train), BY_BLOCKING));
-    }
-
-    private List<Engine> castListToEngine(List<RollingStock> list) {
-        List<Engine> out = new ArrayList<Engine>();
-        for (RollingStock rs : list) {
-            out.add((Engine) rs);
-        }
-        return out;
+        return getByList(super.getByTrainList(train), BY_BLOCKING);
     }
 
     /**

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/EngineSetFrame.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/EngineSetFrame.java
@@ -5,7 +5,6 @@ import java.util.ResourceBundle;
 import javax.swing.JOptionPane;
 import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsXml;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.RollingStockSetFrame;
 
 /**
@@ -13,7 +12,7 @@ import jmri.jmrit.operations.rollingstock.RollingStockSetFrame;
  *
  * @author Dan Boudreau Copyright (C) 2008, 2010
  */
-public class EngineSetFrame extends RollingStockSetFrame implements
+public class EngineSetFrame extends RollingStockSetFrame<Engine> implements
         java.beans.PropertyChangeListener {
 
     protected static final ResourceBundle rb = ResourceBundle
@@ -69,7 +68,7 @@ public class EngineSetFrame extends RollingStockSetFrame implements
             if (JOptionPane.showConfirmDialog(this, Bundle.getMessage("engineInConsist"),
                     Bundle.getMessage("enginePartConsist"), JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
                 // convert cars list to rolling stock list
-                List<RollingStock> list = _engine.getConsist().getGroup();
+                List<Engine> list = _engine.getConsist().getGroup();
                 if (!updateGroup(list)) {
                     return false;
                 }

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/EnginesTableFrame.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/EnginesTableFrame.java
@@ -22,7 +22,6 @@ import javax.swing.table.TableColumnModel;
 import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsFrame;
 import jmri.jmrit.operations.OperationsXml;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.setup.Control;
 import jmri.jmrit.operations.setup.Setup;
 import jmri.swing.JTablePersistenceManager;
@@ -251,7 +250,7 @@ public class EnginesTableFrame extends OperationsFrame implements PropertyChange
         }
     }
 
-    public List<RollingStock> getSortByList() {
+    public List<Engine> getSortByList() {
         return enginesModel.getSelectedEngineList();
     }
 

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/EnginesTableModel.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/EnginesTableModel.java
@@ -75,7 +75,7 @@ public class EnginesTableModel extends javax.swing.table.AbstractTableModel impl
 
     /**
      * Not all columns are visible at the same time.
-     * 
+     *
      * @param sort which sort is active
      */
     public void setSort(int sort) {
@@ -165,8 +165,8 @@ public class EnginesTableModel extends javax.swing.table.AbstractTableModel impl
         }
     }
 
-    public List<RollingStock> getSelectedEngineList() {
-        List<RollingStock> list;
+    public List<Engine> getSelectedEngineList() {
+        List<Engine> list;
         if (_sort == SORTBY_ROAD) {
             list = manager.getByRoadNameList();
         } else if (_sort == SORTBY_MODEL) {
@@ -197,7 +197,7 @@ public class EnginesTableModel extends javax.swing.table.AbstractTableModel impl
         return list;
     }
 
-    List<RollingStock> sysList = null;
+    List<Engine> sysList = null;
 
     JTable _table;
     EnginesTableFrame _frame;

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/ExportEngines.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/ExportEngines.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.operations.rollingstock.engines;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -12,7 +11,6 @@ import java.util.List;
 import javax.swing.JOptionPane;
 import jmri.InstanceManager;
 import jmri.jmrit.XmlFile;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.setup.OperationsSetupXml;
 import jmri.jmrit.operations.setup.Setup;
 import org.slf4j.Logger;
@@ -63,8 +61,6 @@ public class ExportEngines extends XmlFile {
         }
     }
 
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
-            justification = "EngineManager only provides Engine Objects")
     public void writeFile(String name) {
         log.debug("writeFile {}", name);
         // This is taken in large part from "Java and XML" page 368
@@ -84,7 +80,7 @@ public class ExportEngines extends XmlFile {
         }
 
         EngineManager manager = InstanceManager.getDefault(EngineManager.class);
-        List<RollingStock> engineList = manager.getByNumberList();
+        List<Engine> engineList = manager.getByNumberList();
         String line = "";
         // check for delimiter in the following Engine fields
         String engineModel;
@@ -123,8 +119,7 @@ public class ExportEngines extends XmlFile {
         fileOut.println(header);
 
         // store engine number, road, model, length, owner, built date, location and track
-        for (RollingStock rs : engineList) {
-            Engine engine = (Engine) rs;
+        for (Engine engine : engineList) {
             engineModel = engine.getModel();
             if (engineModel.contains(del)) {
                 engineModel = ESC + engine.getModel() + ESC;

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/NceConsistEngines.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/NceConsistEngines.java
@@ -7,7 +7,6 @@ import java.util.List;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import jmri.InstanceManager;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrix.nce.NceBinaryCommand;
 import jmri.jmrix.nce.NceMessage;
 import jmri.jmrix.nce.NceReply;
@@ -46,7 +45,7 @@ public class NceConsistEngines extends Thread implements jmri.jmrix.nce.NceListe
 
     private boolean syncOK = true; // used to flag status messages
     EngineManager engineManager = InstanceManager.getDefault(EngineManager.class);
-    List<RollingStock> engineList;
+    List<Engine> engineList;
     List<String> consists;
 
     javax.swing.JLabel textConsist = new javax.swing.JLabel();
@@ -77,7 +76,6 @@ public class NceConsistEngines extends Thread implements jmri.jmrix.nce.NceListe
     }
 
     @Override
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "EngineManager only provides Engine Objects")
     // we use a thread so the status frame will work!
     public void run() {
         if (tc == null) {
@@ -126,7 +124,7 @@ public class NceConsistEngines extends Thread implements jmri.jmrix.nce.NceListe
         if (syncOK) {
             // now check each engine in the operations to see if there are any matches
             engineList = engineManager.getByNumberList();
-            consists = new ArrayList<String>();
+            consists = new ArrayList<>();
 
             // look for lead engines
             for (int consistNum = 1; consistNum < 128; consistNum++) {
@@ -135,8 +133,7 @@ public class NceConsistEngines extends Thread implements jmri.jmrix.nce.NceListe
                 if (engNum != 0) {
                     log.debug("NCE consist {} has lead engine {}", consistNum, engNum);
                     boolean engMatch = false;
-                    for (RollingStock rs : engineList) {
-                        Engine engine = (Engine) rs;
+                    for (Engine engine : engineList) {
                         if (engine.getNumber().equals(Integer.toString(engNum))) {
                             log.debug("found lead engine match {}", engine.getNumber());
                             Consist engConsist = engineManager.newConsist(NCE + consistNum);
@@ -171,15 +168,13 @@ public class NceConsistEngines extends Thread implements jmri.jmrix.nce.NceListe
         }
     }
 
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "EngineManager only provides Engine Objects")
     private void syncEngines(int offset, int step) {
         for (int consistNum = 1; consistNum < 128; consistNum++) {
             int engNum = getEngineNumberFromArray(consistNum, offset, step);
             if (engNum != 0) {
-                log.debug("NCE consist " + consistNum + " has engine " + engNum);
+                log.debug("NCE consist {} has engine {}", consistNum, engNum);
                 boolean engMatch = false;
-                for (RollingStock rs : engineList) {
-                    Engine engine = (Engine) rs;
+                for (Engine engine : engineList) {
                     if (engine.getNumber().equals(Integer.toString(engNum))) {
                         log.debug("found engine match {}", engine.getNumber());
                         engMatch = true;

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/PrintEngineRosterAction.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/PrintEngineRosterAction.java
@@ -1,13 +1,11 @@
 package jmri.jmrit.operations.rollingstock.engines;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.io.IOException;
 import java.util.List;
 import javax.swing.AbstractAction;
 import jmri.InstanceManager;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.cars.CarRoads;
 import jmri.jmrit.operations.setup.Control;
 import jmri.jmrit.operations.setup.Setup;
@@ -53,7 +51,6 @@ public class PrintEngineRosterAction extends AbstractAction {
     static final String TAB = "\t"; // NOI18N
 
     @Override
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "EngineManager only provides Engine Objects")
     public void actionPerformed(ActionEvent e) {
 
         // obtain a HardcopyWriter to do this
@@ -64,7 +61,7 @@ public class PrintEngineRosterAction extends AbstractAction {
             log.debug("Print cancelled");
             return;
         }
-        
+
         numberCharPerLine = writer.getCharactersPerLine();
 
         // Loop through the Roster, printing as needed
@@ -80,7 +77,7 @@ public class PrintEngineRosterAction extends AbstractAction {
         String rfid = "";
         String location;
 
-        List<RollingStock> engines = panel.getSortByList();
+        List<Engine> engines = panel.getSortByList();
         try {
             // header
             String header = padAttribute(Bundle.getMessage("Number"), Control.max_len_string_print_road_number)
@@ -98,8 +95,7 @@ public class PrintEngineRosterAction extends AbstractAction {
                                     .getMessage("Built"), Control.max_len_string_built_name) : "")
                     + Bundle.getMessage("Location") + NEW_LINE;
             writer.write(header);
-            for (RollingStock rs : engines) {
-                Engine engine = (Engine) rs;
+            for (Engine engine : engines) {
 
                 // loco number
                 number = padAttribute(engine.getNumber(), Control.max_len_string_print_road_number);

--- a/java/src/jmri/jmrit/operations/trains/Train.java
+++ b/java/src/jmri/jmrit/operations/trains/Train.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.operations.trains;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
@@ -51,8 +50,6 @@ import org.slf4j.LoggerFactory;
  *
  * @author Rodney Black Copyright (C) 2011
  */
-@SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
-        justification = "CarManager only provides Car Objects") // NOI18N
 public class Train implements java.beans.PropertyChangeListener {
     /*
      * WARNING DO NOT LOAD CAR OR ENGINE MANAGERS WHEN Train.java IS CREATED IT
@@ -431,7 +428,7 @@ public class Train implements java.beans.PropertyChangeListener {
         if (routeLocation == getTrainDepartsRouteLocation())
             return minutes;
         // add any work at this location
-        for (RollingStock rs : InstanceManager.getDefault(CarManager.class).getList(this)) {
+        for (Car rs : InstanceManager.getDefault(CarManager.class).getList(this)) {
             if (rs.getRouteLocation() == routeLocation && !rs.getTrackName().equals(RollingStock.NONE)) {
                 minutes += Setup.getSwitchTime();
             }
@@ -1905,7 +1902,7 @@ public class Train implements java.beans.PropertyChangeListener {
      */
     public int getNumberCarsWorked() {
         int count = 0;
-        for (RollingStock rs : InstanceManager.getDefault(CarManager.class).getList(this)) {
+        for (Car rs : InstanceManager.getDefault(CarManager.class).getList(this)) {
             if (rs.getRouteLocation() != null) {
                 count++;
             }
@@ -1951,7 +1948,7 @@ public class Train implements java.beans.PropertyChangeListener {
         Route route = getRoute();
         if (route != null) {
             for (RouteLocation rl : route.getLocationsBySequenceList()) {
-                for (RollingStock rs : InstanceManager.getDefault(CarManager.class).getList(this)) {
+                for (Car rs : InstanceManager.getDefault(CarManager.class).getList(this)) {
                     if (rs.getRouteLocation() == rl) {
                         number++;
                     }
@@ -1980,8 +1977,7 @@ public class Train implements java.beans.PropertyChangeListener {
         Route route = getRoute();
         if (route != null) {
             for (RouteLocation rl : route.getLocationsBySequenceList()) {
-                for (RollingStock rs : InstanceManager.getDefault(CarManager.class).getList(this)) {
-                    Car car = (Car) rs;
+                for (Car car : InstanceManager.getDefault(CarManager.class).getList(this)) {
                     if (!car.getLoadType().equals(CarLoad.LOAD_TYPE_EMPTY)) {
                         continue;
                     }
@@ -2067,8 +2063,7 @@ public class Train implements java.beans.PropertyChangeListener {
                         weight += -rs.getAdjustedWeightTons();
                     }
                 }
-                for (RollingStock rs : InstanceManager.getDefault(CarManager.class).getList(this)) {
-                    Car car = (Car) rs;
+                for (Car car : InstanceManager.getDefault(CarManager.class).getList(this)) {
                     if (car.getRouteLocation() == rl) {
                         weight += car.getAdjustedWeightTons(); // weight depends on car load
                     }
@@ -2095,8 +2090,7 @@ public class Train implements java.beans.PropertyChangeListener {
         Route route = getRoute();
         if (route != null) {
             for (RouteLocation rl : route.getLocationsBySequenceList()) {
-                for (RollingStock rs : InstanceManager.getDefault(EngineManager.class).getList(this)) {
-                    Engine eng = (Engine) rs;
+                for (Engine eng : InstanceManager.getDefault(EngineManager.class).getList(this)) {
                     if (eng.getRouteLocation() == rl) {
                         hp += eng.getHpInteger();
                     }
@@ -2121,9 +2115,8 @@ public class Train implements java.beans.PropertyChangeListener {
     @Nonnull public String getCabooseRoadAndNumber() {
         String cabooseRoadNumber = NONE;
         RouteLocation rl = getCurrentLocation();
-        List<RollingStock> cars = InstanceManager.getDefault(CarManager.class).getByTrainList(this);
-        for (RollingStock rs : cars) {
-            Car car = (Car) rs;
+        List<Car> cars = InstanceManager.getDefault(CarManager.class).getByTrainList(this);
+        for (Car car : cars) {
             if (car.getRouteLocation() == rl && car.getRouteDestination() != rl && car.isCaboose()) {
                 cabooseRoadNumber = car.toString();
             }

--- a/java/src/jmri/jmrit/operations/trains/TrainBuilder.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainBuilder.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.operations.trains;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -44,8 +43,6 @@ import org.slf4j.LoggerFactory;
  * @author Daniel Boudreau Copyright (C) 2008, 2009, 2010, 2011, 2012, 2013,
  *         2014, 2015
  */
-@SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
-        justification = "CarManager only provides Car Objects")
 public class TrainBuilder extends TrainCommon {
 
     // report levels
@@ -2809,8 +2806,7 @@ public class TrainBuilder extends TrainCommon {
         }
 
         if (departStageTrack.getNumberEngines() > 0) {
-            for (RollingStock rs : engineManager.getList()) {
-                Engine eng = (Engine) rs;
+            for (Engine eng : engineManager.getList()) {
                 if (eng.getTrack() == departStageTrack) {
                     // has engine been assigned to another train?
                     if (eng.getRouteLocation() != null) {
@@ -2875,8 +2871,7 @@ public class TrainBuilder extends TrainCommon {
         boolean foundCaboose = false;
         boolean foundFRED = false;
         if (departStageTrack.getNumberCars() > 0) {
-            for (RollingStock rs : carManager.getList()) {
-                Car car = (Car) rs;
+            for (Car car : carManager.getList()) {
                 if (car.getTrack() != departStageTrack) {
                     continue;
                 }
@@ -4570,9 +4565,8 @@ public class TrainBuilder extends TrainCommon {
             return false;
         }
         boolean redirected = false;
-        List<RollingStock> cars = carManager.getByTrainList(_train);
-        for (RollingStock rs : cars) {
-            Car car = (Car) rs;
+        List<Car> cars = carManager.getByTrainList(_train);
+        for (Car car : cars) {
             // does the car have a final destination and the destination is this one?
             if (car.getFinalDestination() == null ||
                     car.getFinalDestinationTrack() == null ||
@@ -4884,8 +4878,8 @@ public class TrainBuilder extends TrainCommon {
         }
         int numberLocos = 0;
         // determine how many locos have already been assigned to the train
-        List<RollingStock> engines = InstanceManager.getDefault(EngineManager.class).getList(_train);
-        for (RollingStock rs : engines) {
+        List<Engine> engines = InstanceManager.getDefault(EngineManager.class).getList(_train);
+        for (Engine rs : engines) {
             if (rs.getRouteLocation() == rl) {
                 numberLocos++;
             }

--- a/java/src/jmri/jmrit/operations/trains/TrainCommon.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainCommon.java
@@ -71,7 +71,7 @@ public class TrainCommon {
 
     /**
      * Used to generate "Two Column" format for engines.
-     * 
+     *
      * @param file Manifest or Switch List File
      * @param engineList List of engines for this train.
      * @param rl The RouteLocation being printed.
@@ -102,7 +102,7 @@ public class TrainCommon {
     /**
      * Adds a list of locomotive pick ups for the route location to the output
      * file. Used to generate "Standard" format.
-     * 
+     *
      * @param file Manifest or Switch List File
      * @param engineList List of engines for this train.
      * @param rl The RouteLocation being printed.
@@ -177,7 +177,7 @@ public class TrainCommon {
     /**
      * Returns the pick up string for a loco. Useful for frames like the train
      * conductor and yardmaster.
-     * 
+     *
      * @param engine The Engine.
      *
      * @return engine pick up string
@@ -193,7 +193,7 @@ public class TrainCommon {
     /**
      * Returns the drop string for a loco. Useful for frames like the train
      * conductor and yardmaster.
-     * 
+     *
      * @param engine The Engine.
      *
      * @return engine drop string
@@ -214,7 +214,7 @@ public class TrainCommon {
     /**
      * Block cars by track, then pick up and set out for each location in a
      * train's route. This routine is used for the "Standard" format.
-     * 
+     *
      * @param file Manifest or switch list File
      * @param train The train being printed.
      * @param carList List of cars for this train
@@ -240,7 +240,7 @@ public class TrainCommon {
             }
             trackNames.add(splitString(track.getName())); // use a track name once
             // block pick up cars by destination
-            // except for passenger cars 
+            // except for passenger cars
             boolean found = false; // begin blocking at rl
             for (RouteLocation rld : routeList) {
                 if (rld != rl && !found) {
@@ -360,7 +360,7 @@ public class TrainCommon {
      * Produces a two column format for car pick ups and set outs. Sorted by
      * track and then by destination. This routine is used for the "Two Column"
      * format.
-     * 
+     *
      * @param file Manifest or switch list File
      * @param train The train being printed.
      * @param carList List of cars for this train
@@ -458,7 +458,7 @@ public class TrainCommon {
      * track and then by destination. Track name in header format, track name
      * removed from format. This routine is used to generate the
      * "Two Column by Track" format.
-     * 
+     *
      * @param file Manifest or switch list File
      * @param train The train being printed.
      * @param carList List of cars for this train
@@ -656,7 +656,7 @@ public class TrainCommon {
     /**
      * Adds the car's pick up string to the output file using the truncated
      * manifest format
-     * 
+     *
      * @param file Manifest or switch list File
      * @param car The car being printed.
      * @param isManifest True if manifest, false if switch list.
@@ -671,7 +671,7 @@ public class TrainCommon {
     /**
      * Adds the car's pick up string to the output file using the manifest or
      * switch list format
-     * 
+     *
      * @param file Manifest or switch list File
      * @param car The car being printed.
      * @param isManifest True if manifest, false if switch list.
@@ -710,7 +710,7 @@ public class TrainCommon {
     /**
      * Returns the pick up car string. Useful for frames like train conductor
      * and yardmaster.
-     * 
+     *
      * @param car The car being printed.
      *
      * @param isManifest when true use manifest format, when false use switch
@@ -741,7 +741,7 @@ public class TrainCommon {
      * Adds the car's set out string to the output file using the truncated
      * manifest format. Does not print out local moves. Local moves are only
      * shown on the switch list for that location.
-     * 
+     *
      * @param file Manifest or switch list File
      * @param car The car being printed.
      * @param isManifest True if manifest, false if switch list.
@@ -759,7 +759,7 @@ public class TrainCommon {
     /**
      * Adds the car's set out string to the output file using the manifest or
      * switch list format
-     * 
+     *
      * @param file Manifest or switch list File
      * @param car The car being printed.
      * @param isManifest True if manifest, false if switch list.
@@ -809,7 +809,7 @@ public class TrainCommon {
     /**
      * Returns the drop car string. Useful for frames like train conductor and
      * yardmaster.
-     * 
+     *
      * @param car The car being printed.
      *
      * @param isManifest when true use manifest format, when false use switch
@@ -847,7 +847,7 @@ public class TrainCommon {
     /**
      * Returns the move car string. Useful for frames like train conductor and
      * yardmaster.
-     * 
+     *
      * @param car The car being printed.
      *
      * @param isManifest when true use manifest format, when false use switch
@@ -875,7 +875,7 @@ public class TrainCommon {
     /**
      * Add a list of utility cars scheduled for pick up from the route location
      * to the output file. The cars are blocked by destination.
-     * 
+     *
      * @param file Manifest or Switch List File.
      * @param carList List of cars for this train.
      * @param car The utility car.
@@ -903,7 +903,7 @@ public class TrainCommon {
     /**
      * Add a list of utility cars scheduled for drop at the route location to
      * the output file.
-     * 
+     *
      * @param file Manifest or Switch List File.
      * @param carList List of cars for this train.
      * @param car The utility car.
@@ -973,7 +973,7 @@ public class TrainCommon {
 
     /**
      * For the Conductor and Yardmaster windows.
-     * 
+     *
      * @param carList List of cars for this train.
      * @param car The utility car.
      * @param isLocal True if local move.
@@ -1039,7 +1039,7 @@ public class TrainCommon {
      * Scans the car list for utility cars that have the same attributes as the
      * car provided. Returns 0 if this car type has already been processed,
      * otherwise the number of cars with the same attribute.
-     * 
+     *
      * @param format Message format.
      * @param carList List of cars for this train
      * @param car The utility car.
@@ -1191,7 +1191,7 @@ public class TrainCommon {
 
     /**
      * Used to determine if car is a local move
-     * 
+     *
      * @param car The Car to test.
      *
      * @return true if the move is at the same location
@@ -1238,7 +1238,7 @@ public class TrainCommon {
 
     /**
      * Writes string to file. No line length wrap or protection.
-     * 
+     *
      * @param file The File to write to.
      * @param string The string to write.
      *
@@ -1253,7 +1253,7 @@ public class TrainCommon {
     /**
      * Writes a string to a file. Checks for string length, and will
      * automatically wrap lines.
-     * 
+     *
      * @param file The File to write to.
      * @param string The string to write.
      *
@@ -1283,7 +1283,7 @@ public class TrainCommon {
 
     /**
      * Adds a blank line to the file.
-     * 
+     *
      * @param file The File to write to.
      *
      */
@@ -1295,7 +1295,7 @@ public class TrainCommon {
      * Splits a string (example-number) as long as the second part of the string
      * is an integer or if the first character after the hyphen is a left
      * parenthesis "(".
-     * 
+     *
      * @param name The string to split if necessary.
      *
      * @return First half of the string.
@@ -1348,7 +1348,7 @@ public class TrainCommon {
 
     /**
      * returns true if the train has work at the location
-     * 
+     *
      * @param train The Train.
      * @param location The Location.
      *
@@ -1364,7 +1364,7 @@ public class TrainCommon {
         return false;
     }
 
-    private static boolean isThereWorkAtLocation(Train train, Location location, List<RollingStock> list) {
+    private static boolean isThereWorkAtLocation(Train train, Location location, List<? extends RollingStock> list) {
         for (RollingStock rs : list) {
             if ((rs.getRouteLocation() != null &&
                     rs.getTrack() != null &&
@@ -1617,7 +1617,7 @@ public class TrainCommon {
 
     /**
      * Two column header format. Left side pick ups, right side set outs
-     * 
+     *
      * @param file Manifest or switch list File.
      * @param isManifest True if manifest, false if switch list.
      *
@@ -1655,7 +1655,7 @@ public class TrainCommon {
     /**
      * Prints the two column header for cars. Left side pick ups, right side set
      * outs.
-     * 
+     *
      * @param file Manifest or Switch List File
      * @param isManifest True if manifest, false if switch list.
      * @param isTwoColumnTrack True if two column format.
@@ -1878,7 +1878,7 @@ public class TrainCommon {
 
     /**
      * Prints a line across the entire page.
-     * 
+     *
      * @param file The File to print to.
      * @param isManifest True if manifest, false if switch list.
      *
@@ -1938,7 +1938,7 @@ public class TrainCommon {
      * Pads out a string by adding spaces to the end of the string, and will
      * remove characters from the end of the string if the string exceeds the
      * field size.
-     * 
+     *
      * @param s The string to pad.
      * @param fieldSize The maximum length of the string.
      *
@@ -1962,7 +1962,7 @@ public class TrainCommon {
     /**
      * Adjusts string to be a certain number of characters by adding spaces to
      * the end of the string.
-     * 
+     *
      * @param s The string to pad
      * @param fieldSize The fixed length of the string.
      *
@@ -1979,7 +1979,7 @@ public class TrainCommon {
     /**
      * Adds the requested number of spaces to the start of the string. Tabs must
      * be enabled. Setup.isTabEnabled()
-     * 
+     *
      * @param s The string to pad out.
      * @param tabSize The fixed length of the string.
      *
@@ -2065,7 +2065,7 @@ public class TrainCommon {
     /**
      * Produces a string using commas and spaces between the strings provided in
      * the array. Does not check for embedded commas in the string array.
-     * 
+     *
      * @param array The string array to be formated.
      *
      * @return formated string using commas and spaces

--- a/java/src/jmri/jmrit/operations/trains/TrainCsvManifest.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainCsvManifest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.operations.trains;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -13,7 +12,6 @@ import jmri.InstanceManager;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.locations.Track;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.cars.Car;
 import jmri.jmrit.operations.rollingstock.cars.CarLoad;
 import jmri.jmrit.operations.rollingstock.cars.CarLoads;
@@ -30,7 +28,7 @@ import org.slf4j.LoggerFactory;
  * Builds a train's manifest using Comma Separated Values (csv).
  *
  * @author Daniel Boudreau Copyright (C) 2011, 2015
- * 
+ *
  */
 public class TrainCsvManifest extends TrainCsvCommon {
 
@@ -40,7 +38,6 @@ public class TrainCsvManifest extends TrainCsvCommon {
 
     private final static Logger log = LoggerFactory.getLogger(TrainCsvManifest.class);
 
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "CarManager only provides Car Objects")
     public TrainCsvManifest(Train train) {
         // create comma separated value manifest file
         File file = InstanceManager.getDefault(TrainManagerXml.class).createTrainCsvManifestFile(train.getName());
@@ -190,11 +187,11 @@ public class TrainCsvManifest extends TrainCsvCommon {
                 }
             }
             // car holds
-            List<RollingStock> rsByLocation = InstanceManager.getDefault(CarManager.class).getByLocationList();
-            List<Car> cList = new ArrayList<Car>();
-            for (RollingStock rs : rsByLocation) {
+            List<Car> rsByLocation = InstanceManager.getDefault(CarManager.class).getByLocationList();
+            List<Car> cList = new ArrayList<>();
+            for (Car rs : rsByLocation) {
                 if (rs.getLocation() == rl.getLocation() && rs.getRouteLocation() == null && rs.getTrack() != null) {
-                    cList.add((Car) rs);
+                    cList.add(rs);
                 }
             }
             clearUtilityCarTypes(); // list utility cars by quantity

--- a/java/src/jmri/jmrit/operations/trains/TrainCsvSwitchLists.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainCsvSwitchLists.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.operations.trains;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -11,7 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 import jmri.InstanceManager;
 import jmri.jmrit.operations.locations.Location;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.cars.Car;
 import jmri.jmrit.operations.rollingstock.cars.CarManager;
 import jmri.jmrit.operations.rollingstock.engines.Engine;
@@ -27,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * railroad.
  *
  * @author Daniel Boudreau (C) Copyright 2011, 2013, 2014, 2015
- * 
+ *
  *
  */
 public class TrainCsvSwitchLists extends TrainCsvCommon {
@@ -38,7 +36,6 @@ public class TrainCsvSwitchLists extends TrainCsvCommon {
      *
      * @return File
      */
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "CarManager only provides Car Objects")
     public File buildSwitchList(Location location) {
 
         // create csv switch list file
@@ -240,14 +237,14 @@ public class TrainCsvSwitchLists extends TrainCsvCommon {
             }
         }
         addLine(fileOut, END); // done with switch list
-        
+
         // now list hold cars
-        List<RollingStock> rsByLocation = InstanceManager.getDefault(CarManager.class).getByLocationList();
-        List<Car> carList = new ArrayList<Car>();
-        for (RollingStock rs : rsByLocation) {
-            if (rs.getLocation() != null && splitString(rs.getLocation().getName()).equals(splitString(location.getName())) 
+        List<Car> rsByLocation = InstanceManager.getDefault(CarManager.class).getByLocationList();
+        List<Car> carList = new ArrayList<>();
+        for (Car rs : rsByLocation) {
+            if (rs.getLocation() != null && splitString(rs.getLocation().getName()).equals(splitString(location.getName()))
                     && rs.getRouteLocation() == null) {
-                carList.add((Car)rs);
+                carList.add(rs);
             }
         }
         clearUtilityCarTypes(); // list utility cars by quantity
@@ -262,7 +259,7 @@ public class TrainCsvSwitchLists extends TrainCsvCommon {
             fileOutCsvCar(fileOut, car, HOLD, count);
         }
         addLine(fileOut, END); // done with hold cars
-        
+
         // Are there any cars that need to be found?
         listCarsLocationUnknown(fileOut);
         fileOut.flush();

--- a/java/src/jmri/jmrit/operations/trains/TrainIcon.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainIcon.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.operations.trains;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
@@ -13,7 +12,6 @@ import javax.swing.JPopupMenu;
 import jmri.InstanceManager;
 import jmri.jmrit.display.Editor;
 import jmri.jmrit.display.LocoIcon;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.cars.Car;
 import jmri.jmrit.operations.rollingstock.cars.CarManager;
 import jmri.jmrit.operations.routes.Route;
@@ -119,14 +117,13 @@ public class TrainIcon extends LocoIcon {
         _tf.toFront();
     }
 
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "CarManager only provides Car Objects")
     private JMenu makeTrainRouteMenu() {
         JMenu routeMenu = new JMenu(Bundle.getMessage("Route"));
         Route route = _train.getRoute();
         if (route == null) {
             return routeMenu;
         }
-        List<RollingStock> carList = InstanceManager.getDefault(CarManager.class).getByTrainList(_train);
+        List<Car> carList = InstanceManager.getDefault(CarManager.class).getByTrainList(_train);
         for (RouteLocation rl : route.getLocationsBySequenceList()) {
             int pickupCars = 0;
             int dropCars = 0;
@@ -134,8 +131,7 @@ public class TrainIcon extends LocoIcon {
             if (_train.getCurrentLocation() == rl) {
                 current = "-> "; // NOI18N
             }
-            for (RollingStock rs : carList) {
-                Car car = (Car) rs;
+            for (Car car : carList) {
                 if (car.getRouteLocation() == rl && !car.getTrackName().equals(Car.NONE)) {
                     pickupCars++;
                 }

--- a/java/src/jmri/jmrit/operations/trains/TrainSwitchLists.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainSwitchLists.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.operations.trains;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -13,7 +12,6 @@ import java.util.List;
 import jmri.InstanceManager;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.Track;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.cars.Car;
 import jmri.jmrit.operations.rollingstock.cars.CarColors;
 import jmri.jmrit.operations.rollingstock.cars.CarLoads;
@@ -34,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * Builds a switch list for a location on the railroad
  *
  * @author Daniel Boudreau (C) Copyright 2008, 2011, 2012, 2013, 2015
- * 
+ *
  *
  */
 public class TrainSwitchLists extends TrainCommon {
@@ -52,15 +50,13 @@ public class TrainSwitchLists extends TrainCommon {
      * which can cause an IllegalArgumentException. Some messages have more
      * arguments than the default message allowing the user to customize the
      * message to their liking.
-     * 
+     *
      * There also an option to list all of the car work by track name. This option
      * is only available in real time and is shown after the switch list by
      * train.
      *
      * @param location The Location needing a switch list
      */
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
-            justification = "CarManager only provides Car Objects") // NOI18N
     public void buildSwitchList(Location location) {
         // Append switch list data if not operating in real time
         boolean newTrainsOnly = !Setup.isSwitchListRealTime();
@@ -339,19 +335,19 @@ public class TrainSwitchLists extends TrainCommon {
                 }
                 newLine(fileOut, MessageFormat.format(messageFormatText = TrainSwitchListText
                         .getStringSwitchListByTrack(), new Object[]{splitString(location.getName())}));
-                
+
                 // we only need the cars delivered to or at this location
-                List<RollingStock> rsList = carManager.getByTrainList();
-                List<Car> carList = new ArrayList<Car>();
-                for (RollingStock rs : rsList) {
+                List<Car> rsList = carManager.getByTrainList();
+                List<Car> carList = new ArrayList<>();
+                for (Car rs : rsList) {
                     if ((rs.getLocation() != null &&
                             splitString(rs.getLocation().getName()).equals(splitString(location.getName()))) ||
                             (rs.getDestination() != null &&
                                     splitString(rs.getDestination().getName()).equals(splitString(location.getName()))))
-                        carList.add((Car) rs);
+                        carList.add(rs);
                 }
-                
-                List<String> trackNames = new ArrayList<String>(); // locations and tracks can have "similar" names, only list track names once
+
+                List<String> trackNames = new ArrayList<>(); // locations and tracks can have "similar" names, only list track names once
                 for (Location loc : locationManager.getLocationsByNameList()) {
                     if (!splitString(loc.getName()).equals(splitString(location.getName())))
                         continue;
@@ -360,8 +356,8 @@ public class TrainSwitchLists extends TrainCommon {
                         if (trackNames.contains(trackName))
                             continue;
                         trackNames.add(trackName);
-                        
-                        String trainName = ""; // for printing train message once                     
+
+                        String trainName = ""; // for printing train message once
                         newLine(fileOut);
                         newLine(fileOut, trackName); // print out just the track name
                         // now show the cars pickup and holds for this track

--- a/java/src/jmri/jmrit/operations/trains/tools/TrainByCarTypeFrame.java
+++ b/java/src/jmri/jmrit/operations/trains/tools/TrainByCarTypeFrame.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.operations.trains.tools;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.awt.Dimension;
 import java.awt.GridBagLayout;
 import java.text.MessageFormat;
@@ -19,7 +18,6 @@ import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.locations.Track;
 import jmri.jmrit.operations.locations.schedules.Schedule;
 import jmri.jmrit.operations.locations.schedules.ScheduleItem;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.cars.Car;
 import jmri.jmrit.operations.rollingstock.cars.CarLoads;
 import jmri.jmrit.operations.rollingstock.cars.CarManager;
@@ -394,27 +392,21 @@ public class TrainByCarTypeFrame extends OperationsFrame implements java.beans.P
         InstanceManager.getDefault(CarTypes.class).updateComboBox(typeComboBox);
     }
 
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
-            justification = "CarManager only provides Car Objects")
     private void updateCarsComboBox() {
         log.debug("update car combobox");
         carsComboBox.removeAllItems();
         String carType = (String) typeComboBox.getSelectedItem();
         // load car combobox
         carsComboBox.addItem(null);
-        List<RollingStock> cars = InstanceManager.getDefault(CarManager.class).getByTypeList(carType);
-        for (RollingStock rs : cars) {
-            Car car = (Car) rs;
+        List<Car> cars = InstanceManager.getDefault(CarManager.class).getByTypeList(carType);
+        for (Car car : cars) {
             carsComboBox.addItem(car);
         }
     }
 
-    @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
-            justification = "CarManager only provides Car Objects")
     private void adjustCarsComboBoxSize() {
-        List<RollingStock> cars = InstanceManager.getDefault(CarManager.class).getList();
-        for (RollingStock rs : cars) {
-            Car car = (Car) rs;
+        List<Car> cars = InstanceManager.getDefault(CarManager.class).getList();
+        for (Car car : cars) {
             carsComboBox.addItem(car);
         }
         Dimension boxsize = carsComboBox.getMinimumSize();

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/CarManagerTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/CarManagerTest.java
@@ -5,7 +5,6 @@ import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsTestCase;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.Track;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.routes.Route;
 import jmri.jmrit.operations.routes.RouteLocation;
 import jmri.jmrit.operations.trains.Train;
@@ -40,7 +39,7 @@ public class CarManagerTest extends OperationsTestCase {
 
     public void testAddCars() {
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList = manager.getByIdList();
+        List<Car> carList = manager.getByIdList();
 
         Assert.assertEquals("Starting Number of Cars", 0, carList.size());
         c1 = manager.newCar("CP", "1");
@@ -60,7 +59,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList = manager.getByIdList();
+        List<Car> carList = manager.getByIdList();
 
         // now get cars by id
         carList = manager.getByIdList();
@@ -77,7 +76,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList;
+        List<Car> carList;
 
         c1.setBuilt("06-66"); // this becomes 1966
         c2.setBuilt("01-09"); // this becomes 1909
@@ -101,7 +100,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList;
+        List<Car> carList;
 
         c1.setMoves(2);
         c2.setMoves(44);
@@ -125,7 +124,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList = manager.getByIdList();
+        List<Car> carList = manager.getByIdList();
         // now get cars by owner
         carList = manager.getByOwnerList();
         Assert.assertEquals("Number of Cars by owner", 6, carList.size());
@@ -141,7 +140,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList;
+        List<Car> carList;
 
         c1.setColor("RED");
         c2.setColor("BLUE");
@@ -164,7 +163,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList = manager.getByIdList();
+        List<Car> carList = manager.getByIdList();
         // now get cars by road name
         carList = manager.getByRoadNameList();
         Assert.assertEquals("Number of Cars by road name", 6, carList.size());
@@ -180,7 +179,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList = manager.getByIdList();
+        List<Car> carList = manager.getByIdList();
         // now get cars by load
         carList = manager.getByLoadList();
         Assert.assertEquals("Number of Cars by load", 6, carList.size());
@@ -196,7 +195,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList;
+        List<Car> carList;
 
         // set car weight so there won't be an exception when setting car in a kernel
         c1.setWeight("20");
@@ -228,7 +227,7 @@ public class CarManagerTest extends OperationsTestCase {
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
         // now get cars by location
-        List<RollingStock> carList = manager.getByLocationList();
+        List<Car> carList = manager.getByLocationList();
         Assert.assertEquals("Number of Cars by location", 6, carList.size());
         Assert.assertEquals("1st car in list by location", c6, carList.get(0));
         Assert.assertEquals("2nd car in list by location", c5, carList.get(1));
@@ -242,7 +241,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList = manager.getByIdList();
+        List<Car> carList = manager.getByIdList();
         // now get cars by destination
         carList = manager.getByDestinationList();
         Assert.assertEquals("Number of Cars by destination", 6, carList.size());
@@ -258,7 +257,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList;
+        List<Car> carList;
 
         Route r = new Route("id", "Test");
         r.addLocation(l1);
@@ -294,7 +293,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList;
+        List<Car> carList;
         Route r = new Route("id", "Test");
         r.addLocation(l1);
         r.addLocation(l2);
@@ -427,7 +426,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList = manager.getByIdList();
+        List<Car> carList = manager.getByIdList();
         // now get cars by road number
         carList = manager.getByNumberList();
         Assert.assertEquals("Number of Cars by number", 6, carList.size());
@@ -457,7 +456,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList = manager.getByIdList();
+        List<Car> carList = manager.getByIdList();
         // now get cars by RFID
         carList = manager.getByRfidList();
         Assert.assertEquals("Number of Cars by rfid", 6, carList.size());
@@ -487,7 +486,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList = manager.getByIdList();
+        List<Car> carList = manager.getByIdList();
         // change car types so sort will work
         c1.setTypeName("F");
         c2.setTypeName("D");
@@ -511,7 +510,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList;
+        List<Car> carList;
 
         java.util.Calendar cal = java.util.Calendar.getInstance();
         java.util.Date start = cal.getTime(); // save to rest time, to avoid
@@ -560,7 +559,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList;
+        List<Car> carList;
 
         java.util.Calendar cal = java.util.Calendar.getInstance();
         java.util.Date start = cal.getTime(); // save to rest time, to avoid
@@ -632,7 +631,7 @@ public class CarManagerTest extends OperationsTestCase {
         resetCarManager();
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList = manager.getList(l1);
+        List<Car> carList = manager.getList(l1);
         Assert.assertEquals("Number of Cars at location", 2, carList.size());
         Assert.assertTrue("c1 in car list at location", carList.contains(c1));
         Assert.assertTrue("c2 in car list at location", carList.contains(c2));
@@ -644,7 +643,7 @@ public class CarManagerTest extends OperationsTestCase {
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
         Track l1t1 = l1.getTrackByName("A", Track.SPUR);
-        List<RollingStock> carList = manager.getList(l1t1);
+        List<Car> carList = manager.getList(l1t1);
         Assert.assertEquals("Number of Cars on track", 1, carList.size());
         Assert.assertTrue("c1 in car list on track", carList.contains(c1));
         Assert.assertFalse("c2 not in car list on track", carList.contains(c2));

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/CarsTableFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/CarsTableFrameTest.java
@@ -8,7 +8,6 @@ import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.locations.Track;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.setup.Setup;
 import jmri.util.JUnitUtil;
 import org.junit.After;
@@ -102,7 +101,7 @@ public class CarsTableFrameTest extends OperationsSwingTestCase {
         Assert.assertEquals("number of cars", "5", ctf.numCars.getText());
 
         // default is sort by number
-        List<RollingStock> cars = ctf.carsTableModel.getSelectedCarList();
+        List<Car> cars = ctf.carsTableModel.getSelectedCarList();
         Assert.assertEquals("1st car in sort by number list", c1.getId(), cars.get(0).getId());
         Assert.assertEquals("2nd car in sort by number list", c4.getId(), cars.get(1).getId());
         Assert.assertEquals("3rd car in sort by number list", c3.getId(), cars.get(2).getId());

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/ExportCarsTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/ExportCarsTest.java
@@ -2,7 +2,6 @@ package jmri.jmrit.operations.rollingstock.cars;
 
 import java.util.List;
 import jmri.InstanceManager;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -18,7 +17,7 @@ public class ExportCarsTest {
     @Test
     public void testCTor() {
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> carList = manager.getByIdList();
+        List<Car> carList = manager.getByIdList();
         ExportCars t = new ExportCars(carList);
         Assert.assertNotNull("exists", t);
     }

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/XmlTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/XmlTest.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.List;
 import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsTestCase;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.jdom2.JDOMException;
@@ -35,7 +34,7 @@ public class XmlTest extends OperationsTestCase {
         Assert.assertEquals("Default car load", "L", InstanceManager.getDefault(CarLoads.class).getDefaultLoadName());
 
         CarManager manager = InstanceManager.getDefault(CarManager.class);
-        List<RollingStock> tempcarList = manager.getByIdList();
+        List<Car> tempcarList = manager.getByIdList();
 
         Assert.assertEquals("Starting Number of Cars", 0, tempcarList.size());
         Car c1 = manager.newCar("CP", "Test Number 1");

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/EngineManagerTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/EngineManagerTest.java
@@ -5,7 +5,6 @@ import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsTestCase;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.Track;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.routes.Route;
 import jmri.jmrit.operations.trains.Train;
 import junit.framework.Test;
@@ -42,7 +41,7 @@ public class EngineManagerTest extends OperationsTestCase {
 
     public void testAddEngines() {
         EngineManager manager = InstanceManager.getDefault(EngineManager.class);
-        List<RollingStock> engineList = manager.getByIdList();
+        List<Engine> engineList = manager.getByIdList();
 
         Assert.assertEquals("Starting Number of Engines", 0, engineList.size());
         e1 = manager.newEngine("CP", "1");
@@ -64,7 +63,7 @@ public class EngineManagerTest extends OperationsTestCase {
         EngineManager manager = InstanceManager.getDefault(EngineManager.class);
 
         // now get engines by id
-        List<RollingStock> engineList = manager.getByIdList();
+        List<Engine> engineList = manager.getByIdList();
         Assert.assertEquals("Number of Engines by id", 6, engineList.size());
         Assert.assertEquals("1st engine in list by id", e6, engineList.get(0));
         Assert.assertEquals("2nd engine in list by id", e2, engineList.get(1));
@@ -88,7 +87,7 @@ public class EngineManagerTest extends OperationsTestCase {
         e6.setBuilt("1956");
 
         // now get engines by built
-        List<RollingStock> engineList = manager.getByBuiltList();
+        List<Engine> engineList = manager.getByBuiltList();
         Assert.assertEquals("Number of Engines by built", 6, engineList.size());
         Assert.assertEquals("1st engine in list by built", e3, engineList.get(0));
         Assert.assertEquals("2nd engine in list by built", e2, engineList.get(1));
@@ -112,7 +111,7 @@ public class EngineManagerTest extends OperationsTestCase {
         e6.setMoves(9999);
 
         // now get engines by moves
-        List<RollingStock> engineList = manager.getByMovesList();
+        List<Engine> engineList = manager.getByMovesList();
         Assert.assertEquals("Number of Engines by move", 6, engineList.size());
         Assert.assertEquals("1st engine in list by move", e1, engineList.get(0));
         Assert.assertEquals("2nd engine in list by move", e5, engineList.get(1));
@@ -136,7 +135,7 @@ public class EngineManagerTest extends OperationsTestCase {
         e6.setOwner("BOB");
 
         // now get engines by owner
-        List<RollingStock> engineList = manager.getByOwnerList();
+        List<Engine> engineList = manager.getByOwnerList();
         Assert.assertEquals("Number of Engines by owner", 6, engineList.size());
         Assert.assertEquals("1st engine in list by owner", e3, engineList.get(0));
         Assert.assertEquals("2nd engine in list by owner", e6, engineList.get(1));
@@ -152,7 +151,7 @@ public class EngineManagerTest extends OperationsTestCase {
         EngineManager manager = InstanceManager.getDefault(EngineManager.class);
 
         // now get engines by road name
-        List<RollingStock> engineList = manager.getByRoadNameList();
+        List<Engine> engineList = manager.getByRoadNameList();
         Assert.assertEquals("Number of Engines by road name", 6, engineList.size());
         Assert.assertEquals("1st engine in list by road name", e6, engineList.get(0));
         Assert.assertEquals("2nd engine in list by road name", e2, engineList.get(1));
@@ -176,7 +175,7 @@ public class EngineManagerTest extends OperationsTestCase {
         e6.setConsist(new Consist("E"));
 
         // now get engines by consist
-        List<RollingStock> engineList = manager.getByConsistList();
+        List<Engine> engineList = manager.getByConsistList();
         Assert.assertEquals("Number of Engines by consist", 6, engineList.size());
         Assert.assertEquals("1st engine in list by consist", e4, engineList.get(0));
         Assert.assertEquals("2nd engine in list by consist", e3, engineList.get(1));
@@ -192,7 +191,7 @@ public class EngineManagerTest extends OperationsTestCase {
         EngineManager manager = InstanceManager.getDefault(EngineManager.class);
 
         // now get engines by location
-        List<RollingStock> engineList = manager.getByLocationList();
+        List<Engine> engineList = manager.getByLocationList();
         Assert.assertEquals("Number of Engines by location", 6, engineList.size());
         Assert.assertEquals("1st engine in list by location", e6, engineList.get(0));
         Assert.assertEquals("2nd engine in list by location", e5, engineList.get(1));
@@ -208,7 +207,7 @@ public class EngineManagerTest extends OperationsTestCase {
         EngineManager manager = InstanceManager.getDefault(EngineManager.class);
 
         // now get engines by destination
-        List<RollingStock> engineList = manager.getByDestinationList();
+        List<Engine> engineList = manager.getByDestinationList();
         Assert.assertEquals("Number of Engines by destination", 6, engineList.size());
         Assert.assertEquals("1st engine in list by destination", e2, engineList.get(0));
         Assert.assertEquals("2nd engine in list by destination", e1, engineList.get(1));
@@ -242,7 +241,7 @@ public class EngineManagerTest extends OperationsTestCase {
         e6.setTrain(new Train("id6", "A"));
 
         // now get engines by train
-        List<RollingStock> engineList = manager.getByTrainList();
+        List<Engine> engineList = manager.getByTrainList();
         Assert.assertEquals("Number of Engines by train", 6, engineList.size());
         Assert.assertEquals("1st engine in list by train", e6, engineList.get(0));
         Assert.assertEquals("2nd engine in list by train", e4, engineList.get(1));
@@ -370,7 +369,7 @@ public class EngineManagerTest extends OperationsTestCase {
         EngineManager manager = InstanceManager.getDefault(EngineManager.class);
 
         // now get engines by road number
-        List<RollingStock> engineList = manager.getByNumberList();
+        List<Engine> engineList = manager.getByNumberList();
         Assert.assertEquals("Number of Engines by number", 6, engineList.size());
         Assert.assertEquals("1st engine in list by number", e6, engineList.get(0));
         Assert.assertEquals("2nd engine in list by number", e1, engineList.get(1));
@@ -417,7 +416,7 @@ public class EngineManagerTest extends OperationsTestCase {
         e6.setRfid("B12");
 
         // now get engines by RFID
-        List<RollingStock> engineList = manager.getByRfidList();
+        List<Engine> engineList = manager.getByRfidList();
         Assert.assertEquals("Number of Engines by rfid", 6, engineList.size());
         Assert.assertEquals("1st engine in list by rfid", e2, engineList.get(0));
         Assert.assertEquals("2nd engine in list by rfid", e5, engineList.get(1));
@@ -464,7 +463,7 @@ public class EngineManagerTest extends OperationsTestCase {
 
         EngineManager manager = InstanceManager.getDefault(EngineManager.class);
         // now get engines by model
-        List<RollingStock> engineList = manager.getByModelList();
+        List<Engine> engineList = manager.getByModelList();
         Assert.assertEquals("Number of Engines by type", 6, engineList.size());
         Assert.assertEquals("1st engine in list by type", e3, engineList.get(0));
         Assert.assertEquals("2nd engine in list by type", e4, engineList.get(1));
@@ -512,7 +511,7 @@ public class EngineManagerTest extends OperationsTestCase {
         e6.setLastDate(time); // one year ago.
 
         // now get engines by last move date.
-        List<RollingStock> engineList = manager.getByLastDateList();
+        List<Engine> engineList = manager.getByLastDateList();
         Assert.assertEquals("Number of Engines by last move date", 6, engineList.size());
         Assert.assertEquals("1st engine in list by move date", e6, engineList.get(0));
         Assert.assertEquals("2nd engine in list by move date", e4, engineList.get(1));
@@ -560,7 +559,7 @@ public class EngineManagerTest extends OperationsTestCase {
         e6.setLastDate(time); // one year ago.
 
         // now get engines by last move date.
-        List<RollingStock> engineList = manager.getByLastDateList(manager.getByIdList());
+        List<Engine> engineList = manager.getByLastDateList(manager.getByIdList());
         Assert.assertEquals("Number of Engines by last move date", 6, engineList.size());
         Assert.assertEquals("1st engine in list by move date", e6, engineList.get(0));
         Assert.assertEquals("2nd engine in list by move date", e4, engineList.get(1));
@@ -574,7 +573,7 @@ public class EngineManagerTest extends OperationsTestCase {
         resetEngineManager();
 
         EngineManager manager = InstanceManager.getDefault(EngineManager.class);
-        List<RollingStock> engineList = manager.getList(l1);
+        List<Engine> engineList = manager.getList(l1);
         Assert.assertEquals("Number of Engines at location", 2, engineList.size());
         Assert.assertTrue("e1 in engine list at location", engineList.contains(e1));
         Assert.assertTrue("e2 in engine list at location", engineList.contains(e2));
@@ -586,7 +585,7 @@ public class EngineManagerTest extends OperationsTestCase {
 
         EngineManager manager = InstanceManager.getDefault(EngineManager.class);
         Track l1t1 = l1.getTrackByName("A", Track.SPUR);
-        List<RollingStock> engineList = manager.getList(l1t1);
+        List<Engine> engineList = manager.getList(l1t1);
         Assert.assertEquals("Number of Engines on track", 1, engineList.size());
         Assert.assertTrue("e1 in engine list on track", engineList.contains(e1));
         Assert.assertFalse("e2 not in engine list on track", engineList.contains(e2));

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/EnginesTableFrameTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/EnginesTableFrameTest.java
@@ -8,7 +8,6 @@ import jmri.jmrit.operations.OperationsSwingTestCase;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.locations.Track;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import jmri.jmrit.operations.rollingstock.cars.CarOwners;
 import jmri.jmrit.operations.rollingstock.cars.CarRoads;
 import jmri.jmrit.operations.setup.Setup;
@@ -45,7 +44,7 @@ public class EnginesTableFrameTest extends OperationsSwingTestCase {
         Engine e5 = eManager.getByRoadAndNumber("NH", "5");
 
         // default is sort by number
-        List<RollingStock> Engines = etf.enginesModel.getSelectedEngineList();
+        List<Engine> Engines = etf.enginesModel.getSelectedEngineList();
         Assert.assertEquals("1st Engine in sort by number list", e1.getId(), Engines.get(0).getId());
         Assert.assertEquals("2nd Engine in sort by number list", e4.getId(), Engines.get(1).getId());
         Assert.assertEquals("3rd Engine in sort by number list", e2.getId(), Engines.get(2).getId());

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/XmlTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/XmlTest.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.List;
 import jmri.InstanceManager;
 import jmri.jmrit.operations.OperationsTestCase;
-import jmri.jmrit.operations.rollingstock.RollingStock;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.jdom2.JDOMException;
@@ -30,7 +29,7 @@ public class XmlTest extends OperationsTestCase {
         Assert.assertEquals("OperationsJUnitTestEngineRoster.xml", InstanceManager.getDefault(EngineManagerXml.class).getOperationsFileName());
 
         EngineManager manager = InstanceManager.getDefault(EngineManager.class);
-        List<RollingStock> tempengineList = manager.getByIdList();
+        List<Engine> tempengineList = manager.getByIdList();
 
         Assert.assertEquals("Starting Number of Engines", 0, tempengineList.size());
         Engine e1 = manager.newEngine("CP", "Test Number 1");


### PR DESCRIPTION
Using generics to avoid extensive unconfirmed casting of RollingStock to Car or Engine allows about 100 LOC to be removed and the removal of some FindBugs warning suppression. I think this also makes most Engine/Car handling code easier to read.