### PR TITLE
Handle non-array results in Javascript

### DIFF
--- a/web/js/main.js
+++ b/web/js/main.js
@@ -14,6 +14,9 @@ function getPanels() {
         url: "/panel?format=json",
         data: {},
         success: function (data) {
+            if (!Array.isArray(data)) {
+                data = [data];
+            }
             $(".navbar-panel-item").remove();
             if (data.length !== 0) {
                 $("#empty-panel-list").addClass("hidden").removeClass("show");
@@ -32,6 +35,9 @@ function getRosterGroups() {
         url: "/json/rosterGroups",
         data: {},
         success: function (data) {
+            if (!Array.isArray(data)) {
+                data = [data];
+            }
             $(".navbar-roster-group-item").remove();
             if (data.length !== 0) {
                 $.each(data, function (index, value) {
@@ -50,6 +56,9 @@ function getNetworkServices() {
         url: "/json/networkServices",
         data: {},
         success: function (data) {
+            if (!Array.isArray(data)) {
+                data = [data];
+            }
             // show all hidden when service is available elements 
             $(".hidden-jmri_jmri-json").addClass("show").removeClass("hidden");
             $(".hidden-jmri_jmri-locormi").addClass("show").removeClass("hidden");


### PR DESCRIPTION
When only a single item is available for a query, that item is returned instead of an array of items. This causes some cosmetic issues in browser consoles.