### PR TITLE
Fixes for Issues 4621 and 4660

### DIFF
--- a/java/src/jmri/jmrix/mrc/MrcActionListBundle.properties
+++ b/java/src/jmri/jmrix/mrc/MrcActionListBundle.properties
@@ -3,5 +3,5 @@
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences
 
-jmri.jmrix.mrc.swing.monitor.MrcMonPanel = Open MRC Monitor
-jmri.jmrix.mrc.swing.packetgen.MrcPacketGenPanel = Open Packet Generator
+jmri.jmrix.mrc.swing.monitor.MrcMonPanel$Default = Open MRC Monitor
+jmri.jmrix.mrc.swing.packetgen.MrcPacketGenPanel$Default = Open MRC Packet Generator

--- a/java/src/jmri/jmrix/tmcc/serialdriver/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/tmcc/serialdriver/configurexml/ConnectionConfigXml.java
@@ -29,6 +29,11 @@ public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
     }
 
     @Override
+    protected void getInstance(Object object) {
+        adapter = ((ConnectionConfig) object).getAdapter();
+    }
+
+    @Override
     protected void register() {
         this.register(new ConnectionConfig(adapter));
     }


### PR DESCRIPTION
MRC didn't have the $Default in the action list.
TMCC was missing the getInstance(object), was hint from Paul B.