### PR TITLE
Ant targets to run remotely

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2373,4 +2373,54 @@
     	</chmod>
     </target>
 
+    <!-- end of distribution build targets -->
+
+    <!-- ============================================================================= -->
+    <!-- Run Remote targets                                                    -->
+    <!-- ============================================================================= -->
+
+    <!-- The following properties should be set in local.properties                    -->
+    <!-- YOu can also set remote.platform.password if you do not mind a clear text     -->
+    <!-- password in local.properties. If you do not set remote.platform.password then -->
+    <!-- you will be prompoted to enter the password each time you run a remote target -->
+
+    <target name="-init-remote-platform-properties">
+        <fail unless="remote.platform.host">Must set remote.platform.host (e.g. IP address) in local.properties</fail>
+        <fail unless="remote.platform.port">Must set remote.platform.port (e.g. 22) in local.properties</fail>
+        <fail unless="remote.platform.user">Must set remote.platform.user (your username on the remote device) local.properties</fail>
+        <fail unless="remote.jmri.dir">Must set remote.jmri.dir (path to JMRI install directory) local.properties</fail>
+    </target>
+    
+    <target name="-ask-password" unless="remote.platform.password">
+        <input message="Password ${remote.platform.user}@${remote.platform.host}:" addproperty="remote.platform.password">
+            <handler type="secure"/>
+        </input>
+    </target>
+
+    <target name="-run-remote-passwd" depends="init, debug, jar, -init-remote-platform-properties, -ask-password">
+        <sequential>
+            <echo message="run with passwd"/>
+            <scp file="./jmri.jar" todir="${remote.platform.user}@${remote.platform.host}:${remote.jmri.dir}" port="${remote.platform.port}" password="${remote.platform.password}" trust="true"> </scp>
+            <sshexec host="${remote.platform.host}" port="${remote.platform.port}" username="${remote.platform.user}" password="${remote.platform.password}" trust="true" usepty="true"
+                command="export DISPLAY=:0; cd '${remote.jmri.dir}'; ${remote.jmri.app} "/>
+        </sequential>
+    </target>
+
+    <target name="decoderpro-remote"
+        description="build and run DecoderPro on remote target"
+        depends="-init-remote-platform-properties">
+        <property name="remote.jmri.app" value="${remote.jmri.dir}/DecoderPro"/>
+        <antcall target="-run-remote-passwd"/>
+    </target>
+
+    <target name="panelpro-remote"
+        description="build and run PanelPro app on remote target"
+        depends="-init-remote-platform-properties">
+        <property name="remote.jmri.app" value="${remote.jmri.dir}/PanelPro"/>
+        <antcall target="-run-remote-passwd"/>
+    </target>
+
+    <!-- end of run remote targets -->
+
+
 </project>

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -196,6 +196,16 @@
                         <label>Run DecoderPro</label>
                         <target>decoderpro</target>
                     </action>
+                    <action>
+                        <script>${ant.script}</script>
+                        <label>Run Remote DecoderPro</label>
+                        <target>decoderpro-remote</target>
+                    </action>
+                    <action>
+                        <script>${ant.script}</script>
+                        <label>Run Remote PanelPro</label>
+                        <target>panelpro-remote</target>
+                    </action>
                 </context-menu>
             </view>
             <subprojects/>


### PR DESCRIPTION
Ant target to build, create jar and copy to a remote system where JMRI has been installed. Tested in NetBeans