### PR TITLE
Fix MissingResourceException in SignallingGuiTools

### DIFF
--- a/java/src/jmri/jmrit/signalling/SignallingBundle.properties
+++ b/java/src/jmri/jmrit/signalling/SignallingBundle.properties
@@ -41,7 +41,6 @@ ColumnPermissive = Permissive
 ColumnAspect = Aspect
 
 ButtonDiscover = Discover
-ButtonAdd = Add Logic
 
 # Properties for jmri.jmrit.signalling NX elements
 # Original file:  EntryExitBundle.properties

--- a/java/src/jmri/jmrit/signalling/SignallingBundle_ca.properties
+++ b/java/src/jmri/jmrit/signalling/SignallingBundle_ca.properties
@@ -47,7 +47,6 @@ ColumnPermissive = Permissiu
 ColumnAspect = Aspecte
 
 ButtonDiscover = Descobrir
-ButtonAdd = Afegir l\u00f2gica
 
 # Properties for jmri.jmrit.signalling NX elements
 # Original file:  EntryExitBundle_ca.properties

--- a/java/src/jmri/jmrit/signalling/SignallingBundle_da.properties
+++ b/java/src/jmri/jmrit/signalling/SignallingBundle_da.properties
@@ -42,7 +42,6 @@
 #+ ColumnAspect = Aspect
 
 #+ ButtonDiscover = Discover
-#+ ButtonAdd = Add Logic
 
 # Properties for jmri.jmrit.signalling NX elements
 # Original file:  EntryExitBundle_da.properties

--- a/java/src/jmri/jmrit/signalling/SignallingBundle_de.properties
+++ b/java/src/jmri/jmrit/signalling/SignallingBundle_de.properties
@@ -44,7 +44,6 @@ ColumnPermissive = Permissiv
 ColumnAspect = Signalbegriff
 
 ButtonDiscover = Entdecke
-ButtonAdd = F\u00fcge Logik zu
 
 # Properties for jmri.jmrit.signalling NX elements
 # Original file:  EntryExitBundle_de.properties

--- a/java/src/jmri/jmrit/signalling/SignallingBundle_fr.properties
+++ b/java/src/jmri/jmrit/signalling/SignallingBundle_fr.properties
@@ -57,7 +57,6 @@ ColumnPermissive = Permissive
 ColumnAspect = Aspect
 
 ButtonDiscover = Trouver
-ButtonAdd = Ajt Logique
 
 # Properties for jmri.jmrit.signalling NX elements
 # Original file:  EntryExitBundle_fr.properties

--- a/java/src/jmri/jmrit/signalling/SignallingBundle_it.properties
+++ b/java/src/jmri/jmrit/signalling/SignallingBundle_it.properties
@@ -44,7 +44,6 @@ ColumnPermissive = Facoltativo
 ColumnAspect = Aspetto
 
 ButtonDiscover = Scoprire
-ButtonAdd = Aggiungi Logica
 
 # Properties for jmri.jmrit.signalling NX elements
 # Original file:  EntryExitBundle_it.properties

--- a/java/src/jmri/jmrit/signalling/SignallingBundle_nl.properties
+++ b/java/src/jmri/jmrit/signalling/SignallingBundle_nl.properties
@@ -44,7 +44,6 @@ ColumnPermissive = Permissief
 ColumnAspect = Seinbetekenis
 
 ButtonDiscover = Ontdek
-ButtonAdd = Voeg Logica toe
 
 # Properties for jmri.jmrit.signalling NX elements
 # Original file:  EntryExitBundle_nl.properties

--- a/java/src/jmri/jmrit/signalling/SignallingGuiTools.java
+++ b/java/src/jmri/jmrit/signalling/SignallingGuiTools.java
@@ -104,7 +104,7 @@ public class SignallingGuiTools {
         Object[] options = {Bundle.getMessage("RemoveButton"),  // NOI18N
             Bundle.getMessage("LeaveButton")};  // NOI18N
         int n = JOptionPane.showOptionDialog(frame,
-                java.text.MessageFormat.format(Bundle.getMessage("RemoveAlreadyLogic"),  // NOI18N
+                java.text.MessageFormat.format(Bundle.getMessage("RemoveAlreadyAssignedLogic"),  // NOI18N
                         new Object[]{mast.getDisplayName()}),
                 Bundle.getMessage("RemoveLogicTitle"),  // NOI18N
                 JOptionPane.YES_NO_CANCEL_OPTION,


### PR DESCRIPTION
java.util.MissingResourceException: Resource 'RemoveAlreadyLogic' not found

Changed the key in SignallingGuiTools from **RemoveAlreadyLogic** to **RemoveAlreadyAssignedLogic** to match the property key.

Removed **ButtonAdd** from the property files, was previously replaced by **AddLogic**.