### PR TITLE
Digitrax board programming infrastructure

### DIFF
--- a/help/en/html/hardware/loconet/Addressing.shtml
+++ b/help/en/html/hardware/loconet/Addressing.shtml
@@ -608,6 +608,31 @@
       use both, you should skip version 1 by providing just the
       LOCONETSV2MODE option.</p>
 
+      <a name="boards" id="boards"></a>
+      <h2>Addressing Op Switches in Digitrax boards</h2>
+      <p>(The following was first fully available in <a href=
+      "http://jmri.org/releasenotes/jmri4.9.7.shtml">JMRI
+      4.9.7</a>. Versions before that may not be complete).</p>
+
+        <p>Digitrax boards like the PM4, BDL168, SE8c and 
+        DS64 use a special protocol to program their Op Switches.
+        If you specify a programming mode of LOCONETBDOPSWMODE,
+        DecoderPro will use that protocol.</p>
+        
+        <p>CVs are specified with the format "113/3", 
+        where the part after the slash is the specific
+        Op Switch number, and the part before is 
+        board-specific:<p>
+        <UL>
+            <LI>0x70 - 112 - PM4
+            <LI>0x71 - 113 - BDL16
+            <LI>0x72 - 114 - SE8
+            <LI>0x73 - 115 - DS64
+        </UL>
+        
+
+    <hr>
+
       <p>LocoNet&reg; is a registered trademark of <a href=
       "http://www.digitrax.com">Digitrax, Inc.</a></p>
     </div><!--#include virtual="/Footer" -->

--- a/help/en/html/hardware/loconet/Addressing.shtml
+++ b/help/en/html/hardware/loconet/Addressing.shtml
@@ -619,8 +619,8 @@
         If you specify a programming mode of LOCONETBDOPSWMODE,
         DecoderPro will use that protocol.</p>
         
-        <p>CVs are specified with the format "113/3", 
-        where the part after the slash is the specific
+        <p>CVs are specified with the format "113.3", 
+        where the part after the period is the specific
         Op Switch number, and the part before is 
         board-specific:<p>
         <UL>

--- a/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
@@ -221,9 +221,6 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
 
     @Override
     public void message(LocoNetMessage m) {
-        // see if reply to LNSV 1 or LNSV2 request
-        if ((m.getElement( 0) & 0xFF) != 0xE5) return;
-        if ((m.getElement( 1) & 0xFF) != 0x10) return;
 
         log.debug("reply {}",m);
         if (getMode().equals(LnProgrammerManager.LOCONETBDOPSWMODE)) {
@@ -233,14 +230,14 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
                 log.warn("received board-program reply message with no reply object: {}", m);
                 return;
             }
-            if (!doingWrite) return;
+            if (doingWrite) return;
 
             // check for right type, unit
             if (m.getOpCode() != 0xb4
                     || ((m.getElement(1) != 0x00) && (m.getElement(1) != 0x50))) {
                 return;
             }
-        
+
             // LACK with 0 in opcode; assume its to us.  Note that there
             // should be a 0x50 in the opcode, not zero, but this is what we
             // see...
@@ -261,6 +258,9 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
         
         
         } else if (getMode().equals(LnProgrammerManager.LOCONETSV1MODE)) {
+            // see if reply to LNSV 1 or LNSV2 request
+            if ((m.getElement( 0) & 0xFF) != 0xE5) return;
+            if ((m.getElement( 1) & 0xFF) != 0x10) return;
             if ((m.getElement( 4) & 0xFF) != 0x01) return; // format 1
             if ((m.getElement( 5) & 0x70) != 0x00) return; // 5
         
@@ -292,6 +292,9 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
                 temp.programmingOpReply(val, code);
             }
         } else if (getMode().equals(LnProgrammerManager.LOCONETSV2MODE)) {
+            // see if reply to LNSV 1 or LNSV2 request
+            if ((m.getElement( 0) & 0xFF) != 0xE5) return;
+            if ((m.getElement( 1) & 0xFF) != 0x10) return;
             if ((m.getElement(3) != 0x41) && (m.getElement(3) != 0x42)) return; // need a "Write One Reply", or a "Read One Reply"
             if ((m.getElement( 4) & 0xFF) != 0x02) return; // format 2
             if ((m.getElement( 5) & 0x70) != 0x10) return; // need SVX1 high nibble = 1

--- a/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
@@ -60,6 +60,17 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
         this.p = null;
         // Check mode
         if (getMode().equals(LnProgrammerManager.LOCONETBDOPSWMODE)) {
+            /**
+             * CV format is e.g. "113/12" where the first part defines the
+             * typeword for the specific board type and the second is the specific bit number
+             * Known values:
+             * <UL>
+             * <LI>0x70 112 - PM4
+             * <LI>0x71 113 - BDL16
+             * <LI>0x72 114 - SE8
+             * <LI>0x73 115 - DS64
+             * </ul>
+             */
             this.p = p;
             doingWrite = true;
             // Board programming mode
@@ -67,15 +78,6 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
             String[] parts = CV.split("/");
             int state = Integer.parseInt(parts[1]);
             int typeWord = Integer.parseInt(parts[0]);
-            /**
-             * Known values:
-             * </P><UL>
-             * <LI>0x70 112 - PM4
-             * <LI>0x71 113 - BDL16
-             * <LI>0x72 114 - SE8
-             * <LI>0x73 115 - DS64
-             * </ul>
-             */
             
             // make message
             LocoNetMessage m = new LocoNetMessage(6);
@@ -130,22 +132,24 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
         this.p = null;
         // Check mode
         if (getMode().equals(LnProgrammerManager.LOCONETBDOPSWMODE)) {
-            this.p = p;
-            doingWrite = true;
-            // Board programming mode
-            log.debug("read CV \"{}\" addr:{}", CV, mAddress);
-            String[] parts = CV.split("/");
-            int state = Integer.parseInt(parts[1]);
-            int typeWord = Integer.parseInt(parts[0]);
             /**
+             * CV format is e.g. "113/12" where the first part defines the
+             * typeword for the specific board type and the second is the specific bit number
              * Known values:
-             * </P><UL>
+             * <UL>
              * <LI>0x70 112 - PM4
              * <LI>0x71 113 - BDL16
              * <LI>0x72 114 - SE8
              * <LI>0x73 115 - DS64
              * </ul>
              */
+            this.p = p;
+            doingWrite = false;
+            // Board programming mode
+            log.debug("read CV \"{}\" addr:{}", CV, mAddress);
+            String[] parts = CV.split("/");
+            int state = Integer.parseInt(parts[1]);
+            int typeWord = Integer.parseInt(parts[0]);
             
             // make message
             LocoNetMessage m = new LocoNetMessage(6);

--- a/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
@@ -61,7 +61,7 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
         // Check mode
         if (getMode().equals(LnProgrammerManager.LOCONETBDOPSWMODE)) {
             /**
-             * CV format is e.g. "113/12" where the first part defines the
+             * CV format is e.g. "113.12" where the first part defines the
              * typeword for the specific board type and the second is the specific bit number
              * Known values:
              * <UL>
@@ -75,9 +75,9 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
             doingWrite = true;
             // Board programming mode
             log.debug("write CV \"{}\" to {} addr:{}", CV, val, mAddress);
-            String[] parts = CV.split("/");
-            int state = Integer.parseInt(parts[1]);
+            String[] parts = CV.split("\\.");
             int typeWord = Integer.parseInt(parts[0]);
+            int state = Integer.parseInt(parts[parts.length>1 ? 1 : 0]);
             
             // make message
             LocoNetMessage m = new LocoNetMessage(6);
@@ -133,7 +133,7 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
         // Check mode
         if (getMode().equals(LnProgrammerManager.LOCONETBDOPSWMODE)) {
             /**
-             * CV format is e.g. "113/12" where the first part defines the
+             * CV format is e.g. "113.12" where the first part defines the
              * typeword for the specific board type and the second is the specific bit number
              * Known values:
              * <UL>
@@ -147,9 +147,9 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
             doingWrite = false;
             // Board programming mode
             log.debug("read CV \"{}\" addr:{}", CV, mAddress);
-            String[] parts = CV.split("/");
-            int state = Integer.parseInt(parts[1]);
+            String[] parts = CV.split("\\.");
             int typeWord = Integer.parseInt(parts[0]);
+            int state = Integer.parseInt(parts[parts.length>1 ? 1 : 0]);
             
             // make message
             LocoNetMessage m = new LocoNetMessage(6);

--- a/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
@@ -138,6 +138,41 @@ public class LnOpsModeProgrammerTest extends TestCase {
         
      }
 
+     public void testBoardRead() throws ProgrammerException {
+        LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(sm, memo, 4, true);
+        
+        lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETBDOPSWMODE);
+        lnopsmodeprogrammer.readCV("113.6",pl);
+        
+        // should have written and not returned
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+        
+        Assert.assertEquals("sent byte 0", 0xD0, lnis.outbound.get(0).getElement(0) & 0xFF);
+        Assert.assertEquals("sent byte 1", 0x62, lnis.outbound.get(0).getElement(1) & 0xFF);
+        Assert.assertEquals("sent byte 2", 0x04, lnis.outbound.get(0).getElement(2) & 0xFF);
+        Assert.assertEquals("sent byte 3", 113, lnis.outbound.get(0).getElement(3) & 0xFF);
+        Assert.assertEquals("sent byte 4", 0x0A, lnis.outbound.get(0).getElement(4) & 0xFF);
+
+        int testVal = 1;
+        
+        // check echo of sent message has no effect
+        LocoNetMessage m = lnis.outbound.get(0);
+        lnopsmodeprogrammer.message(m);
+        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+      
+        // Known-good message in reply
+        m = new LocoNetMessage(new int[]{0xB4, 0x50, 0x60, 0x00});
+        lnopsmodeprogrammer.message(m);
+        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("Got programming reply", 1, pl.getRcvdInvoked());
+        Assert.assertEquals("Reply status OK", 0, pl.getRcvdStatus());
+        Assert.assertEquals("Reply value matches", testVal, pl.getRcvdValue());
+        
+     }
+
+
      public void testSv1ARead() throws ProgrammerException {
         LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(sm, memo, 1, true);
         

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <!--Written by JMRI version 4.9.7ish+heap+20171124T1118Z+R6c4d2a5 on Fri Nov 24 22:19:07 AEDT 2017-->
-  <decoderIndex version="862">
+  <!--Written by JMRI version 4.9.7ish+jake+20171125T2350Z+R6d9e2cfa22 on Sat Nov 25 15:51:02 PST 2017-->
+  <decoderIndex version="868">
     <mfgList nmraListDate="2015-03-06" updated="2015-03-25" lastadd="107,124,126,128,134">
       <manufacturer mfg="NMRA" mfgID="999" />
       <manufacturer mfg="A-Train Electronics" mfgID="137" />
@@ -2375,6 +2375,9 @@
           <output name="4" label="Violet" />
         </model>
       </family>
+      <family name="BDL168" mfg="Digitrax" file="Digitrax_BDL168.xml">
+        <model model="BDL168" />
+      </family>
       <family name="Basic FX" mfg="Digitrax" lowVersionID="91" highVersionID="111" file="Digitrax_Basic.xml">
         <model model="DH083" numOuts="5" numFns="3" />
         <model model="DH83FX" numOuts="5" numFns="3" />
@@ -2396,6 +2399,9 @@
       <family name="Basic CS" mfg="Digitrax" lowVersionID="225" highVersionID="239" file="Digitrax_CS.xml">
         <model model="DZ121" numOuts="2" numFns="0" />
         <model model="DN122K2" numOuts="2" numFns="0" />
+      </family>
+      <family name="DS64" mfg="Digitrax" file="Digitrax_DS64.xml">
+        <model model="DS64" />
       </family>
       <family name="Economy Series 3 with FX3, silent" mfg="Digitrax" lowVersionID="35" highVersionID="36" file="Digitrax_Economy.xml">
         <model model="DH123" numOuts="2" numFns="5" connector="9pin" lowVersionID="35" highVersionID="36">
@@ -2431,6 +2437,12 @@
           <output name="2" label="Yellow" connection="plug" />
           <size length="1.074" width="0.672" height="0.259" units="inches" />
         </model>
+      </family>
+      <family name="PM4" mfg="Digitrax" file="Digitrax_PM4.xml">
+        <model model="PM4" />
+      </family>
+      <family name="SE8c" mfg="Digitrax" file="Digitrax_SE8c.xml">
+        <model model="SE8c" />
       </family>
       <family name="Basic STD" mfg="Digitrax" lowVersionID="33" highVersionID="46" file="Digitrax_STD.xml">
         <model model="DH121" numOuts="2" numFns="2" />

--- a/xml/decoders/Digitrax_BDL168.xml
+++ b/xml/decoders/Digitrax_BDL168.xml
@@ -31,14 +31,22 @@
 
         <variables>
           <variable CV="1" comment="Board address" item="Short Address" default="03" infoOnly="yes">
-            <decVal/>
+            <!-- needed to set the board address value -->            
+            <decVal min="1" max="16" />
             <label>Primary Address</label>
           </variable>
 
-            <variable CV="113/3" item="Vstart"
-                      comment="needs a better definition...">
-                <decVal/>
-            </variable>
+          <variable CV="112.3" item="Vstart"
+                      comment="This is Vstart so it shows up on a pane for testing">
+            <enumVal>
+              <enumChoice>
+                <choice>Thrown</choice>
+              </enumChoice>
+              <enumChoice>
+                <choice>Closed</choice>
+              </enumChoice>
+            </enumVal>
+          </variable>
 
         </variables>
     </decoder>

--- a/xml/decoders/Digitrax_BDL168.xml
+++ b/xml/decoders/Digitrax_BDL168.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2002, 2004, 2007, 2015 All rights reserved -->
+<!-- $Id: Public_Domain_FREDi_LNSV2.xml 1810 2015-11-24 12:12:00Z martin $ -->
+<!--                                                                         -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under   -->
+<!-- the terms of version 2 of the GNU General Public License as published   -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy      -->
+<!-- of this license.                                                        -->
+<!--                                                                         -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT     -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or   -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License    -->
+<!-- for more details. -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" 
+                showEmptyPanes="no">
+
+    <version author="Bob Jacobsen" version="1" lastUpdated="20171121" />
+
+    <decoder>
+
+        <family name="BDL168" mfg="Digitrax">
+            <model model="BDL168"/>
+        </family>
+
+        <programming direct="no" paged="no" register="no" ops="no">
+            <mode>LOCONETBDOPSWMODE</mode>
+        </programming>
+
+        <variables>
+          <variable CV="1" comment="Board address" item="Short Address" default="03" infoOnly="yes">
+            <decVal/>
+            <label>Primary Address</label>
+          </variable>
+
+            <variable CV="113/3" item="Vstart"
+                      comment="needs a better definition...">
+                <decVal/>
+            </variable>
+
+        </variables>
+    </decoder>
+
+</decoder-config>

--- a/xml/decoders/Digitrax_DS64.xml
+++ b/xml/decoders/Digitrax_DS64.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2002, 2004, 2007, 2015 All rights reserved -->
+<!-- $Id: Public_Domain_FREDi_LNSV2.xml 1810 2015-11-24 12:12:00Z martin $ -->
+<!--                                                                         -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under   -->
+<!-- the terms of version 2 of the GNU General Public License as published   -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy      -->
+<!-- of this license.                                                        -->
+<!--                                                                         -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT     -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or   -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License    -->
+<!-- for more details. -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" 
+                showEmptyPanes="no">
+
+    <version author="Bob Jacobsen" version="1" lastUpdated="20171121" />
+
+    <decoder>
+
+        <family name="DS64" mfg="Digitrax">
+            <model model="DS64"/>
+        </family>
+
+        <programming direct="no" paged="no" register="no" ops="no">
+            <mode>LOCONETBDOPSWMODE</mode>
+        </programming>
+
+        <variables>
+          <variable CV="1" comment="Board address" item="Short Address" default="03" infoOnly="yes">
+            <decVal/>
+            <label>Primary Address</label>
+          </variable>
+
+            <variable CV="115/3" item="Vstart"
+                      comment="needs a better definition...">
+                <decVal/>
+            </variable>
+
+        </variables>
+    </decoder>
+
+</decoder-config>

--- a/xml/decoders/Digitrax_DS64.xml
+++ b/xml/decoders/Digitrax_DS64.xml
@@ -31,14 +31,22 @@
 
         <variables>
           <variable CV="1" comment="Board address" item="Short Address" default="03" infoOnly="yes">
-            <decVal/>
+            <!-- needed to set the board address value -->            
+            <decVal min="1" max="16" />
             <label>Primary Address</label>
           </variable>
 
-            <variable CV="115/3" item="Vstart"
-                      comment="needs a better definition...">
-                <decVal/>
-            </variable>
+          <variable CV="112.3" item="Vstart"
+                      comment="This is Vstart so it shows up on a pane for testing">
+            <enumVal>
+              <enumChoice>
+                <choice>Thrown</choice>
+              </enumChoice>
+              <enumChoice>
+                <choice>Closed</choice>
+              </enumChoice>
+            </enumVal>
+          </variable>
 
         </variables>
     </decoder>

--- a/xml/decoders/Digitrax_PM4.xml
+++ b/xml/decoders/Digitrax_PM4.xml
@@ -31,14 +31,22 @@
 
         <variables>
           <variable CV="1" comment="Board address" item="Short Address" default="03" infoOnly="yes">
-            <decVal/>
+            <!-- needed to set the board address value -->            
+            <decVal min="1" max="16" />
             <label>Primary Address</label>
           </variable>
 
-            <variable CV="112/3" item="Vstart"
-                      comment="needs a better definition...">
-                <decVal/>
-            </variable>
+          <variable CV="112.3" item="Vstart"
+                      comment="This is Vstart so it shows up on a pane for testing">
+            <enumVal>
+              <enumChoice>
+                <choice>Thrown</choice>
+              </enumChoice>
+              <enumChoice>
+                <choice>Closed</choice>
+              </enumChoice>
+            </enumVal>
+          </variable>
 
         </variables>
     </decoder>

--- a/xml/decoders/Digitrax_PM4.xml
+++ b/xml/decoders/Digitrax_PM4.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2002, 2004, 2007, 2015 All rights reserved -->
+<!-- $Id: Public_Domain_FREDi_LNSV2.xml 1810 2015-11-24 12:12:00Z martin $ -->
+<!--                                                                         -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under   -->
+<!-- the terms of version 2 of the GNU General Public License as published   -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy      -->
+<!-- of this license.                                                        -->
+<!--                                                                         -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT     -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or   -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License    -->
+<!-- for more details. -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" 
+                showEmptyPanes="no">
+
+    <version author="Bob Jacobsen" version="1" lastUpdated="20171121" />
+
+    <decoder>
+
+        <family name="PM4" mfg="Digitrax">
+            <model model="PM4"/>
+        </family>
+
+        <programming direct="no" paged="no" register="no" ops="no">
+            <mode>LOCONETBDOPSWMODE</mode>
+        </programming>
+
+        <variables>
+          <variable CV="1" comment="Board address" item="Short Address" default="03" infoOnly="yes">
+            <decVal/>
+            <label>Primary Address</label>
+          </variable>
+
+            <variable CV="112/3" item="Vstart"
+                      comment="needs a better definition...">
+                <decVal/>
+            </variable>
+
+        </variables>
+    </decoder>
+
+</decoder-config>

--- a/xml/decoders/Digitrax_SE8c.xml
+++ b/xml/decoders/Digitrax_SE8c.xml
@@ -31,14 +31,22 @@
 
         <variables>
           <variable CV="1" comment="Board address" item="Short Address" default="03" infoOnly="yes">
-            <decVal/>
+            <!-- needed to set the board address value -->            
+            <decVal min="1" max="16" />
             <label>Primary Address</label>
           </variable>
 
-            <variable CV="114/3" item="Vstart"
-                      comment="needs a better definition...">
-                <decVal/>
-            </variable>
+          <variable CV="112.3" item="Vstart"
+                      comment="This is Vstart so it shows up on a pane for testing">
+            <enumVal>
+              <enumChoice>
+                <choice>Thrown</choice>
+              </enumChoice>
+              <enumChoice>
+                <choice>Closed</choice>
+              </enumChoice>
+            </enumVal>
+          </variable>
 
         </variables>
     </decoder>

--- a/xml/decoders/Digitrax_SE8c.xml
+++ b/xml/decoders/Digitrax_SE8c.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2002, 2004, 2007, 2015 All rights reserved -->
+<!-- $Id: Public_Domain_FREDi_LNSV2.xml 1810 2015-11-24 12:12:00Z martin $ -->
+<!--                                                                         -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under   -->
+<!-- the terms of version 2 of the GNU General Public License as published   -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy      -->
+<!-- of this license.                                                        -->
+<!--                                                                         -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT     -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or   -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License    -->
+<!-- for more details. -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" 
+                showEmptyPanes="no">
+
+    <version author="Bob Jacobsen" version="1" lastUpdated="20171121" />
+
+    <decoder>
+
+        <family name="SE8c" mfg="Digitrax">
+            <model model="SE8c"/>
+        </family>
+
+        <programming direct="no" paged="no" register="no" ops="no">
+            <mode>LOCONETBDOPSWMODE</mode>
+        </programming>
+
+        <variables>
+          <variable CV="1" comment="Board address" item="Short Address" default="03" infoOnly="yes">
+            <decVal/>
+            <label>Primary Address</label>
+          </variable>
+
+            <variable CV="114/3" item="Vstart"
+                      comment="needs a better definition...">
+                <decVal/>
+            </variable>
+
+        </variables>
+    </decoder>
+
+</decoder-config>

--- a/xml/schema/decoder.xsd
+++ b/xml/schema/decoder.xsd
@@ -924,6 +924,7 @@
       <xs:enumeration value="DIRECTMODE"/>
       <xs:enumeration value="LOCONETSV1MODE"/>
       <xs:enumeration value="LOCONETSV2MODE"/>
+      <xs:enumeration value="LOCONETBDOPSWMODE"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
Initial implementation of programming for Digitrax boards via a new ops-mode programmer mode.

Contains files for defining PM4, BDL168, SE8c and DS64 board CVs that are just stand-ins; these need to have real content added.

Needs tests with real hardware to confirm message coding/decoding.