### PR TITLE
Fix defaulticon xml element

### DIFF
--- a/xml/defaultPanelIcons.xml
+++ b/xml/defaultPanelIcons.xml
@@ -214,12 +214,12 @@
 
     <Light>
       <LeftTurnout>
-        <LightStateOff>
+        <StateOff>
           resources/icons/smallschematics/tracksegments/os-lefthand-east-closed.gif
-        </LightStateOff>
-        <LightStateOn> 
+        </StateOff>
+        <StateOn> 
           resources/icons/smallschematics/tracksegments/os-lefthand-east-thrown.gif
-        </LightStateOn> 
+        </StateOn> 
         <BeanStateInconsistent> 
           resources/icons/smallschematics/tracksegments/os-lefthand-east-error.gif
         </BeanStateInconsistent> 
@@ -228,12 +228,12 @@
         </BeanStateUnknown>
       </LeftTurnout>
       <RightTurnout>
-        <LightStateOff>
+        <StateOff>
           resources/icons/smallschematics/tracksegments/os-righthand-west-closed.gif
-        </LightStateOff>
-        <LightStateOn> 
+        </StateOff>
+        <StateOn> 
           resources/icons/smallschematics/tracksegments/os-righthand-west-thrown.gif
-        </LightStateOn> 
+        </StateOn> 
         <BeanStateInconsistent> 
           resources/icons/smallschematics/tracksegments/os-righthand-west-error.gif
         </BeanStateInconsistent> 


### PR DESCRIPTION
Light state element name matches updated properties key StateOn. Fixes CPE Drag-n-Drop for Lights.