### PR TITLE
DCC++ ESP (WiFi enabled DCC++) customizations

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppConstants.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppConstants.java
@@ -135,7 +135,9 @@ public final class DCCppConstants {
     public final static String PROGRAM_REPLY_REGEX = "\\s*r\\s*(\\d+)\\|(\\d+)\\|(\\d+)\\s+([-]*\\d+)\\s*";
     public final static String PROGRAM_BIT_REPLY_REGEX = "\\s*r\\s*(\\d+)\\|(\\d+)\\|(\\d+)\\s+(\\d+)\\s+(\\d+)\\s*";
     public final static String CURRENT_REPLY_REGEX = "\\s*a\\s*(\\d+)";
+    public final static String CURRENT_REPLY_NAMED_REGEX = "\\s*a\\s*(\\w+)\\s*(\\d+)";
     public final static String TRACK_POWER_REPLY_REGEX = "\\s*p\\s*([0,1])\\s*";
+    public final static String TRACK_POWER_REPLY_NAMED_REGEX = "\\s*p\\s*(\\d+)\\s+(\\w+)\\s*";
     public final static String SENSOR_REPLY_REGEX = "\\s*[Qq]\\s*(\\d+)\\s*";
     public final static String SENSOR_DEF_REPLY_REGEX = "\\s*Q\\s*(\\d+)\\s+(\\d+)\\s+([0|1])\\s*";
     public final static String SENSOR_ACTIVE_REPLY_REGEX = "\\s*Q\\s*(\\d+)\\s*";
@@ -148,6 +150,7 @@ public final class DCCppConstants {
 //    public final static String STATUS_REPLY_REGEX = "i(DCC\\+\\+.*): BUILD (.*)"; // V1.0
 //    public final static String STATUS_REPLY_REGEX = "i(DCC\\+\\+[^:]*): BUILD (.*)"; // V1.0 / V1.1
     public final static String STATUS_REPLY_REGEX = "i(DCC\\+\\+[^:]*):(?:\\sBUILD)? (.*)"; // V1.0 / V1.1 / V1.2
+    public final static String STATUS_REPLY_ESP32_REGEX = "iDCC\\+\\+.*ESP32.*: V-([\\d\\.]+)\\s+/\\s+(.*)"; // V1.0
     //public final static String STATUS_REPLY_REGEX = "i(DCC\\+\\+\\s?.*):\\s?(?:BUILD)? (.*)"; // V1.0 / V1.1 / V1.2
     public final static String FREE_MEMORY_REPLY_REGEX = "\\s*f\\s*(\\d+)\\s*";
     public final static String WRITE_EEPROM_REPLY_REGEX = "\\s*e\\s*(\\d+)\\s+(\\d+)\\s+(\\d+)\\s*";

--- a/java/test/jmri/jmrix/dccpp/DCCppReplyTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppReplyTest.java
@@ -74,6 +74,41 @@ public class DCCppReplyTest {
         
     }
 
+    // Test named power districts
+    @Test
+    public void testNamedPowerDistrictReply() {
+        DCCppReply l = DCCppReply.parseDCCppReply("p 0 MAIN");
+        Assert.assertTrue(l.isNamedPowerReply());
+        Assert.assertEquals('p', l.getOpCodeChar());
+        Assert.assertEquals("MAIN", l.getPowerDistrictName());
+        Assert.assertEquals("OFF", l.getPowerDistrictStatus());
+
+        l = DCCppReply.parseDCCppReply("p 1 MAIN");
+        Assert.assertTrue(l.isNamedPowerReply());
+        Assert.assertEquals('p', l.getOpCodeChar());
+        Assert.assertEquals("MAIN", l.getPowerDistrictName());
+        Assert.assertEquals("ON", l.getPowerDistrictStatus());
+
+        l = DCCppReply.parseDCCppReply("p 2 MAIN");
+        Assert.assertTrue(l.isNamedPowerReply());
+        Assert.assertEquals('p', l.getOpCodeChar());
+        Assert.assertEquals("MAIN", l.getPowerDistrictName());
+        Assert.assertEquals("OVERLOAD", l.getPowerDistrictStatus());
+    }
+
+    // Test named power districts
+    @Test
+    public void testNamedCurrentReply() {
+        DCCppReply l = DCCppReply.parseDCCppReply("a MAIN 0");
+        Assert.assertTrue(l.isNamedCurrentReply());
+        Assert.assertEquals('a', l.getOpCodeChar());
+        Assert.assertEquals("0", l.getCurrentString());
+
+        l = DCCppReply.parseDCCppReply("a MAIN 100");
+        Assert.assertTrue(l.isNamedCurrentReply());
+        Assert.assertEquals('a', l.getOpCodeChar());
+        Assert.assertEquals("100", l.getCurrentString());
+    }
     // The minimal setup for log4J
     @Before
     public void setUp() {


### PR DESCRIPTION
The DCC++ ESP base station has support for additional motorboards, or power districts. As such a couple of the replies need slight adjustment for parsing. The code is structured such that it can function with either the DCC++ESP base station, DCC++ base station, or the to be released DCC++ESP32 base station (runs on the ESP32, no arduino involved).

The DCC++ESP base station code can be found here: https://github.com/atanisoft/BaseStation

The DCC++ESP32 base station code hasn't been pushed yet but will be before Christmas.