### PR TITLE
Prevent NPE that occurs when the LIUSB-Ethernet's keepalive timer triggers.

### DIFF
--- a/java/src/jmri/jmrix/lenz/liusbethernet/LIUSBEthernetAdapter.java
+++ b/java/src/jmri/jmrix/lenz/liusbethernet/LIUSBEthernetAdapter.java
@@ -91,11 +91,14 @@ public class LIUSBEthernetAdapter extends XNetNetworkPortController {
                     jmri.jmrix.lenz.XNetSystemConnectionMemo m = LIUSBEthernetAdapter.this
                             .getSystemConnectionMemo();
                     XNetTrafficController t = m.getXNetTrafficController();
-                    jmri.jmrix.lenz.XNetProgrammer p = (jmri.jmrix.lenz.XNetProgrammer) (m.getProgrammerManager().getGlobalProgrammer());
+                    jmri.jmrix.lenz.XNetProgrammer p = null;
+                    if(m.provides(jmri.GlobalProgrammerManager.class)){
+                        p = (jmri.jmrix.lenz.XNetProgrammer) (m.getProgrammerManager().getGlobalProgrammer());
+                    }
                     if (p == null || !(p.programmerBusy())) {
-                        t.sendXNetMessage(
-                                jmri.jmrix.lenz.XNetMessage.getCSStatusRequestMessage(),
-                                null);
+                       t.sendXNetMessage(
+                        jmri.jmrix.lenz.XNetMessage.getCSStatusRequestMessage(),
+                        null);
                     }
                 }
             };

--- a/java/src/jmri/jmrix/lenz/liusbethernet/LIUSBEthernetAdapter.java
+++ b/java/src/jmri/jmrix/lenz/liusbethernet/LIUSBEthernetAdapter.java
@@ -42,7 +42,6 @@ public class LIUSBEthernetAdapter extends XNetNetworkPortController {
     public void connect() throws java.io.IOException {
         super.connect();
         log.debug("openPort called");
-        keepAliveTimer();
     }
 
     /**
@@ -76,6 +75,7 @@ public class LIUSBEthernetAdapter extends XNetNetworkPortController {
         this.getSystemConnectionMemo().setXNetTrafficController(packets);
 
         new XNetInitializationManager(this.getSystemConnectionMemo());
+        keepAliveTimer();
     }
 
     /**


### PR DESCRIPTION
NPE appears in trace from #4666.  In this case, the issue is the KeepAliveTimer may trigger before initialization is complete, so the code now skips the programming in progress check if the system doesn't provide a programmer.  

In general, if an XPressNet system does not provide a programmer manager (not all do), the code now 
use the memo's provides method to determine if a programmer manager is available before checking to see if the programmer exists or is busy.
