### PR TITLE
BUGFIX-foundObject-not-getting-cleared-on-mouseReleased

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -5673,6 +5673,7 @@ public class LayoutEditor extends PanelEditor implements VetoableChangeListener,
             selectedObject = null;
         }
 
+        // clear these
         beginObject = null;
         foundObject = null;
 
@@ -9299,6 +9300,7 @@ public class LayoutEditor extends PanelEditor implements VetoableChangeListener,
 
     /**
      * highlight the specified block
+     *
      * @param inBlock the block
      * @return true if block was highlighted
      */
@@ -9328,6 +9330,7 @@ public class LayoutEditor extends PanelEditor implements VetoableChangeListener,
 
     /**
      * highlight the specified layout block
+     *
      * @param inLayoutBlock the layout block
      * @return true if layout block was highlighted
      */

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -5672,6 +5672,10 @@ public class LayoutEditor extends PanelEditor implements VetoableChangeListener,
             prevSelectedObject = selectedObject;
             selectedObject = null;
         }
+
+        beginObject = null;
+        foundObject = null;
+
         isDragging = false;
         delayedPopupTrigger = false;
         requestFocusInWindow();


### PR DESCRIPTION
While working on LayoutEditor issues noticed that sometimes I couldn't "let go" of objects after I'd released them… turned out that the foundObject wasn't always getting cleared.