### PR TITLE
Update to communications code

### DIFF
--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -116,10 +116,10 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
         } catch (purejavacomm.UnsupportedCommOperationException e) {
             log.warn("Could not set flow control, ignoring");
         }
-        if (flow != purejavacomm.SerialPort.FLOWCONTROL_RTSCTS_OUT) {
+        if (flow == purejavacomm.SerialPort.FLOWCONTROL_NONE) {
             serialPort.setRTS(rts);  // not connected in some serial ports and adapters
+            serialPort.setDTR(dtr);
         }
-        serialPort.setDTR(dtr);
     }
 
     /**

--- a/java/src/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXml.java
@@ -76,6 +76,8 @@ abstract public class AbstractSerialConnectionConfigXml extends AbstractConnecti
     public boolean load(Element shared, Element perNode) {
         boolean result = true;
         getInstance();
+        log.info("Starting to connect for \"{}\"", adapter.getSystemConnectionMemo()!=null ? adapter.getSystemConnectionMemo().getUserName() : "(Unknown Connection)");
+        
         // configure port name
         String portName = perNode.getAttribute("port").getValue();
         adapter.setPort(portName);


### PR DESCRIPTION
- List the connection name when starting to open a serial connection (see Issue #4711)

- Only initialize EIA control leads if hardware flow control is not configured; seems to be required by some USB drivers