### PR TITLE
WIP: LocoNet throttle acquire improvements

### DIFF
--- a/java/src/jmri/jmrix/loconet/LocoNetSlot.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSlot.java
@@ -56,6 +56,7 @@ public class LocoNetSlot {
      * {@link LnConstants#LOCO_IDLE},
      * {@link LnConstants#LOCO_COMMON},
      * {@link LnConstants#LOCO_FREE}
+     * @return int containing only Slot Status (busy, active) bits of status byte
      */
     public int slotStatus() {
         return stat & LnConstants.LOCOSTAT_MASK;
@@ -71,6 +72,7 @@ public class LocoNetSlot {
      * {@link LnConstants#CONSIST_TOP},
      * {@link LnConstants#CONSIST_MID},
      * {@link LnConstants#CONSIST_SUB}
+     * @return int containing only consisting bits of status byte
      */
     public int consistStatus() {
         return stat & LnConstants.CONSIST_MASK;


### PR DESCRIPTION
Attempt to improve LocoNet throttle acquisition process.

Should address issues #4263, #4225.

- Re-factored slot write of ThrottleID to be done after setting the slot "in-use".
- Removed use of Thread.sleep() which was blocking thread AWT-EventQueue