### PR TITLE
Update references to SF logo

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1644,7 +1644,7 @@
                        <br><a href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</a>
                        <br>Site hosted by:
                        <a href="http://sourceforge.net/projects/jmri">
-                       <img src="http://sflogo.sourceforge.net/sflogo.php?group_id=26788&type=12" width="120" height="30" border="0" alt="Get JMRI Model Railroad Interface at SourceForge.net. Fast, secure and Free Open Source software downloads"/></a>
+                       <img src="https://sourceforge.net/sflogo.php?type=13&group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
                 ]]>
             </bottom>
             <link href="http://docs.oracle.com/javase/8/docs/api/"/>
@@ -1711,7 +1711,7 @@
                        <br><a href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</a>
                        <br>Site hosted by:
                        <a href="http://sourceforge.net/projects/jmri">
-                       <img src="http://sflogo.sourceforge.net/sflogo.php?group_id=26788&type=12" width="120" height="30" border="0" alt="Get JMRI Model Railroad Interface at SourceForge.net. Fast, secure and Free Open Source software downloads"/></a>
+                       <img src="https://sourceforge.net/sflogo.php?type=13&group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
                 ]]>
             </bottom>
             <link href="http://docs.oracle.com/javase/8/docs/api/"/>
@@ -1792,7 +1792,7 @@
                        <br><a href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</a>
                        <br>Site hosted by:
                        <a href="http://sourceforge.net/projects/jmri">
-                       <img src="http://sflogo.sourceforge.net/sflogo.php?group_id=26788&type=12" width="120" height="30" border="0" alt="Get JMRI Model Railroad Interface at SourceForge.net. Fast, secure and Free Open Source software downloads"/></a>
+                       <img src="https://sourceforge.net/sflogo.php?type=13&group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
                 ]]>
             </bottom>
             <link href="http://docs.oracle.com/javase/8/docs/api/"/>

--- a/pom.xml
+++ b/pom.xml
@@ -455,7 +455,7 @@
                        <br><a href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</a>
                        <br>Site hosted by:
                        <a href="http://sourceforge.net/projects/jmri">
-                       <img src="http://sflogo.sourceforge.net/sflogo.php?group_id=26788&type=12" width="120" height="30" border="0" alt="Get JMRI Model Railroad Interface at SourceForge.net. Fast, secure and Free Open Source software downloads"/></a>
+                       <img src="https://sourceforge.net/sflogo.php?type=13&group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
                 ]]>
                     </bottom>
                     <links>

--- a/xml/XSLT/CSVindex.html
+++ b/xml/XSLT/CSVindex.html
@@ -48,8 +48,8 @@
             trademarks and licenses is linked here.</a></p>
 
         <br>Site hosted by:<br>
-        <a href="http://sourceforge.net/projects/jmri/"><img src="https://sourceforge.net/sflogo.php?group_id=26788&type=12" width="120" height="30" border="0"
-        alt="Get JMRI Model Railroad Interface at SourceForge.net. Fast, secure and Free Open Source software downloads" /></a>
+            <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
     </div>
     </div><!-- closes #mainContent-->
 </div><!-- closes #mBody-->

--- a/xml/XSLT/CVsummary.xsl
+++ b/xml/XSLT/CVsummary.xsl
@@ -43,8 +43,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 		</body>
 	</html>
 </xsl:template>

--- a/xml/XSLT/DecoderID.xsl
+++ b/xml/XSLT/DecoderID.xsl
@@ -52,8 +52,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 	</body>
 </html>
 

--- a/xml/XSLT/DecoderMfgIndex.xsl
+++ b/xml/XSLT/DecoderMfgIndex.xsl
@@ -54,8 +54,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 	</body>
 </html>
 

--- a/xml/XSLT/DecoderModelIndex.xsl
+++ b/xml/XSLT/DecoderModelIndex.xsl
@@ -46,8 +46,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 	</body>
 </html>
 

--- a/xml/XSLT/DecoderModelList.xsl
+++ b/xml/XSLT/DecoderModelList.xsl
@@ -45,8 +45,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 	</body>
 </html>
 

--- a/xml/XSLT/LogixToCode.xsl
+++ b/xml/XSLT/LogixToCode.xsl
@@ -50,7 +50,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 
     </body>
 </html>

--- a/xml/XSLT/SelectionGuide.xsl
+++ b/xml/XSLT/SelectionGuide.xsl
@@ -50,8 +50,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 	</body>
 </html>
 

--- a/xml/XSLT/appearancetable.xsl
+++ b/xml/XSLT/appearancetable.xsl
@@ -65,7 +65,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, SoundPro, SignalPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 
 	</body>
 </html>

--- a/xml/XSLT/aspecttable.xsl
+++ b/xml/XSLT/aspecttable.xsl
@@ -62,8 +62,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, SoundPro, SignalPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 	</body>
 </html>
 

--- a/xml/XSLT/consistRoster.xsl
+++ b/xml/XSLT/consistRoster.xsl
@@ -51,8 +51,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 			</body>
 		</html>
 

--- a/xml/XSLT/decoder-with-form.xsl
+++ b/xml/XSLT/decoder-with-form.xsl
@@ -416,8 +416,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
   </body>
 </html>
 

--- a/xml/XSLT/decoder.xsl
+++ b/xml/XSLT/decoder.xsl
@@ -160,8 +160,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
   </body>
 </html>
 

--- a/xml/XSLT/idtags.xsl
+++ b/xml/XSLT/idtags.xsl
@@ -50,7 +50,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <p/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <p/><a href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</a>
 <p/>Site hosted by: <br/>
-<a href="http://sourceforge.net"><img src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </a>
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 </body>
 </html>
 </xsl:template>

--- a/xml/XSLT/index.html
+++ b/xml/XSLT/index.html
@@ -65,8 +65,8 @@
                 trademarks and licenses is linked here.</a></p>
 
             <br>Site hosted by:<br>
-            <a href="http://sourceforge.net/projects/jmri/"><img src="https://sourceforge.net/sflogo.php?group_id=26788&type=12" width="120" height="30" border="0"
-                                                                 alt="Get JMRI Model Railroad Interface at SourceForge.net. Fast, secure and Free Open Source software downloads" /></a>
+                <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
         </div>
     </div><!-- closes #mainContent-->
 </div><!-- closes #mBody-->

--- a/xml/XSLT/locomotive.xsl
+++ b/xml/XSLT/locomotive.xsl
@@ -50,8 +50,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 	</body>
 </html>
 

--- a/xml/XSLT/panelfile-2-9-6.xsl
+++ b/xml/XSLT/panelfile-2-9-6.xsl
@@ -45,8 +45,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <p/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <p/><a href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</a>
 <p/>Site hosted by: <br/>
-<a href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </a>
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 	</body>
 </html>
 

--- a/xml/XSLT/panelfile.xsl
+++ b/xml/XSLT/panelfile.xsl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="iso-8859-1"?>
 
 <!-- Stylesheet to convert a JMRI panel file into an HTML page          -->
 <!-- Used by default when the panel file is displayed in a web browser  -->
@@ -42,8 +42,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 	</body>
 </html>
 

--- a/xml/XSLT/roster.xsl
+++ b/xml/XSLT/roster.xsl
@@ -50,8 +50,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 	</body>
 </html>
 

--- a/xml/XSLT/roster2array.xsl
+++ b/xml/XSLT/roster2array.xsl
@@ -64,9 +64,8 @@
 					<IMG src="http://jmri.org/images/logo-jmri.gif"
 						height="31" border="0" alt="JMRI project" />
 				</A>
-				<A href="http://sourceforge.net">
-					<IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1"
-						width="88" height="31" border="0" alt="SourceForge Logo" />
+                    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 				</A>
 
 			</body>

--- a/xml/XSLT/roster2text.xsl
+++ b/xml/XSLT/roster2text.xsl
@@ -50,7 +50,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 
 	</body>
 </html>

--- a/xml/XSLT/rpsfile.xsl
+++ b/xml/XSLT/rpsfile.xsl
@@ -50,8 +50,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 	</body>
 </html>
 

--- a/xml/XSLT/speedometer.xsl
+++ b/xml/XSLT/speedometer.xsl
@@ -51,7 +51,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <p/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <p/><a href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</a>
 <p/>Site hosted by: <br/>
-<a href="http://sourceforge.net"><img src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </a>
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 </body>
 </html>
 </xsl:template>

--- a/xml/XSLT/throttle.xsl
+++ b/xml/XSLT/throttle.xsl
@@ -52,8 +52,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
-
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 	</body>
 </html>
 

--- a/xml/XSLT/vsdecoder-config.xsl
+++ b/xml/XSLT/vsdecoder-config.xsl
@@ -53,7 +53,8 @@ This page was produced by <a href="http://jmri.org">JMRI</a>.
 <P/>JMRI, DecoderPro, PanelPro, DispatcherPro and associated logos are our trademarks.
 <P/><A href="http://jmri.org/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</A>
 <P/>Site hosted by: <BR/>
-<A href="http://sourceforge.net"><IMG src="http://sourceforge.net/sflogo.php?group_id=26788&amp;type=1" width="88" height="31" border="0" alt="SourceForge Logo"/> </A> 
+    <a href="http://sourceforge.net/projects/jmri">
+    <img src="https://sourceforge.net/sflogo.php?type=13&amp;group_id=26788" border="0" alt="JMRI Model Railroad Interface at SourceForge.net"/></a>
 
 	</body>
 </html>

--- a/xml/signals/NYC-1956/index.shtml
+++ b/xml/signals/NYC-1956/index.shtml
@@ -93,8 +93,6 @@ Signal Mast definitions:
 	<P>JMRI&reg;, DecoderPro&reg;, PanelPro&trade;, DispatcherPro&trade; and associated logos are our trademarks.
 	<P><A href="/Copyright.html">Additional information on copyright, trademarks and licenses is linked here.</a></p>
     
-       <BR/>Site hosted by: <BR/>
-<a href="http://sourceforge.net/projects/jmri"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=26788&type=12" width="120" height="30" border="0" alt="Get JMRI Model Railroad Interface at SourceForge.net. Fast, secure and Free Open Source software downloads" /></a>
     </div>
 
 <!-- Piwik -->


### PR DESCRIPTION
Update the SF Logo, as suggested by @silverailscolo in JMRI/website#251