### PR TITLE
Do not attempt to upload test results to AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,13 +24,6 @@ test_script:
 - ps: |
     mvn test -P appveyor --batch-mode
 
-on_finish:
-- ps: |
-    (new-object System.Net.WebClient).UploadFile(
-      "https://ci.appveyor.com/api/testresults/junit/$env:APPVEYOR_JOB_ID",
-      (Resolve-Path .\junit-results.xml)
-    )
-
 deploy: off
 
 artifacts:


### PR DESCRIPTION
This removes what appears to be a significant cause of false CI failures on AppVeyor.