### PR TITLE
Fixes startup NPE with openlcb connection

### DIFF
--- a/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
@@ -48,10 +48,14 @@ public class CanSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
             return false;
         }
         if (type.equals(jmri.GlobalProgrammerManager.class)) {
-            return ((jmri.GlobalProgrammerManager) get(jmri.GlobalProgrammerManager.class)).isGlobalProgrammerAvailable();
+            jmri.GlobalProgrammerManager mgr = ((jmri.GlobalProgrammerManager) get(jmri.GlobalProgrammerManager.class));
+            if (mgr == null) return false;
+            return mgr.isGlobalProgrammerAvailable();
         }
         if (type.equals(jmri.AddressedProgrammerManager.class)) {
-            return ((jmri.AddressedProgrammerManager) get(jmri.AddressedProgrammerManager.class)).isAddressedModePossible();
+            jmri.AddressedProgrammerManager mgr =((jmri.AddressedProgrammerManager) get(jmri.AddressedProgrammerManager.class));
+            if (mgr == null) return false;
+            return mgr.isAddressedModePossible();
         }
         return manager.provides(type);
     }


### PR DESCRIPTION
Startup of JMRI since 4.9.5 crashes with an NPE when there is an OpenLCB connection present in the profile.

Stacktrace:
```
2017-10-12 05:42:46,523 ptionhandler.UncaughtExceptionHandler ERROR - Uncaught Exception caught by jmri.util.exceptionhandler.UncaughtExceptionHandler [main]
java.lang.NullPointerException
	at jmri.jmrix.can.CanSystemConnectionMemo.provides(CanSystemConnectionMemo.java:51)
	at jmri.managers.ManagerDefaultSelector.lambda$9(ManagerDefaultSelector.java:340)
	at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1549)
	at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:580)
	at jmri.managers.ManagerDefaultSelector.isPreferencesValid(ManagerDefaultSelector.java:338)
	at jmri.managers.ManagerDefaultSelector.configure(ManagerDefaultSelector.java:252)
	at jmri.managers.ManagerDefaultSelector.initialize(ManagerDefaultSelector.java:289)
	at jmri.implementation.JmriConfigurationManager.initializeProvider(JmriConfigurationManager.java:263)
	at jmri.implementation.JmriConfigurationManager.lambda$3(JmriConfigurationManager.java:259)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1375)
	at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:580)
	at jmri.implementation.JmriConfigurationManager.initializeProvider(JmriConfigurationManager.java:258)
	at jmri.implementation.JmriConfigurationManager.lambda$1(JmriConfigurationManager.java:183)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1375)
	at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:580)
	at jmri.implementation.JmriConfigurationManager.load(JmriConfigurationManager.java:182)
	at jmri.implementation.JmriConfigurationManager.load(JmriConfigurationManager.java:170)
	at apps.Apps.<init>(Apps.java:251)
	at apps.PanelPro.PanelPro.<init>(PanelPro.java:40)
	at apps.PanelPro.PanelPro.main(PanelPro.java:102)
```