### PR TITLE
Allow testing of USB Browser without real USB hardware

### DIFF
--- a/java/src/jmri/util/usb/UsbBrowserFrame.java
+++ b/java/src/jmri/util/usb/UsbBrowserFrame.java
@@ -13,7 +13,7 @@ public class UsbBrowserFrame extends JmriJFrame {
         this(new UsbBrowserPanel());
     }
 
-    public UsbBrowserFrame(JPanel rootPanel) {
+    UsbBrowserFrame(JPanel rootPanel) {
         super(Bundle.getMessage("UsbBrowserFrame.Title"));
         super.getRootPane().setContentPane(rootPanel);
         super.pack();

--- a/java/src/jmri/util/usb/UsbBrowserFrame.java
+++ b/java/src/jmri/util/usb/UsbBrowserFrame.java
@@ -1,6 +1,7 @@
 package jmri.util.usb;
 
 import jmri.util.JmriJFrame;
+import javax.swing.JPanel; 
 
 /**
  *
@@ -9,8 +10,12 @@ import jmri.util.JmriJFrame;
 public class UsbBrowserFrame extends JmriJFrame {
 
     public UsbBrowserFrame() {
+        this(new UsbBrowserPanel());
+    }
+
+    public UsbBrowserFrame(JPanel rootPanel) {
         super(Bundle.getMessage("UsbBrowserFrame.Title"));
-        super.getRootPane().setContentPane(new UsbBrowserPanel());
+        super.getRootPane().setContentPane(rootPanel);
         super.pack();
     }
 }

--- a/java/src/jmri/util/usb/UsbBrowserPanel.java
+++ b/java/src/jmri/util/usb/UsbBrowserPanel.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public class UsbBrowserPanel extends javax.swing.JPanel {
 
-    private final UsbTreeNode root;
+    private UsbTreeNode root;
     private final UsbDeviceTableModel deviceModel = new UsbDeviceTableModel();
     private final static Logger log = LoggerFactory.getLogger(UsbBrowserPanel.class);
     private transient final UsbServicesListener usbServicesListener = new UsbServicesListener() {
@@ -66,7 +66,7 @@ public class UsbBrowserPanel extends javax.swing.JPanel {
                     return;
                 }
             }
-            UsbTreeNode root = UsbBrowserPanel.this.root;
+            UsbTreeNode root = UsbBrowserPanel.this.getRootNode();
             root.removeAllChildren();
             UsbBrowserPanel.this.buildTree(root);
         }
@@ -74,7 +74,7 @@ public class UsbBrowserPanel extends javax.swing.JPanel {
         @Override
         public void usbDeviceDetached(UsbServicesEvent use) {
             // subtler method to remove usbDevice from tree
-            UsbTreeNode root = UsbBrowserPanel.this.root;
+            UsbTreeNode root = UsbBrowserPanel.this.getRootNode();
             UsbDevice usbDevice = use.getUsbDevice();
             UsbTreeNode usbTreeNode = findNodeForDevice(root, usbDevice);
             if (usbTreeNode != null) {
@@ -108,7 +108,7 @@ public class UsbBrowserPanel extends javax.swing.JPanel {
      * Create new UsbBrowserPanel.
      */
     public UsbBrowserPanel() {
-        root = new UsbTreeNode();
+        root = getRootNode();
         buildTree(root);
         if (root.getUserObject() != null) {
             try {
@@ -121,6 +121,20 @@ public class UsbBrowserPanel extends javax.swing.JPanel {
         for (int i = 0; i < usbTree.getRowCount(); i++) {
             usbTree.expandRow(i);
         }
+    }
+
+    /*
+     * Protected method to set and retrieve the root node.
+     *
+     * This is partially in place for testing purposes, as
+     * this allows injection of a pre-defined root node by
+     * by overriding this method.
+     */
+    protected UsbTreeNode getRootNode() {
+       if(root == null ) {
+          root = new UsbTreeNode();
+       }
+       return root;
     }
 
     private void buildTree(UsbTreeNode root) {
@@ -231,7 +245,7 @@ public class UsbBrowserPanel extends javax.swing.JPanel {
     private javax.swing.JTree usbTree;
     // End of variables declaration//GEN-END:variables
 
-    private static class UsbTreeNode extends DefaultMutableTreeNode {
+    protected static class UsbTreeNode extends DefaultMutableTreeNode {
 
         public UsbTreeNode() {
             this(null);

--- a/java/test/jmri/jmrix/easydcc/EasyDccTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccTrafficControllerTest.java
@@ -25,7 +25,7 @@ public class EasyDccTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCo
 
     @Test
     public void testSendThenRcvReply() throws Exception {
-        c = (EasyDccTrafficController) tc;
+        EasyDccTrafficController c = (EasyDccTrafficController) tc;
 
         // connect to iostream via port controller
         EasyDccPortControllerScaffold p = new EasyDccPortControllerScaffold();
@@ -144,22 +144,21 @@ public class EasyDccTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCo
     DataOutputStream tistream; // tests write to this
     DataInputStream istream;   // so the traffic controller can read from this
 
-    EasyDccTrafficController c;
-    
     // The minimal setup for log4J
     @Override
     @Before
     public void setUp() {
-        c = null;
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new EasyDccTrafficController(new EasyDccSystemConnectionMemo("E", "EasyDCC Test"));
     }
 
     @Override
     @After
     public void tearDown() {
-        if (c!=null) c.terminateThreads();
-        apps.tests.Log4JFixture.tearDown();
+        if (tc!=null) {
+            tc.terminateThreads();
+        }
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/easydcc/EasyDccTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccTrafficControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.Rule;
 import jmri.util.junit.rules.RetryRule;
+import org.junit.rules.Timeout;
 
 /**
  * JUnit tests for the EasyDccTrafficController class
@@ -19,6 +20,9 @@ import jmri.util.junit.rules.RetryRule;
  * @author	Bob Jacobsen Copyright (C) 2003, 2007, 2015
  */
 public class EasyDccTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficControllerTest {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(90); // 90 second timeout for methods in this test class.
 
     @Rule
     public RetryRule retryRule = new RetryRule(3);  // allow 3 retries

--- a/java/test/jmri/util/usb/UsbBrowserFrameTest.java
+++ b/java/test/jmri/util/usb/UsbBrowserFrameTest.java
@@ -16,10 +16,17 @@ import org.junit.Test;
 public class UsbBrowserFrameTest {
 
     @Test
-    @Ignore("we probably need to mock the USB library to obtain consistent results.")
     public void testCTor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        UsbBrowserFrame t = new UsbBrowserFrame();
+        UsbBrowserPanel bp = new UsbBrowserPanel(){
+           @Override
+           protected UsbTreeNode getRootNode() {
+              UsbTreeNode retval = new UsbTreeNode();
+              retval.setUsbDevice(null);
+              return retval;
+           }
+        };
+        UsbBrowserFrame t = new UsbBrowserFrame(bp);
         Assert.assertNotNull("exists",t);
         JUnitUtil.dispose(t);
     }

--- a/java/test/jmri/util/usb/UsbBrowserFrameTest.java
+++ b/java/test/jmri/util/usb/UsbBrowserFrameTest.java
@@ -1,5 +1,9 @@
 package jmri.util.usb;
 
+import java.io.UnsupportedEncodingException;
+import javax.usb.UsbDevice;
+import javax.usb.UsbDisconnectedException;
+import javax.usb.UsbException;
 import java.awt.GraphicsEnvironment;
 import jmri.util.JUnitUtil;
 import org.junit.After;
@@ -7,7 +11,11 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  *
@@ -15,13 +23,17 @@ import org.junit.Test;
  */
 public class UsbBrowserFrameTest {
 
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
     @Test
     public void testCTor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        UsbDevice mockDevice = Mockito.mock(UsbDevice.class);
         UsbBrowserPanel bp = new UsbBrowserPanel(){
            @Override
            protected UsbTreeNode getRootNode() {
-              UsbTreeNode retval = new UsbTreeNode();
+              UsbTreeNode retval = new UsbTreeNode(mockDevice);
               retval.setUsbDevice(null);
               return retval;
            }

--- a/java/test/jmri/util/usb/UsbBrowserPanelTest.java
+++ b/java/test/jmri/util/usb/UsbBrowserPanelTest.java
@@ -1,10 +1,18 @@
 package jmri.util.usb;
 
+import java.io.UnsupportedEncodingException;
+import javax.usb.UsbDevice;
+import javax.usb.UsbDisconnectedException;
+import javax.usb.UsbException;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  *
@@ -12,12 +20,16 @@ import org.junit.Test;
  */
 public class UsbBrowserPanelTest {
 
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
     @Test
     public void testCTor() {
+        UsbDevice mockDevice = Mockito.mock(UsbDevice.class);
         UsbBrowserPanel t = new UsbBrowserPanel(){
            @Override
            protected UsbTreeNode getRootNode() {
-              UsbTreeNode retval = new UsbTreeNode();
+              UsbTreeNode retval = new UsbTreeNode(mockDevice);
               retval.setUsbDevice(null);
               return retval;
            }

--- a/java/test/jmri/util/usb/UsbBrowserPanelTest.java
+++ b/java/test/jmri/util/usb/UsbBrowserPanelTest.java
@@ -4,7 +4,6 @@ import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -14,9 +13,15 @@ import org.junit.Test;
 public class UsbBrowserPanelTest {
 
     @Test
-    @Ignore("we probably need to mock the USB library to obtain consistent results.")
     public void testCTor() {
-        UsbBrowserPanel t = new UsbBrowserPanel();
+        UsbBrowserPanel t = new UsbBrowserPanel(){
+           @Override
+           protected UsbTreeNode getRootNode() {
+              UsbTreeNode retval = new UsbTreeNode();
+              retval.setUsbDevice(null);
+              return retval;
+           }
+        };
         Assert.assertNotNull("exists",t);
     }
 


### PR DESCRIPTION
update UsbBrowserPanel and UsbBrowserFrame classes so that we can bypass looking at real USB hardware when testing; update previously ignored tests for these two classes.