### PR TITLE
Parsable system names update part 3

### DIFF
--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -72,9 +72,15 @@
 
         <li>Conditionals (for logiX, although these are not entirely named beans)</li>
 
+        <li>signal mast Groups</li>
+        
         <li>signal Heads</li>
+        
+        <li>signal masts (F, for some reason)</li>
 
         <li>Lights (a type of output)</li>
+
+        <li>logiX</li>
 
         <li>Memories</li>
 
@@ -822,6 +828,20 @@
       <!-- this table is maintained on the help/en/html/doc/Technical/Names.shtml based on information from the
       Hardware help pages by Egbert Broerse @silverailscolo July 2017 -->
 
+    <h3>Some Type-Specific Information</h2>
+    
+    <p><b>Block</b> system names are all upper case, have no trailing whitespace and start with IM.
+    
+    <p><b>Memory</b> system names are all upper case, have no trailing whitespace and start with IM.
+        
+    <p><b>SignalGroup</b> system names are all upper case and have no trailing whitespace.
+                        For historical reasons, they're not required to have a system prefix or 
+                        type letter; the example name is "R12".  This might change, so
+                        using "IG" at the start is recommended.
+
+    <p><b>SignalHead</b> system names are all upper case, have no trailing whitespace and mostly, but not always, start with IH.
+                         
+    
       <h2>Naming Conventions For Automated Use</h2>Some
       higher-level constructs create their own items. For example,
       a "Sensor Group" is really just a collection of Routes that

--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -80,8 +80,6 @@
 
         <li>Lights (a type of output)</li>
 
-        <li>logiX</li>
-
         <li>Memories</li>
 
         <li>Outputs</li>
@@ -95,6 +93,9 @@
         <li>Turnouts</li>
 
         <li>logiX</li>
+        
+        <li>Sections (Y, for some reason)</li>
+        
       </ul>Some of these are associated with a specific hardware
       device, e.g. a particular turnout. Others are more virtual,
       e.g. a route, which is a collection on control information
@@ -293,7 +294,8 @@
         position in 3d space</li>
 
         <li>B Block - A software object that keeps track of the
-        contents of a specific block of track</li>
+        contents of a specific block of track.
+        Block system names are all upper case, have no trailing whitespace and start with IB.</li>
 
         <li>D iDentity - A software object that holds information
         about an identity tag that is, typically, attached to a
@@ -310,11 +312,15 @@
         <li>H signal Head - One part of a signal (which may have
         multiple heads). Also interpreted to include indicators on
         control panels that are acting to display signal
-        aspects</li>
+        aspects.
+        SignalHead system names are all upper case, have no trailing whitespace and mostly, 
+        but not always, start with IH.
+        </li>
 
         <li>M Memory - As yet, this has no real equivalent in the
         layout hardware, but is used as a place to store
-        information temporarily and display it on panels, etc.</li>
+        information temporarily and display it on panels, etc.
+        Memory system names are all upper case, have no trailing whitespace and start with IM.</li>
 
         <li>L Light - another form of output, used to e.g. control
         lights on a layout</li>
@@ -335,12 +341,24 @@
         generally be either ACTIVE or INACTIVE. This is most
         commonly used for block occupancy detectors.</li>
 
+        <li>Y Sections - holds a map of trackwork.
+        Section</b> system names are all upper case, have no trailing whitespace and start with IY.</li>
+        
+        <li>SignalGroups - hold a set of signal heads or masts.
+            SignalGroup system names are all upper case and have no trailing whitespace.
+            For historical reasons, they're not required to have a system prefix or 
+            type letter; the example name is "R12".  This might change, so
+            using "IG" at the start is recommended.
+
         <li>T Turnout - actually a general purpose output on the
         layout</li>
 
         <li>X logiX - a set of logic equations used to control the
-        layout</li>
+        layout.
+        Logix system names are all upper case, have no trailing whitespace and start with IX.</li>
       </ul>
+
+
 
       <a name="systeminfo" id="systeminfo"></a>
       <h3>System-specific suffix</h3>
@@ -827,20 +845,6 @@
         </tbody></table>
       <!-- this table is maintained on the help/en/html/doc/Technical/Names.shtml based on information from the
       Hardware help pages by Egbert Broerse @silverailscolo July 2017 -->
-
-    <h3>Some Type-Specific Information</h2>
-    
-    <p><b>Block</b> system names are all upper case, have no trailing whitespace and start with IM.
-    
-    <p><b>Memory</b> system names are all upper case, have no trailing whitespace and start with IM.
-        
-    <p><b>SignalGroup</b> system names are all upper case and have no trailing whitespace.
-                        For historical reasons, they're not required to have a system prefix or 
-                        type letter; the example name is "R12".  This might change, so
-                        using "IG" at the start is recommended.
-
-    <p><b>SignalHead</b> system names are all upper case, have no trailing whitespace and mostly, but not always, start with IH.
-                         
     
       <h2>Naming Conventions For Automated Use</h2>Some
       higher-level constructs create their own items. For example,

--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -216,6 +216,20 @@ public class BlockManager extends AbstractManager<Block> implements PropertyChan
     }
 
     /**
+     * {@inheritDoc}
+     * 
+     * Forces upper case and trims leading and trailing whitespace.
+     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
+     */
+    @CheckReturnValue
+    @Override
+    public @Nonnull
+    String normalizeSystemName(@Nonnull String inputName) {
+        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
+        return inputName.toUpperCase().trim();
+    }
+
+    /**
      * @return the default BlockManager instance
      * @deprecated since 4.9.1; use
      * {@link InstanceManager#getDefault(Class)} instead

--- a/java/src/jmri/SectionManager.java
+++ b/java/src/jmri/SectionManager.java
@@ -9,6 +9,10 @@ import jmri.managers.AbstractManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
 /**
  * Basic Implementation of a SectionManager.
  * <P>
@@ -158,6 +162,20 @@ public class SectionManager extends AbstractManager<Section> implements Property
 
     public Section getByUserName(String key) {
         return _tuser.get(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * Forces upper case and trims leading and trailing whitespace.
+     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
+     */
+    @CheckReturnValue
+    @Override
+    public @Nonnull
+    String normalizeSystemName(@Nonnull String inputName) {
+        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
+        return inputName.toUpperCase().trim();
     }
 
     /**

--- a/java/src/jmri/TransitManager.java
+++ b/java/src/jmri/TransitManager.java
@@ -6,6 +6,10 @@ import java.util.ArrayList;
 import java.util.List;
 import jmri.managers.AbstractManager;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
 /**
  * Implementation of a Transit Manager
  * <P>
@@ -150,6 +154,20 @@ public class TransitManager extends AbstractManager<Transit> implements Property
 
     public Transit getByUserName(String key) {
         return _tuser.get(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * Forces upper case and trims leading and trailing whitespace.
+     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
+     */
+    @CheckReturnValue
+    @Override
+    public @Nonnull
+    String normalizeSystemName(@Nonnull String inputName) {
+        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
+        return inputName.toUpperCase().trim();
     }
 
     /**

--- a/java/src/jmri/jmrit/beantable/BlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/BlockTableAction.java
@@ -37,6 +37,7 @@ import javax.swing.SpinnerNumberModel;
 import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableCellRenderer;
 import jmri.Block;
+import jmri.BlockManager;
 import jmri.InstanceManager;
 import jmri.Manager;
 import jmri.NamedBean;
@@ -984,7 +985,7 @@ public class BlockTableAction extends AbstractTableAction {
         if (user.equals("")) {
             user = null;
         }
-        String sName = sysName.getText().trim().toUpperCase(); // N11N
+        String sName = InstanceManager.getDefault(BlockManager.class).normalizeSystemName(sysName.getText()); // N11N
         // initial check for empty entry
         if (sName.length() < 1 && !_autoSystemName.isSelected()) {
             statusBar.setText(Bundle.getMessage("WarningSysNameEmpty"));

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -1815,7 +1815,9 @@ public class LightTableAction extends AbstractTableAction {
                     if (t == null) {
                         // not user name, try system name
                         t = InstanceManager.turnoutManagerInstance().
-                                getBySystemName(turnoutName.toUpperCase());
+                                getBySystemName(
+                                    InstanceManager.getDefault(jmri.TurnoutManager.class).normalizeSystemName(turnoutName)
+                                );
                         if (t != null) {
                             // update turnout system name in case it changed
                             turnoutName = t.getSystemName();

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -1089,7 +1089,7 @@ public class LogixTableAction extends AbstractTableAction {
      * @return false if name has length &lt; 1 after displaying a dialog
      */
     boolean checkLogixSysName() {
-        String sName = _systemName.getText().toUpperCase().trim();
+        String sName = InstanceManager.getDefault(LogixManager.class).normalizeSystemName(_systemName.getText());
         if ((sName.length() < 1)) {
             // Entered system name is blank or too short
             javax.swing.JOptionPane.showMessageDialog(addLogixFrame,

--- a/java/src/jmri/jmrit/beantable/MemoryTableAction.java
+++ b/java/src/jmri/jmrit/beantable/MemoryTableAction.java
@@ -224,11 +224,11 @@ public class MemoryTableAction extends AbstractTableAction {
             }
         }
 
-        String user = userName.getText().trim(); // N11N
+        String user = jmri.NamedBean.normalizeUserName(userName.getText());
         if (user.equals("")) {
             user = null;
         }
-        String sName = sysName.getText().trim().toUpperCase(); // N11N
+        String sName = jmri.InstanceManager.memoryManagerInstance().normalizeSystemName(sysName.getText());
         // initial check for empty entry
         if (sName.length() < 1 && !autoSystemName.isSelected()) {
             statusBar.setText(Bundle.getMessage("WarningSysNameEmpty"));
@@ -247,13 +247,13 @@ public class MemoryTableAction extends AbstractTableAction {
 
             if (x != 0) {
                 if (user != null) {
-                    b = new StringBuilder(userName.getText().trim()); // N11N
+                    b = new StringBuilder(jmri.NamedBean.normalizeUserName(userName.getText())); // N11N
                     b.append(":");
                     b.append(Integer.toString(x));
                     user = b.toString(); // add :x to user name starting with 2nd item
                 }
                 if (!autoSystemName.isSelected()) {
-                    b = new StringBuilder(sysName.getText().trim()); // N11N
+                    b = new StringBuilder(jmri.InstanceManager.memoryManagerInstance().normalizeSystemName(sysName.getText()));
                     b.append(":");
                     b.append(Integer.toString(x));
                     sName = b.toString();

--- a/java/src/jmri/jmrit/beantable/SectionTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SectionTableAction.java
@@ -717,7 +717,7 @@ public class SectionTableAction extends AbstractTableAction {
         }
 
         // attempt to create the new Section
-        String sName = sysName.getText().trim().toUpperCase(); // N11N
+        String sName = InstanceManager.getDefault(jmri.SectionManager.class).normalizeSystemName(sysName.getText()); // N11N
         try {
             if (_autoSystemName.isSelected()) {
                 curSection = sectionManager.createNewSection(uName);

--- a/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
@@ -10,6 +10,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ResourceBundle;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
@@ -29,18 +34,24 @@ import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableRowSorter;
+
 import jmri.InstanceManager;
 import jmri.Manager;
 import jmri.NamedBean;
 import jmri.SignalGroup;
+import jmri.SignalGroupManager;
 import jmri.SignalHead;
+import jmri.SignalHeadManager;
 import jmri.SignalMast;
+import jmri.SignalMastManager;
 import jmri.swing.RowSorterUtil;
 import jmri.util.JmriJFrame;
 import jmri.util.AlphanumComparator;
+import jmri.util.StringUtil;
 import jmri.util.swing.JmriBeanComboBox;
 import jmri.util.table.ButtonEditor;
 import jmri.util.table.ButtonRenderer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +78,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
     public SignalGroupTableAction(String s) {
         super(s);
         // disable ourself if there is no primary SignalGroup manager available
-        if (jmri.InstanceManager.getNullableDefault(jmri.SignalGroupManager.class) == null) {
+        if (InstanceManager.getNullableDefault(SignalGroupManager.class) == null) {
             setEnabled(false);
         }
     }
@@ -278,17 +289,17 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
 
             @Override
             public Manager getManager() {
-                return jmri.InstanceManager.getDefault(jmri.SignalGroupManager.class);
+                return InstanceManager.getDefault(SignalGroupManager.class);
             }
 
             @Override
             public NamedBean getBySystemName(String name) {
-                return jmri.InstanceManager.getDefault(jmri.SignalGroupManager.class).getBySystemName(name);
+                return InstanceManager.getDefault(SignalGroupManager.class).getBySystemName(name);
             }
 
             @Override
             public NamedBean getByUserName(String name) {
-                return jmri.InstanceManager.getDefault(jmri.SignalGroupManager.class).getByUserName(name);
+                return InstanceManager.getDefault(SignalGroupManager.class).getByUserName(name);
             }
 
             @Override
@@ -346,7 +357,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
      */
     int signalStateFromBox(JComboBox<String> box) {
         String mode = (String) box.getSelectedItem();
-        int result = jmri.util.StringUtil.getStateFromName(mode, signalStatesValues, signalStates);
+        int result = StringUtil.getStateFromName(mode, signalStatesValues, signalStates);
 
         if (result < 0) {
             log.warn("unexpected mode string in signalState Aspect: " + mode);
@@ -363,7 +374,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
      * @param box  in which to enter mode
      */
     void setSignalStateBox(int mode, JComboBox<String> box) {
-        String result = jmri.util.StringUtil.getNameFromState(mode, signalStatesValues, signalStates);
+        String result = StringUtil.getNameFromState(mode, signalStatesValues, signalStates);
         box.setSelectedItem(result);
     }
 
@@ -429,7 +440,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
         inEditMode = true;
         _mastAspectsList = null;
 
-        jmri.SignalHeadManager shm = InstanceManager.getDefault(jmri.SignalHeadManager.class);
+        SignalHeadManager shm = InstanceManager.getDefault(SignalHeadManager.class);
         List<String> systemNameList = shm.getSystemNameList();
         _signalHeadsList = new ArrayList<SignalGroupSignalHead>(systemNameList.size());
         // create list of all available Single Output Signal Heads to choose from
@@ -456,7 +467,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
         // Set up Add/Edit Signal Group window
         if (addFrame == null) { // if it's not yet present, create addFrame
 
-            mainSignalComboBox = new JmriBeanComboBox(jmri.InstanceManager.getDefault(jmri.SignalMastManager.class), null, JmriBeanComboBox.DisplayOptions.DISPLAYNAME);
+            mainSignalComboBox = new JmriBeanComboBox(InstanceManager.getDefault(SignalMastManager.class), null, JmriBeanComboBox.DisplayOptions.DISPLAYNAME);
             mainSignalComboBox.setFirstItemBlank(true); // causes NPE when user selects that 1st line, so do not respond to result null
             addFrame = new JmriJFrame(Bundle.getMessage("AddSignalGroup"), false, true);
             addFrame.addHelpMenu("package.jmri.jmrit.beantable.SignalGroupAddEdit", true);
@@ -772,7 +783,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
      */
     boolean checkNewNamesOK() {
         // Get system name and user name from Add Signal Group pane
-        String sName = _systemName.getText().toUpperCase().trim(); // N11N
+        String sName = InstanceManager.getDefault(SignalGroupManager.class).normalizeSystemName(_systemName.getText());
         // seems field _systemName is not properly filled in when editing an existing mast
         // so prevent it from being called (in line 900)
         String uName = _userName.getText(); // may be empty // N11N
@@ -787,7 +798,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
         SignalGroup g = null;
         // check if a SignalGroup with the same user name exists
         if (!uName.equals("")) {
-            g = jmri.InstanceManager.getDefault(jmri.SignalGroupManager.class).getByUserName(uName);
+            g = InstanceManager.getDefault(SignalGroupManager.class).getByUserName(uName);
             if (g != null) {
                 // SignalGroup with this user name already exists
                 JOptionPane.showMessageDialog(null,
@@ -800,7 +811,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
             }
         }
         // check if a SignalGroup with this system name already exists
-        g = jmri.InstanceManager.getDefault(jmri.SignalGroupManager.class).getBySystemName(sName);
+        g = InstanceManager.getDefault(SignalGroupManager.class).getBySystemName(sName);
         if (g != null) {
             // SignalGroup already exists
             JOptionPane.showMessageDialog(null,
@@ -839,7 +850,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
      */
     SignalGroup checkNamesOK() {
         // Get system name and user name
-        String sName = _systemName.getText().toUpperCase();
+        String sName = InstanceManager.getDefault(SignalGroupManager.class).normalizeSystemName(_systemName.getText());
         String uName = _userName.getText();
         if (sName.length() == 0) {
             JOptionPane.showMessageDialog(null,
@@ -850,7 +861,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
             return null;
         }
         try {
-            SignalGroup g = jmri.InstanceManager.getDefault(jmri.SignalGroupManager.class).provideSignalGroup(sName, uName);
+            SignalGroup g = InstanceManager.getDefault(SignalGroupManager.class).provideSignalGroup(sName, uName);
             return g;
         } catch (IllegalArgumentException ex) {
             // should never get here
@@ -912,7 +923,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
      * the comboBox and store them in a table on the addFrame using _AspectModel
      */
     void setValidSignalMastAspects() {
-        jmri.SignalMast sm = (SignalMast) mainSignalComboBox.getSelectedBean();
+        SignalMast sm = (SignalMast) mainSignalComboBox.getSelectedBean();
         if (sm == null) {
             log.debug("Null picked in mainSignal comboBox. Probably line 1 or no masts in system");
             return;
@@ -956,8 +967,8 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
      */
     void editPressed(ActionEvent e) {
         // identify the Signal Group with this name if it already exists
-        String sName = _systemName.getText().toUpperCase(); // is already filled in from the Signal Group table by addPressed()
-        SignalGroup g = jmri.InstanceManager.getDefault(jmri.SignalGroupManager.class).getBySystemName(sName);
+        String sName = InstanceManager.getDefault(SignalGroupManager.class).normalizeSystemName(_systemName.getText()); // is already filled in from the Signal Group table by addPressed()
+        SignalGroup g = InstanceManager.getDefault(SignalGroupManager.class).getBySystemName(sName);
         if (g == null) {
             // Signal Group does not exist, so cannot be edited
             return;
@@ -968,7 +979,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
         curSignalGroup = g;
         log.debug("curSignalGroup was set");
 
-        jmri.SignalMast sm = jmri.InstanceManager.getDefault(jmri.SignalMastManager.class).getSignalMast(g.getSignalMastName());
+        SignalMast sm = InstanceManager.getDefault(SignalMastManager.class).getSignalMast(g.getSignalMastName());
         if (sm != null) {
             java.util.Vector<String> aspects = sm.getValidAspects();
             _mastAspectsList = new ArrayList<SignalMastAspect>(aspects.size());
@@ -1032,7 +1043,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
      * @param e the event heard
      */
     void deletePressed(ActionEvent e) {
-        InstanceManager.getDefault(jmri.SignalGroupManager.class).deleteSignalGroup(curSignalGroup);
+        InstanceManager.getDefault(SignalGroupManager.class).deleteSignalGroup(curSignalGroup);
         curSignalGroup = null;
         log.debug("DeletePressed; curSignalGroup set to null");
         finishUpdate();
@@ -1151,7 +1162,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
         }
 
         public void dispose() {
-            InstanceManager.getDefault(jmri.SignalMastManager.class).removePropertyChangeListener(this);
+            InstanceManager.getDefault(SignalMastManager.class).removePropertyChangeListener(this);
         }
 
         @Override
@@ -1295,7 +1306,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
     class SignalGroupSignalHeadModel extends SignalGroupOutputModel {
 
         SignalGroupSignalHeadModel() {
-            InstanceManager.getDefault(jmri.SignalHeadManager.class).addPropertyChangeListener(this);
+            InstanceManager.getDefault(SignalHeadManager.class).addPropertyChangeListener(this);
         }
 
         @Override
@@ -1405,7 +1416,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
          * @return bean object of the head
          */
         public SignalHead getBean(int r) {
-            return jmri.InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead((String) getValueAt(r, SNAME_COLUMN));
+            return InstanceManager.getDefault(SignalHeadManager.class).getSignalHead((String) getValueAt(r, SNAME_COLUMN));
         }
 
         /**
@@ -1461,7 +1472,7 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
          * Remove listener from Signal Head in group. Called on Delete.
          */
         public void dispose() {
-            InstanceManager.getDefault(jmri.SignalHeadManager.class).removePropertyChangeListener(this);
+            InstanceManager.getDefault(SignalHeadManager.class).removePropertyChangeListener(this);
         }
     }
 
@@ -1551,10 +1562,10 @@ public class SignalGroupTableAction extends AbstractTableAction implements Prope
          */
         SignalGroupSignalHead(String sysName, String userName) {
             _included = false;
-            SignalHead anySigHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getBySystemName(sysName);
+            SignalHead anySigHead = InstanceManager.getDefault(SignalHeadManager.class).getBySystemName(sysName);
             if (anySigHead != null) {
                 if (anySigHead.getClass().getName().contains("SingleTurnoutSignalHead")) {
-                    jmri.implementation.SingleTurnoutSignalHead oneSigHead = (jmri.implementation.SingleTurnoutSignalHead) InstanceManager.getDefault(jmri.SignalHeadManager.class).getBySystemName(sysName);
+                    jmri.implementation.SingleTurnoutSignalHead oneSigHead = (jmri.implementation.SingleTurnoutSignalHead) InstanceManager.getDefault(SignalHeadManager.class).getBySystemName(sysName);
                     if (oneSigHead != null) {
                         _onState = oneSigHead.getOnAppearance();
                         _offState = oneSigHead.getOffAppearance();

--- a/java/src/jmri/jmrit/beantable/SignalHeadTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalHeadTableAction.java
@@ -28,10 +28,12 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.Border;
 import javax.swing.border.TitledBorder;
 import jmri.InstanceManager;
+import jmri.CommandStation;
 import jmri.Manager;
 import jmri.NamedBean;
 import jmri.NamedBeanHandle;
 import jmri.SignalHead;
+import jmri.SignalHeadManager;
 import jmri.Turnout;
 import jmri.implementation.DccSignalHead;
 import jmri.implementation.DoubleTurnoutSignalHead;
@@ -67,7 +69,7 @@ public class SignalHeadTableAction extends AbstractTableAction {
     public SignalHeadTableAction(String s) {
         super(s);
         // disable ourself if there is no primary Signal Head manager available
-        if (jmri.InstanceManager.getNullableDefault(jmri.SignalHeadManager.class) == null) {
+        if (InstanceManager.getNullableDefault(SignalHeadManager.class) == null) {
             setEnabled(false);
         }
     }
@@ -764,7 +766,7 @@ public class SignalHeadTableAction extends AbstractTableAction {
     @Override
     protected void addPressed(ActionEvent e) {
         if (addFrame == null) {
-            for (Object obj : jmri.InstanceManager.getList(jmri.CommandStation.class)) {
+            for (Object obj : InstanceManager.getList(CommandStation.class)) {
                 jmri.CommandStation station = (jmri.CommandStation) obj;
                 prefixBox.addItem(station.getUserName());
             }
@@ -1201,8 +1203,20 @@ public class SignalHeadTableAction extends AbstractTableAction {
             }
 
         } else {
-            sName = sysName.toUpperCase();
-            if ((sName.length() < 3) || (!sName.substring(1, 2).equals("H"))) {
+            sName = InstanceManager.getDefault(SignalHeadManager.class).normalizeSystemName(sysName);
+            
+            boolean ok = true;
+            try {
+                int i = jmri.Manager.getSystemPrefixLength(sName);
+                if (sName.length() < i+2) {
+                    ok = false;
+                } else {
+                    if (!sName.substring(i, i+1).equals("H")) ok = false;
+                }
+            } catch (jmri.NamedBean.BadSystemNameException e) {
+                ok = false;
+            }
+            if (!ok) {
                 String msg = Bundle.getMessage("InvalidSignalSystemName", new Object[]{sName});
                 JOptionPane.showMessageDialog(addFrame, msg,
                         Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
@@ -1284,7 +1298,7 @@ public class SignalHeadTableAction extends AbstractTableAction {
                 handleSE8cOkPressed();
             } else if (acelaAspect.equals(typeBox.getSelectedItem())) {
                 String inputusername = userNameTextField.getText();
-                String inputsysname = ato1TextField.getText().toUpperCase();
+                String inputsysname = InstanceManager.getDefault(SignalHeadManager.class).normalizeSystemName(ato1TextField.getText());
                 int headnumber;
                 //int aspecttype;
 
@@ -1311,9 +1325,9 @@ public class SignalHeadTableAction extends AbstractTableAction {
                     //if (jmri.jmrix.acela.status()) { // check for an active Acela connection status
                     try {
                         if (inputusername.length() == 0) {
-                            s = new jmri.jmrix.acela.AcelaSignalHead("AH" + headnumber, jmri.InstanceManager.getDefault(jmri.jmrix.acela.AcelaSystemConnectionMemo.class));
+                            s = new jmri.jmrix.acela.AcelaSignalHead("AH" + headnumber, InstanceManager.getDefault(jmri.jmrix.acela.AcelaSystemConnectionMemo.class));
                         } else {
-                            s = new jmri.jmrix.acela.AcelaSignalHead("AH" + headnumber, inputusername, jmri.InstanceManager.getDefault(jmri.jmrix.acela.AcelaSystemConnectionMemo.class));
+                            s = new jmri.jmrix.acela.AcelaSignalHead("AH" + headnumber, inputusername, InstanceManager.getDefault(jmri.jmrix.acela.AcelaSystemConnectionMemo.class));
                         }
                         InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
                     } catch (java.lang.NullPointerException ex) {
@@ -1325,7 +1339,7 @@ public class SignalHeadTableAction extends AbstractTableAction {
 
                 int st = signalheadTypeFromBox(stBox);
                 // This bit returns null I think, will need to check though
-                AcelaNode sh = AcelaAddress.getNodeFromSystemName("AH" + headnumber, jmri.InstanceManager.getDefault(jmri.jmrix.acela.AcelaSystemConnectionMemo.class));
+                AcelaNode sh = AcelaAddress.getNodeFromSystemName("AH" + headnumber, InstanceManager.getDefault(jmri.jmrix.acela.AcelaSystemConnectionMemo.class));
                 switch (st) {
                     case 1:
                         sh.setOutputSignalHeadType(headnumber, AcelaNode.DOUBLE);
@@ -1352,7 +1366,7 @@ public class SignalHeadTableAction extends AbstractTableAction {
                     log.warn("must supply a signalhead number (i.e. GH23)");
                     return;
                 }
-                String inputsysname = systemNameTextField.getText().toUpperCase();
+                String inputsysname = InstanceManager.getDefault(SignalHeadManager.class).normalizeSystemName(systemNameTextField.getText());
                 if (!inputsysname.substring(0, 2).equals("GH")) {
                     log.warn("skipping creation of signal, " + inputsysname + " does not start with GH");
                     String msg = Bundle.getMessage("GrapevineSkippingCreation", new Object[]{inputsysname});
@@ -1361,7 +1375,7 @@ public class SignalHeadTableAction extends AbstractTableAction {
                     return;
                 }
                 if (checkBeforeCreating(inputsysname)) {
-                    s = new jmri.jmrix.grapevine.SerialSignalHead(inputsysname, userNameTextField.getText(), jmri.InstanceManager.getDefault(jmri.jmrix.grapevine.GrapevineSystemConnectionMemo.class));
+                    s = new jmri.jmrix.grapevine.SerialSignalHead(inputsysname, userNameTextField.getText(), InstanceManager.getDefault(jmri.jmrix.grapevine.GrapevineSystemConnectionMemo.class));
                     InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
                 }
             } else if (quadOutput.equals(typeBox.getSelectedItem())) {

--- a/java/src/jmri/jmrit/beantable/TransitTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TransitTableAction.java
@@ -1257,7 +1257,7 @@ public class TransitTableAction extends AbstractTableAction {
         if (_autoSystemName.isSelected()) {
             curTransit = transitManager.createNewTransit(uName);
         } else {
-            String sName = sysName.getText().toUpperCase();
+            String sName = InstanceManager.getDefault(jmri.TransitManager.class).normalizeSystemName(sysName.getText());
             curTransit = transitManager.createNewTransit(sName, uName);
         }
         if (curTransit == null) {

--- a/java/src/jmri/managers/AbstractSignalHeadManager.java
+++ b/java/src/jmri/managers/AbstractSignalHeadManager.java
@@ -1,8 +1,13 @@
 package jmri.managers;
 
 import jmri.Manager;
+import jmri.NamedBean;
 import jmri.SignalHead;
 import jmri.SignalHeadManager;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 
 /**
  * Abstract partial implementation of a SignalHeadManager.
@@ -60,6 +65,20 @@ public class AbstractSignalHeadManager extends AbstractManager<SignalHead>
     @Override
     public SignalHead getByUserName(String key) {
         return _tuser.get(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * Forces upper case and trims leading and trailing whitespace.
+     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
+     */
+    @CheckReturnValue
+    @Override
+    public @Nonnull
+    String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
+        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
+        return inputName.toUpperCase().trim();
     }
 
     @Override

--- a/java/src/jmri/managers/DefaultLogixManager.java
+++ b/java/src/jmri/managers/DefaultLogixManager.java
@@ -10,6 +10,10 @@ import jmri.jmrit.beantable.LRouteTableAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
 /**
  * Basic Implementation of a LogixManager.
  * <P>
@@ -191,6 +195,20 @@ public class DefaultLogixManager extends AbstractManager<Logix>
     @Override
     public Logix getByUserName(String key) {
         return _tuser.get(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * Forces upper case and trims leading and trailing whitespace.
+     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
+     */
+    @CheckReturnValue
+    @Override
+    public @Nonnull
+    String normalizeSystemName(@Nonnull String inputName) {
+        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
+        return inputName.toUpperCase().trim();
     }
 
     /**

--- a/java/src/jmri/managers/DefaultMemoryManager.java
+++ b/java/src/jmri/managers/DefaultMemoryManager.java
@@ -3,6 +3,10 @@ package jmri.managers;
 import jmri.Memory;
 import jmri.implementation.DefaultMemory;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
 /**
  * Provide the concrete implementation for the Internal Memory Manager.
  *
@@ -23,6 +27,20 @@ public class DefaultMemoryManager extends AbstractMemoryManager {
             systemName = "IM" + systemName;
         }
         return new DefaultMemory(systemName, userName);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * Forces upper case and trims leading and trailing whitespace.
+     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
+     */
+    @CheckReturnValue
+    @Override
+    public @Nonnull
+    String normalizeSystemName(@Nonnull String inputName) {
+        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
+        return inputName.toUpperCase().trim();
     }
 
 }

--- a/java/src/jmri/managers/DefaultSignalGroupManager.java
+++ b/java/src/jmri/managers/DefaultSignalGroupManager.java
@@ -4,7 +4,13 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
 import jmri.Manager;
+import jmri.NamedBean;
 import jmri.SignalGroup;
 import jmri.SignalGroupManager;
 import jmri.implementation.DefaultSignalGroup;
@@ -63,6 +69,20 @@ public class DefaultSignalGroupManager extends AbstractManager<SignalGroup>
     @Override
     public SignalGroup getByUserName(String key) {
         return _tuser.get(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * Forces upper case and trims leading and trailing whitespace.
+     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
+     */
+    @CheckReturnValue
+    @Override
+    public @Nonnull
+    String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
+        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
+        return inputName.toUpperCase().trim();
     }
 
     @Override


### PR DESCRIPTION
This is the next step in the sequence laid out in Issue #4670.

It makes sure that prefixes that are created via the Add dialog are consistent for LRST objects.

It also updates the places in jmrit.beantable that were using toUpperCase to normalize system names instead of the proper Manager.normalizeSystemName call, including adding support for several types.