### PR TITLE
Reinstate deleted CV29 Power Mode setting.

### DIFF
--- a/xml/decoders/esu/v4standardCVs.xml
+++ b/xml/decoders/esu/v4standardCVs.xml
@@ -228,6 +228,7 @@
     </variable>
     <xi:include href="http://jmri.org/xml/decoders/nmra/cv29direction.xml"/>
     <xi:include href="http://jmri.org/xml/decoders/nmra/cv29speedSteps.xml"/>
+    <xi:include href="http://jmri.org/xml/decoders/nmra/cv29analog.xml"/>
     <variable CV="29" mask="XXXXVXXX" default="1" exclude="LokPilot Fx V4.0" item="ESU V4 Advanced RailCom Option 1">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
         <label>RailCom® Enable</label>


### PR DESCRIPTION
This was triggered by a complaint on the LokSound users group.

The DC/DCC Conversion setting in CV29 is missing from the Basic Pane.

Had been accidentally removed by @Klb4ever via #3917 

My view is that it should also be fixed in the V4.10 release.