### PR TITLE
Request that two packets be sent in AccessoryOpsModeProgramming.

### DIFF
--- a/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
+++ b/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
@@ -170,7 +170,7 @@ public class AccessoryOpsModeProgrammerFacade extends AbstractProgrammerFacade i
                 programmingOpReply(val, ProgListener.UnknownError);
                 return;
         }
-        InstanceManager.getDefault(CommandStation.class).sendPacket(b, 1); // send packet
+        InstanceManager.getDefault(CommandStation.class).sendPacket(b, 2); // send two packets
 
         // set up a delayed completion reply
         new Thread(new Runnable() {


### PR DESCRIPTION
Ambiguity exists in S9.2.1 as to whether "Two identical packets are needed before the decoder shall modify a configuration variable" applies to AccessoryOpsMode as well as mobile OpsMode.

This covers either possible decoder manufacturer interpretation. Overheads are minimal as only one extra packet generated per CV write and AccessoryOpsModeProgramming is an infrequent occurrence.

#4738 has discussion.