### PR TITLE
Parsable system-name infrastructure & better table sorting

### DIFF
--- a/help/en/html/doc/Technical/Ant.shtml
+++ b/help/en/html/doc/Technical/Ant.shtml
@@ -97,7 +97,7 @@
         <dd><code>mvn test</code><br>Use <code>mvn test -Dtest=PATTERN</code> to
           run specific tests. See
           <a href="https://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html">Running a Single Test</a>
-        for more details, including running only a single test method.</dt>
+        for more details, including running only a single test method.</dd>
         <dt>Check for vulnerabilities in JMRI dependencies</dt>
         <dd><code>mvn compile net.ossindex:ossindex-maven-plugin:audit</code></dd>
         <dt>Check for newer versions of JMRI dependencies</dt>

--- a/help/en/html/doc/Technical/Eclipse.shtml
+++ b/help/en/html/doc/Technical/Eclipse.shtml
@@ -42,7 +42,7 @@
 
       <p>Note that you must also install the
       <a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html">Java Development Kit</a>
-      (not included with Eclipse) to build JMRI with Eclipse.</a>
+      (not included with Eclipse) to build JMRI with Eclipse.
 
       <p>If using versions of Eclipse older than "Mars", the
       <a href="http://www.eclipse.org/m2e/">M2Eclipse</a> plugin must be

--- a/help/en/html/doc/Technical/FindBugs.shtml
+++ b/help/en/html/doc/Technical/FindBugs.shtml
@@ -192,14 +192,15 @@ scanning through the code.
         javax.annotation.Nullable</code></a> - This doesn't really
         mean what people think it does, as FindBugs doesn't really
         check anything when this is used. From the FindBugs documentation:
-        <blockquote>
+          <blockquote>
             FindBugs will treat the annotated items as though they had
             no annotation. In practice this annotation is useful only
             for overriding an overarching NonNull annotation. Use
             javax.annotation.ParametersAreNullableByDefault to set it
             for an entire class. Prefer the use of
-            <code>CheckForNull</code>.</li>
-        </blockquote>
+            <code>CheckForNull</code>.
+          </blockquote>
+        </li>
       </ul>
 
       <h3>Suppressed Warnings</h3>We have turned off the routine

--- a/help/en/html/doc/Technical/GitFAQ.shtml
+++ b/help/en/html/doc/Technical/GitFAQ.shtml
@@ -231,7 +231,7 @@
 </pre>                
                 <p>or</p>
 <pre style="font-family: monospace;">                
-                $ git pull https://github.com/JMRI/JMRI.git</code><br>
+                $ git pull https://github.com/JMRI/JMRI.git<br>
 </pre>
                 </li>
 

--- a/help/en/html/doc/Technical/Javadoc.shtml
+++ b/help/en/html/doc/Technical/Javadoc.shtml
@@ -73,7 +73,7 @@
       "http://docs.oracle.com/javase/7/docs/technotes/guides/javadoc/deprecation/deprecation.html">
       "How and When To Deprecate APIs" page</a>.</p>
 
-    <a name="html" item="html"></a>
+    <a name="html" id="html"></a>
     <h3>HTML in Javadoc</h3>
     
       <p>The Javadoc content is interpreted as HTML 4.01, so it

--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -96,10 +96,10 @@
       and "user names" to reference things.
 
       <p>We want users to be able to call things what they want.
-      Names like "p(24,23)*" are not useful. Every named item will
+      Names like "p(24,23)*" are not useful. Every named item can
       therefore have a "user name", which is an entirely free-form
       string. You can put whatever you want in there, so long as
-      it's not a duplicate of the name given to something else. For
+      it's not a duplicate of the user name given to something else. For
       example, you might call a Turnout "West Yard Lead" or
       "Turnout 32" or "Green Wire from Controller" or whatever.</p>
 
@@ -114,25 +114,48 @@
       <h2>System Name Format</h2>
       
       A system name is formed from a
-      short prefix representing the hardware system, followed by a
-      single upper case letter indicating the type, followed by a
-      system- and type-specific suffix string identifying a specific
-      object. The suffix string is meant to be related to the hardware
-      addressing for the specific hardware system, but is otherwise unconstrained.
+      short "system prefix" representing the hardware system, followed by a
+      single upper case "type letter" indicating the type of the object, 
+      followed by a
+      system- and type-specific "suffix string" identifying a specific
+      object. 
+      <ul>
+        <li>The system prefix is a single uppercase or lowercase letter, optionally followed
+            by one or more digits. Special characters are not allowed.
+            This simple form allows us to always fine the system prefix
+            and type letter even if we don't know the full list of 
+            hardware systems involved.
+        <li>The type letter defines the type of model-railroad object, 
+            such as (T)urnout or (S)ensor.
+        <li>The suffix string is meant to be related to the hardware
+            addressing for the specific hardware system, but is otherwise unconstrained.
+            Some are simple numbers, such as a device address. Others
+            are much more complicated strings to carry more complex 
+            information.
+      </ul>
 
       <p>Examples:</p>
 
+      Note: These assume the default values of system prefix letters,
+      but they certainly could have been defined to be something else.
+      
       <ul>
         <li>LT23 - <u>L</u>ocoNet <u>T</u>urnout <u>23</u>.</li>
+        <li>L2T23 - <u>T</u>urnout <u>23</u> on the second <u>L</u>ocoNet connection.</li>
 
-        <li>CS12 - The <u>12</u>th <u>C</u>/MRI <u>S</u>ensor
-        (input line).</li>
-      </ul>Note that there is no assumption of pattern to the
+        <li>CS2012 - A <u>C</u>/MRI <u>S</u>ensor
+            (input line) addressed as 2012, which means the 12th pin on  
+            on the node with address 2.</li>
+      </ul>
+      
+      Note that there is no assumption of pattern to the
       names; they don't have to be assigned monotonically, nor are
-      they restricted to a single system. <a name="hardware" id=
-      "hardware"></a>
-
-      <h3>Hardware Prefix</h3>Originally, the "hardware prefix" was
+      they restricted to a single system. 
+      
+      <a name="hardware" id="hardware"></a>
+      <h3>System Prefix</h3>
+      
+      Originally, the "hardware prefix" was
       a single uppercase letter identifying a single system
       connection: L for LocoNet, N for NCE, etc. The default
       letters for those are listed below. This is still by far the
@@ -142,8 +165,8 @@
       <p>The JMRI code is much more flexible than that, however.
       This allows it to deal with multiple system connections and
       overlaps of letters (such as the multiple possibilities
-      defined for "M" below). You change the letter associated with
-      a system connection in the preferences to any other uppercase
+      defined for "D" or "M" below). You change the letter associated with
+      a system connection in the preferences to any other uppercase or lowercase
       letter. You can call your NCE connection "P" if you want to.
       If you have two of them, you can call one "X" and the other
       "Y". You can also use an upper case letter followed by
@@ -155,7 +178,9 @@
 
       <ul>
         <li>A CTI <a href=
-        "../../hardware/acela/index.shtml">Acela</a></li>
+        "../../hardware/acela/index.shtml">Acela</a>,
+        Bachrus Speedometer
+        </li>
 
         <li>B Direct DCC control</li>
 
@@ -179,7 +204,7 @@
         <li>I Internal, e.g. objects with no associated
         hardware</li>
 
-        <li>J</li>
+        <li>J JMRI network connections</li>
 
         <li>K <a href="../../hardware/maple/index.shtml">Maple
         Systems</a></li>
@@ -192,7 +217,8 @@
         and <a href="../../hardware/can/cbus/index.shtml">MERG
         CBUS</a>. Also used for the <a href=
         "../../hardware/modbus/index.shtml">Modbus</a> master and
-        slave implementation.</li>
+        slave implementation.
+        </li>
 
         <li>N <a href="../../hardware/nce/NCE.shtml">NCE</a> (also
         <a href="../../hardware/nce/Wangrow.shtml">Wangrow</a>
@@ -227,13 +253,21 @@
         combined with NCE)</li>
 
         <li>X <a href=
-        "../../hardware/XPressNet/index.shtml">XpressNet</a></li>
+        "../../hardware/XPressNet/index.shtml">XpressNet</a>
+        used by a number of Lenz, Atlas, Hornby and other connections
+        </li>
 
-        <li>Z <a href="../../hardware/zimo/Zimo.shtml">Zimo
-        MX-1</a></li>
-      </ul><a name="types" id="types"></a>
+        <li>Z <a href="../../hardware/zimo/Zimo.shtml">ZimoMX-1</a>,
+            IEEE802.15.4
+            and Z21 connections
+        </li>
+      </ul>
+      
+      <a name="types" id="types"></a>
 
-      <h3>Device type letters</h3>Note that some of these are
+      <h3>Device type letters</h3>
+      
+      Note that some of these are
       placeholders, and have no underlying implementation. Also,
       there is no guarantee that any given hardware system will
       ever implement all of them.
@@ -300,9 +334,9 @@
         hardware on the layout. For example, if a signal head is
         implemented as three different outputs, LT1, LT2 and LT3, the
         signal head object might be called IH3. 
-        <a name="special" id=
+        
+     <a name="special" id=
                 "special"></a></p>
-
       <p>Each different hardware system
       can specify the "suffix string" that follows the system and type
       letters. Generally, these are small numbers, but their exact

--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -893,6 +893,15 @@ SENSOR GROUP:my group:LS2
       <a name="programmers" id="programmers"></a>
       <h2>For Programmers</h2>
       
+      <h3>Normalized form of Names, and how to work with it</h3>
+      
+          After multiple long discussions, we decided that both system and user names 
+          should be kept in a "normal" form which enforces certain restrictions.
+          For user names, that's that leading and trailing whitespace (spaces, tabs) 
+          are not allowed.  For system names, it depends on the system, but 
+          at least the system-prefix and type letter must be correct.
+          
+          <p>
           The code to make sure that names are in normal form 
           has been localized to a single routine for user names:
           <br>
@@ -963,6 +972,41 @@ SENSOR GROUP:my group:LS2
 
         </ul>
 
+      <h3>System Name Comparisons</h3>
+      
+        System names are compared and sorted in multiple places: as labels for table rows, 
+        in selection boxes and lists, etc.  We have two <code>java.util.Comparator&lt;&gt;</code>
+        implementations to handle this:
+        <ul>
+            <li><code>SystemNameComparator</code> - a comparison on Strings
+            <li><code>NamedBeanComparator</code> - a comparison on the NamedBeans themselves
+        </ul>
+        Please use one of these whenever you need to compare or sort by system names to keep the complexity in one place.
+        <p>
+        Both of them sort first by system connection prefix, to group all the objects from one system together.
+        If there are objects of multiple types, the type letter is put in alphabetical order next.
+        Finally, the system-specific suffix is sorted.
+        <p>
+        Because it works with String values, <code>SystemNameComparator</code> can only
+        do a default ordering of the system-specific suffix; it can't do anything that
+        uses any information about the system-specific meaning of that string. It therefore
+        uses an alphanumeric-by-chunks sort.
+        Because it's comparing on the actual NamedBean objects, <code>NamedBeanComparator</code>
+        can do more specific comparisons:  It knows what the C/MRI suffixes in 
+        "CT2003" and "C2B2" mean and can take that into account.
+        <p>
+        Therefore, if you can, do the sort/comparison with <code>NamedBeanComparator</code> and
+        then convert to Strings, rather than converting NamedBeans to Strings and using 
+        <code>SystemNameComparator</code>.
+        <p>
+        Also, if you've created a system that has complex information in the suffix,
+        please have your <code>NamedBean</code> subclasses implement a system-specific
+        version of the
+        <a href="http://jmri.org/JavaDoc/doc/jmri/NamedBean.html#compareSystemNameSuffix-java.lang.String-java.lang.String-jmri.NamedBean-">compareSystemNameSuffix()</a>
+        method in <code>NamedBean</code>.
+        For an example, see the bottom of jmri.jmrix.cmri.serial.SerialTurnout
+        and jmri.jmrix.cmri.serial.SerialTurnoutTest.
+      
       <!--#include virtual="/Footer" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->

--- a/help/en/html/doc/Technical/NewSystem.shtml
+++ b/help/en/html/doc/Technical/NewSystem.shtml
@@ -31,7 +31,6 @@
     <div id="mainContent">
       <h1>JMRI: Adding A New System</h1>
 
-      <div class="para">
         <p>This page describes the steps to add a new data-type,
         e.g. Powerline devices, to JMRI.</p>
 
@@ -55,7 +54,6 @@
         <a href="SystemStructure.shtml">intended system connection structure</a>
         which is documented on
         <a href="SystemStructure.shtml">another page</a>.
-      </div>
 
         <p>We list the files that are modified and created in the
         order they were done in this case; other orders may also
@@ -268,7 +266,7 @@
 
           </dl>
             <h3>Complete the documentation</h3>
-          </dl>
+          <dl>
 
           <dt>Create The Help Tree</dt>
 
@@ -405,7 +403,8 @@ also needs some parts copied over.
           information and reload it, respectively. C/MRI uses this
           to store its node information.</li>
         </ul>
-      </div><!--#include virtual="/Footer" -->
+
+    <!--#include virtual="/Footer" -->
     </div><!-- closes #mainContent-->
   </div><!-- closes #mBody-->
 </body>

--- a/help/en/html/doc/Technical/RP.shtml
+++ b/help/en/html/doc/Technical/RP.shtml
@@ -147,7 +147,7 @@
 
     <h2>Exceptions</h2>
     
-    <a href="">FindBugs</a>
+    FindBugs
     will object to
     <a href="http://jmri.tagadab.com/jenkins/job/Development/job/Findbugs/lastSuccessfulBuild/findbugsResult/type.-1293684328/">code like this</a>:
 

--- a/help/en/html/doc/Technical/webupdate/UpdatingDocs.shtml
+++ b/help/en/html/doc/Technical/webupdate/UpdatingDocs.shtml
@@ -136,7 +136,7 @@
       image file name. Generally, a good size for the width of an
       image is 500 pixels or less, at a web resolution of 72 pixels
       per inch. If you know how to resize your images, it would be
-      very helpful.</a>
+      very helpful.
 
       <h2><a name="submitpage" id="submitpage">Submitting
       to GitHub</a></h2>
@@ -144,7 +144,7 @@
       <p>If you understand this, you
       are ready to help us update the many JMRI documents that we
       use for both the JMRI website and for the Help files in a
-      next software build.</a></p>
+      next software build.</p>
 
       <p>When you submit your changes to be included in future JMRI
       releases, they are given a quick check and then merged into

--- a/help/en/html/tools/signaling/IntroToSignalingYourMRR.html
+++ b/help/en/html/tools/signaling/IntroToSignalingYourMRR.html
@@ -73,8 +73,8 @@
 
 <body dir="ltr" style=
 "max-width:21.59cm;margin-top:2cm; margin-bottom:2cm; margin-left:2cm; margin-right:2cm;">
-<h1 class="P8"><a name=
-"_Signals_For_Your_Model_Railroad_-_Getting_Started"></a>Signals
+<h1 class="P8">
+<a id="Signals_For_Your_Model_Railroad_-_Getting_Started" name="Signals_For_Your_Model_Railroad_-_Getting_Started"></a>Signals
 For Your Model Railroad - Getting Started</h1>
 
   <p class="P4">By Elmer McKay</p>
@@ -101,8 +101,8 @@ For Your Model Railroad - Getting Started</h1>
   system, stay with the simplest type of signal system, one that
   does not require a computer. &Acirc;</p>
 
-  <h3 class="Heading_20_3"><a name=
-  "_Type_of_Signals_to_Use"></a>Type of Signals to Use</h3>
+  <h3 class="Heading_20_3">
+  <a id="Type_of_Signals_to_Use" name="Type_of_Signals_to_Use"></a>Type of Signals to Use</h3>
 
   <p class="Text_20_body"><br />
   &Acirc; &Acirc; &Acirc; If you don't know anything about railroad
@@ -125,7 +125,7 @@ For Your Model Railroad - Getting Started</h1>
   "T1">http://www.railroadsignals.us/</span></a> is a good place to
   start your research.</p>
 
-  <h3 class="Heading_20_3"><a name="_Signal_Plan"></a>Signal
+  <h3 class="Heading_20_3"><a id="Signal_Plan" name="Signal_Plan"></a>Signal
   Plan</h3>
 
   <p class="Text_20_body"><br />
@@ -189,7 +189,7 @@ For Your Model Railroad - Getting Started</h1>
     </div>
   </div>
 
-  <h3 class="P7"><a name="_Block_Detection"></a>Block
+  <h3 class="P7"><a id="Block_Detection" name="Block_Detection"></a>Block
   Detection</h3>
 
   <div class="Text_20_body">
@@ -214,7 +214,7 @@ For Your Model Railroad - Getting Started</h1>
 
   <p class="Text_20_body">&Acirc;</p>
 
-  <h3 class="P9"><a name="_Turnout_Position_Detection"></a>Turnout
+  <h3 class="P9"><a id="Turnout_Position_Detection" name="Turnout_Position_Detection"></a>Turnout
   Position Detection</h3>
 
   <p class="Text_20_body"><br />
@@ -225,7 +225,7 @@ For Your Model Railroad - Getting Started</h1>
   will use the same computer signal that is sent to the DCC turnout
   controller when throwing a turnout.</p>
 
-  <h3 class="P9"><a name="_Signal_Board"></a>Signal Board</h3>
+  <h3 class="P9"><a id="Signal_Board" name="Signal_Board"></a>Signal Board</h3>
 
   <p class="P1"><br />
   &Acirc; &Acirc; &Acirc; The signal board takes the computer
@@ -244,7 +244,7 @@ For Your Model Railroad - Getting Started</h1>
 
   <p class="P6">&Acirc;</p>
 
-  <h3 class="P9"><a name="_Computer_Program"></a>Computer
+  <h3 class="P9"><a id="Computer_Program" name="Computer_Program"></a>Computer
   Program</h3>
 
   <p class="Text_20_body"><br />
@@ -276,7 +276,7 @@ For Your Model Railroad - Getting Started</h1>
 
   <p class="P2">&Acirc;</p>
 
-  <h3 class="P11"><a name="_Equipment_Types"></a>Equipment
+  <h3 class="P11"><a id="Equipment_Types" name="Equipment_Types"></a>Equipment
   Types</h3>
 
   <p class="P2"><span class="T3"><br />
@@ -319,7 +319,7 @@ For Your Model Railroad - Getting Started</h1>
   "http://www.freiwald.com/"><span class=
   "T4">http://www.freiwald.com/</span></a></p>
 
-  <h3 class="P10"><a name="_The_System_I_use"></a>The System I
+  <h3 class="P10"><a id="The_System_I_use" name="The_System_I_use"></a>The System I
   use</h3>
 
   <p class="P3"><br />

--- a/help/en/html/tools/signaling/Logic.shtml
+++ b/help/en/html/tools/signaling/Logic.shtml
@@ -165,7 +165,7 @@
       <div class="section">
 
         <a name="traildiv" id="traildiv"></a>
-        <h2>On Diverging Leg of Trailing-Point Turnout</a></h2>
+        <h2>On Diverging Leg of Trailing-Point Turnout</h2>
 
         <div class="para">
 
@@ -230,7 +230,7 @@
 
       <div class="section">
         <a name="face" id="face"></a>
-        <h2>On Facing-Point Turnout</a></h2>
+        <h2>On Facing-Point Turnout</h2>
 
         <div class="para">
 

--- a/help/en/html/tools/signaling/SignalHeads.shtml
+++ b/help/en/html/tools/signaling/SignalHeads.shtml
@@ -83,9 +83,9 @@
       <h3><a name="edit" id="edit">Editing an Existing Signal
       Head</a></h3>
 
-      <p><a name="edit" id="edit">Click on the <b>Edit</b> button
+      <p>Click on the <b>Edit</b> button
       at the right of the Signal Head Table to open the Edit Signal
-      Head window.</a></p>
+      Head window.</p>
 
       <p>Once a Signal Head has been defined, its connection Type
       and System Name can't be changed. You can ignore Signal Heads

--- a/help/en/html/tools/signaling/SignalingSetup.shtml
+++ b/help/en/html/tools/signaling/SignalingSetup.shtml
@@ -37,10 +37,10 @@
       describe in detail how to set up Signaling in JMRI.</p>
 
       <ul>
-        <li><a href="#7steps">JMRI Signaling in 7 steps</a></li>
+        <li>JMRI Signaling in 7 steps</li>
 
         <li><a href="#magic">Magic SignalMan Set Up</a></li>
-      </ul><a name="7steps"></a>
+      </ul>
 
       <h2>Start to use JMRI Signaling in 7 steps</h2>
 

--- a/help/en/html/tools/signaling/index.shtml
+++ b/help/en/html/tools/signaling/index.shtml
@@ -497,22 +497,19 @@
       <h4><a name="action" id="action">Signal Actions in
       Logix</a></h4>
 
-      <p><a name="action" id="action">Actions related to Signals
+      <p>Actions related to Signals
       Heads and Masts currently available for use in Logix
       Conditionals are listed below along with information on each.
-      <i>Note:</i> Not all Logix actions are included here.</a></p>
+      <i>Note:</i> Not all Logix actions are included here.</p>
 
       <ul>
-        <li><a name="action" id="action"><b>Set Signal Head
+        <li><b>Set Signal Head
         Appearance</b>: Sets the specified Signal Head to the
         chosen Appearance. Specify the Signal Head to set by
         entering its System Name or User Name. Specify the
         Appearance to set by choosing from the popup menu that
         appears after you enter a Signal Head System Name (or drag
-        it from one of the Pick Lists).</a></li>
-
-        <li style="list-style: none"><a name="action" id=
-        "action"></a></li>
+        it from one of the Pick Lists).</li>
 
         <li><b>Set Signal Head Held</b>: Sets the specified Signal
         Head to Hold. Specify the Signal Head to hold by entering

--- a/help/en/html/tools/signaling/ldt/output1.shtml
+++ b/help/en/html/tools/signaling/ldt/output1.shtml
@@ -31,14 +31,14 @@
       L Signals</h2>
 
       <h2><b>Home signal with 5 or 7 lamps</b> <img src=
-      "output1_html_m4f5f2ce4.png" name="obr&#225;zky2" align=
+      "output1_html_m4f5f2ce4.png" align=
       "middle" width="8" height="26" border="0"> <img src=
-      "output1_html_44a4ff16.png" name="obr&#225;zky3" align=
+      "output1_html_44a4ff16.png" align=
       "middle" width="12" height="26" border="0"></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-SBB</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -197,12 +197,12 @@
       <p style="margin-bottom: 0in"><br></p>
 
       <h2><b>Home signal with 4 lamps</b> <img src=
-      "output1_html_m55495bcc.png" name="obr&#225;zky1" align=
+      "output1_html_m55495bcc.png" align=
       "middle" width="8" height="21" border="0"></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-SBB</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -361,12 +361,12 @@
       <p style="margin-bottom: 0in"><br></p>
 
       <h2><b>Home signal with 3 lamps</b> <img src=
-      "output1_html_7f201b69.png" name="obr&#225;zky4" align=
+      "output1_html_7f201b69.png" align=
       "middle" width="8" height="17" border="0"></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-DB</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -525,12 +525,12 @@
       <p style="margin-bottom: 0in"><br></p>
 
       <h2><b>Advance signal with 5 lamps</b> <img src=
-      "output1_html_m140dd523.png" name="obr&#225;zky6" align=
+      "output1_html_m140dd523.png" align=
       "middle" width="15" height="17" border="0"></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-SBB</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -689,12 +689,12 @@
       <p style="margin-bottom: 0in"><br></p>
 
       <h2><b>Advance signal with 4 lamps</b> <img src=
-      "output1_html_4a835f8c.png" name="obr&#225;zky5" align=
+      "output1_html_4a835f8c.png" align=
       "middle" width="15" height="16" border="0"></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-DB</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -853,12 +853,12 @@
       <p style="margin-bottom: 0in"><br></p>
 
       <h2><b>Dwarf signal</b> <img src="output1_html_m5bfb00d.png"
-      name="obr&#225;zky7" align="middle" width="14" height="14"
+      align="middle" width="14" height="14"
       border="0"></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-DB</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -1018,7 +1018,7 @@
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-DB</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">

--- a/help/en/html/tools/signaling/ldt/output2.shtml
+++ b/help/en/html/tools/signaling/ldt/output2.shtml
@@ -30,13 +30,13 @@
       <h2>JMRI: LDT Signaling for DB (German Federal Railways )
       Signals</h2>
 
-      <h2 b="">Exit signal <b><img src="output2_html_cf50511.png"
-      name="obr&#225;zky8" align="middle" width="10" height="18"
+      <h2>Exit signal <b><img src="output2_html_cf50511.png"
+      align="middle" width="10" height="18"
       border="0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-DB</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -194,13 +194,13 @@
 
       <p style="margin-bottom: 0in"><br></p>
 
-      <h2 b="">Entry signal <b><img src="output2_html_116eed62.png"
-      name="obr&#225;zky9" align="middle" width="10" height="18"
+      <h2>Entry signal <b><img src="output2_html_116eed62.png"
+      align="middle" width="10" height="18"
       border="0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-DB</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -358,13 +358,13 @@
 
       <p style="margin-bottom: 0in"><br></p>
 
-      <h2 b="">Advance signal <b><img src=
-      "output2_html_m30be16a8.png" name="obr&#225;zky10" align=
+      <h2>Advance signal <b><img src=
+      "output2_html_m30be16a8.png" align=
       "middle" width="16" height="15" border="0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-DB</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">

--- a/help/en/html/tools/signaling/ldt/output3.shtml
+++ b/help/en/html/tools/signaling/ldt/output3.shtml
@@ -31,13 +31,12 @@
       Signals</h2>
 
       <h2><b>Home signal with green and yellow light
-      bar</b><b><img src="output3_html_258f4a97.png" name=
-      "obr&#225;zky12" align="middle" width="9" height="23" border=
+      bar</b><b><img src="output3_html_258f4a97.png" align="middle" width="9" height="23" border=
       "0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-DR</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -196,12 +195,12 @@
       <p style="margin-bottom: 0in"><br></p>
 
       <h2><b>Home signal without light bar</b><b><img src=
-      "output3_html_11be9e7b.png" name="obr&#225;zky14" align=
+      "output3_html_11be9e7b.png" align=
       "middle" width="9" height="17" border="0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-DR</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -360,12 +359,12 @@
       <p style="margin-bottom: 0in"><br></p>
 
       <h2><b>Advance signal</b> <b><img src=
-      "output3_html_40375239.png" name="obr&#225;zky11" align=
+      "output3_html_40375239.png" align=
       "middle" width="9" height="17" border="0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-DR</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">

--- a/help/en/html/tools/signaling/ldt/output4.shtml
+++ b/help/en/html/tools/signaling/ldt/output4.shtml
@@ -31,16 +31,13 @@
       <h2>JMRI: Examples of LDT Signaling for NS - Nederlandse
       Spoorwegen (Dutch National Railways) Signals</h2>
 
-      <h2><b>Three-aspects signal with/without illuminated speed
-      sign</b><b><img src="output4_html_3840eb.png" name=
-      "obr&#225;zky13" align="middle" width="9" height="31" border=
-      "0"> <img src="output4_html_71c5a86b.png" name=
-      "obr&#225;zky15" align="middle" width="9" height="20" border=
-      "0"></b></h2>
+      <h2><b>Three-aspects signal with/without illuminated speed sign</b>
+      <b><img src="output4_html_3840eb.png" align="middle" width="9" height="31" border="0"> 
+      <img src="output4_html_71c5a86b.png" align="middle" width="9" height="20" border="0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-NS</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">

--- a/help/en/html/tools/signaling/ldt/output5.shtml
+++ b/help/en/html/tools/signaling/ldt/output5.shtml
@@ -31,14 +31,13 @@
       Signals</h2>
 
       <h2><b>Home signal</b> <b><img src="output5_html_289c901.png"
-      name="obr&#225;zky16" align="middle" width="14" height="35"
-      border="0"> <img src="output5_html_m212244f.png" name=
-      "obr&#225;zky17" align="middle" width="15" height="28"
+      align="middle" width="14" height="35"
+      border="0"> <img src="output5_html_m212244f.png" align="middle" width="15" height="28"
       border="0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-OEBB</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -197,12 +196,12 @@
       <p style="margin-bottom: 0in"><br></p>
 
       <h2><b>Advance signal</b> <b><img src=
-      "output5_html_5402c321.png" name="obr&#225;zky18" align=
+      "output5_html_5402c321.png" align=
       "middle" width="16" height="15" border="0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: LS-DEC-OEBB</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">

--- a/help/en/html/tools/signaling/ldt/output6.shtml
+++ b/help/en/html/tools/signaling/ldt/output6.shtml
@@ -30,14 +30,14 @@
       <h2>JMRI: LDT Signaling for CSD/CD/ZSR Signals</h2>
 
       <h2><b>Entry signal <img src="output6_html_6f691e17.png"
-      name="obr&#225;zky20" align="middle" width="6" height="30"
+      align="middle" width="6" height="30"
       border="0"></b><b>+</b> <b>advance signal <img src=
-      "output6_html_7e3459b4.png" name="obr&#225;zky21" align=
+      "output6_html_7e3459b4.png" align=
       "middle" width="6" height="13" border="0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: DP2N, mode 0</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -196,12 +196,12 @@
       <p style="margin-bottom: 0in"><br></p>
 
       <h2><b>Exit signal</b> <b><img src=
-      "output6_html_m5289f733.png" name="obr&#225;zky19" align=
+      "output6_html_m5289f733.png" align=
       "middle" width="6" height="20" border="0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: DP2N, mode 1</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">
@@ -360,12 +360,12 @@
       <p style="margin-bottom: 0in"><br></p>
 
       <h2><b>Repeating signal <img src="output6_html_m2a349567.png"
-      name="obr&#225;zky22" align="middle" width="6" height="23"
+      align="middle" width="6" height="23"
       border="0"></b></h2>
 
       <p style="margin-bottom: 0in">decoder: DP2N, mode 2</p>
 
-      <table width="100%" border="1" bordercolor="#000000"
+      <table width="100%" border="1"
       cellpadding="3" cellspacing="0">
         <col width="40*">
         <col width="29*">

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -304,6 +304,13 @@ public interface Manager<E extends NamedBean> {
     static public
     int getSystemPrefixLength(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
         if (inputName.isEmpty()) throw new NamedBean.BadSystemNameException();
+    
+        // As a very special case, check for legacy prefixs - to be removed
+        // This is also quite a bit slower than the tuned implementation below
+        int p = startsWithLegacySystemPrefix(inputName);
+        if (p > 0) return p;
+
+        // implementation for well-formed names
         int i = 1;
         for (i = 1; i < inputName.length(); i++) {
             if ( !Character.isDigit(inputName.charAt(i)))

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Basic interface for access to named, managed objects.
@@ -326,6 +327,48 @@ public interface Manager<E extends NamedBean> {
     static public @Nonnull
     String getSystemPrefix(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
         return inputName.substring(0,getSystemPrefixLength(inputName));
+    }
+
+    /**
+     * Indicate whether a system-prefix is one of the legacy non-parsable ones
+     * that are being removed during the JMRI 4.11 cycle.
+     * @deprecated to make sure we remember to remove this post-4.11
+     * @since 4.11.2
+     * @return true if a legacy prefix, hence non-parsable
+     */
+    @Deprecated
+    @SuppressWarnings("fallthrough")
+    @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH", justification="intentional to make code more readable")
+    @CheckReturnValue
+    public static boolean isLegacySystemPrefix(@Nonnull String prefix) {
+        return legacyPrefixes.contains(prefix);
+    }
+    
+    @Deprecated
+    static final java.util.TreeSet<String> legacyPrefixes 
+        = new java.util.TreeSet<>(java.util.Arrays.asList(
+            new String[]{
+                "DX", "DCCPP", "DP", "json", "MR", "MC", "PI", "TM" 
+            }));
+
+    /**
+     * If the argument starts with one of the legacy prefixes, detect that and
+     * indicate its length.
+     * <p>
+     * This is a slightly-expensive operation, and should be used sparingly
+     * 
+     * @deprecated to make sure we remember to remove this post-4.11
+     * @since 4.11.2
+     * @return length of a legacy prefix, if present, otherwise -1
+     */
+    @Deprecated
+    @CheckReturnValue
+    public static int startsWithLegacySystemPrefix(@Nonnull String prefix) {
+        // implementation replies on legacy suffix length properties to gain a bit of speed...
+        if (legacyPrefixes.contains(prefix.substring(0,2))) return 2;
+        else if (prefix.startsWith("DCCPP"))  return 5;
+        else if (prefix.startsWith("json"))  return 5;
+        else return -1;
     }
 
     /**

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -27,6 +27,9 @@ import javax.annotation.Nonnull;
  * add/remove PropertyChangeListener methods are provided. At a minimum,
  * subclasses must notify of changes to the list of available NamedBeans; they
  * may have other properties that will also notify.
+ * <p>
+ * Probably should have been called NamedBeanManager
+ * 
  * <hr>
  * This file is part of JMRI.
  * <P>
@@ -284,6 +287,46 @@ public interface Manager<E extends NamedBean> {
     @CheckReturnValue
     public @Nonnull
     String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException;
+
+    /**
+     * Provides length of the system prefix of the given system name. 
+     * <p>
+     * This is a common operation across JMRI, as the system prefix can be
+     * parsed out without knowledge of the type of NamedBean involved.
+     *
+     * @param inputName System name to provide the prefix
+     * @throws NamedBean.BadSystemNameException If the inputName can't be
+     *                                          converted to normalized form
+     * @return The length of the system-prefix part of the system name in standard normalized form
+     */
+    @CheckReturnValue
+    static public
+    int getSystemPrefixLength(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
+        if (inputName.isEmpty()) throw new NamedBean.BadSystemNameException();
+        int i = 1;
+        for (i = 1; i < inputName.length(); i++) {
+            if ( !Character.isDigit(inputName.charAt(i)))
+                break;
+        }
+        return i;
+    }
+
+    /**
+     * Provides the system prefix of the given system name. 
+     * <p>
+     * This is a common operation across JMRI, as the system prefix can be
+     * parsed out without knowledge of the type of NamedBean involved.
+     *
+     * @param inputName System name to provide the prefix
+     * @throws NamedBean.BadSystemNameException If the inputName can't be
+     *                                          converted to normalized form
+     * @return The system-prefix part of the system name in standard normalized form
+     */
+    @CheckReturnValue
+    static public @Nonnull
+    String getSystemPrefix(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
+        return inputName.substring(0,getSystemPrefixLength(inputName));
+    }
 
     /**
      * Get a manager-specific tool tip for adding an entry to the manager.

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -340,6 +340,54 @@ public interface NamedBean {
         return result;
     }
 
+    /**
+     * Provide a comparison between the system names of two beans.
+     * This provides a implementation for e.g. {@link java.util.Comparable<NamedBean>).
+     * @return 0 if the names are the same, -1 if the first argument orders before
+     * the second argument's name, +1 if the first argument's name  orders after the second argument's name.
+     * The comparison is alphanumeric on the system prefix, then alphabetic on the
+     * type letter, then system-specific comparison on the two suffix parts
+     * via the {@link compareSystemNameSuffix} method.
+     *
+     * @parm n1 The first NamedBean in the comparison
+     * @parm n2 The second NamedBean in the comparison
+     * @returns -1,0,+1 for ordering if the names are well-formed; may not provide proper ordering if the names are not well-formed.
+     */
+    @CheckReturnValue
+    static public int compareSystemName(@Nonnull NamedBean n1, @Nonnull NamedBean n2) {
+        jmri.util.AlphanumComparator ac = new jmri.util.AlphanumComparator();
+        String o1 = n1.getSystemName();
+        String o2 = n2.getSystemName();
+        
+        int p1len = Manager.getSystemPrefixLength(o1);
+        int p2len = Manager.getSystemPrefixLength(o2);
+        
+        int comp = ac.compare(o1.substring(0, p1len), o2.substring(0, p2len));
+        if (comp != 0) return comp;
+
+        char c1 = o1.charAt(p1len);
+        char c2 = o2.charAt(p2len);
+           
+        if (c1 != c2) {
+            return (c1 > c2) ? +1 : -1 ;
+        } else {
+            return n1.compareSystemNameSuffix(o1.substring(p1len+1), o2.substring(p2len+1), n2);
+        }
+    }
+
+    /**
+     * Compare the suffix of this NamedBean's name with the 
+     * suffix of the argument NamedBean's name for the {@link compareSystemName} operation.
+     * This is intended to be a system-specific comparison that understands the various formats, etc.
+     *
+     * @parm suffix1 The suffix for the 1st bean in the comparison
+     * @parm suffix2 The suffix for the 2nd bean in the comparison
+     * @parm n2 The other (second) NamedBean in the comparison
+     * @returns -1,0,+1 for ordering if the names are well-formed; may not provide proper ordering if the names are not well-formed.
+     */
+    @CheckReturnValue
+    public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull NamedBean n2);
+
     public class BadUserNameException extends IllegalArgumentException {
     }
 

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -342,16 +342,16 @@ public interface NamedBean {
 
     /**
      * Provide a comparison between the system names of two beans.
-     * This provides a implementation for e.g. {@link java.util.Comparable<NamedBean>).
+     * This provides a implementation for e.g. {@link java.util.Comparator}.
      * @return 0 if the names are the same, -1 if the first argument orders before
      * the second argument's name, +1 if the first argument's name  orders after the second argument's name.
      * The comparison is alphanumeric on the system prefix, then alphabetic on the
      * type letter, then system-specific comparison on the two suffix parts
      * via the {@link compareSystemNameSuffix} method.
      *
-     * @parm n1 The first NamedBean in the comparison
-     * @parm n2 The second NamedBean in the comparison
-     * @returns -1,0,+1 for ordering if the names are well-formed; may not provide proper ordering if the names are not well-formed.
+     * @param n1 The first NamedBean in the comparison
+     * @param n2 The second NamedBean in the comparison
+     * @return -1,0,+1 for ordering if the names are well-formed; may not provide proper ordering if the names are not well-formed.
      */
     @CheckReturnValue
     static public int compareSystemName(@Nonnull NamedBean n1, @Nonnull NamedBean n2) {
@@ -380,10 +380,10 @@ public interface NamedBean {
      * suffix of the argument NamedBean's name for the {@link compareSystemName} operation.
      * This is intended to be a system-specific comparison that understands the various formats, etc.
      *
-     * @parm suffix1 The suffix for the 1st bean in the comparison
-     * @parm suffix2 The suffix for the 2nd bean in the comparison
-     * @parm n2 The other (second) NamedBean in the comparison
-     * @returns -1,0,+1 for ordering if the names are well-formed; may not provide proper ordering if the names are not well-formed.
+     * @param suffix1 The suffix for the 1st bean in the comparison
+     * @param suffix2 The suffix for the 2nd bean in the comparison
+     * @param n2 The other (second) NamedBean in the comparison
+     * @return -1,0,+1 for ordering if the names are well-formed; may not provide proper ordering if the names are not well-formed.
      */
     @CheckReturnValue
     public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull NamedBean n2);

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -56,7 +56,7 @@ import javax.annotation.Nonnull;
  * @author Bob Jacobsen Copyright (C) 2001, 2002, 2003, 2004
  * @see jmri.Manager
  */
-public interface NamedBean {
+public interface NamedBean extends Comparable<NamedBean> {
 
     /**
      * Constant representing an "unknown" state, indicating that the object's
@@ -96,11 +96,20 @@ public interface NamedBean {
      * Get a system-specific name. This encodes the hardware addressing
      * information. Any given system name must be unique within the layout.
      *
+     *
      * @return the system-specific name.
      */
     @CheckReturnValue
     @Nonnull
     public String getSystemName();
+
+    /**
+     * Display the system-specific name. 
+     *
+     * @return the system-specific name.
+     */
+    @Nonnull
+    public String toString(); 
 
     /**
      * return user name if it exists, otherwise return System name
@@ -349,14 +358,13 @@ public interface NamedBean {
      * type letter, then system-specific comparison on the two suffix parts
      * via the {@link compareSystemNameSuffix} method.
      *
-     * @param n1 The first NamedBean in the comparison
-     * @param n2 The second NamedBean in the comparison
+     * @param n2 The second NamedBean in the comparison ("this" is the first one)
      * @return -1,0,+1 for ordering if the names are well-formed; may not provide proper ordering if the names are not well-formed.
      */
     @CheckReturnValue
-    static public int compareSystemName(@Nonnull NamedBean n1, @Nonnull NamedBean n2) {
+    public default int compareTo(@Nonnull NamedBean n2) {
         jmri.util.AlphanumComparator ac = new jmri.util.AlphanumComparator();
-        String o1 = n1.getSystemName();
+        String o1 = this.getSystemName();
         String o2 = n2.getSystemName();
         
         int p1len = Manager.getSystemPrefixLength(o1);
@@ -371,7 +379,7 @@ public interface NamedBean {
         if (c1 != c2) {
             return (c1 > c2) ? +1 : -1 ;
         } else {
-            return n1.compareSystemNameSuffix(o1.substring(p1len+1), o2.substring(p2len+1), n2);
+            return this.compareSystemNameSuffix(o1.substring(p1len+1), o2.substring(p2len+1), n2);
         }
     }
 

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -385,7 +385,7 @@ public interface NamedBean extends Comparable<NamedBean> {
 
     /**
      * Compare the suffix of this NamedBean's name with the 
-     * suffix of the argument NamedBean's name for the {@link compareSystemName} operation.
+     * suffix of the argument NamedBean's name for the {@link #compareTo} operation.
      * This is intended to be a system-specific comparison that understands the various formats, etc.
      *
      * @param suffix1 The suffix for the 1st bean in the comparison

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -202,6 +202,13 @@ public abstract class AbstractNamedBean implements NamedBean {
         return mSystemName;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Nonnull
+    public String toString() { return getSystemName(); }
+
+
     @Override
     public String getUserName() {
         return mUserName;

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -333,4 +333,17 @@ public abstract class AbstractNamedBean implements NamedBean {
         }
         return result;
     }
+    
+    /**
+     * {@inheritDoc} 
+     * 
+     * By default, does an alphanumeric-by-chunks comparison
+     */
+    @CheckReturnValue
+    public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull NamedBean n) {
+        jmri.util.AlphanumComparator ac = new jmri.util.AlphanumComparator();
+        return ac.compare(suffix1, suffix2);
+    }
+    
+
 }

--- a/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
+++ b/java/src/jmri/jmrit/beantable/AbstractTableTabAction.java
@@ -19,7 +19,6 @@ import jmri.Manager;
 import jmri.swing.RowSorterUtil;
 import jmri.util.AlphanumComparator;
 import jmri.util.ConnectionNameFromSystemName;
-import jmri.util.SystemNameComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -186,7 +185,6 @@ abstract public class AbstractTableTabAction extends AbstractTableAction {
             dataTable = dataModel.makeJTable(dataModel.getMasterClassName() + ":" + getItemString(), dataModel, sorter);
             dataScroll = new JScrollPane(dataTable);
 
-            sorter.setComparator(BeanTableDataModel.SYSNAMECOL, new SystemNameComparator());
             RowSorterUtil.setSortOrder(sorter, BeanTableDataModel.SYSNAMECOL, SortOrder.ASCENDING);
 
             sorter.setComparator(BeanTableDataModel.USERNAMECOL, new AlphanumComparator());

--- a/java/src/jmri/jmrit/beantable/AudioTablePanel.java
+++ b/java/src/jmri/jmrit/beantable/AudioTablePanel.java
@@ -66,7 +66,8 @@ public class AudioTablePanel extends JPanel {
         super();
         listenerDataModel = listenerModel;
         TableRowSorter<AudioTableDataModel> sorter = new TableRowSorter<>(listenerDataModel);
-        sorter.setComparator(AudioTableDataModel.SYSNAMECOL, new SystemNameComparator());
+
+        // use NamedBean's built-in Comparator interface for sorting the system name column
         RowSorterUtil.setSortOrder(sorter, AudioTableDataModel.SYSNAMECOL, SortOrder.ASCENDING);
         listenerDataTable = listenerDataModel.makeJTable(listenerDataModel.getMasterClassName(), listenerDataModel, sorter);
         listenerDataScroll = new JScrollPane(listenerDataTable);

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -173,6 +173,7 @@ abstract public class BeanTableDataModel extends AbstractTableModel implements P
     public Class<?> getColumnClass(int col) {
         switch (col) {
             case SYSNAMECOL:
+                return NamedBean.class;
             case USERNAMECOL:
             case COMMENTCOL:
                 return String.class;
@@ -209,7 +210,7 @@ abstract public class BeanTableDataModel extends AbstractTableModel implements P
         NamedBean b;
         switch (col) {
             case SYSNAMECOL:  // slot number
-                return sysNameList.get(row);
+                return getBySystemName(sysNameList.get(row));
             case USERNAMECOL:  // return user name
                 // sometimes, the TableSorter invokes this on rows that no longer exist, so we check
                 b = getBySystemName(sysNameList.get(row));

--- a/java/src/jmri/jmrit/beantable/BeanTableFrame.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableFrame.java
@@ -17,7 +17,6 @@ import javax.swing.SortOrder;
 import javax.swing.table.TableRowSorter;
 import jmri.swing.RowSorterUtil;
 import jmri.util.AlphanumComparator;
-import jmri.util.SystemNameComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +64,7 @@ public class BeanTableFrame extends jmri.util.JmriJFrame {
         // give system name column as smarter sorter and use it initially
         TableRowSorter<BeanTableDataModel> sorter = new TableRowSorter<>(dataModel);
 
-        sorter.setComparator(BeanTableDataModel.SYSNAMECOL, new SystemNameComparator());
+        // use NamedBean's built-in Comparator interface for sorting the system name column
         RowSorterUtil.setSortOrder(sorter, BeanTableDataModel.SYSNAMECOL, SortOrder.ASCENDING);
 
         sorter.setComparator(BeanTableDataModel.USERNAMECOL, new AlphanumComparator());

--- a/java/src/jmri/jmrit/beantable/BeanTablePane.java
+++ b/java/src/jmri/jmrit/beantable/BeanTablePane.java
@@ -8,7 +8,6 @@ import javax.swing.JTable;
 import javax.swing.SortOrder;
 import javax.swing.table.TableRowSorter;
 import jmri.swing.RowSorterUtil;
-import jmri.util.SystemNameComparator;
 
 /**
  * Provide a JPanel to display a table of NamedBeans.
@@ -41,8 +40,7 @@ public class BeanTablePane extends jmri.util.swing.JmriPanel {
         dataTable = dataModel.makeJTable(dataModel.getMasterClassName(), dataModel, sorter);
         dataScroll = new JScrollPane(dataTable);
 
-        // give system name column as smarter sorter and use it initially
-        sorter.setComparator(BeanTableDataModel.SYSNAMECOL, new SystemNameComparator());
+        // use NamedBean's built-in Comparator interface for sorting the system name column
         RowSorterUtil.setSortOrder(sorter, BeanTableDataModel.SYSNAMECOL, SortOrder.ASCENDING);
         this.dataTable.setRowSorter(sorter);
 

--- a/java/src/jmri/jmrit/beantable/LRouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LRouteTableAction.java
@@ -2468,14 +2468,16 @@ public class LRouteTableAction extends AbstractTableAction {
     /**
      * Sorts RouteElement
      */
-    public static class RouteElementComparator extends SystemNameComparator {
+    public static class RouteElementComparator implements java.util.Comparator<RouteElement> {
 
         RouteElementComparator() {
         }
 
-        @Override
-        public int compare(Object o1, Object o2) {
-            return super.compare(((RouteElement) o1).getSysName(), ((RouteElement) o2).getSysName());
+        private SystemNameComparator sc = new SystemNameComparator();
+        
+        @Override 
+        public int compare(RouteElement o1, RouteElement o2) {
+            return sc.compare(o1.getSysName(), o2.getSysName());
         }
     }
 

--- a/java/src/jmri/jmrit/beantable/LRouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LRouteTableAction.java
@@ -200,8 +200,7 @@ public class LRouteTableAction extends AbstractTableAction {
                 case EDITCOL:
                     return Bundle.getMessage("ButtonEdit");
                 case ENABLECOL:
-                    return ((Logix) getBySystemName((String) getValueAt(row,
-                            SYSNAMECOL))).getEnabled();
+                    return ((Logix) getValueAt(row, SYSNAMECOL)).getEnabled();
                 default:
                     return super.getValueAt(row, col);
             }
@@ -212,13 +211,12 @@ public class LRouteTableAction extends AbstractTableAction {
             switch (col) {
                 case EDITCOL:
                     // set up to edit
-                    String sName = (String) getValueAt(row, SYSNAMECOL);
+                    String sName = ((Logix) getValueAt(row, SYSNAMECOL)).getSystemName();
                     editPressed(sName);
                     break;
                 case ENABLECOL:
                     // alternate
-                    Logix x = (Logix) getBySystemName((String) getValueAt(row,
-                            SYSNAMECOL));
+                    Logix x = (Logix) getValueAt(row, SYSNAMECOL);
                     boolean v = x.getEnabled();
                     x.setEnabled(!v);
                     break;

--- a/java/src/jmri/jmrit/beantable/LRouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LRouteTableAction.java
@@ -2483,7 +2483,7 @@ public class LRouteTableAction extends AbstractTableAction {
      * Base class for all the output (ConditionalAction) and input
      * (ConditionalVariable) elements
      */
-    class RouteElement {
+    static class RouteElement {
 
         String _sysName;
         String _userName;

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -173,7 +173,7 @@ public class LightTableAction extends AbstractTableAction {
                     return true;
                 }
                 if (col == INTENSITYCOL) {
-                    return ((Light) getBySystemName((String) getValueAt(row, SYSNAMECOL))).isIntensityVariable();
+                    return ((Light) getValueAt(row, SYSNAMECOL)).isIntensityVariable();
                 }
                 if (col == ENABLECOL) {
                     return true;
@@ -215,9 +215,9 @@ public class LightTableAction extends AbstractTableAction {
                     case EDITCOL:
                         return Bundle.getMessage("ButtonEdit");
                     case INTENSITYCOL:
-                        return ((Light) getBySystemName((String) getValueAt(row, SYSNAMECOL))).getTargetIntensity();
+                        return ((Light) getValueAt(row, SYSNAMECOL)).getTargetIntensity();
                     case ENABLECOL:
-                        return ((Light) getBySystemName((String) getValueAt(row, SYSNAMECOL))).getEnabled();
+                        return ((Light) getValueAt(row, SYSNAMECOL)).getEnabled();
                     default:
                         return super.getValueAt(row, col);
                 }
@@ -240,7 +240,7 @@ public class LightTableAction extends AbstractTableAction {
                             public void run() {
                                 // set up to edit
                                 addPressed(null);
-                                fixedSystemName.setText((String) getValueAt(row, SYSNAMECOL));
+                                fixedSystemName.setText(((Light) getValueAt(row, SYSNAMECOL)).getSystemName());
                                 editPressed(); // don't really want to stop Light w/o user action
                             }
                         }
@@ -250,7 +250,7 @@ public class LightTableAction extends AbstractTableAction {
                     case INTENSITYCOL:
                         // alternate
                         try {
-                            Light l = (Light) getBySystemName((String) getValueAt(row, SYSNAMECOL));
+                            Light l = (Light) getValueAt(row, SYSNAMECOL);
                             double intensity = ((Double) value);
                             if (intensity < 0) {
                                 intensity = 0;
@@ -266,13 +266,13 @@ public class LightTableAction extends AbstractTableAction {
                         break;
                     case ENABLECOL:
                         // alternate
-                        Light l = (Light) getBySystemName((String) getValueAt(row, SYSNAMECOL));
+                        Light l = (Light) getValueAt(row, SYSNAMECOL);
                         boolean v = l.getEnabled();
                         l.setEnabled(!v);
                         break;
                     case VALUECOL:
                         if (_graphicState) { // respond to clicking on ImageIconRenderer CellEditor
-                            Light ll = (Light) getBySystemName((String) getValueAt(row, SYSNAMECOL));
+                            Light ll = (Light) getValueAt(row, SYSNAMECOL);
                             clickOn(ll);
                             fireTableRowsUpdated(row, row);
                             break;

--- a/java/src/jmri/jmrit/beantable/ListedTableFrame.java
+++ b/java/src/jmri/jmrit/beantable/ListedTableFrame.java
@@ -34,7 +34,6 @@ import jmri.InstanceManager;
 import jmri.UserPreferencesManager;
 import jmri.swing.RowSorterUtil;
 import jmri.util.AlphanumComparator;
-import jmri.util.SystemNameComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -369,7 +368,7 @@ public class ListedTableFrame extends BeanTableFrame {
             dataTable = dataModel.makeJTable(dataModel.getMasterClassName() + ":" + getItemString(), dataModel, sorter);
             dataScroll = new JScrollPane(dataTable);
 
-            sorter.setComparator(BeanTableDataModel.SYSNAMECOL, new SystemNameComparator());
+            // use NamedBean's built-in Comparator interface for sorting the system name column
             RowSorterUtil.setSortOrder(sorter, BeanTableDataModel.SYSNAMECOL, SortOrder.ASCENDING);
 
             sorter.setComparator(BeanTableDataModel.USERNAMECOL, new AlphanumComparator());

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -189,7 +189,7 @@ public class LogixTableAction extends AbstractTableAction {
                 if (col == EDITCOL) {
                     return Bundle.getMessage("ButtonSelect");  // NOI18N
                 } else if (col == ENABLECOL) {
-                    Logix logix = (Logix) getBySystemName((String) getValueAt(row, SYSNAMECOL));
+                    Logix logix = (Logix) getValueAt(row, SYSNAMECOL);
                     if (logix == null) {
                         return null;
                     }
@@ -203,7 +203,7 @@ public class LogixTableAction extends AbstractTableAction {
             public void setValueAt(Object value, int row, int col) {
                 if (col == EDITCOL) {
                     // set up to edit
-                    String sName = (String) getValueAt(row, SYSNAMECOL);
+                    String sName = ((Logix) getValueAt(row, SYSNAMECOL)).getSystemName();
                     if (Bundle.getMessage("ButtonEdit").equals(value)) {  // NOI18N
                         editPressed(sName);
 
@@ -219,8 +219,7 @@ public class LogixTableAction extends AbstractTableAction {
                     }
                 } else if (col == ENABLECOL) {
                     // alternate
-                    Logix x = (Logix) getBySystemName((String) getValueAt(row,
-                            SYSNAMECOL));
+                    Logix x = (Logix) getValueAt(row, SYSNAMECOL);
                     boolean v = x.getEnabled();
                     x.setEnabled(!v);
                 } else {

--- a/java/src/jmri/jmrit/beantable/RouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableAction.java
@@ -48,7 +48,6 @@ import jmri.swing.RowSorterUtil;
 import jmri.util.AlphanumComparator;
 import jmri.util.FileUtil;
 import jmri.util.JmriJFrame;
-import jmri.util.SystemNameComparator;
 import jmri.util.swing.JmriBeanComboBox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -186,7 +185,7 @@ public class RouteTableAction extends AbstractTableAction {
                 }
                 // Route lock is available if turnouts are lockable
                 if (col == LOCKCOL) {
-                    Route r = (Route) getBySystemName((String) getValueAt(row, SYSNAMECOL));
+                    Route r = (Route) getValueAt(row, SYSNAMECOL);
                     return r.canLock();
                 } else {
                     return super.isCellEditable(row, col);
@@ -199,11 +198,11 @@ public class RouteTableAction extends AbstractTableAction {
                     case SETCOL:
                         return Bundle.getMessage("ButtonEdit");
                     case ENABLECOL:
-                        return ((Route) getBySystemName((String) getValueAt(row, SYSNAMECOL))).getEnabled();
+                        return ((Route)getValueAt(row, SYSNAMECOL)).getEnabled();
                     case LOCKCOL:
-                        Route r = (Route) getBySystemName((String) getValueAt(row, SYSNAMECOL));
+                        Route r = (Route) getValueAt(row, SYSNAMECOL);
                         if (r.canLock()) {
-                            return ((Route) getBySystemName((String) getValueAt(row, SYSNAMECOL))).getLocked();
+                            return r.getLocked();
                         } else {
                             // this covers the case when route was locked and lockable turnouts were removed from the route
                             r.setLocked(false);
@@ -251,7 +250,7 @@ public class RouteTableAction extends AbstractTableAction {
                             @Override
                             public void run() {
                                 addPressed(null);
-                                _systemName.setText((String) getValueAt(row, SYSNAMECOL));
+                                _systemName.setText(((Route) getValueAt(row, SYSNAMECOL)).getSystemName());
                                 editPressed(null); // don't really want to stop Route w/o user action
                             }
                         }
@@ -260,14 +259,14 @@ public class RouteTableAction extends AbstractTableAction {
                         break;
                     case ENABLECOL: {
                         // alternate
-                        Route r = (Route) getBySystemName((String) getValueAt(row, SYSNAMECOL));
+                        Route r = (Route) getValueAt(row, SYSNAMECOL);
                         boolean v = r.getEnabled();
                         r.setEnabled(!v);
                         break;
                     }
                     case LOCKCOL: {
                         // alternate
-                        Route r = (Route) getBySystemName((String) getValueAt(row, SYSNAMECOL));
+                        Route r = (Route) getValueAt(row, SYSNAMECOL);
                         boolean v = r.getLocked();
                         r.setLocked(!v);
                         break;
@@ -577,7 +576,8 @@ public class RouteTableAction extends AbstractTableAction {
             _routeTurnoutModel = new RouteTurnoutModel();
             JTable routeTurnoutTable = new JTable(_routeTurnoutModel);
             TableRowSorter<RouteTurnoutModel> rtSorter = new TableRowSorter<>(_routeTurnoutModel);
-            rtSorter.setComparator(RouteTurnoutModel.SNAME_COLUMN, new SystemNameComparator());
+
+            // use NamedBean's built-in Comparator interface for sorting the system name column
             RowSorterUtil.setSortOrder(rtSorter, RouteTurnoutModel.SNAME_COLUMN, SortOrder.ASCENDING);
             rtSorter.setComparator(RouteTurnoutModel.UNAME_COLUMN, new AlphanumComparator());
             RowSorterUtil.setSortOrder(rtSorter, RouteTurnoutModel.UNAME_COLUMN, SortOrder.ASCENDING);
@@ -631,7 +631,8 @@ public class RouteTableAction extends AbstractTableAction {
             _routeSensorModel = new RouteSensorModel();
             JTable routeSensorTable = new JTable(_routeSensorModel);
             TableRowSorter<RouteSensorModel> rsSorter = new TableRowSorter<>(_routeSensorModel);
-            rsSorter.setComparator(RouteSensorModel.SNAME_COLUMN, new SystemNameComparator());
+
+            // use NamedBean's built-in Comparator interface for sorting the system name column
             RowSorterUtil.setSortOrder(rsSorter, RouteSensorModel.SNAME_COLUMN, SortOrder.ASCENDING);
             rtSorter.setComparator(RouteTurnoutModel.UNAME_COLUMN, new AlphanumComparator());
             RowSorterUtil.setSortOrder(rtSorter, RouteTurnoutModel.UNAME_COLUMN, SortOrder.ASCENDING);

--- a/java/src/jmri/jmrit/beantable/SectionTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SectionTableAction.java
@@ -190,7 +190,7 @@ public class SectionTableAction extends AbstractTableAction {
 
                         @Override
                         public void run() {
-                            String sName = (String) getValueAt(row, SYSNAMECOL);
+                            String sName = ((Section) getValueAt(row, SYSNAMECOL)).getSystemName();
                             editPressed(sName);
                         }
                     }

--- a/java/src/jmri/jmrit/beantable/SignalGroupSubTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalGroupSubTableAction.java
@@ -35,7 +35,6 @@ import jmri.SignalHead;
 import jmri.Turnout;
 import jmri.swing.RowSorterUtil;
 import jmri.util.JmriJFrame;
-import jmri.util.SystemNameComparator;
 import jmri.util.table.ButtonEditor;
 import jmri.util.table.ButtonRenderer;
 import org.slf4j.Logger;
@@ -388,7 +387,8 @@ public class SignalGroupSubTableAction {
             _SignalGroupTurnoutModel = new SignalGroupTurnoutModel();
             JTable SignalGroupTurnoutTable = new JTable(_SignalGroupTurnoutModel);
             TableRowSorter<SignalGroupTurnoutModel> sgtSorter = new TableRowSorter<>(_SignalGroupTurnoutModel);
-            sgtSorter.setComparator(SignalGroupTurnoutModel.SNAME_COLUMN, new SystemNameComparator());
+
+            // use NamedBean's built-in Comparator interface for sorting the system name column
             RowSorterUtil.setSortOrder(sgtSorter, SignalGroupTurnoutModel.SNAME_COLUMN, SortOrder.ASCENDING);
             SignalGroupTurnoutTable.setRowSorter(sgtSorter);
             SignalGroupTurnoutTable.setRowSelectionAllowed(false);
@@ -446,7 +446,8 @@ public class SignalGroupSubTableAction {
             _SignalGroupSensorModel = new SignalGroupSensorModel();
             JTable SignalGroupSensorTable = new JTable(_SignalGroupSensorModel);
             TableRowSorter<SignalGroupSensorModel> sgsSorter = new TableRowSorter<>(_SignalGroupSensorModel);
-            sgsSorter.setComparator(SignalGroupSensorModel.SNAME_COLUMN, new SystemNameComparator());
+
+            // use NamedBean's built-in Comparator interface for sorting the system name column
             RowSorterUtil.setSortOrder(sgsSorter, SignalGroupSensorModel.SNAME_COLUMN, SortOrder.ASCENDING);
             SignalGroupSensorTable.setRowSorter(sgsSorter);
             SignalGroupSensorTable.setRowSelectionAllowed(false);

--- a/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
@@ -38,6 +38,7 @@ import jmri.SignalMast;
 import jmri.swing.RowSorterUtil;
 import jmri.util.JmriJFrame;
 import jmri.util.SystemNameComparator;
+import jmri.util.AlphanumComparator;
 import jmri.util.swing.JmriBeanComboBox;
 import jmri.util.table.ButtonEditor;
 import jmri.util.table.ButtonRenderer;
@@ -543,7 +544,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
             _AspectModel = new SignalMastAspectModel();
             JTable SignalMastAspectTable = new JTable(_AspectModel);
             TableRowSorter<SignalMastAspectModel> smaSorter = new TableRowSorter<>(_AspectModel);
-            smaSorter.setComparator(SignalMastAspectModel.ASPECT_COLUMN, new SystemNameComparator());
+            smaSorter.setComparator(SignalMastAspectModel.ASPECT_COLUMN, new AlphanumComparator());
             RowSorterUtil.setSortOrder(smaSorter, SignalMastAspectModel.ASPECT_COLUMN, SortOrder.ASCENDING);
             SignalMastAspectTable.setRowSorter(smaSorter);
             SignalMastAspectTable.setRowSelectionAllowed(false);

--- a/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
@@ -37,7 +37,6 @@ import jmri.SignalHead;
 import jmri.SignalMast;
 import jmri.swing.RowSorterUtil;
 import jmri.util.JmriJFrame;
-import jmri.util.SystemNameComparator;
 import jmri.util.AlphanumComparator;
 import jmri.util.swing.JmriBeanComboBox;
 import jmri.util.table.ButtonEditor;
@@ -189,10 +188,10 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
                 if (col == EDITCOL) {
                     return Bundle.getMessage("ButtonEdit");
                 } else if (col == ENABLECOL) {
-                    return Boolean.valueOf(((SignalGroup) getBySystemName((String) getValueAt(row, SYSNAMECOL))).getEnabled());
+                    return Boolean.valueOf(((SignalGroup) getValueAt(row, SYSNAMECOL)).getEnabled());
                     //return true;
                 } else if (col == COMMENTCOL) {
-                    b = getBySystemName(sysNameList.get(row));
+                    b = (NamedBean) getValueAt(row, SYSNAMECOL);
                     return (b != null) ? b.getComment() : null;
                 } else if (col == DELETECOL) //
                 {
@@ -217,7 +216,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
                         @Override
                         public void run() {
                             addPressed(null); // set up add/edit panel addFrame (starts as Add pane)
-                            _systemName.setText((String) getValueAt(row, SYSNAMECOL));
+                            _systemName.setText(((SignalGroup) getValueAt(row, SYSNAMECOL)).toString());
                             editPressed(null); // adjust addFrame for Edit
                         }
                     }
@@ -225,7 +224,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
                     javax.swing.SwingUtilities.invokeLater(t);
                 } else if (col == ENABLECOL) {
                     // alternate
-                    SignalGroup r = (SignalGroup) getBySystemName((String) getValueAt(row, SYSNAMECOL));
+                    SignalGroup r = (SignalGroup) getValueAt(row, SYSNAMECOL);
                     boolean v = r.getEnabled();
                     r.setEnabled(!v);
                 } else if (col == COMMENTCOL) {
@@ -607,7 +606,8 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
             _SignalGroupHeadModel = new SignalGroupSignalHeadModel();
             JTable SignalGroupHeadTable = new JTable(_SignalGroupHeadModel);
             TableRowSorter<SignalGroupSignalHeadModel> sgsSorter = new TableRowSorter<>(_SignalGroupHeadModel);
-            sgsSorter.setComparator(SignalGroupSignalHeadModel.SNAME_COLUMN, new SystemNameComparator());
+
+            // use NamedBean's built-in Comparator interface for sorting the system name column
             RowSorterUtil.setSortOrder(sgsSorter, SignalGroupSignalHeadModel.SNAME_COLUMN, SortOrder.ASCENDING);
             SignalGroupHeadTable.setRowSorter(sgsSorter);
             SignalGroupHeadTable.setRowSelectionAllowed(false);

--- a/java/src/jmri/jmrit/beantable/SignalHeadTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalHeadTableAction.java
@@ -286,7 +286,7 @@ public class SignalHeadTableAction extends AbstractTableAction {
             public void clickOn(NamedBean t) {
                 int oldState = ((SignalHead) t).getAppearance();
                 int newState = 99;
-                int[] stateList = ((SignalHead) t).getValidStates(); // getValidAppearances((String)
+                int[] stateList = ((SignalHead) t).getValidStates();
                 for (int i = 0; i < stateList.length; i++) {
                     if (oldState == stateList[i]) {
                         if (i < stateList.length - 1) {
@@ -452,10 +452,9 @@ public class SignalHeadTableAction extends AbstractTableAction {
              * @param head the name of the signal head
              * @return List of valid signal head appearance names
              */
-            public Vector<String> getValidAppearances(String head) {
+            public Vector<String> getValidAppearances(SignalHead head) {
                 // convert String[] validStateNames to Vector
-                String[] app = InstanceManager.getDefault(jmri.SignalHeadManager.class)
-                        .getSignalHead(head).getValidStateNames();
+                String[] app = head.getValidStateNames();
                 Vector<String> v = new Vector<String>();
                 for (int i = 0; i < app.length; i++) {
                     String appearance = app[i];
@@ -476,7 +475,7 @@ public class SignalHeadTableAction extends AbstractTableAction {
                 Vector<String> comboappearances = boxMap.get(this.getValueAt(row, SYSNAMECOL));
                 if (comboappearances == null) {
                     // create a new one with right appearance
-                    Vector<String> v = getValidAppearances((String) this.getValueAt(row, SYSNAMECOL));
+                    Vector<String> v = getValidAppearances((SignalHead) this.getValueAt(row, SYSNAMECOL));
                     comboappearances = v;
                     boxMap.put(this.getValueAt(row, SYSNAMECOL), comboappearances);
                 }
@@ -1821,9 +1820,9 @@ public class SignalHeadTableAction extends AbstractTableAction {
 
     private void editSignal(int row) {
         // Logix was found, initialize for edit
-        String eSName = (String) m.getValueAt(row, BeanTableDataModel.SYSNAMECOL);
-        _curSignal = InstanceManager.getDefault(jmri.SignalHeadManager.class).getBySystemName(eSName);
-        //numConditionals = _curLogix.getNumConditionals();
+        _curSignal = (SignalHead) m.getValueAt(row, BeanTableDataModel.SYSNAMECOL);
+        String eSName = _curSignal.getSystemName();
+
         // create the Edit Logix Window
         // Use separate Runnable so window is created on top
         Runnable t = new Runnable() {

--- a/java/src/jmri/jmrit/beantable/TransitTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TransitTableAction.java
@@ -190,7 +190,7 @@ public class TransitTableAction extends AbstractTableAction {
 
                         @Override
                         public void run() {
-                            String sName = (String) getValueAt(row, SYSNAMECOL);
+                            String sName = ((Transit) getValueAt(row, SYSNAMECOL)).getSystemName();
                             editPressed(sName);
                         }
                     }
@@ -208,7 +208,7 @@ public class TransitTableAction extends AbstractTableAction {
 
                         @Override
                         public void run() {
-                            String sName = (String) getValueAt(row, SYSNAMECOL);
+                            String sName = ((Transit) getValueAt(row, SYSNAMECOL)).getSystemName();
                             duplicatePressed(sName);
                         }
                     }

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -731,6 +731,7 @@ public class TurnoutTableAction extends AbstractTableAction {
                     TableCellRenderer getRenderer(int row, int column) {
                         TableCellRenderer retval = null;
                         Turnout t = (Turnout) getModel().getValueAt(row, SYSNAMECOL);
+                        java.util.Objects.requireNonNull(t, "SYSNAMECOL column content must be nonnull");
                         if (column == SENSOR1COL) {
                             retval = rendererMapSensor1.get(t);
                         } else if (column == SENSOR2COL) {
@@ -739,12 +740,7 @@ public class TurnoutTableAction extends AbstractTableAction {
                             return null;
                         }
 
-                        if (retval == null) {
-                            if (t == null) {
-                                log.warn("renderer unexpectedly found null turnout in row {}", row);
-                                return null;
-                            }
-                                                        
+                        if (retval == null) {                                                        
                             if (column == SENSOR1COL) {
                                 loadRenderEditMaps(rendererMapSensor1, editorMapSensor1, t, t.getFirstSensor());
                                 retval = rendererMapSensor1.get(t);
@@ -760,6 +756,7 @@ public class TurnoutTableAction extends AbstractTableAction {
                     TableCellEditor getEditor(int row, int column) {
                         TableCellEditor retval = null;
                         Turnout t = (Turnout) getModel().getValueAt(row, SYSNAMECOL);
+                        java.util.Objects.requireNonNull(t, "SYSNAMECOL column content must be nonnull");
                         switch (column) {
                             case SENSOR1COL:
                                 retval = editorMapSensor1.get(t);
@@ -771,10 +768,6 @@ public class TurnoutTableAction extends AbstractTableAction {
                                 return null;
                         }
                         if (retval == null) {
-                            if (t == null) {
-                                log.warn("editor unexpectedly found null turnout in row {}", row);
-                                return null;
-                            }
                             if (column == SENSOR1COL) {
                                 loadRenderEditMaps(rendererMapSensor1, editorMapSensor1, t, t.getFirstSensor());
                                 retval = editorMapSensor1.get(t);

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -50,6 +50,7 @@ import jmri.InstanceManager;
 import jmri.Manager;
 import jmri.NamedBean;
 import jmri.Turnout;
+import jmri.Sensor;
 import jmri.TurnoutManager;
 import jmri.TurnoutOperation;
 import jmri.TurnoutOperationManager;
@@ -729,66 +730,82 @@ public class TurnoutTableAction extends AbstractTableAction {
 
                     TableCellRenderer getRenderer(int row, int column) {
                         TableCellRenderer retval = null;
+                        Turnout t = (Turnout) getModel().getValueAt(row, SYSNAMECOL);
                         if (column == SENSOR1COL) {
-                            retval = rendererMapSensor1.get(getModel().getValueAt(row, SYSNAMECOL));
+                            retval = rendererMapSensor1.get(t);
                         } else if (column == SENSOR2COL) {
-                            retval = rendererMapSensor2.get(getModel().getValueAt(row, SYSNAMECOL));
+                            retval = rendererMapSensor2.get(t);
                         } else {
                             return null;
                         }
 
                         if (retval == null) {
-                            Turnout t = turnManager.getBySystemName((String) getModel().getValueAt(row, SYSNAMECOL));
                             if (t == null) {
+                                log.warn("renderer unexpectedly found null turnout in row {}", row);
                                 return null;
                             }
-                            retval = new BeanBoxRenderer();
+                                                        
                             if (column == SENSOR1COL) {
-                                ((JmriBeanComboBox) retval).setSelectedBean(t.getFirstSensor());
-                                rendererMapSensor1.put(getModel().getValueAt(row, SYSNAMECOL), retval);
+                                loadRenderEditMaps(rendererMapSensor1, editorMapSensor1, t, t.getFirstSensor());
+                                retval = rendererMapSensor1.get(t);
                             } else {
-                                ((JmriBeanComboBox) retval).setSelectedBean(t.getSecondSensor());
-                                rendererMapSensor2.put(getModel().getValueAt(row, SYSNAMECOL), retval);
+                                loadRenderEditMaps(rendererMapSensor2, editorMapSensor2, t, t.getSecondSensor());
+                                retval = rendererMapSensor1.get(t);
                             }
                         }
+                        log.debug("fetched for Turnout \"{}\" renderer", t, retval);
                         return retval;
                     }
-                    Hashtable<Object, TableCellRenderer> rendererMapSensor1 = new Hashtable<>();
-                    Hashtable<Object, TableCellRenderer> rendererMapSensor2 = new Hashtable<>();
 
                     TableCellEditor getEditor(int row, int column) {
                         TableCellEditor retval = null;
+                        Turnout t = (Turnout) getModel().getValueAt(row, SYSNAMECOL);
                         switch (column) {
                             case SENSOR1COL:
-                                retval = editorMapSensor1.get(getModel().getValueAt(row, SYSNAMECOL));
+                                retval = editorMapSensor1.get(t);
                                 break;
                             case SENSOR2COL:
-                                retval = editorMapSensor2.get(getModel().getValueAt(row, SYSNAMECOL));
+                                retval = editorMapSensor2.get(t);
                                 break;
                             default:
                                 return null;
                         }
                         if (retval == null) {
-                            Turnout t = turnManager.getBySystemName((String) getModel().getValueAt(row, SYSNAMECOL));
                             if (t == null) {
+                                log.warn("editor unexpectedly found null turnout in row {}", row);
                                 return null;
                             }
-                            JmriBeanComboBox c;
                             if (column == SENSOR1COL) {
-                                c = new JmriBeanComboBox(InstanceManager.sensorManagerInstance(), t.getFirstSensor(), JmriBeanComboBox.DisplayOptions.DISPLAYNAME);
-                                retval = new BeanComboBoxEditor(c);
-                                editorMapSensor1.put(getModel().getValueAt(row, SYSNAMECOL), retval);
+                                loadRenderEditMaps(rendererMapSensor1, editorMapSensor1, t, t.getFirstSensor());
+                                retval = editorMapSensor1.get(t);
                             } else { //Must be two
-                                c = new JmriBeanComboBox(InstanceManager.sensorManagerInstance(), t.getSecondSensor(), JmriBeanComboBox.DisplayOptions.DISPLAYNAME);
-                                retval = new BeanComboBoxEditor(c);
-                                editorMapSensor2.put(getModel().getValueAt(row, SYSNAMECOL), retval);
+                                loadRenderEditMaps(rendererMapSensor2, editorMapSensor2, t, t.getSecondSensor());
+                                retval = editorMapSensor2.get(t);
                             }
-                            c.setFirstItemBlank(true);
                         }
+                        log.debug("fetched for Turnout \"{}\" editor", t, retval);
                         return retval;
                     }
-                    Hashtable<Object, TableCellEditor> editorMapSensor1 = new Hashtable<>();
-                    Hashtable<Object, TableCellEditor> editorMapSensor2 = new Hashtable<>();
+
+                    protected void loadRenderEditMaps(Hashtable<Turnout, TableCellRenderer> r, Hashtable<Turnout, TableCellEditor> e,
+                                                        Turnout t, Sensor s) {
+                            JmriBeanComboBox c = new JmriBeanComboBox(InstanceManager.sensorManagerInstance(), s, JmriBeanComboBox.DisplayOptions.DISPLAYNAME);            
+                            c.setFirstItemBlank(true);
+                            
+                            TableCellRenderer renderer = new BeanBoxRenderer();
+                            ((JmriBeanComboBox)renderer).setSelectedBean(s);
+                            r.put(t, renderer);
+                            
+                            TableCellEditor editor = new BeanComboBoxEditor(c);
+                            e.put(t, editor);
+                            log.error("initialize for Turnout \"{}\" Sensor \"{}\"", t, s);
+                    }
+                                                        
+                    Hashtable<Turnout, TableCellRenderer> rendererMapSensor1 = new Hashtable<>();
+                    Hashtable<Turnout, TableCellEditor> editorMapSensor1 = new Hashtable<>();
+
+                    Hashtable<Turnout, TableCellRenderer> rendererMapSensor2 = new Hashtable<>();
+                    Hashtable<Turnout, TableCellEditor> editorMapSensor2 = new Hashtable<>();
                 };
             }
 

--- a/java/src/jmri/jmrit/beantable/oblock/TableFrames.java
+++ b/java/src/jmri/jmrit/beantable/oblock/TableFrames.java
@@ -432,7 +432,7 @@ public class TableFrames extends jmri.util.JmriJFrame implements InternalFrameLi
         _oBlockModel = new OBlockTableModel(this);
         _oBlockTable = new JTable(_oBlockModel);
         TableRowSorter<OBlockTableModel> sorter = new TableRowSorter<>(_oBlockModel);
-        sorter.setComparator(OBlockTableModel.SYSNAMECOL, new jmri.util.SystemNameComparator());
+        // use NamedBean's built-in Comparator interface for sorting
         _oBlockTable.setRowSorter(sorter);
         _oBlockTable.setTransferHandler(new jmri.util.DnDTableImportExportHandler(new int[]{OBlockTableModel.EDIT_COL,
             OBlockTableModel.DELETE_COL, OBlockTableModel.REPORT_CURRENTCOL, OBlockTableModel.SPEEDCOL,

--- a/java/src/jmri/jmrit/beantable/signalmast/SignalMastRepeaterPanel.java
+++ b/java/src/jmri/jmrit/beantable/signalmast/SignalMastRepeaterPanel.java
@@ -65,8 +65,7 @@ public class SignalMastRepeaterPanel extends jmri.util.swing.JmriPanel implement
         _RepeaterModel = new SignalMastRepeaterModel();
         JTable _RepeaterTable = new JTable(_RepeaterModel);
 
-        TableRowSorter<SignalMastRepeaterModel> sorter = new TableRowSorter<>(_RepeaterModel);
-        sorter.setComparator(SignalMastRepeaterModel.DIR_COLUMN, new jmri.util.SystemNameComparator());
+        TableRowSorter<SignalMastRepeaterModel> sorter = new TableRowSorter<>(_RepeaterModel); // leave default sorting
         RowSorterUtil.setSortOrder(sorter, SignalMastRepeaterModel.DIR_COLUMN, SortOrder.ASCENDING);
         _RepeaterTable.setRowSorter(sorter);
 

--- a/java/src/jmri/jmrit/beantable/signalmast/SignalMastTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/signalmast/SignalMastTableDataModel.java
@@ -502,8 +502,7 @@ public class SignalMastTableDataModel extends BeanTableDataModel {
         Vector<String> comboaspects = boxMap.get(this.getValueAt(row, SYSNAMECOL));
         if (comboaspects == null) {
             // create a new one with right aspects
-            Vector<String> v = InstanceManager.getDefault(jmri.SignalMastManager.class)
-                    .getSignalMast((String) this.getValueAt(row, SYSNAMECOL)).getValidAspects();
+            Vector<String> v = ((SignalMast) this.getValueAt(row, SYSNAMECOL)).getValidAspects();
             comboaspects = v;
             boxMap.put(this.getValueAt(row, SYSNAMECOL), comboaspects);
         }

--- a/java/src/jmri/jmrit/catalog/AbstractCatalogTree.java
+++ b/java/src/jmri/jmrit/catalog/AbstractCatalogTree.java
@@ -5,6 +5,7 @@ import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
 import java.util.HashMap;
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import javax.swing.tree.DefaultTreeModel;
 import jmri.CatalogTree;
 import jmri.NamedBean;
@@ -268,6 +269,17 @@ public abstract class AbstractCatalogTree extends DefaultTreeModel implements Ca
 
     @Override
     public void vetoableChange(java.beans.PropertyChangeEvent evt) throws java.beans.PropertyVetoException {
+    }
+
+    /**
+     * {@inheritDoc} 
+     * 
+     * By default, does an alphanumeric-by-chunks comparison
+     */
+    @CheckReturnValue
+    public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull NamedBean n) {
+        jmri.util.AlphanumComparator ac = new jmri.util.AlphanumComparator();
+        return ac.compare(suffix1, suffix2);
     }
 
     private final static Logger log = LoggerFactory.getLogger(AbstractCatalogTree.class);

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -74,8 +74,7 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
         dataScroll = new JScrollPane(dataTable);
         dataTable.setRowHeight(InstanceManager.getDefault(GuiLafPreferencesManager.class).getFontSize() + 4);
 
-        // Use a "Numeric, if not, Alphanumeric" comparator
-        sorter.setComparator(RosterTableModel.IDCOL, new jmri.util.PreferNumericComparator());
+        sorter.setComparator(RosterTableModel.IDCOL, new jmri.util.AlphanumComparator());
 
         // set initial sort
         List<RowSorter.SortKey> sortKeys = new ArrayList<>();

--- a/java/src/jmri/jmrit/roster/swing/rostergroup/RosterGroupTableFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/rostergroup/RosterGroupTableFrame.java
@@ -46,8 +46,7 @@ public class RosterGroupTableFrame extends jmri.util.JmriJFrame {
         TableRowSorter<RosterGroupTableModel> sorter = new TableRowSorter<>(dataModel);
         dataTable.setRowSorter(sorter);
 
-        // not sure I understand how to address this unchecked warning
-        sorter.setComparator(RosterGroupTableModel.IDCOL, new jmri.util.SystemNameComparator());
+        sorter.setComparator(RosterGroupTableModel.IDCOL, new jmri.util.AlphanumComparator());
         sorter.toggleSortOrder(RosterGroupTableModel.IDCOL);
         dataTable = new JTable(dataModel);
         

--- a/java/src/jmri/jmrit/sensorgroup/SensorGroupFrame.java
+++ b/java/src/jmri/jmrit/sensorgroup/SensorGroupFrame.java
@@ -77,14 +77,7 @@ public class SensorGroupFrame extends jmri.util.JmriJFrame {
         p2xs.add(p21s);
         _sensorModel = new SensorTableModel();
         JTable sensorTable = new JTable(_sensorModel);
-        /*
-         JTable sensorTable = jmri.util.JTableUtil.sortableDataModel(sensorModel);
-         try {
-         jmri.util.com.sun.TableSorter tmodel = ((jmri.util.com.sun.TableSorter)sensorTable.getModel());
-         tmodel.setColumnComparator(String.class, new jmri.util.SystemNameComparator());
-         tmodel.setSortingStatus(SensorTableModel.SNAME_COLUMN, jmri.util.com.sun.TableSorter.ASCENDING);
-         } catch (ClassCastException e3) {}  // if not a sortable table model
-         */
+
         sensorTable.setRowSelectionAllowed(false);
         sensorTable.setPreferredScrollableViewportSize(new java.awt.Dimension(450, 200));
         TableColumnModel sensorColumnModel = sensorTable.getColumnModel();

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
@@ -2150,7 +2150,7 @@ public class PaneProgPane extends javax.swing.JPanel
 
         JTable cvTable = new JTable(_cvModel);
 
-        sorter.setComparator(CvTableModel.NUMCOLUMN, new jmri.util.PreferNumericComparator());
+        sorter.setComparator(CvTableModel.NUMCOLUMN, new jmri.util.AlphanumComparator());
 
         List<RowSorter.SortKey> sortKeys = new ArrayList<>();
         sortKeys.add(new RowSorter.SortKey(0, SortOrder.ASCENDING));

--- a/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
@@ -153,7 +153,7 @@ public class CMRISystemConnectionMemo extends SystemConnectionMemo {
             }
         } else { // k = position of "B" char in name
             try {
-                n = Integer.parseInt(systemName.substring(k)); // why use a different formula than 13 lines up?
+                n = Integer.parseInt(systemName.substring(k));
             } catch (NumberFormatException e) {
                 log.warn("invalid character in bit number field of CMRI system name: {}", systemName);
                 return 0;

--- a/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
@@ -2,6 +2,7 @@ package jmri.jmrix.cmri;
 
 import java.util.ResourceBundle;
 import javax.annotation.Nonnull;
+import javax.annotation.CheckReturnValue;
 import jmri.InstanceManager;
 import jmri.Light;
 import jmri.Manager.NameValidity;
@@ -589,6 +590,45 @@ public class CMRISystemConnectionMemo extends SystemConnectionMemo {
             }
         }
         return ua;
+    }
+
+    /**
+     * See {@link jmri.NamedBean#compareSystemNameSuffix} for background.
+     * 
+     * This is a common implementation for C/MRI Lights, Sensors and Turnouts
+     * of the comparison method.
+     */
+    @CheckReturnValue
+    public static int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2) {
+        
+        // extract node numbers and bit numbers
+        int node1 = 0, node2 = 0, bit1, bit2;
+        int t; // a temporary
+        
+        if ((t = suffix1.indexOf("B")) >= 0) {
+            // alt format
+            bit1 = Integer.parseInt(suffix1.substring(t+1));
+            if (t>0) node1 = Integer.parseInt(suffix1.substring(0, t));
+        } else {
+            // std format
+            int len = suffix1.length();
+            bit1 = Integer.parseInt(suffix1.substring(Math.max(0, len-3)));
+            if (len>3) node1 = Integer.parseInt(suffix1.substring(0, len-3));
+        }
+        
+        if ((t = suffix2.indexOf("B")) >= 0) {
+            // alt format
+            bit2 = Integer.parseInt(suffix2.substring(t+1));
+            if (t>0) node2 = Integer.parseInt(suffix2.substring(0, t));
+        } else {
+            // std format
+            int len = suffix2.length();
+            bit2 = Integer.parseInt(suffix2.substring(Math.max(0, len-3)));
+            if (len>3) node2 = Integer.parseInt(suffix2.substring(0, len-3));
+        }
+        
+        if (node1 != node2 ) return Integer.signum(node1-node2);
+        return Integer.signum(bit1-bit2);
     }
 
     @Override

--- a/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/cmri/CMRISystemConnectionMemo.java
@@ -605,7 +605,9 @@ public class CMRISystemConnectionMemo extends SystemConnectionMemo {
         int node1 = 0, node2 = 0, bit1, bit2;
         int t; // a temporary
         
-        if ((t = suffix1.indexOf("B")) >= 0) {
+        t = suffix1.indexOf("B");
+        if (t < 0) t = suffix1.indexOf(":");
+        if (t >= 0) {
             // alt format
             bit1 = Integer.parseInt(suffix1.substring(t+1));
             if (t>0) node1 = Integer.parseInt(suffix1.substring(0, t));
@@ -616,7 +618,9 @@ public class CMRISystemConnectionMemo extends SystemConnectionMemo {
             if (len>3) node1 = Integer.parseInt(suffix1.substring(0, len-3));
         }
         
-        if ((t = suffix2.indexOf("B")) >= 0) {
+        t = suffix2.indexOf("B");
+        if (t < 0) t = suffix2.indexOf(":");
+        if (t >= 0) {
             // alt format
             bit2 = Integer.parseInt(suffix2.substring(t+1));
             if (t>0) node2 = Integer.parseInt(suffix2.substring(0, t));

--- a/java/src/jmri/jmrix/cmri/serial/SerialLight.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialLight.java
@@ -2,6 +2,11 @@ package jmri.jmrix.cmri.serial;
 
 import jmri.implementation.AbstractLight;
 import jmri.jmrix.cmri.CMRISystemConnectionMemo;
+import jmri.jmrix.cmri.CMRISystemConnectionMemo;
+
+import javax.annotation.Nonnull;
+import javax.annotation.CheckReturnValue;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,6 +81,16 @@ public class SerialLight extends AbstractLight {
                 log.warn("illegal state requested for Light: " + getSystemName());
             }
         }
+    }
+
+    /**
+     * {@inheritDoc} 
+     * 
+     * Sorts by node number and then by bit
+     */
+    @CheckReturnValue
+    public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull jmri.NamedBean n) {
+        return CMRISystemConnectionMemo.compareSystemNameSuffix(suffix1, suffix2);
     }
 
     private final static Logger log = LoggerFactory.getLogger(SerialLight.class);

--- a/java/src/jmri/jmrix/cmri/serial/SerialSensor.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialSensor.java
@@ -1,6 +1,10 @@
 package jmri.jmrix.cmri.serial;
 
 import jmri.implementation.AbstractSensor;
+import jmri.jmrix.cmri.CMRISystemConnectionMemo;
+
+import javax.annotation.Nonnull;
+import javax.annotation.CheckReturnValue;
 
 /**
  * Extend jmri.AbstractSensor for C/MRI serial systems
@@ -28,6 +32,16 @@ public class SerialSensor extends AbstractSensor {
      */
     @Override
     public void requestUpdateFromLayout() {
+    }
+
+    /**
+     * {@inheritDoc} 
+     * 
+     * Sorts by node number and then by bit
+     */
+    @CheckReturnValue
+    public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull jmri.NamedBean n) {
+        return CMRISystemConnectionMemo.compareSystemNameSuffix(suffix1, suffix2);
     }
 
 }

--- a/java/src/jmri/jmrix/cmri/serial/SerialTurnout.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialTurnout.java
@@ -3,6 +3,8 @@ package jmri.jmrix.cmri.serial;
 import jmri.Turnout;
 import jmri.implementation.AbstractTurnout;
 import jmri.jmrix.cmri.CMRISystemConnectionMemo;
+import javax.annotation.Nonnull;
+import javax.annotation.CheckReturnValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +58,7 @@ public class SerialTurnout extends AbstractTurnout {
      * <P>
      * 'systemName' was previously validated in SerialTurnoutManager
      */
-    public SerialTurnout(String systemName, String userName, CMRISystemConnectionMemo memo) {
+    public SerialTurnout(@Nonnull String systemName, String userName, CMRISystemConnectionMemo memo) {
         super(systemName, userName);
         // Save system Name
         tSystemName = systemName;
@@ -263,6 +265,45 @@ public class SerialTurnout extends AbstractTurnout {
                 }
             }
         }
+    }
+
+    /**
+     * {@inheritDoc} 
+     * 
+     * By default, does an alphanumeric-by-chunks comparison
+     */
+    @CheckReturnValue
+    public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull jmri.NamedBean n) {
+        jmri.util.AlphanumComparator ac = new jmri.util.AlphanumComparator();
+        
+        // extract node numbers and bit numbers
+        int node1 = 0, node2 = 0, bit1, bit2;
+        int t; // a temporary
+        
+        if ((t = suffix1.indexOf("B")) >= 0) {
+            // alt format
+            bit1 = Integer.parseInt(suffix1.substring(t+1));
+            if (t>0) node1 = Integer.parseInt(suffix1.substring(0, t));
+        } else {
+            // std format
+            int len = suffix1.length();
+            bit1 = Integer.parseInt(suffix1.substring(Math.max(0, len-3)));
+            if (len>3) node1 = Integer.parseInt(suffix1.substring(0, len-3));
+        }
+        
+        if ((t = suffix2.indexOf("B")) >= 0) {
+            // alt format
+            bit2 = Integer.parseInt(suffix2.substring(t+1));
+            if (t>0) node2 = Integer.parseInt(suffix2.substring(0, t));
+        } else {
+            // std format
+            int len = suffix2.length();
+            bit2 = Integer.parseInt(suffix2.substring(Math.max(0, len-3)));
+            if (len>3) node2 = Integer.parseInt(suffix2.substring(0, len-3));
+        }
+        
+        if (node1 != node2 ) return Integer.signum(node1-node2);
+        return Integer.signum(bit1-bit2);
     }
 
     private final static Logger log = LoggerFactory.getLogger(SerialTurnout.class);

--- a/java/src/jmri/jmrix/cmri/serial/SerialTurnout.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialTurnout.java
@@ -270,40 +270,11 @@ public class SerialTurnout extends AbstractTurnout {
     /**
      * {@inheritDoc} 
      * 
-     * By default, does an alphanumeric-by-chunks comparison
+     * Sorts by node number and then by bit
      */
     @CheckReturnValue
     public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull jmri.NamedBean n) {
-        jmri.util.AlphanumComparator ac = new jmri.util.AlphanumComparator();
-        
-        // extract node numbers and bit numbers
-        int node1 = 0, node2 = 0, bit1, bit2;
-        int t; // a temporary
-        
-        if ((t = suffix1.indexOf("B")) >= 0) {
-            // alt format
-            bit1 = Integer.parseInt(suffix1.substring(t+1));
-            if (t>0) node1 = Integer.parseInt(suffix1.substring(0, t));
-        } else {
-            // std format
-            int len = suffix1.length();
-            bit1 = Integer.parseInt(suffix1.substring(Math.max(0, len-3)));
-            if (len>3) node1 = Integer.parseInt(suffix1.substring(0, len-3));
-        }
-        
-        if ((t = suffix2.indexOf("B")) >= 0) {
-            // alt format
-            bit2 = Integer.parseInt(suffix2.substring(t+1));
-            if (t>0) node2 = Integer.parseInt(suffix2.substring(0, t));
-        } else {
-            // std format
-            int len = suffix2.length();
-            bit2 = Integer.parseInt(suffix2.substring(Math.max(0, len-3)));
-            if (len>3) node2 = Integer.parseInt(suffix2.substring(0, len-3));
-        }
-        
-        if (node1 != node2 ) return Integer.signum(node1-node2);
-        return Integer.signum(bit1-bit2);
+        return CMRISystemConnectionMemo.compareSystemNameSuffix(suffix1, suffix2);
     }
 
     private final static Logger log = LoggerFactory.getLogger(SerialTurnout.class);

--- a/java/src/jmri/jmrix/dcc4pc/swing/boardlists/BoardListPanel.java
+++ b/java/src/jmri/jmrix/dcc4pc/swing/boardlists/BoardListPanel.java
@@ -19,7 +19,6 @@ import javax.swing.table.TableRowSorter;
 import jmri.jmrix.dcc4pc.Dcc4PcSystemConnectionMemo;
 import jmri.jmrix.dcc4pc.swing.Dcc4PcPanelInterface;
 import jmri.swing.RowSorterUtil;
-import jmri.util.SystemNameComparator;
 import jmri.util.table.ButtonEditor;
 import jmri.util.table.ButtonRenderer;
 import org.slf4j.Logger;
@@ -64,8 +63,7 @@ public class BoardListPanel extends jmri.jmrix.dcc4pc.swing.Dcc4PcPanel implemen
 
         _BoardModel = new ReaderBoardModel();
         JTable boardTable = new JTable(_BoardModel);
-        TableRowSorter<ReaderBoardModel> sorter = new TableRowSorter<>(_BoardModel);
-        sorter.setComparator(ReaderBoardModel.ADDRESS_COLUMN, new SystemNameComparator());
+        TableRowSorter<ReaderBoardModel> sorter = new TableRowSorter<>(_BoardModel); // leave default comparator for Integers
         RowSorterUtil.setSortOrder(sorter, ReaderBoardModel.ADDRESS_COLUMN, SortOrder.ASCENDING);
         
         boardTable.setRowSelectionAllowed(false);

--- a/java/src/jmri/jmrix/loconet/soundloader/EditorFilePane.java
+++ b/java/src/jmri/jmrix/loconet/soundloader/EditorFilePane.java
@@ -14,7 +14,6 @@ import javax.swing.SortOrder;
 import javax.swing.table.TableRowSorter;
 import jmri.jmrix.loconet.spjfile.SpjFile;
 import jmri.swing.RowSorterUtil;
-import jmri.util.SystemNameComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,9 +50,8 @@ public class EditorFilePane extends javax.swing.JPanel {
         JTable dataTable = new JTable(dataModel);
         JScrollPane dataScroll = new JScrollPane(dataTable);
 
-        // give system name column a smarter sorter and use it initially
+        // set default sort order
         TableRowSorter<EditorTableDataModel> sorter = new TableRowSorter<>(dataModel);
-        sorter.setComparator(EditorTableDataModel.HEADERCOL, new SystemNameComparator());
         RowSorterUtil.setSortOrder(sorter, EditorTableDataModel.HEADERCOL, SortOrder.ASCENDING);
 
         // configure items for GUI

--- a/java/src/jmri/jmrix/openlcb/OlcbAddress.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbAddress.java
@@ -7,6 +7,8 @@ import jmri.jmrix.can.CanReply;
 import org.openlcb.EventID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import javax.annotation.Nonnull;
+import javax.annotation.CheckReturnValue;
 
 /**
  * Utilities for handling OpenLCB event messages as addresses.
@@ -107,6 +109,22 @@ public class OlcbAddress {
         return ret;
     }
 
+    public int compare(@Nonnull OlcbAddress opp) {
+        // if neither matched, just do a lexical sort
+        if (!match && !opp.match) return aString.compareTo(opp.aString);
+        
+        // match sorts before non-matched
+        if (match && !opp.match) return -1;
+        if (!match && opp.match) return +1;
+        
+        // usual case: comparing on content
+        for (int i = 0; i < Math.min(aFrame.length, opp.aFrame.length); i++) {
+            if (aFrame[i] != opp.aFrame[i]) return Integer.signum(aFrame[i] - opp.aFrame[i]);
+        }
+        // check for different length (shorter sorts first)
+        return Integer.signum(aFrame.length - opp.aFrame.length);
+    }
+    
     public CanMessage makeMessage() {
         CanMessage c = new CanMessage(aFrame, 0x195B4000);
         c.setExtended(true);

--- a/java/src/jmri/jmrix/openlcb/OlcbSensor.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbSensor.java
@@ -11,6 +11,8 @@ import org.openlcb.implementations.EventTable;
 import org.openlcb.implementations.VersionedValueListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import javax.annotation.Nonnull;
+import javax.annotation.CheckReturnValue;
 
 /**
  * Extend jmri.AbstractSensor for OpenLCB controls.
@@ -177,6 +179,16 @@ public class OlcbSensor extends AbstractSensor {
         if (sensorListener != null) sensorListener.release();
         if (pc != null) pc.release();
         super.dispose();
+    }
+
+    /**
+     * {@inheritDoc} 
+     * 
+     * Sorts by decoded EventID(s)
+     */
+    @CheckReturnValue
+    public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull jmri.NamedBean n) {
+        return OlcbSystemConnectionMemo.compareSystemNameSuffix(suffix1, suffix2);
     }
 
     private final static Logger log = LoggerFactory.getLogger(OlcbSensor.class);

--- a/java/src/jmri/jmrix/openlcb/OlcbSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbSystemConnectionMemo.java
@@ -4,6 +4,8 @@ import java.util.ResourceBundle;
 import jmri.GlobalProgrammerManager;
 import jmri.InstanceManager;
 import org.openlcb.OlcbInterface;
+import javax.annotation.Nonnull;
+import javax.annotation.CheckReturnValue;
 
 /**
  * Lightweight class to denote that a system is active, and provide general
@@ -161,5 +163,27 @@ public class OlcbSystemConnectionMemo extends jmri.jmrix.can.CanSystemConnection
             InstanceManager.deregister(sensorManager, OlcbSensorManager.class);
         }
         super.dispose();
+    }
+
+    /**
+     * See {@link jmri.NamedBean#compareSystemNameSuffix} for background.
+     * 
+     * This is a common implementation for OpenLCB Sensors and Turnouts
+     * of the comparison method.
+     */
+    @CheckReturnValue
+    public static int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2) {
+        
+        // extract addresses
+        OlcbAddress[] array1 = new OlcbAddress(suffix1).split();
+        OlcbAddress[] array2 = new OlcbAddress(suffix2).split();
+
+        // compare on content
+        for (int i = 0; i < Math.min(array1.length, array2.length); i++) {
+            int c = array1[i].compare(array2[i]);
+            if (c != 0) return c;
+        }
+        // check for different length (shorter sorts first)
+        return Integer.signum(array1.length - array2.length);
     }
 }

--- a/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbTurnout.java
@@ -9,6 +9,8 @@ import org.openlcb.implementations.EventTable;
 import org.openlcb.implementations.VersionedValueListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import javax.annotation.Nonnull;
+import javax.annotation.CheckReturnValue;
 
 /**
  * Turnout for OpenLCB connections.
@@ -61,7 +63,7 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout {
     }
 
     /**
-     * Common initialization for both constructors.
+     * Common initialization for constructor.
      * <p>
      *
      */
@@ -219,6 +221,16 @@ public class OlcbTurnout extends jmri.implementation.AbstractTurnout {
         if (turnoutListener != null) turnoutListener.release();
         if (pc != null) pc.release();
         super.dispose();
+    }
+
+    /**
+     * {@inheritDoc} 
+     * 
+     * Sorts by decoded EventID(s)
+     */
+    @CheckReturnValue
+    public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull jmri.NamedBean n) {
+        return OlcbSystemConnectionMemo.compareSystemNameSuffix(suffix1, suffix2);
     }
 
     private final static Logger log = LoggerFactory.getLogger(OlcbTurnout.class);

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -8,6 +8,7 @@ import javax.annotation.Nonnull;
 import jmri.Manager;
 import jmri.NamedBean;
 import jmri.util.SystemNameComparator;
+import jmri.util.NamedBeanComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -415,7 +416,7 @@ abstract public class AbstractProxyManager<E extends NamedBean> implements Manag
 
     @Override
     public List<E> getNamedBeanList() {
-        TreeSet<E> ts = new TreeSet<>(new SystemNameComparator());
+        TreeSet<E> ts = new TreeSet<>(new NamedBeanComparator());
         mgrs.stream().forEach((m) -> {
             ts.addAll(m.getNamedBeanList());
         });

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -7,7 +7,6 @@ import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import jmri.Manager;
 import jmri.NamedBean;
-import jmri.util.SystemNameComparator;
 import jmri.util.NamedBeanComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -391,30 +390,48 @@ abstract public class AbstractProxyManager<E extends NamedBean> implements Manag
         return getMgr(0).makeSystemName(s);
     }
 
-    @Override
-    public String[] getSystemNameArray() {
-        TreeSet<String> ts = new TreeSet<>(new SystemNameComparator());
-        this.mgrs.stream().forEach((mgr) -> {
-            ts.addAll(mgr.getSystemNameList());
-        });
-        return ts.toArray(new String[ts.size()]);
-    }
-
     /**
      * Get a list of all system names.
+     * <p>
+     * The list is ordered by system name
      *
      * @return a list, possibly empty, of system names
      */
     @Override
-    public List<String> getSystemNameList() {
-        TreeSet<String> ts = new TreeSet<>(new SystemNameComparator());
-        for (int i = 0; i < nMgrs(); i++) {
-            ts.addAll(getMgr(i).getSystemNameList());
-        }
-        return new ArrayList<>(ts);
+    @Nonnull
+    public String[] getSystemNameArray() {
+        List<E> list = getNamedBeanList();
+        String[] retval = new String[list.size()];
+        int i = 0;
+        for (E e : list) retval[i++] = e.getSystemName();
+        return retval;
     }
 
+    /**
+     * Get a list of all system names.
+     * <p>
+     * The list is ordered by system name
+     *
+     * @return a list, possibly empty, of system names
+     */
     @Override
+    @Nonnull
+    public List<String> getSystemNameList() {
+        List<E> list = getNamedBeanList();
+        ArrayList<String> retval = new ArrayList<>(list.size());
+        for (E e : list) retval.add(e.getSystemName());
+        return retval;
+    }
+
+    /**
+     * Get a list of all system names.
+     * <p>
+     * The list is ordered by system name
+     *
+     * @return a list, possibly empty, of system names
+     */
+    @Override
+    @Nonnull
     public List<E> getNamedBeanList() {
         TreeSet<E> ts = new TreeSet<>(new NamedBeanComparator());
         mgrs.stream().forEach((m) -> {

--- a/java/src/jmri/util/AlphanumComparator.java
+++ b/java/src/jmri/util/AlphanumComparator.java
@@ -104,6 +104,6 @@ public class AlphanumComparator implements Comparator<String> {
         if (result == 0 && marker1 == length1 && marker2 < length2) return -1;
         if (result == 0 && marker1 < length1 && marker2 == length2) return +1;
         
-        return result;
+        return Integer.signum(result);  // limit to -1, 0, 1
     }
 }

--- a/java/src/jmri/util/AlphanumComparator.java
+++ b/java/src/jmri/util/AlphanumComparator.java
@@ -53,18 +53,42 @@ public class AlphanumComparator implements Comparator<String> {
     // Length of string is passed in for improved efficiency (only need to calculate it once)
     private final String getChunk(String s, int slength, int marker) {
         StringBuilder chunk = new StringBuilder();
+        int markstart = marker;
         char c = s.charAt(marker);
-        chunk.append(c);
         boolean startIsDigit = isDigit(c);
+        if (c == '0') {
+            // strip leading zeros - cases:
+            //    This is or isn't the only leading zero
+            //    There are or aren't more digits after the run of zeros
+            while (marker+1 < slength && s.charAt(marker+1) == '0') {
+                marker++; // skip that zero
+            }
+            // now what's the next character?
+            if (marker+1 >= slength) {
+                // nothing more, continue with that single zero
+            } else if (isDigit(s.charAt(marker+1))) {
+                // number, drop the leading zero
+                marker++;
+                c = s.charAt(marker);
+            } else {
+                // is letter, let the zero go
+            }
+        }
+        chunk.append(c);
         while (++marker < slength) {
             c = s.charAt(marker);
             if (isDigit(c) != startIsDigit)
                 break;
             chunk.append(c);
         }
+
+        skip = marker - markstart;
         return chunk.toString();
     }
 
+    // internal temporary used to efficiently return how many characters were skipped
+    int skip;
+    
     @Override
     public int compare(String s1, String s2) {
         int length1 = s1.length();
@@ -74,10 +98,10 @@ public class AlphanumComparator implements Comparator<String> {
         int marker1 = 0, marker2 = 0;
         while (marker1 < length1 && marker2 < length2) {
             String chunk1 = getChunk(s1, length1, marker1);
-            marker1 += chunk1.length();
+            marker1 += skip;
 
             String chunk2 = getChunk(s2, length2, marker2);
-            marker2 += chunk2.length();
+            marker2 += skip;
 
             // If both chunks contain numeric characters, sort them numerically
             if (isDigit(chunk1.charAt(0)) && isDigit(chunk2.charAt(0))) {

--- a/java/src/jmri/util/LocoAddressComparator.java
+++ b/java/src/jmri/util/LocoAddressComparator.java
@@ -19,9 +19,9 @@ public class LocoAddressComparator implements Comparator<LocoAddress> {
     public int compare(LocoAddress l1, LocoAddress l2) {
          if( l1.getProtocol() == l2.getProtocol() ){
              // protocol is the same, compare the number fields
-             return (l1.getNumber() - l2.getNumber());
+             return Integer.signum(l1.getNumber() - l2.getNumber());
          } else {
-             return (l1.getProtocol().getShortName().compareTo(l2.getProtocol().getShortName()));
+             return Integer.signum((l1.getProtocol().getShortName().compareTo(l2.getProtocol().getShortName())));
          }
     }
 }

--- a/java/src/jmri/util/NamedBeanComparator.java
+++ b/java/src/jmri/util/NamedBeanComparator.java
@@ -9,7 +9,7 @@ import jmri.Manager;
  * A System Name is a system prefix followed by type letter then a suffix with a system-specific format. 
  * This class first compares on prefix, then if the prefixes are equal it 
  * compares the type letter, then if they're still equal it
- * does an {@lnk AlphanumComparater} compare on suffix.
+ * does an {@link AlphanumComparator} compare on suffix.
  * <p>
  * This sorts on the information in the NamedBean itself, including using 
  * the actual type by deferring prefix comparison into the specific NamedBean subclass.

--- a/java/src/jmri/util/NamedBeanComparator.java
+++ b/java/src/jmri/util/NamedBeanComparator.java
@@ -1,39 +1,46 @@
 package jmri.util;
 
 import jmri.NamedBean;
+import jmri.Manager;
 
 /**
- * Comparator for JMRI System Names.
+ * Comparator for JMRI NamedBeans via their system Names.
  * <P>
- * A System Name is two letters followed by either an alpha name or a number. In
- * the number case, this does a numeric comparison. If the number is appended
- * with letters, does the numeric sort on the digits followed by a lexigraphic
- * sort on the remainder.
+ * A System Name is a system prefix followed by type letter then a suffix with a system-specific format. 
+ * This class first compares on prefix, then if the prefixes are equal it 
+ * compares the type letter, then if they're still equal it
+ * does an {@lnk AlphanumComparater} compare on suffix.
+ * <p>
+ * This sorts on the information in the NamedBean itself, including using 
+ * the actual type by deferring prefix comparison into the specific NamedBean subclass.
+ * This different from {@link SystemNameComparator}, which only does a common
+ * lexical sort.  
+ * See the <a href="http://jmri.org/help/en/html/doc/Technical/Names.shtml">Names documentation page</a>.
  *
- * @author	Pete Cressman Copyright (C) 2009
  *
  */
-public class NamedBeanComparator extends SystemNameComparator {
+public class NamedBeanComparator implements java.util.Comparator<NamedBean> {
 
     public NamedBeanComparator() {
     }
 
+    static AlphanumComparator ac = new AlphanumComparator();
+    
     @Override
-    public int compare(Object ob1, Object ob2) {
-        String uName1 = ((NamedBean) ob1).getUserName();
-        String uName2 = ((NamedBean) ob2).getUserName();
-        if (uName2 == null || uName2.trim().length() == 0) {
-            if (uName1 == null || uName1.trim().length() == 0) {
-                return super.compare(ob1, ob2);
-            } else {
-                return -1;
-            }
-        } else {
-            if (uName1 == null || uName1.trim().length() == 0) {
-                return 1;
-            } else {
-                return uName1.compareTo(uName2);
-            }
-        }
+    public int compare(NamedBean ob1, NamedBean ob2) {
+        String o1 = ob1.getSystemName();
+        String o2 = ob2.getSystemName();
+        
+        int p1len = Manager.getSystemPrefixLength(o1);
+        int p2len = Manager.getSystemPrefixLength(o2);
+        
+        int comp = ac.compare(o1.substring(0, p1len), o2.substring(0, p2len));
+        if (comp != 0) return comp;
+
+        char c1 = o1.charAt(p1len);
+        char c2 = o2.charAt(p2len);
+           
+        if (c1 == c2) return ac.compare(o1.substring(p1len+1), o2.substring(p2len+1));
+        else return (c1 > c2) ? +1 : -1 ;
     }
 }

--- a/java/src/jmri/util/NamedBeanComparator.java
+++ b/java/src/jmri/util/NamedBeanComparator.java
@@ -5,6 +5,8 @@ import jmri.Manager;
 
 /**
  * Comparator for JMRI NamedBeans via their system Names.
+ * <p>
+ * Uses the in-built Comparable interface of the named beans.
  * <P>
  * A System Name is a system prefix followed by type letter then a suffix with a system-specific format. 
  * This class first compares on prefix, then if the prefixes are equal it 
@@ -26,6 +28,6 @@ public class NamedBeanComparator implements java.util.Comparator<NamedBean> {
 
     @Override
     public int compare(NamedBean n1, NamedBean n2) {
-        return NamedBean.compareSystemName(n1, n2);
+        return n1.compareTo(n2);
     }
 }

--- a/java/src/jmri/util/NamedBeanComparator.java
+++ b/java/src/jmri/util/NamedBeanComparator.java
@@ -24,8 +24,6 @@ public class NamedBeanComparator implements java.util.Comparator<NamedBean> {
     public NamedBeanComparator() {
     }
 
-    static AlphanumComparator ac = new AlphanumComparator();
-    
     @Override
     public int compare(NamedBean n1, NamedBean n2) {
         return NamedBean.compareSystemName(n1, n2);

--- a/java/src/jmri/util/NamedBeanComparator.java
+++ b/java/src/jmri/util/NamedBeanComparator.java
@@ -27,20 +27,7 @@ public class NamedBeanComparator implements java.util.Comparator<NamedBean> {
     static AlphanumComparator ac = new AlphanumComparator();
     
     @Override
-    public int compare(NamedBean ob1, NamedBean ob2) {
-        String o1 = ob1.getSystemName();
-        String o2 = ob2.getSystemName();
-        
-        int p1len = Manager.getSystemPrefixLength(o1);
-        int p2len = Manager.getSystemPrefixLength(o2);
-        
-        int comp = ac.compare(o1.substring(0, p1len), o2.substring(0, p2len));
-        if (comp != 0) return comp;
-
-        char c1 = o1.charAt(p1len);
-        char c2 = o2.charAt(p2len);
-           
-        if (c1 == c2) return ac.compare(o1.substring(p1len+1), o2.substring(p2len+1));
-        else return (c1 > c2) ? +1 : -1 ;
+    public int compare(NamedBean n1, NamedBean n2) {
+        return NamedBean.compareSystemName(n1, n2);
     }
 }

--- a/java/src/jmri/util/PreferNumericComparator.java
+++ b/java/src/jmri/util/PreferNumericComparator.java
@@ -3,57 +3,12 @@ package jmri.util;
 import java.util.Comparator;
 
 /**
- * If the two objects are Strings that can be made into integers, compare like
- * that otherwise as Strings.
+ * Originally, this attempted to compare as Integer, and then alphanumeric.
+ * It's now deprecated in favor of the more general AlphanumComparator
+ * @deprecated 4.11.1 use AlphanumComparator
  *
- * @author	Bob Jacobsen Copyright (C) 2013
+ * @author	Bob Jacobsen Copyright (C) 2013, 2017
  */
-public class PreferNumericComparator implements Comparator<Object> {
-
-    public PreferNumericComparator() {
-    }
-
-    @Override
-    public int compare(Object oo1, Object oo2) {
-
-        boolean isFirstNumeric, isSecondNumeric;
-        String o1 = oo1.toString(), o2 = oo2.toString();
-
-        isFirstNumeric = o1.matches("\\d+");
-        isSecondNumeric = o2.matches("\\d+");
-
-        if (isFirstNumeric) {
-            if (isSecondNumeric) {
-                return Integer.valueOf(o1).compareTo(Integer.valueOf(o2));
-            } else {
-                return -1; // numbers always smaller than letters
-            }
-        } else {
-            if (isSecondNumeric) {
-                return 1; // numbers always smaller than letters
-            } else {
-                // Neither numeric
-                isFirstNumeric = o1.split("\\.")[0].matches("\\d+");
-                isSecondNumeric = o2.split("\\.")[0].matches("\\d+");
-
-                if (isFirstNumeric) {
-                    if (isSecondNumeric) {
-                        int intCompare = Integer.valueOf(o1.split("\\.")[0]).compareTo(Integer.valueOf(o2.split("\\.")[0]));
-                        if (intCompare == 0) {
-                            return o1.compareToIgnoreCase(o2);
-                        }
-                        return intCompare;
-                    } else {
-                        return -1; // numbers always smaller than letters
-                    }
-                } else {
-                    if (isSecondNumeric) {
-                        return 1; // numbers always smaller than letters
-                    } else {
-                        return o1.compareToIgnoreCase(o2);
-                    }
-                }
-            }
-        }
-    }
+@Deprecated // in 4.11.1 use AlphanumComparator
+public class PreferNumericComparator extends AlphanumComparator {
 }

--- a/java/src/jmri/util/SystemNameComparator.java
+++ b/java/src/jmri/util/SystemNameComparator.java
@@ -10,7 +10,7 @@ import jmri.Manager;
  * A System Name is a system prefix followed by type letter then a suffix with a system-specific format. 
  * This class first compares on prefix, then if the prefixes are equal it 
  * compares the type letter, then if they're still equal it
- * does an {@lnk AlphanumComparater} compare on suffix.
+ * does an {@link AlphanumComparator} compare on suffix.
  * <p>
  * Note it's better to use {@link NamedBeanComparator} if possible, as that 
  * can do type-specific comparison of the suffix part of complicated names.

--- a/java/src/jmri/util/SystemNameComparator.java
+++ b/java/src/jmri/util/SystemNameComparator.java
@@ -19,8 +19,10 @@ import jmri.Manager;
  * Note this is intended to take names as provided:  It does not do normalization or
  * expansion.
  *
- * @author	Bob Jacobsen Copyright (C) 2004
+ * @author	Bob Jacobsen Copyright (C) 2004, 2009, 2017
+ * @deprecated Use NamedBean comparison instead
  */
+@Deprecated
 public class SystemNameComparator implements Comparator<String> {
 
     public SystemNameComparator() {

--- a/java/src/jmri/util/SystemNameComparator.java
+++ b/java/src/jmri/util/SystemNameComparator.java
@@ -33,7 +33,7 @@ public class SystemNameComparator implements Comparator<String> {
 
         int p1len = Manager.getSystemPrefixLength(o1);
         int p2len = Manager.getSystemPrefixLength(o2);
-        
+
         int comp = ac.compare(o1.substring(0, p1len), o2.substring(0, p2len));
         if (comp != 0) return comp;
 

--- a/java/src/jmri/util/SystemNameComparator.java
+++ b/java/src/jmri/util/SystemNameComparator.java
@@ -14,6 +14,7 @@ import jmri.Manager;
  * <p>
  * Note it's better to use {@link NamedBeanComparator} if possible, as that 
  * can do type-specific comparison of the suffix part of complicated names.
+ * See the <a href="http://jmri.org/help/en/html/doc/Technical/Names.shtml">Names documentation page</a>.
  * <p>
  * Note this is intended to take names as provided:  It does not do normalization or
  * expansion.

--- a/java/src/jmri/util/SystemNameComparator.java
+++ b/java/src/jmri/util/SystemNameComparator.java
@@ -2,85 +2,44 @@ package jmri.util;
 
 import java.util.Comparator;
 
+import jmri.Manager;
+
 /**
  * Comparator for JMRI System Names.
  * <P>
- * A System Name is two letters followed by either an alpha name or a number. In
- * the number case, this does a numeric comparison. If the number is appended
- * with letters, does the numeric sort on the digits followed by a lexigraphic
- * sort on the remainder.
+ * A System Name is a system prefix followed by type letter then a suffix with a system-specific format. 
+ * This class first compares on prefix, then if the prefixes are equal it 
+ * compares the type letter, then if they're still equal it
+ * does an {@lnk AlphanumComparater} compare on suffix.
+ * <p>
+ * Note it's better to use {@link NamedBeanComparator} if possible, as that 
+ * can do type-specific comparison of the suffix part of complicated names.
  * <p>
  * Note this is intended to take names as provided:  It does not do normalization or
  * expansion.
  *
  * @author	Bob Jacobsen Copyright (C) 2004
- * @author Howard Penny
- * @author Pete Cressman
  */
-public class SystemNameComparator implements Comparator<Object> {
+public class SystemNameComparator implements Comparator<String> {
 
     public SystemNameComparator() {
     }
 
+    static AlphanumComparator ac = new AlphanumComparator();
+    
     @Override
-    public int compare(Object o1, Object o2) {
+    public int compare(String o1, String o2) {
 
-        // if both strings are three or less characters long
-        if (o1.toString().length() <= 3 && o2.toString().length() <= 3) {
-            return o1.toString().compareTo(o2.toString());
-        } else  // if the first two characters of both strings match
-        if (!o1.toString().regionMatches(0, o2.toString(), 0, 2)) {
-            return o1.toString().compareTo(o2.toString());
-        } else {
-            if (true) {
-                AlphanumComparator ac = new AlphanumComparator();
-                return ac.compare(o1.toString(), o2.toString());
-            } else {    //TODO: dead-code strip this
-                // extract length of digits
-                char[] ch1 = o1.toString().substring(2).toCharArray();
-                char[] ch2 = o2.toString().substring(2).toCharArray();
-                int numDigit1 = 0;
-                int numDigit2 = 0;
-                for (int i = 0; i < ch1.length; i++) {
-                    if (Character.isDigit(ch1[i])) {
-                        numDigit1++;
-                    } else {
-                        break;
-                    }
-                }
-                for (int i = 0; i < ch2.length; i++) {
-                    if (Character.isDigit(ch2[i])) {
-                        numDigit2++;
-                    } else {
-                        break;
-                    }
-                }
-                if (numDigit1 == numDigit2) {
-                    try {
-                        int diff = Integer.parseInt(new String(ch1, 0, numDigit1))
-                                - Integer.parseInt(new String(ch2, 0, numDigit2));
-                        if (diff != 0) {
-                            return diff;
-                        }
-                        if (numDigit1 == ch1.length && numDigit2 == ch2.length) {
-                            return diff;
-                        } else {
-                            if (numDigit1 == ch1.length) {
-                                return -1;
-                            }
-                            // both have non-digit chars remaining
-                            return new String(ch1, numDigit1, ch1.length - numDigit1).compareTo(
-                                    new String(ch2, numDigit2, ch2.length - numDigit2));
-                        }
-                    } catch (NumberFormatException nfe) {
-                        return o1.toString().compareTo(o2.toString());
-                    } catch (IndexOutOfBoundsException ioob) {
-                        return o1.toString().compareTo(o2.toString());
-                    }
-                } else {
-                    return (numDigit1 - numDigit2);
-                }
-            }
-        }
+        int p1len = Manager.getSystemPrefixLength(o1);
+        int p2len = Manager.getSystemPrefixLength(o2);
+        
+        int comp = ac.compare(o1.substring(0, p1len), o2.substring(0, p2len));
+        if (comp != 0) return comp;
+
+        char c1 = o1.charAt(p1len);
+        char c2 = o2.charAt(p2len);
+           
+        if (c1 == c2) return ac.compare(o1.substring(p1len+1), o2.substring(p2len+1));
+        else return (c1 > c2) ? +1 : -1 ;
     }
 }

--- a/java/test/jmri/ManagerTest.java
+++ b/java/test/jmri/ManagerTest.java
@@ -1,0 +1,62 @@
+package jmri;
+
+import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Bob Jacobsen Copyright (C) 2017	
+ */
+public class ManagerTest {
+
+    @Test
+    public void testGetSystemPrefixLengthOK() {
+        Assert.assertEquals("LT1", 1, Manager.getSystemPrefixLength("LT1"));
+        Assert.assertEquals("L2T1", 2, Manager.getSystemPrefixLength("L2T1"));
+        Assert.assertEquals("L21T1", 3, Manager.getSystemPrefixLength("L21T1"));
+    }
+
+    @Test
+    public void testGetSystemPrefixLengthBad() {
+        try {
+            Assert.assertEquals("LT1", 0, Manager.getSystemPrefixLength(""));
+        } catch (NamedBean.BadSystemNameException e) {
+            return; // OK
+        }
+        Assert.fail("should have thrown");
+    }
+
+    @Test
+    public void testGetSystemPrefixOK() {
+        Assert.assertEquals("LT1", "L", Manager.getSystemPrefix("LT1"));
+        Assert.assertEquals("L2T1", "L2", Manager.getSystemPrefix("L2T1"));
+        Assert.assertEquals("L21T1", "L21", Manager.getSystemPrefix("L21T1"));
+    }
+
+    @Test
+    public void testGetSystemPrefixBad() {
+        try {
+            Assert.assertEquals("LT1", "L", Manager.getSystemPrefix(""));
+        } catch (NamedBean.BadSystemNameException e) {
+            return; // OK
+        }
+        Assert.fail("should have thrown");
+    }
+
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+    // private final static Logger log = LoggerFactory.getLogger(ManagerTest.class);
+
+}

--- a/java/test/jmri/ManagerTest.java
+++ b/java/test/jmri/ManagerTest.java
@@ -7,7 +7,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- *
+ * Tests the static methods of the interface
+ * 
  * @author Bob Jacobsen Copyright (C) 2017	
  */
 public class ManagerTest {
@@ -44,6 +45,42 @@ public class ManagerTest {
             return; // OK
         }
         Assert.fail("should have thrown");
+    }
+    
+    public void testIsLegacySystemPrefix() {
+        Assert.assertTrue(Manager.isLegacySystemPrefix("DX"));
+        Assert.assertTrue(Manager.isLegacySystemPrefix("DCCPP"));
+        Assert.assertTrue(Manager.isLegacySystemPrefix("DP"));
+        Assert.assertTrue(Manager.isLegacySystemPrefix("json"));
+        
+        Assert.assertFalse(Manager.isLegacySystemPrefix("C"));
+        Assert.assertFalse(Manager.isLegacySystemPrefix("C2"));
+        Assert.assertFalse(Manager.isLegacySystemPrefix("D"));
+        
+        for (String s : Manager.legacyPrefixes.toArray(new String[0])) {
+            Assert.assertTrue(Manager.isLegacySystemPrefix(s));
+        }
+    }
+    
+    public void testLegacyPrefixes() {
+        // catch if this is changed, so we remember to change
+        // rest of tests
+        Assert.assertEquals("length of legacy set", 8, Manager.legacyPrefixes.toArray().length);
+    }
+
+    public void startsWithLegacySystemPrefix() {
+        Assert.assertEquals(2, Manager.startsWithLegacySystemPrefix("DXS1"));
+        Assert.assertEquals(5, Manager.startsWithLegacySystemPrefix("DCCPPT4"));
+        Assert.assertEquals(2, Manager.startsWithLegacySystemPrefix("DPS12"));
+        Assert.assertEquals(4, Manager.startsWithLegacySystemPrefix("jsonL1"));
+        
+        Assert.assertEquals(-1, Manager.startsWithLegacySystemPrefix("CT1"));
+        Assert.assertEquals(-1, Manager.startsWithLegacySystemPrefix("C2T12"));
+        Assert.assertEquals(-1, Manager.startsWithLegacySystemPrefix("DT12132"));
+        
+        for (String s : Manager.legacyPrefixes.toArray(new String[0])) {
+            Assert.assertEquals(s.length()+3, Manager.startsWithLegacySystemPrefix(s+"T12"));
+        }
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/ManagerTest.java
+++ b/java/test/jmri/ManagerTest.java
@@ -20,6 +20,15 @@ public class ManagerTest {
         Assert.assertEquals("L21T1", 3, Manager.getSystemPrefixLength("L21T1"));
     }
 
+    // Test legacy prefixes
+    @Deprecated
+    @Test
+    public void testGetSystemPrefixLengthLegacyPrefixes() {
+        Assert.assertEquals("DCCPPT12", 5, Manager.getSystemPrefixLength("DCCPPT12"));
+        Assert.assertEquals("MRT13", 2, Manager.getSystemPrefixLength("MRT13"));
+        Assert.assertEquals("DXT512", 2, Manager.getSystemPrefixLength("DXT512"));
+    }
+
     @Test
     public void testGetSystemPrefixLengthBad() {
         try {
@@ -37,6 +46,15 @@ public class ManagerTest {
         Assert.assertEquals("L21T1", "L21", Manager.getSystemPrefix("L21T1"));
     }
 
+    // Test legacy prefixes
+    @Deprecated
+    @Test
+    public void testGetSystemPrefixLegacyPrefixes() {
+        Assert.assertEquals("DCCPPT12", "DCCPP", Manager.getSystemPrefix("DCCPPT12"));
+        Assert.assertEquals("MRT13", "MR", Manager.getSystemPrefix("MRT13"));
+        Assert.assertEquals("DXT512", "DX", Manager.getSystemPrefix("DXT512"));
+    }
+
     @Test
     public void testGetSystemPrefixBad() {
         try {
@@ -47,6 +65,8 @@ public class ManagerTest {
         Assert.fail("should have thrown");
     }
     
+    // Test legacy prefixes
+    @Deprecated
     public void testIsLegacySystemPrefix() {
         Assert.assertTrue(Manager.isLegacySystemPrefix("DX"));
         Assert.assertTrue(Manager.isLegacySystemPrefix("DCCPP"));
@@ -62,12 +82,16 @@ public class ManagerTest {
         }
     }
     
+    // Test legacy prefixes
+    @Deprecated
     public void testLegacyPrefixes() {
         // catch if this is changed, so we remember to change
         // rest of tests
         Assert.assertEquals("length of legacy set", 8, Manager.legacyPrefixes.toArray().length);
     }
 
+    // Test legacy prefixes
+    @Deprecated
     public void startsWithLegacySystemPrefix() {
         Assert.assertEquals(2, Manager.startsWithLegacySystemPrefix("DXS1"));
         Assert.assertEquals(5, Manager.startsWithLegacySystemPrefix("DCCPPT4"));

--- a/java/test/jmri/PackageTest.java
+++ b/java/test/jmri/PackageTest.java
@@ -14,6 +14,7 @@ import org.junit.runners.Suite;
     InstanceManagerTest.class,
     NamedBeanTest.class,
     LightTest.class,
+    ManagerTest.class,
     NmraPacketTest.class,
     ConditionalVariableTest.class,
     PathTest.class,

--- a/java/test/jmri/jmrit/beantable/LRouteTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LRouteTableActionTest.java
@@ -27,6 +27,9 @@ public class LRouteTableActionTest extends jmri.util.SwingTestCase //TestCase //
     private LRouteTableAction _lRouteTable;
     private LogixTableAction _logixTable;
 
+    public void testRouteElementComparator() {
+    }
+    
     public void testCreate() {
         if (GraphicsEnvironment.isHeadless()) {
             return; // can't Assume in TestCase

--- a/java/test/jmri/jmrit/beantable/LRouteTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LRouteTableActionTest.java
@@ -28,6 +28,15 @@ public class LRouteTableActionTest extends jmri.util.SwingTestCase //TestCase //
     private LogixTableAction _logixTable;
 
     public void testRouteElementComparator() {
+        LRouteTableAction.RouteElement e1 = new LRouteTableAction.RouteElement("ISname1", "B", 0);
+        LRouteTableAction.RouteElement e2 = new LRouteTableAction.RouteElement("ISname2", "B", 0);
+        
+        LRouteTableAction.RouteElementComparator rc = new LRouteTableAction.RouteElementComparator();
+        
+        assertTrue("e1 = e1", rc.compare(e1, e1) == 0);
+        assertTrue("e2 > e1", rc.compare(e2, e1) > 0);
+        assertTrue("e1 < e2", rc.compare(e1, e2) < 0);
+        
     }
     
     public void testCreate() {

--- a/java/test/jmri/jmrix/cmri/serial/SerialLightTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialLightTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.cmri.serial;
 
 import jmri.util.JUnitUtil;
+import jmri.*;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -25,6 +27,65 @@ public class SerialLightTest {
     public void test3ParamCTor() {
         SerialLight t = new SerialLight("CL4","t4",memo);
         Assert.assertNotNull("exists",t);
+    }
+
+    @Test
+    public void testSystemSpecificComparisonOfStandardNames() {
+        jmri.util.NamedBeanComparator t = new jmri.util.NamedBeanComparator();
+        
+        Light t1 = new SerialLight("CL1", "to1", memo);
+        Light t2 = new SerialLight("CL2", "to2", memo);
+        Light t10 = new SerialLight("CL10", "to10", memo);
+
+        Assert.assertEquals("L1 == L1", 0, t.compare(t1, t1));
+
+        Assert.assertEquals("L1 < L2", -1, t.compare(t1, t2));
+        Assert.assertEquals("L2 > L1", +1, t.compare(t2, t1));
+
+        Assert.assertEquals("L10 > L2", +1, t.compare(t10, t2));
+        Assert.assertEquals("L2 < L10", -1, t.compare(t2, t10));    
+    }
+
+    @Test
+    public void testSystemSpecificComparisonOfSpecificFormats() {
+        jmri.util.NamedBeanComparator t = new jmri.util.NamedBeanComparator();
+        
+        // test by putting into a tree set, then extracting and checking order
+        java.util.TreeSet<Light> set = new java.util.TreeSet(new jmri.util.NamedBeanComparator());
+        
+        set.add(new SerialLight("CL3B4",    "to3004", memo));
+        set.add(new SerialLight("CL3003",    "to3003", memo));
+        set.add(new SerialLight("CL3B2",    "to3002", memo));
+        set.add(new SerialLight("CL3001",    "to3001", memo));
+
+        set.add(new SerialLight("CL005",    "to1", memo));
+
+        set.add(new SerialLight("CL01004",    "to1004", memo));
+        set.add(new SerialLight("CL1003",    "to1003", memo));
+        set.add(new SerialLight("CL1002",    "to1002", memo));
+        set.add(new SerialLight("CL01001",    "to1001", memo));
+
+        set.add(new SerialLight("CL2",    "to2", memo));
+        set.add(new SerialLight("CL10",   "to10", memo));
+        set.add(new SerialLight("CL1",    "to1", memo));
+        
+        
+        java.util.Iterator<Light> it = set.iterator();
+        
+        Assert.assertEquals("CL1", it.next().getSystemName());
+        Assert.assertEquals("CL2", it.next().getSystemName());
+        Assert.assertEquals("CL005", it.next().getSystemName());
+        Assert.assertEquals("CL10", it.next().getSystemName());
+
+        Assert.assertEquals("CL01001", it.next().getSystemName());
+        Assert.assertEquals("CL1002", it.next().getSystemName());
+        Assert.assertEquals("CL1003", it.next().getSystemName());
+        Assert.assertEquals("CL01004", it.next().getSystemName());
+
+        Assert.assertEquals("CL3001", it.next().getSystemName());
+        Assert.assertEquals("CL3B2", it.next().getSystemName());
+        Assert.assertEquals("CL3003", it.next().getSystemName());
+        Assert.assertEquals("CL3B4", it.next().getSystemName());
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/cmri/serial/SerialLightTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialLightTest.java
@@ -48,8 +48,6 @@ public class SerialLightTest {
 
     @Test
     public void testSystemSpecificComparisonOfSpecificFormats() {
-        jmri.util.NamedBeanComparator t = new jmri.util.NamedBeanComparator();
-        
         // test by putting into a tree set, then extracting and checking order
         java.util.TreeSet<Light> set = new java.util.TreeSet(new jmri.util.NamedBeanComparator());
         

--- a/java/test/jmri/jmrix/cmri/serial/SerialLightTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialLightTest.java
@@ -60,6 +60,7 @@ public class SerialLightTest {
 
         set.add(new SerialLight("CL005",    "to1", memo));
 
+        // Lights don't do : notation
         set.add(new SerialLight("CL01004",    "to1004", memo));
         set.add(new SerialLight("CL1003",    "to1003", memo));
         set.add(new SerialLight("CL1002",    "to1002", memo));

--- a/java/test/jmri/jmrix/cmri/serial/SerialSensorTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialSensorTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.cmri.serial;
 
 import jmri.util.JUnitUtil;
+import jmri.*;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -25,6 +26,65 @@ public class SerialSensorTest {
     public void test2ParamCTor() {
         SerialSensor t = new SerialSensor("CS4","Test");
         Assert.assertNotNull("exists",t);
+    }
+
+    @Test
+    public void testSystemSpecificComparisonOfStandardNames() {
+        jmri.util.NamedBeanComparator t = new jmri.util.NamedBeanComparator();
+        
+        Sensor t1 = new SerialSensor("CS1");
+        Sensor t2 = new SerialSensor("CS2");
+        Sensor t10 = new SerialSensor("CS10");
+
+        Assert.assertEquals("S1 == S1", 0, t.compare(t1, t1));
+
+        Assert.assertEquals("S1 < S2", -1, t.compare(t1, t2));
+        Assert.assertEquals("S2 > S1", +1, t.compare(t2, t1));
+
+        Assert.assertEquals("S10 > S2", +1, t.compare(t10, t2));
+        Assert.assertEquals("S2 < S10", -1, t.compare(t2, t10));    
+    }
+
+    @Test
+    public void testSystemSpecificComparisonOfSpecificFormats() {
+        jmri.util.NamedBeanComparator t = new jmri.util.NamedBeanComparator();
+        
+        // test by putting into a tree set, then extracting and checking order
+        java.util.TreeSet<Sensor> set = new java.util.TreeSet(new jmri.util.NamedBeanComparator());
+        
+        set.add(new SerialSensor("CS3B4"));
+        set.add(new SerialSensor("CS3003"));
+        set.add(new SerialSensor("CS3B2"));
+        set.add(new SerialSensor("CS3001"));
+
+        set.add(new SerialSensor("CS005"));
+
+        set.add(new SerialSensor("CS01004"));
+        set.add(new SerialSensor("CS1003"));
+        set.add(new SerialSensor("CS1002"));
+        set.add(new SerialSensor("CS01001"));
+
+        set.add(new SerialSensor("CS2"));
+        set.add(new SerialSensor("CS10"));
+        set.add(new SerialSensor("CS1"));
+        
+        
+        java.util.Iterator<Sensor> it = set.iterator();
+        
+        Assert.assertEquals("CS1", it.next().getSystemName());
+        Assert.assertEquals("CS2", it.next().getSystemName());
+        Assert.assertEquals("CS005", it.next().getSystemName());
+        Assert.assertEquals("CS10", it.next().getSystemName());
+
+        Assert.assertEquals("CS01001", it.next().getSystemName());
+        Assert.assertEquals("CS1002", it.next().getSystemName());
+        Assert.assertEquals("CS1003", it.next().getSystemName());
+        Assert.assertEquals("CS01004", it.next().getSystemName());
+
+        Assert.assertEquals("CS3001", it.next().getSystemName());
+        Assert.assertEquals("CS3B2", it.next().getSystemName());
+        Assert.assertEquals("CS3003", it.next().getSystemName());
+        Assert.assertEquals("CS3B4", it.next().getSystemName());
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/cmri/serial/SerialSensorTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialSensorTest.java
@@ -47,8 +47,6 @@ public class SerialSensorTest {
 
     @Test
     public void testSystemSpecificComparisonOfSpecificFormats() {
-        jmri.util.NamedBeanComparator t = new jmri.util.NamedBeanComparator();
-        
         // test by putting into a tree set, then extracting and checking order
         java.util.TreeSet<Sensor> set = new java.util.TreeSet(new jmri.util.NamedBeanComparator());
         

--- a/java/test/jmri/jmrix/cmri/serial/SerialSensorTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialSensorTest.java
@@ -59,6 +59,7 @@ public class SerialSensorTest {
 
         set.add(new SerialSensor("CS005"));
 
+        set.add(new SerialSensor("CS1:5"));
         set.add(new SerialSensor("CS01004"));
         set.add(new SerialSensor("CS1003"));
         set.add(new SerialSensor("CS1002"));
@@ -80,6 +81,7 @@ public class SerialSensorTest {
         Assert.assertEquals("CS1002", it.next().getSystemName());
         Assert.assertEquals("CS1003", it.next().getSystemName());
         Assert.assertEquals("CS01004", it.next().getSystemName());
+        Assert.assertEquals("CS1:5", it.next().getSystemName());
 
         Assert.assertEquals("CS3001", it.next().getSystemName());
         Assert.assertEquals("CS3B2", it.next().getSystemName());

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
@@ -83,19 +83,21 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
         // test by putting into a tree set, then extracting and checking order
         java.util.TreeSet<Turnout> set = new java.util.TreeSet(new jmri.util.NamedBeanComparator());
         
-        set.add(new SerialTurnout("CT2",    "to2", memo));
-        set.add(new SerialTurnout("CT10",   "to10", memo));
-        set.add(new SerialTurnout("CT1",    "to1", memo));
-        set.add(new SerialTurnout("CT005",    "to1", memo));
-        set.add(new SerialTurnout("CT1003",    "to1003", memo));
-        set.add(new SerialTurnout("CT1002",    "to1002", memo));
-        set.add(new SerialTurnout("CT01001",    "to1001", memo));
-        set.add(new SerialTurnout("CT01004",    "to1004", memo));
-
         set.add(new SerialTurnout("CT3B4",    "to3004", memo));
         set.add(new SerialTurnout("CT3003",    "to3003", memo));
         set.add(new SerialTurnout("CT3B2",    "to3002", memo));
         set.add(new SerialTurnout("CT3001",    "to3001", memo));
+
+        set.add(new SerialTurnout("CT005",    "to1", memo));
+
+        set.add(new SerialTurnout("CT01004",    "to1004", memo));
+        set.add(new SerialTurnout("CT1003",    "to1003", memo));
+        set.add(new SerialTurnout("CT1002",    "to1002", memo));
+        set.add(new SerialTurnout("CT01001",    "to1001", memo));
+
+        set.add(new SerialTurnout("CT2",    "to2", memo));
+        set.add(new SerialTurnout("CT10",   "to10", memo));
+        set.add(new SerialTurnout("CT1",    "to1", memo));
         
         
         java.util.Iterator<Turnout> it = set.iterator();
@@ -114,7 +116,6 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
         Assert.assertEquals("CT3B2", it.next().getSystemName());
         Assert.assertEquals("CT3003", it.next().getSystemName());
         Assert.assertEquals("CT3B4", it.next().getSystemName());
-
     }
 
 }

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
@@ -78,8 +78,6 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
 
     @Test
     public void testSystemSpecificComparisonOfSpecificFormats() {
-        jmri.util.NamedBeanComparator t = new jmri.util.NamedBeanComparator();
-        
         // test by putting into a tree set, then extracting and checking order
         java.util.TreeSet<Turnout> set = new java.util.TreeSet(new jmri.util.NamedBeanComparator());
         

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.cmri.serial;
 
 import jmri.implementation.AbstractTurnoutTestBase;
+import jmri.*;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,6 +57,64 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
 //                tcis.sendSerialMessage(tcis.nextWrite(), null); // force outbound message; normally done by poll loop
 //		Assert.assertTrue("message sent", tcis.outbound.size()>0);
 //		Assert.assertEquals("content", "41 54 00", tcis.outbound.elementAt(tcis.outbound.size()-1).toString());  // CLOSED message
+    }
+
+    @Test
+    public void testSystemSpecificComparisonOfStandardNames() {
+        jmri.util.NamedBeanComparator t = new jmri.util.NamedBeanComparator();
+        
+        Turnout t1 = new SerialTurnout("CT1", "to1", memo);
+        Turnout t2 = new SerialTurnout("CT2", "to2", memo);
+        Turnout t10 = new SerialTurnout("CT10", "to10", memo);
+
+        Assert.assertEquals("T1 == T1", 0, t.compare(t1, t1));
+
+        Assert.assertEquals("T1 < T2", -1, t.compare(t1, t2));
+        Assert.assertEquals("T2 > T1", +1, t.compare(t2, t1));
+
+        Assert.assertEquals("T10 > T2", +1, t.compare(t10, t2));
+        Assert.assertEquals("T2 < T10", -1, t.compare(t2, t10));    
+    }
+
+    @Test
+    public void testSystemSpecificComparisonOfSpecificFormats() {
+        jmri.util.NamedBeanComparator t = new jmri.util.NamedBeanComparator();
+        
+        // test by putting into a tree set, then extracting and checking order
+        java.util.TreeSet<Turnout> set = new java.util.TreeSet(new jmri.util.NamedBeanComparator());
+        
+        set.add(new SerialTurnout("CT2",    "to2", memo));
+        set.add(new SerialTurnout("CT10",   "to10", memo));
+        set.add(new SerialTurnout("CT1",    "to1", memo));
+        set.add(new SerialTurnout("CT005",    "to1", memo));
+        set.add(new SerialTurnout("CT1003",    "to1003", memo));
+        set.add(new SerialTurnout("CT1002",    "to1002", memo));
+        set.add(new SerialTurnout("CT01001",    "to1001", memo));
+        set.add(new SerialTurnout("CT01004",    "to1004", memo));
+
+        set.add(new SerialTurnout("CT3B4",    "to3004", memo));
+        set.add(new SerialTurnout("CT3003",    "to3003", memo));
+        set.add(new SerialTurnout("CT3B2",    "to3002", memo));
+        set.add(new SerialTurnout("CT3001",    "to3001", memo));
+        
+        
+        java.util.Iterator<Turnout> it = set.iterator();
+        
+        Assert.assertEquals("CT1", it.next().getSystemName());
+        Assert.assertEquals("CT2", it.next().getSystemName());
+        Assert.assertEquals("CT005", it.next().getSystemName());
+        Assert.assertEquals("CT10", it.next().getSystemName());
+
+        Assert.assertEquals("CT01001", it.next().getSystemName());
+        Assert.assertEquals("CT1002", it.next().getSystemName());
+        Assert.assertEquals("CT1003", it.next().getSystemName());
+        Assert.assertEquals("CT01004", it.next().getSystemName());
+
+        Assert.assertEquals("CT3001", it.next().getSystemName());
+        Assert.assertEquals("CT3B2", it.next().getSystemName());
+        Assert.assertEquals("CT3003", it.next().getSystemName());
+        Assert.assertEquals("CT3B4", it.next().getSystemName());
+
     }
 
 }

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
@@ -90,6 +90,7 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
 
         set.add(new SerialTurnout("CT005",    "to1", memo));
 
+        set.add(new SerialTurnout("CT1:5",    "to1005", memo));
         set.add(new SerialTurnout("CT01004",    "to1004", memo));
         set.add(new SerialTurnout("CT1003",    "to1003", memo));
         set.add(new SerialTurnout("CT1002",    "to1002", memo));
@@ -111,6 +112,7 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
         Assert.assertEquals("CT1002", it.next().getSystemName());
         Assert.assertEquals("CT1003", it.next().getSystemName());
         Assert.assertEquals("CT01004", it.next().getSystemName());
+        Assert.assertEquals("CT1:5", it.next().getSystemName());
 
         Assert.assertEquals("CT3001", it.next().getSystemName());
         Assert.assertEquals("CT3B2", it.next().getSystemName());

--- a/java/test/jmri/jmrix/openlcb/OlcbAddressTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbAddressTest.java
@@ -83,6 +83,20 @@ public class OlcbAddressTest extends TestCase {
         assertTrue((new OlcbAddress("x013405009A0B0E00")).equals(new OlcbAddress("X013405009A0B0E00")));
     }
 
+    public void testCompare() {
+        assertEquals(0, (new OlcbAddress("1.34.5.0.9A.B.E.0")).compare(new OlcbAddress("x013405009A0B0E00")));
+        assertEquals(0, (new OlcbAddress("x013405009A0B0E00")).compare(new OlcbAddress("1.34.5.0.9A.B.E.0")));
+        assertEquals(0, (new OlcbAddress("x013405009A0B0E00")).compare(new OlcbAddress("X013405009A0B0E00")));
+        
+        assertEquals(-1, (new OlcbAddress("x013405009A0B0E00")).compare(new OlcbAddress("X013405009A0B0E01")));
+        assertEquals(+1, (new OlcbAddress("x013405009A0B0E01")).compare(new OlcbAddress("X013405009A0B0E00")));
+
+        assertEquals(-1, (new OlcbAddress("x013405009A0B0E")).compare(new OlcbAddress("X013405009A0B0E00")));
+        assertEquals(+1, (new OlcbAddress("x013405009A0B0E00")).compare(new OlcbAddress("X013405009A0B0E")));
+
+        // not testing the cases for non-match addresses
+    }
+    
     public void testSplitCheckOK() {
         assertTrue(new OlcbAddress("x123456789ABCDEF0").checkSplit());
         assertTrue(new OlcbAddress("12.34.56.78.9A.BC.DE.F0").checkSplit());

--- a/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
@@ -23,7 +23,7 @@ public class OlcbSensorTest extends TestCase {
 
     public void testIncomingChange() {
         Assert.assertNotNull("exists", t);
-        OlcbSensor s = new OlcbSensor("MS", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
+        OlcbSensor s = new OlcbSensor("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
 
         // message for Active and Inactive
         CanMessage mActive = new CanMessage(
@@ -53,7 +53,7 @@ public class OlcbSensorTest extends TestCase {
         Assert.assertNotNull("exists", t);
         t.tc.rcvMessage = null;
 
-        OlcbSensor s = new OlcbSensor("MS", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
+        OlcbSensor s = new OlcbSensor("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
         t.flush();
 
         assertNotNull(t.tc.rcvMessage);
@@ -88,7 +88,7 @@ public class OlcbSensorTest extends TestCase {
 
     public void testMomentarySensor() throws Exception {
         Assert.assertNotNull("exists", t);
-        OlcbSensor s = new OlcbSensor("MS", "1.2.3.4.5.6.7.8", t.iface);
+        OlcbSensor s = new OlcbSensor("M", "1.2.3.4.5.6.7.8", t.iface);
 
         // message for Active and Inactive
         CanMessage mActive = new CanMessage(
@@ -125,7 +125,7 @@ public class OlcbSensorTest extends TestCase {
     }
 
     public void testLocalChange() throws jmri.JmriException {
-        OlcbSensor s = new OlcbSensor("MS", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
+        OlcbSensor s = new OlcbSensor("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
         t.waitForStartup();
 
         t.tc.rcvMessage = null;
@@ -151,7 +151,7 @@ public class OlcbSensorTest extends TestCase {
     }
 
     public void testEventTable() {
-        OlcbSensor s = new OlcbSensor("MS", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
+        OlcbSensor s = new OlcbSensor("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
 
         EventTable.EventTableEntry[] elist = t.iface.getEventTable()
                 .getEventInfo(new EventID("1.2.3.4.5.6.7.8")).getAllEntries();
@@ -172,6 +172,24 @@ public class OlcbSensorTest extends TestCase {
 
         Assert.assertEquals(1, elist.length);
         Assert.assertEquals("Sensor MyInput Inactive", elist[0].getDescription());
+    }
+
+    public void testSystemSpecificComparisonOfSpecificFormats() {
+
+        // test by putting into a tree set, then extracting and checking order
+        java.util.TreeSet<Sensor> set = new java.util.TreeSet(new jmri.util.NamedBeanComparator());
+        
+        set.add(new OlcbSensor("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface));
+        set.add(new OlcbSensor("M", "X0501010114FF2000;X0501010114FF2011", t.iface));
+        set.add(new OlcbSensor("M", "X0501010114FF2000;X0501010114FF2001", t.iface));
+        set.add(new OlcbSensor("M", "1.2.3.4.5.6.7.9;1.2.3.4.5.6.7.9", t.iface));
+        
+        java.util.Iterator<Sensor> it = set.iterator();
+        
+        Assert.assertEquals("MS1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", it.next().getSystemName());
+        Assert.assertEquals("MS1.2.3.4.5.6.7.9;1.2.3.4.5.6.7.9", it.next().getSystemName());
+        Assert.assertEquals("MSX0501010114FF2000;X0501010114FF2001", it.next().getSystemName());
+        Assert.assertEquals("MSX0501010114FF2000;X0501010114FF2011", it.next().getSystemName());
     }
 
     OlcbTestInterface t;

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutTest.java
@@ -34,7 +34,7 @@ public class OlcbTurnoutTest extends TestCase {
     private static final String KNOWN_STATE = "KnownState";
     public void testIncomingChange() {
         Assert.assertNotNull("exists", t);
-        OlcbTurnout s = new OlcbTurnout("MT", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
+        OlcbTurnout s = new OlcbTurnout("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
         s.finishLoad();
 
         // message for Active and Inactive
@@ -71,7 +71,7 @@ public class OlcbTurnoutTest extends TestCase {
 
     public void testLocalChange() throws jmri.JmriException {
         // load dummy TrafficController
-        OlcbTurnout s = new OlcbTurnout("MT", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
+        OlcbTurnout s = new OlcbTurnout("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
         s.finishLoad();
 
         s.addPropertyChangeListener(l);
@@ -108,7 +108,7 @@ public class OlcbTurnoutTest extends TestCase {
     }
 
     public void testDirectFeedback() throws jmri.JmriException {
-        OlcbTurnout s = new OlcbTurnout("MT", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
+        OlcbTurnout s = new OlcbTurnout("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
         s.setFeedbackMode(Turnout.DIRECT);
         s.finishLoad();
 
@@ -158,9 +158,9 @@ public class OlcbTurnoutTest extends TestCase {
     public void testLoopback() throws jmri.JmriException {
         // Two turnouts behaving in opposite ways. One will be used to generate an event and the
         // other will be observed to make sure it catches it.
-        OlcbTurnout s = new OlcbTurnout("MT", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
+        OlcbTurnout s = new OlcbTurnout("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
         s.finishLoad();
-        OlcbTurnout r = new OlcbTurnout("MT", "1.2.3.4.5.6.7.9;1.2.3.4.5.6.7.8", t.iface);
+        OlcbTurnout r = new OlcbTurnout("M", "1.2.3.4.5.6.7.9;1.2.3.4.5.6.7.8", t.iface);
         r.finishLoad();
 
         r.addPropertyChangeListener(l);
@@ -181,7 +181,7 @@ public class OlcbTurnoutTest extends TestCase {
     }
 
     public void testEventTable() {
-        OlcbTurnout s = new OlcbTurnout("MT", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
+        OlcbTurnout s = new OlcbTurnout("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface);
         s.finishLoad();
 
         EventTable.EventTableEntry[] elist = t.iface.getEventTable()
@@ -207,7 +207,7 @@ public class OlcbTurnoutTest extends TestCase {
 
     public void testNameFormatXlower() {
         // load dummy TrafficController
-        OlcbTurnout s = new OlcbTurnout("MT", "x0501010114FF2000;x0501010114FF2001", t.iface);
+        OlcbTurnout s = new OlcbTurnout("M", "x0501010114FF2000;x0501010114FF2001", t.iface);
         s.finishLoad();
         Assert.assertNotNull("to exists", s);
 
@@ -237,7 +237,7 @@ public class OlcbTurnoutTest extends TestCase {
 
     public void testNameFormatXupper() {
         // load dummy TrafficController
-        OlcbTurnout s = new OlcbTurnout("MT", "X0501010114FF2000;X0501010114FF2001", t.iface);
+        OlcbTurnout s = new OlcbTurnout("M", "X0501010114FF2000;X0501010114FF2001", t.iface);
         s.finishLoad();
         Assert.assertNotNull("to exists", s);
 
@@ -263,6 +263,24 @@ public class OlcbTurnoutTest extends TestCase {
         t.sendMessage(mInactive);
         Assert.assertTrue(s.getCommandedState() == Turnout.CLOSED);
 
+    }
+
+    public void testSystemSpecificComparisonOfSpecificFormats() {
+
+        // test by putting into a tree set, then extracting and checking order
+        java.util.TreeSet<Turnout> set = new java.util.TreeSet(new jmri.util.NamedBeanComparator());
+        
+        set.add(new OlcbTurnout("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface));
+        set.add(new OlcbTurnout("M", "X0501010114FF2000;X0501010114FF2011", t.iface));
+        set.add(new OlcbTurnout("M", "X0501010114FF2000;X0501010114FF2001", t.iface));
+        set.add(new OlcbTurnout("M", "1.2.3.4.5.6.7.9;1.2.3.4.5.6.7.9", t.iface));
+        
+        java.util.Iterator<Turnout> it = set.iterator();
+        
+        Assert.assertEquals("MT1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", it.next().getSystemName());
+        Assert.assertEquals("MT1.2.3.4.5.6.7.9;1.2.3.4.5.6.7.9", it.next().getSystemName());
+        Assert.assertEquals("MTX0501010114FF2000;X0501010114FF2001", it.next().getSystemName());
+        Assert.assertEquals("MTX0501010114FF2000;X0501010114FF2011", it.next().getSystemName());
     }
 
     // from here down is testing infrastructure

--- a/java/test/jmri/util/AlphanumComparatorTest.java
+++ b/java/test/jmri/util/AlphanumComparatorTest.java
@@ -1,5 +1,6 @@
 package jmri.util;
 
+import java.util.Comparator;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.junit.After;
@@ -14,6 +15,61 @@ import org.junit.Before;
 public class AlphanumComparatorTest extends TestCase {
 
     private static AlphanumComparator ac;
+
+    public void testAlphanumCompare1LTA() {
+        Assert.assertEquals("1 < A", ac.compare("1", "A") < 0, true);
+    }
+
+    public void testAlphanumCompareEquals() {
+        Assert.assertEquals(" 1 == 1", 0, ac.compare("1", "1"));
+        Assert.assertEquals(" 10 == 10", 0, ac.compare("10", "10"));
+        Assert.assertEquals(" 100 == 100", 0, ac.compare("100", "100"));
+    }
+
+    public void testAlphanumCompareNumbersGreater() {
+        Assert.assertEquals(" 1 > 0", 1, ac.compare("1", "0"));
+        Assert.assertEquals(" 10 > 2", 1, ac.compare("10", "2"));
+        Assert.assertEquals(" 2 > 1", 1, ac.compare("2", "1"));
+    }
+
+    public void testAlphanumCompareNumbersLesser() {
+        Assert.assertEquals(" 1 < 2", -1, ac.compare("1", "2"));
+        Assert.assertEquals(" 1 < 10", -1, ac.compare("1", "10"));
+        Assert.assertEquals(" 2 < 10 ", -1, ac.compare("2", "10"));
+    }
+
+    public void testAlphanumCompareNestedNumeric() {
+        Assert.assertEquals(" 1.1.0 < 2.1.0", -1, ac.compare("1.1.0", "2.1.0"));
+        Assert.assertEquals(" 1.1.1 == 1.1.1", 0, ac.compare("1.1.1", "1.1.1"));
+        Assert.assertEquals(" 2.1.0 > 1.1.0", 1, ac.compare("2.1.0", "1.1.0"));
+
+        Assert.assertEquals(" 1.10.0 > 1.2.0", 1, ac.compare("1.10.0", "1.2.0"));
+        Assert.assertEquals(" 1.2.0 < 1.10.0", -1, ac.compare("1.2.0", "1.10.0"));
+        
+        Assert.assertEquals(" 1.1.10 > 1.1.2", 1, ac.compare("1.1.10", "1.1.2"));
+        
+    }
+
+    public void testAlphanumCompareTestNeedForDots() {
+        Assert.assertEquals(" 10.1.1 > 2.1.1", 1, ac.compare("10.1.1", "2.1.1"));
+        Assert.assertEquals(" 2.1.1 < 10.1.1", -1, ac.compare("2.1.1", "10.1.1"));
+        
+        Assert.assertEquals(" 1.10.1 > 1.2.1", 1, ac.compare("1.10.1", "1.2.1"));
+        Assert.assertEquals(" 1.2.1 < 1.10.1", -1, ac.compare("1.2.1", "1.10.1"));
+        
+        Assert.assertEquals(" 1.1.10 > 1.1.2", 1, ac.compare("1.1.10", "1.1.2"));
+        Assert.assertEquals(" 1.1.2 < 1.1.10", -1, ac.compare("1.1.2", "1.1.10"));
+   }
+
+    public void testHexadecimal() {
+        Assert.assertEquals(" A0 < B0", -1, ac.compare("A0", "B0"));
+
+        Assert.assertEquals(" 21.A0 < 21.B0", -1, ac.compare("21.A0", "21.B0"));
+
+        // non-intuitive, but what it does
+        Assert.assertEquals(" 21.1F < 21.10", -1, ac.compare("21.1F", "21.10"));
+        Assert.assertEquals(" 1F < 10", -1, ac.compare("1F", "10"));
+    }
 
     public void testAlphanumCompareALTB() {
         Assert.assertEquals("A < B", ac.compare("A", "B") < 0, true);
@@ -63,6 +119,12 @@ public class AlphanumComparatorTest extends TestCase {
         Assert.assertEquals("A10Z10 > A10Z2", ac.compare("A10Z10", "A10Z2") > 0, true);
     }
 
+    public void testMixedComparison() {     
+        Assert.assertEquals("IS100 < IS100A", -1, ac.compare("IS100", "IS100A"));
+        Assert.assertEquals("IS100A > IS100", +1, ac.compare("IS100A", "IS100"));
+    }
+
+    
     // from here down is testing infrastructure
     @Before
     protected void setUp() throws Exception {

--- a/java/test/jmri/util/AlphanumComparatorTest.java
+++ b/java/test/jmri/util/AlphanumComparatorTest.java
@@ -16,6 +16,30 @@ public class AlphanumComparatorTest extends TestCase {
 
     private static AlphanumComparator ac;
 
+    public void testHandlingLeadingZeros() {
+        Assert.assertEquals("01 == 1", 0, ac.compare("01", "1") );
+        Assert.assertEquals("1 == 01", 0, ac.compare("1", "01") );
+        Assert.assertEquals("001 == 1", 0, ac.compare("001", "1") );
+        Assert.assertEquals("1 == 001", 0, ac.compare("1", "001") );
+        Assert.assertEquals("0001 == 1", 0, ac.compare("0001", "1") );
+        Assert.assertEquals("1 == 0001", 0, ac.compare("1", "0001") );
+
+        Assert.assertEquals("001 == 01", 0, ac.compare("001", "01") );
+        Assert.assertEquals("01 == 001", 0, ac.compare("01", "001") );
+        
+        Assert.assertEquals("00A == 0A", 0, ac.compare("00A", "0A") );
+        Assert.assertEquals("0A == 00A", 0, ac.compare("0A", "00A") );
+
+        Assert.assertEquals("B00A == B0A", 0, ac.compare("B00A", "B0A") );
+        Assert.assertEquals("B0A == B00A", 0, ac.compare("B0A", "B00A") );
+
+        Assert.assertEquals("100 > 10", +1, ac.compare("100", "10") );
+        Assert.assertEquals("10 < 100", -1, ac.compare("10", "100") );
+
+        Assert.assertEquals("00 == 0", 0, ac.compare("00", "0") );
+        Assert.assertEquals("0 == 00", 0, ac.compare("0", "00") );
+    }
+    
     public void testAlphanumCompare1LTA() {
         Assert.assertEquals("1 < A", ac.compare("1", "A") < 0, true);
     }
@@ -50,8 +74,8 @@ public class AlphanumComparatorTest extends TestCase {
         
     }
 
-    public void testChunkWithLeadingZeros() {
-        Assert.assertEquals("not same IS001 IS1", 1, ac.compare("IS001", "IS1"));         // imperfect? but what it does
+    public void testChunkWithLeadingZeros() { // skip leading zero
+        Assert.assertEquals("same IS001 IS1", 0, ac.compare("IS001", "IS1"));
     }
     
     public void testAlphanumCompareTestNeedForDots() {
@@ -107,12 +131,12 @@ public class AlphanumComparatorTest extends TestCase {
         Assert.assertEquals("A10 > A2", ac.compare("A10", "A2") > 0, true);
     }
 
-    public void testAlphanumCompareA10LTA010() {
-        Assert.assertEquals("A10 < A010", ac.compare("A10", "A010") < 0, true);
+    public void testAlphanumCompareA10LTA010() { // skip leading zero
+        Assert.assertEquals("A10 == A010", ac.compare("A10", "A010") == 0, true);
     }
 
-    public void testAlphanumCompareA010GTA10() {
-        Assert.assertEquals("A010 > A10", ac.compare("A010", "A10") > 0, true);
+    public void testAlphanumCompareA010GTA10() { // skip leading zero
+        Assert.assertEquals("A010 == A10", ac.compare("A010", "A10") == 0, true);
     }
 
     public void testAlphanumCompareA10Z2LTA10Z10() {

--- a/java/test/jmri/util/AlphanumComparatorTest.java
+++ b/java/test/jmri/util/AlphanumComparatorTest.java
@@ -38,10 +38,14 @@ public class AlphanumComparatorTest extends TestCase {
 
         Assert.assertEquals("00 == 0", 0, ac.compare("00", "0") );
         Assert.assertEquals("0 == 00", 0, ac.compare("0", "00") );
+        
+        Assert.assertEquals("0 < A", -1, ac.compare("0", "A") );
+        Assert.assertEquals("A < 0", +1, ac.compare("A", "0") );
+
     }
     
     public void testAlphanumCompare1LTA() {
-        Assert.assertEquals("1 < A", ac.compare("1", "A") < 0, true);
+        Assert.assertTrue("1 < A", ac.compare("1", "A") < 0);
     }
 
     public void testAlphanumCompareEquals() {
@@ -100,51 +104,51 @@ public class AlphanumComparatorTest extends TestCase {
     }
 
     public void testAlphanumCompareALTB() {
-        Assert.assertEquals("A < B", ac.compare("A", "B") < 0, true);
+        Assert.assertTrue("A < B", ac.compare("A", "B") < 0);
     }
 
     public void testAlphanumCompareBGTA() {
-        Assert.assertEquals("B > A", ac.compare("B", "A") > 0, true);
+        Assert.assertTrue("B > A", ac.compare("B", "A") > 0);
     }
 
     public void testAlphanumCompareA1LTB1() {
-        Assert.assertEquals("A1 < B1", ac.compare("A1", "B1") < 0, true);
+        Assert.assertTrue("A1 < B1", ac.compare("A1", "B1") < 0);
     }
 
     public void testAlphanumCompareB1GTA1() {
-        Assert.assertEquals("A1 > B1", ac.compare("B1", "A1") > 0, true);
+        Assert.assertTrue("A1 > B1", ac.compare("B1", "A1") > 0);
     }
 
     public void testAlphanumCompareA10LTB1() {
-        Assert.assertEquals("A10 < B1", ac.compare("A10", "B1") < 0, true);
+        Assert.assertTrue("A10 < B1", ac.compare("A10", "B1") < 0);
     }
 
     public void testAlphanumCompareB1GTA10() {
-        Assert.assertEquals("B1 > A10", ac.compare("B1", "A10") > 0, true);
+        Assert.assertTrue("B1 > A10", ac.compare("B1", "A10") > 0);
     }
 
     public void testAlphanumCompareA2LTA10() {
-        Assert.assertEquals("A2 < A10", ac.compare("A2", "A10") < 0, true);
+        Assert.assertTrue("A2 < A10", ac.compare("A2", "A10") < 0);
     }
 
     public void testAlphanumCompareA10GTA2() {
-        Assert.assertEquals("A10 > A2", ac.compare("A10", "A2") > 0, true);
+        Assert.assertTrue("A10 > A2", ac.compare("A10", "A2") > 0);
     }
 
     public void testAlphanumCompareA10LTA010() { // skip leading zero
-        Assert.assertEquals("A10 == A010", ac.compare("A10", "A010") == 0, true);
+        Assert.assertTrue("A10 == A010", ac.compare("A10", "A010") == 0);
     }
 
     public void testAlphanumCompareA010GTA10() { // skip leading zero
-        Assert.assertEquals("A010 == A10", ac.compare("A010", "A10") == 0, true);
+        Assert.assertTrue("A010 == A10", ac.compare("A010", "A10") == 0);
     }
 
     public void testAlphanumCompareA10Z2LTA10Z10() {
-        Assert.assertEquals("A10Z2 < A10Z10", ac.compare("A10Z2", "A10Z10") < 0, true);
+        Assert.assertTrue("A10Z2 < A10Z10", ac.compare("A10Z2", "A10Z10") < 0);
     }
 
     public void testAlphanumCompareA10Z10GTA10Z2() {
-        Assert.assertEquals("A10Z10 > A10Z2", ac.compare("A10Z10", "A10Z2") > 0, true);
+        Assert.assertTrue("A10Z10 > A10Z2", ac.compare("A10Z10", "A10Z2") > 0);
     }
 
     public void testMixedComparison() {     

--- a/java/test/jmri/util/AlphanumComparatorTest.java
+++ b/java/test/jmri/util/AlphanumComparatorTest.java
@@ -50,6 +50,10 @@ public class AlphanumComparatorTest extends TestCase {
         
     }
 
+    public void testChunkWithLeadingZeros() {
+        Assert.assertEquals("not same IS001 IS1", 1, ac.compare("IS001", "IS1"));         // imperfect? but what it does
+    }
+    
     public void testAlphanumCompareTestNeedForDots() {
         Assert.assertEquals(" 10.1.1 > 2.1.1", 1, ac.compare("10.1.1", "2.1.1"));
         Assert.assertEquals(" 2.1.1 < 10.1.1", -1, ac.compare("2.1.1", "10.1.1"));

--- a/java/test/jmri/util/LocoAddressComparatorTest.java
+++ b/java/test/jmri/util/LocoAddressComparatorTest.java
@@ -5,6 +5,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import jmri.*;
+
 /**
  *
  * @author Paul Bender Copyright (C) 2017	
@@ -17,6 +19,24 @@ public class LocoAddressComparatorTest {
         Assert.assertNotNull("exists",t);
     }
 
+    @Test
+    public void testEquals() {
+        LocoAddressComparator t = new LocoAddressComparator();
+        
+        LocoAddress l1 = new DccLocoAddress(200, true);
+        LocoAddress l2 = new DccLocoAddress(200, true);
+        LocoAddress l3 = new DccLocoAddress(300, true);
+        LocoAddress l4 = new DccLocoAddress(30, true);
+        LocoAddress l5 = new DccLocoAddress(30, false);
+        
+        Assert.assertEquals("200, true == 200, true", 0, t.compare(l1, l2));
+        Assert.assertEquals("200, true < 300, true", -1, t.compare(l1, l3));
+        Assert.assertEquals("300, true > 200, true", +1, t.compare(l3, l2));
+        
+        Assert.assertEquals("30, true < 30, false", -1, t.compare(l4, l5));
+        Assert.assertEquals("30, false > 30, true", +1, t.compare(l5, l4));
+    }
+    
     // The minimal setup for log4J
     @Before
     public void setUp() {

--- a/java/test/jmri/util/NamedBeanComparatorTest.java
+++ b/java/test/jmri/util/NamedBeanComparatorTest.java
@@ -5,6 +5,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import jmri.*;
+
 /**
  *
  * @author Paul Bender Copyright (C) 2017	
@@ -12,9 +14,87 @@ import org.junit.Test;
 public class NamedBeanComparatorTest {
 
     @Test
-    public void testCTor() {
+    public void testOneLetterCases() {
         NamedBeanComparator t = new NamedBeanComparator();
-        Assert.assertNotNull("exists",t);
+
+        Turnout it1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
+        Turnout it10 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT10");
+        Turnout it2 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT2");
+        
+        Assert.assertEquals("IT1 == IT1", 0, t.compare(it1, it1));
+
+        Assert.assertEquals("IT1 < IT2", -1, t.compare(it1, it2));
+        Assert.assertEquals("IT2 > IT1", +1, t.compare(it2, it1));
+
+        Assert.assertEquals("IT10 > IT2", +1, t.compare(it10, it2));
+        Assert.assertEquals("IT2 < IT10", -1, t.compare(it2, it10));
+    }
+
+    @Test
+    public void testTwoLetterCases() {
+        NamedBeanComparator t = new NamedBeanComparator();
+
+        Turnout i2t1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I2T1");
+        Turnout i2t10 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I2T10");
+        Turnout i2t2 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I2T2");
+        
+        Assert.assertEquals("I2T1 == I2T1", 0, t.compare(i2t1, i2t1));
+
+        Assert.assertEquals("I2T1 < I2T2", -1, t.compare(i2t1, i2t2));
+        Assert.assertEquals("I2T2 > I2T1", +1, t.compare(i2t2, i2t1));
+
+        Assert.assertEquals("I2T10 > I2T2", +1, t.compare(i2t10, i2t2));
+        Assert.assertEquals("I2T2 < I2T10", -1, t.compare(i2t2, i2t10));
+    }
+
+    @Test
+    public void testThreeLetterCases() {
+        NamedBeanComparator t = new NamedBeanComparator();
+
+        Turnout i23t1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T1");
+        Turnout i23t10 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T10");
+        Turnout i23t2 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T2");
+        
+        Assert.assertEquals("I23T1 == I23T1", 0, t.compare(i23t1, i23t1));
+
+        Assert.assertEquals("I23T1 < I23T2", -1, t.compare(i23t1, i23t2));
+        Assert.assertEquals("I23T2 > I23T1", +1, t.compare(i23t2, i23t1));
+
+        Assert.assertEquals("I23T10 > I23T2", +1, t.compare(i23t10, i23t2));
+        Assert.assertEquals("I23T2 < I23T10", -1, t.compare(i23t2, i23t10));
+    }
+
+    boolean hit = false;
+    
+    @Test
+    public void testSystemSpecificCase() {
+        NamedBeanComparator t = new NamedBeanComparator();
+
+        // this just checks that the local sort is called
+        Turnout it1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
+        Turnout it2 = new jmri.implementation.AbstractTurnout("it2") {
+
+            @Override
+            protected void forwardCommandChangeToLayout(int s) {
+            }
+
+            @Override
+            protected void turnoutPushbuttonLockout(boolean b) {
+            }
+
+            public int compareSystemNameSuffix(String suffix1, String suffix2, jmri.NamedBean n) {
+                hit = true;
+                return super.compareSystemNameSuffix(suffix1, suffix2, n);
+            }
+        };
+
+        hit = false;
+        Assert.assertEquals("IT1 < IT2", -1, t.compare(it1, it2));
+        Assert.assertFalse(hit);
+        
+        hit = false;        
+        Assert.assertEquals("IT2 < IT1", +1, t.compare(it2, it1));
+        Assert.assertTrue(hit);
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/util/PreferNumericComparatorTest.java
+++ b/java/test/jmri/util/PreferNumericComparatorTest.java
@@ -14,28 +14,28 @@ import org.junit.Assert;
 public class PreferNumericComparatorTest extends TestCase {
 
     public void testCompareNumbersEquals() {
-        Comparator<Object> c = new PreferNumericComparator();
+        Comparator<String> c = new PreferNumericComparator();
         Assert.assertEquals(" 1 == 1", 0, c.compare("1", "1"));
         Assert.assertEquals(" 10 == 10", 0, c.compare("10", "10"));
         Assert.assertEquals(" 100 == 100", 0, c.compare("100", "100"));
     }
 
     public void testCompareNumbersGreater() {
-        Comparator<Object> c = new PreferNumericComparator();
+        Comparator<String> c = new PreferNumericComparator();
         Assert.assertEquals(" 1 > 0", 1, c.compare("1", "0"));
         Assert.assertEquals(" 10 > 2", 1, c.compare("10", "2"));
         Assert.assertEquals(" 2 > 1", 1, c.compare("2", "1"));
     }
 
     public void testCompareNumbersLesser() {
-        Comparator<Object> c = new PreferNumericComparator();
+        Comparator<String> c = new PreferNumericComparator();
         Assert.assertEquals(" 1 < 2", -1, c.compare("1", "2"));
         Assert.assertEquals(" 1 < 10", -1, c.compare("1", "10"));
         Assert.assertEquals(" 2 < 10 ", -1, c.compare("2", "10"));
     }
 
     public void testCompareNestedNumeric() {
-        Comparator<Object> c = new PreferNumericComparator();
+        Comparator<String> c = new PreferNumericComparator();
         Assert.assertEquals(" 1.1.0 < 2.1.0", -1, c.compare("1.1.0", "2.1.0"));
         Assert.assertEquals(" 1.1.1 == 1.1.1", 0, c.compare("1.1.1", "1.1.1"));
         Assert.assertEquals(" 2.1.0 > 1.1.0", 1, c.compare("2.1.0", "1.1.0"));

--- a/java/test/jmri/util/SystemNameComparatorTest.java
+++ b/java/test/jmri/util/SystemNameComparatorTest.java
@@ -18,6 +18,28 @@ public class SystemNameComparatorTest {
     }
 
     @Test
+    public void testSystemPrefixTests() {
+        SystemNameComparator t = new SystemNameComparator();
+
+        Assert.assertEquals("IS1 < I2S1", -1, t.compare("IS1", "I2S1"));
+        Assert.assertEquals("I2S1 > IS1", +1, t.compare("I2S1", "IS1"));
+
+        Assert.assertEquals("I2S1 < I10S1", -1, t.compare("I2S1", "I10S1"));
+        Assert.assertEquals("I10S1 > I2S1", +1, t.compare("I10S1", "I2S1"));
+    }
+
+    @Test
+    public void testTypeLetterTests() {
+        SystemNameComparator t = new SystemNameComparator();
+
+        Assert.assertEquals("IS1 < IT1", -1, t.compare("IS1", "IT1"));
+        Assert.assertEquals("IT1 > IS1", +1, t.compare("IT1", "IS1"));
+
+        Assert.assertEquals("I2S1 > IT1", +1, t.compare("I2S1", "IT1"));
+        Assert.assertEquals("IT1 < I2S1", -1, t.compare("IT1", "I2S1"));
+    }
+
+    @Test
     public void testNumericComparison() {
         SystemNameComparator t = new SystemNameComparator();
 

--- a/java/test/jmri/util/SystemNameComparatorTest.java
+++ b/java/test/jmri/util/SystemNameComparatorTest.java
@@ -26,9 +26,9 @@ public class SystemNameComparatorTest {
         Assert.assertEquals("IS100 < IS101", -1, t.compare("IS100", "IS101"));
         Assert.assertEquals("IS101 > IS100", +1, t.compare("IS101", "IS100"));
 
-        Assert.assertEquals("not same IS001 IS1", 1, t.compare("IS001", "IS1"));         // imperfect, but what it does
-        Assert.assertEquals("not same IS0100 IS100", 1, t.compare("IS0100", "IS100"));  // imperfect, but what it does
-        Assert.assertEquals("not same IS100 IS0100", -1, t.compare("IS100", "IS0100"));  // imperfect, but what it does
+        Assert.assertEquals("not same IS001 IS1", 0, t.compare("IS1", "IS1")); 
+        Assert.assertEquals("not same IS0100 IS100", 0, t.compare("IS100", "IS100"));
+        Assert.assertEquals("not same IS100 IS0100", 0, t.compare("IS100", "IS100"));
     }
 
     @Test

--- a/java/test/jmri/util/SystemNameComparatorTest.java
+++ b/java/test/jmri/util/SystemNameComparatorTest.java
@@ -17,6 +17,31 @@ public class SystemNameComparatorTest {
         Assert.assertNotNull("exists", t);
     }
 
+    @Test
+    public void testNumericComparison() {
+        SystemNameComparator t = new SystemNameComparator();
+
+        Assert.assertEquals("same IS100", 0, t.compare("IS100", "IS100"));
+
+        Assert.assertEquals("IS100 < IS101", -1, t.compare("IS100", "IS101"));
+        Assert.assertEquals("IS101 > IS100", +1, t.compare("IS101", "IS100"));
+
+        Assert.assertEquals("not same IS001 IS1", 1, t.compare("IS001", "IS1"));         // imperfect, but what it does
+        Assert.assertEquals("not same IS0100 IS100", 1, t.compare("IS0100", "IS100"));  // imperfect, but what it does
+        Assert.assertEquals("not same IS100 IS0100", -1, t.compare("IS100", "IS0100"));  // imperfect, but what it does
+    }
+
+    @Test
+    public void testMixedComparison() {
+        SystemNameComparator t = new SystemNameComparator();
+
+        Assert.assertEquals("same IS100A", 0, t.compare("IS100A", "IS100A"));
+
+        Assert.assertEquals("IS100 < IS100A", -1, t.compare("IS100", "IS100A"));
+        Assert.assertEquals("IS100A > IS100", +1, t.compare("IS100A", "IS100"));
+
+    }
+
     // The minimal setup for log4J
     @Before
     public void setUp() {

--- a/java/test/jmri/util/SystemNameComparatorTest.java
+++ b/java/test/jmri/util/SystemNameComparatorTest.java
@@ -64,6 +64,21 @@ public class SystemNameComparatorTest {
 
     }
 
+    @Test
+    public void testLegacyCases() {
+        SystemNameComparator t = new SystemNameComparator();
+
+        Assert.assertEquals("same DCCPP100", 0, t.compare("DCCPP100", "DCCPP100"));
+        Assert.assertEquals("same DX12",    0, t.compare("DX12", "DX12"));
+
+        // Should sort first by system, then letter, then rest:
+        //   Compare DCCPP T 100 to D S 100 - DCCPP>D
+        Assert.assertEquals("DCCPPT100 > DS100", +1, t.compare("DCCPPT100", "DS100"));
+        Assert.assertEquals("DS100 < DCCPPT100", -1, t.compare("DS100", "DCCPPT100"));
+
+    }
+
+
     // The minimal setup for log4J
     @Before
     public void setUp() {


### PR DESCRIPTION
Update to comparison and sorting of JMRI system names, which required an overhaul of how system prefixes are handled, including a small number of legacy non-parsable prefixes.

See Issue #4670 for more background.

- [X] Update documentation to make the format very clear. 

- [X] deprecate and replace PreferNumericComparator - this can’t ever work reliably because of 100A > 100, 100 > 99, 99 > 100A

- [X] Improve and add tests for LocoAddressComparator - not directly on topic, but while we’re working on comparators we might as well ensure it obeys the Comparator contract

- [X] Add support for leading zeros to AlphanumComparator - this is just necessary work while we’re working on Comparators:
    - [X] including tests
    - [X] ensure only -1, 0, +1 output

- [X] Add service methods in Manager to keep all the formatting in one place
    - [X] including deprecated methods to identify existing special cases, deprecated so we remember  to remove them

- [X] add parsing to system-name-specific Comparators - this will work poorly if the name doesn’t have conforming prefixes, but that’s hopefully temporary
    - [X] SystemName comparator
    - [X] NamedBeanComparator

- [X] and finally make NamedBean itself a Comparator, so that it can be natively sorted in tables, etc.
    - [X] AbstractNamedBean.toString() returns the system name

- [X] build infrastructure for parsing within individual NamedBean types 
    - [X] Base structure in NamedBean
    - [X] Tests & JavaDoc
    - [X] Default implementations in AbstactNamedBean and the Catalog base class 
    - [X] Proof of concept & first implementation: C/MRI CT3004, CT3B4 and CT3:4 forms. 
    - [X] Add system-specific address comparators for OpenLCB hex format

- [X] convert the various jmri.beantable tables to have their SYSNAMECOL items be NamedBeans, not the system names of named beans. This invokes proper comparison, etc.

That last point needs more user-level testing, as there’s a huge number of runtime casts in that code.  It’ll take actually running it (and it doesn’t have very many tests) to determine if anything was broken, but at least any missing updates won’t be subtle:  A feature will show a cast-class exception in the log if it wasn’t updated properly.
