### PR TITLE
Metadata class cannot be meaningfully constructed

### DIFF
--- a/java/src/jmri/Metadata.java
+++ b/java/src/jmri/Metadata.java
@@ -25,7 +25,7 @@ import jmri.profile.ProfileManager;
  *
  * @author Randall Wood Copyright (C) 2011
  */
-public class Metadata {
+public interface Metadata {
 
     public static final String JMRIVERSION = "JMRIVERSION"; // NOI18N
     public static final String JMRIVERCANON = "JMRIVERCANON"; // NOI18N

--- a/java/test/jmri/MetadataTest.java
+++ b/java/test/jmri/MetadataTest.java
@@ -1,5 +1,7 @@
 package jmri;
 
+import java.util.Arrays;
+import jmri.profile.ProfileManager;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -8,17 +10,10 @@ import org.junit.Test;
 
 /**
  *
- * @author Paul Bender Copyright (C) 2017	
+ * @author Paul Bender Copyright (C) 2017
  */
 public class MetadataTest {
 
-    @Test
-    public void testCTor() {
-        Metadata t = new Metadata();
-        Assert.assertNotNull("exists",t);
-    }
-
-    // The minimal setup for log4J
     @Before
     public void setUp() {
         JUnitUtil.setUp();
@@ -29,6 +24,63 @@ public class MetadataTest {
         JUnitUtil.tearDown();
     }
 
-    // private final static Logger log = LoggerFactory.getLogger(MetadataTest.class);
+    /**
+     * Test of getBySystemName method, of class Metadata.
+     */
+    @Test
+    public void testGetBySystemName() {
+        // non-existant properties should return null
+        Assert.assertNull("Non-existant property", Metadata.getBySystemName("non-existant-property"));
+        // Java System properties are returned if in proper case
+        Assert.assertEquals("Java System property in correct case", System.getProperty("path.separator"), Metadata.getBySystemName("path.separator"));
+        Assert.assertNull("Java System property in wrong case", Metadata.getBySystemName("Path.Separator"));
+        // Named properties are case insenitive
+        Assert.assertEquals("COPYRIGHT", Metadata.getBySystemName(Metadata.COPYRIGHT), Metadata.getBySystemName("COPYRIGHT"));
+        Assert.assertEquals("copyright", Metadata.getBySystemName(Metadata.COPYRIGHT), Metadata.getBySystemName("copyright"));
+        Assert.assertEquals("CopyRight", Metadata.getBySystemName(Metadata.COPYRIGHT), Metadata.getBySystemName("CopyRight"));
+        Assert.assertEquals("cOPYrIGHT", Metadata.getBySystemName(Metadata.COPYRIGHT), Metadata.getBySystemName("cOPYrIGHT"));
+        // Test that every named property returns an expected result
+        Assert.assertEquals(Metadata.JMRIVERSION, jmri.Version.name(), Metadata.getBySystemName(Metadata.JMRIVERSION));
+        Assert.assertEquals(Metadata.JMRIVERCANON, jmri.Version.getCanonicalVersion(), Metadata.getBySystemName(Metadata.JMRIVERCANON));
+        Assert.assertEquals(Metadata.JMRIVERMAJOR, Integer.toString(jmri.Version.major), Metadata.getBySystemName(Metadata.JMRIVERMAJOR));
+        Assert.assertEquals(Metadata.JMRIVERMINOR, Integer.toString(jmri.Version.minor), Metadata.getBySystemName(Metadata.JMRIVERMINOR));
+        Assert.assertEquals(Metadata.JMRIVERTEST, Integer.toString(jmri.Version.test), Metadata.getBySystemName(Metadata.JMRIVERTEST));
+        Assert.assertEquals(Metadata.JVMVERSION, System.getProperty("java.version", "<unknown>"), Metadata.getBySystemName(Metadata.JVMVERSION));
+        Assert.assertEquals(Metadata.JVMVENDOR, System.getProperty("java.vendor", "<unknown>"), Metadata.getBySystemName(Metadata.JVMVENDOR));
+        Assert.assertEquals(Metadata.ACTIVEPROFILE, ProfileManager.getDefault().getActiveProfileName(), Metadata.getBySystemName(Metadata.ACTIVEPROFILE));
+        Assert.assertEquals(Metadata.COPYRIGHT, jmri.Version.getCopyright(), Metadata.getBySystemName(Metadata.COPYRIGHT));
+    }
+
+    /**
+     * Test of getSystemNameArray method, of class Metadata.
+     */
+    @Test
+    public void testGetSystemNameArray() {
+        Assert.assertArrayEquals("Known property names", new String[]{Metadata.JMRIVERSION,
+            Metadata.JMRIVERCANON,
+            Metadata.JMRIVERMAJOR,
+            Metadata.JMRIVERMINOR,
+            Metadata.JMRIVERTEST,
+            Metadata.JVMVERSION,
+            Metadata.JVMVENDOR,
+            Metadata.ACTIVEPROFILE,
+            Metadata.COPYRIGHT}, Metadata.getSystemNameArray());
+    }
+
+    /**
+     * Test of getSystemNameList method, of class Metadata.
+     */
+    @Test
+    public void testGetSystemNameList() {
+        Assert.assertEquals("Known property names", Arrays.asList(new String[]{Metadata.JMRIVERSION,
+            Metadata.JMRIVERCANON,
+            Metadata.JMRIVERMAJOR,
+            Metadata.JMRIVERMINOR,
+            Metadata.JMRIVERTEST,
+            Metadata.JVMVERSION,
+            Metadata.JVMVENDOR,
+            Metadata.ACTIVEPROFILE,
+            Metadata.COPYRIGHT}), Metadata.getSystemNameList());
+    }
 
 }


### PR DESCRIPTION
Metadata is completely static, and has no meaningful constructor, so make it an Interface to prevent construction (Static methods in Interfaces is only possible Java 8+).
Replace meaningless constructor test with meaningful tests.