### PR TITLE
Support 'altsignal' as an Address Type in decoder definitions.

### DIFF
--- a/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
+++ b/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
@@ -641,12 +641,16 @@ selects the different algorithm needed here.
           <li>If it is "accessory" or "output", the current address is interpreted as an 11-bit accessory output address.</li>
           <li>If it is "signal", the current address is interpreted as an 11-bit signal decoder address.</li>
           <li>
+              If it is "altsignal", the current address is interpreted as an 11-bit signal decoder address,
+              using an alternative interpretation of
+              <a href="https://www.nmra.org/sites/default/files/s-9.2.1_2012_07.pdf"
+                target="_blank">NMRA standard 9.2.1</a>).
+           </li>
+          <li>
               If it is "legacy", the current address is interpreted as a 9-bit address (as for "decoder")
               but a "legacy" programming packet (as per Appendix A of
-     <a href=
-      "http://www.nmra.org/sites/default/files/standards/sandrp/pdf/s-9.2.2_decoder_cvs_2012.07.pdf"
-            target="_blank">
-      NMRA standard 9.2.2</a>)
+              <a href="https://www.nmra.org/sites/default/files/s-9.2.1_2012_07.pdf"
+                target="_blank">NMRA standard 9.2.1</a>)
            is sent.
           </li>
       </ul>

--- a/java/src/jmri/NmraPacket.java
+++ b/java/src/jmri/NmraPacket.java
@@ -387,7 +387,7 @@ public class NmraPacket {
 
     /**
      * Create a signal accessory instruction packet.
-     *
+     * <p>
      * From the RP: Extended Accessory Decoder Control Packet Format The
      * Extended Accessory Decoder Control Packet is included for the purpose of
      * transmitting aspect control to signal decoders or data bytes to more
@@ -662,6 +662,54 @@ public class NmraPacket {
         return accSignalDecoderPktCommon(lowAddr, boardAddr, aspect);
     }
 
+    /**
+     * Provide an extended operations mode accessory CV programming packet via a
+     * simplified interface, given a signal address, using the alternative
+     * interpretation of S-9.2.1, due to an omission in the address definition
+     * of extended accessory packets.
+     *
+     * @param addr  the signal address
+     * @param cvNum the CV
+     * @param data  the data
+     * @return a packet
+     */
+    public static byte[] altAccSignalDecoderPktOpsMode(int addr, int cvNum, int data) {
+
+        if (addr < 1 || addr > 2044) {
+            log.error("invalid address " + addr);
+            throw new IllegalArgumentException();
+        }
+
+        if (cvNum < 1 || cvNum > 1024) {
+            log.error("invalid CV number " + cvNum);
+            return null;
+        }
+
+        if (data < 0 || data > 255) {
+            log.error("invalid data " + data);
+            return null;
+        }
+
+        int outputAddr = addr - 1; // Make the address 0 based
+        int lowAddr = (outputAddr & 0x03);
+        int boardAddr = (outputAddr >> 2); // Board Address
+        int midAddr = (boardAddr & 0x3F);
+        int highAddr = (~(boardAddr >> 6)) & 0x07;
+
+        int lowCVnum = (cvNum - 1) & 0xFF;
+        int highCVnum = ((cvNum - 1) >> 8) & 0x03;
+
+        byte[] retVal = new byte[6];
+        retVal[0] = (byte) (0x80 | midAddr);
+        retVal[1] = (byte) (0x01 | (highAddr << 4) | (lowAddr << 1));
+        retVal[2] = (byte) (0xEC | highCVnum);
+        retVal[3] = (byte) (lowCVnum);
+        retVal[4] = (byte) (0xFF & data);
+        retVal[5] = (byte) (retVal[0] ^ retVal[1] ^ retVal[2] ^ retVal[3] ^ retVal[4]);
+
+        return retVal;
+    }
+
     protected static byte[] accSignalDecoderPktCommon(int lowAddr, int boardAddr, int aspect) {
 
         if (aspect < 0 || aspect > 31) {
@@ -883,11 +931,11 @@ public class NmraPacket {
      * method in that it cannot create a 28 step speed packet for maximum speed.
      * Input speed value in the range 0 - 28 is converted to speed steps, 0,
      * estop, 1, 2, ..., 27.
-     *
+     * <p>
      * This method should probably be deprecated. It is used only by
      * NceThrottle.java and EasyDccThrottle.java which themselves have issues in
      * the way floating point speed values are converted to integer speed steps.
-     *
+     * <p>
      * A speed and direction instruction is used send information to motors
      * connected to Multi Function Digital Decoders. Instruction "010" indicates
      * a Speed and Direction Instruction for reverse operation and instruction
@@ -935,7 +983,7 @@ public class NmraPacket {
     /**
      * New version of speedStep28Packet to allow access to the whole range of 28
      * step speed packets.
-     *
+     * <p>
      * Simply constructs a packet using the 5 bit speed value. This is
      * consistent with the 128 and 14 step methods which do no further
      * processing of the speed value.
@@ -951,7 +999,7 @@ public class NmraPacket {
     public static byte[] speedStep28Packet(boolean full, int address, boolean longAddr, int speed, boolean fwd) {
         log.debug("28 step packet {} {}", address, speed);
 
-        if (full != true) {
+        if (!full) {
             log.error("invalid method invocation");
             return null;    // failed!
         }

--- a/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
+++ b/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
@@ -141,6 +141,12 @@ public class AccessoryOpsModeProgrammerFacade extends AbstractProgrammerFacade i
                         aprog.getAddressNumber(), Integer.parseInt(cv), val);
                 b = NmraPacket.accSignalDecoderPktOpsMode(aprog.getAddressNumber(), Integer.parseInt(cv), val);
                 break;
+            case "altsignal":
+                // interpret address as signal address using the alternative interpretation of S-9.2.1
+                log.debug("Send an altAccSignalDecoderPktOpsMode: address={}, cv={}, value={}",
+                        aprog.getAddressNumber(), Integer.parseInt(cv), val);
+                b = NmraPacket.altAccSignalDecoderPktOpsMode(aprog.getAddressNumber(), Integer.parseInt(cv), val);
+                break;
             case "decoder":
                 // interpet address as decoder address
                 log.debug("Send an accDecPktOpsMode: address={}, cv={}, value={}",

--- a/java/test/jmri/NmraPacketTest.java
+++ b/java/test/jmri/NmraPacketTest.java
@@ -1361,6 +1361,182 @@ public class NmraPacketTest {
     }
 
     @Test
+    public void testAltAccSignalDecoderPktOpsMode1() {
+        int address = 1;
+        int cv = 384;
+        int data = 255;
+        byte[] ba = NmraPacket.altAccSignalDecoderPktOpsMode(address, cv, data);
+
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0x80, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x71, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xED, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x7F, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xFF, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x9C, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAltAccSignalDecoderPktOpsMode4() {
+        int address = 4;
+        int cv = 384;
+        int data = 255;
+        byte[] ba = NmraPacket.altAccSignalDecoderPktOpsMode(address, cv, data);
+
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 1", 0x77, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xED, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x7F, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xFF, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x9A, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAltAccSignalDecoderPktOpsMode5() {
+        int address = 5;
+        int cv = 384;
+        int data = 255;
+        byte[] ba = NmraPacket.altAccSignalDecoderPktOpsMode(address, cv, data);
+
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0x81, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x71, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xED, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x7F, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xFF, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x9D, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAltAccSignalDecoderPktOpsMode8() {
+        int address = 8;
+        int cv = 56;
+        int data = 0;
+        byte[] ba = NmraPacket.altAccSignalDecoderPktOpsMode(address, cv, data);
+
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0x81, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x77, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEC, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x37, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x00, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x2D, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAltAccSignalDecoderPktOpsMode9() {
+        int address = 9;
+        int cv = 1;
+        int data = 30;
+        byte[] ba = NmraPacket.altAccSignalDecoderPktOpsMode(address, cv, data);
+
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0x82, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x71, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEC, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x00, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x1E, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x01, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAltAccSignalDecoderPktOpsMode256() {
+        int address = 256;
+        int cv = 999;
+        int data = 179;
+        byte[] ba = NmraPacket.altAccSignalDecoderPktOpsMode(address, cv, data);
+
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0xBF, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x77, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEF, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0xE6, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xB3, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x72, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAltAccSignalDecoderPktOpsMode257() {
+        int address = 257;
+        int cv = 1;
+        int data = 241;
+        byte[] ba = NmraPacket.altAccSignalDecoderPktOpsMode(address, cv, data);
+
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0x80, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x61, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEC, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x00, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xF1, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0xFC, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAltAccSignalDecoderPktOpsMode260() {
+        int address = 260;
+        int cv = 55;
+        int data = 127;
+        byte[] ba = NmraPacket.altAccSignalDecoderPktOpsMode(address, cv, data);
+
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0x80, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x67, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEC, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x36, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x7F, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x42, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAltAccSignalDecoderPktOpsMode261() {
+        int address = 261;
+        int cv = 55;
+        int data = 99;
+        byte[] ba = NmraPacket.altAccSignalDecoderPktOpsMode(address, cv, data);
+
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0x81, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x61, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEC, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x36, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x63, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x59, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAltAccSignalDecoderPktOpsMode2041() {
+        int address = 2041;
+        int cv = 556;
+        int data = 175;
+        byte[] ba = NmraPacket.altAccSignalDecoderPktOpsMode(address, cv, data);
+
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0xBE, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x01, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEE, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x2B, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0xAF, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0xD5, ba[5] & 0xFF);
+    }
+
+    @Test
+    public void testAltAccSignalDecoderPktOpsMode2044() {
+        int address = 2044;
+        int cv = 771;
+        int data = 102;
+        byte[] ba = NmraPacket.altAccSignalDecoderPktOpsMode(address, cv, data);
+
+        Assert.assertEquals("length", 6, ba.length);
+        Assert.assertEquals("byte 0", 0xBE, ba[0] & 0xFF);
+        Assert.assertEquals("byte 1", 0x07, ba[1] & 0xFF);
+        Assert.assertEquals("byte 2", 0xEF, ba[2] & 0xFF);
+        Assert.assertEquals("byte 3", 0x02, ba[3] & 0xFF);
+        Assert.assertEquals("byte 4", 0x66, ba[4] & 0xFF);
+        Assert.assertEquals("byte 5", 0x32, ba[5] & 0xFF);
+    }
+
+
+    @Test
     public void testExtractAddressTypeAcc() {
         byte[] ba = NmraPacket.accSignalDecoderPkt(123, 12);
         Assert.assertEquals("Accessory", NmraPacket.DccAddressType.ACCESSORY_ADDRESS, NmraPacket.extractAddressType(ba));


### PR DESCRIPTION
Adds `altAccSignalDecoderPktOpsMode(addr, cvNum, data)`as a packet type in `NmraPacket`. Differs from `accSignalDecoderPktOpsMode(addr, cvNum, data)`only in interpretation of the `addr` parameter.