### PR TITLE
BUGFIX: anchor popup menu action "Merge track segments"

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -6918,8 +6918,8 @@ public class LayoutEditor extends PanelEditor implements VetoableChangeListener,
         setDirty();
 
         //link to connected objects
-        setLink(newTrack, LayoutTrack.TRACK, beginObject, beginPointType);
-        setLink(newTrack, LayoutTrack.TRACK, foundObject, foundPointType);
+        setLink(beginObject, beginPointType, newTrack, LayoutTrack.TRACK);
+        setLink(foundObject, foundPointType, newTrack, LayoutTrack.TRACK);
 
         //check on layout block
         String newName = blockIDComboBox.getDisplayName();
@@ -7230,77 +7230,82 @@ public class LayoutEditor extends PanelEditor implements VetoableChangeListener,
     } //validatePhysicalTurnout
 
     /**
-     * Adds a link in the 'to' object to the 'from' object
+     * link the 'from' object and type to the 'to' object and type
+     * @param fromObject the object to link from
+     * @param fromPointType the object type to link from
+     * @param toObject the object to link to
+     * @param toPointType the object type to link to
      */
     protected void setLink(@Nonnull LayoutTrack fromObject, int fromPointType,
             @Nonnull LayoutTrack toObject, int toPointType) {
-        switch (toPointType) {
+        switch (fromPointType) {
             case LayoutTrack.POS_POINT: {
-                if (fromPointType == LayoutTrack.TRACK) {
-                    ((PositionablePoint) toObject).setTrackConnection((TrackSegment) fromObject);
+                if (toPointType == LayoutTrack.TRACK) {
+                    ((PositionablePoint) fromObject).setTrackConnection((TrackSegment) toObject);
                 } else {
-                    log.error("Attempt to set a non-TRACK connection to a Positionable Point");
+                    log.error("Attempt to link a non-TRACK connection ('{}')to a Positionable Point ('{}')", 
+                            toObject.getName(), fromObject.getName());
                 }
                 break;
             }
 
             case LayoutTrack.TURNOUT_A: {
-                ((LayoutTurnout) toObject).setConnectA(fromObject, fromPointType);
+                ((LayoutTurnout) fromObject).setConnectA(toObject, toPointType);
                 break;
             }
 
             case LayoutTrack.TURNOUT_B: {
-                ((LayoutTurnout) toObject).setConnectB(fromObject, fromPointType);
+                ((LayoutTurnout) fromObject).setConnectB(toObject, toPointType);
                 break;
             }
 
             case LayoutTrack.TURNOUT_C: {
-                ((LayoutTurnout) toObject).setConnectC(fromObject, fromPointType);
+                ((LayoutTurnout) fromObject).setConnectC(toObject, toPointType);
                 break;
             }
 
             case LayoutTrack.TURNOUT_D: {
-                ((LayoutTurnout) toObject).setConnectD(fromObject, fromPointType);
+                ((LayoutTurnout) fromObject).setConnectD(toObject, toPointType);
                 break;
             }
 
             case LayoutTrack.LEVEL_XING_A: {
-                ((LevelXing) toObject).setConnectA(fromObject, fromPointType);
+                ((LevelXing) fromObject).setConnectA(toObject, toPointType);
                 break;
             }
 
             case LayoutTrack.LEVEL_XING_B: {
-                ((LevelXing) toObject).setConnectB(fromObject, fromPointType);
+                ((LevelXing) fromObject).setConnectB(toObject, toPointType);
                 break;
             }
 
             case LayoutTrack.LEVEL_XING_C: {
-                ((LevelXing) toObject).setConnectC(fromObject, fromPointType);
+                ((LevelXing) fromObject).setConnectC(toObject, toPointType);
                 break;
             }
 
             case LayoutTrack.LEVEL_XING_D: {
-                ((LevelXing) toObject).setConnectD(fromObject, fromPointType);
+                ((LevelXing) fromObject).setConnectD(toObject, toPointType);
                 break;
             }
 
             case LayoutTrack.SLIP_A: {
-                ((LayoutSlip) toObject).setConnectA(fromObject, fromPointType);
+                ((LayoutSlip) fromObject).setConnectA(toObject, toPointType);
                 break;
             }
 
             case LayoutTrack.SLIP_B: {
-                ((LayoutSlip) toObject).setConnectB(fromObject, fromPointType);
+                ((LayoutSlip) fromObject).setConnectB(toObject, toPointType);
                 break;
             }
 
             case LayoutTrack.SLIP_C: {
-                ((LayoutSlip) toObject).setConnectC(fromObject, fromPointType);
+                ((LayoutSlip) fromObject).setConnectC(toObject, toPointType);
                 break;
             }
 
             case LayoutTrack.SLIP_D: {
-                ((LayoutSlip) toObject).setConnectD(fromObject, fromPointType);
+                ((LayoutSlip) fromObject).setConnectD(toObject, toPointType);
                 break;
             }
 
@@ -7311,9 +7316,9 @@ public class LayoutEditor extends PanelEditor implements VetoableChangeListener,
             }
 
             default: {
-                if ((toPointType >= LayoutTrack.TURNTABLE_RAY_OFFSET) && (fromPointType == LayoutTrack.TRACK)) {
-                    ((LayoutTurntable) toObject).setRayConnect((TrackSegment) fromObject,
-                            toPointType - LayoutTrack.TURNTABLE_RAY_OFFSET);
+                if ((fromPointType >= LayoutTrack.TURNTABLE_RAY_OFFSET) && (toPointType == LayoutTrack.TRACK)) {
+                    ((LayoutTurntable) fromObject).setRayConnect((TrackSegment) toObject,
+                            fromPointType - LayoutTrack.TURNTABLE_RAY_OFFSET);
                 }
                 break;
             }

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.display.layoutEditor;
 
+import static jmri.jmrit.display.layoutEditor.LayoutTrack.TRACK;
+
 import java.awt.BasicStroke;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -19,6 +21,7 @@ import java.util.Set;
 import javax.annotation.CheckForNull;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.swing.AbstractAction;
 import javax.swing.JButton;
 import javax.swing.JCheckBoxMenuItem;
@@ -630,18 +633,63 @@ public class PositionablePoint extends LayoutTrack {
     }
 
     /**
-     * Setup and remove connections to track
+     * setup a connection to a track
+     *
+     * @param track the track we want to connect to
+     * @return true if successful
      */
-    public boolean setTrackConnection(TrackSegment track) {
-        if (track == null) {
-            return false;
-        }
-        if ((connect1 != track) && (connect2 != track)) {
-            // not connected to this track
-            if (connect1 == null) {
-                connect1 = track;
-            } else if ((type == ANCHOR) && (connect2 == null)) {
-                connect2 = track;
+    public boolean setTrackConnection(@Nonnull TrackSegment track) {
+        return replaceTrackConnection(null, track);
+    }
+
+    /**
+     * remove a connection to a track
+     *
+     * @param track the track we want to disconnect from
+     * @return true if successful
+     */
+    public boolean removeTrackConnection(@Nonnull TrackSegment track) {
+        return replaceTrackConnection(track, null);
+    }
+
+    /**
+     * replace old track connection with new track connection
+     *
+     * @param oldTrack the old track connection
+     * @param newTrack the new track connection
+     * @return true if successful
+     */
+    public boolean replaceTrackConnection(@Nullable TrackSegment oldTrack, @Nullable TrackSegment newTrack) {
+        boolean result = false; // assume failure (pessimist!)
+        // trying to replace old track with null?
+        if (newTrack == null) {
+            // (yes) remove old connection
+            if (oldTrack != null) {
+                result = true;  // assume success (optimist!)
+                if (connect1 == oldTrack) {
+                    connect1 = null;
+                    reCheckBlockBoundary();
+                    removeLinkedPoint();
+                } else if (connect2 == oldTrack) {
+                    connect2 = null;
+                    reCheckBlockBoundary();
+                } else {
+                    result = false; // didn't find old connection
+                }
+            } else {
+                result = false; // can't replace null with null
+            }
+            if (!result) {
+                log.error("Attempt to remove non-existant track connection");
+            }
+        } else // already connected to newTrack?
+        if ((connect1 != newTrack) && (connect2 != newTrack)) {
+            // (no) find a connection we can connect to
+            result = true;  // assume success (optimist!)
+            if (connect1 == oldTrack) {
+                connect1 = newTrack;
+            } else if ((type == ANCHOR) && (connect2 == oldTrack)) {
+                connect2 = newTrack;
                 if (connect1.getLayoutBlock() == connect2.getLayoutBlock()) {
                     westBoundSignalMastNamed = null;
                     eastBoundSignalMastNamed = null;
@@ -650,23 +698,10 @@ public class PositionablePoint extends LayoutTrack {
                 }
             } else {
                 log.error("Attempt to assign more than allowed number of connections");
-                return false;
+                result = false;
             }
         }
-        return true;
-    }
-
-    public void removeTrackConnection(TrackSegment track) {
-        if (track == connect1) {
-            connect1 = null;
-            reCheckBlockBoundary();
-            removeLinkedPoint();
-        } else if (track == connect2) {
-            connect2 = null;
-            reCheckBlockBoundary();
-        } else {
-            log.error("Attempt to remove non-existant track connection");
-        }
+        return result;
     }
 
     void removeSML(SignalMast signalMast) {
@@ -855,44 +890,50 @@ public class PositionablePoint extends LayoutTrack {
             if (blockBoundary) {
                 jmi = popup.add(new JMenuItem(Bundle.getMessage("CanNotMergeAtBlockBoundary")));
                 jmi.setEnabled(false);
-            } else {
+            } else if ((connect1 != null) && (connect2 != null)) {
                 jmi = popup.add(new AbstractAction(Bundle.getMessage("MergeAdjacentTracks")) {
                     @Override
                     public void actionPerformed(ActionEvent e) {
+                        PositionablePoint pp_this = PositionablePoint.this;
                         // if I'm fully connected...
                         if ((connect1 != null) && (connect2 != null)) {
-                            // this is the other ("not me") connection to connect2
+                            // who is my connect2 connected to (that's not me)?
                             LayoutTrack newConnect2 = null;
                             int newType2 = TRACK;
-                            if (connect2.connect1 == PositionablePoint.this) {
+                            if (connect2.connect1 == pp_this) {
                                 newConnect2 = connect2.connect2;
                                 newType2 = connect2.type2;
-                            } else if (connect2.connect2 == PositionablePoint.this) {
+                            } else if (connect2.connect2 == pp_this) {
                                 newConnect2 = connect2.connect1;
                                 newType2 = connect2.type1;
                             } else {
                                 //this should never happen however...
-                                log.error("Join: wrong connects error.");
+                                log.error("Join: wrong connect2 error.");
                             }
 
-                            // connect the other connection to my connect1
-                            if (newConnect2 != null) {  // (this should NEVER happen... however...)
-                                layoutEditor.setLink(connect1, TRACK, newConnect2, newType2);
-                            }
-
-                            // connect my old connect1 to the new connect 2
-                            if (connect1.connect1 == PositionablePoint.this) {
-                                connect1.connect1 = newConnect2;
-                                connect1.type1 = newType2;
-                            } else if (connect1.connect2 == PositionablePoint.this) {
-                                connect1.connect2 = newConnect2;
-                                connect1.type2 = newType2;
+                            // connect the other connection to my connect2 to my connect1
+                            if (newConnect2 == null) {
+                                // (this should NEVER happen... however...)
+                                log.error("Merge: no 'other' connection to connect2.");
                             } else {
-                                //this should never happen however...
-                                log.error("Join: wrong connects error.");
+                                if (newConnect2 instanceof PositionablePoint) {
+                                    PositionablePoint pp = (PositionablePoint) newConnect2;
+                                    pp.replaceTrackConnection(connect2, connect1);
+                                } else {
+                                    layoutEditor.setLink(connect1, TRACK, newConnect2, newType2);
+                                }
+                                // connect the track at my connect1 to the newConnect2
+                                if (connect1.getConnect1() == pp_this) {
+                                    connect1.setNewConnect1(newConnect2, newType2);
+                                } else if (connect1.getConnect2() == pp_this) {
+                                    connect1.setNewConnect2(newConnect2, newType2);
+                                } else {
+                                    // (this should NEVER happen... however...)
+                                    log.error("Merge: no connection to connect1.");
+                                }
                             }
 
-                            //remove connect2 from selection information
+                            // remove connect2 from selection information
                             if (layoutEditor.selectedObject == connect2) {
                                 layoutEditor.selectedObject = null;
                             }
@@ -919,29 +960,32 @@ public class PositionablePoint extends LayoutTrack {
                             connect2.dispose();
                             connect2 = null;
 
-                            //remove me from selection information
-                            if (layoutEditor.selectedObject == PositionablePoint.this) {
+                            //remove pp_this from selection information
+                            if (layoutEditor.selectedObject == pp_this) {
                                 layoutEditor.selectedObject = null;
                             }
-                            if (layoutEditor.prevSelectedObject == PositionablePoint.this) {
+                            if (layoutEditor.prevSelectedObject == pp_this) {
                                 layoutEditor.prevSelectedObject = null;
                             }
 
-                            // remove me from the layoutEditor's list of layout tracks
-                            if (layoutEditor.getLayoutTracks().contains(PositionablePoint.this)) {
-                                layoutEditor.getLayoutTracks().remove(PositionablePoint.this);
+                            // remove pp_this from the layoutEditor's list of layout tracks
+                            if (layoutEditor.getLayoutTracks().contains(pp_this)) {
+                                layoutEditor.getLayoutTracks().remove(pp_this);
                                 layoutEditor.setDirty();
                                 layoutEditor.redrawPanel();
                             }
-                            PositionablePoint.this.remove();
-                            PositionablePoint.this.dispose();
+                            pp_this.remove();
+                            pp_this.dispose();
 
                             layoutEditor.setDirty();
                             layoutEditor.redrawPanel();
+                        } else {
+                            // (this should NEVER happen... however...)
+                            log.error("Merge: missing connection(s).");
                         }   // if ((connect1 != null) && (connect2 != null))
                     }   // actionPerformed
                 }); // jmi = popup.add(new AbstractAction(...) {
-            }   // if (blockBoundary) {} else {}
+            }   // if (blockBoundary) {} else if ((connect1 != null) && (connect2 != null))
         }   // if (getType() == ANCHOR)
 
         popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -680,7 +680,7 @@ public class PositionablePoint extends LayoutTrack {
                 result = false; // can't replace null with null
             }
             if (!result) {
-                log.error("Attempt to remove non-existant track connection: {}", oldTrack.getName());
+                log.error("Attempt to remove non-existant track connection: {}", oldTrack);
             }
         } else // already connected to newTrack?
         if ((connect1 != newTrack) && (connect2 != newTrack)) {
@@ -705,7 +705,7 @@ public class PositionablePoint extends LayoutTrack {
                 result = false;
         }
         return result;
-    }
+    }   // replaceTrackConnection
 
     void removeSML(SignalMast signalMast) {
         if (signalMast == null) {

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -680,7 +680,7 @@ public class PositionablePoint extends LayoutTrack {
                 result = false; // can't replace null with null
             }
             if (!result) {
-                log.error("Attempt to remove non-existant track connection");
+                log.error("Attempt to remove non-existant track connection: {}", oldTrack.getName());
             }
         } else // already connected to newTrack?
         if ((connect1 != newTrack) && (connect2 != newTrack)) {
@@ -700,6 +700,9 @@ public class PositionablePoint extends LayoutTrack {
                 log.error("Attempt to assign more than allowed number of connections");
                 result = false;
             }
+        } else {
+                log.error("Already connected to {}", newTrack.getName());
+                result = false;
         }
         return result;
     }
@@ -920,7 +923,7 @@ public class PositionablePoint extends LayoutTrack {
                                     PositionablePoint pp = (PositionablePoint) newConnect2;
                                     pp.replaceTrackConnection(connect2, connect1);
                                 } else {
-                                    layoutEditor.setLink(connect1, TRACK, newConnect2, newType2);
+                                    layoutEditor.setLink(newConnect2, newType2, connect1, TRACK);
                                 }
                                 // connect the track at my connect1 to the newConnect2
                                 if (connect1.getConnect1() == pp_this) {

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -1,5 +1,7 @@
 package jmri.jmrit.display.layoutEditor;
 
+import static jmri.jmrit.display.layoutEditor.LayoutTrack.TRACK;
+
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
@@ -183,6 +185,54 @@ public class TrackSegment extends LayoutTrack {
         type2 = connectionType;
     }
 
+
+    /**
+     * replace old track connection with new track connection
+     *
+     * @param oldTrack the old track connection
+     * @param newTrack the new track connection
+     * @return true if successful
+     */
+    public boolean replaceTrackConnection(@Nullable LayoutTrack oldTrack, @Nullable LayoutTrack newTrack, int newType) {
+        boolean result = false; // assume failure (pessimist!)
+        // trying to replace old track with null?
+        if (newTrack == null) {
+            // (yes) remove old connection
+            if (oldTrack != null) {
+                result = true;  // assume success (optimist!)
+                if (connect1 == oldTrack) {
+                    connect1 = null;
+                    type1 = NONE;
+                } else if (connect2 == oldTrack) {
+                    connect2 = null;
+                    type2 = NONE;
+                } else {
+                    result = false; // didn't find old connection
+                }
+            } else {
+                result = false; // can't replace null with null
+            }
+            if (!result) {
+                log.error("Attempt to remove non-existant track connection");
+            }
+        } else // already connected to newTrack?
+        if ((connect1 != newTrack) && (connect2 != newTrack)) {
+            // (no) find a connection we can connect to
+            result = true;  // assume success (optimist!)
+            if (connect1 == oldTrack) {
+                connect1 = newTrack;
+                type1 = newType;
+            } else if (connect2 == oldTrack) {
+                connect2 = newTrack;
+                type2 = newType;
+            } else {
+                log.error("Attempt to replace invalid connection");
+                result = false;
+            }
+        }
+        return result;
+    }
+    
     /**
      * @return true if track segment should be drawn dashed
      * @deprecated since 4.9.4; use {@link #isDashed()} instead
@@ -751,11 +801,12 @@ public class TrackSegment extends LayoutTrack {
         popup.add(new AbstractAction(Bundle.getMessage("SplitTrackSegment")) {
             @Override
             public void actionPerformed(ActionEvent e) {
+                TrackSegment ts_this = TrackSegment.this;
                 // create a new anchor
                 Point2D p = getCentreSeg();
                 PositionablePoint newAnchor = layoutEditor.addAnchor(p);
                 // link it to me
-                layoutEditor.setLink(TrackSegment.this, TRACK, newAnchor, POS_POINT);
+                layoutEditor.setLink(newAnchor, POS_POINT, ts_this, TRACK);
 
                 //get unique name for a new track segment
                 String name = layoutEditor.getFinder().uniqueName("T", 0);
@@ -770,23 +821,28 @@ public class TrackSegment extends LayoutTrack {
                 layoutEditor.setDirty();
 
                 // copy attributes to new track segment
-                newTrackSegment.setArc(TrackSegment.this.isArc());
-                newTrackSegment.setCircle(TrackSegment.this.isCircle());
-                //newTrackSegment.setBezier(TrackSegment.this.isBezier());
-                newTrackSegment.setFlip(TrackSegment.this.isFlip());
+                newTrackSegment.setArc(ts_this.isArc());
+                newTrackSegment.setCircle(ts_this.isCircle());
+                //newTrackSegment.setBezier(ts_this.isBezier());
+                newTrackSegment.setFlip(ts_this.isFlip());
 
                 // link my connect2 to the new track segment
-                layoutEditor.setLink(newTrackSegment, TRACK, connect2, type2);
+                if (connect2 instanceof PositionablePoint) {
+                    PositionablePoint pp = (PositionablePoint) connect2;
+                    pp.replaceTrackConnection(ts_this, newTrackSegment);
+                } else {
+                    layoutEditor.setLink(connect2, type2, newTrackSegment, TRACK);
+                }
 
                 // link the new anchor to the new track segment
-                layoutEditor.setLink(newTrackSegment, TRACK, newAnchor, POS_POINT);
+                layoutEditor.setLink(newAnchor, POS_POINT, newTrackSegment, TRACK);
 
                 // link me to the new newAnchor
                 connect2 = newAnchor;
                 type2 = POS_POINT;
 
                 //check on layout block
-                LayoutBlock b = TrackSegment.this.getLayoutBlock();
+                LayoutBlock b = ts_this.getLayoutBlock();
 
                 if (b != null) {
                     newTrackSegment.setLayoutBlock(b);

--- a/java/test/jmri/jmrit/display/layoutEditor/PositionablePointTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/PositionablePointTest.java
@@ -345,8 +345,9 @@ public class PositionablePointTest {
         // test null track segment
         Assert.assertFalse("pp.setTrackConnection(null) is false",
                 pp.setTrackConnection(null));
+        jmri.util.JUnitAppender.assertErrorMessage("Attempt to remove non-existant track connection: null");
 
-        PositionablePoint ppA = new PositionablePoint("A", PositionablePoint.ANCHOR, new Point2D.Double( 0.0,  0.0), le);
+        PositionablePoint ppA = new PositionablePoint("A", PositionablePoint.ANCHOR, new Point2D.Double(0.0, 0.0), le);
         PositionablePoint ppB = new PositionablePoint("B", PositionablePoint.ANCHOR, new Point2D.Double(10.0, 10.0), le);
         PositionablePoint ppC = new PositionablePoint("C", PositionablePoint.ANCHOR, new Point2D.Double(20.0, 20.0), le);
         PositionablePoint ppD = new PositionablePoint("D", PositionablePoint.ANCHOR, new Point2D.Double(30.0, 30.0), le);
@@ -361,20 +362,22 @@ public class PositionablePointTest {
         Assert.assertTrue("pp.setTrackConnection(tsAB) is true",
                 pp.setTrackConnection(tsAB));
 
-        // test already connected is true
-        Assert.assertTrue("pp.setTrackConnection(tsAB) is true",
+        // test already connected
+        Assert.assertFalse("pp.setTrackConnection(tsAB) is false",
                 pp.setTrackConnection(tsAB));
+        jmri.util.JUnitAppender.assertErrorMessage("Already connected to testAB");
 
         // test 2nd non-null track segment
         Assert.assertTrue("pp.setTrackConnection(tsBC) is true",
                 pp.setTrackConnection(tsBC));
 
-        // test already connected is true
-        Assert.assertTrue("pp.setTrackConnection(tsBC) is true",
+        // test already connected
+        Assert.assertFalse("pp.setTrackConnection(tsBC) is false",
                 pp.setTrackConnection(tsBC));
+        jmri.util.JUnitAppender.assertErrorMessage("Already connected to testBC");
 
         // test 3rd non-null track segment
-        Assert.assertFalse("pp.setTrackConnection(tsCD) is true",
+        Assert.assertFalse("pp.setTrackConnection(tsCD) is false",
                 pp.setTrackConnection(tsCD));
         jmri.util.JUnitAppender.assertErrorMessage("Attempt to assign more than allowed number of connections");
     }


### PR DESCRIPTION
BUGFIX: incorrect link from my connect1 to 'other' connection to my connect2.
Minor refactor [set|remove]TrackConnection() to replaceTrackConnection().
Minor refactor LayoutEditor.setLink(from, to):
    Direction was actually backwards from direction implied by the parameter names.
