### PR TITLE
Fix failure to delete Turnout

### DIFF
--- a/java/src/jmri/jmrit/blockboss/BlockBossLogic.java
+++ b/java/src/jmri/jmrit/blockboss/BlockBossLogic.java
@@ -167,6 +167,7 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
      * @return system name of the driven signal head
      */
     public String getDrivenSignal() {
+        if (driveSignal == null) return null;
         return driveSignal.getName();
     }
 


### PR DESCRIPTION
Protect against hidden NPE when a SSL has no signal defined.

Closes #3941 and #4514