### PR TITLE
Fix Preferences "wants to save when nothing changed" behavior

### DIFF
--- a/java/src/jmri/jmrix/AbstractPortController.java
+++ b/java/src/jmri/jmrix/AbstractPortController.java
@@ -230,12 +230,9 @@ abstract public class AbstractPortController implements PortAdapter {
             this.displayText = displayText;
             this.options = new String[options.length];
             System.arraycopy(options, 0, this.options, 0, options.length);
-            System.out.println("Option ctor: "+displayText);
         }
 
         void configure(String value) {
-            System.out.println("configure: "+displayText+" from "+currentValue+" to "+value);
-            
             if (configuredValue == null ) configuredValue = value;
             currentValue = value;
         }

--- a/java/src/jmri/jmrix/AbstractPortController.java
+++ b/java/src/jmri/jmrix/AbstractPortController.java
@@ -209,6 +209,14 @@ abstract public class AbstractPortController implements PortAdapter {
     static protected class Option {
 
         String currentValue = null;
+        
+        /** 
+         * As a heuristic, we consider the 1st non-null
+         * currentValue as the configured value.  Changes away from that
+         * mark an Option object as "dirty".
+         */
+        String configuredValue = null;
+        
         String displayText;
         String[] options;
         Boolean advancedOption = true;
@@ -222,9 +230,13 @@ abstract public class AbstractPortController implements PortAdapter {
             this.displayText = displayText;
             this.options = new String[options.length];
             System.arraycopy(options, 0, this.options, 0, options.length);
+            System.out.println("Option ctor: "+displayText);
         }
 
         void configure(String value) {
+            System.out.println("configure: "+displayText+" from "+currentValue+" to "+value);
+            
+            if (configuredValue == null ) configuredValue = value;
             currentValue = value;
         }
 
@@ -248,7 +260,7 @@ abstract public class AbstractPortController implements PortAdapter {
         }
 
         boolean isDirty() {
-            return (currentValue != null && !currentValue.equals(options[0]));
+            return (currentValue != null && !currentValue.equals(configuredValue));
         }
     }
 


### PR DESCRIPTION
Resolves preferences "wants to save when nothing changed" behavior due to poor isDirty checking in the connection code. Does this with a heuristic, which is that the first configured non-null value for options is the value from the previous configuration.  This works with the existing preferences code in any case.

Closes #4562 at least in that specific case.  I think this is the general solution, but it's certainly possible that there's other causes of similar behavior in the communications code. Please open a new issue if there's still "wants to save then nothing changed" behavior
  