### PR TITLE
explictly define the LayoutBlockManager, rather than relying on the instancemanager autodefault.

### DIFF
--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -719,6 +719,7 @@ public class LayoutEditorTest {
         JUnitUtil.setUp();
         if (!GraphicsEnvironment.isHeadless()) {
             le = new LayoutEditor("Test Layout");
+            jmri.InstanceManager.setDefault(LayoutBlockManager.class,new LayoutBlockManager());
         }
     }
 


### PR DESCRIPTION
This should prevent the issue seen while testing #4359 