### PR TITLE
use Not instead of ~ in command line cucumber options on CI engines

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1353,7 +1353,7 @@
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
-            <sysproperty key="cucumber.options" value="--tags ~@Ignore"/>
+            <sysproperty key="cucumber.options" value="--tags 'not @Ignore'"/>
 
             <classpath refid="test.class.path"/>
 

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -11,8 +11,8 @@ if [[ "$HEADLESS" == "true" ]] ; then
     # FindBugs configuration is in pom.xml
     mvn test -U -P travis-findbugs --batch-mode
     # run headless tests
-    mvn test -U -P travis-headless --batch-mode -Dsurefire.printSummary=${PRINT_SUMMARY} -Dsurefire.runOrder=${RUN_ORDER} -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" -Djava.awt.headless=${HEADLESS} -Dcucumber.options="--tags ~@Ignore --tags ~@firefox" 
+    mvn test -U -P travis-headless --batch-mode -Dsurefire.printSummary=${PRINT_SUMMARY} -Dsurefire.runOrder=${RUN_ORDER} -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" -Djava.awt.headless=${HEADLESS} -Dcucumber.options="--tags 'not @Ignore' --tags 'not @firefox'" 
 else
     # run full GUI test suite and fail on coverage issues
-    mvn javadoc:javadoc verify -U -P travis-coverage --batch-mode -Dsurefire.printSummary=${PRINT_SUMMARY} -Dsurefire.runOrder=${RUN_ORDER} -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" -Djava.awt.headless=${HEADLESS} -Dcucumber.options="--tags ~@Ignore" 
+    mvn javadoc:javadoc verify -U -P travis-coverage --batch-mode -Dsurefire.printSummary=${PRINT_SUMMARY} -Dsurefire.runOrder=${RUN_ORDER} -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" -Djava.awt.headless=${HEADLESS} -Dcucumber.options="--tags 'not @Ignore'" 
 fi


### PR DESCRIPTION
prevents a warning message caused by the recent version update.