### PR TITLE
layoutEditor.configurexml.Bundle inherits wrong bundle

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/Bundle.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/Bundle.java
@@ -21,7 +21,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * @author Bob Jacobsen Copyright (C) 2012
  * @since 3.3.1
  */
-public class Bundle extends jmri.jmrit.display.Bundle {
+public class Bundle extends jmri.jmrit.display.layoutEditor.Bundle {
 
     @Nullable
     private static final String name = null;

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/Bundle.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/Bundle.java
@@ -22,7 +22,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * @since 3.3.1
  */
 public class Bundle extends jmri.jmrit.display.layoutEditor.Bundle {
-
+ 
     @Nullable
     private static final String name = null;
 


### PR DESCRIPTION
jmri.jmrit.display.layoutEditor.configurexml.Bundle inherits the wrong bundle and therefore some resources can't be found.