### PR TITLE
Make ProgDebugger.writeCV notify correct value in programmingOpReply.

### DIFF
--- a/java/src/jmri/progdebugger/ProgDebugger.java
+++ b/java/src/jmri/progdebugger/ProgDebugger.java
@@ -135,7 +135,7 @@ public class ProgDebugger implements AddressedProgrammer {
             public void run() {
                 log.debug("write CV reply");
                 if (l != null) {
-                    l.programmingOpReply(-1, 0);
+                    l.programmingOpReply(val, 0);
                 }
             }  // 0 is OK status
         };


### PR DESCRIPTION
`ProgDebugger.writeCV(args)` currently notifies a value of -1 instead of the value written as per [ProgListener.programmingOpReply](http://jmri.org/JavaDoc/doc/jmri/ProgListener.html#programmingOpReply-int-int-).

This was preventing me from checking the return values from a new Facade I am working on.

The change doesn't appear to break any existing tests.