### PR TITLE
Fix Eclipse failure to build if git not on path

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -53,7 +53,6 @@
 	<classpathentry kind="lib" path="lib/jhall.jar"/>
 	<classpathentry kind="lib" path="lib/jhidrawplugin.jar"/>
 	<classpathentry kind="lib" path="lib/jinput.jar"/>
-	<classpathentry kind="lib" path="lib/jmdns.jar"/>
 	<classpathentry kind="lib" path="lib/joal.jar"/>
 	<classpathentry kind="lib" path="lib/jsr305.jar"/>
 	<classpathentry kind="lib" path="lib/junit-4.12.jar"/>

--- a/pom.xml
+++ b/pom.xml
@@ -378,7 +378,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <shortRevisionLength>8</shortRevisionLength>
+                    <shortRevisionLength>7</shortRevisionLength>
+                    <revisionOnScmFailure>UNKNOWN</revisionOnScmFailure>
                     <timestampFormat>yyyyMMddHHmm</timestampFormat>
                     <timezone>UTC</timezone>
                     <!-- want false to generate Version.properties -->


### PR DESCRIPTION
If the git command is not on the user's execution path, builds in Eclipse fail. This fixes that by allowing the metadata generator to substitute ```UNKNOWN``` for the git revision if the git command is not available or fails for other reasons.
Also changes the revision to be 7 characters in length to match both Github's short revision length and the length of ```UNKNOWN```.

Fixes #4344, at least on new clones of the JMRI code base from Github.