### PR TITLE
Handle case of no signal name for SSL elements

### DIFF
--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -70,6 +70,8 @@
 
         <li>Blocks (track segments)</li>
 
+        <li>Conditionals (for logiX, although these are not entirely named beans)</li>
+
         <li>signal Heads</li>
 
         <li>Lights (a type of output)</li>

--- a/java/src/jmri/jmrit/blockboss/BlockBossLogic.java
+++ b/java/src/jmri/jmrit/blockboss/BlockBossLogic.java
@@ -1200,7 +1200,8 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
      * @param sh signal head object
      * @return never null
      */
-    public static BlockBossLogic getStoppedObject(SignalHead sh) {
+    @Nonnull
+    public static BlockBossLogic getStoppedObject(@Nonnull SignalHead sh) {
         BlockBossLogic b = null;
 
         for (BlockBossLogic bbl : bblList) {

--- a/java/src/jmri/jmrit/blockboss/BlockBossLogic.java
+++ b/java/src/jmri/jmrit/blockboss/BlockBossLogic.java
@@ -172,7 +172,6 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
     }
 
     public NamedBeanHandle<SignalHead> getDrivenSignalNamedBean() {
-        if (driveSignal == null) return null;
         return driveSignal;
     }
 
@@ -1189,6 +1188,7 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
      * @param signal name of the signal head object
      * @return never null
      */
+    @Nonnull
     public static BlockBossLogic getStoppedObject(String signal) {
         return getStoppedObject(InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(signal));
     }
@@ -1205,7 +1205,7 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
         BlockBossLogic b = null;
 
         for (BlockBossLogic bbl : bblList) {
-            if (bbl.getDrivenSignalNamedBean().getBean() == sh) {
+            if (bbl.getDrivenSignalNamedBean()!=null && bbl.getDrivenSignalNamedBean().getBean() == sh) {
                 b = bbl;
                 break;
             }
@@ -1253,7 +1253,7 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
     @Nonnull
     public static BlockBossLogic getExisting(@Nonnull SignalHead sh) {
         for (BlockBossLogic bbl : bblList) {
-            if (bbl.getDrivenSignalNamedBean().getBean() == sh) {
+            if (bbl.getDrivenSignalNamedBean()!=null && bbl.getDrivenSignalNamedBean().getBean() == sh) {
                 return bbl;
             }
         }
@@ -1270,7 +1270,7 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             boolean found = false;
 
             if (nb instanceof SignalHead) {
-                if (getDrivenSignalNamedBean().getBean().equals(nb)) {
+                if (getDrivenSignalNamedBean()!=null && nb.equals(getDrivenSignalNamedBean().getBean())) {
                     message.append("<br><b>" + Bundle.getMessage("InUseThisSslWillBeDeleted") + "</b>");
                     throw new java.beans.PropertyVetoException(message.toString(), evt);
                 }
@@ -1328,7 +1328,7 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
             }
         } else if ("DoDelete".equals(evt.getPropertyName())) { // NOI18N
             if (nb instanceof SignalHead) {
-                if (getDrivenSignalNamedBean().getBean().equals(nb)) {
+                if (getDrivenSignalNamedBean()!=null && nb.equals(getDrivenSignalNamedBean().getBean())) {
                     stop();
                     bblList.remove(this);
                 }

--- a/java/src/jmri/jmrit/blockboss/configurexml/BlockBossLogicXml.java
+++ b/java/src/jmri/jmrit/blockboss/configurexml/BlockBossLogicXml.java
@@ -2,7 +2,10 @@ package jmri.jmrit.blockboss.configurexml;
 
 import java.util.Enumeration;
 import java.util.List;
+
 import jmri.jmrit.blockboss.BlockBossLogic;
+import jmri.*;
+
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,9 +154,20 @@ public class BlockBossLogicXml extends jmri.configurexml.AbstractXmlAdapter {
             Element block = l.get(i);
             BlockBossLogic bb = null;
             try {
-                bb = BlockBossLogic.getStoppedObject(block.getAttributeValue("signal"));
+                String signalName = block.getAttributeValue("signal");
+                if (signalName == null || signalName.isEmpty()) {
+                    // this is an error
+                    log.error("Ignoring a <signalelement> element with no signal attribute value");
+                    break;
+                }
+                if (InstanceManager.getDefault(SignalHeadManager.class).getSignalHead(signalName) == null) {
+                    // this is an error
+                    log.error("SignalHead {} not defined, <signalelement> element referring to it is ignored", signalName);
+                    break;
+                }
+                bb = BlockBossLogic.getStoppedObject(signalName);
             } catch (Exception e) {
-                log.error("An error occurred trying to find the signal for the signal elements for " + block.getAttributeValue("signal"));
+                log.error("An error occurred trying to find the signal for the signal elements for " + block.getAttributeValue("signal"), e);
                 result = false;
             }
             if (bb != null) {

--- a/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
+++ b/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
@@ -180,6 +180,18 @@ public class BlockBossLogicTest extends TestCase {
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "missing signal is green, show yellow");  // wait and test
     }
 
+    // check for basic not-fail if no signal name was set
+    public void testSimpleBlockNoSignal() throws jmri.JmriException {
+
+        try { 
+            p = new BlockBossLogic(null);
+        } catch (java.lang.IllegalArgumentException e) {
+            // this is expected
+        }
+        jmri.util.JUnitAppender.assertWarnMessage("Signal Head \"null\" was not found");
+    }
+
+
     // check that user names were preserved
     public void testUserNamesRetained() {
         BlockBossLogic p = new BlockBossLogic("IH1");

--- a/java/test/jmri/jmrit/blockboss/configurexml/BlockBossLogicXmlTest.java
+++ b/java/test/jmri/jmrit/blockboss/configurexml/BlockBossLogicXmlTest.java
@@ -1,10 +1,18 @@
 package jmri.jmrit.blockboss.configurexml;
 
 import jmri.util.JUnitUtil;
+import jmri.jmrit.blockboss.*;
+import jmri.implementation.*;
+import jmri.*;
+
+import java.util.Enumeration;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import org.jdom2.*;
 
 /**
  * BlockBossLogicXmlTest.java
@@ -19,11 +27,119 @@ public class BlockBossLogicXmlTest {
     public void testCtor(){
       Assert.assertNotNull("BlockBossLogicXml constructor",new BlockBossLogicXml());
     }
+    
+    int count() {
+        int ret = 0;
+        Enumeration<BlockBossLogic> en = BlockBossLogic.entries();
+        
+        while (en.hasMoreElements()) {
+            en.nextElement();
+            ret++;
+        }
+        return ret;
+    }
+
+    @Test
+    public void testOneElement(){
+        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(
+                new DefaultSignalHead("IH1") {
+                    @Override
+                    protected void updateOutput() {
+                    }
+                }
+        );
+        Sensor is1 = InstanceManager.getDefault(jmri.SensorManager.class).getSensor("IS1");
+        
+        Element el = new Element("signalelements")
+                .setAttribute("class", "jmri.jmrit.blockboss.configurexml.BlockBossLogicXml")
+                .addContent(
+                        new Element("signalelement")
+                        .setAttribute("signal", "IH1")
+                        .setAttribute("mode", "2")
+                        .addContent(
+                            new Element("sensorname")
+                                .addContent("IS1")
+                        )
+                );
+
+        Assert.assertEquals("zero before", count(), 0);
+        
+        BlockBossLogicXml bb = new BlockBossLogicXml();
+        bb.load(el, null);
+
+        Assert.assertEquals("one after", count(), 1);
+    }
+
+    @Test
+    public void testBadSignalName(){
+        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(
+                new DefaultSignalHead("IH2") {
+                    @Override
+                    protected void updateOutput() {
+                    }
+                }
+        );
+        Sensor is1 = InstanceManager.getDefault(jmri.SensorManager.class).getSensor("IS1");
+        
+        Element el = new Element("signalelements")
+                .setAttribute("class", "jmri.jmrit.blockboss.configurexml.BlockBossLogicXml")
+                .addContent(
+                        new Element("signalelement")
+                        .setAttribute("signal", "IH1")
+                        .setAttribute("mode", "2")
+                        .addContent(
+                            new Element("sensorname")
+                                .addContent("IS1")
+                        )
+                );
+
+        Assert.assertEquals("zero before", count(), 0);
+        
+        BlockBossLogicXml bb = new BlockBossLogicXml();
+        bb.load(el, null);
+
+        Assert.assertEquals("zero after", count(), 0);
+
+        jmri.util.JUnitAppender.assertErrorMessage("SignalHead IH1 not defined, <signalelement> element referring to it is ignored");
+    }
+
+    @Test
+    public void testMissingSignalAttribute(){
+        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(
+                new DefaultSignalHead("IH1") {
+                    @Override
+                    protected void updateOutput() {
+                    }
+                }
+        );
+        Sensor is1 = InstanceManager.getDefault(jmri.SensorManager.class).getSensor("IS1");
+        
+        Element el = new Element("signalelements")
+                .setAttribute("class", "jmri.jmrit.blockboss.configurexml.BlockBossLogicXml")
+                .addContent(
+                        new Element("signalelement")
+                        .setAttribute("mode", "2")
+                        .addContent(
+                            new Element("sensorname")
+                                .addContent("IS1")
+                        )
+                );
+
+        Assert.assertEquals("zero before", count(), 0);
+        
+        BlockBossLogicXml bb = new BlockBossLogicXml();
+        bb.load(el, null);
+
+        Assert.assertEquals("zero after", count(), 0);
+        
+        jmri.util.JUnitAppender.assertErrorMessage("Ignoring a <signalelement> element with no signal attribute value");
+    }
 
     // The minimal setup for log4J
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        jmri.util.JUnitUtil.initInternalSensorManager();
     }
 
     @After

--- a/xml/schema/types/general.xsd
+++ b/xml/schema/types/general.xsd
@@ -102,7 +102,10 @@
         </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:token">
-      <xs:minLength value="3"/>
+        <!-- "[A-Z]([0-9]*)[A-Z].*" is more correct, but fails lots of short signal head names -->
+        <!-- type letter pattern can also be constrained: ABCHLMOPRSTX but also Y? -->
+        <!-- the following is "at least two characters" -->
+             <xs:pattern value="..*"/>
     </xs:restriction>
   </xs:simpleType>
   

--- a/xml/schema/types/general.xsd
+++ b/xml/schema/types/general.xsd
@@ -102,7 +102,7 @@
         </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:token">
-      <xs:minLength value="2"/>
+      <xs:minLength value="3"/>
     </xs:restriction>
   </xs:simpleType>
   

--- a/xml/schema/types/logix-2-9-6.xsd
+++ b/xml/schema/types/logix-2-9-6.xsd
@@ -87,10 +87,13 @@
                   <xs:attribute name="type" type="xs:integer" use="required" />
                   <xs:attribute name="systemName"  use="required">
                     <xs:simpleType>
-                      <xs:annotation><xs:documentation>Allow empty string and single space, emitted by old code</xs:documentation></xs:annotation>
+                      <xs:annotation><xs:documentation>Allow user names, empty string and single space, emitted by old code</xs:documentation></xs:annotation>
                       <xs:union>
                         <xs:simpleType>
                           <xs:restriction base="systemNameType" />
+                        </xs:simpleType>
+                        <xs:simpleType>
+                          <xs:restriction base="userNameType" />
                         </xs:simpleType>
                         <xs:simpleType>
                           <xs:restriction base="xs:string">
@@ -113,10 +116,13 @@
                   <xs:attribute name="type" type="xs:integer" use="required" />
                   <xs:attribute name="systemName"  use="required">
                     <xs:simpleType>
-                      <xs:annotation><xs:documentation>Allow single or empty space, emitted by old code</xs:documentation></xs:annotation>
+                      <xs:annotation><xs:documentation>Allow user names, single or empty space, emitted by old code</xs:documentation></xs:annotation>
                       <xs:union>
                         <xs:simpleType>
                           <xs:restriction base="systemNameType" />
+                        </xs:simpleType>
+                        <xs:simpleType>
+                          <xs:restriction base="userNameType" />
                         </xs:simpleType>
                         <xs:simpleType>
                           <xs:restriction base="xs:string">

--- a/xml/schema/types/logix.xsd
+++ b/xml/schema/types/logix.xsd
@@ -79,10 +79,13 @@
                   <xs:attribute name="type" type="xs:integer" use="required" />
                   <xs:attribute name="systemName"  use="required">
                     <xs:simpleType>
-                      <xs:annotation><xs:documentation>Allow empty string and single space, emitted by old code</xs:documentation></xs:annotation>
+                      <xs:annotation><xs:documentation>Allow user names, empty string and single space, emitted by old code</xs:documentation></xs:annotation>
                       <xs:union>
                         <xs:simpleType>
                           <xs:restriction base="systemNameType" />
+                        </xs:simpleType>
+                        <xs:simpleType>
+                          <xs:restriction base="userNameType" />
                         </xs:simpleType>
                         <xs:simpleType>
                           <xs:restriction base="xs:string">
@@ -105,10 +108,13 @@
                   <xs:attribute name="type" type="xs:integer" use="required" />
                   <xs:attribute name="systemName"  use="required">
                     <xs:simpleType>
-                      <xs:annotation><xs:documentation>Allow single or empty space, emitted by old code</xs:documentation></xs:annotation>
+                      <xs:annotation><xs:documentation>Allow user names, single or empty space, emitted by old code</xs:documentation></xs:annotation>
                       <xs:union>
                         <xs:simpleType>
                           <xs:restriction base="systemNameType" />
+                        </xs:simpleType>
+                        <xs:simpleType>
+                          <xs:restriction base="userNameType" />
                         </xs:simpleType>
                         <xs:simpleType>
                           <xs:restriction base="xs:string">

--- a/xml/schema/types/oblocks-2-9-6.xsd
+++ b/xml/schema/types/oblocks-2-9-6.xsd
@@ -46,12 +46,12 @@
               <xs:element name="comment" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
               <xs:element name="sensor" minOccurs="0" maxOccurs="unbounded" >
                 <xs:complexType>
-                  <xs:attribute name="systemName" type="systemNameType" />
+                  <xs:attribute name="systemName" type="beanNameType" /> <!-- user or system name OK -->
                 </xs:complexType>
               </xs:element>
               <xs:element name="errorSensor" minOccurs="0" maxOccurs="1" >
                 <xs:complexType>
-                  <xs:attribute name="systemName" type="systemNameType" />
+                  <xs:attribute name="systemName" type="beanNameType" /> <!-- user or system name OK -->
                 </xs:complexType>
               </xs:element>
               <xs:element name="path" type="OBlockPathType" minOccurs="0" maxOccurs="unbounded" />

--- a/xml/schema/types/signalheads-2-9-6.xsd
+++ b/xml/schema/types/signalheads-2-9-6.xsd
@@ -68,7 +68,7 @@
           Deprecated in JMRI 2.7.7 in favor of turnoutname element
           </xs:documentation></xs:annotation>
           <xs:complexType>
-            <xs:attribute name="systemName" type="systemNameType" use="required" />
+            <xs:attribute name="systemName" type="beanNameType" use="required" /> <!-- could be just a number, e.g. user name, in old files -->
             <xs:attribute name="userName" type="userNameType" />
             <xs:attribute name="state" type="xs:string" />
           </xs:complexType>


### PR DESCRIPTION
 - added tests
 - SSL (BlockBossLogic) objects better armored against NPEs due to missing SignalHead value
 - When reading a panel file, `<signalelement>` elements without a valid SignalHead are dropped with a message in the log

This is in the service of resolving #4593