### PR TITLE
Consistency in getRail[rR]oadName() method names

### DIFF
--- a/java/src/jmri/jmrit/operations/locations/YardmasterPanel.java
+++ b/java/src/jmri/jmrit/operations/locations/YardmasterPanel.java
@@ -216,8 +216,8 @@ public class YardmasterPanel extends CommonConductorYardmasterPanel {
                     textTrainRouteCommentPane.setVisible(!route.getComment().equals(Route.NONE) && Setup.isPrintRouteCommentsEnabled());
                     textTrainRouteCommentPane.setText(route.getComment());
                     // Does this train have a unique railroad name?
-                    if (!_train.getTrainRailroadName().equals(Train.NONE)) {
-                        textRailRoadName.setText(_train.getTrainRailroadName());
+                    if (!_train.getRailroadName().equals(Train.NONE)) {
+                        textRailRoadName.setText(_train.getRailroadName());
                     } else {
                         textRailRoadName.setText(Setup.getRailroadName());
                     }

--- a/java/src/jmri/jmrit/operations/trains/JsonManifest.java
+++ b/java/src/jmri/jmrit/operations/trains/JsonManifest.java
@@ -56,8 +56,8 @@ public class JsonManifest extends TrainCommon {
 
     public void build() throws IOException {
         ObjectNode root = this.mapper.createObjectNode();
-        if (!this.train.getTrainRailroadName().equals(Train.NONE)) {
-            root.put(JSON.RAILROAD, StringEscapeUtils.escapeHtml4(this.train.getTrainRailroadName()));
+        if (!this.train.getRailroadName().equals(Train.NONE)) {
+            root.put(JSON.RAILROAD, StringEscapeUtils.escapeHtml4(this.train.getRailroadName()));
         } else {
             root.put(JSON.RAILROAD, StringEscapeUtils.escapeHtml4(Setup.getRailroadName()));
         }

--- a/java/src/jmri/jmrit/operations/trains/Train.java
+++ b/java/src/jmri/jmrit/operations/trains/Train.java
@@ -2613,7 +2613,7 @@ public class Train implements java.beans.PropertyChangeListener {
      *
      * @return Train's railroad name.
      */
-    public String getTrainRailroadName() {
+    public String getRailroadName() {
         return _railroadName;
     }
 
@@ -2622,7 +2622,7 @@ public class Train implements java.beans.PropertyChangeListener {
      *
      * @param name The railroad name for this train.
      */
-    public void setTrainRailroadName(String name) {
+    public void setRailroadName(String name) {
         String old = _railroadName;
         _railroadName = name;
         if (!old.equals(name)) {
@@ -3950,7 +3950,7 @@ public class Train implements java.beans.PropertyChangeListener {
         // check for optional railroad name and logo
         if ((e.getChild(Xml.RAIL_ROAD) != null) && (a = e.getChild(Xml.RAIL_ROAD).getAttribute(Xml.NAME)) != null) {
             String name = a.getValue();
-            setTrainRailroadName(name);
+            setRailroadName(name);
         }
         if ((e.getChild(Xml.MANIFEST_LOGO) != null)) {
             if ((a = e.getChild(Xml.MANIFEST_LOGO).getAttribute(Xml.NAME)) != null) {
@@ -4200,9 +4200,9 @@ public class Train implements java.beans.PropertyChangeListener {
             }
             e.addContent(es);
         }
-        if (!getTrainRailroadName().equals(NONE)) {
+        if (!getRailroadName().equals(NONE)) {
             Element r = new Element(Xml.RAIL_ROAD);
-            r.setAttribute(Xml.NAME, getTrainRailroadName());
+            r.setAttribute(Xml.NAME, getRailroadName());
             e.addContent(r);
         }
         if (!getManifestLogoURL().equals(NONE)) {

--- a/java/src/jmri/jmrit/operations/trains/TrainConductorPanel.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainConductorPanel.java
@@ -126,8 +126,8 @@ public class TrainConductorPanel extends CommonConductorYardmasterPanel {
             }
 
             // Does this train have a unique railroad name?
-            if (!_train.getTrainRailroadName().equals(Train.NONE)) {
-                textRailRoadName.setText(_train.getTrainRailroadName());
+            if (!_train.getRailroadName().equals(Train.NONE)) {
+                textRailRoadName.setText(_train.getRailroadName());
             } else {
                 textRailRoadName.setText(Setup.getRailroadName());
             }

--- a/java/src/jmri/jmrit/operations/trains/TrainManager.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainManager.java
@@ -773,7 +773,7 @@ public class TrainManager implements InstanceManagerAutoDefault, InstanceManager
             newTrain.addTerminationScript(scriptName);
         }
         // manifest options
-        newTrain.setTrainRailroadName(train.getTrainRailroadName());
+        newTrain.setRailroadName(train.getRailroadName());
         newTrain.setManifestLogoURL(train.getManifestLogoURL());
         newTrain.setShowArrivalAndDepartureTimes(train.isShowArrivalAndDepartureTimesEnabled());
         // build options

--- a/java/src/jmri/jmrit/operations/trains/TrainManifest.java
+++ b/java/src/jmri/jmrit/operations/trains/TrainManifest.java
@@ -50,8 +50,8 @@ public class TrainManifest extends TrainCommon {
 
         try {
             // build header
-            if (!train.getTrainRailroadName().equals(Train.NONE)) {
-                newLine(fileOut, train.getTrainRailroadName());
+            if (!train.getRailroadName().equals(Train.NONE)) {
+                newLine(fileOut, train.getRailroadName());
             } else {
                 newLine(fileOut, Setup.getRailroadName());
             }

--- a/java/src/jmri/jmrit/operations/trains/tools/TrainManifestOptionFrame.java
+++ b/java/src/jmri/jmrit/operations/trains/tools/TrainManifestOptionFrame.java
@@ -109,7 +109,7 @@ public class TrainManifestOptionFrame extends OperationsFrame {
 
         // load fields
         if (_train != null) {
-            railroadNameTextField.setText(_train.getTrainRailroadName());
+            railroadNameTextField.setText(_train.getRailroadName());
             showTimesCheckBox.setSelected(_train.isShowArrivalAndDepartureTimesEnabled());
         }
 
@@ -174,7 +174,7 @@ public class TrainManifestOptionFrame extends OperationsFrame {
         }
         if (ae.getSource() == saveButton) {
             if (_train != null) {
-                _train.setTrainRailroadName(railroadNameTextField.getText());
+                _train.setRailroadName(railroadNameTextField.getText());
                 _train.setShowArrivalAndDepartureTimes(showTimesCheckBox.isSelected());
                 _train.setModified(true);
             }

--- a/java/src/jmri/web/server/WebServerPreferences.java
+++ b/java/src/jmri/web/server/WebServerPreferences.java
@@ -441,15 +441,6 @@ public class WebServerPreferences extends PreferencesBean {
     }
 
     /**
-     * @return the railroadName
-     * @deprecated since 4.9.1; use {@link #getRailroadName()} instead
-     */
-    @Deprecated
-    public String getRailRoadName() {
-        return this.getRailroadName();
-    }
-
-    /**
      * Set the railroad name.
      *
      * @param railroadName the railroadName to set
@@ -464,16 +455,6 @@ public class WebServerPreferences extends PreferencesBean {
             }
             this.firePropertyChange(RAILROAD_NAME, old, this.railroadName);
         }
-    }
-
-    /**
-     * @param railroadName the railroadName to set
-     * @deprecated since 4.9.1; use {@link #setRailroadName(java.lang.String)}
-     * instead
-     */
-    @Deprecated
-    public void setRailRoadName(String railroadName) {
-        this.setRailroadName(railroadName);
     }
 
     /**

--- a/java/src/jmri/web/servlet/operations/OperationsServlet.java
+++ b/java/src/jmri/web/servlet/operations/OperationsServlet.java
@@ -197,7 +197,7 @@ public class OperationsServlet extends HttpServlet {
                             )
                     ),
                     InstanceManager.getDefault(ServletUtil.class).getNavBar(request.getLocale(), request.getContextPath()),
-                    !train.getTrainRailroadName().equals("") ? train.getTrainRailroadName() : InstanceManager.getDefault(ServletUtil.class).getRailroadName(false),
+                    !train.getRailroadName().equals("") ? train.getRailroadName() : InstanceManager.getDefault(ServletUtil.class).getRailroadName(false),
                     InstanceManager.getDefault(ServletUtil.class).getFooter(request.getLocale(), request.getContextPath()),
                     train.getId()
             ));
@@ -243,7 +243,7 @@ public class OperationsServlet extends HttpServlet {
                             )
                     ),
                     InstanceManager.getDefault(ServletUtil.class).getNavBar(request.getLocale(), request.getContextPath()),
-                    !train.getTrainRailroadName().equals("") ? train.getTrainRailroadName() : InstanceManager.getDefault(ServletUtil.class).getRailroadName(false),
+                    !train.getRailroadName().equals("") ? train.getRailroadName() : InstanceManager.getDefault(ServletUtil.class).getRailroadName(false),
                     InstanceManager.getDefault(ServletUtil.class).getFooter(request.getLocale(), request.getContextPath()),
                     train.getId()
             ));

--- a/java/test/jmri/jmrit/operations/trains/TrainTest.java
+++ b/java/test/jmri/jmrit/operations/trains/TrainTest.java
@@ -358,7 +358,7 @@ public class TrainTest extends OperationsTestCase {
         Train train = tmanager.newTrain("Test");
 
         // exercise manifest build
-        train.setTrainRailroadName("Working Railroad");
+        train.setRailroadName("Working Railroad");
         train.setComment("One Hard Working Train");
 
         // now add a route that doesn't have any locations
@@ -377,7 +377,7 @@ public class TrainTest extends OperationsTestCase {
         Train train = tmanager.newTrain("Test");
 
         // exercise manifest build
-        train.setTrainRailroadName("Working Railroad");
+        train.setRailroadName("Working Railroad");
         train.setComment("One Hard Working Train");
 
         // now add a route that doesn't have any locations
@@ -458,7 +458,7 @@ public class TrainTest extends OperationsTestCase {
         Train train = tmanager.newTrain("Test");
 
         // exercise manifest build
-        train.setTrainRailroadName("Working Railroad");
+        train.setRailroadName("Working Railroad");
         train.setComment("One Hard Working Train");
 
         // now add a route that doesn't have any locations

--- a/java/test/jmri/jmrit/operations/trains/XmlTest.java
+++ b/java/test/jmri/jmrit/operations/trains/XmlTest.java
@@ -164,7 +164,7 @@ public class XmlTest extends OperationsTestCase {
         t3.setManifestLogoURL("t3 X pathName");
         t3.setNumberEngines("7");
         t3.setOwnerOption("t3 X owner option");
-        t3.setTrainRailroadName("t3 X railroad name");
+        t3.setRailroadName("t3 X railroad name");
         t3.setRequirements(Train.CABOOSE);
         t3.setRoadOption("t3 X raod option");
         t3.setRoute(B);
@@ -203,7 +203,7 @@ public class XmlTest extends OperationsTestCase {
         t1.setManifestLogoURL("t1 pathName");
         t1.setNumberEngines("1");
         t1.setOwnerOption("t1 owner option");
-        t1.setTrainRailroadName("t1 railroad name");
+        t1.setRailroadName("t1 railroad name");
         t1.setRequirements(Train.NO_CABOOSE_OR_FRED);
         t1.setRoadOption("t1 raod option");
         t1.setRoute(C);
@@ -244,7 +244,7 @@ public class XmlTest extends OperationsTestCase {
         t3.setManifestLogoURL("t3 pathName");
         t3.setNumberEngines("1");
         t3.setOwnerOption("t3 owner option");
-        t3.setTrainRailroadName("t3 railroad name");
+        t3.setRailroadName("t3 railroad name");
         t3.setRequirements(Train.NO_CABOOSE_OR_FRED);
         t3.setRoadOption("t3 raod option");
         t3.setRoute(A);
@@ -268,7 +268,7 @@ public class XmlTest extends OperationsTestCase {
         t5.setManifestLogoURL("t5 pathName");
         t5.setNumberEngines("1");
         t5.setOwnerOption("t5 owner option");
-        t5.setTrainRailroadName("t5 railroad name");
+        t5.setRailroadName("t5 railroad name");
         t5.setRequirements(Train.NO_CABOOSE_OR_FRED);
         t5.setRoadOption("t5 raod option");
         t5.setRoute(B);
@@ -296,7 +296,7 @@ public class XmlTest extends OperationsTestCase {
         Assert.assertEquals("t1 path name", "t1 pathName", t1.getManifestLogoURL());
         Assert.assertEquals("t1 number of engines", "1", t1.getNumberEngines());
         Assert.assertEquals("t1 Owner option", "t1 owner option", t1.getOwnerOption());
-        Assert.assertEquals("t1 railroad name", "t1 railroad name", t1.getTrainRailroadName());
+        Assert.assertEquals("t1 railroad name", "t1 railroad name", t1.getRailroadName());
         Assert.assertEquals("t1 requirements", Train.NO_CABOOSE_OR_FRED, t1.getRequirements());
         Assert.assertEquals("t1 road option", "t1 raod option", t1.getRoadOption());
         Assert.assertEquals("t1 route", C, t1.getRoute());
@@ -345,7 +345,7 @@ public class XmlTest extends OperationsTestCase {
         Assert.assertEquals("t3 path name", "t3 pathName", t3.getManifestLogoURL());
         Assert.assertEquals("t3 number of engines", "1", t3.getNumberEngines());
         Assert.assertEquals("t3 Owner option", "t3 owner option", t3.getOwnerOption());
-        Assert.assertEquals("t3 railroad name", "t3 railroad name", t3.getTrainRailroadName());
+        Assert.assertEquals("t3 railroad name", "t3 railroad name", t3.getRailroadName());
         Assert.assertEquals("t3 requirements", Train.NO_CABOOSE_OR_FRED, t3.getRequirements());
         Assert.assertEquals("t3 road option", "t3 raod option", t3.getRoadOption());
         Assert.assertEquals("t3 route", A, t3.getRoute());
@@ -386,7 +386,7 @@ public class XmlTest extends OperationsTestCase {
         Assert.assertEquals("t5 path name", "t5 pathName", t5.getManifestLogoURL());
         Assert.assertEquals("t5 number of engines", "1", t5.getNumberEngines());
         Assert.assertEquals("t5 Owner option", "t5 owner option", t5.getOwnerOption());
-        Assert.assertEquals("t5 railroad name", "t5 railroad name", t5.getTrainRailroadName());
+        Assert.assertEquals("t5 railroad name", "t5 railroad name", t5.getRailroadName());
         Assert.assertEquals("t5 requirements", Train.NO_CABOOSE_OR_FRED, t5.getRequirements());
         Assert.assertEquals("t5 road option", "t5 raod option", t5.getRoadOption());
         Assert.assertEquals("t5 route", B, t5.getRoute());
@@ -458,7 +458,7 @@ public class XmlTest extends OperationsTestCase {
         Assert.assertEquals("t1 path name", "t1 pathName", t1.getManifestLogoURL());
         Assert.assertEquals("t1 number of engines", "1", t1.getNumberEngines());
         Assert.assertEquals("t1 Owner option", "t1 owner option", t1.getOwnerOption());
-        Assert.assertEquals("t1 railroad name", "t1 railroad name", t1.getTrainRailroadName());
+        Assert.assertEquals("t1 railroad name", "t1 railroad name", t1.getRailroadName());
         Assert.assertEquals("t1 requirements", Train.NO_CABOOSE_OR_FRED, t1.getRequirements());
         Assert.assertEquals("t1 road option", "t1 raod option", t1.getRoadOption());
         Assert.assertEquals("t1 route", C, t1.getRoute());
@@ -507,7 +507,7 @@ public class XmlTest extends OperationsTestCase {
         Assert.assertEquals("t3 path name", "t3 pathName", t3.getManifestLogoURL());
         Assert.assertEquals("t3 number of engines", "1", t3.getNumberEngines());
         Assert.assertEquals("t3 Owner option", "t3 owner option", t3.getOwnerOption());
-        Assert.assertEquals("t3 railroad name", "t3 railroad name", t3.getTrainRailroadName());
+        Assert.assertEquals("t3 railroad name", "t3 railroad name", t3.getRailroadName());
         Assert.assertEquals("t3 requirements", Train.NO_CABOOSE_OR_FRED, t3.getRequirements());
         Assert.assertEquals("t3 road option", "t3 raod option", t3.getRoadOption());
         Assert.assertEquals("t3 route", A, t3.getRoute());
@@ -548,7 +548,7 @@ public class XmlTest extends OperationsTestCase {
         Assert.assertEquals("t5 path name", "t5 pathName", t5.getManifestLogoURL());
         Assert.assertEquals("t5 number of engines", "1", t5.getNumberEngines());
         Assert.assertEquals("t5 Owner option", "t5 owner option", t5.getOwnerOption());
-        Assert.assertEquals("t5 railroad name", "t5 railroad name", t5.getTrainRailroadName());
+        Assert.assertEquals("t5 railroad name", "t5 railroad name", t5.getRailroadName());
         Assert.assertEquals("t5 requirements", Train.NO_CABOOSE_OR_FRED, t5.getRequirements());
         Assert.assertEquals("t5 road option", "t5 raod option", t5.getRoadOption());
         Assert.assertEquals("t5 route", B, t5.getRoute());
@@ -600,7 +600,7 @@ public class XmlTest extends OperationsTestCase {
         Assert.assertEquals("t3 path name", "t3 X pathName", t3.getManifestLogoURL());
         Assert.assertEquals("t3 number of engines", "7", t3.getNumberEngines());
         Assert.assertEquals("t3 Owner option", "t3 X owner option", t3.getOwnerOption());
-        Assert.assertEquals("t3 railroad name", "t3 X railroad name", t3.getTrainRailroadName());
+        Assert.assertEquals("t3 railroad name", "t3 X railroad name", t3.getRailroadName());
         Assert.assertEquals("t3 requirements", Train.CABOOSE, t3.getRequirements());
         Assert.assertEquals("t3 raod option", "t3 X raod option", t3.getRoadOption());
         Assert.assertEquals("t3 status", Train.UNKNOWN, t3.getStatus());


### PR DESCRIPTION
Be consistent in capitalization of the method getRailroadName() even in different contexts, since being inconsistent triggers FindBugs/SpotBugs warnings.