### PR TITLE
Really basic fix to Comparator for system names

### DIFF
--- a/java/src/jmri/util/AlphanumComparator.java
+++ b/java/src/jmri/util/AlphanumComparator.java
@@ -44,7 +44,7 @@ import java.util.Comparator;
  * 0001 is seem as larger than 1 because it's the longer number. A
  * version that does not compare leading zeros is forthcoming.
  */
-public final class AlphanumComparator implements Comparator<String> {
+public class AlphanumComparator implements Comparator<String> {
 
     private final boolean isDigit(char ch) {
         return (('0' <= ch) && (ch <= '9'));
@@ -101,6 +101,9 @@ public final class AlphanumComparator implements Comparator<String> {
                 break;
             }
         }
+        if (result == 0 && marker1 == length1 && marker2 < length2) return -1;
+        if (result == 0 && marker1 < length1 && marker2 == length2) return +1;
+        
         return result;
     }
 }


### PR DESCRIPTION
Resolves issue with some Sensors not appearing in the Sensor table, broken since in 4.9.2, see #4529 for further background.

Does not address system-specific comparison, esp. proper handling of complicated hexadecimal system names. System prefixes of more than 2 characters (e.g. that weird long DCC++ prefix) might not sort in system-prefix-order.

Closes #4529

This is a reposting of the change in (partially, but only partially, redundant) #4605 with minimal changes to get it through faster