### PR TITLE
Remove double semi-colon that was causing Jenkins compile to fail

### DIFF
--- a/java/src/jmri/jmrix/secsi/serialdriver/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/secsi/serialdriver/configurexml/ConnectionConfigXml.java
@@ -2,7 +2,7 @@ package jmri.jmrix.secsi.serialdriver.configurexml;
 
 import java.util.List;
 import jmri.jmrix.configurexml.AbstractSerialConnectionConfigXml;
-import jmri.jmrix.secsi.SecsiSystemConnectionMemo;;
+import jmri.jmrix.secsi.SecsiSystemConnectionMemo;
 import jmri.jmrix.secsi.SerialNode;
 import jmri.jmrix.secsi.SerialTrafficController;
 import jmri.jmrix.secsi.serialdriver.ConnectionConfig;


### PR DESCRIPTION
There was a double semicolon (;;) in java/src/jmri/jmrix/secsi/serialdriver/configurexml/ConnectionConfigXml.java that was causing Jenkins to fail with:

```
    [javac] 184. WARNING in /var/lib/jenkins/jobs/Development/jobs/Builds/workspace/java/src/jmri/jmrix/secsi/serialdriver/configurexml/ConnectionConfigXml.java (at line 5)
    [javac] 	import jmri.jmrix.secsi.SecsiSystemConnectionMemo;;
    [javac] 	                                                  ^
    [javac] Unnecessary semicolon
    [javac] ----------
    [javac] 185. ERROR in /var/lib/jenkins/jobs/Development/jobs/Builds/workspace/java/src/jmri/jmrix/secsi/serialdriver/configurexml/ConnectionConfigXml.java (at line 5)
    [javac] 	import jmri.jmrix.secsi.SecsiSystemConnectionMemo;;
    [javac] 	                                                  ^
    [javac] Syntax error on token ";", delete this token
    [javac] ----------
```

(Note that the same line is being referred to in those two messages)
