### PR TITLE
BUGFIX: LayoutEditor:Icon popup menu: Flatten “Rotate (degrees)” menu

### DIFF
--- a/java/src/jmri/jmrit/display/CoordinateEdit.java
+++ b/java/src/jmri/jmrit/display/CoordinateEdit.java
@@ -158,7 +158,7 @@ public class CoordinateEdit extends JmriJFrame {
     //////////////////////////////////////////////////////////////
 
     public static AbstractAction getRotateEditAction(final Positionable pos) {
-        return new AbstractAction(Bundle.getMessage("Rotate", "...")) {
+        return new AbstractAction(Bundle.getMessage("Rotate", " (" + pos.getDegrees() + "°)")) {
 
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -658,7 +658,7 @@ public class CoordinateEdit extends JmriJFrame {
                 if (pp.isIcon() || hasText) {
                     pp._text = hasText;
                     if (pp instanceof SensorIcon) {
-                       ((SensorIcon)pp).setOriginalText(t);
+                        ((SensorIcon) pp).setOriginalText(t);
                     }
                     pp.setText(t);
                     pp.updateSize();

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -637,7 +637,7 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
             Graphics2D g2d = null;
             if (g instanceof Graphics2D) {
                 g2d = (Graphics2D) g;
-                g2d.scale(_paintScale, _paintScale);                
+                g2d.scale(_paintScale, _paintScale);
             }
 
             super.paint(g);
@@ -647,11 +647,11 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
             if (g2d != null) {
                 stroke = g2d.getStroke();
             }
-            Color color = g.getColor();                
+            Color color = g.getColor();
             if (_selectRect != null) {
                 //Draw a rectangle on top of the image.
                 if (g2d != null) {
-                    g2d.setStroke(_selectRectStroke);                    
+                    g2d.setStroke(_selectRectStroke);
                 }
                 g.setColor(_selectRectColor);
                 g.drawRect(_selectRect.x, _selectRect.y, _selectRect.width, _selectRect.height);
@@ -659,7 +659,7 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
             if (_selectionGroup != null) {
                 g.setColor(_selectGroupColor);
                 if (g2d != null) {
-                    g2d.setStroke(new BasicStroke(2.0f));                    
+                    g2d.setStroke(new BasicStroke(2.0f));
                 }
                 for (Positionable p : _selectionGroup) {
                     if (!(p instanceof PositionableShape)) {
@@ -674,7 +674,7 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
             if (_highlightcomponent != null) {
                 g.setColor(_highlightColor);
                 if (g2d != null) {
-                    g2d.setStroke(new BasicStroke(2.0f));                    
+                    g2d.setStroke(new BasicStroke(2.0f));
                 }
                 g.drawRect(_highlightcomponent.x, _highlightcomponent.y,
                         _highlightcomponent.width, _highlightcomponent.height);
@@ -1206,11 +1206,7 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
      * @return always returns true
      */
     public boolean setShowRotationMenu(Positionable p, JPopupMenu popup) {
-        JMenu edit = new JMenu(Bundle.getMessage("Rotation", "..."));
-        JMenuItem jmi = edit.add(Bundle.getMessage("Rotation", " = " + p.getDegrees()));
-        jmi.setEnabled(false);
-        edit.add(CoordinateEdit.getRotateEditAction(p));
-        popup.add(edit);
+        popup.add(CoordinateEdit.getRotateEditAction(p));
         return true;
     }
 

--- a/java/src/jmri/jmrit/display/PositionableLabel.java
+++ b/java/src/jmri/jmrit/display/PositionableLabel.java
@@ -58,6 +58,7 @@ public class PositionableLabel extends JLabel implements Positionable {
 
     /**
      * {@inheritDoc}
+     *
      * @param editor where this label is displayed
      */
     public PositionableLabel(String s, Editor editor) {
@@ -503,8 +504,8 @@ public class PositionableLabel extends JLabel implements Positionable {
     public boolean setRotateOrthogonalMenu(JPopupMenu popup) {
 
         if (isIcon() && _displayLevel > Editor.BKG) {
-            popup.add(new AbstractAction(Bundle.getMessage("RotateOrthogonal")) {
-
+            popup.add(new AbstractAction(Bundle.getMessage("RotateOrthogonal")
+                    + " (" + (_namedIcon.getRotation() * 90) + "°)") {
                 @Override
                 public void actionPerformed(ActionEvent e) {
                     rotateOrthogonal();


### PR DESCRIPTION
Also added the current rotation info to the "Rotate Orthongonal" menu