### PR TITLE
Basic fix to Comparator for system names

### DIFF
--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -75,7 +75,7 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
         dataTable.setRowHeight(InstanceManager.getDefault(GuiLafPreferencesManager.class).getFontSize() + 4);
 
         // Use a "Numeric, if not, Alphanumeric" comparator
-        sorter.setComparator(RosterTableModel.IDCOL, new jmri.util.PreferNumericComparator());
+        sorter.setComparator(RosterTableModel.IDCOL, new jmri.util.AlphanumComparator());
 
         // set initial sort
         List<RowSorter.SortKey> sortKeys = new ArrayList<>();

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
@@ -2150,7 +2150,7 @@ public class PaneProgPane extends javax.swing.JPanel
 
         JTable cvTable = new JTable(_cvModel);
 
-        sorter.setComparator(CvTableModel.NUMCOLUMN, new jmri.util.PreferNumericComparator());
+        sorter.setComparator(CvTableModel.NUMCOLUMN, new jmri.util.AlphanumComparator());
 
         List<RowSorter.SortKey> sortKeys = new ArrayList<>();
         sortKeys.add(new RowSorter.SortKey(0, SortOrder.ASCENDING));

--- a/java/src/jmri/jmrix/loconet/soundloader/EditorFilePane.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/EditorFilePane.java
@@ -53,7 +53,7 @@ public class EditorFilePane extends javax.swing.JPanel {
 
         // give system name column a smarter sorter and use it initially
         TableRowSorter<EditorTableDataModel> sorter = new TableRowSorter<>(dataModel);
-        sorter.setComparator(EditorTableDataModel.HEADERCOL, new SystemNameComparator());
+        // uses default Comparator for Integer HEADERCOL
         RowSorterUtil.setSortOrder(sorter, EditorTableDataModel.HEADERCOL, SortOrder.ASCENDING);
 
         // configure items for GUI

--- a/java/src/jmri/util/AlphanumComparator.java
+++ b/java/src/jmri/util/AlphanumComparator.java
@@ -44,7 +44,7 @@ import java.util.Comparator;
  * 0001 is seem as larger than 1 because it's the longer number. A
  * version that does not compare leading zeros is forthcoming.
  */
-public final class AlphanumComparator implements Comparator<String> {
+public class AlphanumComparator implements Comparator<String> {
 
     private final boolean isDigit(char ch) {
         return (('0' <= ch) && (ch <= '9'));
@@ -101,6 +101,9 @@ public final class AlphanumComparator implements Comparator<String> {
                 break;
             }
         }
+        if (result == 0 && marker1 == length1 && marker2 < length2) return -1;
+        if (result == 0 && marker1 < length1 && marker2 == length2) return +1;
+        
         return result;
     }
 }

--- a/java/src/jmri/util/PreferNumericComparator.java
+++ b/java/src/jmri/util/PreferNumericComparator.java
@@ -7,7 +7,9 @@ import java.util.Comparator;
  * that otherwise as Strings.
  *
  * @author	Bob Jacobsen Copyright (C) 2013
+ * @deprecated 4.11.1 in favor of more-general @{link AlphanumComparator}
  */
+@Deprecated
 public class PreferNumericComparator implements Comparator<Object> {
 
     public PreferNumericComparator() {

--- a/java/src/jmri/util/SystemNameComparator.java
+++ b/java/src/jmri/util/SystemNameComparator.java
@@ -4,83 +4,18 @@ import java.util.Comparator;
 
 /**
  * Comparator for JMRI System Names.
- * <P>
- * A System Name is two letters followed by either an alpha name or a number. In
- * the number case, this does a numeric comparison. If the number is appended
- * with letters, does the numeric sort on the digits followed by a lexigraphic
- * sort on the remainder.
  * <p>
  * Note this is intended to take names as provided:  It does not do normalization or
  * expansion.
  *
- * @author	Bob Jacobsen Copyright (C) 2004
+ * @author	Bob Jacobsen Copyright (C) 2004, 2017
  * @author Howard Penny
  * @author Pete Cressman
  */
-public class SystemNameComparator implements Comparator<Object> {
+public class SystemNameComparator extends AlphanumComparator {
 
     public SystemNameComparator() {
     }
 
-    @Override
-    public int compare(Object o1, Object o2) {
 
-        // if both strings are three or less characters long
-        if (o1.toString().length() <= 3 && o2.toString().length() <= 3) {
-            return o1.toString().compareTo(o2.toString());
-        } else  // if the first two characters of both strings match
-        if (!o1.toString().regionMatches(0, o2.toString(), 0, 2)) {
-            return o1.toString().compareTo(o2.toString());
-        } else {
-            if (true) {
-                AlphanumComparator ac = new AlphanumComparator();
-                return ac.compare(o1.toString(), o2.toString());
-            } else {    //TODO: dead-code strip this
-                // extract length of digits
-                char[] ch1 = o1.toString().substring(2).toCharArray();
-                char[] ch2 = o2.toString().substring(2).toCharArray();
-                int numDigit1 = 0;
-                int numDigit2 = 0;
-                for (int i = 0; i < ch1.length; i++) {
-                    if (Character.isDigit(ch1[i])) {
-                        numDigit1++;
-                    } else {
-                        break;
-                    }
-                }
-                for (int i = 0; i < ch2.length; i++) {
-                    if (Character.isDigit(ch2[i])) {
-                        numDigit2++;
-                    } else {
-                        break;
-                    }
-                }
-                if (numDigit1 == numDigit2) {
-                    try {
-                        int diff = Integer.parseInt(new String(ch1, 0, numDigit1))
-                                - Integer.parseInt(new String(ch2, 0, numDigit2));
-                        if (diff != 0) {
-                            return diff;
-                        }
-                        if (numDigit1 == ch1.length && numDigit2 == ch2.length) {
-                            return diff;
-                        } else {
-                            if (numDigit1 == ch1.length) {
-                                return -1;
-                            }
-                            // both have non-digit chars remaining
-                            return new String(ch1, numDigit1, ch1.length - numDigit1).compareTo(
-                                    new String(ch2, numDigit2, ch2.length - numDigit2));
-                        }
-                    } catch (NumberFormatException nfe) {
-                        return o1.toString().compareTo(o2.toString());
-                    } catch (IndexOutOfBoundsException ioob) {
-                        return o1.toString().compareTo(o2.toString());
-                    }
-                } else {
-                    return (numDigit1 - numDigit2);
-                }
-            }
-        }
-    }
 }

--- a/java/test/jmri/util/AlphanumComparatorTest.java
+++ b/java/test/jmri/util/AlphanumComparatorTest.java
@@ -1,5 +1,6 @@
 package jmri.util;
 
+import java.util.Comparator;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.junit.After;
@@ -14,6 +15,31 @@ import org.junit.Before;
 public class AlphanumComparatorTest extends TestCase {
 
     private static AlphanumComparator ac;
+
+    public void testAlphanumCompareEquals() {
+        Assert.assertEquals(" 1 == 1", 0, ac.compare("1", "1"));
+        Assert.assertEquals(" 10 == 10", 0, ac.compare("10", "10"));
+        Assert.assertEquals(" 100 == 100", 0, ac.compare("100", "100"));
+    }
+
+    public void testAlphanumCompareNumbersGreater() {
+        Assert.assertEquals(" 1 > 0", 1, ac.compare("1", "0"));
+        Assert.assertEquals(" 10 > 2", 1, ac.compare("10", "2"));
+        Assert.assertEquals(" 2 > 1", 1, ac.compare("2", "1"));
+    }
+
+    public void testAlphanumCompareNumbersLesser() {
+        Assert.assertEquals(" 1 < 2", -1, ac.compare("1", "2"));
+        Assert.assertEquals(" 1 < 10", -1, ac.compare("1", "10"));
+        Assert.assertEquals(" 2 < 10 ", -1, ac.compare("2", "10"));
+    }
+
+    public void testAlphanumCompareNestedNumeric() {
+        Assert.assertEquals(" 1.1.0 < 2.1.0", -1, ac.compare("1.1.0", "2.1.0"));
+        Assert.assertEquals(" 1.1.1 == 1.1.1", 0, ac.compare("1.1.1", "1.1.1"));
+        Assert.assertEquals(" 2.1.0 > 1.1.0", 1, ac.compare("2.1.0", "1.1.0"));
+    }
+
 
     public void testAlphanumCompareALTB() {
         Assert.assertEquals("A < B", ac.compare("A", "B") < 0, true);
@@ -63,6 +89,13 @@ public class AlphanumComparatorTest extends TestCase {
         Assert.assertEquals("A10Z10 > A10Z2", ac.compare("A10Z10", "A10Z2") > 0, true);
     }
 
+    public void testMixedComparison() {     
+        System.out.println("start");   
+        Assert.assertEquals("IS100 < IS100A", -1, ac.compare("IS100", "IS100A"));
+        Assert.assertEquals("IS100A > IS100", +1, ac.compare("IS100A", "IS100"));
+    }
+
+    
     // from here down is testing infrastructure
     @Before
     protected void setUp() throws Exception {

--- a/java/test/jmri/util/AlphanumComparatorTest.java
+++ b/java/test/jmri/util/AlphanumComparatorTest.java
@@ -46,18 +46,17 @@ public class AlphanumComparatorTest extends TestCase {
         Assert.assertEquals(" 1.10.0 > 1.2.0", 1, ac.compare("1.10.0", "1.2.0"));
         Assert.assertEquals(" 1.2.0 < 1.10.0", -1, ac.compare("1.2.0", "1.10.0"));
         
-        // non-intuitive, but what it does
-        Assert.assertEquals(" 1.1.10 < 1.1.2", 1, ac.compare("1.1.10", "1.1.2"));
+        Assert.assertEquals(" 1.1.10 > 1.1.2", 1, ac.compare("1.1.10", "1.1.2"));
         
     }
 
     public void testHexadecimal() {
         Assert.assertEquals(" A0 < B0", -1, ac.compare("A0", "B0"));
 
-        Assert.assertEquals(" 21.1F > 21.10", 1, ac.compare("21.1F", "21.10"));
         Assert.assertEquals(" 21.A0 < 21.B0", -1, ac.compare("21.A0", "21.B0"));
 
         // non-intuitive, but what it does
+        Assert.assertEquals(" 21.1F < 21.10", -1, ac.compare("21.1F", "21.10"));
         Assert.assertEquals(" 1F < 10", -1, ac.compare("1F", "10"));
     }
 

--- a/java/test/jmri/util/AlphanumComparatorTest.java
+++ b/java/test/jmri/util/AlphanumComparatorTest.java
@@ -16,6 +16,10 @@ public class AlphanumComparatorTest extends TestCase {
 
     private static AlphanumComparator ac;
 
+    public void testAlphanumCompare1LTA() {
+        Assert.assertEquals("1 < A", ac.compare("1", "A") < 0, true);
+    }
+
     public void testAlphanumCompareEquals() {
         Assert.assertEquals(" 1 == 1", 0, ac.compare("1", "1"));
         Assert.assertEquals(" 10 == 10", 0, ac.compare("10", "10"));
@@ -38,8 +42,24 @@ public class AlphanumComparatorTest extends TestCase {
         Assert.assertEquals(" 1.1.0 < 2.1.0", -1, ac.compare("1.1.0", "2.1.0"));
         Assert.assertEquals(" 1.1.1 == 1.1.1", 0, ac.compare("1.1.1", "1.1.1"));
         Assert.assertEquals(" 2.1.0 > 1.1.0", 1, ac.compare("2.1.0", "1.1.0"));
+
+        Assert.assertEquals(" 1.10.0 > 1.2.0", 1, ac.compare("1.10.0", "1.2.0"));
+        Assert.assertEquals(" 1.2.0 < 1.10.0", -1, ac.compare("1.2.0", "1.10.0"));
+        
+        // non-intuitive, but what it does
+        Assert.assertEquals(" 1.1.10 < 1.1.2", 1, ac.compare("1.1.10", "1.1.2"));
+        
     }
 
+    public void testHexadecimal() {
+        Assert.assertEquals(" A0 < B0", -1, ac.compare("A0", "B0"));
+
+        Assert.assertEquals(" 21.1F > 21.10", 1, ac.compare("21.1F", "21.10"));
+        Assert.assertEquals(" 21.A0 < 21.B0", -1, ac.compare("21.A0", "21.B0"));
+
+        // non-intuitive, but what it does
+        Assert.assertEquals(" 1F < 10", -1, ac.compare("1F", "10"));
+    }
 
     public void testAlphanumCompareALTB() {
         Assert.assertEquals("A < B", ac.compare("A", "B") < 0, true);

--- a/java/test/jmri/util/AlphanumComparatorTest.java
+++ b/java/test/jmri/util/AlphanumComparatorTest.java
@@ -50,6 +50,17 @@ public class AlphanumComparatorTest extends TestCase {
         
     }
 
+    public void testAlphanumCompareTestNeedForDots() {
+        Assert.assertEquals(" 10.1.1 > 2.1.1", 1, ac.compare("10.1.1", "2.1.1"));
+        Assert.assertEquals(" 2.1.1 < 10.1.1", -1, ac.compare("2.1.1", "10.1.1"));
+        
+        Assert.assertEquals(" 1.10.1 > 1.2.1", 1, ac.compare("1.10.1", "1.2.1"));
+        Assert.assertEquals(" 1.2.1 < 1.10.1", -1, ac.compare("1.2.1", "1.10.1"));
+        
+        Assert.assertEquals(" 1.1.10 > 1.1.2", 1, ac.compare("1.1.10", "1.1.2"));
+        Assert.assertEquals(" 1.1.2 < 1.1.10", -1, ac.compare("1.1.2", "1.1.10"));
+   }
+
     public void testHexadecimal() {
         Assert.assertEquals(" A0 < B0", -1, ac.compare("A0", "B0"));
 
@@ -109,7 +120,6 @@ public class AlphanumComparatorTest extends TestCase {
     }
 
     public void testMixedComparison() {     
-        System.out.println("start");   
         Assert.assertEquals("IS100 < IS100A", -1, ac.compare("IS100", "IS100A"));
         Assert.assertEquals("IS100A > IS100", +1, ac.compare("IS100A", "IS100"));
     }

--- a/java/test/jmri/util/SystemNameComparatorTest.java
+++ b/java/test/jmri/util/SystemNameComparatorTest.java
@@ -17,6 +17,32 @@ public class SystemNameComparatorTest {
         Assert.assertNotNull("exists", t);
     }
 
+    @Test
+    public void testNumericComparison() {
+        SystemNameComparator t = new SystemNameComparator();
+        
+        Assert.assertEquals("same IS100", 0, t.compare("IS100", "IS100"));
+
+        Assert.assertEquals("IS100 < IS101", -1, t.compare("IS100", "IS101"));
+        Assert.assertEquals("IS101 > IS100", +1, t.compare("IS101", "IS100"));
+
+        Assert.assertEquals("not same IS001 IS1", -1, t.compare("IS001", "IS1"));        // imperfect, but what it does
+        Assert.assertEquals("not same IS0100 IS100", -1, t.compare("IS0100", "IS100"));  // imperfect, but what it does
+        Assert.assertEquals("not same IS100 IS0100", +1, t.compare("IS100", "IS0100"));  // imperfect, but what it does
+
+    }
+
+    @Test
+    public void testMixedComparison() {
+        SystemNameComparator t = new SystemNameComparator();
+        
+        Assert.assertEquals("same IS100A", 0, t.compare("IS100A", "IS100A"));
+
+        Assert.assertEquals("IS100 < IS100A", -1, t.compare("IS100", "IS100A"));
+        Assert.assertEquals("IS100A > IS100", +1, t.compare("IS100A", "IS100"));
+
+    }
+
     // The minimal setup for log4J
     @Before
     public void setUp() {

--- a/java/test/jmri/util/SystemNameComparatorTest.java
+++ b/java/test/jmri/util/SystemNameComparatorTest.java
@@ -26,9 +26,9 @@ public class SystemNameComparatorTest {
         Assert.assertEquals("IS100 < IS101", -1, t.compare("IS100", "IS101"));
         Assert.assertEquals("IS101 > IS100", +1, t.compare("IS101", "IS100"));
 
-        Assert.assertEquals("not same IS001 IS1", -1, t.compare("IS001", "IS1"));        // imperfect, but what it does
-        Assert.assertEquals("not same IS0100 IS100", -1, t.compare("IS0100", "IS100"));  // imperfect, but what it does
-        Assert.assertEquals("not same IS100 IS0100", +1, t.compare("IS100", "IS0100"));  // imperfect, but what it does
+        Assert.assertEquals("not same IS001 IS1", 2, t.compare("IS001", "IS1"));         // imperfect, but what it does
+        Assert.assertEquals("not same IS0100 IS100", 1, t.compare("IS0100", "IS100"));  // imperfect, but what it does
+        Assert.assertEquals("not same IS100 IS0100", -1, t.compare("IS100", "IS0100"));  // imperfect, but what it does
 
     }
 


### PR DESCRIPTION
Resolves issue with some Sensors not appearing in the Sensor table, broken since in 4.9.2, see #4529 for further background.

- Includes additional tests
- Deprecates no-longer-relevant PreferNumericComparator

Does not address system-specific comparison, esp. proper handling of complicated hexadecimal system names.  System prefixes of more than 2 characters (e.g. that weird long DCC++ prefix) might not sort in system-prefix-order.

Closes #4529 