### PR TITLE
Improve SerialInput scripts

### DIFF
--- a/jython/serialinput/SerialPortDevice.py
+++ b/jython/serialinput/SerialPortDevice.py
@@ -65,8 +65,19 @@ class SerialPortDevice(jmri.jmrit.automat.AbstractAutomaton) :
     def handle(self) : 
         # if initial flush pending, do that just once
         if (self.flush) :
-            next = 0
-            while (next != 13) : next = self.inputStream.read()
+            # skip anything listed as available now
+            count = self.inputStream.available()
+            self.inputStream.skip(count)
+            print "Skipping count:", count
+            count = self.inputStream.available()
+            self.inputStream.skip(count)
+            print "Skipping count:", count
+            # now skip 10 lines in hope to flush buffers of partial lines
+            count = 0
+            while (count < 10) :
+                next = 0
+                while (next != 13) : next = self.inputStream.read()  # 13 is Newline
+                count++
             self.flush = False
             print "Ready to process"
             

--- a/jython/serialinput/SerialPortDevice.py
+++ b/jython/serialinput/SerialPortDevice.py
@@ -77,7 +77,7 @@ class SerialPortDevice(jmri.jmrit.automat.AbstractAutomaton) :
             while (count < 10) :
                 next = 0
                 while (next != 13) : next = self.inputStream.read()  # 13 is Newline
-                count++
+                count = count+1
             self.flush = False
             print "Ready to process"
             

--- a/jython/serialinput/SerialPortDevice.py
+++ b/jython/serialinput/SerialPortDevice.py
@@ -97,13 +97,13 @@ class SerialPortDevice(jmri.jmrit.automat.AbstractAutomaton) :
         # send that array to be processed        
         self.process(values);
         
-        # flush buffer and skip line (test of performance)
+        # flush buffer and skip line if falling behind
         count = self.inputStream.available()
-        self.inputStream.skip(count)
-        if (count > 10) : print "  Found buffer with excess: ", count
-        next = self.inputStream.read()       
-        while (next != 13) :  # loop until consume CR
-            next = self.inputStream.read()
+        if (count > 60) : # falling behind, flush
+            self.inputStream.skip(count)
+            next = self.inputStream.read()       
+            while (next != 13) :  # loop until consume CR
+                next = self.inputStream.read()
 
         # and continue around again
         return 1


### PR DESCRIPTION
The SerialInput scripts are used to acquire analog and digital input data via an Arduino.  This improves how the input is handled when the JMRI instance is having trouble keeping up.