### PR TITLE
Do not build LaunchJMRI.exe with every build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2046,11 +2046,13 @@
             <fileset dir="${libdir}/windows"/>
         </copy>
         <mkdir dir="${dist.release}"/>
+        <!-- do not rebuild LaunchJMRI (see https://github.com/JMRI/JMRI/pull/3959)
         <exec executable="${nsis.home}makensis"
               dir="${dist.windows}/JMRI"
               failonerror="true">
             <arg line="-V2 LaunchJMRI.nsi"/>
         </exec>
+        -->
         <exec executable="${nsis.home}makensis"
               dir="${dist.windows}/JMRI"
               failonerror="true">


### PR DESCRIPTION
This snuck in when updating from NSIS 2.x to 3.0, but should not have.