### PR TITLE
WIP: Test that an object is disposed when cleared from InstanceManager

### DIFF
--- a/java/test/jmri/InstanceManagerDisposeTest.java
+++ b/java/test/jmri/InstanceManagerDisposeTest.java
@@ -1,0 +1,68 @@
+package jmri;
+
+import jmri.util.JUnitUtil;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test InstanceManager
+ */
+public class InstanceManagerDisposeTest extends TestCase implements InstanceManagerAutoDefault {
+
+    // Test that an object that is added to the InstanceManager and then
+    // removed is also disposed.
+    
+    static boolean b = false;
+    
+    public static class DisposableClass implements Disposable {
+        @Override
+        public void dispose() {
+            b = true;
+        }
+    }
+    
+    public void testClear() {
+        
+        DisposableClass disposable = new DisposableClass();
+
+        InstanceManager.store(disposable, DisposableClass.class);
+        InstanceManager.getDefault().clear(DisposableClass.class);
+
+        Assert.assertTrue("the disposable has been disposed", b);
+    }
+
+    // from here down is testing infrastructure
+    public InstanceManagerDisposeTest(String s) {
+        super(s);
+    }
+
+    // Main entry point
+    static public void main(String[] args) {
+        String[] testCaseName = {InstanceManagerDisposeTest.class.getName()};
+        junit.textui.TestRunner.main(testCaseName);
+    }
+
+    // test suite from all defined tests
+    public static Test suite() {
+        apps.tests.AllTest.initLogging();
+        TestSuite suite = new TestSuite(InstanceManagerDisposeTest.class);
+        return suite;
+    }
+
+    // The minimal setup for log4J
+    @Override
+    protected void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @Override
+    protected void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(InstanceManagerDisposeTest.class);
+}

--- a/java/test/jmri/InstanceManagerDisposeTest.java
+++ b/java/test/jmri/InstanceManagerDisposeTest.java
@@ -1,17 +1,22 @@
 package jmri;
 
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+// import junit.framework.Test;
+// import junit.framework.TestCase;
+// import junit.framework.TestSuite;
+//import org.junit.Assert;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Test InstanceManager
  */
-public class InstanceManagerDisposeTest extends TestCase implements InstanceManagerAutoDefault {
+public class InstanceManagerDisposeTest {
 
     // Test that an object that is added to the InstanceManager and then
     // removed is also disposed.
@@ -25,6 +30,7 @@ public class InstanceManagerDisposeTest extends TestCase implements InstanceMana
         }
     }
     
+    @Test
     public void testClear() {
         
         DisposableClass disposable = new DisposableClass();
@@ -36,31 +42,14 @@ public class InstanceManagerDisposeTest extends TestCase implements InstanceMana
     }
 
     // from here down is testing infrastructure
-    public InstanceManagerDisposeTest(String s) {
-        super(s);
-    }
 
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {InstanceManagerDisposeTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        apps.tests.AllTest.initLogging();
-        TestSuite suite = new TestSuite(InstanceManagerDisposeTest.class);
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
+    @Before
+    public void setUp() {
         JUnitUtil.setUp();
     }
 
-    @Override
-    protected void tearDown() {
+    @After
+    public void tearDown() {
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/PackageTest.java
+++ b/java/test/jmri/PackageTest.java
@@ -14,6 +14,7 @@ import org.junit.runners.Suite;
         jmri.BlockManagerTest.class,
         jmri.DccLocoAddressTest.class,
         jmri.InstanceManagerTest.class,
+        jmri.InstanceManagerDisposeTest.class,
         jmri.NamedBeanTest.class,
         jmri.LightTest.class,
         NmraPacketTest.class,


### PR DESCRIPTION
This PR adds a test to show the problem behind PR #4587 

It registers a disposable object in the InstanceManager and then clear the InstanceManager on that kind of objects and then assert that the disposable object has been disposed.