### PR TITLE
Fix errors reading slots in Slot Monitor

### DIFF
--- a/java/src/jmri/jmrix/loconet/LnReporterManager.java
+++ b/java/src/jmri/jmrix/loconet/LnReporterManager.java
@@ -5,8 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Manage the LocoNet-specific Reporter implementation.
- * System names are "LRnnn", where nnn is the Reporter number without padding.
+ * Manage the LocoNet-specific Reporter implementation. System names are
+ * "LRnnn", where nnn is the Reporter number without padding.
  * <P>
  * Some of the message formats used in this class are Copyright Digitrax, Inc.
  * and used with permission as part of the JMRI project. That permission does
@@ -48,7 +48,7 @@ public class LnReporterManager extends jmri.managers.AbstractReporterManager imp
     @Override
     public Reporter createNewReporter(String systemName, String userName) {
         Reporter t;
-        int addr = Integer.valueOf(systemName.substring(prefix.length() + 1)).intValue();
+        int addr = Integer.parseInt(systemName.substring(prefix.length() + 1));
         t = new LnReporter(addr, tc, prefix);
         t.setUserName(userName);
         t.addPropertyChangeListener(this);
@@ -58,29 +58,31 @@ public class LnReporterManager extends jmri.managers.AbstractReporterManager imp
 
     /**
      * Get the bit address from the system name.
+     *
+     * @param systemName the system name
+     * @return the bit address
      */
     public int getBitFromSystemName(String systemName) {
         // validate the system Name leader characters
         if ((!systemName.startsWith(getSystemPrefix())) || (!systemName.startsWith(getSystemPrefix() + "R"))) {
-            // here if an illegal loconet light system name
-            log.error("invalid character in header field of loconet reporter system name: " + systemName);
+            // here if an illegal loconet reporter system name
+            log.error("invalid character in header field of loconet reporter system name: {}", systemName);
             return (0);
         }
         // name must be in the LRnnnnn format (L is user configurable)
-        int num = 0;
+        int num;
         try {
-            num = Integer.valueOf(systemName.substring(
-                    getSystemPrefix().length() + 1, systemName.length())
-            ).intValue();
-        } catch (Exception e) {
-            log.warn("invalid character in number field of system name: " + systemName);
+            num = Integer.parseInt(systemName.substring(
+                    getSystemPrefix().length() + 1, systemName.length()));
+        } catch (NumberFormatException e) {
+            log.warn("invalid character in number field of system name: {}", systemName);
             return (0);
         }
         if (num <= 0) {
-            log.warn("invalid loconet reporter system name: " + systemName);
+            log.warn("invalid loconet reporter system name: {}", systemName);
             return (0);
         } else if (num > 4096) {
-            log.warn("bit number out of range in loconet reporter system name: " + systemName);
+            log.warn("bit number out of range in loconet reporter system name: {}", systemName);
             return (0);
         }
         return (num);
@@ -89,20 +91,17 @@ public class LnReporterManager extends jmri.managers.AbstractReporterManager imp
     /**
      * Public method to validate system name format.
      *
-     * @return 'true' if system name has a valid format, else returns 'false'
+     * @param systemName the name to validate
+     * @return VALID if system name has a valid format; otherwise return INVALID
      */
     @Override
     public NameValidity validSystemNameFormat(String systemName) {
         return (getBitFromSystemName(systemName) != 0) ? NameValidity.VALID : NameValidity.INVALID;
     }
 
-    /**
-     * Provide a manager-specific tooltip for the Add new item beantable pane.
-     */
     @Override
     public String getEntryToolTip() {
-        String entryToolTip = Bundle.getMessage("AddInputEntryToolTip");
-        return entryToolTip;
+        return Bundle.getMessage("AddInputEntryToolTip");
     }
 
     // listen for transponder messages, creating Reporters as needed

--- a/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
@@ -1,9 +1,21 @@
 package jmri.jmrix.loconet;
 
 import java.util.ResourceBundle;
+import jmri.AddressedProgrammerManager;
+import jmri.ClockControl;
+import jmri.CommandStation;
+import jmri.ConsistManager;
 import jmri.GlobalProgrammerManager;
 import jmri.InstanceManager;
+import jmri.LightManager;
+import jmri.PowerManager;
+import jmri.ReporterManager;
+import jmri.SensorManager;
 import jmri.ThrottleManager;
+import jmri.TurnoutManager;
+import jmri.jmrix.debugthrottle.DebugThrottleManager;
+import jmri.jmrix.loconet.swing.LnComponentFactory;
+import jmri.jmrix.swing.ComponentFactory;
 import jmri.managers.DefaultProgrammerManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,8 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
-    public LocoNetSystemConnectionMemo(LnTrafficController lt,
-            SlotManager sm) {
+    public LocoNetSystemConnectionMemo(LnTrafficController lt, SlotManager sm) {
         super("L", "LocoNet"); // NOI18N
         this.lt = lt;
 
@@ -30,8 +41,8 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
         InstanceManager.store(this, LocoNetSystemConnectionMemo.class); // also register as specific type
 
         // create and register the ComponentFactory for the GUI
-        InstanceManager.store(cf = new jmri.jmrix.loconet.swing.LnComponentFactory(this),
-                jmri.jmrix.swing.ComponentFactory.class);
+        InstanceManager.store(cf = new LnComponentFactory(this),
+                ComponentFactory.class);
     }
 
     public LocoNetSystemConnectionMemo() {
@@ -40,11 +51,11 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
         InstanceManager.store(this, LocoNetSystemConnectionMemo.class); // also register as specific type
 
         // create and register the ComponentFactory for the GUI
-        InstanceManager.store(cf = new jmri.jmrix.loconet.swing.LnComponentFactory(this),
-                jmri.jmrix.swing.ComponentFactory.class);
+        InstanceManager.store(cf = new LnComponentFactory(this),
+                ComponentFactory.class);
     }
 
-    jmri.jmrix.swing.ComponentFactory cf = null;
+    ComponentFactory cf = null;
     private LnTrafficController lt;
     private SlotManager sm;
     private LnMessageManager lnm = null;
@@ -126,7 +137,7 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
             sm.setSystemConnectionMemo(this);
 
             // store as CommandStation object
-            jmri.InstanceManager.setCommandStation(sm);
+            InstanceManager.setCommandStation(sm);
         }
 
     }
@@ -139,38 +150,38 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
         if (getDisabled()) {
             return false;
         }
-        if (type.equals(jmri.GlobalProgrammerManager.class)) {
+        if (type.equals(GlobalProgrammerManager.class)) {
             return getProgrammerManager().isGlobalProgrammerAvailable();
         }
-        if (type.equals(jmri.AddressedProgrammerManager.class)) {
+        if (type.equals(AddressedProgrammerManager.class)) {
             return getProgrammerManager().isAddressedModePossible();
         }
 
-        if (type.equals(jmri.ThrottleManager.class)) {
+        if (type.equals(ThrottleManager.class)) {
             return true;
         }
-        if (type.equals(jmri.PowerManager.class)) {
+        if (type.equals(PowerManager.class)) {
             return true;
         }
-        if (type.equals(jmri.SensorManager.class)) {
+        if (type.equals(SensorManager.class)) {
             return true;
         }
-        if (type.equals(jmri.TurnoutManager.class)) {
+        if (type.equals(TurnoutManager.class)) {
             return true;
         }
-        if (type.equals(jmri.LightManager.class)) {
+        if (type.equals(LightManager.class)) {
             return true;
         }
-        if (type.equals(jmri.ReporterManager.class)) {
+        if (type.equals(ReporterManager.class)) {
             return true;
         }
-        if (type.equals(jmri.ConsistManager.class)) {
+        if (type.equals(ConsistManager.class)) {
             return true;
         }
-        if (type.equals(jmri.ClockControl.class)) {
+        if (type.equals(ClockControl.class)) {
             return true;
         }
-        if (type.equals(jmri.CommandStation.class)) {
+        if (type.equals(CommandStation.class)) {
             return true;
         }
         return super.provides(type);
@@ -185,38 +196,38 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
         if (getDisabled()) {
             return null;
         }
-        if (T.equals(jmri.GlobalProgrammerManager.class)) {
+        if (T.equals(GlobalProgrammerManager.class)) {
             return (T) getProgrammerManager();
         }
-        if (T.equals(jmri.AddressedProgrammerManager.class)) {
+        if (T.equals(AddressedProgrammerManager.class)) {
             return (T) getProgrammerManager();
         }
 
-        if (T.equals(jmri.ThrottleManager.class)) {
+        if (T.equals(ThrottleManager.class)) {
             return (T) getThrottleManager();
         }
-        if (T.equals(jmri.PowerManager.class)) {
+        if (T.equals(PowerManager.class)) {
             return (T) getPowerManager();
         }
-        if (T.equals(jmri.SensorManager.class)) {
+        if (T.equals(SensorManager.class)) {
             return (T) getSensorManager();
         }
-        if (T.equals(jmri.TurnoutManager.class)) {
+        if (T.equals(TurnoutManager.class)) {
             return (T) getTurnoutManager();
         }
-        if (T.equals(jmri.LightManager.class)) {
+        if (T.equals(LightManager.class)) {
             return (T) getLightManager();
         }
-        if (T.equals(jmri.ClockControl.class)) {
+        if (T.equals(ClockControl.class)) {
             return (T) getClockControl();
         }
-        if (T.equals(jmri.ReporterManager.class)) {
+        if (T.equals(ReporterManager.class)) {
             return (T) getReporterManager();
         }
-        if (T.equals(jmri.ConsistManager.class)) {
+        if (T.equals(ConsistManager.class)) {
             return (T) getConsistManager();
         }
-        if (T.equals(jmri.CommandStation.class)) {
+        if (T.equals(CommandStation.class)) {
             return (T) getSlotManager();
         }
         return super.get(T);
@@ -237,7 +248,7 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
             log.debug("set turnout retry: {}", mTurnoutNoRetry);
         }
 
-        InstanceManager.store(getPowerManager(), jmri.PowerManager.class);
+        InstanceManager.store(getPowerManager(), PowerManager.class);
 
         InstanceManager.setSensorManager(
                 getSensorManager());
@@ -261,7 +272,7 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
         InstanceManager.setReporterManager(
                 getReporterManager());
 
-        setConsistManager(new jmri.jmrix.loconet.LocoNetConsistManager(this));
+        setConsistManager(new LocoNetConsistManager(this));
 
         InstanceManager.addClockControl(
                 getClockControl());
@@ -275,7 +286,7 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
             return null;
         }
         if (powerManager == null) {
-            powerManager = new jmri.jmrix.loconet.LnPowerManager(this);
+            powerManager = new LnPowerManager(this);
         }
         return powerManager;
     }
@@ -310,7 +321,7 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
             return null;
         }
         if (turnoutManager == null) {
-            turnoutManager = new jmri.jmrix.loconet.LnTurnoutManager(getLnTrafficController(), tm, getSystemPrefix(), mTurnoutNoRetry);
+            turnoutManager = new LnTurnoutManager(getLnTrafficController(), tm, getSystemPrefix(), mTurnoutNoRetry);
         }
         return turnoutManager;
     }
@@ -322,7 +333,7 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
             return null;
         }
         if (clockControl == null) {
-            clockControl = new jmri.jmrix.loconet.LnClockControl(getSlotManager(), getLnTrafficController());
+            clockControl = new LnClockControl(getSlotManager(), getLnTrafficController());
         }
         return clockControl;
     }
@@ -334,7 +345,7 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
             return null;
         }
         if (reporterManager == null) {
-            reporterManager = new jmri.jmrix.loconet.LnReporterManager(getLnTrafficController(), getSystemPrefix());
+            reporterManager = new LnReporterManager(getLnTrafficController(), getSystemPrefix());
         }
         return reporterManager;
     }
@@ -346,7 +357,7 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
             return null;
         }
         if (sensorManager == null) {
-            sensorManager = new jmri.jmrix.loconet.LnSensorManager(getLnTrafficController(), getSystemPrefix());
+            sensorManager = new LnSensorManager(getLnTrafficController(), getSystemPrefix());
         }
         return sensorManager;
     }
@@ -358,7 +369,7 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
             return null;
         }
         if (lightManager == null) {
-            lightManager = new jmri.jmrix.loconet.LnLightManager(getLnTrafficController(), getSystemPrefix());
+            lightManager = new LnLightManager(getLnTrafficController(), getSystemPrefix());
         }
         return lightManager;
     }
@@ -374,32 +385,32 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
         sm = null;
         InstanceManager.deregister(this, LocoNetSystemConnectionMemo.class);
         if (cf != null) {
-            InstanceManager.deregister(cf, jmri.jmrix.swing.ComponentFactory.class);
+            InstanceManager.deregister(cf, ComponentFactory.class);
         }
         if (powerManager != null) {
-            InstanceManager.deregister(powerManager, jmri.jmrix.loconet.LnPowerManager.class);
+            InstanceManager.deregister(powerManager, LnPowerManager.class);
         }
         if (turnoutManager != null) {
-            InstanceManager.deregister(turnoutManager, jmri.jmrix.loconet.LnTurnoutManager.class);
+            InstanceManager.deregister(turnoutManager, LnTurnoutManager.class);
         }
         if (lightManager != null) {
-            InstanceManager.deregister(lightManager, jmri.jmrix.loconet.LnLightManager.class);
+            InstanceManager.deregister(lightManager, LnLightManager.class);
         }
         if (sensorManager != null) {
-            InstanceManager.deregister(sensorManager, jmri.jmrix.loconet.LnSensorManager.class);
+            InstanceManager.deregister(sensorManager, LnSensorManager.class);
         }
         if (reporterManager != null) {
-            InstanceManager.deregister(reporterManager, jmri.jmrix.loconet.LnReporterManager.class);
+            InstanceManager.deregister(reporterManager, LnReporterManager.class);
         }
         if (throttleManager != null) {
             if (throttleManager instanceof LnThrottleManager) {
-                InstanceManager.deregister(((LnThrottleManager) throttleManager), jmri.jmrix.loconet.LnThrottleManager.class);
-            } else if (throttleManager instanceof jmri.jmrix.debugthrottle.DebugThrottleManager) {
-                InstanceManager.deregister(((jmri.jmrix.debugthrottle.DebugThrottleManager) throttleManager), jmri.jmrix.debugthrottle.DebugThrottleManager.class);
+                InstanceManager.deregister(((LnThrottleManager) throttleManager), LnThrottleManager.class);
+            } else if (throttleManager instanceof DebugThrottleManager) {
+                InstanceManager.deregister(((DebugThrottleManager) throttleManager), DebugThrottleManager.class);
             }
         }
         if (clockControl != null) {
-            InstanceManager.deregister(clockControl, jmri.jmrix.loconet.LnClockControl.class);
+            InstanceManager.deregister(clockControl, LnClockControl.class);
         }
         super.dispose();
     }

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonDataModel.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonDataModel.java
@@ -70,31 +70,6 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
     @Override
     public int getRowCount() {
         return 128;
-        /* handled by filter in SlotMonPane
-        if (_allSlots) {
-            // will show the entire set, so don't bother counting
-            if (_systemSlots) {
-                return 128;
-            } else {
-                return 120;  // skip 0, and 120 through 127
-            }
-        }
-        int n = 0;
-        int nMin = 1;
-        int nMax = 120;
-        if (_systemSlots) {
-            nMin = 0;
-            nMax = 128;
-        }
-        for (int i = nMin; i < nMax; i++) {
-            LocoNetSlot s = memo.getSlotManager().slot(i);
-            if (s.slotStatus() != LnConstants.LOCO_FREE
-                    || i == 0 || i >= 120) {
-                n++;    // always show system slots if requested
-            }
-        }
-        return n;
-         */
     }
 
     @Override
@@ -192,7 +167,7 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
             case F7COLUMN:
             case F8COLUMN:
                 // system slots to be marked Read only
-                return (slotNum(row) < 120);
+                return (row < 120);
             default:
                 return false;
         }
@@ -200,7 +175,7 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
 
     @Override
     public Object getValueAt(int row, int col) {
-        LocoNetSlot s = memo.getSlotManager().slot(slotNum(row));
+        LocoNetSlot s = memo.getSlotManager().slot(row);
         String t;
         if (s == null) {
             log.error("slot pointer was null for slot row: {} col: {}", row, col);
@@ -209,7 +184,7 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
 
         switch (col) {
             case SLOTCOLUMN:  // slot number
-                return slotNum(row);
+                return row;
             case ESTOPCOLUMN:
                 return Bundle.getMessage("ButtonEstop"); // will be name of button in default GUI
             case ADDRCOLUMN:
@@ -348,7 +323,7 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
     public void setValueAt(Object value, int row, int col) {
         int status;
         LocoNetMessage msg;
-        LocoNetSlot s = memo.getSlotManager().slot(slotNum(row));
+        LocoNetSlot s = memo.getSlotManager().slot(row);
         if (s == null) {
             log.error("slot pointer was null for slot row: {} col: {}", row, col);
             return;
@@ -384,7 +359,7 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
             case F3COLUMN:
             case F4COLUMN:
                 log.debug("F0-F4 change requested {}", row);
-                s = memo.getSlotManager().slot(slotNum(row));
+                s = memo.getSlotManager().slot(row);
                 if (s == null) {
                     log.error("slot pointer was null for slot row: {} col: {}", row, col);
                     return;
@@ -514,7 +489,7 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
         int count = getRowCount();
 
         for (int row = 0; row < (count - 1); row++) {
-            LocoNetSlot s = memo.getSlotManager().slot(slotNum(row));
+            LocoNetSlot s = memo.getSlotManager().slot(row);
 
             if ((s.slotStatus() != LnConstants.LOCO_IN_USE) && (s.consistStatus() == LnConstants.CONSIST_NO)) {
                 log.debug("Freeing {} from slot {}, old status: {}", s.locoAddr(), s.getSlot(), s.slotStatus());
@@ -576,33 +551,6 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
                 _model.fireTableRowsUpdated(_row, _row);  // just that row
             }
         }
-    }
-
-    /**
-     * Returns slot number for a specific row.
-     * <P>
-     * This should probably use a local cache instead of counting/searching each
-     * time.
-     *
-     * @param row Row number in the displayed table
-     * @return the slot number for a row
-     */
-    protected int slotNum(int row) {
-        int slotNum;
-        int n = -1;   // need to find a used slot to have the 0th one!
-        int nMin = 0;
-        int nMax = 128;
-        for (slotNum = nMin; slotNum < nMax; slotNum++) {
-            LocoNetSlot s = memo.getSlotManager().slot(slotNum);
-            if (s.slotStatus() != LnConstants.LOCO_FREE
-                    || slotNum == 0 || slotNum >= 120) {
-                n++;    // always show system slots if requested
-            }
-            if (n == row) {
-                break;
-            }
-        }
-        return slotNum;
     }
 
     protected LocoNetSlot getSlot(int row) {

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonDataModel.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonDataModel.java
@@ -1,21 +1,17 @@
 package jmri.jmrix.loconet.slotmon;
 
-import java.awt.event.MouseEvent;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
-import javax.swing.table.TableCellEditor;
-import javax.swing.table.TableColumnModel;
 import jmri.Throttle;
 import jmri.jmrix.loconet.LnConstants;
 import jmri.jmrix.loconet.LocoNetMessage;
 import jmri.jmrix.loconet.LocoNetSlot;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import jmri.jmrix.loconet.SlotListener;
 import jmri.util.StringUtil;
-import jmri.util.table.ButtonEditor;
-import jmri.util.table.ButtonRenderer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,9 +45,9 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
 
     static public final int NUMCOLUMN = 19;
 
-    jmri.jmrix.loconet.LocoNetSystemConnectionMemo memo;
+    private final transient LocoNetSystemConnectionMemo memo;
 
-    SlotMonDataModel(int row, int column, jmri.jmrix.loconet.LocoNetSystemConnectionMemo memo) {
+    SlotMonDataModel(int row, int column, LocoNetSystemConnectionMemo memo) {
         this.memo = memo;
 
         // connect to SlotManager for updates
@@ -68,9 +64,13 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
      * <p>
      * This should probably use a local cache instead of counting/searching each
      * time.
+     *
+     * @return the number of rows
      */
     @Override
     public int getRowCount() {
+        return 128;
+        /* handled by filter in SlotMonPane
         if (_allSlots) {
             // will show the entire set, so don't bother counting
             if (_systemSlots) {
@@ -94,6 +94,7 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
             }
         }
         return n;
+         */
     }
 
     @Override
@@ -181,8 +182,6 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
     @Override
     public boolean isCellEditable(int row, int col) {
         switch (col) {
-            case ESTOPCOLUMN:
-            case DISPCOLUMN:
             case F0COLUMN:
             case F1COLUMN:
             case F2COLUMN:
@@ -193,32 +192,29 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
             case F7COLUMN:
             case F8COLUMN:
                 // system slots to be marked Read only
-                return (Integer.valueOf(slotNum(row)) >= 120) ? false : true;
+                return (slotNum(row) < 120);
             default:
                 return false;
         }
     }
-
-    static final Boolean True = Boolean.valueOf(true);
-    static final Boolean False = Boolean.valueOf(false);
 
     @Override
     public Object getValueAt(int row, int col) {
         LocoNetSlot s = memo.getSlotManager().slot(slotNum(row));
         String t;
         if (s == null) {
-            log.error("slot pointer was null for slot row: " + row + " col: " + col);
+            log.error("slot pointer was null for slot row: {} col: {}", row, col);
             return null;
         }
 
         switch (col) {
             case SLOTCOLUMN:  // slot number
-                return Integer.valueOf(slotNum(row));
-            case ESTOPCOLUMN:  //
+                return slotNum(row);
+            case ESTOPCOLUMN:
                 return Bundle.getMessage("ButtonEstop"); // will be name of button in default GUI
-            case ADDRCOLUMN:  //
-                return Integer.valueOf(s.locoAddr());
-            case SPDCOLUMN:  //
+            case ADDRCOLUMN:
+                return s.locoAddr();
+            case SPDCOLUMN:
                 switch (s.consistStatus()) {
                     case LnConstants.CONSIST_TOP:
                     case LnConstants.CONSIST_NO:
@@ -234,7 +230,7 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
                     default:
                         return Bundle.getMessage("StateError");
                 }
-            case TYPECOLUMN:  //
+            case TYPECOLUMN:
                 switch (s.decoderType()) {
                     case LnConstants.DEC_MODE_128A:
                         return "128 step adv";
@@ -251,7 +247,7 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
                     default:
                         return Bundle.getMessage("StateUnknown");
                 }
-            case STATCOLUMN:  //
+            case STATCOLUMN:
                 switch (s.slotStatus()) {
                     case LnConstants.LOCO_IN_USE:
                         return Bundle.getMessage("StateInUse");
@@ -264,7 +260,7 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
                     default:
                         return Bundle.getMessage("StateError");
                 }
-            case CONSCOLUMN:  //
+            case CONSCOLUMN:
                 switch (s.consistStatus()) {
                     case LnConstants.CONSIST_MID:
                         t = Bundle.getMessage("SlotConsistMidX", s.speed());
@@ -279,41 +275,39 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
                     default:
                         return Bundle.getMessage("StateError");
                 }
-            case DISPCOLUMN:  //
+            case DISPCOLUMN:
                 return Bundle.getMessage("ButtonRelease"); // will be name of button in default GUI
-            case DIRCOLUMN:  //
-                return (s.isForward() ? Bundle.getMessage("DirColForward") : Bundle.getMessage("DirColReverse"));
-            case F0COLUMN:  //
-                return (s.isF0() ? True : False);
-            case F1COLUMN:  //
-                return (s.isF1() ? True : False);
-            case F2COLUMN:  //
-                return (s.isF2() ? True : False);
-            case F3COLUMN:  //
-                return (s.isF3() ? True : False);
-            case F4COLUMN:  //
-                return (s.isF4() ? True : False);
-            case F5COLUMN:  //
-                return (s.isF5() ? True : False);
-            case F6COLUMN:  //
-                return (s.isF6() ? True : False);
-            case F7COLUMN:  //
-                return (s.isF7() ? True : False);
-            case F8COLUMN:  //
-                return (s.isF8() ? True : False);
+            case DIRCOLUMN:
+                return s.isForward() ? Bundle.getMessage("DirColForward") : Bundle.getMessage("DirColReverse");
+            case F0COLUMN:
+                return s.isF0();
+            case F1COLUMN:
+                return s.isF1();
+            case F2COLUMN:
+                return s.isF2();
+            case F3COLUMN:
+                return s.isF3();
+            case F4COLUMN:
+                return s.isF4();
+            case F5COLUMN:
+                return s.isF5();
+            case F6COLUMN:
+                return s.isF6();
+            case F7COLUMN:
+                return s.isF7();
+            case F8COLUMN:
+                return s.isF8();
             case THROTCOLUMN:
                 int upper = (s.id() >> 7) & 0x7F;
                 int lower = s.id() & 0x7F;
                 return StringUtil.twoHexFromInt(upper) + " " + StringUtil.twoHexFromInt(lower);
 
             default:
-                log.error("internal state inconsistent with table requst for " + row + " " + col);
+                log.error("internal state inconsistent with table requst for {} {}", row, col);
                 return null;
         }
-    }         
-   
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "DB_DUPLICATE_SWITCH_CLAUSES",
-                                justification="better to keep cases in column order rather than to combine")
+    }
+
     public int getPreferredWidth(int col) {
         switch (col) {
             case SLOTCOLUMN:
@@ -323,11 +317,10 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
             case ADDRCOLUMN:
                 return new JTextField(5).getPreferredSize().width;
             case SPDCOLUMN:
+            case STATCOLUMN:
                 return new JTextField(6).getPreferredSize().width;
             case TYPECOLUMN:
                 return new JTextField(12).getPreferredSize().width;
-            case STATCOLUMN:
-                return new JTextField(6).getPreferredSize().width;
             case CONSCOLUMN:
                 return new JTextField(4).getPreferredSize().width;
             case DIRCOLUMN:
@@ -353,153 +346,24 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
 
     @Override
     public void setValueAt(Object value, int row, int col) {
-        int status = 0;
+        int status;
+        LocoNetMessage msg;
+        LocoNetSlot s = memo.getSlotManager().slot(slotNum(row));
+        if (s == null) {
+            log.error("slot pointer was null for slot row: {} col: {}", row, col);
+            return;
+        }
 
-        if (col == ESTOPCOLUMN) {
-            log.debug("Start estop in slot " + row);
-            // check for in use
-            LocoNetSlot s = memo.getSlotManager().slot(slotNum(row));
-            if (s == null) {
-                log.error("slot pointer was null for slot row: " + row + " col: " + col);
-                return;
-            }
-            if ((s.consistStatus() == LnConstants.CONSIST_SUB)
-                    || (s.consistStatus() == LnConstants.CONSIST_MID)) {
-                Object[] options = {Bundle.getMessage("ButtonOK"), Bundle.getMessage("ButtonCancel")};
-                int result
-                        = JOptionPane.showOptionDialog(null,
-                                Bundle.getMessage("SlotEstopWarning"),
-                                Bundle.getMessage("WarningTitle"),
-                                JOptionPane.DEFAULT_OPTION,
-                                JOptionPane.WARNING_MESSAGE,
-                                null, options, options[1]);
-                if (result == 1) {
-                    return;
-                }
-            }
-            LocoNetMessage msg = new LocoNetMessage(4);
-            msg.setOpCode(LnConstants.OPC_LOCO_SPD);
-            msg.setElement(1, s.getSlot());
-            msg.setElement(2, 1);       // 1 here is estop
-            memo.getLnTrafficController().sendLocoNetMessage(msg);
-            fireTableRowsUpdated(row, row);
-        } else if ((col == F0COLUMN)
-                || (col == F1COLUMN)
-                || (col == F2COLUMN)
-                || (col == F3COLUMN)
-                || (col == F4COLUMN)) {
-            log.debug("F0-F4 change requested " + row);
-            LocoNetSlot s = memo.getSlotManager().slot(slotNum(row));
-            if (s == null) {
-                log.error("slot pointer was null for slot row: " + row + " col: " + col);
-                return;
-            }
-            boolean tempF0 = (col == F0COLUMN) ? !s.isF0() : s.isF0();
-            boolean tempF1 = (col == F1COLUMN) ? !s.isF1() : s.isF1();
-            boolean tempF2 = (col == F2COLUMN) ? !s.isF2() : s.isF2();
-            boolean tempF3 = (col == F3COLUMN) ? !s.isF3() : s.isF3();
-            boolean tempF4 = (col == F4COLUMN) ? !s.isF4() : s.isF4();
-
-            int new_dirf = ((s.isForward() ? 0 : LnConstants.DIRF_DIR)
-                    | (tempF0 ? LnConstants.DIRF_F0 : 0)
-                    | (tempF1 ? LnConstants.DIRF_F1 : 0)
-                    | (tempF2 ? LnConstants.DIRF_F2 : 0)
-                    | (tempF3 ? LnConstants.DIRF_F3 : 0)
-                    | (tempF4 ? LnConstants.DIRF_F4 : 0));
-
-            // set status to 'In Use' if other
-            status = s.slotStatus();
-            if (status != LnConstants.LOCO_IN_USE) {
-                memo.getLnTrafficController().sendLocoNetMessage(
-                        s.writeStatus(LnConstants.LOCO_IN_USE
-                        ));
-            }
-            LocoNetMessage msg = new LocoNetMessage(4);
-            msg.setOpCode(LnConstants.OPC_LOCO_DIRF);
-            msg.setElement(1, s.getSlot());
-            msg.setElement(2, new_dirf);       // 1 here is estop
-            memo.getLnTrafficController().sendLocoNetMessage(msg);
-            // Delay here allows command station time to xmit on the rails.
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException ex) {
-                log.error(null, ex);
-            }
-            // reset status to original value if not previously 'in use'
-            if (status != LnConstants.LOCO_IN_USE) {
-                memo.getLnTrafficController().sendLocoNetMessage(
-                        s.writeStatus(status));
-            }
-            fireTableRowsUpdated(row, row);
-        } else if ((col == F5COLUMN)
-                || (col == F6COLUMN)
-                || (col == F7COLUMN)
-                || (col == F8COLUMN)) {
-            log.debug("F5-F8 change requested " + row);
-            LocoNetSlot s = memo.getSlotManager().slot(slotNum(row));
-            if (s == null) {
-                log.error("slot pointer was null for slot row: " + row + " col: " + col);
-                return;
-            }
-
-            boolean tempF5 = (col == F5COLUMN) ? !s.isF5() : s.isF5();
-            boolean tempF6 = (col == F6COLUMN) ? !s.isF6() : s.isF6();
-            boolean tempF7 = (col == F7COLUMN) ? !s.isF7() : s.isF7();
-            boolean tempF8 = (col == F8COLUMN) ? !s.isF8() : s.isF8();
-
-            int new_snd = ((tempF8 ? LnConstants.SND_F8 : 0)
-                    | (tempF7 ? LnConstants.SND_F7 : 0)
-                    | (tempF6 ? LnConstants.SND_F6 : 0)
-                    | (tempF5 ? LnConstants.SND_F5 : 0));
-
-            // set status to 'In Use' if other
-            status = s.slotStatus();
-            if (status != LnConstants.LOCO_IN_USE) {
-                memo.getLnTrafficController().sendLocoNetMessage(
-                        s.writeStatus(LnConstants.LOCO_IN_USE
-                        ));
-            }
-
-            LocoNetMessage msg = new LocoNetMessage(4);
-            msg.setOpCode(LnConstants.OPC_LOCO_SND);
-            msg.setElement(1, s.getSlot());
-            msg.setElement(2, new_snd);       // 1 here is estop
-            memo.getLnTrafficController().sendLocoNetMessage(msg);
-            // Delay here allows command station time to xmit on the rails.
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException ex) {
-                log.error(null, ex);
-            }
-
-            // reset status to original value if not previously 'in use'
-            if (status != LnConstants.LOCO_IN_USE) {
-                memo.getLnTrafficController().sendLocoNetMessage(
-                        s.writeStatus(status));
-            }
-
-            fireTableRowsUpdated(row, row);
-        } else if (col == DISPCOLUMN) {
-            log.debug("Start freeing slot " + row);
-            // check for in use
-            LocoNetSlot s = memo.getSlotManager().slot(slotNum(row));
-            if (s == null) {
-                log.error("slot pointer was null for slot row: " + row + " col: " + col);
-                return;
-            }
-            if (s.slotStatus() != LnConstants.LOCO_FREE) {
-                if (s.consistStatus() != LnConstants.CONSIST_NO) {
-                    // Freeing a member takes it out of the consist
-                    // entirely (i.e., while the slot is LOCO_FREE, it
-                    // still reads the former consist information, but
-                    // the next time that loco is selected, it comes
-                    // back as CONSIST_NO).  Freeing the CONSIST_TOP
-                    // will kill the entire consist.
-                    Object[] options = {"OK", "Cancel"};
+        switch (col) {
+            case ESTOPCOLUMN:
+                log.debug("Start estop in slot {}", row);
+                if ((s.consistStatus() == LnConstants.CONSIST_SUB)
+                        || (s.consistStatus() == LnConstants.CONSIST_MID)) {
+                    Object[] options = {Bundle.getMessage("ButtonOK"), Bundle.getMessage("ButtonCancel")};
                     int result
                             = JOptionPane.showOptionDialog(null,
-                                    "Freeing a consist member will destroy the consist.\n\nAre you sure you want to do that?",
-                                    "Warning",
+                                    Bundle.getMessage("SlotEstopWarning"),
+                                    Bundle.getMessage("WarningTitle"),
                                     JOptionPane.DEFAULT_OPTION,
                                     JOptionPane.WARNING_MESSAGE,
                                     null, options, options[1]);
@@ -507,18 +371,144 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
                         return;
                     }
                 }
-                // send status to free
-                memo.getLnTrafficController().sendLocoNetMessage(
-                        s.writeStatus(LnConstants.LOCO_FREE
-                        ));
-            } else {
-                log.debug("Slot not in use");
-            }
-            fireTableRowsUpdated(row, row);
+                msg = new LocoNetMessage(4);
+                msg.setOpCode(LnConstants.OPC_LOCO_SPD);
+                msg.setElement(1, s.getSlot());
+                msg.setElement(2, 1);       // 1 here is estop
+                memo.getLnTrafficController().sendLocoNetMessage(msg);
+                fireTableRowsUpdated(row, row);
+                break;
+            case F0COLUMN:
+            case F1COLUMN:
+            case F2COLUMN:
+            case F3COLUMN:
+            case F4COLUMN:
+                log.debug("F0-F4 change requested {}", row);
+                s = memo.getSlotManager().slot(slotNum(row));
+                if (s == null) {
+                    log.error("slot pointer was null for slot row: {} col: {}", row, col);
+                    return;
+                }
+                boolean tempF0 = (col == F0COLUMN) ? !s.isF0() : s.isF0();
+                boolean tempF1 = (col == F1COLUMN) ? !s.isF1() : s.isF1();
+                boolean tempF2 = (col == F2COLUMN) ? !s.isF2() : s.isF2();
+                boolean tempF3 = (col == F3COLUMN) ? !s.isF3() : s.isF3();
+                boolean tempF4 = (col == F4COLUMN) ? !s.isF4() : s.isF4();
+
+                int new_dirf = ((s.isForward() ? 0 : LnConstants.DIRF_DIR)
+                        | (tempF0 ? LnConstants.DIRF_F0 : 0)
+                        | (tempF1 ? LnConstants.DIRF_F1 : 0)
+                        | (tempF2 ? LnConstants.DIRF_F2 : 0)
+                        | (tempF3 ? LnConstants.DIRF_F3 : 0)
+                        | (tempF4 ? LnConstants.DIRF_F4 : 0));
+
+                // set status to 'In Use' if other
+                status = s.slotStatus();
+                if (status != LnConstants.LOCO_IN_USE) {
+                    memo.getLnTrafficController().sendLocoNetMessage(
+                            s.writeStatus(LnConstants.LOCO_IN_USE
+                            ));
+                }
+                msg = new LocoNetMessage(4);
+                msg.setOpCode(LnConstants.OPC_LOCO_DIRF);
+                msg.setElement(1, s.getSlot());
+                msg.setElement(2, new_dirf);       // 1 here is estop
+                memo.getLnTrafficController().sendLocoNetMessage(msg);
+                // Delay here allows command station time to xmit on the rails.
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ex) {
+                    log.error(null, ex);
+                }
+                // reset status to original value if not previously 'in use'
+                if (status != LnConstants.LOCO_IN_USE) {
+                    memo.getLnTrafficController().sendLocoNetMessage(
+                            s.writeStatus(status));
+                }
+                fireTableRowsUpdated(row, row);
+                break;
+            case F5COLUMN:
+            case F6COLUMN:
+            case F7COLUMN:
+            case F8COLUMN:
+                log.debug("F5-F8 change requested {}", row);
+
+                boolean tempF5 = (col == F5COLUMN) ? !s.isF5() : s.isF5();
+                boolean tempF6 = (col == F6COLUMN) ? !s.isF6() : s.isF6();
+                boolean tempF7 = (col == F7COLUMN) ? !s.isF7() : s.isF7();
+                boolean tempF8 = (col == F8COLUMN) ? !s.isF8() : s.isF8();
+
+                int new_snd = ((tempF8 ? LnConstants.SND_F8 : 0)
+                        | (tempF7 ? LnConstants.SND_F7 : 0)
+                        | (tempF6 ? LnConstants.SND_F6 : 0)
+                        | (tempF5 ? LnConstants.SND_F5 : 0));
+
+                // set status to 'In Use' if other
+                status = s.slotStatus();
+                if (status != LnConstants.LOCO_IN_USE) {
+                    memo.getLnTrafficController().sendLocoNetMessage(
+                            s.writeStatus(LnConstants.LOCO_IN_USE
+                            ));
+                }
+
+                msg = new LocoNetMessage(4);
+                msg.setOpCode(LnConstants.OPC_LOCO_SND);
+                msg.setElement(1, s.getSlot());
+                msg.setElement(2, new_snd);       // 1 here is estop
+                memo.getLnTrafficController().sendLocoNetMessage(msg);
+                // Delay here allows command station time to xmit on the rails.
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ex) {
+                    log.error(null, ex);
+                }
+
+                // reset status to original value if not previously 'in use'
+                if (status != LnConstants.LOCO_IN_USE) {
+                    memo.getLnTrafficController().sendLocoNetMessage(
+                            s.writeStatus(status));
+                }
+
+                fireTableRowsUpdated(row, row);
+                break;
+            case DISPCOLUMN:
+                log.debug("Start freeing slot {}", row);
+                if (s.slotStatus() != LnConstants.LOCO_FREE) {
+                    if (s.consistStatus() != LnConstants.CONSIST_NO) {
+                        // Freeing a member takes it out of the consist
+                        // entirely (i.e., while the slot is LOCO_FREE, it
+                        // still reads the former consist information, but
+                        // the next time that loco is selected, it comes
+                        // back as CONSIST_NO).  Freeing the CONSIST_TOP
+                        // will kill the entire consist.
+                        Object[] options = {"OK", "Cancel"};
+                        int result
+                                = JOptionPane.showOptionDialog(null,
+                                        "Freeing a consist member will destroy the consist.\n\nAre you sure you want to do that?",
+                                        "Warning",
+                                        JOptionPane.DEFAULT_OPTION,
+                                        JOptionPane.WARNING_MESSAGE,
+                                        null, options, options[1]);
+                        if (result == 1) {
+                            return;
+                        }
+                    }
+                    // send status to free
+                    memo.getLnTrafficController().sendLocoNetMessage(
+                            s.writeStatus(LnConstants.LOCO_FREE
+                            ));
+                } else {
+                    log.debug("Slot not in use");
+                }
+                fireTableRowsUpdated(row, row);
+                break;
+            default:
+                // nothing to do if column not recognized
+                break;
         }
     }
 
-    //Added by Jeffrey Machacek, date: 2013 
+    //Added by Jeffrey Machacek, date: 2013
     //changed 8/22/2013
     public void clearAllSlots() {
         int count = getRowCount();
@@ -542,57 +532,9 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
      * optional, in that other table formats can use this table model. But we
      * put it here to help keep it consistent.
      *
+     * @param slotTable the table to configure
      */
     public void configureTable(JTable slotTable) {
-        // allow reordering of the columns
-        slotTable.getTableHeader().setReorderingAllowed(true);
-
-        // shut off autoResizeMode to get horizontal scroll to work (JavaSwing p 541)
-        slotTable.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
-
-        // resize columns as requested
-        for (int i = 0; i < slotTable.getColumnCount(); i++) {
-            int width = getPreferredWidth(i);
-            slotTable.getColumnModel().getColumn(i).setPreferredWidth(width);
-        }
-        slotTable.sizeColumnsToFit(-1);
-
-        // install a button renderer & editor in the "DISP" column for freeing a slot
-        setColumnToHoldButton(slotTable, SlotMonDataModel.DISPCOLUMN);
-
-        // install a button renderer & editor in the "ESTOP" column for stopping a loco
-        setColumnToHoldEStopButton(slotTable, SlotMonDataModel.ESTOPCOLUMN);
-    }
-
-    void setColumnToHoldButton(JTable slotTable, int column) {
-        TableColumnModel tcm = slotTable.getColumnModel();
-        // install the button renderers & editors in this column
-        ButtonRenderer buttonRenderer = new ButtonRenderer();
-        tcm.getColumn(column).setCellRenderer(buttonRenderer);
-        TableCellEditor buttonEditor = new ButtonEditor(new JButton());
-        tcm.getColumn(column).setCellEditor(buttonEditor);
-        // ensure the table rows, columns have enough room for buttons
-        slotTable.setRowHeight(new JButton("  " + getValueAt(1, column)).getPreferredSize().height);
-        slotTable.getColumnModel().getColumn(column)
-                .setPreferredWidth(new JButton("  " + getValueAt(1, column)).getPreferredSize().width);
-    }
-
-    void setColumnToHoldEStopButton(JTable slotTable, int column) {
-        TableColumnModel tcm = slotTable.getColumnModel();
-        // install the button renderers & editors in this column
-        ButtonRenderer buttonRenderer = new ButtonRenderer();
-        tcm.getColumn(column).setCellRenderer(buttonRenderer);
-        TableCellEditor buttonEditor = new ButtonEditor(new JButton()) {
-            @Override
-            public void mousePressed(MouseEvent e) {
-                stopCellEditing();
-            }
-        };
-        tcm.getColumn(column).setCellEditor(buttonEditor);
-        // ensure the table rows, columns have enough room for buttons
-        slotTable.setRowHeight(new JButton("  " + getValueAt(1, column)).getPreferredSize().height);
-        slotTable.getColumnModel().getColumn(column)
-                .setPreferredWidth(new JButton("  " + getValueAt(1, column)).getPreferredSize().width);
     }
 
     // methods to communicate with SlotManager
@@ -608,24 +550,16 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
                 memo.getSlotManager().update();
             }
         } else {
-            slotNum = -1;
+            slotNum = -1; // all rows
         }
 
-        if (_allSlots) {        // this will be row until we show only active slots
-            slotNum = s.getSlot();  // and we are displaying the System slots otherwise
-            if (!_systemSlots) // we need to subtract 1 as slot 0 will not be displayed
-            {
-                slotNum--;
-            }
-        }
         // notify the JTable object that a row has changed; do that in the Swing thread!
-        Runnable r = new Notify(slotNum, this);   // -1 in first arg means all
-        javax.swing.SwingUtilities.invokeLater(r);
+        javax.swing.SwingUtilities.invokeLater(new Notify(slotNum, this));
     }
 
-    static class Notify implements Runnable {
+    static private class Notify implements Runnable {
 
-        private int _row;
+        private final int _row;
         javax.swing.table.AbstractTableModel _model;
 
         public Notify(int row, javax.swing.table.AbstractTableModel model) {
@@ -644,20 +578,6 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
         }
     }
 
-    // methods for control of "all slots" vs "only active slots"
-    private boolean _allSlots = true;
-
-    public void showAllSlots(boolean val) {
-        _allSlots = val;
-    }
-
-    // methods for control of display of system slots
-    private boolean _systemSlots = true;
-
-    public void showSystemSlots(boolean val) {
-        _systemSlots = val;
-    }
-
     /**
      * Returns slot number for a specific row.
      * <P>
@@ -665,19 +585,16 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
      * time.
      *
      * @param row Row number in the displayed table
+     * @return the slot number for a row
      */
     protected int slotNum(int row) {
         int slotNum;
         int n = -1;   // need to find a used slot to have the 0th one!
-        int nMin = 1;
-        int nMax = 120;
-        if (_systemSlots) {
-            nMin = 0;
-            nMax = 128;
-        }
+        int nMin = 0;
+        int nMax = 128;
         for (slotNum = nMin; slotNum < nMax; slotNum++) {
             LocoNetSlot s = memo.getSlotManager().slot(slotNum);
-            if (_allSlots || s.slotStatus() != LnConstants.LOCO_FREE
+            if (s.slotStatus() != LnConstants.LOCO_FREE
                     || slotNum == 0 || slotNum >= 120) {
                 n++;    // always show system slots if requested
             }
@@ -686,6 +603,10 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
             }
         }
         return slotNum;
+    }
+
+    protected LocoNetSlot getSlot(int row) {
+        return memo.getSlotManager().slot(row);
     }
 
     /**
@@ -711,8 +632,6 @@ public class SlotMonDataModel extends javax.swing.table.AbstractTableModel imple
 
     public void dispose() {
         memo.getSlotManager().removeSlotListener(this);
-        // table.removeAllElements();
-        // table = null;
     }
 
     private final static Logger log = LoggerFactory.getLogger(SlotMonDataModel.class);

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
@@ -11,8 +11,10 @@ import javax.swing.JTable;
 import javax.swing.RowFilter;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableRowSorter;
+import jmri.InstanceManager;
 import jmri.jmrix.loconet.LnConstants;
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
+import jmri.swing.JmriJTablePersistenceManager;
 import jmri.util.table.ButtonRenderer;
 
 /**
@@ -53,8 +55,12 @@ public class SlotMonPane extends jmri.jmrix.loconet.swing.LnPanel {
 
         slotModel = new SlotMonDataModel(128, 16, memo);
         slotTable = new JTable(slotModel);
+        slotTable.setName(this.getTitle());
         sorter = new TableRowSorter<>(slotModel);
         slotTable.setRowSorter(sorter);
+        InstanceManager.getOptionalDefault(JmriJTablePersistenceManager.class).ifPresent((tpm) -> {
+            tpm.persist(slotTable, true);
+        });
         slotScroll = new JScrollPane(slotTable);
 
         // configure items for GUI

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
@@ -58,9 +58,6 @@ public class SlotMonPane extends jmri.jmrix.loconet.swing.LnPanel {
         slotTable.setName(this.getTitle());
         sorter = new TableRowSorter<>(slotModel);
         slotTable.setRowSorter(sorter);
-        InstanceManager.getOptionalDefault(JmriJTablePersistenceManager.class).ifPresent((tpm) -> {
-            tpm.persist(slotTable, true);
-        });
         slotScroll = new JScrollPane(slotTable);
 
         // configure items for GUI
@@ -87,11 +84,18 @@ public class SlotMonPane extends jmri.jmrix.loconet.swing.LnPanel {
         }
         slotTable.sizeColumnsToFit(-1);
 
+        InstanceManager.getOptionalDefault(JmriJTablePersistenceManager.class).ifPresent((tpm) -> {
+            // unable to persist because Default class provides no mechanism to
+            // ensure window is destroyed when closed or that existing window is
+            // reused when hidden and user reopens it from menu
+            // tpm.persist(slotTable, true);
+        });
+
         // install a button renderer & editor in the "DISP" column for freeing a slot
-        setColumnToHoldButton(slotTable, SlotMonDataModel.DISPCOLUMN);
+        setColumnToHoldButton(slotTable, slotTable.convertColumnIndexToView(SlotMonDataModel.DISPCOLUMN));
 
         // install a button renderer & editor in the "ESTOP" column for stopping a loco
-        setColumnToHoldEStopButton(slotTable, SlotMonDataModel.ESTOPCOLUMN);
+        setColumnToHoldEStopButton(slotTable, slotTable.convertColumnIndexToView(SlotMonDataModel.ESTOPCOLUMN));
 
         // add listener object so checkboxes function
         showUnusedCheckBox.addActionListener((ActionEvent e) -> {

--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
@@ -172,7 +172,6 @@ public class SlotMonPane extends jmri.jmrix.loconet.swing.LnPanel {
     }
 
     private void filter() {
-        // This filter is probably incorrect
         RowFilter<SlotMonDataModel, Integer> rf = new RowFilter<SlotMonDataModel, Integer>() {
             @Override
             public boolean include(RowFilter.Entry<? extends SlotMonDataModel, ? extends Integer> entry) {

--- a/java/src/jmri/jmrix/loconet/swing/LnPanel.java
+++ b/java/src/jmri/jmrix/loconet/swing/LnPanel.java
@@ -36,12 +36,19 @@ abstract public class LnPanel extends jmri.util.swing.JmriPanel implements LnPan
         }
     }
 
-    public String getTitle(String menuTitle) { return getTitleHelper(memo, menuTitle); }
-    
+    public String getTitle(String menuTitle) {
+        return getTitleHelper(memo, menuTitle);
+    }
+
     /**
      * Create menu title from connection name.
      * <p>
-     * Static to allow code to be shared by other LnPanelInterface implementations.
+     * Static to allow code to be shared by other LnPanelInterface
+     * implementations.
+     *
+     * @param memo      the memo to get connection name from
+     * @param menuTitle window title
+     * @return window title with connection name
      */
     public static String getTitleHelper(LocoNetSystemConnectionMemo memo, String menuTitle) {
         String uName = "";

--- a/java/src/jmri/managers/AbstractReporterManager.java
+++ b/java/src/jmri/managers/AbstractReporterManager.java
@@ -164,14 +164,14 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
 
     /**
      * Provide a manager-agnostic tooltip for the Add new item beantable pane.
+     *
+     * @return the tooltip
      */
     @Override
     public String getEntryToolTip() {
-        String entryToolTip = "Enter a number from 1 to 9999"; // Basic number format help
-        return entryToolTip;
+        return "Enter a number from 1 to 9999"; // Basic number format help
     }
 
     private final static Logger log = LoggerFactory.getLogger(AbstractReporterManager.class);
 
 }
-

--- a/java/src/jmri/util/swing/JmriNamedPaneAction.java
+++ b/java/src/jmri/util/swing/JmriNamedPaneAction.java
@@ -20,7 +20,7 @@ public class JmriNamedPaneAction extends JmriAbstractAction {
      * Constructor that associates a newly created panel with the given window, showing a name
      *
      * @param s         Human-readable panel name for display by the action
-     * @param wi        Window into which to install the new panel. If you want it to be put into a existing 
+     * @param wi        Window into which to install the new panel. If you want it to be put into a existing
      *                  one, provide a reference. To create a new window
      *                  containing just this pane, use "new jmri.util.swing.sdi.JmriJFrameInterface()"
      * @param paneClass Name of the panel's class, which must be a subclass of JmriPanel. That's not
@@ -37,7 +37,7 @@ public class JmriNamedPaneAction extends JmriAbstractAction {
      *
      * @param s         Human-readable panel name for display by the action
      * @param i         Icon for display by the action
-     * @param wi        Window into which to install the new panel. If you want it to be put into a existing 
+     * @param wi        Window into which to install the new panel. If you want it to be put into a existing
      *                  one, provide a reference. To create a new window
      *                  containing just this pane, use "new jmri.util.swing.sdi.JmriJFrameInterface()"
      * @param paneClass Name of the panel's class, which must be a subclass of JmriPanel. That's not
@@ -65,7 +65,7 @@ public class JmriNamedPaneAction extends JmriAbstractAction {
 
     /**
      * Invoked as part of the action being invoked, e.g. when button pressed
-     * or menu item selected, this runs the panel through the initial part of 
+     * or menu item selected, this runs the panel through the initial part of
      * its life cycle and installs in the given window interface.
      * <p>
      * It different or additional initialization is needed, inherit from this class and
@@ -80,9 +80,8 @@ public class JmriNamedPaneAction extends JmriAbstractAction {
             p.initContext(context);
 
             return p;
-        } catch (Exception ex) {
-            log.warn("could not load pane class: " + paneClass + " due to:" + ex);
-            ex.printStackTrace();
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
+            log.warn("could not load pane class: {}", paneClass, ex);
             return null;
         }
     }


### PR DESCRIPTION
Fix IndexOutOfBounds errors in the LocoNet Slot Monitor.

This was done by refactoring the Slot Monitor so that:
- the model does not filter the table, but provides the complete model at all times
- the table is never passed to the model as a object to be directly manipulated
- table creation and configuration are the responsibility of the owning panel