### PR TITLE
SPROG version updates

### DIFF
--- a/java/src/jmri/jmrix/sprog/SPROGMenu.java
+++ b/java/src/jmri/jmrix/sprog/SPROGMenu.java
@@ -24,7 +24,8 @@ public class SPROGMenu extends JMenu {
             add(new jmri.jmrix.sprog.packetgen.SprogPacketGenAction(Bundle.getMessage("SendCommandTitle"), memo));
             add(new jmri.jmrix.sprog.console.SprogConsoleAction(Bundle.getMessage("MenuItemConsole"), memo));
             add(new jmri.jmrix.sprog.update.SprogVersionAction(Bundle.getMessage("GetSprogFirmwareVersion"), memo));
-            add(new jmri.jmrix.sprog.update.Sprogv4UpdateAction(Bundle.getMessage("SprogXFirmwareUpdate", "v3/v4"), memo));
+            // Removed top avoid confusion with newer SPROG II and 3 athat have now reached v3 and v4
+            //add(new jmri.jmrix.sprog.update.Sprogv4UpdateAction(Bundle.getMessage("SprogXFirmwareUpdate", "v3/v4"), memo));
             add(new jmri.jmrix.sprog.update.SprogIIUpdateAction(Bundle.getMessage("SprogXFirmwareUpdate", " II/SPROG 3"), memo));
         }
     }

--- a/java/src/jmri/jmrix/sprog/update/SprogIIUpdateFrame.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogIIUpdateFrame.java
@@ -132,7 +132,7 @@ public class SprogIIUpdateFrame
                     // Force SPROG version SPROG II 1.x or 2.x
                     sv = new SprogVersion(new SprogType(SprogType.SPROGII), "");
                 } else {
-                    // Force SPROG version SPROG SPROG II v3.x (also covers SPROG 3 and Nano)
+                    // Force SPROG version SPROG SPROG II v3.x (also covers IIv4, SPROG 3 and Nano)
                     sv = new SprogVersion(new SprogType(SprogType.SPROGIIv3), "");
                 }
                 blockLen = sv.sprogType.getBlockLen();

--- a/java/src/jmri/jmrix/sprog/update/SprogType.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogType.java
@@ -22,6 +22,7 @@ public class SprogType {
     public static final int SPROGII = 20;
     public static final int SPROGIIUSB = 21;
     public static final int SPROGIIv3 = 23;
+    public static final int SPROGIIv4 = 24;
     public static final int SPROG3 = 30;
     public static final int SPROGIV = 40;
     public static final int SPROG5 = 50;
@@ -61,7 +62,7 @@ public class SprogType {
      * @return true if this object holds a SPROG II type
      */
     public boolean isSprogII() {
-        if ((sprogType >= SPROGII) && (sprogType <= SPROGIIv3)) {
+        if ((sprogType >= SPROGII) && (sprogType <= SPROGIIv4)) {
             return true;
         }
         return false;
@@ -107,6 +108,7 @@ public class SprogType {
                 return 8;
 
             case SPROGIIv3:
+            case SPROGIIv4:
             case SPROG3:
             case SPROGIV:
             case SPROG5:
@@ -156,6 +158,7 @@ public class SprogType {
                 break;
 
             case SPROGIIv3:
+            case SPROGIIv4:
             case SPROG3:
             case SPROGIV:
             case SPROG5:
@@ -191,6 +194,7 @@ public class SprogType {
                 return 0x200;
 
             case SPROGIIv3:
+            case SPROGIIv4:
             case SPROG3:
             case SPROGIV:
             case SPROG5:
@@ -243,6 +247,8 @@ public class SprogType {
                 return "SPROG II ";
             case SPROGIIv3:
                 return "SPROG IIv3 ";
+            case SPROGIIv4:
+                return "SPROG IIv4 ";
             case SPROG3:
                 return "SPROG 3 ";
             case SPROGIV:

--- a/java/src/jmri/jmrix/sprog/update/SprogVersion.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogVersion.java
@@ -98,7 +98,7 @@ public class SprogVersion {
                 || ((major == 2) && (minor >= 1))
                 || (major >= 3))
                 || ((this.sprogType.sprogType >= SprogType.SPROGIIv3)
-                && (this.sprogType.sprogType < SprogType.NANO))) {
+                    && (this.sprogType.sprogType < SprogType.NANO))) {
             if (log.isDebugEnabled()) {
                 log.debug("This version has extra features");
             }

--- a/java/src/jmri/jmrix/sprog/update/SprogVersionQuery.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogVersionQuery.java
@@ -233,9 +233,11 @@ public class SprogVersionQuery implements SprogListener {
                         v = new SprogVersion(new SprogType(SprogType.NOT_RECOGNISED));
                     }
 
-                    if ((v.sprogType.sprogType == SprogType.SPROGII) && (v.getMajorVersion() >= 3)) {
-                        // Correct for SPROG IIv3 which is different hardware
+                    // Correct for SPROG IIv3/IIv4 which are different hardware
+                    if ((v.sprogType.sprogType == SprogType.SPROGII) && (v.getMajorVersion() == 3)) {
                         v = new SprogVersion(new SprogType(SprogType.SPROGIIv3), v.sprogVersion);
+                    } else if ((v.sprogType.sprogType == SprogType.SPROGII) && (v.getMajorVersion() >= 4)) {
+                        v = new SprogVersion(new SprogType(SprogType.SPROGIIv4), v.sprogVersion);
                     }
                     log.debug("Found: " + v.toString());
                     notifyVersion(v);

--- a/java/src/jmri/jmrix/sprog/update/Sprogv4UpdateAction.java
+++ b/java/src/jmri/jmrix/sprog/update/Sprogv4UpdateAction.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Andrew crosland Copyright (C) 2004
  * 
- * @Deprecated since 4.11.1; supports uncommon Sprog versions that are confused with Sprog II versions.
+ * @deprecated since 4.11.1; supports uncommon Sprog versions that are confused with Sprog II versions.
  */
 @Deprecated
 public class Sprogv4UpdateAction extends SprogUpdateAction {

--- a/java/src/jmri/jmrix/sprog/update/Sprogv4UpdateAction.java
+++ b/java/src/jmri/jmrix/sprog/update/Sprogv4UpdateAction.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Andrew crosland Copyright (C) 2004
  */
+@Deprecated
 public class Sprogv4UpdateAction extends SprogUpdateAction {
 
     public Sprogv4UpdateAction(String s,SprogSystemConnectionMemo memo) {

--- a/java/src/jmri/jmrix/sprog/update/Sprogv4UpdateAction.java
+++ b/java/src/jmri/jmrix/sprog/update/Sprogv4UpdateAction.java
@@ -10,6 +10,8 @@ import org.slf4j.LoggerFactory;
  * Swing action to create and register a SprogIIUpdateFrame object
  *
  * @author	Andrew crosland Copyright (C) 2004
+ * 
+ * @Deprecated since 4.11.1; supports uncommon Sprog versions that are confused with Sprog II versions.
  */
 @Deprecated
 public class Sprogv4UpdateAction extends SprogUpdateAction {

--- a/java/src/jmri/jmrix/sprog/update/Sprogv4UpdateFrame.java
+++ b/java/src/jmri/jmrix/sprog/update/Sprogv4UpdateFrame.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Andrew Crosland Copyright (C) 2004
   */
+@Deprecated
 public class Sprogv4UpdateFrame
         extends SprogUpdateFrame
         implements SprogVersionListener {

--- a/java/src/jmri/jmrix/sprog/update/Sprogv4UpdateFrame.java
+++ b/java/src/jmri/jmrix/sprog/update/Sprogv4UpdateFrame.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Andrew Crosland Copyright (C) 2004
  * 
- * @Deprecated since 4.11.1; supports uncommon Sprog versions that are confused with Sprog II versions.
+ * @deprecated since 4.11.1; supports uncommon Sprog versions that are confused with Sprog II versions.
  */
 @Deprecated
 public class Sprogv4UpdateFrame

--- a/java/src/jmri/jmrix/sprog/update/Sprogv4UpdateFrame.java
+++ b/java/src/jmri/jmrix/sprog/update/Sprogv4UpdateFrame.java
@@ -13,7 +13,9 @@ import org.slf4j.LoggerFactory;
  * Refactored
  *
  * @author	Andrew Crosland Copyright (C) 2004
-  */
+ * 
+ * @Deprecated since 4.11.1; supports uncommon Sprog versions that are confused with Sprog II versions.
+ */
 @Deprecated
 public class Sprogv4UpdateFrame
         extends SprogUpdateFrame


### PR DESCRIPTION
Correct version string for SPROG IIv4.
Remove old SPROG v3/v4 update from menu. These have not been sold for some time and we get very few requests for updates. Causes confusion with new SPROG II and 3 products that are now at version 3/4.