### PR TITLE
Fix Script Entry warning messages

### DIFF
--- a/java/src/jmri/jmrit/jython/InputWindow.java
+++ b/java/src/jmri/jmrit/jython/InputWindow.java
@@ -191,8 +191,8 @@ public class InputWindow extends JPanel {
                         buf = new char[1024];
                     }
                 }
-
                 area.setText(fileData.toString());
+                results = true;
 
             } catch (IOException e) {
                 log.error("Unhandled problem in loadFile: " + e);
@@ -230,6 +230,7 @@ public class InputWindow extends JPanel {
                 try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
                     writer.append(fileData);
                 }
+                results = true;
 
             } catch (HeadlessException | IOException e) {
                 log.error("Unhandled problem in storeFile: " + e);


### PR DESCRIPTION
The load and store options were displaying file error warnings for successful actions.