### PR TITLE
Use a newer version of ossindex.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -571,7 +571,7 @@
             <plugin>
                 <groupId>net.ossindex</groupId>
                 <artifactId>ossindex-maven-plugin</artifactId>
-                <version>2.3.3</version>
+                <version>2.3.7</version>
                 <configuration>
                     <failOnError>true</failOnError>
                     <!-- List packages with vulnerabilities to ignore. -->


### PR DESCRIPTION
This makes a one line summary possible by using the option ```-Daudit.quiet``` and adds the ability to warn if an ignored version of a dependency has a vulnerability using the option ```-Daudit.warnOnIgnore``` (these options still cause the ossindex checks to fail if a vulnerability exists in a non-ignored dependency).