### PR TITLE
Fix performance regression in JmriBeanComboBox when loading a panel file

### DIFF
--- a/java/src/jmri/util/swing/DedupingPropertyChangeListener.java
+++ b/java/src/jmri/util/swing/DedupingPropertyChangeListener.java
@@ -16,7 +16,7 @@ import javax.swing.SwingUtilities;
  * guaranteed to be the last call's getNewValue(). Listeners that depend on exact sequencing of
  * oldValue and newValue objects should probably not be wrapped in this class.
  * <p>
- * Created by bracz on 10/14/17.
+ * @author Balazs Racz Copyright (C) 2017
  */
 
 public class DedupingPropertyChangeListener implements PropertyChangeListener {

--- a/java/src/jmri/util/swing/DedupingPropertyChangeListener.java
+++ b/java/src/jmri/util/swing/DedupingPropertyChangeListener.java
@@ -1,0 +1,49 @@
+package jmri.util.swing;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.HashMap;
+
+import javax.swing.SwingUtilities;
+
+/**
+ * Helper class for wrapping a PropertyChangeListener. This wrapper ensures that the events are
+ * dispatched to the target listener only on the swing thread, and collapses multiple events into
+ * a single call.
+ * <p>
+ * The property change events get de-duplicated and only the last one pending is
+ * sent to the listener object; this means that the getOldValue() in the change event is not
+ * guaranteed to be the last call's getNewValue(). Listeners that depend on exact sequencing of
+ * oldValue and newValue objects should probably not be wrapped in this class.
+ * <p>
+ * Created by bracz on 10/14/17.
+ */
+
+public class DedupingPropertyChangeListener implements PropertyChangeListener {
+    public DedupingPropertyChangeListener(PropertyChangeListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public synchronized void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+        String key = propertyChangeEvent.getPropertyName();
+        boolean hasPendingNotify = eventMap.containsKey(key);
+        eventMap.put(key, propertyChangeEvent);
+        if (hasPendingNotify) {
+            return;
+        }
+        SwingUtilities.invokeLater(() -> invokePropertyChange(key));
+    }
+
+    private void invokePropertyChange(String key) {
+        PropertyChangeEvent ev = null;
+        synchronized (this) {
+            ev = eventMap.get(key);
+            eventMap.remove(key);
+        }
+        listener.propertyChange(ev);
+    }
+
+    final PropertyChangeListener listener;
+    final HashMap<String, PropertyChangeEvent> eventMap = new HashMap<>();
+}

--- a/java/src/jmri/util/swing/JmriBeanComboBox.java
+++ b/java/src/jmri/util/swing/JmriBeanComboBox.java
@@ -58,7 +58,7 @@ public class JmriBeanComboBox extends JComboBox<String> implements java.beans.Pr
         _manager = inManager;
         setSelectedBean(inNamedBean);
         //setEditable(true);
-        _manager.addPropertyChangeListener(this);
+        _manager.addPropertyChangeListener(new DedupingPropertyChangeListener(this));
         setKeySelectionManager(new BeanSelectionManager());
 
         //fires when drop down list item is selected

--- a/java/test/jmri/implementation/DoubleTurnoutSignalHeadTest.java
+++ b/java/test/jmri/implementation/DoubleTurnoutSignalHeadTest.java
@@ -15,6 +15,8 @@ import jmri.SignalHead;
 import jmri.Turnout;
 import jmri.TurnoutManager;
 import jmri.util.JUnitUtil;
+import jmri.util.MockPropertyChangeListener;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,24 +29,7 @@ import org.junit.Test;
  */
 public class DoubleTurnoutSignalHeadTest extends AbstractSignalHeadTestBase {
 
-    interface MockablePropertyChangeListener {
-        void onChange(String property, Object newValue);
-    }
-
-    class FakePropertyChangeListener implements PropertyChangeListener {
-        MockablePropertyChangeListener m;
-
-        FakePropertyChangeListener() {
-            m = mock(MockablePropertyChangeListener.class);
-        }
-
-        @Override
-        public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
-            m.onChange(propertyChangeEvent.getPropertyName(), propertyChangeEvent.getNewValue());
-        }
-    }
-
-    protected FakePropertyChangeListener l = new FakePropertyChangeListener();
+    protected MockPropertyChangeListener l = new MockPropertyChangeListener();
 
     @Test
     public void testCTor() {

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutTest.java
@@ -10,6 +10,8 @@ import java.beans.PropertyChangeListener;
 import java.util.regex.Pattern;
 import jmri.Turnout;
 import jmri.jmrix.can.CanMessage;
+import jmri.util.MockPropertyChangeListener;
+
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -26,22 +28,7 @@ import org.slf4j.LoggerFactory;
 public class OlcbTurnoutTest extends TestCase {
     private final static Logger log = LoggerFactory.getLogger(OlcbTurnoutTest.class);
 
-    interface MockablePropertyChangeListener {
-        void onChange(String property, Object newValue);
-    }
-    class FPropertyChangeListener implements PropertyChangeListener {
-        MockablePropertyChangeListener m;
-        FPropertyChangeListener() {
-            m = mock(MockablePropertyChangeListener.class);
-        }
-
-        @Override
-        public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
-            m.onChange(propertyChangeEvent.getPropertyName(), propertyChangeEvent.getNewValue());
-        }
-    }
-
-    protected FPropertyChangeListener l = new FPropertyChangeListener();
+    protected MockPropertyChangeListener l = new MockPropertyChangeListener();
 
     private static final String COMMANDED_STATE = "CommandedState";
     private static final String KNOWN_STATE = "KnownState";

--- a/java/test/jmri/swing/PackageTest.java
+++ b/java/test/jmri/swing/PackageTest.java
@@ -4,6 +4,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import jmri.util.swing.DedupingPropertyChangeListenerTest;
+
 /**
  * Invokes complete set of tests in the jmri.swing tree
  *
@@ -19,7 +21,8 @@ import org.junit.runners.Suite.SuiteClasses;
     DefaultEditableListModelTest.class,
     RowSorterUtilTest.class,
     JTitledSeparatorTest.class,
-    DefaultListCellEditorTest.class
+    DefaultListCellEditorTest.class,
+    DedupingPropertyChangeListenerTest.class
 })
 public class PackageTest {
 }

--- a/java/test/jmri/util/MockPropertyChangeListener.java
+++ b/java/test/jmri/util/MockPropertyChangeListener.java
@@ -1,0 +1,29 @@
+package jmri.util;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test utility class that allows running Mockito verifications for beans PropertyChange events.
+ * <p>
+ * @author Balazs Racz Copyright (C) 2017
+ */
+
+public class MockPropertyChangeListener implements PropertyChangeListener {
+    public interface MockInterface {
+        void onChange(String property, Object newValue);
+    }
+
+    public MockInterface m;
+
+    public MockPropertyChangeListener() {
+        m = mock(MockInterface.class);
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+        m.onChange(propertyChangeEvent.getPropertyName(), propertyChangeEvent.getNewValue());
+    }
+}

--- a/java/test/jmri/util/swing/DedupingPropertyChangeListenerTest.java
+++ b/java/test/jmri/util/swing/DedupingPropertyChangeListenerTest.java
@@ -4,14 +4,30 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.beans.PropertyChangeSupport;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Semaphore;
+
+import javax.swing.SwingUtilities;
+
 import jmri.util.JUnitUtil;
+import jmri.util.MockPropertyChangeListener;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
- * Created by bracz on 10/14/17.
+ * @author Balazs Racz Copyright (C) 2017
  */
 public class DedupingPropertyChangeListenerTest {
+    PropertyChangeSupport source = new PropertyChangeSupport(this);
+    MockPropertyChangeListener l = new MockPropertyChangeListener();
+
+    Semaphore semaphore = new Semaphore(1);
+
     @Before
     public void setUp() throws Exception {
         JUnitUtil.setUp();
@@ -22,9 +38,97 @@ public class DedupingPropertyChangeListenerTest {
         JUnitUtil.tearDown();
     }
 
-    @Test
-    public void propertyChange() throws Exception {
+    /// Blocks the calling thread until the swing thread drains its entire queue.
+    private void waitForEventThread() throws Exception {
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+            }
+        });
+    }
 
+    /// Blocks the swing execution thread, ensuring that no new work enqueued can be executed
+    /// until releaseEventThread is called.
+    private void blockEventThread() throws Exception {
+        semaphore.acquire();
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    semaphore.acquire();
+                } catch (InterruptedException e) {
+                } finally {
+                    semaphore.release();
+                }
+            }
+        });
+    }
+
+    /// Undoes the effect of blockEventThread and waits for all queued callbacks to execute.
+    private void releaseEventThread() throws Exception {
+        semaphore.release();
+        waitForEventThread();
+    }
+
+    @Test
+    public void testSimplePropertyChange() throws Exception {
+        source.addPropertyChangeListener(new DedupingPropertyChangeListener(l));
+        source.firePropertyChange("test", null, 42);
+        waitForEventThread();
+        verify(l.m).onChange("test", 42);
+    }
+
+    @Test
+    public void testMultipleSequentialPropertyChange() throws Exception {
+        source.addPropertyChangeListener(new DedupingPropertyChangeListener(l));
+        source.firePropertyChange("test", null, 42);
+        waitForEventThread();
+        source.firePropertyChange("test", null, 43);
+        waitForEventThread();
+        source.firePropertyChange("test", null, 44);
+        waitForEventThread();
+        verify(l.m).onChange("test", 42);
+        verify(l.m).onChange("test", 43);
+        verify(l.m).onChange("test", 44);
+        verifyNoMoreInteractions(l.m);
+    }
+
+    @Test
+    public void testMultipleIdenticalPropertyChange() throws Exception {
+        source.addPropertyChangeListener(new DedupingPropertyChangeListener(l));
+        source.firePropertyChange("test", null, 42);
+        waitForEventThread();
+        source.firePropertyChange("test", null, 42);
+        waitForEventThread();
+        source.firePropertyChange("test", null, 42);
+        waitForEventThread();
+        verify(l.m, times(3)).onChange("test", 42);
+        verifyNoMoreInteractions(l.m);
+    }
+
+    @Test
+    public void testCollapseIdenticalPropertyChange() throws Exception {
+        source.addPropertyChangeListener(new DedupingPropertyChangeListener(l));
+        blockEventThread();
+        source.firePropertyChange("test", null, 42);
+        source.firePropertyChange("test", null, 44);
+        source.firePropertyChange("test", null, 43);
+        releaseEventThread();
+        verify(l.m, times(1)).onChange("test", 43);
+        verifyNoMoreInteractions(l.m);
+    }
+
+    @Test
+    public void testNoCollapseDifferentPropertyChange() throws Exception {
+        source.addPropertyChangeListener(new DedupingPropertyChangeListener(l));
+        blockEventThread();
+        source.firePropertyChange("testx", null, 42);
+        source.firePropertyChange("testy", null, 44);
+        source.firePropertyChange("testx", null, 43);
+        releaseEventThread();
+        verify(l.m, times(1)).onChange("testx", 43);
+        verify(l.m, times(1)).onChange("testy", 44);
+        verifyNoMoreInteractions(l.m);
     }
 
 }

--- a/java/test/jmri/util/swing/DedupingPropertyChangeListenerTest.java
+++ b/java/test/jmri/util/swing/DedupingPropertyChangeListenerTest.java
@@ -1,0 +1,30 @@
+package jmri.util.swing;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import jmri.util.JUnitUtil;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by bracz on 10/14/17.
+ */
+public class DedupingPropertyChangeListenerTest {
+    @Before
+    public void setUp() throws Exception {
+        JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        JUnitUtil.tearDown();
+    }
+
+    @Test
+    public void propertyChange() throws Exception {
+
+    }
+
+}


### PR DESCRIPTION
Ensures that during a panel file load there is only one PropertyChangeNotification delivered to the JmriBeanComboBox object, instead of one after each object created. This reduces cost incurred from O(N^2 log N) to O(N log N).

Refactors some helper classes for testing PropertyChangeListener features.