### PR TITLE
Allow Jenkins tidy-scan of HTML to focus on one language

### DIFF
--- a/scripts/tidy-scan.sh
+++ b/scripts/tidy-scan.sh
@@ -1,4 +1,11 @@
 #! /bin/bash
-# scan the English help files for HMTL errors, used in Jenkins
+# scan the help files for HMTL errors, used in Jenkins
+# if an argument is provided, i.e. "help/en/*/" scan there, otherwise scan all the help
 
-find help/*/*/ -name \*html -exec echo Filename: {} \; -exec tidy -e -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | tr '<' '&lt;' | tr '>' '&gt;' | awk -f scripts/tidy.awk
+if [[ "$@" == "" ]] ; then
+    WHERE=help/*/*/
+else
+    WHERE=$@
+fi
+
+find ${WHERE} -name \*html -exec echo Filename: {} \; -exec tidy -e -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | tr '<' '&lt;' | tr '>' '&gt;' | awk -f scripts/tidy.awk


### PR DESCRIPTION
The [Jenkins HTML scan](http://jmri.tagadab.com/jenkins/job/Development/job/HTML%20Scan/) uses the scripts/tidy-scan.sh script to do it's scan of HTML contents for issues. 

Originally, this automatically scanned everything, every time.  This change lets you scan just the part of the tree you're working on.  The default, if you provide no argument, remains the entire help tree (also fixes comment about that, which was previously wrong).  

No JMRI runtime effect.