### PR TITLE
WIP: update LocoNet throttle acquire dispatch process

### DIFF
--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.loconet;
 
-import java.util.ArrayList;
 import java.util.Hashtable;
 import jmri.DccLocoAddress;
 import jmri.DccThrottle;
@@ -98,7 +97,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
         retrySetupThread.start();
         waitingForNotification.put(address.getNumber(), retrySetupThread);
     }
-
+    
     volatile Thread retrySetupThread;
     
     Hashtable<Integer, Thread> waitingForNotification = new Hashtable<Integer, Thread>(5);
@@ -152,7 +151,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
                 slotForAddress.put(s.locoAddr(),s);
                 notifyStealRequest(s.locoAddr());
                 return;
-            }
+            } 
         }
         if ((s.consistStatus() == LnConstants.CONSIST_MID) ||
                 (s.consistStatus() == LnConstants.CONSIST_SUB)) {
@@ -167,14 +166,6 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
     }
 
     private void commitToAcquireThrottle(LocoNetSlot s) {
-        tc.sendLocoNetMessage(s.writeThrottleID(throttleID));
-        try {
-            Thread.sleep(60);   // temporary attempt to resolve DCS51 problem acquiring locos.
-        } catch (InterruptedException ex) {
-            log.warn("Interrupted exception during throttle acquire wait:{}",ex);
-        }
-        log.debug("Attempting to update slot with this JMRI instance's throttle id ({})", throttleID);
-
         // haven't identified a particular reason to refuse throttle acquisition at this time...
         DccThrottle throttle = createThrottle((LocoNetSystemConnectionMemo) adapterMemo, s);
         s.notifySlotListeners();    // make sure other listeners for this slot know about what's going on!
@@ -218,10 +209,6 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             }
             Thread thr = new Thread(new InformRejection( address, cause));
             thr.start();
-
-            
-            
-            
         }
         
     }
@@ -281,20 +268,39 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
     @Override
     public void dispatchThrottle(DccThrottle t, ThrottleListener l) {
         log.debug("dispatchThrottle - throttle {}", t.getLocoAddress());
-        // set status to common
         if (t instanceof LocoNetThrottle){
             LocoNetThrottle lnt = (LocoNetThrottle) t;
             LocoNetSlot tSlot = lnt.getLocoNetSlot();
 
+            // set status to idle
             tc.sendLocoNetMessage(
-                    tSlot.writeStatus(LnConstants.LOCO_COMMON));
+                    tSlot.writeStatus(LnConstants.LOCO_IDLE));
 
             // and dispatch to slot 0
             tc.sendLocoNetMessage(tSlot.dispatchSlot());
         }
-        super.releaseThrottle(t, l);
-    }
+        setupDispatchDelay(t, l);
 
+    }
+    
+    private void finishTheDispatch(DccThrottle t, ThrottleListener l) {
+        super.dispatchThrottle(t,l);
+    }
+    javax.swing.Timer delayedDispatch = null;
+
+    private void setupDispatchDelay(DccThrottle t, ThrottleListener l) {
+        delayedDispatch = new javax.swing.Timer(200, new java.awt.event.ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent e) {
+                log.debug("delayed throttle dispatch timer triggered.");
+            delayedDispatch.stop();
+            finishTheDispatch(t,l);
+            }
+        });
+        delayedDispatch.setRepeats(false);
+        delayedDispatch.start();
+
+    }
     @Override
     public void releaseThrottle(DccThrottle t, ThrottleListener l) {
         log.debug("releaseThrottle - throttle {}", t.getLocoAddress());
@@ -302,8 +308,10 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             LocoNetThrottle lnt = (LocoNetThrottle) t;
             LocoNetSlot tSlot = lnt.getLocoNetSlot();
             if (tSlot != null) {
-                tc.sendLocoNetMessage(
-                        tSlot.writeStatus(LnConstants.LOCO_COMMON));
+                if (tSlot.slotStatus() == LnConstants.LOCO_IN_USE) {
+                    tc.sendLocoNetMessage(
+                            tSlot.writeStatus(LnConstants.LOCO_COMMON));
+                }
             }
         }
         super.releaseThrottle(t, l);

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -33,6 +33,8 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
         this.tc = memo.getLnTrafficController();
         slotForAddress = new Hashtable<>();
         throttleRequests = new java.util.HashSet<>(5);
+        waitingForNotification = new java.util.ArrayList<>();
+        waitingForNotification.add(-999999); // make sure ArrayList isn't empty.
     }
 
     /**
@@ -101,15 +103,12 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
         log.debug("beginThrottleRequest- beginning actual acquisition of loco address {}", address);
         
         slotManager.slotFromLocoAddress(address, this);  //first try
-
-        setupRetryThread(new DccLocoAddress(address, isLongAddress(address)), this);
-       
-        waitingForNotification.put(address, retrySetupThread);
+        
+        setupRetryTimer();
+        waitingForNotification.add(address);
     }
 
-    volatile Thread retrySetupThread;
-
-    Hashtable<Integer, Thread> waitingForNotification = new Hashtable<Integer, Thread>(5);
+    java.util.ArrayList<Integer> waitingForNotification = null;
 
     /**
      * LocoNet does have a Dispatch function
@@ -148,7 +147,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             return;
         }
         
-        if (waitingForNotification.containsKey(s.locoAddr())) {
+        if (waitingForNotification.contains(s.locoAddr())) {
             // This is invoked only if the SlotManager knows that the LnThrottleManager is
             // interested in the address associated with this slot.
             
@@ -192,7 +191,9 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
                     log.debug("notifyChangedSlot for slot {} address {} is being sent to 'commitToAcquireThrottle'", s.getSlot(), s.locoAddr());
                     commitToAcquireThrottle(s);
                     log.debug("deleting entry in waitingForNotification for address {}", s.locoAddr());
-                    waitingForNotification.remove(s.locoAddr());
+                    if (waitingForNotification.contains(s.locoAddr())) {
+                        waitingForNotification.remove(waitingForNotification.indexOf(s.locoAddr()));
+                    }
                     inProgressThrottleAddress = -1;
                     removeThrottleRequestEntry(s.locoAddr());
                 }
@@ -213,7 +214,9 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
                         s.getSlot(), s.locoAddr());
                 // notify the LnThrottleManager about failure of acquisition.
                 notifyRefused(s.locoAddr(), "Locomotive burried in a consist cannot be acquired.");
-                waitingForNotification.remove(s.locoAddr());
+                if (waitingForNotification.contains(s.locoAddr())) {
+                    waitingForNotification.remove(waitingForNotification.indexOf(s.locoAddr()));
+                }
                 inProgressThrottleAddress = -1;
                 removeThrottleRequestEntry(s.locoAddr());
                 return;
@@ -226,16 +229,20 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
 
     private void commitToAcquireThrottle(LocoNetSlot s) {
         // haven't identified a particular reason to refuse throttle acquisition at this time...
-        if (waitingForNotification.containsKey(s.locoAddr())) {
+        if (waitingForNotification.contains(s.locoAddr())) {
             if (s.slotStatus() == LnConstants.LOCO_IN_USE ) {
                 DccThrottle throttle = createThrottle((LocoNetSystemConnectionMemo) adapterMemo, s);
                 s.notifySlotListeners();    // make sure other listeners for this slot know about what's going on!
                 log.debug("Notifying throttle user of concrete throttle for address {}", s.locoAddr());
                 notifyThrottleKnown(throttle, new DccLocoAddress(s.locoAddr(), isLongAddress(s.locoAddr())));
-                //end the waiting thread since we got a response
+                //end the retry timer since we got a response
                 log.debug("LnThrottleManager.commitToAcquireThrottle() - removing throttle acquisition notification flagging for address {}", s.locoAddr() );
-                waitingForNotification.get(s.locoAddr()).interrupt();
-                waitingForNotification.remove(s.locoAddr());
+                if (waitingForNotification.contains(s.locoAddr())) {
+                    waitingForNotification.remove(waitingForNotification.indexOf(s.locoAddr()));
+                }
+                inProgressThrottleAddress = -1;
+                retryDelayTimer.stop();
+
             } else {
                 log.debug("performing NULL MOVE for for slot {} address {}", s.getSlot(), s.locoAddr());
                 LocoNetMessage m = new LocoNetMessage(4);
@@ -252,10 +259,11 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
 
     public void notifyRefused(int address, String cause) {
         //end the waiting thread since we got a failure response
-        if (waitingForNotification.containsKey(address)) {
-            waitingForNotification.get(address).interrupt();
-            waitingForNotification.remove(address);
-            // notify the throttle - in some other thread!
+        if (waitingForNotification.contains(address)) {
+            waitingForNotification.remove(waitingForNotification.indexOf(address));
+            inProgressThrottleAddress = -1;
+            retryDelayTimer.stop();
+            // notify the User's throttle object, via some other thread!
 
             class InformRejection implements Runnable {
                 // inform the throttle from a new thread, so that
@@ -403,9 +411,11 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
         super.failedThrottleRequest(address, reason);
         log.debug("failedThrottleRequest - address {}, reason {}", address, reason);
         //now end and remove any waiting thread
-        if (waitingForNotification.containsKey(address.getNumber())) {
-            waitingForNotification.get(address.getNumber()).interrupt();
-            waitingForNotification.remove(address.getNumber());
+        if (waitingForNotification.contains(address.getNumber())) {
+            log.debug("going to remove item {} from waitingForNotification", address.getNumber());
+            waitingForNotification.remove(waitingForNotification.indexOf(address.getNumber()));
+            inProgressThrottleAddress = -1;
+            retryDelayTimer.stop();
         }
         inProgressThrottleAddress = -1;
         removeThrottleRequestEntry(address.getNumber());
@@ -425,9 +435,10 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
     public void cancelThrottleRequest(int address, boolean isLong, ThrottleListener l) {
         super.cancelThrottleRequest(address, isLong, l);
         log.debug("cancelThrottleRequest - address {}", address);
-        if (waitingForNotification.containsKey(address)) {
-            waitingForNotification.get(address).interrupt();
-            waitingForNotification.remove(address);
+        if (waitingForNotification.contains(address)) {
+            waitingForNotification.remove(waitingForNotification.indexOf(address));
+            inProgressThrottleAddress = -1;
+            retryDelayTimer.stop();
         }
         inProgressThrottleAddress = -1;
         removeThrottleRequestEntry(address);
@@ -438,14 +449,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
      * Dispose of this manager, typically for testing
      */
     void dispose() {
-        if (retrySetupThread != null) {
-            try {
-                retrySetupThread.interrupt();
-                retrySetupThread.join();
-            } catch (InterruptedException ex) {
-                log.warn("dispose interrupted");
-            }
-        }
+        retryDelayTimer.stop();
     }
 
     /**
@@ -464,16 +468,11 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
      * @param locoAddr address of DCC loco or consist
      */
     public void notifyStealRequest(int locoAddr) {
-        // first, stop the retry timer thread - don't want it running while waiting 
+        // first, stop the retry timer - don't want it running while waiting 
         // for the user input!
-        retrySetupThread.interrupt();
-        try {
-            retrySetupThread.join();
-        } catch (InterruptedException ex) {
-            log.debug("InterruptedException happened while killing the retry thread; this is to be ignored.");
-        }
+            retryDelayTimer.stop();
 
-        if (waitingForNotification.containsKey(locoAddr)) {
+        if (waitingForNotification.contains(locoAddr)) {
             notifyStealRequest(new DccLocoAddress(locoAddr, isLongAddress(locoAddr)));
         }
     }
@@ -501,50 +500,24 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             failedThrottleRequest(address, "User chose not to 'steal' the throttle.");
        } else {
            log.warn("user agreed to steal address {}, but no code is in-place to handle the 'steal' (yet)",address.getNumber());
-           setupRetryThread(address, this);
+           retryDelayTimer.restart();
         commitToAcquireThrottle(slotForAddress.get(address.getNumber()));
        }
     }
 
-    private void setupRetryThread(DccLocoAddress address, SlotListener listen) {
-        log.debug("setupRetryThread - setting up retry thread for address {}", address.getNumber());
-        retrySetupThread = new Thread(new RetrySetup(address, listen));
-        retrySetupThread.setName("LnThrottleManager RetrySetup "+address);
-        retrySetupThread.start();
+    javax.swing.Timer retryDelayTimer = null;
+    private void setupRetryTimer() {
+
+        retryDelayTimer = new javax.swing.Timer(1000, new java.awt.event.ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent e) {
+                log.debug("Retry Timer triggered.");
+                tryBeginNextThrottleRequest();
+            }
+        });
+        retryDelayTimer.setRepeats(true);
+        retryDelayTimer.start();
     }
     
-    private class RetrySetup implements Runnable {  //setup for retries and failure check
-
-        DccLocoAddress address;
-        SlotListener list;
-
-        RetrySetup(DccLocoAddress address, SlotListener list) {
-            this.address = address;
-            this.list = list;
-        }
-
-        @Override
-        public void run() {
-            int attempts = 1;  //already tried once above
-            int maxAttempts = 10;
-            while (attempts <= maxAttempts) {
-                try {
-                    Thread.sleep(1000);  //wait one second
-                } catch (InterruptedException ex) {
-                    log.debug("ending because interrupted");
-                    return;  //stop waiting if slot is found or error occurs
-                }
-                String msg = "No response to slot request for {}, attempt {}"; // NOI18N
-                if (attempts < maxAttempts) {
-                    slotManager.slotFromLocoAddress(address.getNumber(), list);
-                    msg += ", trying again."; // NOI18N
-                }
-                log.debug(msg, address, attempts);
-                attempts++;
-            }
-            log.error("No response to slot request for {} after {} attempts.", address, attempts - 1); // NOI18N
-            failedThrottleRequest(address, "Failed to get response from command station");
-        }
-    }
     private final static Logger log = LoggerFactory.getLogger(LnThrottleManager.class);
 }

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -167,7 +167,12 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
     }
 
     private void commitToAcquireThrottle(LocoNetSlot s) {
-                tc.sendLocoNetMessage(s.writeThrottleID(throttleID));
+        tc.sendLocoNetMessage(s.writeThrottleID(throttleID));
+        try {
+            Thread.sleep(60);   // temporary attempt to resolve DCS51 problem acquiring locos.
+        } catch (InterruptedException ex) {
+            log.warn("Interrupted exception during throttle acquire wait:{}",ex);
+        }
         log.debug("Attempting to update slot with this JMRI instance's throttle id ({})", throttleID);
 
         // haven't identified a particular reason to refuse throttle acquisition at this time...

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -89,19 +89,19 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
                 failedThrottleRequest(address, "Failed to get response from command station");
             }
         }
-        
+
         retrySetupThread = new Thread(
-                new RetrySetup(new DccLocoAddress(address.getNumber(), 
+                new RetrySetup(new DccLocoAddress(address.getNumber(),
                         isLongAddress(address.getNumber())), this));
         retrySetupThread.setName("LnThrottleManager RetrySetup "+address);
         retrySetupThread.start();
         waitingForNotification.put(address.getNumber(), retrySetupThread);
     }
-    
+
     volatile Thread retrySetupThread;
-    
+
     Hashtable<Integer, Thread> waitingForNotification = new Hashtable<Integer, Thread>(5);
-    
+
     Hashtable<Integer, LocoNetSlot> slotForAddress;
 
     /**
@@ -134,28 +134,28 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
     @Override
     public void notifyChangedSlot(LocoNetSlot s) {
         log.debug("notifyChangedSlot - slot {}, slotStatus {}", s.getSlot(), Integer.toHexString(s.slotStatus()));
-        // This is invoked only if the SlotManager knows that the LnThrottleManager is 
+        // This is invoked only if the SlotManager knows that the LnThrottleManager is
         // interested in the address associated with this slot.
-                
+
         // need to check to see if the slot is in a suitable state for creating a throttle.
         if (s.slotStatus() == LnConstants.LOCO_IN_USE) {
-            // loco is already in-use or is consist-mid or consist-sub 
+            // loco is already in-use or is consist-mid or consist-sub
             log.warn("slot {} address {} is  already in-use.",
                     s.getSlot(), s.locoAddr());
             // is the throttle ID the same as for this JMRI instance?  If not, do not accept the slot.
             if (s.id() != throttleID) {
                 // notify the LnThrottleManager about failure of acquisition.
                 // NEED TO TRIGGER THE NEW "STEAL REQUIRED" FUNCITONALITY HERE
-                //note: throttle listener expects to have "callback" method notifyStealThrottleRequired 
+                //note: throttle listener expects to have "callback" method notifyStealThrottleRequired
                 //invoked if a "steal" is required.  Make that happen as part of the "acquisition" process
                 slotForAddress.put(s.locoAddr(),s);
                 notifyStealRequest(s.locoAddr());
                 return;
-            } 
+            }
         }
         if ((s.consistStatus() == LnConstants.CONSIST_MID) ||
                 (s.consistStatus() == LnConstants.CONSIST_SUB)) {
-            // cannot acquire loco account is consist-mid or consist-sub 
+            // cannot acquire loco account is consist-mid or consist-sub
             log.warn("slot {} address {} cannot be acquired for loco control account already in-use, consist-mid or consist-sub.",
                     s.getSlot(), s.locoAddr());
             // notify the LnThrottleManager about failure of acquisition.
@@ -180,17 +180,17 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             log.debug("LnThrottleManager.notifyChangedSlot() - ignoring slot notification for slot {}, address {} account not attempting to acquire that address", s.getSlot(), s.locoAddr() );
         }
     }
-    
+
     public void notifyRefused(int address, String cause) {
         //end the waiting thread since we got a failure response
         if (waitingForNotification.containsKey(address)) {
             waitingForNotification.get(address).interrupt();
             waitingForNotification.remove(address);
             // notify the throttle - in some other thread!
-            
-            class InformRejection implements Runnable {  
+
+            class InformRejection implements Runnable {
                 // inform the throttle from a new thread, so that
-                // the modal dialog box doesn't block other LocoNet 
+                // the modal dialog box doesn't block other LocoNet
                 // message handling
 
                 int address;
@@ -202,7 +202,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
                 }
 
                 public void run() {
-                    
+
                     log.debug("New thread launched to inform throttle user of failure to acquire loco {} - {}", address, cause);
                     failedThrottleRequest(new DccLocoAddress(address, isLongAddress(address)), cause);
                 }
@@ -210,9 +210,9 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             Thread thr = new Thread(new InformRejection( address, cause));
             thr.start();
         }
-        
+
     }
-    
+
 
     DccThrottle createThrottle(LocoNetSystemConnectionMemo memo, LocoNetSlot s) {
         log.debug("createThrottle: slot {}", s.getSlot());
@@ -273,9 +273,9 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             LocoNetSlot tSlot = lnt.getLocoNetSlot();
 
             // set status to idle
-            // Note: the DT400 throttle marks slot "Idle" when the user 
+            // Note: the DT400 throttle marks slot "Idle" when the user
             // "DISP"atches a locomotive
-            
+
             tc.sendLocoNetMessage(
                     tSlot.writeStatus(LnConstants.LOCO_IDLE));
 
@@ -285,7 +285,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
         setupDispatchDelay(t, l);
 
     }
-    
+
     private void finishTheDispatch(DccThrottle t, ThrottleListener l) {
         super.dispatchThrottle(t,l);
     }
@@ -294,7 +294,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
     private void setupDispatchDelay(DccThrottle t, ThrottleListener l) {
         delayedDispatch = new javax.swing.Timer(200, new java.awt.event.ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) { 
+            public void actionPerformed(java.awt.event.ActionEvent e) {
                 log.debug("delayed throttle dispatch timer triggered.");
             delayedDispatch.stop();
             finishTheDispatch(t,l);
@@ -313,9 +313,9 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             if (tSlot != null) {
                 if (tSlot.slotStatus() == LnConstants.LOCO_IN_USE) {
                     // set status to Common
-                    // Note: the DT400 throttle marks slot "Common" when the user 
+                    // Note: the DT400 throttle marks slot "Common" when the user
                     // "EXIT"s a locomotive
-            
+
                     tc.sendLocoNetMessage(
                             tSlot.writeStatus(LnConstants.LOCO_COMMON));
                 }
@@ -343,7 +343,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
      *                address.
      * @param l       The ThrottleListener cancelling request for a throttle.
      */
-    
+
     @Override
     public void cancelThrottleRequest(int address, boolean isLong, ThrottleListener l) {
         super.cancelThrottleRequest(address, isLong, l);
@@ -368,46 +368,46 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             }
         }
     }
-    
+
     /**
-     * Inform the requesting throttle object (not the connection-specific throttle 
-     * implementation!)  that the address is in-use and the throttle user may 
-     * either choose to "steal" the address, or quit the acquisition process.  
-     * The LocoNet acquisition process "retry" timer is stopped as part of this 
+     * Inform the requesting throttle object (not the connection-specific throttle
+     * implementation!)  that the address is in-use and the throttle user may
+     * either choose to "steal" the address, or quit the acquisition process.
+     * The LocoNet acquisition process "retry" timer is stopped as part of this
      * process, since a positive response has been received from the command station
      * and since user intervention is required.
      *
-     * Reminder: for LocoNet throttles which are not using "expanded slot" 
+     * Reminder: for LocoNet throttles which are not using "expanded slot"
      * functionality, "steal" really means "share".  For those LocoNet throttles
-     * which are using "expanded slots", "steal" really means take control and 
+     * which are using "expanded slots", "steal" really means take control and
      * let the command station issue a "StealZap" LocoNet message to the other throttle.
      *
-     * @param locoAddr address of DCC loco or consist   
+     * @param locoAddr address of DCC loco or consist
      */
     public void notifyStealRequest(int locoAddr) {
         // need to find the "throttleListener" associated with the request for locoAddr, and
-        // send that "throttleListener" a notification that the command station needs 
+        // send that "throttleListener" a notification that the command station needs
         // permission to "steal" the loco address.
         if (waitingForNotification.containsKey(locoAddr)) {
             waitingForNotification.get(locoAddr).interrupt();
             waitingForNotification.remove(locoAddr);
 
             notifyStealRequest(new DccLocoAddress(locoAddr, isLongAddress(locoAddr)));
-        }   
+        }
     }
 
     /**
      * Perform the actual "Steal" of the requested throttle.
      * <p>
-     * This is a call-back, as a result of the throttle user's agreement to 
+     * This is a call-back, as a result of the throttle user's agreement to
      * "steal" the locomotive.
      * <p>
-     * Reminder: for LocoNet throttles which are not using "expanded slot" 
+     * Reminder: for LocoNet throttles which are not using "expanded slot"
      * functionality, "steal" really means "share".  For those LocoNet throttles
-     * which are using "expanded slots", "steal" really means "force any other 
+     * which are using "expanded slots", "steal" really means "force any other
      * throttle running that address to drop the loco".
      * <p>
-     * @param address desired DccLocoAddress 
+     * @param address desired DccLocoAddress
      * @param l  ThrottleListener requesting the throttle steal occur.
      * @param steal true if the request should continue, false otherwise.
      * @since 4.9.2
@@ -421,7 +421,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
            log.warn("user agreed to steal address {}, but no code is in-place to handle the 'steal' (yet)",address.getNumber());
         commitToAcquireThrottle(slotForAddress.get(address.getNumber()));
        }
-    }   
+    }
 
     private final static Logger log = LoggerFactory.getLogger(LnThrottleManager.class);
 }

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -177,7 +177,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             // need to check to see if the slot is in a suitable state for creating a throttle.
             if (s.slotStatus() == LnConstants.LOCO_IN_USE) {
                 // loco is already in-use or is consist-mid or consist-sub
-                log.warn("notifyChangedSlot: slot is marked as 'in-use' for slot {} address {}", s.getSlot(), s.locoAddr());
+                log.debug("notifyChangedSlot: slot is marked as 'in-use' for slot {} address {}", s.getSlot(), s.locoAddr());
                 // is the throttle ID the same as for this JMRI instance?  If not, do not accept the slot.
                 if ((s.id() != throttleID) && (s.id() != 0)) {
                     // notify the LnThrottleManager about failure of acquisition.
@@ -473,9 +473,6 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             log.debug("InterruptedException happened while killing the retry thread; this is to be ignored.");
         }
 
-        // need to find the "throttleListener" associated with the request for locoAddr, and
-        // send that "throttleListener" a notification that the command station needs
-        // permission to "steal" the loco address.
         if (waitingForNotification.containsKey(locoAddr)) {
             notifyStealRequest(new DccLocoAddress(locoAddr, isLongAddress(locoAddr)));
         }

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -141,6 +141,8 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             // NOTE: NEED TO REMOVE duplicate slot numbers from slotForAddress 
             // before adding this slot, to prevent a single slot from being inaccurately 
             // associated with multiple different loco addresses.
+            // Note that the command station may "change to a different slot number" 
+            // during the loco acquire process.
             log.debug("notifychangedSlot - is waiting on notifications from {}", s.locoAddr());
 
             java.util.Enumeration keySet = slotForAddress.keys();
@@ -434,9 +436,6 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
         // send that "throttleListener" a notification that the command station needs
         // permission to "steal" the loco address.
         if (waitingForNotification.containsKey(locoAddr)) {
-            waitingForNotification.get(locoAddr).interrupt();
-            waitingForNotification.remove(locoAddr);
-
             notifyStealRequest(new DccLocoAddress(locoAddr, isLongAddress(locoAddr)));
         }
     }

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.loconet;
 
-import java.util.ArrayList;
 import java.util.Hashtable;
 import jmri.DccLocoAddress;
 import jmri.DccThrottle;
@@ -98,7 +97,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
         retrySetupThread.start();
         waitingForNotification.put(address.getNumber(), retrySetupThread);
     }
-
+    
     volatile Thread retrySetupThread;
     
     Hashtable<Integer, Thread> waitingForNotification = new Hashtable<Integer, Thread>(5);
@@ -152,7 +151,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
                 slotForAddress.put(s.locoAddr(),s);
                 notifyStealRequest(s.locoAddr());
                 return;
-            }
+            } 
         }
         if ((s.consistStatus() == LnConstants.CONSIST_MID) ||
                 (s.consistStatus() == LnConstants.CONSIST_SUB)) {
@@ -167,14 +166,6 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
     }
 
     private void commitToAcquireThrottle(LocoNetSlot s) {
-        tc.sendLocoNetMessage(s.writeThrottleID(throttleID));
-        try {
-            Thread.sleep(60);   // temporary attempt to resolve DCS51 problem acquiring locos.
-        } catch (InterruptedException ex) {
-            log.warn("Interrupted exception during throttle acquire wait:{}",ex);
-        }
-        log.debug("Attempting to update slot with this JMRI instance's throttle id ({})", throttleID);
-
         // haven't identified a particular reason to refuse throttle acquisition at this time...
         DccThrottle throttle = createThrottle((LocoNetSystemConnectionMemo) adapterMemo, s);
         s.notifySlotListeners();    // make sure other listeners for this slot know about what's going on!
@@ -218,10 +209,6 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             }
             Thread thr = new Thread(new InformRejection( address, cause));
             thr.start();
-
-            
-            
-            
         }
         
     }
@@ -281,20 +268,42 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
     @Override
     public void dispatchThrottle(DccThrottle t, ThrottleListener l) {
         log.debug("dispatchThrottle - throttle {}", t.getLocoAddress());
-        // set status to common
         if (t instanceof LocoNetThrottle){
             LocoNetThrottle lnt = (LocoNetThrottle) t;
             LocoNetSlot tSlot = lnt.getLocoNetSlot();
 
+            // set status to idle
+            // Note: the DT400 throttle marks slot "Idle" when the user 
+            // "DISP"atches a locomotive
+            
             tc.sendLocoNetMessage(
-                    tSlot.writeStatus(LnConstants.LOCO_COMMON));
+                    tSlot.writeStatus(LnConstants.LOCO_IDLE));
 
             // and dispatch to slot 0
             tc.sendLocoNetMessage(tSlot.dispatchSlot());
         }
-        super.releaseThrottle(t, l);
-    }
+        setupDispatchDelay(t, l);
 
+    }
+    
+    private void finishTheDispatch(DccThrottle t, ThrottleListener l) {
+        super.dispatchThrottle(t,l);
+    }
+    javax.swing.Timer delayedDispatch = null;
+
+    private void setupDispatchDelay(DccThrottle t, ThrottleListener l) {
+        delayedDispatch = new javax.swing.Timer(200, new java.awt.event.ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent e) { 
+                log.debug("delayed throttle dispatch timer triggered.");
+            delayedDispatch.stop();
+            finishTheDispatch(t,l);
+            }
+        });
+        delayedDispatch.setRepeats(false);
+        delayedDispatch.start();
+
+    }
     @Override
     public void releaseThrottle(DccThrottle t, ThrottleListener l) {
         log.debug("releaseThrottle - throttle {}", t.getLocoAddress());
@@ -302,8 +311,14 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
             LocoNetThrottle lnt = (LocoNetThrottle) t;
             LocoNetSlot tSlot = lnt.getLocoNetSlot();
             if (tSlot != null) {
-                tc.sendLocoNetMessage(
-                        tSlot.writeStatus(LnConstants.LOCO_COMMON));
+                if (tSlot.slotStatus() == LnConstants.LOCO_IN_USE) {
+                    // set status to Common
+                    // Note: the DT400 throttle marks slot "Common" when the user 
+                    // "EXIT"s a locomotive
+            
+                    tc.sendLocoNetMessage(
+                            tSlot.writeStatus(LnConstants.LOCO_COMMON));
+                }
             }
         }
         super.releaseThrottle(t, l);

--- a/java/src/jmri/jmrix/loconet/LocoNetSlot.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSlot.java
@@ -390,6 +390,7 @@ public class LocoNetSlot {
         l.setOpCode(LnConstants.OPC_SLOT_STAT1);
         l.setElement(1, slot);
         l.setElement(2, (stat & ~LnConstants.DEC_MODE_MASK) | status);
+        log.debug("writeSlotMode for slot {}", slot);
         return l;
     }
     
@@ -409,6 +410,7 @@ public class LocoNetSlot {
         l.setOpCode(LnConstants.OPC_SLOT_STAT1);
         l.setElement(1, slot);
         l.setElement(2, (stat & ~LnConstants.LOCOSTAT_MASK) | status);
+        log.debug("writeSlotStatus for slot {} with new status ", slot, (stat & ~LnConstants.LOCOSTAT_MASK) | status);
         return l;
     }
 
@@ -416,7 +418,9 @@ public class LocoNetSlot {
      * Update the status mode bits in STAT1 (D5, D4)
      *
      * @param status New values for STAT1 (D5, D4)
+     * @deprecated 4.9.5 account does not do anything useful
      */
+    @Deprecated
     public void sendWriteStatus(int status) {
         LocoNetMessage l = new LocoNetMessage(4);
         l.setOpCode(LnConstants.OPC_SLOT_STAT1);
@@ -450,12 +454,11 @@ public class LocoNetSlot {
      * @return LocoNet message which "releases" the slot
     */
     public LocoNetMessage releaseSlot() {
-        LocoNetMessage l = new LocoNetMessage(4);
-        l.setOpCode(LnConstants.OPC_SLOT_STAT1);
-        l.setElement(1, slot);
-        // set slot status to "Idle" - valid address in slot, but it's not refreshed on the track signal.
-        stat = stat & (~LnConstants.STAT1_SL_ACTIVE) | LnConstants.STAT1_SL_BUSY;
-        l.setElement(2, stat);
+        // want to effect the same activity as a DT400 throttle when it "exits" 
+        // a loco assignment: transition the slot status to "COMMON" state, not "Idle"
+        
+        LocoNetMessage l = writeStatus(LnConstants.LOCO_COMMON);
+        log.debug("releaseSlot is setting slot status to Idle");
         return l;
     }
 
@@ -522,12 +525,11 @@ public class LocoNetSlot {
         synchronized (this) {
             v = new ArrayList<SlotListener>(slotListeners);
         }
-        if (log.isDebugEnabled()) {
-            log.debug("notify " + v.size() // NOI18N
-                    + " SlotListeners"); // NOI18N
-        }
         // forward to all listeners
         int cnt = v.size();
+        if (log.isDebugEnabled() && (cnt > 0)) {
+            log.debug("notify {} SlotListeners", cnt ); // NOI18N
+        }
         for (int i = 0; i < cnt; i++) {
             SlotListener client = v.get(i);
             client.notifyChangedSlot(this);

--- a/java/src/jmri/jmrix/loconet/LocoNetSlot.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSlot.java
@@ -445,6 +445,10 @@ public class LocoNetSlot {
         return l;
     }
 
+    public int getTrk() {
+        return trk;
+    }
+
     /**
      * Create LocoNet message which releases this slot
      *

--- a/java/src/jmri/jmrix/loconet/LocoNetSlot.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSlot.java
@@ -38,7 +38,7 @@ public class LocoNetSlot {
 
 
     /** Get decoder mode.
-     * Possible values are  
+     * Possible values are
      * {@link LnConstants#DEC_MODE_128A},
      * {@link LnConstants#DEC_MODE_28A},
      * {@link LnConstants#DEC_MODE_128},
@@ -51,7 +51,7 @@ public class LocoNetSlot {
     }
 
     /** Get slot status.
-     * Possible values are 
+     * Possible values are
      * {@link LnConstants#LOCO_IN_USE},
      * {@link LnConstants#LOCO_IDLE},
      * {@link LnConstants#LOCO_COMMON},
@@ -66,7 +66,7 @@ public class LocoNetSlot {
     }
 
     /** Get consist status.
-     * Possible values are 
+     * Possible values are
      * {@link LnConstants#CONSIST_NO},
      * {@link LnConstants#CONSIST_TOP},
      * {@link LnConstants#CONSIST_MID},
@@ -393,7 +393,7 @@ public class LocoNetSlot {
         log.debug("writeSlotMode for slot {}", slot);
         return l;
     }
-    
+
     public LocoNetMessage writeThrottleID(int newID) {
         id = (newID & 0x17F);
         return writeSlot();
@@ -426,15 +426,15 @@ public class LocoNetSlot {
         l.setOpCode(LnConstants.OPC_SLOT_STAT1);
         l.setElement(1, slot);
         l.setElement(2, (stat & ~LnConstants.LOCOSTAT_MASK) | status);
-        
+
     }
 
     /**
      * Create LocoNet message which dispatches this slot
-     * 
-     * Note that the invoking method ought to invoke the slot's NotifySlotListeners 
+     *
+     * Note that the invoking method ought to invoke the slot's NotifySlotListeners
      * method to inform any other interested parties that the slot status has changed.
-     * 
+     *
      * @return LocoNet message which "dispatches" the slot
     */
     public LocoNetMessage dispatchSlot() {
@@ -447,16 +447,16 @@ public class LocoNetSlot {
 
     /**
      * Create LocoNet message which releases this slot
-     * 
-     * Note that the invoking method ought to invoke the slot's NotifySlotListeners 
+     *
+     * Note that the invoking method ought to invoke the slot's NotifySlotListeners
      * method to inform any other interested parties that the slot status has changed.
-     * 
+     *
      * @return LocoNet message which "releases" the slot
     */
     public LocoNetMessage releaseSlot() {
-        // want to effect the same activity as a DT400 throttle when it "exits" 
+        // want to effect the same activity as a DT400 throttle when it "exits"
         // a loco assignment: transition the slot status to "COMMON" state, not "Idle"
-        
+
         LocoNetMessage l = writeStatus(LnConstants.LOCO_COMMON);
         log.debug("releaseSlot is setting slot status to Idle");
         return l;

--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -50,6 +50,7 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
      */
     public LocoNetThrottle(LocoNetSystemConnectionMemo memo, LocoNetSlot slot) {
         super(memo);
+        log.debug("Creeating LocoNetThrottle for address {}", slot.locoAddr());
         this.slot = slot;
         network = memo.getLnTrafficController();
         needToSetThrottleID = (slot.id() != throttleID);
@@ -453,7 +454,7 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         if (slot != pSlot) {
             log.error("notified of change in different slot");
         }
-        log.debug("notifyChangedSlot executing for slot {}, slotStatus {}", slot.getSlot(), Integer.toHexString(slot.slotStatus()));
+        log.debug("notifyChangedSlot executing for slot {}, slotStatus {} address {}", slot.getSlot(), Integer.toHexString(slot.slotStatus()), slot.locoAddr());
 
         // Save current layout state of spd/dirf/snd so we won't run amok
         // toggling values if another LocoNet entity accesses the slot while

--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -34,7 +34,7 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
 
     // slot status to be warned if slot released or dispatched
     protected int slotStatus;
-    
+
     // ThrottleID management
     protected final static int throttleID = 0x0171;
     protected boolean needToSetThrottleID;
@@ -53,9 +53,9 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         this.slot = slot;
         network = memo.getLnTrafficController();
         needToSetThrottleID = (slot.id() != throttleID);
-        
-        // Note - command station may promote slot from 'common' to 'IN_USE' 
-        // upon address request, and some command stations may reject the 
+
+        // Note - command station may promote slot from 'common' to 'IN_USE'
+        // upon address request, and some command stations may reject the
         // "OPC_MOVE_SLOTS" null-move if the slot was already in-use.
         if (slot.slotStatus() != LnConstants.LOCO_IN_USE) {
             LocoNetMessage msg = new LocoNetMessage(4);
@@ -341,20 +341,20 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
      */
     @Override
     protected void throttleDispose() {
-        
+
         log.debug("throttleDispose - disposing of throttle (and setting slot = null)");
-        
+
         // release connections
         int delayTime = 5;
         if (slot != null) {
             if ((slot.speed() != 0) && (slot.speed() != 1)) {
                 // TODO: stopping a slot upon release is a SUBTRACTIVE change - is it justified?
-                setSpeedSetting(0); // stop the loco (if it is not already stopped).  
+                setSpeedSetting(0); // stop the loco (if it is not already stopped).
                                     // This will re-start the refresh timer.
                 log.debug("Stopping loco address {} slot {} during dispose", slot.locoAddr(), slot.getSlot());
                 delayTime=200;
             }
-            
+
             javax.swing.Timer delayBeforeDispose = new javax.swing.Timer(delayTime, new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
@@ -402,7 +402,7 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         });
         throttleDisposeTimer.setRepeats(false);
         throttleDisposeTimer.start();
-        
+
         log.debug("Starting throttle dispose timer for slot {} address {}", slot.getSlot(), slot.locoAddr());
     }
     javax.swing.Timer mRefreshTimer = null;
@@ -443,7 +443,7 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         return;
     }
 
-    
+
     /**
      * Get notified when underlying slot information changes
      */
@@ -461,7 +461,7 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         layout_spd = slot.speed();
         layout_dirf = slot.dirf();
         layout_snd = slot.snd();
-        
+
         // handle change in each state
         if (this.speedSetting != floatSpeed(slot.speed())) {
             Float newSpeed = Float.valueOf(floatSpeed(slot.speed()));
@@ -477,7 +477,7 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
             notifyPropertyChangeListener("IsForward", Boolean.valueOf(temp), Boolean.valueOf(slot.isForward())); // NOI18N
         }
 
-        // Slot status        
+        // Slot status
         if (slotStatus != slot.slotStatus()) {
             int newStat = slot.slotStatus();
             if (log.isDebugEnabled()) {
@@ -488,14 +488,14 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
                     !((slotStatus & LnConstants.LOCOSTAT_MASK) == LnConstants.LOCO_IN_USE));
             slotStatus = newStat;
         }
-        
+
         // It is possible that the slot status change we are being notified of
         // is the slot being set to status COMMON. In which case the slot just
         // got set to null. No point in continuing. In fact to do so causes a NPE.
         if (slot == null) {
             return;
         }
-        
+
         // Functions
         if (this.f0 != slot.isF0()) {
             temp = this.f0;
@@ -648,13 +648,13 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
             if (slot.id() != throttleID) {
                 // Timer delays Throttle ID write until after other slot users see initial access.
                 setupThrottleIdWriteTimer();
-    
+
             }
             needToSetThrottleID = false; // assume we can set it or it is properly set by now
         }
-            
+
     }
-    
+
         protected void setupThrottleIdWriteTimer() {
         throttleIdWriteTimer = new javax.swing.Timer(150, new java.awt.event.ActionListener() {
             @Override
@@ -721,7 +721,7 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         }
         if (mRefreshTimer != null) // the refresh timer isn't created until
         // after initilization.  We only want to
-        // modify the slot after the initilization 
+        // modify the slot after the initilization
         // is complete.
         {
             network.sendLocoNetMessage(slot.writeMode(status));
@@ -745,8 +745,8 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         log.debug("getLocoAddress replying address {} for slot not in-use or for sub-consisted slot or for null slot", address);
         return new DccLocoAddress(address, LnThrottleManager.isLongAddress(65536));
     }
-    
-    //note: throttle listener expects to have "callback" method notifyStealThrottleRequired 
+
+    //note: throttle listener expects to have "callback" method notifyStealThrottleRequired
     //invoked if a "steal" is required.  Make that happen as part of the "acquisition" process
 
     // initialize logging

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -182,18 +182,19 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
      * The SlotListener is not subscribed for slot notifications; it can do that
      * later if it wants. We don't currently think that's a race condition.
      *
-     * @param i Specific slot, counted starting from zero.
+     * @param address Specific loco address, counted starting from zero.
      * @param l The SlotListener to notify of the answer.
      */
-    public void slotFromLocoAddress (int i, SlotListener l) {
+    public void slotFromLocoAddress (int address, SlotListener l) {
         // store connection between this address and listener for later
-        mLocoAddrHash.put(Integer.valueOf(i), l);
+        log.debug("slotFromLocoAddress - request for address {}", address);
+        mLocoAddrHash.put(Integer.valueOf(address), l);
 
         // send info request
         LocoNetMessage m = new LocoNetMessage(4);
         m.setOpCode(LnConstants.OPC_LOCO_ADR);  // OPC_LOCO_ADR
-        m.setElement(1, (i / 128) & 0x7F);
-        m.setElement(2, i & 0x7F);
+        m.setElement(1, (address / 128) & 0x7F);
+        m.setElement(2, address & 0x7F);
         tc.sendLocoNetMessage(m);
     }
 

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -596,7 +596,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
             // to reflect the content of the LocoNet message, so _slots[i]
             // has the locomotive address of this request 
             int addr = _slots[i].locoAddr();
-            log.debug("LOCO_ADR resp is slot {} for addr {}", i, addr); // NOI18N
+            log.debug("OPC_SL_RD_DATA resp is slot {} for addr {} with status {}", i, addr, LnConstants.LOCO_STAT(_slots[i].slotStatus())); // NOI18N
             SlotListener l = mLocoAddrHash.get(Integer.valueOf(addr));
             if (l != null) {
                 // send the notification

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -1,8 +1,5 @@
 package jmri.jmrix.loconet;
 
-import static jmri.jmrix.loconet.LnConstants.STAT1_SL_ACTIVE;
-import static jmri.jmrix.loconet.LnConstants.STAT1_SL_BUSY;
-
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
@@ -1129,7 +1126,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
 
         // schedule next read if needed
         if (nextReadSlot < 127) {
-            javax.swing.Timer t = new javax.swing.Timer(500, new java.awt.event.ActionListener() {
+            javax.swing.Timer t = new javax.swing.Timer(200, new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     readNextSlot();

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -598,11 +598,12 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
             log.debug("LOCO_ADR resp is slot {} for addr {}", i, addr); // NOI18N
             SlotListener l = mLocoAddrHash.get(Integer.valueOf(addr));
             if (l != null) {
-                // only notify once per request
-                mLocoAddrHash.remove(Integer.valueOf(addr));
-                // and send the notification
+                // send the notification
                 log.debug("notify listener"); // NOI18N
                 l.notifyChangedSlot(_slots[i]);
+                if (_slots[i].slotStatus() == LnConstants.LOCO_IN_USE) {
+                    mLocoAddrHash.remove(Integer.valueOf(addr));
+                }
             } else {
                 log.debug("no request for addr {}", addr); // NOI18N
             }


### PR DESCRIPTION
Another attempt to resolve issues with LocoNet throttle acquire.

- Includes changes to "dispatching" and "releasing" throttles, to align to DT400 behavior for "DISP"atching and "EXIT"ing, respectively.

- Includes use of swing timers instead of some Thread.sleep() invocations.

_Developer testing using different hardware and is desired.  Testing with WiThrottle Server is desired._

This is an alternative to #4269 and #4265, and relates to #4263 and #4225.

This code has been tested with a DCS51.  

Additional testing with a DCS210 is planned.

