### PR TITLE
LaisDCC update

### DIFF
--- a/xml/decoders/LaisDcc.xml
+++ b/xml/decoders/LaisDcc.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
-<!-- Copyright (C) JMRI 2016 All rights reserved -->
-<!-- $Id$ -->
+<!-- Copyright (C) JMRI 2016, 2017, 2018 All rights reserved                -->
 <!--                                                                        -->
 <!-- JMRI is free software; you can redistribute it and/or modify it under  -->
 <!-- the terms of version 2 of the GNU General Public License as published  -->
@@ -13,11 +12,107 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <version author="Stanley@laisdcc.com" version="2" lastUpdated="20170916"/>
-  <!-- Version 1.0 -->
+  <version author="Stanley@laisdcc.com" version="1" lastUpdated="20160923"/>
+  <version author="Alain Le Marchand" version="2" lastUpdated="20170408"/>
+  <version author="Stanley@laisdcc.com" version="3" lastUpdated="20180103"/>
+  <version author="Alain Le Marchand" version="4" lastUpdated="20180106"/>
+  <!-- Version 1: original version from LaisDCC website                                  -->
+  <!-- Version 2: updated low and high values for decoder version, based on real models -->
+  <!--            Updated manufacturer name to "LaisDCC" - with capital lettter for DCC -->
+  <!--            Re-ordered by decoder reference increasing number                     -->
+  <!--            Added 860020                                                          -->
+  <!-- Version 3: original version 3 from LaisDCC website                               -->
+  <!--            Added 860015 and 860016                                               -->
+  <!--            Additional outputs for 860019                                         -->
+  <!--            updated decoder version high value to 04                              -->
+  <!-- Version 4: Fixes from version 3 of LaisDcc :                                     -->
+  <!--            - Updated manufacturer to "LaisDCC" - with CAPITAL lettter for DCC    -->
+  <!--              Manufacturer name is case sensitive, automatic identification       -->
+  <!--              cannot work if name not fully matching                              -->
+  <!--            - Re-ordered by decoder reference increasing number                   -->
+  <!--            - 860018 replaced by 860020                                           -->
+  <!--            - Removed CV8 reset definition -> reset is already in 'resets' section-->
+  <!--            - Removed CV15 CV lock: used for dynamic programming                  -->
+  <!--              not as permanent value. Not in JMRI to avoid errors.                -->
+  <!--            Added 860010/LaisDcc-Z2                                               -->
   <decoder>
-    <family name="LaisDcc" mfg="LaisDcc" comment="LaisDcc decoder range" lowVersionID="02" highVersionID="03">
-
+    <family name="Locomotive Decoders" mfg="LaisDCC" comment="LaisDCC decoder range" lowVersionID="02" highVersionID="04">
+      <model model="860010/LaisDcc-Z2" numOuts="2" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860010" formFactor="Z" connector="Wires" comment="Z/N scale, wires NEM651">
+        <output name="1" label="White|Pin 5" connection="wire" maxcurrent="100 mA"/>
+        <output name="2" label="Yellow|Pin 6" connection="wire" maxcurrent="100 mA"/>
+        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
+        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
+        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
+        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
+        <size length="13.3" width="7.3" height="3.8" units="mm"/>
+      </model>
+      <model model="860012" numOuts="2" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860012" formFactor="N" connector="Wires" comment="N scale, wires NEM651">
+        <output name="1" label="White|Pin 5" connection="wire" maxcurrent="100 mA"/>
+        <output name="2" label="Yellow|Pin 6" connection="wire" maxcurrent="100 mA"/>
+        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
+        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
+        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
+        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
+        <size length="14.5" width="8.2" height="3" units="mm"/>
+      </model>
+      <model model="860013" numOuts="2" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860013" formFactor="N" connector="NEM651" comment="N scale, 6-pin direct NEM651 plug">
+        <output name="1" label="White|Pin 5" connection="plug" maxcurrent="100 mA"/>
+        <output name="2" label="Yellow|Pin 6" connection="plug" maxcurrent="100 mA"/>
+        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
+        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
+        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
+        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
+        <size length="14.5" width="8.2" height="3" units="mm"/>
+      </model>
+      <model model="860014" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860014" formFactor="HO" connector="Wires" comment="HO-scale, 9 Wires">
+        <output name="1" label="White|Wire" connection="wire" maxcurrent="100 mA"/>
+        <output name="2" label="Yellow|Wire" connection="wire" maxcurrent="100 mA"/>
+        <output name="3" label="Green|Wire" connection="wire" maxcurrent="100 mA"/>
+        <output name="4" label="Purple|Wire" connection="wire" maxcurrent="100 mA"/>
+        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
+        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
+        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
+        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
+        <size length="15" width="7" height="2.7" units="mm"/>
+      </model>
+			<model model="860015" numOuts="6" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860015" formFactor="HO" connector="Next18" comment="HO-scale, with Next18 harness">
+        <output name="1" label="White|Pin 8" connection="plug" maxcurrent="100 mA"/>
+        <output name="2" label="Yellow|Pin 17" connection="plug" maxcurrent="100 mA"/>
+        <output name="3" label="Green|Pin 3" connection="plug" maxcurrent="100 mA"/>
+        <output name="4" label="Purple|Pin 12" connection="plug" maxcurrent="100 mA"/>
+        <output name="5" label="Pink|Pin 4" connection="plug" maxcurrent="100 mA"/>
+        <output name="6" label="Brown|Pin 13"  connection="plug" maxcurrent="100 mA"/>
+        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
+        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
+        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
+        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
+        <size length="15" width="9.5" height="2.9" units="mm"/>
+      </model>
+			<model model="860016" numOuts="6" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860016" formFactor="HO" connector="PluX22" comment="HO-scale, with Plux22 harness">
+        <output name="1" label="White|Pin 7" connection="plug" maxcurrent="100 mA"/>
+        <output name="2" label="Yellow|Pin 13" connection="plug" maxcurrent="100 mA"/>
+        <output name="3" label="Green|Pin 16" connection="plug" maxcurrent="100 mA"/>
+        <output name="4" label="Purple|Pin 18" connection="plug" maxcurrent="100 mA"/>
+        <output name="5" label="Pink|Pin 2" connection="plug" maxcurrent="100 mA"/>
+        <output name="6" label="Brown|Pin 19"  connection="plug" maxcurrent="100 mA"/>
+        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
+        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
+        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
+        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
+        <size length="16" width="17.5" height="3" units="mm"/>
+      </model>
+      <!-- Model 860018 replaced by 860020 -->
+      <model show="maybe" model="860018" replacementModel="860020" replacementFamily="Locomotive Decoders" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860018" formFactor="HO" connector="NEM652" comment="HO-scale, direct NEM652 + wire for F2">
+        <output name="1" label="White|Pin 6" connection="plug" maxcurrent="100 mA"/>
+        <output name="2" label="Yellow|Pin 2" connection="plug" maxcurrent="100 mA"/>
+        <output name="3" label="Green|Pin 3" connection="plug" maxcurrent="100 mA"/>
+        <output name="4" label="Purple|Wire" connection="wire" maxcurrent="100 mA"/>
+        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
+        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
+        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
+        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
+        <size length="14.2" width="12.5" height="3.5" units="mm"/>
+      </model>
       <model model="860019" numOuts="6" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860019" formFactor="HO" connector="21MTC" comment="HO-scale, with 21MTC harness">
         <output name="1" label="White|Pin 8" connection="plug" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Pin 7" connection="plug" maxcurrent="100 mA"/>
@@ -31,33 +126,7 @@
         <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
         <size length="17" width="16" height="3.5" units="mm"/>
       </model>
-	  <model model="860015" numOuts="6" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860015" formFactor="HO" connector="Next18" comment="HO-scale, with Next18 harness">
-        <output name="1" label="White|Pin 8" connection="plug" maxcurrent="100 mA"/>
-        <output name="2" label="Yellow|Pin 17" connection="plug" maxcurrent="100 mA"/>
-        <output name="3" label="Green|Pin 3" connection="plug" maxcurrent="100 mA"/>
-        <output name="4" label="Purple|Pin 12" connection="plug" maxcurrent="100 mA"/>
-        <output name="5" label="Pink|Pin 4" connection="plug" maxcurrent="100 mA"/>
-        <output name="6" label="Brown|Pin 13"  connection="plug" maxcurrent="100 mA"/>
-        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
-        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
-        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
-        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
-        <size length="15" width="9.5" height="2.9" units="mm"/>
-      </model>
-	  <model model="860016" numOuts="6" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860016" formFactor="HO" connector="PluX22" comment="HO-scale, with PluX22 harness">
-        <output name="1" label="White|Pin 7" connection="plug" maxcurrent="100 mA"/>
-        <output name="2" label="Yellow|Pin 13" connection="plug" maxcurrent="100 mA"/>
-        <output name="3" label="Green|Pin 16" connection="plug" maxcurrent="100 mA"/>
-        <output name="4" label="Purple|Pin 18" connection="plug" maxcurrent="100 mA"/>
-        <output name="5" label="Pink|Pin 2" connection="plug" maxcurrent="100 mA"/>
-        <output name="6" label="Brown|Pin 19"  connection="plug" maxcurrent="100 mA"/>
-        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
-        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
-        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
-        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
-        <size length="16" width="17.5" height="3" units="mm"/>
-      </model>
-      <model model="860020" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860020" formFactor="HO" connector="NEM652" comment="HO-scale, direct NEM652">
+      <model model="860020" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860020" formFactor="HO" connector="NEM652" comment="HO-scale, direct NEM652 + wire for F2">
         <output name="1" label="White|Pin 6" connection="plug" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Pin 2" connection="plug" maxcurrent="100 mA"/>
         <output name="3" label="Green|Pin 3" connection="plug" maxcurrent="100 mA"/>
@@ -66,41 +135,12 @@
         <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
         <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
         <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
-        <size length="14.2" width="12.5" height="3.5" units="mm"/>
+        <size length="15" width="15" height="3.5" units="mm"/>
       </model>
-      <model model="860013" numOuts="2" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860013" formFactor="N" connector="NEM651" comment="Nano 6-pin direct NEM651">
-        <output name="1" label="White|Pin 5" connection="plug" maxcurrent="100 mA"/>
-        <output name="2" label="Yellow|Pin 6" connection="plug" maxcurrent="100 mA"/>
-        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
-        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
-        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
-        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
-        <size length="14.5" width="8.2" height="3" units="mm"/>
-      </model>
-      <model model="860012" numOuts="2" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860012" formFactor="N" connector="NEM651" comment="NEM651 Wire">
-        <output name="1" label="White|Pin 5" connection="wire" maxcurrent="100 mA"/>
-        <output name="2" label="Yellow|Pin 6" connection="wire" maxcurrent="100 mA"/>
-        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
-        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
-        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
-        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
-        <size length="14.5" width="8.2" height="3" units="mm"/>
-      </model>
-      <model model="860021" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860021" formFactor="HO" connector="Wires/NEM652" comment="Wire and NEM652">
+      <model model="860021" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860021" formFactor="HO" connector="Wires/NEM652" comment="HO-scale, Wires and NEM652">
         <output name="1" label="White|Pin 6" connection="plug" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Pin 2" connection="plug" maxcurrent="100 mA"/>
         <output name="3" label="Green|Pin 3" connection="plug" maxcurrent="100 mA"/>
-        <output name="4" label="Purple|Wire" connection="wire" maxcurrent="100 mA"/>
-        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
-        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
-        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
-        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
-        <size length="15" width="7" height="2.7" units="mm"/>
-      </model>
-      <model model="860014" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860014" formFactor="HO" connector="Wires" comment="9 Wire">
-        <output name="1" label="White|Wire" connection="wire" maxcurrent="100 mA"/>
-        <output name="2" label="Yellow|Wire" connection="wire" maxcurrent="100 mA"/>
-		<output name="3" label="Green|Wire" connection="wire" maxcurrent="100 mA"/>
         <output name="4" label="Purple|Wire" connection="wire" maxcurrent="100 mA"/>
         <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
         <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
@@ -152,26 +192,20 @@
           <label xml:lang="de">Mittengeschwindigkeit</label>
           <comment>Range 0-255, 0 in CV 2, 6, 5 produces straight line acceleration</comment>
         </variable>
-       <!-- CV7 & CV8 are left as readonly = no, so they will display in basic pane -->
-      <variable CV="7" readOnly="no" item="Decoder Version">
-        <decVal/>
-        <label>Version ID</label>
-        <label xml:lang="it">Versione Decoder: </label>
-        <label xml:lang="fr">Version décodeur: </label>
-        <label xml:lang="de">Decoder Version: </label>
-      </variable>
-      <variable CV="8" readOnly="no" item="Manufacturer">
-        <decVal/>
-        <label>Manufacturer ID</label>
-        <label xml:lang="it">ID Costruttore: </label>
-        <label xml:lang="fr">ID constructeur: </label>
-        <label xml:lang="de">Hersteller ID: </label>
-      </variable>
-      <variable item="Manufacturer ID - Reset" CV="8" default="0" readOnly="yes" mask="XXXXXXVX">
-        <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
-        <label>Manufacturer ID - Reset</label>
-        <label xml:lang="it">ID Costruttore - Reset</label>
-      </variable>
+        <variable CV="7" readOnly="yes" item="Decoder Version" tooltip="Decoder Version, Read Only">
+          <decVal/>
+          <label>Manufacturer Version No: </label>
+          <label xml:lang="it">Versione Decoder: </label>
+          <label xml:lang="fr">Version décodeur: </label>
+          <label xml:lang="de">Decoder Version: </label>
+        </variable>
+        <variable CV="8" readOnly="yes" item="Manufacturer" default="134" tooltip="Decoder Maker, Read Only">
+          <decVal/>
+          <label>Manufacturer ID: </label>
+          <label xml:lang="it">ID Costruttore: </label>
+          <label xml:lang="fr">ID constructeur: </label>
+          <label xml:lang="de">Hersteller ID: </label>
+        </variable>
         <variable CV="10" default="88" item="EMF Control Reference" tooltip="turn off BEMF above this speed step">
           <decVal/>
           <label>BEMF Feedback Cut Out</label>
@@ -274,14 +308,8 @@
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F12</label>
             <label>Analog Mode Function Status - F12</label>
         </variable>
-		<variable item="Decoder Lock control number" CV="15" mask="XXXXXVVV" default="0" tooltip="To unlock a decoder make CV15=0 or CV15=CV16">
-		<decVal/>
-		<label>Decoder Lock control number</label>
-		<label xml:lang="it">Codice Blocco Decoder</label>
-		<tooltip xml:lang="it">Per sbloccare il decoder metti CV15=0 o CV15=CV16</tooltip>
-		</variable>
-		<!-- CV16 -->
-		<xi:include href="http://jmri.org/xml/decoders/nmra/decoderLockId16.xml"/>
+        <!-- CV=16 Decoder Lock -->
+        <xi:include href="http://jmri.org/xml/decoders/nmra/decoderLockId16.xml"/>
         <!-- Consist CVs -->
         <xi:include href="http://jmri.org/xml/decoders/nmra/consistAddrDirection.xml"/>
         <xi:include href="http://jmri.org/xml/decoders/nmra/cv21.22_F12.xml"/>


### PR DESCRIPTION
Reverted some changes introduced by #4183 and #4408, that caused regression, and updated to latest version available on manufacturer's website.
- Updated manufacturer to "LaisDCC" - with CAPITAL lettter for DCC: Manufacturer name is case sensitive, automatic identification cannot work if name not fully matching
- Removed CV8 reset definition -> reset is already in 'resets' section
- Removed CV15 CV lock: used for dynamic programming not as permanent value. Not in JMRI to avoid errors.

Added 860010/LaisDcc-Z2
  