### PR TITLE
Package Test JUnit4 conversion

### DIFF
--- a/java/test/apps/tests/AllTest.java
+++ b/java/test/apps/tests/AllTest.java
@@ -42,7 +42,7 @@ public class AllTest extends TestCase {
         // all tests from here down in heirarchy
         TestSuite suite = new TestSuite("AllTest");  // no tests in this class itself
         // all tests from other classes
-        suite.addTest(jmri.PackageTest.suite());
+        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.PackageTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(apps.PackageTest.class));
         // at the end, we check for Log4J messages again
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.Log4JErrorIsErrorTest.class));

--- a/java/test/jmri/HeadLessTest.java
+++ b/java/test/jmri/HeadLessTest.java
@@ -42,7 +42,7 @@ public class HeadLessTest extends TestCase {
         apps.tests.AllTest.initLogging();
         TestSuite suite = new TestSuite("jmri.JmriTest");  // no tests in this class itself
 
-        suite.addTest(jmri.PackageTest.suite());
+        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.PackageTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(apps.PackageTest.class));
         return suite;
     }

--- a/java/test/jmri/PackageTest.java
+++ b/java/test/jmri/PackageTest.java
@@ -1,106 +1,79 @@
 package jmri;
 
 import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.BeanSettingTest.class,
+        BundleTest.class,
+        jmri.NamedBeanHandleManagerTest.class,
+        jmri.BlockTest.class,
+        jmri.BlockManagerTest.class,
+        jmri.DccLocoAddressTest.class,
+        jmri.InstanceManagerTest.class,
+        jmri.NamedBeanTest.class,
+        jmri.LightTest.class,
+        NmraPacketTest.class,
+        jmri.ConditionalVariableTest.class,
+        jmri.PathTest.class,
+        jmri.PathLengthTest.class,
+        jmri.PushbuttonPacketTest.class,
+        SectionTest.class,
+        jmri.SignalGroupTest.class,
+        jmri.SignalMastLogicTest.class,
+        TransitTest.class,
+        TransitSectionTest.class,
+        TransitSectionActionTest.class,
+        jmri.TurnoutTest.class,
+        jmri.TurnoutOperationTest.class,
+        jmri.ApplicationTest.class,
+        jmri.AudioTest.class,
+        jmri.IdTagTest.class,
+        jmri.SchemaTest.class,
+        jmri.ProgrammingModeTest.class,
+        VersionTest.class,
+        jmri.beans.PackageTest.class,
+        jmri.progdebugger.PackageTest.class,
+        jmri.configurexml.PackageTest.class,
+        jmri.implementation.PackageTest.class,
+        jmri.managers.PackageTest.class,
+        jmri.jmrix.PackageTest.class,
+        jmri.jmrit.PackageTest.class,
+        jmri.swing.PackageTest.class,
+        jmri.util.PackageTest.class,
+        jmri.web.PackageTest.class,
+        jmri.jmris.PackageTest.class,
+        jmri.profile.PackageTest.class,
+        jmri.server.PackageTest.class,
+        jmri.plaf.PackageTest.class,
+        jmri.script.PackageTest.class,
+        AudioExceptionTest.class,
+        JmriExceptionTest.class,
+        ProgrammerExceptionTest.class,
+        ProgReadExceptionTest.class,
+        ProgWriteExceptionTest.class,
+        TimebaseRateExceptionTest.class,
+        jmri.spi.PackageTest.class,
+        JmriPluginTest.class,
+        MetadataTest.class,
+        NoFeedbackTurnoutOperationTest.class,
+        RawTurnoutOperationTest.class,
+        ScaleTest.class,
+        SectionManagerTest.class,
+        SensorTurnoutOperationTest.class,
+        TransitManagerTest.class,
+        TurnoutOperationManagerTest.class,
+        EntryPointTest.class,
+        RunCucumberTest.class,
+})
 
 /**
  * Invoke complete set of tests for the Jmri package
  *
  * @author	Bob Jacobsen, Copyright (C) 2001, 2002, 2007
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.PackageTest");  // no tests in this class itself
-
-        suite.addTest(jmri.BeanSettingTest.suite());
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(jmri.NamedBeanHandleManagerTest.suite());
-        suite.addTest(jmri.BlockTest.suite());
-        suite.addTest(jmri.BlockManagerTest.suite());
-        suite.addTest(jmri.DccLocoAddressTest.suite());
-        suite.addTest(jmri.InstanceManagerTest.suite());
-        suite.addTest(jmri.NamedBeanTest.suite());
-        suite.addTest(jmri.LightTest.suite());
-        suite.addTest(new JUnit4TestAdapter(NmraPacketTest.class));
-        suite.addTest(jmri.ConditionalVariableTest.suite());
-        suite.addTest(jmri.PathTest.suite());
-        suite.addTest(jmri.PathLengthTest.suite());
-        suite.addTest(jmri.PushbuttonPacketTest.suite());
-        suite.addTest(new JUnit4TestAdapter(SectionTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.SignalGroupTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.SignalMastLogicTest.class));
-        suite.addTest(new JUnit4TestAdapter(TransitTest.class));
-        suite.addTest(new JUnit4TestAdapter(TransitSectionTest.class));
-        suite.addTest(new JUnit4TestAdapter(TransitSectionActionTest.class));
-        suite.addTest(jmri.TurnoutTest.suite());
-        suite.addTest(jmri.TurnoutOperationTest.suite());
-        suite.addTest(jmri.ApplicationTest.suite());
-        suite.addTest(jmri.AudioTest.suite());
-        suite.addTest(jmri.IdTagTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.SchemaTest.class));
-        suite.addTest(jmri.ProgrammingModeTest.suite());
-        suite.addTest(new JUnit4TestAdapter(VersionTest.class));
-        suite.addTest(jmri.beans.PackageTest.suite());
-        suite.addTest(jmri.progdebugger.PackageTest.suite());
-        suite.addTest(jmri.configurexml.PackageTest.suite());
-        suite.addTest(jmri.implementation.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.managers.PackageTest.class));
-        suite.addTest(jmri.jmrix.PackageTest.suite());
-        suite.addTest(jmri.jmrit.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.swing.PackageTest.class));
-        suite.addTest(jmri.util.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.web.PackageTest.class));
-        suite.addTest(jmri.jmris.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.profile.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.server.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.plaf.PackageTest.class));
-        suite.addTest(jmri.script.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(AudioExceptionTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriExceptionTest.class));
-        suite.addTest(new JUnit4TestAdapter(ProgrammerExceptionTest.class));
-        suite.addTest(new JUnit4TestAdapter(ProgReadExceptionTest.class));
-        suite.addTest(new JUnit4TestAdapter(ProgWriteExceptionTest.class));
-        suite.addTest(new JUnit4TestAdapter(TimebaseRateExceptionTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.spi.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriPluginTest.class));
-        suite.addTest(new JUnit4TestAdapter(MetadataTest.class));
-        suite.addTest(new JUnit4TestAdapter(NoFeedbackTurnoutOperationTest.class));
-        suite.addTest(new JUnit4TestAdapter(RawTurnoutOperationTest.class));
-        suite.addTest(new JUnit4TestAdapter(ScaleTest.class));
-        suite.addTest(new JUnit4TestAdapter(SectionManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(SensorTurnoutOperationTest.class));
-        suite.addTest(new JUnit4TestAdapter(TransitManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(TurnoutOperationManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(EntryPointTest.class));
-        suite.addTest(new JUnit4TestAdapter(RunCucumberTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest {
 }

--- a/java/test/jmri/beans/PackageTest.java
+++ b/java/test/jmri/beans/PackageTest.java
@@ -1,49 +1,25 @@
 package jmri.beans;
 
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BeansTest.class,
+        UnboundBeanTest.class,
+        ArbitraryPropertySupportTest.class,
+        UnboundArbitraryBeanTest.class,
+	    ConstrainedArbitraryBeanTest.class,
+})
 
 /**
  * Invoke complete set of tests for the Jmri package
  *
  * @author	Bob Jacobsen, Copyright (C) 2001, 2002, 2007
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.beans.PackageTest");  // no tests in this class itself
-        suite.addTest(new TestSuite(BeansTest.class));
-        suite.addTest(new TestSuite(UnboundBeanTest.class));
-        suite.addTest(new TestSuite(ArbitraryPropertySupportTest.class));
-        suite.addTest(new TestSuite(UnboundArbitraryBeanTest.class));
-	suite.addTest(new junit.framework.JUnit4TestAdapter(ConstrainedArbitraryBeanTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest {
 }
 

--- a/java/test/jmri/configurexml/PackageTest.java
+++ b/java/test/jmri/configurexml/PackageTest.java
@@ -1,75 +1,44 @@
 package jmri.configurexml;
 
 import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SchemaTest.class,
+        LoadAndCheckTest.class,
+        LoadAndStoreTest.class,
+        ConfigXmlManagerTest.class,
+        BlockManagerXmlTest.class,
+        SectionManagerXmlTest.class,
+        TransitManagerXmlTest.class,
+        DefaultJavaBeanConfigXMLTest.class,
+        BundleTest.class,
+        DccLocoAddressXmlTest.class,
+        JmriConfigureXmlExceptionTest.class,
+        jmri.configurexml.turnoutoperations.PackageTest.class,
+        jmri.configurexml.swing.PackageTest.class,
+        ErrorHandlerTest.class,
+        LoadXmlConfigActionTest.class,
+        LoadXmlUserActionTest.class,
+        LocoAddressXmlTest.class,
+        SaveMenuTest.class,
+        StoreXmlAllActionTest.class,
+        StoreXmlConfigActionTest.class,
+        StoreXmlUserActionTest.class,
+        TurnoutOperationManagerXmlTest.class,
+        ErrorMemoTest.class,
+        ClassMigrationManagerTest.class,
+        DefaultClassMigrationTest.class,
+})
 
 /**
  * Test the jmri.configxml package.
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests, including others in the package
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.configurexml.PackageTest");  // no tests in this class itself
-
-        suite.addTest(new JUnit4TestAdapter(SchemaTest.class));
-        suite.addTest(new JUnit4TestAdapter(LoadAndCheckTest.class));
-        suite.addTest(new JUnit4TestAdapter(LoadAndStoreTest.class));
-
-        suite.addTest(ConfigXmlManagerTest.suite());
-
-        suite.addTest(BlockManagerXmlTest.suite());
-        //suite.addTest(OBlockManagerXmlTest.suite());
-        suite.addTest(SectionManagerXmlTest.suite());
-        suite.addTest(new JUnit4TestAdapter(TransitManagerXmlTest.class));
-
-        suite.addTest(DefaultJavaBeanConfigXMLTest.suite());
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new JUnit4TestAdapter(DccLocoAddressXmlTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriConfigureXmlExceptionTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.configurexml.turnoutoperations.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.configurexml.swing.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(ErrorHandlerTest.class));
-        suite.addTest(new JUnit4TestAdapter(LoadXmlConfigActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(LoadXmlUserActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(LocoAddressXmlTest.class));
-        suite.addTest(new JUnit4TestAdapter(SaveMenuTest.class));
-        suite.addTest(new JUnit4TestAdapter(StoreXmlAllActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(StoreXmlConfigActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(StoreXmlUserActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(TurnoutOperationManagerXmlTest.class));
-        suite.addTest(new JUnit4TestAdapter(ErrorMemoTest.class));
-        suite.addTest(new JUnit4TestAdapter(ClassMigrationManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(DefaultClassMigrationTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest {
 }
 

--- a/java/test/jmri/implementation/PackageTest.java
+++ b/java/test/jmri/implementation/PackageTest.java
@@ -1,9 +1,78 @@
 package jmri.implementation;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        // fundamental aspects
+        NamedBeanTest.class,
+
+        // implementations
+        AbstractSensorTest.class,
+        AccessoryOpsModeProgrammerFacadeTest.class,
+        OpsModeDelayedProgrammerFacadeTest.class,
+        AddressedHighCvProgrammerFacadeTest.class,
+        DccSignalHeadTest.class,
+        DccSignalMastTest.class,
+        DefaultConditionalTest.class,
+        DefaultConditionalActionTest.class,
+        DefaultIdTagTest.class,
+        DefaultLogixTest.class,
+        DefaultSignalSystemTest.class,
+        DefaultSignalAppearanceMapTest.class,
+        MultiIndexProgrammerFacadeTest.class,
+        VerifyWriteProgrammerFacadeTest.class,
+        OffsetHighCvProgrammerFacadeTest.class,
+        ResettingOffsetHighCvProgrammerFacadeTest.class,
+        RouteTest.class,
+        SE8cSignalHeadTest.class,
+        SignalHeadSignalMastTest.class,
+        SignalSpeedMapTest.class,
+        SignalSystemFileCheckTest.class,
+        SingleTurnoutSignalHeadTest.class,
+        TwoIndexTcsProgrammerFacadeTest.class,
+        BundleTest.class,
+        DccConsistTest.class,
+        NmraConsistTest.class,
+        MatrixSignalMastTest.class,
+        DefaultRailComTest.class,
+
+        // sub-packages
+        jmri.implementation.swing.PackageTest.class,
+        ReporterTest.class,
+        jmri.implementation.configurexml.PackageTest.class,
+        LightControlTest.class,
+        DccConsistManagerTest.class,
+        DefaultClockControlTest.class,
+        FileLocationsPreferencesTest.class,
+        JmriConfigurationManagerTest.class,
+        NmraConsistManagerTest.class,
+        ProgrammerFacadeSelectorTest.class,
+        AbstractRailComReporterTest.class,
+        DefaultConditionalTest.class,
+        DefaultSignalMastLogicTest.class,
+        DoubleTurnoutSignalHeadTest.class,
+        JmriClockPropertyListenerTest.class,
+        JmriMemoryPropertyListenerTest.class,
+        JmriMultiStatePropertyListenerTest.class,
+        JmriSimplePropertyListenerTest.class,
+        JmriTwoStatePropertyListenerTest.class,
+        LsDecSignalHeadTest.class,
+        MergSD2SignalHeadTest.class,
+        NoFeedbackTurnoutOperatorTest.class,
+        QuadOutputSignalHeadTest.class,
+        RawTurnoutOperatorTest.class,
+        SensorGroupConditionalTest.class,
+        SensorTurnoutOperatorTest.class,
+        SignalMastRepeaterTest.class,
+        TripleOutputSignalHeadTest.class,
+        TripleTurnoutSignalHeadTest.class,
+        TurnoutSignalMastTest.class,
+        VirtualSignalMastTest.class,
+        AbstractInstanceInitializerTest.class,
+
+})
 
 /**
  * PackageTest.java
@@ -12,93 +81,6 @@ import junit.framework.TestSuite;
  *
  * @author	Bob Jacobsen 2009, 2017
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.implementation");   // no tests in this class itself
-
-        // fundamental aspects
-        suite.addTest(NamedBeanTest.suite());
-
-        // implementations
-        suite.addTest(AbstractSensorTest.suite());
-        suite.addTest(new JUnit4TestAdapter(AccessoryOpsModeProgrammerFacadeTest.class));
-        suite.addTest(new JUnit4TestAdapter(OpsModeDelayedProgrammerFacadeTest.class));
-        suite.addTest(AddressedHighCvProgrammerFacadeTest.suite());
-        suite.addTest(new JUnit4TestAdapter(DccSignalHeadTest.class));
-        suite.addTest(new JUnit4TestAdapter(DccSignalMastTest.class));
-        suite.addTest(DefaultConditionalTest.suite());
-        suite.addTest(DefaultConditionalActionTest.suite());
-        suite.addTest(new JUnit4TestAdapter(DefaultIdTagTest.class));
-        suite.addTest(DefaultLogixTest.suite());
-        suite.addTest(new JUnit4TestAdapter(DefaultSignalSystemTest.class));
-        suite.addTest(new JUnit4TestAdapter(DefaultSignalAppearanceMapTest.class));
-        suite.addTest(MultiIndexProgrammerFacadeTest.suite());
-        suite.addTest(VerifyWriteProgrammerFacadeTest.suite());
-        suite.addTest(OffsetHighCvProgrammerFacadeTest.suite());
-        suite.addTest(ResettingOffsetHighCvProgrammerFacadeTest.suite());
-        suite.addTest(RouteTest.suite());
-        suite.addTest(new JUnit4TestAdapter(SE8cSignalHeadTest.class));
-        suite.addTest(new JUnit4TestAdapter(SignalHeadSignalMastTest.class));
-        suite.addTest(SignalSpeedMapTest.suite());
-        suite.addTest(new JUnit4TestAdapter(SignalSystemFileCheckTest.class));
-        suite.addTest(new JUnit4TestAdapter(SingleTurnoutSignalHeadTest.class));
-        suite.addTest(TwoIndexTcsProgrammerFacadeTest.suite());
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new JUnit4TestAdapter(DccConsistTest.class));
-        suite.addTest(new JUnit4TestAdapter(NmraConsistTest.class));
-        suite.addTest(new JUnit4TestAdapter(MatrixSignalMastTest.class));
-        suite.addTest(new JUnit4TestAdapter(DefaultRailComTest.class));
-
-        // sub-packages
-        suite.addTest(jmri.implementation.swing.PackageTest.suite());
-        suite.addTest(ReporterTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.implementation.configurexml.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(LightControlTest.class));
-        suite.addTest(new JUnit4TestAdapter(DccConsistManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(DefaultClockControlTest.class));
-        suite.addTest(new JUnit4TestAdapter(FileLocationsPreferencesTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriConfigurationManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(NmraConsistManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(ProgrammerFacadeSelectorTest.class));
-        suite.addTest(new JUnit4TestAdapter(AbstractRailComReporterTest.class));
-        suite.addTest(new JUnit4TestAdapter(DefaultConditionalTest.class));
-        suite.addTest(new JUnit4TestAdapter(DefaultSignalMastLogicTest.class));
-        suite.addTest(new JUnit4TestAdapter(DoubleTurnoutSignalHeadTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriClockPropertyListenerTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriMemoryPropertyListenerTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriMultiStatePropertyListenerTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriSimplePropertyListenerTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriTwoStatePropertyListenerTest.class));
-        suite.addTest(new JUnit4TestAdapter(LsDecSignalHeadTest.class));
-        suite.addTest(new JUnit4TestAdapter(MergSD2SignalHeadTest.class));
-        suite.addTest(new JUnit4TestAdapter(NoFeedbackTurnoutOperatorTest.class));
-        suite.addTest(new JUnit4TestAdapter(QuadOutputSignalHeadTest.class));
-        suite.addTest(new JUnit4TestAdapter(RawTurnoutOperatorTest.class));
-        suite.addTest(new JUnit4TestAdapter(SensorGroupConditionalTest.class));
-        suite.addTest(new JUnit4TestAdapter(SensorTurnoutOperatorTest.class));
-        suite.addTest(new JUnit4TestAdapter(SignalMastRepeaterTest.class));
-        suite.addTest(new JUnit4TestAdapter(TripleOutputSignalHeadTest.class));
-        suite.addTest(new JUnit4TestAdapter(TripleTurnoutSignalHeadTest.class));
-        suite.addTest(new JUnit4TestAdapter(TurnoutSignalMastTest.class));
-        suite.addTest(new JUnit4TestAdapter(VirtualSignalMastTest.class));
-        suite.addTest(new JUnit4TestAdapter(AbstractInstanceInitializerTest.class));
-
-
-        return suite;
-    }
-
+public class PackageTest {
 }
 

--- a/java/test/jmri/implementation/swing/PackageTest.java
+++ b/java/test/jmri/implementation/swing/PackageTest.java
@@ -7,32 +7,15 @@
  */
 package jmri.implementation.swing;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
-public class PackageTest extends TestCase {
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SwingShutDownTaskDemo.class,  // Normally a user-invoked demo, but in this case also a test
+        BundleTest.class,
+        SwingShutDownTaskTest.class,
+})
 
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.implementation.swing");   // no tests in this class itself
-
-        suite.addTest(SwingShutDownTaskDemo.suite());  // Normally a user-invoked demo, but in this case also a test
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SwingShutDownTaskTest.class));
-
-        return suite;
-    }
-
+public class PackageTest {
 }

--- a/java/test/jmri/jmris/PackageTest.java
+++ b/java/test/jmri/jmris/PackageTest.java
@@ -2,55 +2,29 @@
 package jmri.jmris;
 
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmris.srcp.SRCPTest.class,
+        jmri.jmris.simpleserver.PackageTest.class,
+        jmri.jmris.json.PackageTest.class,
+        jmri.jmris.JmriServerTest.class,
+        jmri.jmris.JmriConnectionTest.class,
+        jmri.jmris.ServiceHandlerTest.class,
+        BundleTest.class,
+        JmriServerFrameTest.class,
+        JmriServerActionTest.class,
+        ServerMenuTest.class,
+})
 
 /**
  * Set of tests for the jmri.jmris package
  *
  * @author	Paul Bender Copyright 2010
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmris.JmrisTest");
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmris.srcp.SRCPTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmris.simpleserver.PackageTest.class));
-        suite.addTest(jmri.jmris.json.PackageTest.suite());
-        suite.addTest(jmri.jmris.JmriServerTest.suite());
-        suite.addTest(jmri.jmris.JmriConnectionTest.suite());
-        suite.addTest(jmri.jmris.ServiceHandlerTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JmriServerFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JmriServerActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ServerMenuTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest {
 }

--- a/java/test/jmri/jmris/json/PackageTest.java
+++ b/java/test/jmri/jmris/json/PackageTest.java
@@ -1,38 +1,22 @@
 package jmri.jmris.json;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        JsonServerTest.class,
+        BundleTest.class,
+        JsonServerActionTest.class,
+        JsonServerPreferencesPanelTest.class,
+        JsonServerPreferencesTest.class,
+        JsonProgrammerServerTest.class,
+})
 
 /**
  * Tests for the jmri.jmris.json package
  *
  * @author Paul Bender
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class.getPackage().getName());
-        suite.addTest(new JUnit4TestAdapter(JsonServerTest.class));
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new JUnit4TestAdapter(JsonServerActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(JsonServerPreferencesPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(JsonServerPreferencesTest.class));
-        suite.addTest(new JUnit4TestAdapter(JsonProgrammerServerTest.class));
-        return suite;
-    }
-
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/PackageTest.java
+++ b/java/test/jmri/jmrit/PackageTest.java
@@ -1,103 +1,76 @@
 package jmri.jmrit;
 
 import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrit.AbstractIdentifyTest.class,
+        BundleTest.class,
+        DccLocoAddressSelectorTest.class,
+        MemoryContentsTest.class,
+        SoundTest.class,
+        XmlFileTest.class,
+        jmri.jmrit.automat.PackageTest.class,
+        jmri.jmrit.beantable.PackageTest.class,
+        jmri.jmrit.blockboss.PackageTest.class,
+        jmri.jmrit.catalog.PackageTest.class,
+        jmri.jmrit.conditional.PackageTest.class,
+        jmri.jmrit.decoderdefn.PackageTest.class,
+        jmri.jmrit.dispatcher.PackageTest.class,
+        jmri.jmrit.display.PackageTest.class,
+        jmri.jmrit.entryexit.PackageTest.class,
+        jmri.jmrit.jython.PackageTest.class,
+        jmri.jmrit.log.PackageTest.class,
+        jmri.jmrit.logix.PackageTest.class,
+        jmri.jmrit.operations.PackageTest.class,
+        jmri.jmrit.progsupport.PackageTest.class,
+        jmri.jmrit.mastbuilder.PackageTest.class,
+        jmri.jmrit.mailreport.PackageTest.class,
+        jmri.jmrit.powerpanel.PackageTest.class,
+        jmri.jmrit.roster.PackageTest.class,
+        jmri.jmrit.sendpacket.PackageTest.class,
+        jmri.jmrit.sensorgroup.PackageTest.class,
+        jmri.jmrit.simpleclock.PackageTest.class,
+        jmri.jmrit.symbolicprog.PackageTest.class,
+        jmri.jmrit.tracker.PackageTest.class,
+        jmri.jmrit.ussctc.PackageTest.class,
+        jmri.jmrit.consisttool.PackageTest.class,
+        jmri.jmrit.withrottle.PackageTest.class,
+        jmri.jmrit.ampmeter.PackageTest.class,
+        jmri.jmrit.lcdclock.PackageTest.class,
+        jmri.jmrit.throttle.PackageTest.class,
+        jmri.jmrit.audio.PackageTest.class,
+        jmri.jmrit.turnoutoperations.PackageTest.class,
+        jmri.jmrit.dualdecoder.PackageTest.class,
+        jmri.jmrit.nixieclock.PackageTest.class,
+        jmri.jmrit.simpleprog.PackageTest.class,
+        jmri.jmrit.signalling.PackageTest.class,
+        jmri.jmrit.picker.PackageTest.class,
+        jmri.jmrit.speedometer.PackageTest.class,
+        jmri.jmrit.analogclock.PackageTest.class,
+        jmri.jmrit.revhistory.PackageTest.class,
+        jmri.jmrit.sound.PackageTest.class,
+        jmri.jmrit.vsdecoder.PackageTest.class,
+        jmri.jmrit.simplelightctrl.PackageTest.class,
+        jmri.jmrit.simpleturnoutctrl.PackageTest.class,
+        MemoryFrameActionTest.class,
+        ToolsMenuTest.class,
+        XmlFileLocationActionTest.class,
+        XmlFileValidateActionTest.class,
+        XmlFileValidateStartupActionFactoryTest.class,
+        DebugMenuTest.class,
+        LogixLoadActionTest.class,
+        XmlFileCheckActionTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.PackageTest");   // no tests in this class itself
-
-        suite.addTest(jmri.jmrit.AbstractIdentifyTest.suite());
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(DccLocoAddressSelectorTest.suite());
-        suite.addTest(MemoryContentsTest.suite());
-        suite.addTest(new JUnit4TestAdapter(SoundTest.class));
-        suite.addTest(XmlFileTest.suite());
-
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.automat.PackageTest.class));
-        suite.addTest(jmri.jmrit.beantable.PackageTest.suite());
-        suite.addTest(jmri.jmrit.blockboss.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.catalog.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.conditional.PackageTest.class));
-        suite.addTest(jmri.jmrit.decoderdefn.PackageTest.suite());
-        suite.addTest(jmri.jmrit.dispatcher.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.display.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.entryexit.PackageTest.class));
-        suite.addTest(jmri.jmrit.jython.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.log.PackageTest.class));
-        suite.addTest(jmri.jmrit.logix.PackageTest.suite());
-        suite.addTest(jmri.jmrit.operations.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.progsupport.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.mastbuilder.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.mailreport.PackageTest.class));
-        suite.addTest(jmri.jmrit.powerpanel.PackageTest.suite());
-        suite.addTest(jmri.jmrit.roster.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.sendpacket.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.sensorgroup.PackageTest.class));
-        suite.addTest(jmri.jmrit.simpleclock.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.symbolicprog.PackageTest.class));
-        suite.addTest(jmri.jmrit.tracker.PackageTest.suite());
-        suite.addTest(jmri.jmrit.ussctc.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.consisttool.PackageTest.class));
-        suite.addTest(jmri.jmrit.withrottle.PackageTest.suite());
-        suite.addTest(jmri.jmrit.ampmeter.PackageTest.suite());
-        suite.addTest(jmri.jmrit.lcdclock.PackageTest.suite());
-        suite.addTest(jmri.jmrit.throttle.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.audio.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.turnoutoperations.PackageTest.class));
-        suite.addTest(jmri.jmrit.dualdecoder.PackageTest.suite());
-        suite.addTest(jmri.jmrit.nixieclock.PackageTest.suite());
-        suite.addTest(jmri.jmrit.simpleprog.PackageTest.suite());
-        suite.addTest(jmri.jmrit.signalling.PackageTest.suite());
-        suite.addTest(jmri.jmrit.picker.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.speedometer.PackageTest.class));
-        suite.addTest(jmri.jmrit.analogclock.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.revhistory.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.sound.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.vsdecoder.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.simplelightctrl.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.simpleturnoutctrl.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(MemoryFrameActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(ToolsMenuTest.class));
-        suite.addTest(new JUnit4TestAdapter(XmlFileLocationActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(XmlFileValidateActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(XmlFileValidateStartupActionFactoryTest.class));
-        suite.addTest(new JUnit4TestAdapter(DebugMenuTest.class));
-        suite.addTest(new JUnit4TestAdapter(LogixLoadActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(XmlFileCheckActionTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest {
 }
 

--- a/java/test/jmri/jmrit/ampmeter/PackageTest.java
+++ b/java/test/jmri/jmrit/ampmeter/PackageTest.java
@@ -1,47 +1,22 @@
 package jmri.jmrit.ampmeter;
 
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        AmpMeterActionTest.class,
+        AmpMeterFrameTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.ampmeter tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
+public class PackageTest {
 
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.ampmeter.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AmpMeterActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AmpMeterFrameTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
 }

--- a/java/test/jmri/jmrit/analogclock/PackageTest.java
+++ b/java/test/jmri/jmrit/analogclock/PackageTest.java
@@ -1,47 +1,21 @@
 package jmri.jmrit.analogclock;
 
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        AnalogClockActionTest.class,
+        AnalogClockFrameTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.analogclock tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.analogclock.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AnalogClockActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AnalogClockFrameTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/beantable/PackageTest.java
+++ b/java/test/jmri/jmrit/beantable/PackageTest.java
@@ -1,88 +1,62 @@
 package jmri.jmrit.beantable;
 
 import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BlockTableActionTest.class,
+        LightTableWindowTest.class,
+        LogixTableActionTest.class,
+        LRouteTableActionTest.class,
+        OBlockTableActionTest.class,
+        RouteTableActionTest.class,
+        SensorTableWindowTest.class,
+        SignalGroupTableActionTest.class,
+        SignalHeadTableActionTest.class,
+        TurnoutTableWindowTest.class,
+        BundleTest.class,
+        jmri.jmrit.beantable.signalmast.PackageTest.class,
+        jmri.jmrit.beantable.sensor.PackageTest.class,
+        jmri.jmrit.beantable.oblock.PackageTest.class,
+        jmri.jmrit.beantable.beanedit.PackageTest.class,
+        jmri.jmrit.beantable.usermessagepreferences.PackageTest.class,
+        MemoryTableActionTest.class,
+        AudioTableActionTest.class,
+        BeanTableFrameTest.class,
+        BeanTablePaneTest.class,
+        EnablingCheckboxRendererTest.class,
+        IdTagTableActionTest.class,
+        LightTableActionTest.class,
+        LightTableTabActionTest.class,
+        ListedTableActionTest.class,
+        ListedTableFrameTest.class,
+        MaintenanceTest.class,
+        RailComTableActionTest.class,
+        ReporterTableActionTest.class,
+        SectionTableActionTest.class,
+        SensorTableActionTest.class,
+        SensorTableTabActionTest.class,
+        SignalGroupSubTableActionTest.class,
+        SignalMastLogicTableActionTest.class,
+        SignalMastTableActionTest.class,
+        TransitTableActionTest.class,
+        TurnoutTableActionTest.class,
+        TurnoutTableTabActionTest.class,
+        SetPhysicalLocationActionTest.class,
+        AudioTablePanelTest.class,
+        AudioTableFrameTest.class,
+        AddNewBeanPanelTest.class,
+        AddNewDevicePanelTest.class,
+        AddNewHardwareDevicePanelTest.class,
+})
 
 /**
  * Tests for classes in the jmri.jmrit.beantable package
  *
  * @author	Bob Jacobsen Copyright 2004
   */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class.getName());
-        suite.addTest(new JUnit4TestAdapter(BlockTableActionTest.class));
-        suite.addTest(LightTableWindowTest.suite());
-        suite.addTest(new JUnit4TestAdapter(LogixTableActionTest.class));
-        suite.addTest(LRouteTableActionTest.suite());
-        suite.addTest(OBlockTableActionTest.suite());
-        suite.addTest(new JUnit4TestAdapter(RouteTableActionTest.class));
-        suite.addTest(SensorTableWindowTest.suite());
-        suite.addTest(new JUnit4TestAdapter(SignalGroupTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(SignalHeadTableActionTest.class));
-        suite.addTest(TurnoutTableWindowTest.suite());
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.beantable.signalmast.PackageTest.class));
-        suite.addTest(jmri.jmrit.beantable.sensor.PackageTest.suite());
-        suite.addTest(jmri.jmrit.beantable.oblock.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.beantable.beanedit.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.beantable.usermessagepreferences.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(MemoryTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(AudioTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(BeanTableFrameTest.class));
-        suite.addTest(new JUnit4TestAdapter(BeanTablePaneTest.class));
-        suite.addTest(new JUnit4TestAdapter(EnablingCheckboxRendererTest.class));
-        suite.addTest(new JUnit4TestAdapter(IdTagTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(LightTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(LightTableTabActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(ListedTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(ListedTableFrameTest.class));
-        suite.addTest(new JUnit4TestAdapter(MaintenanceTest.class));
-        suite.addTest(new JUnit4TestAdapter(RailComTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(ReporterTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(SectionTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(SensorTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(SensorTableTabActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(SignalGroupSubTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(SignalMastLogicTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(SignalMastTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(TransitTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(TurnoutTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(TurnoutTableTabActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(SetPhysicalLocationActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(AudioTablePanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(AudioTableFrameTest.class));
-        suite.addTest(new JUnit4TestAdapter(AddNewBeanPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(AddNewDevicePanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(AddNewHardwareDevicePanelTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/beantable/oblock/PackageTest.java
+++ b/java/test/jmri/jmrit/beantable/oblock/PackageTest.java
@@ -1,56 +1,28 @@
 package jmri.jmrit.beantable.oblock;
 
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        BlockPathTableModelTest.class,
+        PathTurnoutTableModelTest.class,
+        TableFramesTest.class,
+        OBlockTableModelTest.class,
+        BlockPortalTableModelTest.class,
+        PortalTableModelTest.class,
+        SignalTableModelTest.class,
+        DnDJTableTest.class,
+})
 
 /**
  * Tests for classes in the jmri.jmrit.beantable.oblock package
  *
  * @author	Bob Jacobsen Copyright 2014
  */
-public class PackageTest extends TestCase {
-
-    public void testCreate() {
-    }
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BlockPathTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PathTurnoutTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TableFramesTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OBlockTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BlockPortalTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PortalTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SignalTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DnDJTableTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest{
 }

--- a/java/test/jmri/jmrit/beantable/sensor/PackageTest.java
+++ b/java/test/jmri/jmrit/beantable/sensor/PackageTest.java
@@ -16,5 +16,5 @@ import org.junit.runners.Suite;
  *
  * @author	Bob Jacobsen Copyright 2014
  */
-public class PackageTest extends TestCase {
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/beantable/sensor/PackageTest.java
+++ b/java/test/jmri/jmrit/beantable/sensor/PackageTest.java
@@ -1,9 +1,15 @@
 package jmri.jmrit.beantable.sensor;
 
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        SensorTableDataModelTest.class,
+})
 
 /**
  * Tests for classes in the jmri.jmrit.beantable.sensor package
@@ -11,39 +17,4 @@ import junit.framework.TestSuite;
  * @author	Bob Jacobsen Copyright 2014
  */
 public class PackageTest extends TestCase {
-
-    public void testCreate() {
-    }
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SensorTableDataModelTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
 }

--- a/java/test/jmri/jmrit/blockboss/PackageTest.java
+++ b/java/test/jmri/jmrit/blockboss/PackageTest.java
@@ -1,36 +1,21 @@
 package jmri.jmrit.blockboss;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BlockBossLogicTest.class,
+        BundleTest.class,
+        jmri.jmrit.blockboss.configurexml.PackageTest.class,
+        BlockBossActionTest.class,
+        BlockBossFrameTest.class,
+})
 
 /**
  * Tests for the jmrit.blockboss package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.blockboss.BlockBossTest"); // no tests in class itself
-        suite.addTest(jmri.jmrit.blockboss.BlockBossLogicTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.blockboss.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BlockBossActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BlockBossFrameTest.class));
-        return suite;
-    }
-
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/decoderdefn/PackageTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/PackageTest.java
@@ -1,46 +1,30 @@
 package jmri.jmrit.decoderdefn;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        IdentifyDecoderTest.class,
+        DecoderIndexFileTest.class,
+        DecoderFileTest.class,
+        SchemaTest.class,
+        DecoderIndexBuilderTest.class,
+        NameCheckActionTest.class,
+        DecoderIndexCreateActionTest.class,
+        InstallDecoderFileActionTest.class,
+        InstallDecoderURLActionTest.class,
+        PrintDecoderListActionTest.class,
+        BundleTest.class,
+        // Disabled until #2601 is resolved
+        // DuplicateTest.class,
+})
 
 /**
  * Tests for the jmrit.decoderdefn package
  *
  * @author	Bob Jacobsen
   */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.decoderdefn");
-        suite.addTest(new JUnit4TestAdapter(IdentifyDecoderTest.class));
-        suite.addTest(DecoderIndexFileTest.suite());
-        suite.addTest(DecoderFileTest.suite());
-        suite.addTest(new JUnit4TestAdapter(SchemaTest.class));
-        suite.addTest(new JUnit4TestAdapter(DecoderIndexBuilderTest.class));
-        suite.addTest(new JUnit4TestAdapter(NameCheckActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(DecoderIndexCreateActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(InstallDecoderFileActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(InstallDecoderURLActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(PrintDecoderListActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        // Disabled until #2601 is resolved
-        // suite.addTest(new JUnit4TestAdapter(DuplicateTest.class));
-
-        return suite;
-    }
+public class PackageTest {
 
 }

--- a/java/test/jmri/jmrit/dispatcher/PackageTest.java
+++ b/java/test/jmri/jmrit/dispatcher/PackageTest.java
@@ -1,50 +1,37 @@
 package jmri.jmrit.dispatcher;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        DispatcherTrainInfoTest.class,
+        DispatcherTrainInfoFileTest.class,
+        BundleTest.class,
+        DispatcherFrameTest.class,
+        DispatcherActionTest.class,
+        OptionsFileTest.class,
+        TrainInfoFileTest.class,
+        TrainInfoTest.class,
+        ActivateTrainFrameTest.class,
+        AutoTrainsFrameTest.class,
+        AutoAllocateTest.class,
+        AutoTurnoutsTest.class,
+        OptionsMenuTest.class,
+        ActiveTrainTest.class,
+        AllocatedSectionTest.class,
+        AllocationRequestTest.class,
+        AllocationPlanTest.class,
+        AutoActiveTrainTest.class,
+        AutoTrainActionTest.class,
+})
 
 /**
  * Tests for the jmrit.dispatcher package
  *
  * @author	Dave Duchamp
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.dispatcher.PackageTest"); // no tests in class itself
-        suite.addTest(jmri.jmrit.dispatcher.DispatcherTrainInfoTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DispatcherTrainInfoFileTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DispatcherFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DispatcherActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OptionsFileTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainInfoFileTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainInfoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ActivateTrainFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutoTrainsFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutoAllocateTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutoTurnoutsTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OptionsMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ActiveTrainTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AllocatedSectionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AllocationRequestTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AllocationPlanTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutoActiveTrainTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutoTrainActionTest.class));
-        return suite;
-    }
-
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/dualdecoder/PackageTest.java
+++ b/java/test/jmri/jmrit/dualdecoder/PackageTest.java
@@ -1,48 +1,23 @@
 package jmri.jmrit.dualdecoder;
 
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        DualDecoderSelectFrameTest.class,
+        DualDecoderSelectPaneTest.class,
+        DualDecoderToolActionTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.dualdecoder tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.dualdecoder.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DualDecoderSelectFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DualDecoderSelectPaneTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DualDecoderToolActionTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/jython/PackageTest.java
+++ b/java/test/jmri/jmrit/jython/PackageTest.java
@@ -1,57 +1,30 @@
 package jmri.jmrit.jython;
 
 import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        JythonWindowsTest.class,
+        SampleScriptTest.class,
+        InputWindowActionTest.class,
+        InputWindowTest.class,
+        JynstrumentFactoryTest.class,
+        JythonWindowTest.class,
+        JynstrumentTest.class,
+        JynstrumentPopupMenuTest.class,
+        RunJythonScriptTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.jython tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.jython.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-
-        suite.addTest(new JUnit4TestAdapter(JythonWindowsTest.class));
-
-        suite.addTest(SampleScriptTest.suite());
-        suite.addTest(new JUnit4TestAdapter(InputWindowActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(InputWindowTest.class));
-        suite.addTest(new JUnit4TestAdapter(JynstrumentFactoryTest.class));
-        suite.addTest(new JUnit4TestAdapter(JythonWindowTest.class));
-        suite.addTest(new JUnit4TestAdapter(JynstrumentTest.class));
-        suite.addTest(new JUnit4TestAdapter(JynstrumentPopupMenuTest.class));
-        suite.addTest(new JUnit4TestAdapter(RunJythonScriptTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/jython/SampleScriptTest.java
+++ b/java/test/jmri/jmrit/jython/SampleScriptTest.java
@@ -1,106 +1,68 @@
 package jmri.jmrit.jython;
 
 import java.io.File;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 /**
  * Invokes Python-language scripts in jython/tests
  *
  * @author	Bob Jacobsen Copyright 2016
+ * @author	Paul Bender Copyright (C) 2017
  * @since JMRI 4.3.6
  */
-public class SampleScriptTest extends TestCase {
+@RunWith(Parameterized.class)
+public class SampleScriptTest {
 
     /**
      * Create the tests from each sample script in test directory
      */
-    static protected void testsFromDirectory(TestSuite suite) {
-        TestSuite subsuite = new TestSuite("Jython sample scripts");
-        suite.addTest(subsuite);
-
-        if (System.getProperty("jmri.skipjythontests", "false").equals("true")) return; // skipping check
+    @Parameters
+    public static Collection<File> testsFromDirectory() {
+        if (System.getProperty("jmri.skipjythontests", "false").equals("true")) return null; // skipping check
 
         java.io.File dir = new java.io.File("jython/test");
-        java.io.File[] files = dir.listFiles();
+        java.io.File[] files = dir.listFiles((File a, String b) -> { return b.endsWith(".py");});
         if (files == null) {
-            return;
+            return null;
         }
 
-        for (int i = 0; i < files.length; i++) {
-            if (files[i].getName().toLowerCase().endsWith("test.py")) {
-                subsuite.addTest(new CheckOneScript(files[i]));
-            }
+        else {
+            return Arrays.asList(files);
         }
+
     }
 
-    /**
-     * Internal TestCase class to allow separate tests for every file
-     */
-    static protected class CheckOneScript extends TestCase {
-        File file;
-        
-        public CheckOneScript(File file) {
-            super("Test script: " + file);
-            this.file = file;
-        }
+    @Parameter
+    public File file = null;
 
-        @Override
-        public void runTest() throws javax.script.ScriptException, java.io.IOException {
-            jmri.script.JmriScriptEngineManager.getDefault().eval(file);
-        }
-        
-        @Override
-        protected void setUp() throws Exception {
-            apps.tests.Log4JFixture.setUp();
-            super.setUp();
-        
-            jmri.util.JUnitUtil.resetInstanceManager();
-            jmri.util.JUnitUtil.initConfigureManager();
-            jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
-            jmri.util.JUnitUtil.initDebugPowerManager();
-            jmri.util.JUnitUtil.initInternalSensorManager();
-            jmri.util.JUnitUtil.initInternalTurnoutManager();
-        }
-        
-        @Override
-        protected void tearDown() throws Exception {
-            jmri.util.JUnitUtil.tearDown();
-        }
+    @Test 
+    public void runTest() throws javax.script.ScriptException, java.io.IOException {
+        jmri.script.JmriScriptEngineManager.getDefault().eval(file);
     }
-
-
-    // from here down is testing infrastructure
-    public SampleScriptTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", SampleScriptTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.jython.SampleScriptTest"); // no tests in this class itself
-        testsFromDirectory(suite);
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
-        super.setUp();
         
+    @Before
+    public void setUp() throws Exception {
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
+        jmri.util.JUnitUtil.initConfigureManager();
         jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
+        jmri.util.JUnitUtil.initDebugPowerManager();
+        jmri.util.JUnitUtil.initInternalSensorManager();
+        jmri.util.JUnitUtil.initInternalTurnoutManager();
     }
-
-    @Override
-    protected void tearDown() throws Exception {
+        
+    @After 
+    public void tearDown() throws Exception {
         jmri.util.JUnitUtil.tearDown();
     }
+
 }

--- a/java/test/jmri/jmrit/lcdclock/PackageTest.java
+++ b/java/test/jmri/jmrit/lcdclock/PackageTest.java
@@ -1,46 +1,22 @@
 package jmri.jmrit.lcdclock;
 
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        LcdClockActionTest.class,
+        LcdClockFrameTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.lcdclock tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.lcdclock.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LcdClockActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LcdClockFrameTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/logix/PackageTest.java
+++ b/java/test/jmri/jmrit/logix/PackageTest.java
@@ -1,81 +1,55 @@
 package jmri.jmrit.logix;
 
 import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+//		Something wrong in the xsd files?  maybe using -2-9-6 version?
+        SchemaTest.class,
+        OBlockTest.class,
+        OBlockManagerTest.class,
+        OPathTest.class,
+        PortalTest.class,
+        WarrantTest.class,
+        LogixActionTest.class,
+        BundleTest.class,
+        jmri.jmrit.logix.configurexml.PackageTest.class,
+        NXFrameTest.class, //formerly NXWarrantTest        
+        LearnWarrantTest.class,
+        PortalManagerTest.class,
+        ThrottleSettingTest.class,
+        WarrantManagerTest.class,
+        WarrantPreferencesPanelTest.class,
+        WarrantPreferencesTest.class,
+        TrackerTableActionTest.class,
+        WarrantFrameTest.class,
+        WarrantTableActionTest.class,
+        WarrantTableFrameTest.class,
+        WarrantTableModelTest.class,
+        LearnThrottleFrameTest.class,
+        TrackerTest.class,
+        BlockOrderTest.class,
+        ControlPanelTest.class,
+        OpSessionLogTest.class,
+        SCWarrantTest.class,
+        EngineerTest.class,
+        SpeedUtilTest.class,
+        FunctionPanelTest.class,
+        WarrantShutdownTaskTest.class,
+        SpeedProfilePanelTest.class,
+        RouteFinderTest.class,
+        MergePromptTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.logix tree
  *
  * @author	Bob Jacobsen Copyright 2010
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        apps.tests.Log4JFixture.initLogging();
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.logix.PackageTest");   // no tests in this class itself
-
-//		Something wrong in the xsd files?  maybe using -2-9-6 version?
-        suite.addTest(new JUnit4TestAdapter(SchemaTest.class));
-        suite.addTest(new JUnit4TestAdapter(OBlockTest.class));
-        suite.addTest(new JUnit4TestAdapter(OBlockManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(OPathTest.class));
-        suite.addTest(new JUnit4TestAdapter(PortalTest.class));
-        suite.addTest(new JUnit4TestAdapter(WarrantTest.class));
-        suite.addTest(new JUnit4TestAdapter(LogixActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.logix.configurexml.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(NXFrameTest.class)); //formerly NXWarrantTest        
-        suite.addTest(LearnWarrantTest.suite());
-        suite.addTest(new JUnit4TestAdapter(PortalManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(ThrottleSettingTest.class));
-        suite.addTest(new JUnit4TestAdapter(WarrantManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(WarrantPreferencesPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(WarrantPreferencesTest.class));
-        suite.addTest(new JUnit4TestAdapter(TrackerTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(WarrantFrameTest.class));
-        suite.addTest(new JUnit4TestAdapter(WarrantTableActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(WarrantTableFrameTest.class));
-        suite.addTest(new JUnit4TestAdapter(WarrantTableModelTest.class));
-        suite.addTest(new JUnit4TestAdapter(LearnThrottleFrameTest.class));
-        suite.addTest(new JUnit4TestAdapter(TrackerTest.class));
-        suite.addTest(new JUnit4TestAdapter(BlockOrderTest.class));
-        suite.addTest(new JUnit4TestAdapter(ControlPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(OpSessionLogTest.class));
-        suite.addTest(new JUnit4TestAdapter(SCWarrantTest.class));
-        suite.addTest(new JUnit4TestAdapter(EngineerTest.class));
-        suite.addTest(new JUnit4TestAdapter(SpeedUtilTest.class));
-        suite.addTest(new JUnit4TestAdapter(FunctionPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(WarrantShutdownTaskTest.class));
-        suite.addTest(new JUnit4TestAdapter(SpeedProfilePanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(RouteFinderTest.class));
-        suite.addTest(new JUnit4TestAdapter(MergePromptTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/nixieclock/PackageTest.java
+++ b/java/test/jmri/jmrit/nixieclock/PackageTest.java
@@ -1,47 +1,22 @@
 package jmri.jmrit.nixieclock;
 
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        NixieClockActionTest.class,
+        NixieClockFrameTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.nixieclock tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.nixieclock.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NixieClockActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NixieClockFrameTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/operations/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/PackageTest.java
@@ -1,8 +1,31 @@
 package jmri.jmrit.operations;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrit.operations.setup.PackageTest.class,
+        jmri.jmrit.operations.rollingstock.PackageTest.class,
+        jmri.jmrit.operations.routes.PackageTest.class,
+        jmri.jmrit.operations.trains.PackageTest.class,  // fixed references to Swing, 10/10/2012
+        jmri.jmrit.operations.router.PackageTest.class,  // fixed references to Swing, 10/10/2012
+        jmri.jmrit.operations.locations.PackageTest.class, // fixed references to Swing, 10/10/2012
+        jmri.jmrit.operations.automation.PackageTest.class,
+
+        XmlLoadTest.class, // no tests in class itself
+        BundleTest.class, 
+        CommonConductorYardmasterPanelTest.class, 
+        jmri.jmrit.operations.locations.PackageTest.class, // fixed references to Swing, 10/10/2012
+        OperationsFrameTest.class,
+        OperationsMenuTest.class,
+        OperationsPanelTest.class,
+        OpsPropertyChangeListenerTest.class,
+        OperationsManagerTest.class,
+        ExceptionContextTest.class,
+        ExceptionDisplayFrameTest.class,
+        UnexpectedExceptionContextTest.class,
+})
 
 /**
  * Tests for the jmrit.operations package
@@ -10,43 +33,4 @@ import junit.framework.TestSuite;
  * @author	Bob Coleman
  */
 public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.PackageTest"); // no tests in class itself
-        suite.addTest(jmri.jmrit.operations.setup.PackageTest.suite());
-        suite.addTest(jmri.jmrit.operations.rollingstock.PackageTest.suite());
-        suite.addTest(jmri.jmrit.operations.routes.PackageTest.suite());
-        suite.addTest(jmri.jmrit.operations.trains.PackageTest.suite());  // fixed references to Swing, 10/10/2012
-        suite.addTest(jmri.jmrit.operations.router.PackageTest.suite());  // fixed references to Swing, 10/10/2012
-        suite.addTest(jmri.jmrit.operations.locations.PackageTest.suite()); // fixed references to Swing, 10/10/2012
-        suite.addTest(jmri.jmrit.operations.automation.PackageTest.suite());
-
-        suite.addTest(XmlLoadTest.suite()); // no tests in class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class)); 
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CommonConductorYardmasterPanelTest.class)); 
-        suite.addTest(jmri.jmrit.operations.locations.PackageTest.suite()); // fixed references to Swing, 10/10/2012
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OpsPropertyChangeListenerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ExceptionContextTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ExceptionDisplayFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(UnexpectedExceptionContextTest.class));
-
-        return suite;
-    }
-
 }

--- a/java/test/jmri/jmrit/operations/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/PackageTest.java
@@ -32,5 +32,5 @@ import org.junit.runners.Suite;
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/operations/automation/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/automation/PackageTest.java
@@ -1,58 +1,34 @@
 package jmri.jmrit.operations.automation;
 
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        AutomationManagerTest.class,
+        AutomationItemTest.class,
+        BundleTest.class,
+        jmri.jmrit.operations.automation.actions.PackageTest.class,
+        AutomationTableFrameTest.class,
+        AutomationCopyFrameTest.class,
+        AutomationCopyActionTest.class,
+        AutomationTableModelTest.class,
+        AutomationsTableFrameActionTest.class,
+        AutomationsTableFrameTest.class,
+        AutomationsTableFrameTest.class,
+        AutomationsTableModelTest.class,
+        XmlTest.class, 
+        AutomationTest.class,
+        AutomationResetActionTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.operations.automations tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.automations.PackageTest");   // no tests in this class itself
-
-        suite.addTest(AutomationManagerTest.suite());
-        suite.addTest(AutomationItemTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(jmri.jmrit.operations.automation.actions.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutomationTableFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutomationCopyFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutomationCopyActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutomationTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutomationsTableFrameActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutomationsTableFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutomationsTableFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutomationsTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XmlTest.class)); 
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutomationTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutomationResetActionTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest {
 }

--- a/java/test/jmri/jmrit/operations/automation/actions/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/automation/actions/PackageTest.java
@@ -1,75 +1,51 @@
 package jmri.jmrit.operations.automation.actions;
 
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        ActionCodesTest.class,
+        ActivateTimetableActionTest.class,
+        ApplyTimetableActionTest.class,
+        BuildTrainActionTest.class,
+        BuildTrainIfSelectedActionTest.class,
+        DeselectTrainActionTest.class,
+        GotoActionTest.class,
+        GotoFailureActionTest.class,
+        GotoSuccessActionTest.class,
+        HaltActionTest.class,
+        IsTrainEnRouteActionTest.class,
+        MessageYesNoActionTest.class,
+        MoveTrainActionTest.class,
+        NoActionTest.class,
+        PrintSwitchListActionTest.class,
+        PrintSwitchListChangesActionTest.class,
+        PrintTrainManifestActionTest.class,
+        PrintTrainManifestIfSelectedActionTest.class,
+        ResetTrainActionTest.class,
+        ResumeAutomationActionTest.class,
+        RunAutomationActionTest.class,
+        RunSwitchListActionTest.class,
+        RunSwitchListChangesActionTest.class,
+        RunTrainActionTest.class,
+        SelectTrainActionTest.class,
+        StopAutomationActionTest.class,
+        TerminateTrainActionTest.class,
+        UpdateSwitchListActionTest.class,
+        WaitSwitchListActionTest.class,
+        WaitTrainActionTest.class,
+        WaitTrainTerminatedActionTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.operations.automations.actions tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.automations.actions.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ActionCodesTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ActivateTimetableActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ApplyTimetableActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BuildTrainActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BuildTrainIfSelectedActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DeselectTrainActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(GotoActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(GotoFailureActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(GotoSuccessActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(HaltActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(IsTrainEnRouteActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(MessageYesNoActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(MoveTrainActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NoActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintSwitchListActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintSwitchListChangesActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintTrainManifestActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintTrainManifestIfSelectedActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ResetTrainActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ResumeAutomationActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RunAutomationActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RunSwitchListActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RunSwitchListChangesActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RunTrainActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SelectTrainActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(StopAutomationActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TerminateTrainActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(UpdateSwitchListActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(WaitSwitchListActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(WaitTrainActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(WaitTrainTerminatedActionTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/locations/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/locations/PackageTest.java
@@ -1,62 +1,46 @@
 package jmri.jmrit.operations.locations;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        LocationTest.class,
+        XmlTest.class,
+        TrackTest.class,
+        OperationsPoolTest.class,
+        BundleTest.class,
+        jmri.jmrit.operations.locations.tools.PackageTest.class,
+        jmri.jmrit.operations.locations.schedules.PackageTest.class,
+        InterchangeEditFrameTest.class,
+        LocationEditFrameTest.class,
+        SidingEditFrameTest.class,
+        StagingEditFrameTest.class,
+        YardEditFrameTest.class,
+        YardmasterPanelTest.class,
+        InterchangeTableModelTest.class,
+        LocationManagerTest.class,
+        LocationManagerXmlTest.class,
+        LocationsTableActionTest.class,
+        LocationsTableFrameTest.class,
+        LocationsTableModelTest.class,
+        SpurEditFrameTest.class,
+        SpurTableModelTest.class,
+        StagingTableModelTest.class,
+        TrackEditFrameTest.class,
+        TrackTableModelTest.class,
+        YardTableModelTest.class,
+        YardmasterByTrackActionTest.class,
+        YardmasterByTrackPanelTest.class,
+        YardmasterByTrackFrameTest.class,
+        YardmasterFrameTest.class,
+        PoolTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.locations package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.locations.PackageTest"); // no tests in class itself
-        suite.addTest(LocationTest.suite());
-        suite.addTest(XmlTest.suite());
-        suite.addTest(TrackTest.suite());
-        suite.addTest(OperationsPoolTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-
-        suite.addTest(jmri.jmrit.operations.locations.tools.PackageTest.suite());
-        suite.addTest(jmri.jmrit.operations.locations.schedules.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(InterchangeEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SidingEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(StagingEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(YardEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(YardmasterPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(InterchangeTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationManagerXmlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationsTableActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationsTableFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationsTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SpurEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SpurTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(StagingTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrackEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrackTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(YardTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(YardmasterByTrackActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(YardmasterByTrackPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(YardmasterByTrackFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(YardmasterFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PoolTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/locations/schedules/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/locations/schedules/PackageTest.java
@@ -1,52 +1,37 @@
 package jmri.jmrit.operations.locations.schedules;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        ScheduleItemTest.class,
+        ScheduleTest.class,
+        ScheduleManagerTest.class,
+        BundleTest.class,
+        ScheduleEditFrameGuiTest.class,
+        ScheduleGuiTests.class,
+        ScheduleCopyActionTest.class,
+        ScheduleCopyFrameTest.class,
+        ScheduleTableModelTest.class,
+        SchedulesByLoadFrameTest.class,
+        SchedulesTableFrameTest.class,
+        SchedulesTableModelTest.class,
+        XmlTest.class,
+        ScheduleResetHitsActionTest.class,
+        SchedulesByLoadActionTest.class,
+        SchedulesResetHitsActionTest.class,
+        SchedulesTableActionTest.class,
+        ScheduleEditFrameTest.class,
+        ScheduleOptionsActionTest.class,
+        ScheduleOptionsFrameTest.class,
+        LocationTrackPairTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.locations package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.locations.schedules.PackageTest"); // no tests in class itself
-        suite.addTest(ScheduleItemTest.suite());
-        suite.addTest(ScheduleTest.suite());
-        suite.addTest(ScheduleManagerTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ScheduleEditFrameGuiTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ScheduleGuiTests.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ScheduleCopyActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ScheduleCopyFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ScheduleTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SchedulesByLoadFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SchedulesTableFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SchedulesTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XmlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ScheduleResetHitsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SchedulesByLoadActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SchedulesResetHitsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SchedulesTableActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ScheduleEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ScheduleOptionsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ScheduleOptionsFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationTrackPairTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/locations/tools/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/locations/tools/PackageTest.java
@@ -1,72 +1,57 @@
 package jmri.jmrit.operations.locations.tools;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        PoolTrackGuiTest.class,
+        EditCarTypeActionTest.class,
+        LocationCopyActionTest.class,
+        LocationCopyFrameTest.class,
+        LocationTrackBlockingOrderActionTest.class,
+        LocationTrackBlockingOrderFrameTest.class,
+        LocationTrackBlockingOrderTableModelTest.class,
+        LocationsByCarLoadFrameTest.class,
+        LocationsByCarTypeFrameTest.class,
+        ModifyLocationsActionTest.class,
+        ModifyLocationsCarLoadsActionTest.class,
+        ShowTrackMovesActionTest.class,
+        ShowTrainsServingLocationFrameTest.class,
+        TrackDestinationEditFrameTest.class,
+        TrackLoadEditFrameTest.class,
+        TrackRoadEditFrameTest.class,
+        AlternateTrackFrameTest.class,
+        AlternateTrackActionTest.class,
+        ChangeTrackFrameTest.class,
+        ChangeTrackTypeActionTest.class,
+        IgnoreUsedTrackActionTest.class,
+        IgnoreUsedTrackFrameTest.class,
+        PoolTrackFrameTest.class,
+        PoolTrackActionTest.class,
+        TrackDestinationEditActionTest.class,
+        TrackLoadEditActionTest.class, 
+        TrackRoadEditActionTest.class,
+        TrackEditCommentsActionTest.class,
+        TrackEditCommentsFrameTest.class,
+        ChangeTracksFrameTest.class,
+        ChangeTracksTypeActionTest.class,
+        TrackCopyActionTest.class,
+        TrackCopyFrameTest.class,
+        ShowCarsByLocationActionTest.class,
+        PrintSwitchListActionTest.class,
+        SetPhysicalLocationActionTest.class,
+        SetPhysicalLocationFrameTest.class,
+        PrintLocationsActionTest.class,
+        ShowTrainsServingLocationActionTest.class,
+        PrintLocationsByCarTypesActionTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.locations package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.locations.tools.PackageTest"); // no tests in class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PoolTrackGuiTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditCarTypeActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationCopyActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationCopyFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationTrackBlockingOrderActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationTrackBlockingOrderFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationTrackBlockingOrderTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationsByCarLoadFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocationsByCarTypeFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ModifyLocationsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ModifyLocationsCarLoadsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ShowTrackMovesActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ShowTrainsServingLocationFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrackDestinationEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrackLoadEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrackRoadEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AlternateTrackFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AlternateTrackActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ChangeTrackFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ChangeTrackTypeActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(IgnoreUsedTrackActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(IgnoreUsedTrackFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PoolTrackFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PoolTrackActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrackDestinationEditActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrackLoadEditActionTest.class)); 
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrackRoadEditActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrackEditCommentsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrackEditCommentsFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ChangeTracksFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ChangeTracksTypeActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrackCopyActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrackCopyFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ShowCarsByLocationActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintSwitchListActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SetPhysicalLocationActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SetPhysicalLocationFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintLocationsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ShowTrainsServingLocationActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintLocationsByCarTypesActionTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/rollingstock/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/PackageTest.java
@@ -1,47 +1,31 @@
 package jmri.jmrit.operations.rollingstock;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        OperationsRollingStockTest.class,
+        jmri.jmrit.operations.rollingstock.cars.PackageTest.class,
+        jmri.jmrit.operations.rollingstock.engines.PackageTest.class,
+        BundleTest.class,
+        ImportRollingStockTest.class,
+        RollingStockAttributeTest.class,
+        RollingStockLoggerTest.class,
+        RollingStockManagerTest.class,
+        RollingStockSetFrameTest.class,
+        RollingStockTest.class,
+        XmlTest.class,
+        RollingStockGroupTest.class,
+
+        // Last test, deletes log file if one exists
+        OperationsLoggerTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.rollingstock package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.rollingstock.PackageTest"); // no tests in class itself
-        suite.addTest(OperationsRollingStockTest.suite());
-        suite.addTest(jmri.jmrit.operations.rollingstock.cars.PackageTest.suite());
-        suite.addTest(jmri.jmrit.operations.rollingstock.engines.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ImportRollingStockTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RollingStockAttributeTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RollingStockLoggerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RollingStockManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RollingStockSetFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RollingStockTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XmlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RollingStockGroupTest.class));
-
-        // Last test, deletes log file if one exists
-        suite.addTest(OperationsLoggerTest.suite());
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/rollingstock/cars/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/PackageTest.java
@@ -1,70 +1,54 @@
 package jmri.jmrit.operations.rollingstock.cars;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        CarsTest.class,
+        CarColorsTest.class,
+        CarTypesTest.class,
+        CarLengthsTest.class,
+        CarOwnersTest.class,
+        CarRoadsTest.class,
+        CarLoadsTest.class,
+        KernelTest.class,
+        CarManagerTest.class,
+        XmlTest.class,
+        BundleTest.class,
+        CarsTableFrameTest.class,
+        CarEditFrameTest.class,
+        CarAttributeEditFrameTest.class,
+        CarLoadEditFrameTest.class,
+        CarSetFrameTest.class,
+        CarManagerXmlTest.class,
+        CarTest.class,
+        CarsSetFrameTest.class,
+        CarsTableActionTest.class,
+        ImportCarsTest.class,
+        CarLoadTest.class,
+        ShowCheckboxesCarsTableActionTest.class,
+        ResetCheckboxesCarsTableActionTest.class,
+        CarsSetFrameActionTest.class,
+        CarAttributeActionTest.class,
+        CarDeleteAttributeActionTest.class,
+        CarLoadAttributeActionTest.class,
+        DeleteCarRosterActionTest.class,
+        CarRosterMenuTest.class,
+        CarsTableModelTest.class,
+        EnableDestinationActionTest.class,
+        ExportCarRosterActionTest.class,
+        ImportCarRosterActionTest.class,
+        PrintCarLoadsActionTest.class,
+        ResetCarMovesActionTest.class,
+        PrintCarRosterActionTest.class,
+        ExportCarsTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.rollingstock.cars package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.rollingstock.cars.PackageTest"); // no tests in class itself
-        suite.addTest(CarsTest.suite());
-        suite.addTest(CarColorsTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarTypesTest.class));
-        suite.addTest(CarLengthsTest.suite());
-        suite.addTest(CarOwnersTest.suite());
-        suite.addTest(CarRoadsTest.suite());
-        suite.addTest(CarLoadsTest.suite());
-        suite.addTest(KernelTest.suite());
-        suite.addTest(CarManagerTest.suite());
-        suite.addTest(XmlTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarsTableFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarAttributeEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarLoadEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarSetFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarManagerXmlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarsSetFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarsTableActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ImportCarsTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarLoadTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ShowCheckboxesCarsTableActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ResetCheckboxesCarsTableActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarsSetFrameActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarAttributeActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarDeleteAttributeActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarLoadAttributeActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DeleteCarRosterActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarRosterMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CarsTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EnableDestinationActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ExportCarRosterActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ImportCarRosterActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintCarLoadsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ResetCarMovesActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintCarRosterActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ExportCarsTest.class));
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/PackageTest.java
@@ -1,57 +1,42 @@
 package jmri.jmrit.operations.rollingstock.engines;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        EngineTest.class,
+        EngineLengthsTest.class,
+        EngineTypesTest.class,
+        EngineModelsTest.class,
+        NceConsistEnginesTest.class,
+        EngineManagerTest.class,
+        XmlTest.class,
+        BundleTest.class,
+        EnginesTableFrameTest.class,
+        EngineEditFrameTest.class,
+        EngineAttributeEditFrameTest.class,
+        EngineSetFrameTest.class,
+        EngineManagerXmlTest.class,
+        EnginesTableActionTest.class,
+        EnginesTableModelTest.class,
+        ExportEnginesTest.class,
+        ImportEnginesTest.class,
+        ImportRosterEnginesTest.class,
+        ConsistTest.class,
+        ExportEngineRosterActionTest.class,
+        DeleteEngineRosterActionTest.class, 
+        ImportEngineActionTest.class, 
+        ImportRosterEngineActionTest.class,
+        NceConsistEngineActionTest.class,
+        ResetEngineMovesActionTest.class,
+        PrintEngineRosterActionTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.rollingstock package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.rollingstock.engines.PackageTest"); // no tests in class itself
-        suite.addTest(EngineTest.suite());
-        suite.addTest(EngineLengthsTest.suite());
-        suite.addTest(EngineTypesTest.suite());
-        suite.addTest(EngineModelsTest.suite());
-        suite.addTest(NceConsistEnginesTest.suite());
-        suite.addTest(EngineManagerTest.suite());
-        suite.addTest(XmlTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EnginesTableFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EngineEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EngineAttributeEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EngineSetFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EngineManagerXmlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EnginesTableActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EnginesTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ExportEnginesTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ImportEnginesTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ImportRosterEnginesTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConsistTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ExportEngineRosterActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DeleteEngineRosterActionTest.class)); 
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ImportEngineActionTest.class)); 
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ImportRosterEngineActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceConsistEngineActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ResetEngineMovesActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintEngineRosterActionTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/router/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/router/PackageTest.java
@@ -1,34 +1,19 @@
 package jmri.jmrit.operations.router;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        OperationsCarRouterTest.class,
+        BundleTest.class,
+        RouterTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.router package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.router.PackageTest"); // no tests in class itself
-        suite.addTest(OperationsCarRouterTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RouterTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/routes/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/routes/PackageTest.java
@@ -1,52 +1,37 @@
 package jmri.jmrit.operations.routes;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        OperationsRoutesTest.class,
+        BundleTest.class,
+        OperationsRoutesGuiTest.class,
+        RouteCopyFrameTest.class,
+        RouteEditFrameTest.class,
+        RouteEditTableModelTest.class,
+        RouteManagerTest.class,
+        RouteManagerXmlTest.class,
+        RoutesTableActionTest.class,
+        RoutesTableFrameTest.class,
+        RoutesTableModelTest.class,
+        SetTrainIconPositionFrameTest.class,
+        XmlTest.class,
+        RouteCopyActionTest.class,
+        SetTrainIconPositionActionTest.class,
+        RouteLocationTest.class,
+        RouteTest.class,
+        SetTrainIconRouteActionTest.class,
+        SetTrainIconRouteFrameTest.class,
+        PrintRoutesActionTest.class,
+        PrintRouteActionTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.routes package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.routes.PackageTest"); // no tests in class itself
-        suite.addTest(OperationsRoutesTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsRoutesGuiTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RouteCopyFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RouteEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RouteEditTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RouteManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RouteManagerXmlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RoutesTableActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RoutesTableFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RoutesTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SetTrainIconPositionFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XmlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RouteCopyActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SetTrainIconPositionActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RouteLocationTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RouteTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SetTrainIconRouteActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SetTrainIconRouteFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintRoutesActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintRouteActionTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/setup/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/setup/PackageTest.java
@@ -1,75 +1,60 @@
 package jmri.jmrit.operations.setup;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        OperationsSetupTest.class,
+        OperationsBackupTest.class,
+        BundleTest.class,
+        OperationsBackupGuiTest.class,
+        AutoBackupTest.class,
+        AutoSaveTest.class,
+        BackupDialogTest.class,
+        BuildReportOptionActionTest.class,
+        BuildReportOptionFrameTest.class,
+        BuildReportOptionPanelTest.class,
+        ControlTest.class,
+        DefaultBackupTest.class,
+        EditManifestHeaderTextActionTest.class,
+        EditManifestHeaderTextFrameTest.class,
+        EditManifestHeaderTextPanelTest.class,
+        EditManifestTextActionTest.class,
+        EditManifestTextFrameTest.class,
+        EditManifestTextPanelTest.class,
+        EditSwitchListTextActionTest.class,
+        EditSwitchListTextFrameTest.class,
+        EditSwitchListTextPanelTest.class,
+        ManageBackupsDialogTest.class,
+        OperationsSetupActionTest.class,
+        OperationsSetupFrameTest.class,
+        OperationsSetupPanelTest.class,
+        OperationsSetupXmlTest.class,
+        OptionFrameTest.class,
+        OptionPanelTest.class,
+        PrintMoreOptionActionTest.class,
+        PrintMoreOptionFrameTest.class,
+        PrintMoreOptionPanelTest.class,
+        PrintOptionActionTest.class,
+        PrintOptionFrameTest.class,
+        PrintOptionPanelTest.class,
+        RestoreDialogTest.class,
+        SetupTest.class,
+        XmlTest.class,
+        BackupFilesActionTest.class,
+        LoadDemoActionTest.class,
+        ManageBackupsActionTest.class,
+        OptionActionTest.class,
+        ResetActionTest.class,
+        RestoreFilesActionTest.class,
+        BackupSetTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.setup package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.setup.PackageTest"); // no tests in class itself
-        suite.addTest(OperationsSetupTest.suite());
-        suite.addTest(OperationsBackupTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsBackupGuiTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutoBackupTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AutoSaveTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BackupDialogTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BuildReportOptionActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BuildReportOptionFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BuildReportOptionPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ControlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DefaultBackupTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditManifestHeaderTextActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditManifestHeaderTextFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditManifestHeaderTextPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditManifestTextActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditManifestTextFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditManifestTextPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditSwitchListTextActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditSwitchListTextFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditSwitchListTextPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ManageBackupsDialogTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsSetupActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsSetupFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsSetupPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsSetupXmlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OptionFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OptionPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintMoreOptionActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintMoreOptionFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintMoreOptionPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintOptionActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintOptionFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintOptionPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RestoreDialogTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SetupTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XmlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BackupFilesActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LoadDemoActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ManageBackupsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OptionActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ResetActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RestoreFilesActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BackupSetTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/trains/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/trains/PackageTest.java
@@ -1,72 +1,57 @@
 package jmri.jmrit.operations.trains;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        TrainManagerTest.class,
+        TrainTest.class,
+        TrainCommonTest.class,
+        TrainBuilderTest.class,
+        XmlTest.class,
+        BundleTest.class,
+        jmri.jmrit.operations.trains.tools.PackageTest.class,
+        jmri.jmrit.operations.trains.excel.PackageTest.class,
+        jmri.jmrit.operations.trains.timetable.PackageTest.class,
+        jmri.jmrit.operations.trains.configurexml.PackageTest.class,
+        OperationsTrainsGuiTest.class,
+        BuildFailedExceptionTest.class,
+        TrainConductorPanelTest.class, 
+        TrainCsvCommonTest.class,
+        TrainCsvSwitchListsTest.class,
+        TrainEditBuildOptionsFrameTest.class,
+        TrainLoadOptionsFrameTest.class,
+        TrainLoggerTest.class,
+        TrainManagerXmlTest.class,
+        TrainManifestHeaderTextTest.class,
+        TrainManifestTextTest.class,
+        TrainPrintUtilitiesTest.class,
+        TrainRoadOptionsFrameTest.class,
+        TrainSwitchListEditFrameTest.class,
+        TrainSwitchListTextTest.class,
+        TrainSwitchListsTest.class,
+        TrainUtilitiesTest.class,
+        TrainsTableActionTest.class,
+        TrainsTableFrameTest.class,
+        TrainsTableModelTest.class,
+        JsonManifestTest.class,
+        TrainConductorActionTest.class,
+        TrainConductorFrameTest.class,
+        TrainCsvManifestTest.class,
+        TrainEditFrameTest.class,
+        TrainManifestTest.class,
+        TrainEditBuildOptionsActionTest.class,
+        TrainLoadOptionsActionTest.class,
+        TrainRoadOptionsActionTest.class,
+        TrainIconTest.class,
+        TrainIconAnimationTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.trains package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.trains.PackageTest"); // no tests in class itself
-        suite.addTest(TrainManagerTest.suite());
-        suite.addTest(TrainTest.suite());
-        suite.addTest(TrainCommonTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainBuilderTest.class));
-        suite.addTest(XmlTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(jmri.jmrit.operations.trains.tools.PackageTest.suite());
-        suite.addTest(jmri.jmrit.operations.trains.excel.PackageTest.suite());
-        suite.addTest(jmri.jmrit.operations.trains.timetable.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.operations.trains.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsTrainsGuiTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BuildFailedExceptionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainConductorPanelTest.class)); 
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainCsvCommonTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainCsvSwitchListsTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainEditBuildOptionsFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainLoadOptionsFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainLoggerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainManagerXmlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainManifestHeaderTextTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainManifestTextTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainPrintUtilitiesTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainRoadOptionsFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainSwitchListEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainSwitchListTextTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainSwitchListsTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainUtilitiesTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsTableActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsTableFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JsonManifestTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainConductorActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainConductorFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainCsvManifestTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainManifestTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainEditBuildOptionsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainLoadOptionsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainRoadOptionsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainIconTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainIconAnimationTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/trains/excel/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/trains/excel/PackageTest.java
@@ -1,40 +1,25 @@
 package jmri.jmrit.operations.trains.excel;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        SetupExcelProgramFrameTest.class,
+        SetupExcelProgramManifestFrameTest.class,
+        SetupExcelProgramSwitchListFrameTest.class,
+        TrainCustomManifestTest.class,
+        TrainCustomSwitchListTest.class,
+        XmlTest.class,
+        SetupExcelProgramFrameActionTest.class,
+        SetupExcelProgramSwitchListFrameActionTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.trains.excel package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.trains.excel.PackageTest"); // no tests in class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SetupExcelProgramFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SetupExcelProgramManifestFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SetupExcelProgramSwitchListFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainCustomManifestTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainCustomSwitchListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XmlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SetupExcelProgramFrameActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SetupExcelProgramSwitchListFrameActionTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/trains/timetable/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/trains/timetable/PackageTest.java
@@ -1,41 +1,26 @@
 package jmri.jmrit.operations.trains.timetable;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        OperationsTrainsGuiTest.class,
+        TrainScheduleManagerTest.class,
+        TrainsScheduleEditActionTest.class,
+        TrainsScheduleEditFrameTest.class,
+        TrainsScheduleTableFrameTest.class,
+        TrainsScheduleTableModelTest.class,
+        XmlTest.class,
+        TrainsScheduleActionTest.class,
+        TrainScheduleTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.trains.timetable package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.trains.timetable.PackageTest"); // no tests in class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsTrainsGuiTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainScheduleManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsScheduleEditActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsScheduleEditFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsScheduleTableFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsScheduleTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XmlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsScheduleActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainScheduleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/operations/trains/tools/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/trains/tools/PackageTest.java
@@ -1,60 +1,44 @@
 package jmri.jmrit.operations.trains.tools;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        OperationsTrainsGuiTest.class,
+        ChangeDepartureTimesFrameTest.class,
+        ExportTrainRosterActionTest.class,
+        ExportTrainsTest.class,
+        ShowCarsInTrainFrameTest.class,
+        TrainByCarTypeFrameTest.class,
+        TrainManifestOptionFrameTest.class,
+        TrainScriptFrameTest.class,
+        TrainsScriptFrameTest.class,
+        TrainsByCarTypeActionTest.class,
+        TrainsByCarTypeFrameTest.class,
+        TrainsScriptFrameTest.class,
+        TrainsTableSetColorActionTest.class,
+        TrainsTableSetColorFrameTest.class,
+        TrainCopyActionTest.class,
+        ChangeDepartureTimesActionTest.class,
+        TrainCopyFrameTest.class,
+        TrainByCarTypeActionTest.class,
+        ShowCarsInTrainActionTest.class,
+        PrintSavedTrainManifestActionTest.class,
+        PrintTrainActionTest.class,
+        PrintTrainsActionTest.class,
+        PrintTrainBuildReportActionTest.class,
+        PrintTrainManifestActionTest.class,
+        PrintTrainsByCarTypesActionTest.class,
+        TrainManifestOptionActionTest.class,
+        TrainScriptActionTest.class,
+})
 
 /**
  * Tests for the jmrit.operations.trains.tools package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.operations.trains.tools.PackageTest"); // no tests in class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OperationsTrainsGuiTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ChangeDepartureTimesFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ExportTrainRosterActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ExportTrainsTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ShowCarsInTrainFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainByCarTypeFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainManifestOptionFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainScriptFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsScriptFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsByCarTypeActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsByCarTypeFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsScriptFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsTableSetColorActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainsTableSetColorFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainCopyActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ChangeDepartureTimesActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainCopyFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainByCarTypeActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ShowCarsInTrainActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintSavedTrainManifestActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintTrainActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintTrainsActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintTrainBuildReportActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintTrainManifestActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PrintTrainsByCarTypesActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainManifestOptionActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrainScriptActionTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/picker/PackageTest.java
+++ b/java/test/jmri/jmrit/picker/PackageTest.java
@@ -1,48 +1,20 @@
 package jmri.jmrit.picker;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        PickFrameTest.class,
+        PickSinglePanelTest.class,
+        PickPanelTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.picker tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.picker.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PickFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PickSinglePanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PickPanelTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/powerpanel/PackageTest.java
+++ b/java/test/jmri/jmrit/powerpanel/PackageTest.java
@@ -1,40 +1,21 @@
 package jmri.jmrit.powerpanel;
 
-import java.util.ResourceBundle;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        PowerPaneTest.class,
+        PowerButtonActionTest.class,
+        PowerPanelActionTest.class,
+        PowerPanelFrameTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmrit.PowerPanel package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    static ResourceBundle res = ResourceBundle.getBundle("jmri.jmrit.powerpanel.PowerPanelBundle");
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.powerpanel.PackageTest"); // no tests in class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PowerPaneTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PowerButtonActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PowerPanelActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PowerPanelFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/roster/PackageTest.java
+++ b/java/test/jmri/jmrit/roster/PackageTest.java
@@ -1,70 +1,42 @@
 package jmri.jmrit.roster;
 
-import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        RosterEntryTest.class,
+        RosterTest.class,
+        jmri.jmrit.roster.configurexml.PackageTest.class,
+        CopyRosterItemActionTest.class,
+        RosterEntryPaneTest.class,
+        FunctionLabelPaneTest.class,
+        IdentifyLocoTest.class,
+        jmri.jmrit.roster.swing.PackageTest.class,
+        LocoFileTest.class,
+        RecreateRosterActionTest.class,
+        RosterConfigManagerTest.class,
+        RosterConfigPaneTest.class,
+        RosterIconFactoryTest.class,
+        RosterMediaPaneTest.class,
+        RosterRecorderTest.class,
+        jmri.jmrit.roster.rostergroup.PackageTest.class,
+        DeleteRosterItemActionTest.class,
+        ExportRosterItemActionTest.class,
+        FullBackupExportActionTest.class,
+        FullBackupImportActionTest.class,
+        ImportRosterItemActionTest.class,
+        PrintRosterActionTest.class,
+        PrintRosterEntryTest.class,
+        UpdateDecoderDefinitionActionTest.class,
+        RosterSpeedProfileTest.class,
+})
 
 /**
  * Tests for the jmrit.roster package
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2002, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.roster.PackageTest");
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(RosterEntryTest.suite());
-        suite.addTest(new JUnit4TestAdapter(RosterTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.roster.configurexml.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(CopyRosterItemActionTest.class));
-        suite.addTest(RosterEntryPaneTest.suite());
-        suite.addTest(new JUnit4TestAdapter(FunctionLabelPaneTest.class));
-        suite.addTest(new JUnit4TestAdapter(IdentifyLocoTest.class));
-        suite.addTest(jmri.jmrit.roster.swing.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(LocoFileTest.class));
-        suite.addTest(new JUnit4TestAdapter(RecreateRosterActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(RosterConfigManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(RosterConfigPaneTest.class));
-        suite.addTest(new JUnit4TestAdapter(RosterIconFactoryTest.class));
-        suite.addTest(new JUnit4TestAdapter(RosterMediaPaneTest.class));
-        suite.addTest(new JUnit4TestAdapter(RosterRecorderTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.roster.rostergroup.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(DeleteRosterItemActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(ExportRosterItemActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(FullBackupExportActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(FullBackupImportActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(ImportRosterItemActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(PrintRosterActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(PrintRosterEntryTest.class));
-        suite.addTest(new JUnit4TestAdapter(UpdateDecoderDefinitionActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(RosterSpeedProfileTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/roster/swing/PackageTest.java
+++ b/java/test/jmri/jmrit/roster/swing/PackageTest.java
@@ -1,68 +1,39 @@
 package jmri.jmrit.roster.swing;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        RosterTableModelTest.class,
+        jmri.jmrit.roster.swing.attributetable.PackageTest.class,
+        jmri.jmrit.roster.swing.rostergroup.PackageTest.class,
+        jmri.jmrit.roster.swing.speedprofile.PackageTest.class,
+        jmri.jmrit.roster.swing.rostertree.PackageTest.class,
+        RosterFrameTest.class,
+        GlobalRosterEntryComboBoxTest.class,
+        RosterEntryComboBoxTest.class,
+        RosterEntryListCellRendererTest.class,
+        RosterEntrySelectorPanelTest.class,
+        RosterFrameActionTest.class,
+        RosterFrameStartupActionFactoryTest.class,
+        RosterGroupComboBoxTest.class,
+        RosterGroupsPanelTest.class,
+        RosterTableTest.class,
+        CopyRosterGroupActionTest.class,
+        CreateRosterGroupActionTest.class,
+        DeleteRosterGroupActionTest.class,
+        RenameRosterGroupActionTest.class,
+        RemoveRosterEntryToGroupActionTest.class,
+        RosterEntryToGroupActionTest.class,
+        RosterMenuTest.class,
+})
 
 /**
  * Tests for the jmrit.roster.swing package
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2002, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.roster.swing.PackageTest");
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(RosterTableModelTest.suite());
-
-        suite.addTest(jmri.jmrit.roster.swing.attributetable.PackageTest.suite());
-        suite.addTest(jmri.jmrit.roster.swing.rostergroup.PackageTest.suite());
-        suite.addTest(jmri.jmrit.roster.swing.speedprofile.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.roster.swing.rostertree.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(GlobalRosterEntryComboBoxTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterEntryComboBoxTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterEntryListCellRendererTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterEntrySelectorPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterFrameActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterFrameStartupActionFactoryTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterGroupComboBoxTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterGroupsPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterTableTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CopyRosterGroupActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CreateRosterGroupActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DeleteRosterGroupActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RenameRosterGroupActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RemoveRosterEntryToGroupActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterEntryToGroupActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterMenuTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/roster/swing/attributetable/PackageTest.java
+++ b/java/test/jmri/jmrit/roster/swing/attributetable/PackageTest.java
@@ -1,46 +1,17 @@
 package jmri.jmrit.roster.swing.attributetable;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        AttributeTableModelTest.class,
+})
 
 /**
  * Tests for the jmrit.roster.swing.attributetable package
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2002, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.roster.swing.attributetable.PackageTest");
-
-        suite.addTest(AttributeTableModelTest.suite());
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/roster/swing/rostergroup/PackageTest.java
+++ b/java/test/jmri/jmrit/roster/swing/rostergroup/PackageTest.java
@@ -1,48 +1,20 @@
 package jmri.jmrit.roster.swing.rostergroup;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        RosterGroupTableActionTest.class,
+        RosterGroupTableModelTest.class,
+        RosterGroupTableFrameTest.class,
+})
 
 /**
  * Tests for the jmrit.roster.swing package
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2002, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.roster.swing.rostergroup.PackageTest");
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterGroupTableActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterGroupTableModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RosterGroupTableFrameTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/roster/swing/speedprofile/PackageTest.java
+++ b/java/test/jmri/jmrit/roster/swing/speedprofile/PackageTest.java
@@ -1,49 +1,21 @@
 package jmri.jmrit.roster.swing.speedprofile;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        SpeedProfileFrameTest.class,
+        SpeedProfilePanelTest.class,
+        SpeedProfileTableTest.class,
+        SpeedProfileActionTest.class,
+})
 
 /**
  * Tests for the jmrit.roster.swing package
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2002, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.roster.swing.speedprofile.PackageTest");
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SpeedProfileFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SpeedProfilePanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SpeedProfileTableTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SpeedProfileActionTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/signalling/PackageTest.java
+++ b/java/test/jmri/jmrit/signalling/PackageTest.java
@@ -1,52 +1,25 @@
 package jmri.jmrit.signalling;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        SignallingActionTest.class,
+        SignallingFrameActionTest.class,
+        SignallingFrameTest.class,
+        SignallingSourceActionTest.class,
+        SignallingSourceFrameTest.class,
+        SignallingGuiToolsTest.class,
+        SignallingSourcePanelTest.class,
+        SignallingPanelTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.signalling tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.signalling.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SignallingActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SignallingFrameActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SignallingFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SignallingSourceActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SignallingSourceFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SignallingGuiToolsTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SignallingSourcePanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SignallingPanelTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/simpleclock/PackageTest.java
+++ b/java/test/jmri/jmrit/simpleclock/PackageTest.java
@@ -1,36 +1,21 @@
 package jmri.jmrit.simpleclock;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrit.simpleclock.SimpleTimebaseTest.class,
+        BundleTest.class,
+        jmri.jmrit.simpleclock.configurexml.PackageTest.class,
+        SimpleClockActionTest.class,
+        SimpleClockFrameTest.class,
+})
 
 /**
  * Tests for the jmrit.simpleclock package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.simpleclock.PackageTest"); // no tests in class itself
-        suite.addTest(jmri.jmrit.simpleclock.SimpleTimebaseTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.simpleclock.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SimpleClockActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SimpleClockFrameTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/simpleprog/PackageTest.java
+++ b/java/test/jmri/jmrit/simpleprog/PackageTest.java
@@ -1,46 +1,19 @@
 package jmri.jmrit.simpleprog;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        SimpleProgActionTest.class,
+        SimpleProgFrameTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.simpleprog tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.simpleprog.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SimpleProgActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SimpleProgFrameTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/throttle/PackageTest.java
+++ b/java/test/jmri/jmrit/throttle/PackageTest.java
@@ -1,73 +1,45 @@
 package jmri.jmrit.throttle;
 
-import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        AddressPanelTest.class,
+        BackgroundPanelTest.class,
+        ControlPanelTest.class,
+        ControlPanelPropertyEditorTest.class,
+        FunctionButtonTest.class,
+        FunctionButtonPropertyEditorTest.class,
+        FunctionPanelTest.class,
+        LargePowerManagerButtonTest.class,
+        LoadDefaultXmlThrottlesLayoutActionTest.class,
+        LoadXmlThrottlesLayoutActionTest.class,
+        SmallPowerManagerButtonTest.class,
+        StopAllButtonTest.class,
+        StoreDefaultXmlThrottlesLayoutActionTest.class,
+        StoreXmlThrottlesLayoutActionTest.class,
+        ThrottleCreationActionTest.class,
+        ThrottleFrameTest.class,
+        ThrottleFrameManagerTest.class,
+        ThrottleFramePropertyEditorTest.class,
+        ThrottlesListActionTest.class,
+        ThrottlesPreferencesActionTest.class,
+        ThrottlesPreferencesTest.class,
+        ThrottlesPreferencesPaneTest.class,
+        ThrottlesListPanelTest.class,
+        ThrottlesTableCellRendererTest.class,
+        ThrottlesTableModelTest.class,
+        KeyListenerInstallerTest.class,
+        WindowPreferencesTest.class,
+        SpeedPanelTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.throttle tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.throttle.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(AddressPanelTest.suite());
-        suite.addTest(new JUnit4TestAdapter(BackgroundPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(ControlPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(ControlPanelPropertyEditorTest.class));
-        suite.addTest(FunctionButtonTest.suite());
-        suite.addTest(new JUnit4TestAdapter(FunctionButtonPropertyEditorTest.class));
-        suite.addTest(new JUnit4TestAdapter(FunctionPanelTest.class));
-        suite.addTest(LargePowerManagerButtonTest.suite());
-        suite.addTest(LoadDefaultXmlThrottlesLayoutActionTest.suite());
-        suite.addTest(LoadXmlThrottlesLayoutActionTest.suite());
-        suite.addTest(SmallPowerManagerButtonTest.suite());
-        suite.addTest(StopAllButtonTest.suite());
-        suite.addTest(StoreDefaultXmlThrottlesLayoutActionTest.suite());
-        suite.addTest(StoreXmlThrottlesLayoutActionTest.suite());
-        suite.addTest(ThrottleCreationActionTest.suite());
-        suite.addTest(new JUnit4TestAdapter(ThrottleFrameTest.class));
-        suite.addTest(new JUnit4TestAdapter(ThrottleFrameManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(ThrottleFramePropertyEditorTest.class));
-        suite.addTest(new JUnit4TestAdapter(ThrottlesListActionTest.class));
-        suite.addTest(ThrottlesPreferencesActionTest.suite());
-        suite.addTest(ThrottlesPreferencesTest.suite());
-        suite.addTest(ThrottlesPreferencesPaneTest.suite());
-        suite.addTest(ThrottlesListPanelTest.suite());
-        suite.addTest(ThrottlesTableCellRendererTest.suite());
-        suite.addTest(new JUnit4TestAdapter(ThrottlesTableModelTest.class));
-        suite.addTest(new JUnit4TestAdapter(KeyListenerInstallerTest.class));
-        suite.addTest(new JUnit4TestAdapter(WindowPreferencesTest.class));
-        suite.addTest(new JUnit4TestAdapter(SpeedPanelTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    public void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    public void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/tracker/PackageTest.java
+++ b/java/test/jmri/jmrit/tracker/PackageTest.java
@@ -1,33 +1,18 @@
 package jmri.jmrit.tracker;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        StoppingBlockTest.class,
+        MemoryTrackerTest.class,
+})
 
 /**
  * Tests for the jmrit.blocktrack package
  *
  * @author	Bob Jacobsen Copyright (C) 2006
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.tracker.PackageTest"); // no tests in class itself
-        suite.addTest(StoppingBlockTest.suite());
-        suite.addTest(MemoryTrackerTest.suite());
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/ussctc/PackageTest.java
+++ b/java/test/jmri/jmrit/ussctc/PackageTest.java
@@ -1,73 +1,44 @@
 package jmri.jmrit.ussctc;
 
-import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrit.ussctc.FollowerTest.class,
+        jmri.jmrit.ussctc.FollowerActionTest.class,
+        jmri.jmrit.ussctc.OsIndicatorTest.class,
+        jmri.jmrit.ussctc.OsIndicatorActionTest.class,
+        BasePanelTest.class,
+        FollowerFrameTest.class,
+        FollowerPanelTest.class,
+        OsIndicatorFrameTest.class,
+        OsIndicatorPanelTest.class,
+        ToolsMenuTest.class,
+        
+        // new classes last
+        jmri.jmrit.ussctc.CombinedLockTest.class,
+        jmri.jmrit.ussctc.OccupancyLockTest.class,
+        jmri.jmrit.ussctc.TurnoutLockTest.class,
+        jmri.jmrit.ussctc.RouteLockTest.class,
+        jmri.jmrit.ussctc.TrafficLockTest.class,
+        jmri.jmrit.ussctc.TimeLockTest.class,
+        jmri.jmrit.ussctc.StationTest.class,
+        jmri.jmrit.ussctc.CodeLineTest.class,
+        jmri.jmrit.ussctc.CodeButtonTest.class,
+        jmri.jmrit.ussctc.PhysicalBellTest.class,
+        jmri.jmrit.ussctc.VetoedBellTest.class,
+        jmri.jmrit.ussctc.TrafficRelayTest.class,
+        jmri.jmrit.ussctc.MaintainerCallSectionTest.class,
+        jmri.jmrit.ussctc.TrackCircuitSectionTest.class,
+        jmri.jmrit.ussctc.TurnoutSectionTest.class,
+        jmri.jmrit.ussctc.SignalHeadSectionTest.class,
+})
 
 /**
  * Tests for classes in the jmri.jmrit.ussctc package
  *
  * @author	Bob Jacobsen Copyright 2007
   */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.ussctc.PackageTest");   // no tests in this class itself
-        suite.addTest(jmri.jmrit.ussctc.FollowerTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.ussctc.FollowerActionTest.class));
-        suite.addTest(jmri.jmrit.ussctc.OsIndicatorTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrit.ussctc.OsIndicatorActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(BasePanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(FollowerFrameTest.class));
-        suite.addTest(new JUnit4TestAdapter(FollowerPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(OsIndicatorFrameTest.class));
-        suite.addTest(new JUnit4TestAdapter(OsIndicatorPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(ToolsMenuTest.class));
-        
-        // new classes last
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.CombinedLockTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.OccupancyLockTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.TurnoutLockTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.RouteLockTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.TrafficLockTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.TimeLockTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.StationTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.CodeLineTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.CodeButtonTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.PhysicalBellTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.VetoedBellTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.TrafficRelayTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.MaintainerCallSectionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.TrackCircuitSectionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.TurnoutSectionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrit.ussctc.SignalHeadSectionTest.class));
-        
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrit/withrottle/PackageTest.java
+++ b/java/test/jmri/jmrit/withrottle/PackageTest.java
@@ -1,67 +1,38 @@
 package jmri.jmrit.withrottle;
 
-import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        ConsistControllerTest.class,
+        ConsistFunctionControllerTest.class,
+        DeviceServerTest.class,
+        FacelessServerTest.class,
+        MultiThrottleControllerTest.class,
+        MultiThrottleTest.class,
+        RouteControllerTest.class,
+        ThrottleControllerTest.class,
+        TrackPowerControllerTest.class,
+        TurnoutControllerTest.class,
+        WiFiConsistFileTest.class,
+        WiFiConsistTest.class,
+        WiFiConsistManagerTest.class,
+        WiThrottleManagerTest.class,
+        WiThrottlePreferencesTest.class,
+        WiThrottlesListModelTest.class,
+        WiThrottlePrefsPanelTest.class,
+        ControllerFilterActionTest.class,
+        ControllerFilterFrameTest.class,
+        UserInterfaceTest.class,
+        WiThrottleCreationActionTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.jmrit.withrottle tree
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2012
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrit.withrottle.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(ConsistControllerTest.suite());
-        suite.addTest(ConsistFunctionControllerTest.suite());
-        suite.addTest(DeviceServerTest.suite());
-        suite.addTest(FacelessServerTest.suite());
-        suite.addTest(MultiThrottleControllerTest.suite());
-        suite.addTest(MultiThrottleTest.suite());
-        suite.addTest(RouteControllerTest.suite());
-        suite.addTest(ThrottleControllerTest.suite());
-        suite.addTest(TrackPowerControllerTest.suite());
-        suite.addTest(TurnoutControllerTest.suite());
-        suite.addTest(WiFiConsistFileTest.suite());
-        suite.addTest(new JUnit4TestAdapter(WiFiConsistTest.class));
-        suite.addTest(new JUnit4TestAdapter(WiFiConsistManagerTest.class));
-        suite.addTest(WiThrottleManagerTest.suite());
-        suite.addTest(WiThrottlePreferencesTest.suite());
-        suite.addTest(WiThrottlesListModelTest.suite());
-        suite.addTest(new JUnit4TestAdapter(WiThrottlePrefsPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(ControllerFilterActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(ControllerFilterFrameTest.class));
-        suite.addTest(new JUnit4TestAdapter(UserInterfaceTest.class));
-        suite.addTest(new JUnit4TestAdapter(WiThrottleCreationActionTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/PackageTest.java
+++ b/java/test/jmri/jmrix/PackageTest.java
@@ -1,121 +1,91 @@
 package jmri.jmrix;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        AbstractMRTrafficControllerTest.class,
+        AbstractMRNodeTrafficControllerTest.class,
+
+        jmri.jmrix.AbstractProgrammerTest.class,
+        jmri.jmrix.AbstractMRReplyTest.class,
+        AbstractThrottleTest.class,
+        BundleTest.class,
+        jmri.jmrix.ConnectionConfigManagerTest.class,
+
+        jmri.jmrix.acela.PackageTest.class,
+        jmri.jmrix.anyma.PackageTest.class,
+        jmri.jmrix.bachrus.PackageTest.class,
+        jmri.jmrix.can.PackageTest.class,
+        jmri.jmrix.configurexml.PackageTest.class,
+        jmri.jmrix.cmri.PackageTest.class,
+        jmri.jmrix.dcc.PackageTest.class,
+        jmri.jmrix.dcc4pc.PackageTest.class,
+        jmri.jmrix.direct.PackageTest.class,
+        jmri.jmrix.dccpp.PackageTest.class,
+        jmri.jmrix.easydcc.PackageTest.class,
+        jmri.jmrix.ecos.PackageTest.class,
+        jmri.jmrix.grapevine.PackageTest.class,
+        jmri.jmrix.ieee802154.PackageTest.class,
+        jmri.jmrix.internal.PackageTest.class,
+        jmri.jmrix.jmriclient.PackageTest.class,
+        jmri.jmrix.lenz.PackageTest.class,
+        jmri.jmrix.loconet.PackageTest.class,
+        jmri.jmrix.maple.PackageTest.class,
+        jmri.jmrix.marklin.PackageTest.class,
+        jmri.jmrix.merg.PackageTest.class,
+        jmri.jmrix.modbus.PackageTest.class,
+        jmri.jmrix.mrc.PackageTest.class,
+        jmri.jmrix.nce.PackageTest.class,
+        jmri.jmrix.oaktree.PackageTest.class,
+        jmri.jmrix.openlcb.PackageTest.class,
+        jmri.jmrix.pi.PackageTest.class,
+        jmri.jmrix.powerline.PackageTest.class,
+        jmri.jmrix.pricom.PackageTest.class,
+        jmri.jmrix.qsi.PackageTest.class,
+        jmri.jmrix.rfid.PackageTest.class,
+        jmri.jmrix.roco.PackageTest.class,
+        jmri.jmrix.rps.PackageTest.class,
+        jmri.jmrix.secsi.PackageTest.class,
+        jmri.jmrix.sprog.PackageTest.class,
+        jmri.jmrix.srcp.PackageTest.class,
+        jmri.jmrix.tams.PackageTest.class,
+        jmri.jmrix.tmcc.PackageTest.class,
+        jmri.jmrix.wangrow.PackageTest.class,
+        jmri.jmrix.xpa.PackageTest.class,
+        jmri.jmrix.zimo.PackageTest.class,
+        jmri.jmrix.jinput.PackageTest.class,
+        jmri.jmrix.serialsensor.PackageTest.class,
+        jmri.jmrix.ncemonitor.PackageTest.class,
+        AbstractMRTrafficControllerTest.class,
+        NetworkConfigExceptionTest.class,
+        SerialConfigExceptionTest.class,
+        ConnectionStatusTest.class,
+        jmri.jmrix.swing.PackageTest.class,
+        ActiveSystemsMenuTest.class,
+        DCCManufacturerListTest.class,
+        OtherConnectionTypeListTest.class,
+        jmri.jmrix.debugthrottle.PackageTest.class,
+        AbstractMessageTest.class,
+        AbstractMRMessageTest.class,
+        NetMessageTest.class,
+        AbstractNodeTest.class,
+        AbstractMonFrameTest.class,
+        AbstractMonPaneTest.class,
+        SystemConnectionMemoTest.class,
+        AbstractThrottleManagerTest.class,
+        JmrixConfigPaneTest.class,
+        jmri.jmrix.ztc.PackageTest.class,
+        jmri.jmrix.libusb.PackageTest.class,
+        SystemConnectionMemoManagerTest.class,
+        UsbPortAdapterTest.class,
+})
 
 /**
  * Set of tests for the jmri.jmrix package
  *
  * @author	Bob Jacobsen Copyright 2003, 2007
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.PackageTest");
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractMRTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractMRNodeTrafficControllerTest.class));
-
-        suite.addTest(jmri.jmrix.AbstractProgrammerTest.suite());
-        suite.addTest(jmri.jmrix.AbstractMRReplyTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractThrottleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ConnectionConfigManagerTest.class));
-
-        suite.addTest(jmri.jmrix.acela.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.anyma.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.bachrus.PackageTest.class));
-        suite.addTest(jmri.jmrix.can.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.configurexml.PackageTest.class));
-        //suite.addTest(jmri.jmrix.cmri.serial.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.cmri.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.dcc.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.dcc4pc.PackageTest.class));
-        suite.addTest(jmri.jmrix.direct.PackageTest.suite());
-        suite.addTest(jmri.jmrix.dccpp.PackageTest.suite());
-        suite.addTest(jmri.jmrix.easydcc.PackageTest.suite());
-        suite.addTest(jmri.jmrix.ecos.PackageTest.suite());
-        suite.addTest(jmri.jmrix.grapevine.PackageTest.suite());
-        suite.addTest(jmri.jmrix.ieee802154.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.internal.PackageTest.class));
-        suite.addTest(jmri.jmrix.jmriclient.PackageTest.suite());
-        suite.addTest(jmri.jmrix.lenz.PackageTest.suite());
-        suite.addTest(jmri.jmrix.loconet.PackageTest.suite());
-        suite.addTest(jmri.jmrix.maple.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.marklin.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.merg.PackageTest.class));
-        suite.addTest(jmri.jmrix.modbus.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.mrc.PackageTest.class));
-        suite.addTest(jmri.jmrix.nce.PackageTest.suite());
-        suite.addTest(jmri.jmrix.oaktree.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.openlcb.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.pi.PackageTest.class));
-        suite.addTest(jmri.jmrix.powerline.PackageTest.suite());
-        suite.addTest(jmri.jmrix.pricom.PackageTest.suite());
-        suite.addTest(jmri.jmrix.qsi.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.rfid.PackageTest.class));
-        suite.addTest(jmri.jmrix.roco.PackageTest.suite());
-        suite.addTest(jmri.jmrix.rps.PackageTest.suite());
-        suite.addTest(jmri.jmrix.secsi.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.sprog.PackageTest.class));
-        suite.addTest(jmri.jmrix.srcp.PackageTest.suite());
-        suite.addTest(jmri.jmrix.tams.PackageTest.suite());
-        suite.addTest(jmri.jmrix.tmcc.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.wangrow.PackageTest.class));
-        suite.addTest(jmri.jmrix.xpa.PackageTest.suite());
-        suite.addTest(jmri.jmrix.zimo.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.jinput.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.serialsensor.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ncemonitor.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractMRTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NetworkConfigExceptionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialConfigExceptionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConnectionStatusTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ActiveSystemsMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCManufacturerListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OtherConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.debugthrottle.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractMessageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractMRMessageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NetMessageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractNodeTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractMonFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractMonPaneTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractThrottleManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JmrixConfigPaneTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ztc.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.libusb.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SystemConnectionMemoManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(UsbPortAdapterTest.class));
-        return suite;
-
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/acela/PackageTest.java
+++ b/java/test/jmri/jmrix/acela/PackageTest.java
@@ -1,57 +1,39 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package jmri.jmrix.acela;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        AcelaNodeTest.class,
+        AcelaLightManagerTest.class,
+        AcelaLightTest.class,
+        AcelaTurnoutManagerTest.class,
+        AcelaTurnoutTest.class,
+        jmri.jmrix.acela.configurexml.PackageTest.class,
+        jmri.jmrix.acela.serialdriver.PackageTest.class,
+        jmri.jmrix.acela.nodeconfig.PackageTest.class,
+        jmri.jmrix.acela.acelamon.PackageTest.class,
+        jmri.jmrix.acela.packetgen.PackageTest.class,
+        AcelaSystemConnectionMemoTest.class,
+        AcelaPortControllerTest.class,
+        AcelaTrafficControllerTest.class,
+        AcelaAddressTest.class,
+        AcelaConnectionTypeListTest.class,
+        AcelaMessageTest.class,
+        AcelaReplyTest.class,
+        jmri.jmrix.acela.swing.PackageTest.class,
+        AcelaMenuTest.class,
+        AcelaSensorManagerTest.class,
+        AcelaSensorTest.class,
+        AcelaSignalHeadTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.acela package
  *
  * @author	Bob Coleman
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.acela.AcelaTest");  // no tests in this class itself
-        suite.addTest(new TestSuite(AcelaNodeTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaLightManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaLightTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaTurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaTurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.acela.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.acela.serialdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.acela.nodeconfig.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.acela.acelamon.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.acela.packetgen.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaAddressTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaMessageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaReplyTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.acela.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaSensorManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaSensorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AcelaSignalHeadTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/can/PackageTest.java
+++ b/java/test/jmri/jmrix/can/PackageTest.java
@@ -1,61 +1,29 @@
 package jmri.jmrix.can;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrix.can.CanMessageTest.class,
+        jmri.jmrix.can.CanReplyTest.class,
+        jmri.jmrix.can.nmranet.PackageTest.class,
+        jmri.jmrix.can.adapters.PackageTest.class,
+        jmri.jmrix.can.swing.PackageTest.class,
+        jmri.jmrix.can.cbus.PackageTest.class,
+        AbstractCanTrafficControllerTest.class,
+        TrafficControllerTest.class,
+        CanConnectionTypeListTest.class,
+        CanConstantsTest.class,
+        CanSystemConnectionMemoTest.class,
+        CanConfigurationManagerTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.can package.
  *
  * @author Bob Jacobsen Copyright 2008
  */
-public class PackageTest extends TestCase {
-
-    public void testDefinitions() {
-    }
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        apps.tests.AllTest.initLogging();
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.can.CanTest");
-        suite.addTest(jmri.jmrix.can.CanMessageTest.suite());
-        suite.addTest(jmri.jmrix.can.CanReplyTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.can.nmranet.PackageTest.class));
-        suite.addTest(jmri.jmrix.can.adapters.PackageTest.suite());
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.can.swing.PackageTest.class));
-
-        suite.addTest(jmri.jmrix.can.cbus.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(AbstractCanTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CanConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CanConstantsTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CanSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CanConfigurationManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/can/adapters/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/PackageTest.java
@@ -1,49 +1,19 @@
 package jmri.jmrix.can.adapters;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrix.can.adapters.lawicell.PackageTest.class,
+        jmri.jmrix.can.adapters.gridconnect.PackageTest.class,
+        jmri.jmrix.can.adapters.loopback.PackageTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.can.adapters package.
  *
  * @author Bob Jacobsen Copyright 2009
  */
-public class PackageTest extends TestCase {
-
-    public void testDefinitions() {
-    }
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        apps.tests.AllTest.initLogging();
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.can.adapters.AdapterTest");
-        suite.addTest(jmri.jmrix.can.adapters.lawicell.PackageTest.suite());
-        suite.addTest(jmri.jmrix.can.adapters.gridconnect.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.can.adapters.loopback.PackageTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/PackageTest.java
@@ -1,53 +1,26 @@
 package jmri.jmrix.can.adapters.gridconnect;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        GridConnectMessageTest.class,
+        GridConnectReplyTest.class,
+        jmri.jmrix.can.adapters.gridconnect.canrs.PackageTest.class,
+        jmri.jmrix.can.adapters.gridconnect.lccbuffer.PackageTest.class,
+        jmri.jmrix.can.adapters.gridconnect.net.PackageTest.class,
+        jmri.jmrix.can.adapters.gridconnect.canusb.PackageTest.class,
+        jmri.jmrix.can.adapters.gridconnect.can2usbino.PackageTest.class,
+        GcPortControllerTest.class,
+        GcTrafficControllerTest.class,
+        GcSerialDriverAdapterTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.can.adapters.gridconnect package.
  *
  * @author Bob Jacobsen Copyright 2009
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        apps.tests.AllTest.initLogging();
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.can.adapters.gridconnect");
-        suite.addTest(GridConnectMessageTest.suite());
-        suite.addTest(GridConnectReplyTest.suite());
-        suite.addTest(jmri.jmrix.can.adapters.gridconnect.canrs.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.can.adapters.gridconnect.lccbuffer.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.can.adapters.gridconnect.net.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.can.adapters.gridconnect.canusb.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.can.adapters.gridconnect.can2usbino.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(GcPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(GcTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(GcSerialDriverAdapterTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/PackageTest.java
@@ -1,47 +1,20 @@
 package jmri.jmrix.can.adapters.gridconnect.canrs;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        MergMessageTest.class,
+        MergReplyTest.class,
+        jmri.jmrix.can.adapters.gridconnect.canrs.serialdriver.PackageTest.class,
+        MergTrafficControllerTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.can.adapters.gridconnect.canrs package.
  *
  * @author Bob Jacobsen Copyright 2009
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        apps.tests.AllTest.initLogging();
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.can.adapters.gridconnect.canrs");
-        suite.addTest(MergMessageTest.suite());
-        suite.addTest(MergReplyTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.can.adapters.gridconnect.canrs.serialdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(MergTrafficControllerTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/can/adapters/lawicell/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/lawicell/PackageTest.java
@@ -1,52 +1,22 @@
 package jmri.jmrix.can.adapters.lawicell;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        MessageTest.class,
+        ReplyTest.class,
+        jmri.jmrix.can.adapters.lawicell.canusb.PackageTest.class,
+        SerialDriverAdapterTest.class,
+        PortControllerTest.class,
+        LawicellTrafficControllerTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.can.adapters.lawicell package.
  *
  * @author Bob Jacobsen Copyright 2009
  */
-public class PackageTest extends TestCase {
-
-    public void testDefinitions() {
-    }
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        apps.tests.AllTest.initLogging();
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.can.adapters.lawicell");
-        suite.addTest(MessageTest.suite());
-        suite.addTest(ReplyTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.can.adapters.lawicell.canusb.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialDriverAdapterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LawicellTrafficControllerTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/can/cbus/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/PackageTest.java
@@ -1,61 +1,42 @@
 package jmri.jmrix.can.cbus;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrix.can.cbus.CbusAddressTest.class,
+        jmri.jmrix.can.cbus.CbusProgrammerTest.class,
+        jmri.jmrix.can.cbus.CbusProgrammerManagerTest.class,
+        CbusSensorManagerTest.class,
+        jmri.jmrix.can.cbus.CbusSensorTest.class,
+        jmri.jmrix.can.cbus.configurexml.PackageTest.class,
+        jmri.jmrix.can.cbus.swing.PackageTest.class,
+        CbusReporterManagerTest.class,
+        CbusConstantsTest.class,
+        CbusEventFilterTest.class,
+        CbusMessageTest.class,
+        CbusOpCodesTest.class,
+        CbusCommandStationTest.class,
+        CbusConfigurationManagerTest.class,
+        CbusDccProgrammerManagerTest.class,
+        CbusDccOpsModeProgrammerTest.class,
+        CbusDccProgrammerTest.class,
+        CbusLightManagerTest.class,
+        CbusLightTest.class,
+        CbusPowerManagerTest.class,
+        CbusReporterTest.class,
+        CbusThrottleTest.class,
+        CbusThrottleManagerTest.class,
+        CbusTurnoutManagerTest.class,
+        CbusTurnoutTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.can.cbus package.
  *
  * @author Bob Jacobsen Copyright 2008
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    public void testDefinitions() {
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.can.cbus.CbusTest");
-        suite.addTest(jmri.jmrix.can.cbus.CbusAddressTest.suite());
-        suite.addTest(jmri.jmrix.can.cbus.CbusProgrammerTest.suite());
-        suite.addTest(jmri.jmrix.can.cbus.CbusProgrammerManagerTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusSensorManagerTest.class));
-        suite.addTest(jmri.jmrix.can.cbus.CbusSensorTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.can.cbus.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.can.cbus.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusReporterManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusConstantsTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusEventFilterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusMessageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusOpCodesTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusCommandStationTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusConfigurationManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusDccProgrammerManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusDccOpsModeProgrammerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusDccProgrammerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusLightManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusLightTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusPowerManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusReporterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusThrottleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusThrottleManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusTurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(CbusTurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/dccpp/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/PackageTest.java
@@ -1,8 +1,47 @@
 package jmri.jmrix.dccpp;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+	    DCCppCommandStationTest.class,
+        DCCppConnectionTypeListTest.class,
+        DCCppMessageTest.class,
+        DCCppReplyTest.class,
+        DCCppPacketizerTest.class,
+        DCCppTrafficControllerTest.class,
+        DCCppSystemConnectionMemoTest.class,
+        DCCppThrottleTest.class,
+        DCCppInitializationManagerTest.class,
+        DCCppProgrammerTest.class,
+        DCCppProgrammerManagerTest.class,
+        DCCppPowerManagerTest.class,
+        DCCppThrottleManagerTest.class,
+        DCCppLightTest.class,
+        DCCppLightManagerTest.class,
+        DCCppOpsModeProgrammerTest.class,
+        DCCppStreamPortControllerTest.class,
+        DCCppSensorTest.class,
+        DCCppSensorManagerTest.class,
+        DCCppTurnoutTest.class,
+        jmri.jmrix.dccpp.network.PackageTest.class,
+        jmri.jmrix.dccpp.swing.PackageTest.class,
+        jmri.jmrix.dccpp.dccppovertcp.PackageTest.class,
+        jmri.jmrix.dccpp.simulator.PackageTest.class,
+        jmri.jmrix.dccpp.serial.PackageTest.class,
+        jmri.jmrix.dccpp.configurexml.PackageTest.class,
+        DCCppNetworkPortControllerTest.class,
+        DCCppSerialPortControllerTest.class,
+        DCCppSimulatorPortControllerTest.class,
+        DCCppMessageExceptionTest.class,
+        DCCppConstantsTest.class,
+        DCCppRegisterManagerTest.class,
+        DCCppMultiMeterTest.class,
+        DCCppTurnoutManagerTest.class,
+        DCCppTurnoutReplyCacheTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.dccpp package
@@ -10,59 +49,5 @@ import junit.framework.TestSuite;
  * @author	Bob Jacobsen
  * @author	Mark Underwood
   */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.dccpp.DCCppTest");  // no tests in this class itself
-	suite.addTest(new TestSuite(DCCppCommandStationTest.class));
-        suite.addTest(new TestSuite(DCCppConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppMessageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppReplyTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppPacketizerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppThrottleTest.class));
-        suite.addTest(new TestSuite(DCCppInitializationManagerTest.class));
-        suite.addTest(new TestSuite(DCCppProgrammerTest.class));
-        suite.addTest(new TestSuite(DCCppProgrammerManagerTest.class));
-        suite.addTest(new TestSuite(DCCppPowerManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppThrottleManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppLightTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppLightManagerTest.class));
-        suite.addTest(new TestSuite(DCCppOpsModeProgrammerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppStreamPortControllerTest.class));
-        suite.addTest(new TestSuite(DCCppSensorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppSensorManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppTurnoutTest.class));
-        suite.addTest(jmri.jmrix.dccpp.network.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.dccpp.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.dccpp.dccppovertcp.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.dccpp.simulator.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.dccpp.serial.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.dccpp.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppNetworkPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppSerialPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppSimulatorPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppMessageExceptionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppConstantsTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppRegisterManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppMultiMeterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppTurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppTurnoutReplyCacheTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/dccpp/network/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/network/PackageTest.java
@@ -1,8 +1,15 @@
 package jmri.jmrix.dccpp.network;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        DCCppEthernetAdapterTest.class,
+        DCCppEthernetPacketizerTest.class,
+        ConnectionConfigTest.class,
+        jmri.jmrix.dccpp.network.configurexml.PackageTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.dccpp.network package
@@ -10,27 +17,5 @@ import junit.framework.TestSuite;
  * @author Paul Bender
  * @author Mark Underwood Copyright (C) 2015
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.dccpp.network");  // no tests in this class itself
-        suite.addTest(new TestSuite(DCCppEthernetAdapterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DCCppEthernetPacketizerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConnectionConfigTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.dccpp.network.configurexml.PackageTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/direct/PackageTest.java
+++ b/java/test/jmri/jmrix/direct/PackageTest.java
@@ -1,43 +1,27 @@
 package jmri.jmrix.direct;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrix.direct.MakePacketTest.class,
+        jmri.jmrix.direct.serial.PackageTest.class,
+        jmri.jmrix.direct.configurexml.PackageTest.class,
+        PortControllerTest.class,
+        TrafficControllerTest.class,
+        DirectMenuTest.class,
+        ThrottleManagerTest.class,
+        ThrottleTest.class,
+        MessageTest.class,
+        jmri.jmrix.direct.swing.PackageTest.class,
+        DirectSystemConnectionMemoTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.direct package.
  *
  * @author Bob Jacobsen Copyright 2004
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.direct.DirectTest");
-        suite.addTest(jmri.jmrix.direct.MakePacketTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.direct.serial.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.direct.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DirectMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ThrottleManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ThrottleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(MessageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.direct.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DirectSystemConnectionMemoTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/easydcc/PackageTest.java
+++ b/java/test/jmri/jmrix/easydcc/PackageTest.java
@@ -1,79 +1,43 @@
 package jmri.jmrix.easydcc;
 
-import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        EasyDccTurnoutTest.class,
+        EasyDccTurnoutManagerTest.class,
+        jmri.jmrix.easydcc.EasyDccProgrammerTest.class,
+        EasyDccTrafficControllerTest.class,
+        jmri.jmrix.easydcc.EasyDccMessageTest.class,
+        jmri.jmrix.easydcc.EasyDccReplyTest.class,
+        EasyDccPowerManagerTest.class,
+        EasyDccConsistTest.class,
+        EasyDccConsistManagerTest.class,
+        jmri.jmrix.easydcc.serialdriver.PackageTest.class,
+        jmri.jmrix.easydcc.simulator.PackageTest.class,
+        jmri.jmrix.easydcc.networkdriver.PackageTest.class,
+        jmri.jmrix.easydcc.configurexml.PackageTest.class,
+        jmri.jmrix.easydcc.easydccmon.PackageTest.class,
+        jmri.jmrix.easydcc.packetgen.PackageTest.class,
+        EasyDccNetworkPortControllerTest.class,
+        EasyDccSystemConnectionMemoTest.class,
+        EasyDccPortControllerTest.class,
+        EasyDccMenuTest.class,
+        EasyDccConnectionTypeListTest.class,
+        EasyDccCommandStationTest.class,
+        EasyDccOpsModeProgrammerTest.class,
+        EasyDccProgrammerManagerTest.class,
+        EasyDccThrottleManagerTest.class,
+        EasyDccThrottleTest.class,
+        BundleTest.class,
+        jmri.jmrix.easydcc.swing.PackageTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.easydcc package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // a dummy test to avoid JUnit warning
-    public void testDemo() {
-        assertTrue(true);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.easydcc.EasyDccTest");
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EasyDccTurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EasyDccTurnoutManagerTest.class));
-        suite.addTest(jmri.jmrix.easydcc.EasyDccProgrammerTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EasyDccTrafficControllerTest.class));
-        suite.addTest(jmri.jmrix.easydcc.EasyDccMessageTest.suite());
-        suite.addTest(jmri.jmrix.easydcc.EasyDccReplyTest.suite());
-        suite.addTest(new JUnit4TestAdapter(EasyDccPowerManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(EasyDccConsistTest.class));
-        suite.addTest(new JUnit4TestAdapter(EasyDccConsistManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.easydcc.serialdriver.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.easydcc.simulator.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.easydcc.networkdriver.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.easydcc.configurexml.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.easydcc.easydccmon.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.easydcc.packetgen.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(EasyDccNetworkPortControllerTest.class));
-        suite.addTest(new JUnit4TestAdapter(EasyDccSystemConnectionMemoTest.class));
-        suite.addTest(new JUnit4TestAdapter(EasyDccPortControllerTest.class));
-        suite.addTest(new JUnit4TestAdapter(EasyDccMenuTest.class));
-        suite.addTest(new JUnit4TestAdapter(EasyDccConnectionTypeListTest.class));
-        suite.addTest(new JUnit4TestAdapter(EasyDccCommandStationTest.class));
-        suite.addTest(new JUnit4TestAdapter(EasyDccOpsModeProgrammerTest.class));
-        suite.addTest(new JUnit4TestAdapter(EasyDccProgrammerManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(EasyDccThrottleManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(EasyDccThrottleTest.class));
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.easydcc.swing.PackageTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/ecos/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/PackageTest.java
@@ -1,57 +1,41 @@
 package jmri.jmrix.ecos;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        jmri.jmrix.ecos.swing.PackageTest.class,
+        jmri.jmrix.ecos.networkdriver.PackageTest.class,
+        jmri.jmrix.ecos.configurexml.PackageTest.class,
+        EcosPreferencesTest.class,
+        EcosSystemConnectionMemoTest.class,
+        jmri.jmrix.ecos.utilities.PackageTest.class,
+        EcosReporterManagerTest.class,
+        EcosTrafficControllerTest.class,
+        EcosSensorManagerTest.class,
+        EcosTurnoutManagerTest.class,
+        EcosPortControllerTest.class,
+        EcosConnectionTypeListTest.class,
+        EcosMessageTest.class,
+        EcosReplyTest.class,
+        EcosDccThrottleManagerTest.class,
+        EcosDccThrottleTest.class,
+        EcosLocoAddressManagerTest.class,
+        EcosLocoAddressTest.class,
+        EcosPowerManagerTest.class,
+        EcosProgrammerManagerTest.class,
+        EcosProgrammerTest.class,
+        EcosReporterTest.class,
+        EcosSensorTest.class,
+        EcosTurnoutTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.ecos package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.ecos.PackageTest");  // no tests in this class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(jmri.jmrix.ecos.swing.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ecos.networkdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ecos.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosPreferencesTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ecos.utilities.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosReporterManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosSensorManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosTurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosMessageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosReplyTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosDccThrottleManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosDccThrottleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosLocoAddressManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosLocoAddressTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosPowerManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosProgrammerManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosProgrammerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosReporterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosSensorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosTurnoutTest.class));
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/ecos/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/swing/PackageTest.java
@@ -1,43 +1,26 @@
 package jmri.jmrix.ecos.swing;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        jmri.jmrix.ecos.swing.locodatabase.PackageTest.class,
+        jmri.jmrix.ecos.swing.packetgen.PackageTest.class,
+        jmri.jmrix.ecos.swing.monitor.PackageTest.class,
+        jmri.jmrix.ecos.swing.preferences.PackageTest.class,
+        jmri.jmrix.ecos.swing.statusframe.PackageTest.class,
+        EcosComponentFactoryTest.class,
+        EcosMenuTest.class,
+        BundleTest.class,
+        EcosNamedPaneActionTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.ecos.swing package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.ecos.swing.PackageTest");  // no tests in this class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-
-        suite.addTest(jmri.jmrix.ecos.swing.locodatabase.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ecos.swing.packetgen.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ecos.swing.monitor.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ecos.swing.preferences.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ecos.swing.statusframe.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosComponentFactoryTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosNamedPaneActionTest.class));
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/ecos/swing/locodatabase/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/swing/locodatabase/PackageTest.java
@@ -1,35 +1,19 @@
 package jmri.jmrix.ecos.swing.locodatabase;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        EcosLocoTableActionTest.class,
+        EcosLocoTableTabActionTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.ecos.swing.locodatabase package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.ecos.swing.locodatabase.PackageTest");  // no tests in this class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosLocoTableActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EcosLocoTableTabActionTest.class));
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/grapevine/PackageTest.java
+++ b/java/test/jmri/jmrix/grapevine/PackageTest.java
@@ -1,77 +1,43 @@
 package jmri.jmrix.grapevine;
 
-import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SerialTurnoutTest.class,
+        SerialTurnoutTest1.class,
+        SerialTurnoutTest2.class,
+        SerialTurnoutTest3.class,
+        SerialTurnoutManagerTest.class,
+        SerialLightTest.class,
+        SerialLightManagerTest.class,
+        SerialSensorManagerTest.class,
+        SerialNodeTest.class,
+        SerialMessageTest.class,
+        SerialReplyTest.class,
+        SerialTrafficControllerTest.class,
+        SerialAddressTest.class,
+        jmri.jmrix.grapevine.serialdriver.PackageTest.class,
+        jmri.jmrix.grapevine.configurexml.PackageTest.class,
+        GrapevineMenuTest.class,
+        jmri.jmrix.grapevine.serialmon.PackageTest.class,
+        GrapevineSystemConnectionMemoTest.class,
+        SerialPortControllerTest.class,
+        jmri.jmrix.grapevine.nodeconfig.PackageTest.class,
+        jmri.jmrix.grapevine.nodetable.PackageTest.class,
+        jmri.jmrix.grapevine.packetgen.PackageTest.class,
+        SerialConnectionTypeListTest.class,
+        SerialSensorTest.class,
+        SerialSignalHeadTest.class,
+        BundleTest.class,
+        jmri.jmrix.grapevine.swing.PackageTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.grapevine package.
  *
  * @author Bob Jacobsen Copyright 2003, 2007
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    public void testDefinitions() {
-        Assert.assertEquals("Node definitions match", SerialSensorManager.SENSORSPERNODE,
-                SerialNode.MAXSENSORS + 1);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.grapevine.SerialTest");
-        suite.addTest(new JUnit4TestAdapter(SerialTurnoutTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialTurnoutTest1.class));
-        suite.addTest(new JUnit4TestAdapter(SerialTurnoutTest2.class));
-        suite.addTest(new JUnit4TestAdapter(SerialTurnoutTest3.class));
-        suite.addTest(new JUnit4TestAdapter(SerialTurnoutManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialLightTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialLightManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialSensorManagerTest.class));
-        suite.addTest(SerialNodeTest.suite());
-        suite.addTest(SerialMessageTest.suite());
-        suite.addTest(SerialReplyTest.suite());
-        suite.addTest(new JUnit4TestAdapter(SerialTrafficControllerTest.class));
-        suite.addTest(SerialAddressTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.grapevine.serialdriver.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.grapevine.configurexml.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(GrapevineMenuTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.grapevine.serialmon.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(GrapevineSystemConnectionMemoTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialPortControllerTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.grapevine.nodeconfig.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.grapevine.nodetable.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.grapevine.packetgen.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialConnectionTypeListTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialSensorTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialSignalHeadTest.class));
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.grapevine.swing.PackageTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/ieee802154/PackageTest.java
+++ b/java/test/jmri/jmrix/ieee802154/PackageTest.java
@@ -1,55 +1,27 @@
 package jmri.jmrix.ieee802154;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        IEEE802154MessageTest.class,
+        IEEE802154ReplyTest.class,
+        IEEE802154SystemConnectionMemoTest.class,
+        IEEE802154TrafficControllerTest.class,
+        jmri.jmrix.ieee802154.xbee.PackageTest.class,
+        jmri.jmrix.ieee802154.serialdriver.PackageTest.class,
+        IEEE802154NodeTest.class,
+        BundleTest.class,
+        jmri.jmrix.ieee802154.swing.PackageTest.class,
+        IEEE802154PortControllerTest.class,
+        SerialConnectionTypeListTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.ieee802154 package
  *
  * @author	Paul Bender
   */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.ieee802154.IEEE802154Test");  // no tests in this class itself
-        suite.addTest(new TestSuite(IEEE802154MessageTest.class));
-        suite.addTest(new TestSuite(IEEE802154ReplyTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(IEEE802154SystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(IEEE802154TrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ieee802154.xbee.PackageTest.class));
-        suite.addTest(jmri.jmrix.ieee802154.serialdriver.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(IEEE802154NodeTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ieee802154.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(IEEE802154PortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialConnectionTypeListTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/ieee802154/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/ieee802154/serialdriver/PackageTest.java
@@ -1,37 +1,22 @@
 package jmri.jmrix.ieee802154.serialdriver;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SerialSystemConnectionMemoTest.class,
+        SerialTrafficControllerTest.class,
+        SerialNodeTest.class,
+        SerialDriverAdapterTest.class,
+        ConnectionConfigTest.class,
+        jmri.jmrix.ieee802154.serialdriver.configurexml.PackageTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.ieee802154.serialdriver package
  *
  * @author	Paul Bender
   */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.ieee802154.serialdriver.SerialTest");  // no tests in this class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialNodeTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialDriverAdapterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConnectionConfigTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.ieee802154.serialdriver.configurexml.PackageTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/jmriclient/PackageTest.java
+++ b/java/test/jmri/jmrix/jmriclient/PackageTest.java
@@ -1,51 +1,36 @@
 package jmri.jmrix.jmriclient;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        JMRIClientMessageTest.class,
+        JMRIClientReplyTest.class,
+        JMRIClientTurnoutTest.class,
+        JMRIClientSensorTest.class,
+        JMRIClientReporterTest.class,
+        JMRIClientTurnoutManagerTest.class,
+        JMRIClientSensorManagerTest.class,
+        JMRIClientReporterManagerTest.class,
+        JMRIClientTrafficControllerTest.class,
+        JMRIClientSystemConnectionMemoTest.class,
+        JMRIClientPowerManagerTest.class,
+        BundleTest.class,
+        jmri.jmrix.jmriclient.networkdriver.PackageTest.class,
+        jmri.jmrix.jmriclient.configurexml.PackageTest.class,
+        jmri.jmrix.jmriclient.json.PackageTest.class,
+        jmri.jmrix.jmriclient.swing.PackageTest.class,
+        JMRIClientPortControllerTest.class,
+        JMRIClientConnectionTypeListTest.class,
+        JMRIClientLightManagerTest.class,
+        JMRIClientLightTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.jmriclient package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.jmriclient.JMRiClientTest");  // no tests in this class itself
-        suite.addTest(new TestSuite(JMRIClientMessageTest.class));
-        suite.addTest(new TestSuite(JMRIClientReplyTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JMRIClientTurnoutTest.class));
-        suite.addTest(new TestSuite(JMRIClientSensorTest.class));
-        suite.addTest(new TestSuite(JMRIClientReporterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JMRIClientTurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JMRIClientSensorManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JMRIClientReporterManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JMRIClientTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JMRIClientSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JMRIClientPowerManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.jmriclient.networkdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.jmriclient.configurexml.PackageTest.class));
-        suite.addTest(jmri.jmrix.jmriclient.json.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.jmriclient.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JMRIClientPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JMRIClientConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JMRIClientLightManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JMRIClientLightTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/jmriclient/json/PackageTest.java
+++ b/java/test/jmri/jmrix/jmriclient/json/PackageTest.java
@@ -1,8 +1,23 @@
 package jmri.jmrix.jmriclient.json;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        jmri.jmrix.jmriclient.json.swing.PackageTest.class,
+        jmri.jmrix.jmriclient.json.configurexml.PackageTest.class,
+        JsonNetworkConnectionConfigTest.class,
+        JsonNetworkPortControllerTest.class,
+        JsonClientTrafficControllerTest.class,
+        JsonClientReplyTest.class,
+        JsonClientSystemConnectionMemoTest.class,
+        JsonClientLightManagerTest.class,
+        JsonClientLightTest.class,
+        JsonClientMessageTest.class,
+        JsonClientPowerManagerTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.jmriclient package
@@ -10,36 +25,5 @@ import junit.framework.TestSuite;
  * @author	Bob Jacobsen
  * 
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.jmriclient.json.PackageTest");  // no tests in this class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.jmriclient.json.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.jmriclient.json.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JsonNetworkConnectionConfigTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JsonNetworkPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JsonClientTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JsonClientReplyTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JsonClientSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JsonClientLightManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JsonClientLightTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JsonClientMessageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JsonClientPowerManagerTest.class));
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/lenz/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/PackageTest.java
@@ -1,80 +1,64 @@
 package jmri.jmrix.lenz;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        LenzCommandStationTest.class,
+        LenzConnectionTypeListTest.class,
+        XNetMessageTest.class,
+        XNetReplyTest.class,
+        XNetTurnoutTest.class,
+        XNetSensorTest.class,
+        XNetLightTest.class,
+        XNetPacketizerTest.class,
+        XNetTurnoutManagerTest.class,
+        XNetSensorManagerTest.class,
+        XNetLightManagerTest.class,
+        XNetTrafficControllerTest.class,
+        XNetTrafficRouterTest.class,
+        XNetSystemConnectionMemoTest.class,
+        XNetThrottleTest.class,
+        XNetConsistManagerTest.class,
+        XNetConsistTest.class,
+        XNetInitializationManagerTest.class,
+        XNetProgrammerTest.class,
+        XNetProgrammerManagerTest.class,
+        XNetOpsModeProgrammerTest.class,
+        XNetPowerManagerTest.class,
+        XNetThrottleManagerTest.class,
+        XNetExceptionTest.class,
+        XNetMessageExceptionTest.class,
+        XNetStreamPortControllerTest.class,
+        jmri.jmrix.lenz.li100.PackageTest.class,
+        jmri.jmrix.lenz.li100f.PackageTest.class,
+        jmri.jmrix.lenz.li101.PackageTest.class,
+        jmri.jmrix.lenz.liusb.PackageTest.class,
+        jmri.jmrix.lenz.xntcp.PackageTest.class,
+        jmri.jmrix.lenz.liusbserver.PackageTest.class,
+        jmri.jmrix.lenz.liusbethernet.PackageTest.class,
+        jmri.jmrix.lenz.xnetsimulator.PackageTest.class,
+        jmri.jmrix.lenz.hornbyelite.PackageTest.class,
+        jmri.jmrix.lenz.ztc640.PackageTest.class,
+        BundleTest.class,
+        jmri.jmrix.lenz.swing.PackageTest.class,
+        jmri.jmrix.lenz.configurexml.PackageTest.class,
+        XNetNetworkPortControllerTest.class,
+        XNetSerialPortControllerTest.class,
+        XNetSimulatorPortControllerTest.class,
+        XNetTimeSlotListenerTest.class,
+        XNetConstantsTest.class,
+        XNetFeedbackMessageCacheTest.class,
+        AbstractXNetSerialConnectionConfigTest.class,
+        AbstractXNetInitializationManagerTest.class,
+        XNetAddressTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.lenz package
  *
  * @author	Bob Jacobsen
   */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.lenz.XNetTest");  // no tests in this class itself
-        suite.addTest(new TestSuite(LenzCommandStationTest.class));
-        suite.addTest(new JUnit4TestAdapter(LenzConnectionTypeListTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetMessageTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetReplyTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetTurnoutTest.class));
-        suite.addTest(new TestSuite(XNetSensorTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetLightTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetPacketizerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetTurnoutManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetSensorManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetLightManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetTrafficControllerTest.class));
-        suite.addTest(new TestSuite(XNetTrafficRouterTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetSystemConnectionMemoTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetThrottleTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetConsistManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetConsistTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetInitializationManagerTest.class));
-        suite.addTest(new TestSuite(XNetProgrammerTest.class));
-        suite.addTest(new TestSuite(XNetProgrammerManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetOpsModeProgrammerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetPowerManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetThrottleManagerTest.class));
-        suite.addTest(new TestSuite(XNetExceptionTest.class));
-        suite.addTest(new TestSuite(XNetMessageExceptionTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetStreamPortControllerTest.class));
-        suite.addTest(jmri.jmrix.lenz.li100.PackageTest.suite());
-        suite.addTest(jmri.jmrix.lenz.li100f.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.lenz.li101.PackageTest.class));
-        suite.addTest(jmri.jmrix.lenz.liusb.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.lenz.xntcp.PackageTest.class));
-        suite.addTest(jmri.jmrix.lenz.liusbserver.PackageTest.suite());
-        suite.addTest(jmri.jmrix.lenz.liusbethernet.PackageTest.suite());
-        suite.addTest(jmri.jmrix.lenz.xnetsimulator.PackageTest.suite());
-        suite.addTest(jmri.jmrix.lenz.hornbyelite.PackageTest.suite());
-        suite.addTest(jmri.jmrix.lenz.ztc640.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.lenz.swing.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.lenz.configurexml.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetNetworkPortControllerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetSerialPortControllerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetSimulatorPortControllerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetTimeSlotListenerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetConstantsTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetFeedbackMessageCacheTest.class));
-        suite.addTest(new JUnit4TestAdapter(AbstractXNetSerialConnectionConfigTest.class));
-        suite.addTest(new JUnit4TestAdapter(AbstractXNetInitializationManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(XNetAddressTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/lenz/hornbyelite/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/PackageTest.java
@@ -1,44 +1,29 @@
 package jmri.jmrix.lenz.hornbyelite;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        HornbyEliteCommandStationTest.class,
+        EliteAdapterTest.class,
+        EliteConnectionTypeListTest.class,
+        EliteXNetInitializationManagerTest.class,
+        EliteXNetThrottleManagerTest.class,
+        EliteXNetThrottleTest.class,
+        EliteXNetTurnoutTest.class,
+        EliteXNetTurnoutManagerTest.class,
+        EliteXNetProgrammerTest.class,
+        ConnectionConfigTest.class,
+        jmri.jmrix.lenz.hornbyelite.configurexml.PackageTest.class,
+        EliteXNetSystemConnectionMemoTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.lenz.hornbyelite package
  *
  * @author Paul Bender
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.lenz.hornbyelite");  // no tests in this class itself
-        suite.addTest(new TestSuite(HornbyEliteCommandStationTest.class));
-        suite.addTest(new TestSuite(EliteAdapterTest.class));
-        suite.addTest(new TestSuite(EliteConnectionTypeListTest.class));
-        suite.addTest(new TestSuite(EliteXNetInitializationManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EliteXNetThrottleManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EliteXNetThrottleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EliteXNetTurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EliteXNetTurnoutManagerTest.class));
-        suite.addTest(new TestSuite(EliteXNetProgrammerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConnectionConfigTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.lenz.hornbyelite.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EliteXNetSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/lenz/li100/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/li100/PackageTest.java
@@ -1,38 +1,23 @@
 package jmri.jmrix.lenz.li100;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        LI100AdapterTest.class,
+        LI100XNetInitializationManagerTest.class,
+        LI100XNetProgrammerTest.class,
+        ConnectionConfigTest.class,
+        jmri.jmrix.lenz.li100.configurexml.PackageTest.class,
+        LI100XNetPacketizerTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.lenz.li100 package
  *
  * @author Paul Bender
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.lenz.li100");  // no tests in this class itself
-        suite.addTest(new TestSuite(LI100AdapterTest.class));
-        suite.addTest(new TestSuite(LI100XNetInitializationManagerTest.class));
-        suite.addTest(new TestSuite(LI100XNetProgrammerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConnectionConfigTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.lenz.li100.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LI100XNetPacketizerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/lenz/li100f/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/li100f/PackageTest.java
@@ -1,35 +1,20 @@
 package jmri.jmrix.lenz.li100f;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        LI100fAdapterTest.class,
+        ConnectionConfigTest.class,
+        jmri.jmrix.lenz.li100f.configurexml.PackageTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.lenz.li100f package
  *
  * @author Paul Bender
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.lenz.li100f");  // no tests in this class itself
-        suite.addTest(new TestSuite(LI100fAdapterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConnectionConfigTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.lenz.li100f.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/lenz/liusb/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/liusb/PackageTest.java
@@ -1,36 +1,21 @@
 package jmri.jmrix.lenz.liusb;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        LIUSBAdapterTest.class,
+        LIUSBXNetPacketizerTest.class,
+        ConnectionConfigTest.class,
+        jmri.jmrix.lenz.liusb.configurexml.PackageTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.lenz.liusb package
  *
  * @author Paul Bender
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.lenz.liusb.LIUSBTest");  // no tests in this class itself
-        suite.addTest(new TestSuite(LIUSBAdapterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LIUSBXNetPacketizerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConnectionConfigTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.lenz.liusb.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/lenz/liusbethernet/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/liusbethernet/PackageTest.java
@@ -1,36 +1,21 @@
 package jmri.jmrix.lenz.liusbethernet;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        LIUSBEthernetAdapterTest.class,
+        LIUSBEthernetXNetPacketizerTest.class,
+        ConnectionConfigTest.class,
+        jmri.jmrix.lenz.liusbethernet.configurexml.PackageTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.lenz.liusbethernet package
  *
  * @author Paul Bender
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.lenz.liusbethernet");  // no tests in this class itself
-        suite.addTest(new TestSuite(LIUSBEthernetAdapterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LIUSBEthernetXNetPacketizerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConnectionConfigTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.lenz.liusbethernet.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/lenz/liusbserver/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/liusbserver/PackageTest.java
@@ -1,36 +1,21 @@
 package jmri.jmrix.lenz.liusbserver;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        LIUSBServerAdapterTest.class,
+        LIUSBServerXNetPacketizerTest.class,
+        ConnectionConfigTest.class,
+        jmri.jmrix.lenz.liusbserver.configurexml.PackageTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.lenz.liusbserver package
  *
  * @author Paul Bender
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.lenz.liusbserver");  // no tests in this class itself
-        suite.addTest(new TestSuite(LIUSBServerAdapterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LIUSBServerXNetPacketizerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConnectionConfigTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.lenz.liusbserver.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/lenz/xnetsimulator/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/xnetsimulator/PackageTest.java
@@ -1,35 +1,20 @@
 package jmri.jmrix.lenz.xnetsimulator;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        XNetSimulatorAdapterTest.class,
+        ConnectionConfigTest.class,
+        jmri.jmrix.lenz.xnetsimulator.configurexml.PackageTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.lenz.xnetsimulator package
  *
  * @author Paul Bender
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.lenz.xnetsimulator");  // no tests in this class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XNetSimulatorAdapterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConnectionConfigTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.lenz.xnetsimulator.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/lenz/ztc640/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/ztc640/PackageTest.java
@@ -1,36 +1,21 @@
 package jmri.jmrix.lenz.ztc640;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        ZTC640AdapterTest.class,
+        ZTC640XNetPacketizerTest.class,
+        ConnectionConfigTest.class,
+        jmri.jmrix.lenz.ztc640.configurexml.PackageTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.lenz.ztc640 package
  *
  * @author Paul Bender
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.lenz.ztc640");  // no tests in this class itself
-        suite.addTest(new TestSuite(ZTC640AdapterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ZTC640XNetPacketizerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConnectionConfigTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.lenz.ztc640.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/loconet/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/PackageTest.java
@@ -1,109 +1,93 @@
 package jmri.jmrix.loconet;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrix.loconet.LocoNetThrottledTransmitterTest.class,
+        jmri.jmrix.loconet.locostats.PackageTest.class,
+        jmri.jmrix.loconet.sdf.PackageTest.class,
+        jmri.jmrix.loconet.sdfeditor.PackageTest.class,
+        jmri.jmrix.loconet.locomon.PackageTest.class,
+        jmri.jmrix.loconet.soundloader.PackageTest.class,
+        jmri.jmrix.loconet.spjfile.PackageTest.class,
+        SlotManagerTest.class,
+        LocoNetSlotTest.class,
+        LnOpsModeProgrammerTest.class,
+        LocoNetMessageTest.class,
+        LnTrafficControllerTest.class,
+        LnTrafficRouterTest.class,
+        LnPacketizerTest.class,
+        LocoNetThrottleTest.class,
+        LocoNetConsistTest.class,
+        LnPowerManagerTest.class,
+        LnTurnoutTest.class,
+        LnTurnoutManagerTest.class,
+        LnReporterTest.class,
+        LnSensorTest.class,
+        LnSensorAddressTest.class,
+        LnSensorManagerTest.class,
+        LnCommandStationTypeTest.class,
+        BundleTest.class,
+        jmri.jmrix.loconet.pr3.PackageTest.class,
+        jmri.jmrix.loconet.hexfile.PackageTest.class,
+        jmri.jmrix.loconet.lnsvf2.PackageTest.class,
+        jmri.jmrix.loconet.downloader.PackageTest.class,
+        jmri.jmrix.loconet.configurexml.PackageTest.class,
+        jmri.jmrix.loconet.clockmon.PackageTest.class,
+        jmri.jmrix.loconet.cmdstnconfig.PackageTest.class,
+        jmri.jmrix.loconet.duplexgroup.PackageTest.class,
+        jmri.jmrix.loconet.locoid.PackageTest.class,
+        jmri.jmrix.loconet.slotmon.PackageTest.class,
+        jmri.jmrix.loconet.swing.PackageTest.class,
+        jmri.jmrix.loconet.bdl16.PackageTest.class,
+        jmri.jmrix.loconet.ds64.PackageTest.class,
+        jmri.jmrix.loconet.se8.PackageTest.class,
+        jmri.jmrix.loconet.pm4.PackageTest.class,
+        jmri.jmrix.loconet.Intellibox.PackageTest.class,
+        jmri.jmrix.loconet.bluetooth.PackageTest.class,
+        jmri.jmrix.loconet.locobuffer.PackageTest.class,
+        jmri.jmrix.loconet.locobufferii.PackageTest.class,
+        jmri.jmrix.loconet.locobufferusb.PackageTest.class,
+        jmri.jmrix.loconet.loconetovertcp.PackageTest.class,
+        jmri.jmrix.loconet.ms100.PackageTest.class,
+        jmri.jmrix.loconet.pr2.PackageTest.class,
+        jmri.jmrix.loconet.uhlenbrock.PackageTest.class,
+        jmri.jmrix.loconet.locormi.PackageTest.class,
+        LnReporterManagerTest.class,
+        jmri.jmrix.loconet.locoio.PackageTest.class,
+        jmri.jmrix.loconet.locogen.PackageTest.class,
+        LnNetworkPortControllerTest.class,
+        LocoNetSystemConnectionMemoTest.class,
+        LnPortControllerTest.class,
+        LocoNetExceptionTest.class,
+        LocoNetMessageExceptionTest.class,
+        LnConnectionTypeListTest.class,
+        LnConstantsTest.class,
+        Ib1ThrottleManagerTest.class,
+        Ib1ThrottleTest.class,
+        Ib2ThrottleManagerTest.class,
+        Ib2ThrottleTest.class,
+        LNCPSignalMastTest.class,
+        LnLightManagerTest.class,
+        LnLightTest.class,
+        LnMessageManagerTest.class,
+        LnPr2ThrottleManagerTest.class,
+        Pr2ThrottleTest.class,
+        LnClockControlTest.class,
+        LnProgrammerManagerTest.class,
+        LnThrottleManagerTest.class,
+        LocoNetConsistManagerTest.class,
+        SE8cSignalHeadTest.class,
+        UhlenbrockSlotManagerTest.class,
+        UhlenbrockSlotTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.loconet package.
  *
  * @author	Bob Jacobsen Copyright 2001, 2003
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.loconet.PackageTest");  // no tests in this class itself
-        suite.addTest(jmri.jmrix.loconet.LocoNetThrottledTransmitterTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.locostats.PackageTest.class));
-        suite.addTest(jmri.jmrix.loconet.sdf.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.sdfeditor.PackageTest.class));
-        suite.addTest(jmri.jmrix.loconet.locomon.PackageTest.suite());
-        suite.addTest(jmri.jmrix.loconet.soundloader.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.spjfile.PackageTest.class));
-        suite.addTest(new TestSuite(SlotManagerTest.class));
-        suite.addTest(new TestSuite(LocoNetSlotTest.class));
-        suite.addTest(new TestSuite(LnOpsModeProgrammerTest.class));
-        suite.addTest(new TestSuite(LocoNetMessageTest.class));
-        suite.addTest(new TestSuite(LnTrafficControllerTest.class));
-        suite.addTest(new TestSuite(LnTrafficRouterTest.class));
-        suite.addTest(new TestSuite(LnPacketizerTest.class));
-        suite.addTest(new JUnit4TestAdapter(LocoNetThrottleTest.class));
-        suite.addTest(new JUnit4TestAdapter(LocoNetConsistTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnPowerManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnTurnoutTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnTurnoutManagerTest.class));
-        suite.addTest(LnReporterTest.suite());
-        suite.addTest(LnSensorTest.suite());
-        suite.addTest(LnSensorAddressTest.suite());
-        suite.addTest(new JUnit4TestAdapter(LnSensorManagerTest.class));
-        suite.addTest(LnCommandStationTypeTest.suite());
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(jmri.jmrix.loconet.pr3.PackageTest.suite());
-        suite.addTest(jmri.jmrix.loconet.hexfile.PackageTest.suite());
-        suite.addTest(jmri.jmrix.loconet.lnsvf2.PackageTest.suite());
-        suite.addTest(jmri.jmrix.loconet.downloader.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.configurexml.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.clockmon.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.cmdstnconfig.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.duplexgroup.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.locoid.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.slotmon.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.swing.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.bdl16.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.ds64.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.se8.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.pm4.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.Intellibox.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.bluetooth.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.locobuffer.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.locobufferii.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.locobufferusb.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.loconetovertcp.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.ms100.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.pr2.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.uhlenbrock.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.loconet.locormi.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnReporterManagerTest.class));
-        suite.addTest(jmri.jmrix.loconet.locoio.PackageTest.suite());
-        suite.addTest(jmri.jmrix.loconet.locogen.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(LnNetworkPortControllerTest.class));
-        suite.addTest(new JUnit4TestAdapter(LocoNetSystemConnectionMemoTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnPortControllerTest.class));
-        suite.addTest(new JUnit4TestAdapter(LocoNetExceptionTest.class));
-        suite.addTest(new JUnit4TestAdapter(LocoNetMessageExceptionTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnConnectionTypeListTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnConstantsTest.class));
-        suite.addTest(new JUnit4TestAdapter(Ib1ThrottleManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(Ib1ThrottleTest.class));
-        suite.addTest(new JUnit4TestAdapter(Ib2ThrottleManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(Ib2ThrottleTest.class));
-        suite.addTest(new JUnit4TestAdapter(LNCPSignalMastTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnLightManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnLightTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnMessageManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnPr2ThrottleManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(Pr2ThrottleTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnClockControlTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnProgrammerManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(LnThrottleManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(LocoNetConsistManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(SE8cSignalHeadTest.class));
-        suite.addTest(new JUnit4TestAdapter(UhlenbrockSlotManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(UhlenbrockSlotTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/loconet/downloader/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/downloader/PackageTest.java
@@ -1,33 +1,18 @@
 package jmri.jmrix.loconet.downloader;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        LoaderPaneTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.loconet.downloader package.
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2006, 2008
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.loconet.downloader.LocoStatsTest");  // no tests in this class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LoaderPaneTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/loconet/hexfile/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/hexfile/PackageTest.java
@@ -1,39 +1,24 @@
 package jmri.jmrix.loconet.hexfile;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        jmri.jmrix.loconet.hexfile.configurexml.PackageTest.class,
+        HexFileFrameTest.class,
+        HexFileServerTest.class,
+        LnHexFilePortTest.class,
+        LocoNetSystemConnectionMemoTest.class,
+        LnHexFileActionTest.class,
+        LnSensorManagerTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.loconet.hexfile package.
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2006, 2008
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.loconet.hexfile.LocoStatsTest");  // no tests in this class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.loconet.hexfile.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(HexFileFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(HexFileServerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LnHexFilePortTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocoNetSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LnHexFileActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LnSensorManagerTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/loconet/lnsvf2/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/lnsvf2/PackageTest.java
@@ -1,33 +1,18 @@
 package jmri.jmrix.loconet.lnsvf2;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        LnSv2MessageContentsTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.loconet.lnsvf2 package.
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2006, 2008
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.loconet.lnsvf2.LocoStatsTest");  // no tests in this class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LnSv2MessageContentsTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/loconet/locogen/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/locogen/PackageTest.java
@@ -1,34 +1,19 @@
 package jmri.jmrix.loconet.locogen;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        LocoGenTest.class,
+        BundleTest.class,
+        LocoGenPanelTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.loconet.locogen package
  *
  * @author Bob Jacobsen Copyright 2001, 2003
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.loconet.locogen.PackageTest");  // no tests in this class itself
-        suite.addTest(new TestSuite(LocoGenTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocoGenPanelTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/loconet/locoio/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/locoio/PackageTest.java
@@ -1,50 +1,23 @@
 package jmri.jmrix.loconet.locoio;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        LocoIOPanelTest.class,
+        LocoIOTableModelTest.class,
+        LocoIOModeListTest.class,
+        LocoIOTest.class,
+        LocoIODataTest.class,
+        LocoIOModeTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.loconet.locoio package
  *
  * @author	Bob Jacobsen Copyright (C) 2002, 2010
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.loconet.locoio.LocoIOTest");  // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocoIOPanelTest.class));
-        suite.addTest(LocoIOTableModelTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocoIOModeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocoIOTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocoIODataTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocoIOModeTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/loconet/locomon/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/locomon/PackageTest.java
@@ -1,46 +1,19 @@
 package jmri.jmrix.loconet.locomon;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        LlnmonTest.class,
+        LocoMonPaneTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.loconet.locomon package
  *
  * @author	Bob Jacobsen Copyright (C) 2002, 2007
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.loconet.locomon.LocoMonTest");  // no tests in this class itself
-        suite.addTest(LlnmonTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocoMonPaneTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/loconet/pr3/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/pr3/PackageTest.java
@@ -1,36 +1,21 @@
 package jmri.jmrix.loconet.pr3;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        jmri.jmrix.loconet.pr3.configurexml.PackageTest.class,
+        jmri.jmrix.loconet.pr3.swing.PackageTest.class,
+        PR3AdapterTest.class,
+        PR3SystemConnectionMemoTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.loconet.pr3 package.
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2006, 2008
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.loconet.pr3.LocoStatsTest");  // no tests in this class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.loconet.pr3.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.loconet.pr3.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PR3AdapterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PR3SystemConnectionMemoTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/loconet/sdf/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/sdf/PackageTest.java
@@ -1,49 +1,33 @@
 package jmri.jmrix.loconet.sdf;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        InitiateSoundTest.class,
+        PlayTest.class,
+        SdfBufferTest.class,
+        BranchToTest.class,
+        ChannelStartTest.class,
+        CommentMacroTest.class,
+        DelaySoundTest.class,
+        EndSoundTest.class,
+        FourByteMacroTest.class,
+        GenerateTriggerTest.class,
+        LabelMacroTest.class,
+        MaskCompareTest.class,
+        LoadModifierTest.class,
+        SdlVersionTest.class,
+        SkemeStartTest.class,
+        SkipOnTriggerTest.class,
+        TwoByteMacroTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.loconet.sdf package.
  *
  * @author	Bob Jacobsen Copyright 2007
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.loconet.sdf.SdfTest");  // no tests in this class itself
-        suite.addTest(InitiateSoundTest.suite());
-        suite.addTest(PlayTest.suite());
-        suite.addTest(SdfBufferTest.suite());
-        suite.addTest(new JUnit4TestAdapter(BranchToTest.class));
-        suite.addTest(new JUnit4TestAdapter(ChannelStartTest.class));
-        suite.addTest(new JUnit4TestAdapter(CommentMacroTest.class));
-        suite.addTest(new JUnit4TestAdapter(DelaySoundTest.class));
-        suite.addTest(new JUnit4TestAdapter(EndSoundTest.class));
-        suite.addTest(new JUnit4TestAdapter(FourByteMacroTest.class));
-        suite.addTest(new JUnit4TestAdapter(GenerateTriggerTest.class));
-        suite.addTest(new JUnit4TestAdapter(LabelMacroTest.class));
-        suite.addTest(new JUnit4TestAdapter(MaskCompareTest.class));
-        suite.addTest(new JUnit4TestAdapter(LoadModifierTest.class));
-        suite.addTest(new JUnit4TestAdapter(SdlVersionTest.class));
-        suite.addTest(new JUnit4TestAdapter(SkemeStartTest.class));
-        suite.addTest(new JUnit4TestAdapter(SkipOnTriggerTest.class));
-        suite.addTest(new JUnit4TestAdapter(TwoByteMacroTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/loconet/soundloader/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/soundloader/PackageTest.java
@@ -1,45 +1,22 @@
 package jmri.jmrix.loconet.soundloader;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        LoaderEngineTest.class,
+        BundleTest.class,
+        EditorPaneTest.class,
+        LoaderPaneTest.class,
+        EditorTableDataModelTest.class,
+        EditorFilePaneTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.loconet.soundloader package
  *
  * @author	Bob Jacobsen Copyright (C) 2006
  */
-public class PackageTest extends TestCase {
-
-    public void testCreate() {
-        return;
-    }
-
-    public void testRead() {
-        return;
-    }
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-        suite.addTest(LoaderEngineTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditorPaneTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LoaderPaneTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditorTableDataModelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(EditorFilePaneTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/maple/PackageTest.java
+++ b/java/test/jmri/jmrix/maple/PackageTest.java
@@ -1,63 +1,41 @@
 package jmri.jmrix.maple;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SerialTurnoutTest.class,
+        SerialTurnoutManagerTest.class,
+        SerialSensorManagerTest.class,
+        jmri.jmrix.maple.SerialNodeTest.class,
+        jmri.jmrix.maple.SerialMessageTest.class,
+        SerialTrafficControllerTest.class,
+        SerialAddressTest.class,
+        jmri.jmrix.maple.OutputBitsTest.class,
+        jmri.jmrix.maple.InputBitsTest.class,
+        jmri.jmrix.maple.serialdriver.PackageTest.class,
+        jmri.jmrix.maple.configurexml.PackageTest.class,
+        jmri.jmrix.maple.packetgen.PackageTest.class,
+        jmri.jmrix.maple.serialmon.PackageTest.class,
+        jmri.jmrix.maple.assignment.PackageTest.class,
+        jmri.jmrix.maple.nodeconfig.PackageTest.class,
+        MapleSystemConnectionMemoTest.class,
+        SerialPortControllerTest.class,
+        MapleMenuTest.class,
+        SerialConnectionTypeListTest.class,
+        SerialLightManagerTest.class,
+        SerialReplyTest.class,
+        SerialLightTest.class,
+        SerialSensorTest.class,
+        BundleTest.class,
+        jmri.jmrix.maple.swing.PackageTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.maple package.
  *
  * @author Bob Jacobsen Copyright 2003
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    public void testDefinitions() {
-        Assert.assertEquals("Node definitions match", SerialSensorManager.SENSORSPERUA,
-                SerialNode.MAXSENSORS + 1);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.maple.SerialTest");
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialSensorManagerTest.class));
-        suite.addTest(jmri.jmrix.maple.SerialNodeTest.suite());
-        suite.addTest(jmri.jmrix.maple.SerialMessageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialAddressTest.class));
-        suite.addTest(jmri.jmrix.maple.OutputBitsTest.suite());
-        suite.addTest(jmri.jmrix.maple.InputBitsTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.maple.serialdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.maple.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.maple.packetgen.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.maple.serialmon.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.maple.assignment.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.maple.nodeconfig.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(MapleSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(MapleMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialLightManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialReplyTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialLightTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialSensorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.maple.swing.PackageTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/modbus/PackageTest.java
+++ b/java/test/jmri/jmrix/modbus/PackageTest.java
@@ -1,36 +1,19 @@
 package jmri.jmrix.modbus;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrix.modbus.common.PackageTest.class,
+        jmri.jmrix.modbus.slave.PackageTest.class,
+        jmri.jmrix.modbus.master.PackageTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.modbus package.
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2014
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.modbus.PackageTest");  // no tests in this class itself
-
-        suite.addTest(jmri.jmrix.modbus.common.PackageTest.suite());
-        suite.addTest(jmri.jmrix.modbus.slave.PackageTest.suite());
-        suite.addTest(jmri.jmrix.modbus.master.PackageTest.suite());
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/modbus/common/PackageTest.java
+++ b/java/test/jmri/jmrix/modbus/common/PackageTest.java
@@ -1,31 +1,16 @@
 package jmri.jmrix.modbus.common;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+})
 
 /**
  * Tests for the jmri.jmrix.modbus.common package.
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2014
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.modbus.common.PackageTest");  // no tests in this class itself
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/modbus/master/PackageTest.java
+++ b/java/test/jmri/jmrix/modbus/master/PackageTest.java
@@ -1,31 +1,16 @@
 package jmri.jmrix.modbus.master;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+})
 
 /**
  * Tests for the jmri.jmrix.modbus.master package.
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2014
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.modbus.master.PackageTest");  // no tests in this class itself
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/modbus/slave/PackageTest.java
+++ b/java/test/jmri/jmrix/modbus/slave/PackageTest.java
@@ -1,31 +1,16 @@
 package jmri.jmrix.modbus.slave;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+})
 
 /**
  * Tests for the jmri.jmrix.modbus.slave package.
  *
  * @author	Bob Jacobsen Copyright 2001, 2003, 2014
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.modbus.slave.PackageTest");  // no tests in this class itself
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/nce/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/PackageTest.java
@@ -1,84 +1,61 @@
 package jmri.jmrix.nce;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        NceTurnoutTest.class,
+        NceSensorManagerTest.class,
+        jmri.jmrix.nce.NceAIUTest.class,
+        jmri.jmrix.nce.NceProgrammerTest.class,
+        jmri.jmrix.nce.NceProgrammerManagerTest.class,
+        NceTrafficControllerTest.class,
+        NceSystemConnectionMemoTest.class,
+        jmri.jmrix.nce.NceMessageTest.class,
+        jmri.jmrix.nce.NceReplyTest.class,
+        NcePowerManagerTest.class,
+        BundleTest.class,
+        jmri.jmrix.nce.clockmon.PackageTest.class,
+        NceConsistTest.class,
+        jmri.jmrix.nce.networkdriver.PackageTest.class,
+        jmri.jmrix.nce.usbdriver.PackageTest.class,
+        jmri.jmrix.nce.serialdriver.PackageTest.class,
+        jmri.jmrix.nce.simulator.PackageTest.class,
+        jmri.jmrix.nce.configurexml.PackageTest.class,
+        jmri.jmrix.nce.boosterprog.PackageTest.class,
+        jmri.jmrix.nce.cab.PackageTest.class,
+        jmri.jmrix.nce.macro.PackageTest.class,
+        jmri.jmrix.nce.usbinterface.PackageTest.class,
+        jmri.jmrix.nce.ncemon.PackageTest.class,
+        jmri.jmrix.nce.packetgen.PackageTest.class,
+        NceNetworkPortControllerTest.class,
+        NcePortControllerTest.class,
+        jmri.jmrix.nce.swing.PackageTest.class,
+        jmri.jmrix.nce.consist.PackageTest.class,
+        NceBinaryCommandTest.class,
+        NceCmdStationMemoryTest.class,
+        NceConnectionTypeListTest.class,
+        NceMessageCheckTest.class,
+        NceUSBTest.class,
+        NceAIUCheckerTest.class,
+        NceClockControlTest.class,
+        NceConnectionStatusTest.class,
+        NceConsistManagerTest.class,
+        NceLightManagerTest.class,
+        NceLightTest.class,
+        NceMenuTest.class,
+        NceOpsModeProgrammerTest.class,
+        NceSensorTest.class,
+        NceThrottleManagerTest.class,
+        NceThrottleTest.class,
+        NceTurnoutMonitorTest.class,
+})
 
 /**
  * tests for the jmri.jmrix.nce package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // a dummy test to avoid JUnit warning
-    public void testDemo() {
-        assertTrue(true);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.nce.PackageTest");
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceTurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceSensorManagerTest.class));
-        suite.addTest(jmri.jmrix.nce.NceAIUTest.suite());
-        suite.addTest(jmri.jmrix.nce.NceProgrammerTest.suite());
-        suite.addTest(jmri.jmrix.nce.NceProgrammerManagerTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceSystemConnectionMemoTest.class));
-        suite.addTest(jmri.jmrix.nce.NceMessageTest.suite());
-        suite.addTest(jmri.jmrix.nce.NceReplyTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NcePowerManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.clockmon.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceConsistTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.networkdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.usbdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.serialdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.simulator.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.boosterprog.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.cab.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.macro.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.usbinterface.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.ncemon.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.packetgen.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceNetworkPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NcePortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.nce.consist.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceBinaryCommandTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceCmdStationMemoryTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceMessageCheckTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceUSBTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceAIUCheckerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceClockControlTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceConnectionStatusTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceConsistManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceLightManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceLightTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceOpsModeProgrammerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceSensorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceThrottleManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceThrottleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NceTurnoutMonitorTest.class));
-
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/oaktree/PackageTest.java
+++ b/java/test/jmri/jmrix/oaktree/PackageTest.java
@@ -1,60 +1,38 @@
 package jmri.jmrix.oaktree;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SerialTurnoutTest.class,
+        SerialTurnoutManagerTest.class,
+        SerialSensorManagerTest.class,
+        SerialNodeTest.class,
+        SerialMessageTest.class,
+        SerialTrafficControllerTest.class,
+        SerialAddressTest.class,
+        jmri.jmrix.oaktree.serialdriver.PackageTest.class,
+        jmri.jmrix.oaktree.configurexml.PackageTest.class,
+        jmri.jmrix.oaktree.nodeconfig.PackageTest.class,
+        jmri.jmrix.oaktree.packetgen.PackageTest.class,
+        jmri.jmrix.oaktree.serialmon.PackageTest.class,
+        OakTreeMenuTest.class,
+        OakTreeSystemConnectionMemoTest.class,
+        SerialPortControllerTest.class,
+        SerialConnectionTypeListTest.class,
+        SerialLightManagerTest.class,
+        SerialReplyTest.class,
+        SerialSensorTest.class,
+        SerialLightTest.class,
+        BundleTest.class,
+        jmri.jmrix.oaktree.swing.PackageTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.oaktree package.
  *
  * @author Bob Jacobsen Copyright 2003
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    public void testDefinitions() {
-        Assert.assertEquals("Node definitions match", SerialSensorManager.SENSORSPERNODE,
-                SerialNode.MAXSENSORS + 1);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.oaktree.SerialTest");
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialSensorManagerTest.class));
-        suite.addTest(SerialNodeTest.suite());
-        suite.addTest(SerialMessageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTrafficControllerTest.class));
-        suite.addTest(SerialAddressTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.oaktree.serialdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.oaktree.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.oaktree.nodeconfig.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.oaktree.packetgen.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.oaktree.serialmon.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OakTreeMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OakTreeSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialLightManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialReplyTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialSensorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialLightTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.oaktree.swing.PackageTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/powerline/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/PackageTest.java
@@ -1,55 +1,38 @@
 package jmri.jmrix.powerline;
 
-//import org.junit.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        X10SequenceTest.class,
+        SerialTurnoutTest.class,
+        SerialTurnoutManagerTest.class,
+        SerialSensorManagerTest.class,
+        SerialNodeTest.class,
+        SerialAddressTest.class,
+        jmri.jmrix.powerline.cm11.PackageTest.class,
+        jmri.jmrix.powerline.insteon2412s.PackageTest.class,
+        jmri.jmrix.powerline.simulator.PackageTest.class,
+        jmri.jmrix.powerline.cp290.PackageTest.class,
+        jmri.jmrix.powerline.serialdriver.PackageTest.class,
+        jmri.jmrix.powerline.configurexml.PackageTest.class,
+        jmri.jmrix.powerline.swing.PackageTest.class,
+        SerialSystemConnectionMemoTest.class,
+        SerialPortControllerTest.class,
+        SerialTrafficControllerTest.class,
+        InsteonSequenceTest.class,
+        SerialConnectionTypeListTest.class,
+        SerialSensorTest.class,
+        SerialX10LightTest.class,
+        SystemMenuTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.powerline package.
  *
  * @author Bob Jacobsen Copyright 2003, 2007, 2008
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.powerline.SerialTest");
-        suite.addTest(X10SequenceTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialSensorManagerTest.class));
-        suite.addTest(SerialNodeTest.suite());
-        suite.addTest(SerialAddressTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.powerline.cm11.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.powerline.insteon2412s.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.powerline.simulator.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.powerline.cp290.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.powerline.serialdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.powerline.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.powerline.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(InsteonSequenceTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialSensorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialX10LightTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SystemMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/pricom/PackageTest.java
+++ b/java/test/jmri/jmrix/pricom/PackageTest.java
@@ -1,36 +1,19 @@
 package jmri.jmrix.pricom;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrix.pricom.pockettester.PackageTest.class,
+        jmri.jmrix.pricom.downloader.PackageTest.class,
+        PricomMenuTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.pricom package.
  *
  * @author Bob Jacobsen Copyright 2005
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.pricom.PricomTest");
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.pricom.pockettester.PackageTest.class));
-        suite.addTest(jmri.jmrix.pricom.downloader.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(PricomMenuTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/pricom/downloader/PackageTest.java
+++ b/java/test/jmri/jmrix/pricom/downloader/PackageTest.java
@@ -1,35 +1,20 @@
 package jmri.jmrix.pricom.downloader;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrix.pricom.downloader.PdiFileTest.class,
+        jmri.jmrix.pricom.downloader.LoaderPaneTest.class,
+        LoaderFrameTest.class,
+        LoaderPanelActionTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.pricom.downloader package.
  *
  * @author Bob Jacobsen Copyright 2005
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.pricom.pockettester");
-        suite.addTest(jmri.jmrix.pricom.downloader.PdiFileTest.suite());
-        suite.addTest(jmri.jmrix.pricom.downloader.LoaderPaneTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LoaderFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LoaderPanelActionTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/qsi/PackageTest.java
+++ b/java/test/jmri/jmrix/qsi/PackageTest.java
@@ -1,62 +1,28 @@
 package jmri.jmrix.qsi;
 
-import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrix.qsi.QsiTrafficControllerTest.class,
+        jmri.jmrix.qsi.QsiMessageTest.class,
+        jmri.jmrix.qsi.QsiReplyTest.class,
+        jmri.jmrix.qsi.serialdriver.PackageTest.class,
+        jmri.jmrix.qsi.qsimon.PackageTest.class,
+        jmri.jmrix.qsi.packetgen.PackageTest.class,
+        QsiSystemConnectionMemoTest.class,
+        QsiPortControllerTest.class,
+        jmri.jmrix.swing.PackageTest.class,
+        QSIConnectionTypeListTest.class,
+        QSIMenuTest.class,
+        QsiProgrammerTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.qsi package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // a dummy test to avoid JUnit warning
-    public void testDemo() {
-        assertTrue(true);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.qsi.QsiTest");
-        suite.addTest(jmri.jmrix.qsi.QsiTrafficControllerTest.suite());
-        suite.addTest(jmri.jmrix.qsi.QsiMessageTest.suite());
-        suite.addTest(jmri.jmrix.qsi.QsiReplyTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.qsi.serialdriver.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.qsi.qsimon.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.qsi.packetgen.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(QsiSystemConnectionMemoTest.class));
-        suite.addTest(new JUnit4TestAdapter(QsiPortControllerTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.swing.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(QSIConnectionTypeListTest.class));
-        suite.addTest(new JUnit4TestAdapter(QSIMenuTest.class));
-        suite.addTest(new JUnit4TestAdapter(QsiProgrammerTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/roco/PackageTest.java
+++ b/java/test/jmri/jmrix/roco/PackageTest.java
@@ -1,37 +1,20 @@
 package jmri.jmrix.roco;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        RocoConnectionTypeListTest.class,
+        jmri.jmrix.roco.z21.PackageTest.class,
+        BundleTest.class,
+        RocoCommandStationTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.roco package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        apps.tests.Log4JFixture.initLogging();
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.roco.RocoTest");  // no tests in this class itself
-        suite.addTest(new TestSuite(RocoConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.roco.z21.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RocoCommandStationTest.class));
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/rps/PackageTest.java
+++ b/java/test/jmri/jmrix/rps/PackageTest.java
@@ -1,65 +1,47 @@
 package jmri.jmrix.rps;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        MeasurementTest.class,
+        PositionFileTest.class,
+        ReadingTest.class,
+        EngineTest.class,
+        RpsSensorManagerTest.class,
+        jmri.jmrix.rps.RpsSensorTest.class,
+        jmri.jmrix.rps.RegionTest.class,
+        BundleTest.class,
+        jmri.jmrix.rps.serial.PackageTest.class,
+        jmri.jmrix.rps.configurexml.PackageTest.class,
+        jmri.jmrix.rps.aligntable.PackageTest.class,
+        jmri.jmrix.rps.reversealign.PackageTest.class,
+        RpsPositionIconTest.class,
+        jmri.jmrix.rps.rpsmon.PackageTest.class,
+        jmri.jmrix.rps.swing.PackageTest.class, // do 2nd to display in front
+        jmri.jmrix.rps.csvinput.CsvTest.class, // do 3rd to display in front
+        jmri.jmrix.rps.trackingpanel.PackageTest.class, // do 4th to display in front
+        // test all algorithms as a bunch
+        jmri.jmrix.rps.algorithms.PackageTest.class,
+        AlgorithmsTest.class,
+        DistributorTest.class,
+        ModelTest.class,
+        PollingFileTest.class,
+        RpsConnectionTypeListTest.class,
+        RpsMenuTest.class,
+        RpsReporterManagerTest.class,
+        RpsSystemConnectionMemoTest.class,
+        ReceiverTest.class,
+        TransmitterTest.class,
+        RpsBlockTest.class,
+        RpsReporterTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.rps package.
  *
  * @author Bob Jacobsen Copyright 2006
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.rps.RpsTest");
-        suite.addTest(MeasurementTest.suite());
-        suite.addTest(PositionFileTest.suite());
-        suite.addTest(ReadingTest.suite());
-        suite.addTest(EngineTest.suite());
-        suite.addTest(new JUnit4TestAdapter(RpsSensorManagerTest.class));
-        suite.addTest(jmri.jmrix.rps.RpsSensorTest.suite());
-        suite.addTest(jmri.jmrix.rps.RegionTest.suite());
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.rps.serial.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.rps.configurexml.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.rps.aligntable.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.rps.reversealign.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(RpsPositionIconTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.rps.rpsmon.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.rps.swing.PackageTest.class)); // do 2nd to display in front
-        suite.addTest(jmri.jmrix.rps.csvinput.CsvTest.suite()); // do 3rd to display in front
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.rps.trackingpanel.PackageTest.class)); // do 4th to display in front
-        // test all algorithms as a bunch
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.rps.algorithms.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(AlgorithmsTest.class));
-        suite.addTest(new JUnit4TestAdapter(DistributorTest.class));
-        suite.addTest(new JUnit4TestAdapter(ModelTest.class));
-        suite.addTest(new JUnit4TestAdapter(PollingFileTest.class));
-        suite.addTest(new JUnit4TestAdapter(RpsConnectionTypeListTest.class));
-        suite.addTest(new JUnit4TestAdapter(RpsMenuTest.class));
-        suite.addTest(new JUnit4TestAdapter(RpsReporterManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(RpsSystemConnectionMemoTest.class));
-        suite.addTest(new JUnit4TestAdapter(ReceiverTest.class));
-        suite.addTest(new JUnit4TestAdapter(TransmitterTest.class));
-        suite.addTest(new JUnit4TestAdapter(RpsBlockTest.class));
-        suite.addTest(new JUnit4TestAdapter(RpsReporterTest.class));
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/secsi/PackageTest.java
+++ b/java/test/jmri/jmrix/secsi/PackageTest.java
@@ -1,59 +1,37 @@
 package jmri.jmrix.secsi;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SerialTurnoutTest.class,
+        SerialTurnoutManagerTest.class,
+        SerialSensorManagerTest.class,
+        SerialNodeTest.class,
+        SerialMessageTest.class,
+        SerialTrafficControllerTest.class,
+        SerialAddressTest.class,
+        jmri.jmrix.secsi.serialdriver.PackageTest.class,
+        jmri.jmrix.secsi.configurexml.PackageTest.class,
+        jmri.jmrix.secsi.nodeconfig.PackageTest.class,
+        jmri.jmrix.secsi.packetgen.PackageTest.class,
+        jmri.jmrix.secsi.serialmon.PackageTest.class,
+        SerialPortControllerTest.class,
+        SecsiSystemConnectionMemoTest.class,
+        SecsiMenuTest.class,
+        SerialConnectionTypeListTest.class,
+        SerialLightManagerTest.class,
+        SerialReplyTest.class,
+        SerialSensorTest.class,
+        SerialLightTest.class,
+        jmri.jmrix.secsi.swing.PackageTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.secsi package.
  *
  * @author Bob Jacobsen Copyright 2003, 2007, 2008
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    public void testDefinitions() {
-        Assert.assertEquals("Node definitions match", SerialSensorManager.SENSORSPERNODE,
-                SerialNode.MAXSENSORS + 1);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.secsi.SerialTest");
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialSensorManagerTest.class));
-        suite.addTest(SerialNodeTest.suite());
-        suite.addTest(SerialMessageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialTrafficControllerTest.class));
-        suite.addTest(SerialAddressTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.secsi.serialdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.secsi.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.secsi.nodeconfig.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.secsi.packetgen.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.secsi.serialmon.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SecsiSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SecsiMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialLightManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialReplyTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialSensorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialLightTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.secsi.swing.PackageTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/srcp/PackageTest.java
+++ b/java/test/jmri/jmrix/srcp/PackageTest.java
@@ -1,54 +1,38 @@
 package jmri.jmrix.srcp;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SRCPReplyTest.class,
+        SRCPMessageTest.class,
+        SRCPTrafficControllerTest.class,
+        SRCPSystemConnectionMemoTest.class,
+        SRCPBusConnectionMemoTest.class,
+        SRCPTurnoutManagerTest.class,
+        SRCPTurnoutTest.class,
+        SRCPSensorManagerTest.class,
+        SRCPSensorTest.class,
+        SRCPThrottleManagerTest.class,
+        SRCPThrottleTest.class,
+        SRCPPowerManagerTest.class,
+        SRCPProgrammerTest.class,
+        SRCPProgrammerManagerTest.class,
+        SRCPClockControlTest.class,
+        jmri.jmrix.srcp.parser.PackageTest.class,
+        jmri.jmrix.srcp.networkdriver.PackageTest.class,
+        jmri.jmrix.srcp.configurexml.PackageTest.class,
+        jmri.jmrix.srcp.swing.PackageTest.class,
+        SRCPPortControllerTest.class,
+        SRCPTrafficControllerTest.class,
+        SRCPConnectionTypeListTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.srcp package
  *
  * @author	Paul Bender
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.srcp.SRCPTest");  // no tests in this class itself
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPReplyTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPMessageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPBusConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPTurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPTurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPSensorManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPSensorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPThrottleManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPThrottleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPPowerManagerTest.class));
-        suite.addTest(new TestSuite(SRCPProgrammerTest.class));
-        suite.addTest(new TestSuite(SRCPProgrammerManagerTest.class));
-        suite.addTest(new TestSuite(SRCPClockControlTest.class));
-        suite.addTest(jmri.jmrix.srcp.parser.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.srcp.networkdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.srcp.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.srcp.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPConnectionTypeListTest.class));
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/srcp/parser/PackageTest.java
+++ b/java/test/jmri/jmrix/srcp/parser/PackageTest.java
@@ -1,35 +1,20 @@
 //SRCPClientParserTests.java
 package jmri.jmrix.srcp.parser;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SRCPClientParserTokenizerTest.class,
+        SRCPClientParserTest.class,
+        SRCPClientVisitorTest.class,
+})
 
 /**
  * Tests for the jmri.jmris.srcp.parser package
  *
  * @author Paul Bender
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmris.srcp.SRCPClientParserTests");  // no tests in this class itself
-        suite.addTest(new TestSuite(SRCPClientParserTokenizerTest.class));
-        suite.addTest(new TestSuite(SRCPClientParserTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SRCPClientVisitorTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/tams/PackageTest.java
+++ b/java/test/jmri/jmrix/tams/PackageTest.java
@@ -1,9 +1,33 @@
 package jmri.jmrix.tams;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        TamsTurnoutManagerTest.class,
+        jmri.jmrix.tams.simulator.PackageTest.class,
+        jmri.jmrix.tams.serialdriver.PackageTest.class,
+        jmri.jmrix.tams.configurexml.PackageTest.class,
+        jmri.jmrix.tams.swing.PackageTest.class,
+        TamsSystemConnectionMemoTest.class,
+        TamsPortControllerTest.class,
+        TamsTrafficControllerTest.class,
+        TamsConnectionTypeListTest.class,
+        TamsConstantsTest.class,
+        TamsMessageTest.class,
+        TamsReplyTest.class,
+        TamsOpsModeProgrammerTest.class,
+        TamsProgrammerTest.class,
+        TamsProgrammerManagerTest.class,
+        TamsPowerManagerTest.class,
+        TamsSensorManagerTest.class,
+        TamsSensorTest.class,
+        TamsThrottleManagerTest.class,
+        TamsThrottleTest.class,
+        TamsTurnoutTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.tams package.
@@ -11,56 +35,5 @@ import junit.framework.TestSuite;
  * @author Bob Jacobsen Copyright 2003, 2016
  * @author  Paul Bender Copyright (C) 2016	
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.tams.PackageTest");
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsTurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.tams.simulator.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.tams.serialdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.tams.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.tams.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsConstantsTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsMessageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsReplyTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsOpsModeProgrammerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsProgrammerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsProgrammerManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsPowerManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsSensorManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsSensorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsThrottleManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsThrottleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(TamsTurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/tmcc/PackageTest.java
+++ b/java/test/jmri/jmrix/tmcc/PackageTest.java
@@ -1,64 +1,35 @@
 package jmri.jmrix.tmcc;
 
-import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SerialTurnoutTest.class,
+        SerialTurnoutManagerTest.class,
+        SerialMessageTest.class,
+        SerialReplyTest.class,
+        SerialTrafficControllerTest.class,
+        SerialAddressTest.class,
+        jmri.jmrix.tmcc.serialdriver.PackageTest.class,
+        jmri.jmrix.tmcc.simulator.PackageTest.class,
+        jmri.jmrix.tmcc.configurexml.PackageTest.class,
+        jmri.jmrix.tmcc.packetgen.PackageTest.class,
+        TmccMenuTest.class,
+        jmri.jmrix.tmcc.serialmon.PackageTest.class,
+        TmccSystemConnectionMemoTest.class,
+        SerialPortControllerTest.class,
+        SerialConnectionTypeListTest.class,
+        SerialThrottleManagerTest.class,
+        SerialThrottleTest.class,
+        BundleTest.class,
+        jmri.jmrix.tmcc.swing.PackageTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.tmcc package.
  *
  * @author Bob Jacobsen Copyright 2003
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite("jmri.jmrix.tmcc.SerialTest");
-        suite.addTest(new JUnit4TestAdapter(SerialTurnoutTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialTurnoutManagerTest.class));
-        suite.addTest(SerialMessageTest.suite());
-        suite.addTest(SerialReplyTest.suite());
-        suite.addTest(new JUnit4TestAdapter(SerialTrafficControllerTest.class));
-        suite.addTest(SerialAddressTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.tmcc.serialdriver.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.tmcc.simulator.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.tmcc.configurexml.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.tmcc.packetgen.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(TmccMenuTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.tmcc.serialmon.PackageTest.class));
-        suite.addTest(new JUnit4TestAdapter(TmccSystemConnectionMemoTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialPortControllerTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialConnectionTypeListTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialThrottleManagerTest.class));
-        suite.addTest(new JUnit4TestAdapter(SerialThrottleTest.class));
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new JUnit4TestAdapter(jmri.jmrix.tmcc.swing.PackageTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/xpa/PackageTest.java
+++ b/java/test/jmri/jmrix/xpa/PackageTest.java
@@ -1,44 +1,29 @@
 package jmri.jmrix.xpa;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        XpaMessageTest.class,
+        XpaTrafficControllerTest.class,
+        XpaSystemConnectionMemoTest.class,
+        XpaTurnoutTest.class,
+        XpaThrottleTest.class,
+        XpaTurnoutManagerTest.class,
+        XpaPowerManagerTest.class,
+        XpaThrottleManagerTest.class,
+        jmri.jmrix.xpa.serialdriver.PackageTest.class,
+        jmri.jmrix.xpa.configurexml.PackageTest.class,
+        jmri.jmrix.xpa.swing.PackageTest.class,
+        XpaPortControllerTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.xpa package
  *
  * @author	Paul Bender Copyright (C) 2012,2016
   */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.xpa.XpaTest");  // no tests in this class itself
-        suite.addTest(new TestSuite(XpaMessageTest.class));
-        suite.addTest(new TestSuite(XpaTrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XpaSystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XpaTurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XpaThrottleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XpaTurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XpaPowerManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XpaThrottleManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.xpa.serialdriver.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.xpa.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.xpa.swing.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XpaPortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/zimo/PackageTest.java
+++ b/java/test/jmri/jmrix/zimo/PackageTest.java
@@ -1,52 +1,36 @@
 package jmri.jmrix.zimo;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrix.zimo.swing.PackageTest.class,
+        jmri.jmrix.zimo.mx1.PackageTest.class,
+        jmri.jmrix.zimo.mxulf.PackageTest.class,
+        Mx1SystemConnectionMemoTest.class,
+        Mx1PortControllerTest.class,
+        Mx1TrafficControllerTest.class,
+        Mx1ExceptionTest.class,
+        Mx1MessageExceptionTest.class,
+        Mx1CommandStationTest.class,
+        Mx1ConnectionTypeListTest.class,
+        Mx1MessageTest.class,
+        Mx1PacketizerTest.class,
+        Mx1PowerManagerTest.class,
+        Mx1ProgrammerManagerTest.class,
+        Mx1ProgrammerTest.class,
+        Mx1ThrottleManagerTest.class,
+        Mx1ThrottleTest.class,
+        Mx1TurnoutManagerTest.class,
+        Mx1TurnoutTest.class,
+        BundleTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.zimo package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.zimo.PackageTest");  // no tests in this class itself
-
-        suite.addTest(jmri.jmrix.zimo.swing.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.zimo.mx1.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.zimo.mxulf.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1SystemConnectionMemoTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1PortControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1TrafficControllerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1ExceptionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1MessageExceptionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1CommandStationTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1ConnectionTypeListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1MessageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1PacketizerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1PowerManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1ProgrammerManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1ProgrammerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1ThrottleManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1ThrottleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1TurnoutManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1TurnoutTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/zimo/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/zimo/swing/PackageTest.java
@@ -1,39 +1,22 @@
 package jmri.jmrix.zimo.swing;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.jmrix.zimo.swing.packetgen.PackageTest.class,
+        BundleTest.class,
+        jmri.jmrix.zimo.swing.monitor.PackageTest.class,
+        Mx1ComponentFactoryTest.class,
+        Mx1MenuTest.class,
+        Mx1NamedPaneActionTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.zimo.swing package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.zimo.swing.PackageTest");  // no tests in this class itself
-
-        suite.addTest(jmri.jmrix.zimo.swing.packetgen.PackageTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.jmrix.zimo.swing.monitor.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1ComponentFactoryTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1MenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1NamedPaneActionTest.class));
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/jmrix/zimo/swing/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/zimo/swing/packetgen/PackageTest.java
@@ -1,35 +1,18 @@
 package jmri.jmrix.zimo.swing.packetgen;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        Mx1PacketGenPanelTest.class,
+})
 
 /**
  * Tests for the jmri.jmrix.zimo.swing.packetgen package
  *
  * @author	Bob Jacobsen
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.jmrix.zimo.swing.packetgen.PackageTest");  // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(Mx1PacketGenPanelTest.class));
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/progdebugger/PackageTest.java
+++ b/java/test/jmri/progdebugger/PackageTest.java
@@ -1,8 +1,14 @@
 package jmri.progdebugger;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.progdebugger.DebugProgrammerTest.class,
+        jmri.progdebugger.DebugProgrammerManagerTest.class,
+        ProgDebuggerTest.class,
+})
 
 /**
  * Invoke complete set of tests for the Jmri.progdebugger package.
@@ -12,42 +18,5 @@ import junit.framework.TestSuite;
  *
  * @author	Bob Jacobsen, Copyright (C) 2001, 2002
  */
-public class PackageTest extends TestCase {
-
-    public void testCtor() {
-    }
-
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite(PackageTest.class);
-        suite.addTest(jmri.progdebugger.DebugProgrammerTest.suite());
-        suite.addTest(jmri.progdebugger.DebugProgrammerManagerTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ProgDebuggerTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
-        super.setUp();
-        jmri.util.JUnitUtil.resetInstanceManager();
-        jmri.util.JUnitUtil.initInternalSensorManager();
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-        jmri.util.JUnitUtil.tearDown();
-    }
+public class PackageTest  {
 }

--- a/java/test/jmri/script/PackageTest.java
+++ b/java/test/jmri/script/PackageTest.java
@@ -7,33 +7,16 @@
  */
 package jmri.script;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
-public class PackageTest extends TestCase {
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        JmriScriptEngineManagerTest.class,
+        ScriptFileChooserTest.class,
+        ScriptOutputTest.class,
+})
 
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.script");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JmriScriptEngineManagerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ScriptFileChooserTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ScriptOutputTest.class));
-
-        return suite;
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/util/PackageTest.java
+++ b/java/test/jmri/util/PackageTest.java
@@ -1,124 +1,96 @@
 package jmri.util;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        FileUtilTest.class,
+        JUnitAppenderTest.class,
+        IntlUtilitiesTest.class,
+        Log4JUtilTest.class,
+        NamedBeanHandleTest.class,
+        OrderedHashtableTest.class,
+        PreferNumericComparatorTest.class,
+        StringUtilTest.class,
+        ThreadingUtilTest.class,
+        ThreadingDemoAndTest.class,
+        I18NTest.class,
+        AlphanumComparatorTest.class,
+        ColorUtilTest.class,
+        MathUtilTest.class,
+        SwingTestCaseTest.class,
+        jmri.util.docbook.PackageTest.class,
+        jmri.util.exceptionhandler.PackageTest.class,
+        jmri.util.jdom.PackageTest.class,
+        jmri.util.swing.PackageTest.class,
+
+        jmri.util.WaitHandlerTest.class,
+        jmri.util.PropertyChangeEventQueueTest.class,
+        jmri.util.zeroconf.PackageTest.class,
+        jmri.util.DateUtilTest.class,
+        jmri.util.prefs.PackageTest.class,
+        jmri.util.javamail.PackageTest.class,
+        jmri.util.davidflanagan.PackageTest.class,
+        jmri.util.datatransfer.PackageTest.class,
+        jmri.util.com.PackageTest.class,
+        jmri.util.table.PackageTest.class,
+        jmri.util.iharder.PackageTest.class,
+        BareBonesBrowserLaunchTest.class,
+        ConnectionNameFromSystemNameTest.class,
+        DnDStringImportHandlerTest.class,
+        DnDTableExportHandlerTest.class,
+        DnDTableImportExportHandlerTest.class,
+        FileUtilSupportTest.class,
+        FontUtilTest.class,
+        GetArgumentListTest.class,
+        GetClassPathTest.class,
+        GetJavaPropertyTest.class,
+        HelpUtilTest.class,
+        JTextPaneAppenderTest.class,
+        JmriInsetsTest.class,
+        JmriJFrameTest.class,
+        JmriLocalEntityResolverTest.class,
+        JmriNullEntityResolverTest.class,
+        LocoAddressComparatorTest.class,
+        MouseInputAdapterInstallerTest.class,
+        NamedBeanComparatorTest.class,
+        NonNullArrayListTest.class,
+        NoArchiveFileFilterTest.class,
+        OrderedPropertiesTest.class,
+        PhysicalLocationPanelTest.class,
+        PhysicalLocationTest.class,
+        PortNameMapperTest.class,
+        ResizableImagePanelTest.class,
+        RuntimeUtilTest.class,
+        SerialUtilTest.class,
+        SocketUtilTest.class,
+        SystemNameComparatorTest.class,
+        SystemTypeTest.class,
+        XmlFilenameFilterTest.class,
+        jmri.util.xml.PackageTest.class,
+        JmriJFrameActionTest.class,
+        JLogoutputFrameTest.class,
+        WindowMenuTest.class,
+        jmri.util.usb.PackageTest.class,
+        FileChooserFilterTest.class,
+        JTreeWithPopupTest.class,
+        MenuScrollerTest.class,
+        ExternalLinkContentViewerUITest.class,
+        PipeListenerTest.class,
+        IterableEnumerationTest.class,
+        BusyGlassPaneTest.class,
+        MultipartMessageTest.class,
+
+        // deliberately at end
+        jmri.util.Log4JErrorIsErrorTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.util tree
  *
  * @author	Bob Jacobsen Copyright 2003
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.util.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(FileUtilTest.class));
-        suite.addTest(JUnitAppenderTest.suite());
-        suite.addTest(IntlUtilitiesTest.suite());
-        suite.addTest(Log4JUtilTest.suite());
-        suite.addTest(NamedBeanHandleTest.suite());
-        suite.addTest(OrderedHashtableTest.suite());
-        suite.addTest(PreferNumericComparatorTest.suite());
-        suite.addTest(StringUtilTest.suite());
-        suite.addTest(ThreadingUtilTest.suite());
-        suite.addTest(ThreadingDemoAndTest.suite());
-        suite.addTest(I18NTest.suite());
-        suite.addTest(AlphanumComparatorTest.suite());
-        suite.addTest(ColorUtilTest.suite());
-        suite.addTest(MathUtilTest.suite());
-        suite.addTest(SwingTestCaseTest.suite());
-        suite.addTest(jmri.util.docbook.PackageTest.suite());
-        suite.addTest(jmri.util.exceptionhandler.PackageTest.suite());
-        suite.addTest(jmri.util.jdom.PackageTest.suite());
-        suite.addTest(jmri.util.swing.PackageTest.suite());
-
-        suite.addTest(jmri.util.WaitHandlerTest.suite());
-        suite.addTest(jmri.util.PropertyChangeEventQueueTest.suite());
-        suite.addTest(jmri.util.zeroconf.PackageTest.suite());
-        suite.addTest(jmri.util.DateUtilTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.prefs.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.javamail.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.davidflanagan.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.datatransfer.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.com.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.table.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.iharder.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BareBonesBrowserLaunchTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ConnectionNameFromSystemNameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DnDStringImportHandlerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DnDTableExportHandlerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(DnDTableImportExportHandlerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(FileUtilSupportTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(FontUtilTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(GetArgumentListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(GetClassPathTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(GetJavaPropertyTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(HelpUtilTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JTextPaneAppenderTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JmriInsetsTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JmriJFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JmriLocalEntityResolverTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JmriNullEntityResolverTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(LocoAddressComparatorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(MouseInputAdapterInstallerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NamedBeanComparatorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NonNullArrayListTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(NoArchiveFileFilterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(OrderedPropertiesTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PhysicalLocationPanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PhysicalLocationTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PortNameMapperTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ResizableImagePanelTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RuntimeUtilTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SerialUtilTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SocketUtilTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SystemNameComparatorTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(SystemTypeTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(XmlFilenameFilterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.xml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JmriJFrameActionTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JLogoutputFrameTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(WindowMenuTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.usb.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(FileChooserFilterTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(JTreeWithPopupTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(MenuScrollerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ExternalLinkContentViewerUITest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(PipeListenerTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(IterableEnumerationTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(BusyGlassPaneTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(MultipartMessageTest.class));
-
-        // deliberately at end
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.Log4JErrorIsErrorTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/util/docbook/PackageTest.java
+++ b/java/test/jmri/util/docbook/PackageTest.java
@@ -1,51 +1,20 @@
 // PackageTest
 package jmri.util.docbook;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        RevHistoryTest.class,
+        jmri.util.docbook.configurexml.PackageTest.class,
+        RevisionTest.class,
+})
 
 /**
  * Tests for the jmri.util.docbook package
  *
  * @author	Bob Jacobsen Copyright (C) 2010
  */
-public class PackageTest extends TestCase {
-
-    public void testExtra() {
-    }
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-
-        suite.addTest(RevHistoryTest.suite());
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.docbook.configurexml.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(RevisionTest.class));
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/util/exceptionhandler/PackageTest.java
+++ b/java/test/jmri/util/exceptionhandler/PackageTest.java
@@ -1,48 +1,18 @@
 package jmri.util.exceptionhandler;
 
-import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        UncaughtExceptionHandlerTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.util.swing tree
  *
  * @author	Bob Jacobsen Copyright 2003
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.util.exceptionhandler.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(UncaughtExceptionHandlerTest.suite());
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/util/jdom/PackageTest.java
+++ b/java/test/jmri/util/jdom/PackageTest.java
@@ -1,46 +1,17 @@
 package jmri.util.jdom;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        LocaleSelectorTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.util.jdom tree
  *
  * @author	Bob Jacobsen Copyright 2010
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.util.jdom.PackageTest");   // no tests in this class itself
-
-        suite.addTest(LocaleSelectorTest.suite());
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/util/swing/PackageTest.java
+++ b/java/test/jmri/util/swing/PackageTest.java
@@ -1,78 +1,48 @@
 package jmri.util.swing;
 
-import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BundleTest.class,
+        JmriAbstractActionTest.class,
+        jmri.util.swing.multipane.PackageTest.class,
+        jmri.util.swing.sdi.PackageTest.class,
+        jmri.util.swing.mdi.PackageTest.class,
+        jmri.util.swing.JCBHandleTest.class,
+        FontComboUtilTest.class,
+        EditableResizableImagePanelTest.class,
+        GuiUtilBaseTest.class,
+        JmriBeanComboBoxTest.class,
+        JMenuUtilTest.class,
+        JComboBoxUtilTest.class,
+        JToolBarUtilTest.class,
+        JTreeUtilTest.class,
+        JmriPanelTest.class,
+        ResizableImagePanelTest.class,
+        SliderSnapTest.class,
+        StatusBarTest.class,
+        SwingSettingsTest.class,
+        VerticalLabelUITest.class,
+        XTableColumnModelTest.class,
+        JFrameInterfaceTest.class,
+        JmriNamedPaneActionTest.class,
+        BusyDialogTest.class,
+        TextFilterTest.class,
+        BeanSelectCreatePanelTest.class,
+        ValidatedTextFieldTest.class,
+        ComboBoxColorChooserPanelTest.class,
+        ButtonGroupColorChooserPanelTest.class,
+        ButtonSwatchColorChooserPanelTest.class,
+        DrawSquaresTest.class,
+        ImagePanelTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.util.swing tree
  *
  * @author	Bob Jacobsen Copyright 2003
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.util.swing.PackageTest");   // no tests in this class itself
-
-        suite.addTest(new JUnit4TestAdapter(BundleTest.class));
-        suite.addTest(JmriAbstractActionTest.suite());
-        suite.addTest(jmri.util.swing.multipane.PackageTest.suite());
-        suite.addTest(jmri.util.swing.sdi.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(jmri.util.swing.mdi.PackageTest.class));
-        suite.addTest(jmri.util.swing.JCBHandleTest.suite());
-        suite.addTest(new JUnit4TestAdapter(FontComboUtilTest.class));
-        suite.addTest(new JUnit4TestAdapter(EditableResizableImagePanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(GuiUtilBaseTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriBeanComboBoxTest.class));
-        suite.addTest(new JUnit4TestAdapter(JMenuUtilTest.class));
-        suite.addTest(new JUnit4TestAdapter(JComboBoxUtilTest.class));
-        suite.addTest(new JUnit4TestAdapter(JToolBarUtilTest.class));
-        suite.addTest(new JUnit4TestAdapter(JTreeUtilTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(ResizableImagePanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(SliderSnapTest.class));
-        suite.addTest(new JUnit4TestAdapter(StatusBarTest.class));
-        suite.addTest(new JUnit4TestAdapter(SwingSettingsTest.class));
-        suite.addTest(new JUnit4TestAdapter(VerticalLabelUITest.class));
-        suite.addTest(new JUnit4TestAdapter(XTableColumnModelTest.class));
-        suite.addTest(new JUnit4TestAdapter(JFrameInterfaceTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriNamedPaneActionTest.class));
-        suite.addTest(new JUnit4TestAdapter(BusyDialogTest.class));
-        suite.addTest(new JUnit4TestAdapter(TextFilterTest.class));
-        suite.addTest(new JUnit4TestAdapter(BeanSelectCreatePanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(ValidatedTextFieldTest.class));
-        suite.addTest(new JUnit4TestAdapter(ComboBoxColorChooserPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(ButtonGroupColorChooserPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(ButtonSwatchColorChooserPanelTest.class));
-        suite.addTest(new JUnit4TestAdapter(DrawSquaresTest.class));
-        suite.addTest(new JUnit4TestAdapter(ImagePanelTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/util/swing/multipane/PackageTest.java
+++ b/java/test/jmri/util/swing/multipane/PackageTest.java
@@ -1,52 +1,20 @@
 package jmri.util.swing.multipane;
 
-import jmri.util.JUnitUtil;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        MultiJfcUnitTest.class,
+        MultiPaneWindowTest.class,
+        PanedInterfaceTest.class,
+        ThreePaneTLRWindowTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.util tree
  *
  * @author	Bob Jacobsen Copyright 2003
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class.getName());
-
-        suite.addTest(MultiJfcUnitTest.suite());
-        suite.addTest(new JUnit4TestAdapter(MultiPaneWindowTest.class));
-        suite.addTest(new JUnit4TestAdapter(PanedInterfaceTest.class));
-        suite.addTest(new JUnit4TestAdapter(ThreePaneTLRWindowTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        JUnitUtil.setUp();
-
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/util/swing/sdi/JmriJFrameInterfaceTest.java
+++ b/java/test/jmri/util/swing/sdi/JmriJFrameInterfaceTest.java
@@ -1,5 +1,10 @@
 package jmri.util.swing.sdi;
 
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import jmri.util.JUnitUtil;
+import jmri.util.JmriJFrame;
+import jmri.util.swing.ButtonTestAction;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -18,6 +23,19 @@ public class JmriJFrameInterfaceTest {
         Assert.assertNotNull("exists",t);
     }
 
+    @Test
+    public void testAction() {
+        JmriJFrame f = new JmriJFrame("SDI test");
+        JButton b = new JButton(new ButtonTestAction(
+                "new frame", new jmri.util.swing.sdi.JmriJFrameInterface()));
+        f.add(b);
+        f.pack();
+        f.setVisible(true);
+        JFrame f2 = jmri.util.JmriJFrame.getFrame("SDI test");
+        Assert.assertTrue("found frame", f2 != null);
+        JUnitUtil.dispose(f2);
+    }
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -32,3 +50,4 @@ public class JmriJFrameInterfaceTest {
     // private final static Logger log = LoggerFactory.getLogger(JmriJFrameInterfaceTest.class);
 
 }
+

--- a/java/test/jmri/util/swing/sdi/JmriJFrameInterfaceTest.java
+++ b/java/test/jmri/util/swing/sdi/JmriJFrameInterfaceTest.java
@@ -1,5 +1,6 @@
 package jmri.util.swing.sdi;
 
+import java.awt.GraphicsEnvironment;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import jmri.util.JUnitUtil;
@@ -21,19 +22,6 @@ public class JmriJFrameInterfaceTest {
     public void testCTor() {
         JmriJFrameInterface t = new JmriJFrameInterface();
         Assert.assertNotNull("exists",t);
-    }
-
-    @Test
-    public void testAction() {
-        JmriJFrame f = new JmriJFrame("SDI test");
-        JButton b = new JButton(new ButtonTestAction(
-                "new frame", new jmri.util.swing.sdi.JmriJFrameInterface()));
-        f.add(b);
-        f.pack();
-        f.setVisible(true);
-        JFrame f2 = jmri.util.JmriJFrame.getFrame("SDI test");
-        Assert.assertTrue("found frame", f2 != null);
-        JUnitUtil.dispose(f2);
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/util/swing/sdi/PackageTest.java
+++ b/java/test/jmri/util/swing/sdi/PackageTest.java
@@ -1,69 +1,19 @@
 package jmri.util.swing.sdi;
 
-import javax.swing.JButton;
-import javax.swing.JFrame;
-import jmri.util.JUnitUtil;
-import jmri.util.JmriJFrame;
-import jmri.util.swing.ButtonTestAction;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SdiJfcUnitTest.class,
+        SdiWindowTest.class,
+        JmriJFrameInterfaceTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.util.swing.sdi tree
  *
  * @author	Bob Jacobsen Copyright 2010
  */
-public class PackageTest extends TestCase {
-
-    public void testAction() {
-        JmriJFrame f = new JmriJFrame("SDI test");
-        JButton b = new JButton(new ButtonTestAction(
-                "new frame", new jmri.util.swing.sdi.JmriJFrameInterface()));
-        f.add(b);
-        f.pack();
-        f.setVisible(true);
-//    }
-//  test order isn't guaranteed!
-//    public void testFrameCreation() {
-        JFrame f2 = jmri.util.JmriJFrame.getFrame("SDI test");
-        Assert.assertTrue("found frame", f2 != null);
-        JUnitUtil.dispose(f2);
-    }
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class.getName());
-
-        suite.addTest(SdiJfcUnitTest.suite());
-        suite.addTest(new JUnit4TestAdapter(SdiWindowTest.class));
-        suite.addTest(new JUnit4TestAdapter(JmriJFrameInterfaceTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }

--- a/java/test/jmri/util/swing/sdi/SdiWindowTest.java
+++ b/java/test/jmri/util/swing/sdi/SdiWindowTest.java
@@ -28,9 +28,6 @@ public class SdiWindowTest {
         f.add(b);
         f.pack();
         f.setVisible(true);
-//    }
-//  test order isn't guaranteed!
-//    public void testFrameCreation() {
         JFrame f2 = jmri.util.JmriJFrame.getFrame("SDI test");
         Assert.assertTrue("found frame", f2 != null);
         JUnitUtil.dispose(f2);

--- a/java/test/jmri/util/zeroconf/PackageTest.java
+++ b/java/test/jmri/util/zeroconf/PackageTest.java
@@ -1,9 +1,14 @@
 package jmri.util.zeroconf;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        ZeroConfServiceTest.class,
+        ZeroConfClientTest.class,
+        ZeroConfServiceEventTest.class,
+})
 
 /**
  * Invokes complete set of tests in the jmri.util.zeroconf tree
@@ -11,39 +16,5 @@ import junit.framework.TestSuite;
  * @author	Bob Jacobsen Copyright 2003
  * @author Paul Bender Copyright 2014
  */
-public class PackageTest extends TestCase {
-
-    // from here down is testing infrastructure
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite("jmri.util.zeroconf.ZeroConfTest");   // no tests in this class itself
-
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ZeroConfServiceTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ZeroConfClientTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(ZeroConfServiceEventTest.class));
-
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
-
+public class PackageTest  {
 }


### PR DESCRIPTION
This should eliminate the remaining JUnit3 package test files.

Also removes dummy tests from these files, and moves actual tests to other files, where they will be run using surefire in maven.