### PR TITLE
Add script to start LocoNet logging

### DIFF
--- a/help/en/Acknowledgements.shtml
+++ b/help/en/Acknowledgements.shtml
@@ -104,7 +104,9 @@
         general has made more contributions than can be
         counted.</li>
 
-        <li>Daniel Bergqvist, who 
+        <li>Daniel Bergqvist, who added the "ask before shutdown" code, 
+        improved the Bundle code and added to the Swedish translation
+        
         <li>Andrew Berridge, who debugged and fixed problems with
         the SPROG serial interface</li>
 

--- a/help/en/Acknowledgements.shtml
+++ b/help/en/Acknowledgements.shtml
@@ -104,6 +104,7 @@
         general has made more contributions than can be
         counted.</li>
 
+        <li>Daniel Bergqvist, who 
         <li>Andrew Berridge, who debugged and fixed problems with
         the SPROG serial interface</li>
 
@@ -472,7 +473,8 @@
         <li>Ian Havercroft, who provided the correct identification
         codes for ESU decoders</li>
 
-        <li>David Heap, who provided a QSI decoder fix</li>
+        <li>David Heap, who provided a QSI decoder fix
+        and improved how signal head aspects are supported.</li>
 
         <li>Rob Heikens, who created ESU decoder definitions and
         programmer pages</li>
@@ -975,7 +977,9 @@
         comboboxes (with drop-down menus); added a 2nd turnout
         circle for slips and added left, right & bottom options
         for the toolbar (and re-laid out same) in the Layout Editor.
-        Also wrote all the slip code for the web server.</li>
+        Added support for DMX512 lighting.
+        Also wrote all the slip code for the web server.
+        </li>
 
         <li>Mark Waters, who provided numerous Zimo decoder
         definitions and new Zimo MX620 definitions.</li>

--- a/jython/StartLoggingToFile.py
+++ b/jython/StartLoggingToFile.py
@@ -1,0 +1,21 @@
+# Sample script to find all open LocoNet Monitor windows
+# and tell them to start logging to their (preselected) log file.
+#
+# Author: Bob Jacobsen, copyright 2017
+# Part of the JMRI distribution
+
+import jmri
+import javax.swing
+
+for frame in jmri.util.JmriJFrame.getFrameList() :
+    # We can't use isinstance because monitor frames are just JmriJFrames
+    # so we just try ...
+    try :
+        for panel in frame.contentPane.components :
+            if isinstance(panel, jmri.jmrix.loconet.locomon.LocoMonPane) :
+                panel.startLogButtonActionPerformed(None)
+                print "Started logging on '", frame.title,"' window"
+    except BaseException :
+        # just ignore
+        continue
+    

--- a/jython/test/StartLoggingToFileTest.py
+++ b/jython/test/StartLoggingToFileTest.py
@@ -1,0 +1,6 @@
+# Test the StartLoggingToFile.py script
+
+execfile("jython/StartLoggingToFile.py")
+
+# Just checking that it parses and executes.
+# Note that normally there's no LocoNet Monitor window open here


### PR DESCRIPTION
This is a script that immediately starts the LocoNet Monitor logging to the (default) logging file.

(Also includes an update for the Acknowledgements file from 4.9.6)