### PR TITLE
Refactor ExceptionDisplayFrame

### DIFF
--- a/java/src/jmri/jmrit/operations/ExceptionDisplayFrame.java
+++ b/java/src/jmri/jmrit/operations/ExceptionDisplayFrame.java
@@ -2,8 +2,10 @@ package jmri.jmrit.operations;
 
 import java.awt.Component;
 import java.awt.FlowLayout;
+import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -26,7 +28,7 @@ import javax.swing.border.EmptyBorder;
  */
 public class ExceptionDisplayFrame extends JDialog {
 
-    private final ExceptionContext context;
+    private final transient ExceptionContext context;
 
     // This needs MAJOR clean-up to better organize the controls and their
     // hierarchy.
@@ -71,10 +73,12 @@ public class ExceptionDisplayFrame extends JDialog {
     /**
      * Create the frame.
      *
-     * @param context The ExceptionContext.
+     * @param context the ExceptionContext
+     * @param owner   the associated window, or none if null
      *
      */
-    public ExceptionDisplayFrame(ExceptionContext context) {
+    public ExceptionDisplayFrame(ExceptionContext context, @Nullable Window owner) {
+        super(owner, context.getTitle(), ModalityType.DOCUMENT_MODAL);
         Objects.requireNonNull(context, "ExceptionContext argument passed to ErrorDisplayFrame constructor cannot be null."); // NOI18N
         this.context = context;
 
@@ -84,19 +88,15 @@ public class ExceptionDisplayFrame extends JDialog {
     /**
      * Constructor that takes just an Exception and defaults everything else.
      *
-     * @param ex The Exception.
+     * @param ex    the Exception
+     * @param owner the associated window, or none if null
      *
      */
-    public ExceptionDisplayFrame(Exception ex) {
-        this.context = new ExceptionContext(ex, "Operation unavailable", // NOI18N
-                "Hint unavailable"); // NOI18N
-
-        initComponents();
+    public ExceptionDisplayFrame(Exception ex, @Nullable Window owner) {
+        this(new ExceptionContext(ex, "Operation unavailable", "Hint unavailable"), owner); // NOI18N
     }
 
     private void initComponents() {
-        setTitle(context.getTitle());
-
         contentPane = new JPanel();
         contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
 
@@ -232,9 +232,7 @@ public class ExceptionDisplayFrame extends JDialog {
 
         pack();
 
-        setModalityType(ModalityType.DOCUMENT_MODAL);
         setModal(true);
-        setLocationRelativeTo(null);
-        setVisible(true);
+        setLocationRelativeTo(getOwner());
     }
 }

--- a/java/src/jmri/jmrit/operations/setup/BackupDialog.java
+++ b/java/src/jmri/jmrit/operations/setup/BackupDialog.java
@@ -217,7 +217,7 @@ public class BackupDialog extends JDialog {
                     ex,
                     Bundle.getMessage("BackupDialog.BackingUp") + " " + setName,
                     Bundle.getMessage("BackupDialog.Ensure"));
-            new ExceptionDisplayFrame(context);
+            new ExceptionDisplayFrame(context, this).setVisible(true);
 
         } catch (RuntimeException ex) {
             log.error("Doing backup...", ex);
@@ -225,14 +225,14 @@ public class BackupDialog extends JDialog {
             UnexpectedExceptionContext context = new UnexpectedExceptionContext(
                     ex, Bundle.getMessage("BackupDialog.BackingUp") + " " + setName);
 
-            new ExceptionDisplayFrame(context);
+            new ExceptionDisplayFrame(context, this).setVisible(true);
         } catch (Exception ex) {
             log.error("Doing backup...", ex);
 
             UnexpectedExceptionContext context = new UnexpectedExceptionContext(
                     ex, Bundle.getMessage("BackupDialog.BackingUp") + " " + setName);
 
-            new ExceptionDisplayFrame(context);
+            new ExceptionDisplayFrame(context, this).setVisible(true);
         }
     }
 

--- a/java/src/jmri/jmrit/operations/setup/LoadDemoAction.java
+++ b/java/src/jmri/jmrit/operations/setup/LoadDemoAction.java
@@ -61,7 +61,7 @@ public class LoadDemoAction extends AbstractAction {
         } catch (IOException ex) {
             ExceptionContext context = new ExceptionContext(ex, Bundle.getMessage("LoadingDemoFiles"),
                     Bundle.getMessage("LoadingDemoMakeSure"));
-            new ExceptionDisplayFrame(context);
+            new ExceptionDisplayFrame(context, null).setVisible(true);
         }
     }
 }

--- a/java/src/jmri/jmrit/operations/setup/OperationsSetupPanel.java
+++ b/java/src/jmri/jmrit/operations/setup/OperationsSetupPanel.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.awt.Dimension;
 import java.awt.GridBagLayout;
 import java.beans.PropertyChangeListener;
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.List;
 import javax.swing.BorderFactory;
@@ -475,10 +476,10 @@ public class OperationsSetupPanel extends OperationsPreferencesPanel implements 
             AutoBackup backup = new AutoBackup();
             try {
                 backup.autoBackup();
-            } catch (Exception ex) {
+            } catch (IOException ex) {
                 UnexpectedExceptionContext context = new UnexpectedExceptionContext(ex,
                         "Auto backup before changing Car types"); // NOI18N
-                new ExceptionDisplayFrame(context);
+                new ExceptionDisplayFrame(context, null).setVisible(true);
             }
 
             if (typeDesc.isSelected()) {
@@ -567,7 +568,7 @@ public class OperationsSetupPanel extends OperationsPreferencesPanel implements 
                     .getMessage("ChangeRailroadName"), new Object[]{
                             InstanceManager.getDefault(WebServerPreferences.class).getRailroadName(), Setup.getRailroadName()}), Bundle
                     .getMessage("ChangeJMRIRailroadName"), JOptionPane.YES_NO_OPTION);
-            if (results == JOptionPane.OK_OPTION) {               
+            if (results == JOptionPane.OK_OPTION) {
                 InstanceManager.getDefault(WebServerPreferences.class).setRailroadName(Setup.getRailroadName());
                 InstanceManager.getDefault(WebServerPreferences.class).save();
             }

--- a/java/src/jmri/jmrit/operations/setup/ResetAction.java
+++ b/java/src/jmri/jmrit/operations/setup/ResetAction.java
@@ -60,7 +60,7 @@ public class ResetAction extends AbstractAction {
         } catch (IOException ex) {
             UnexpectedExceptionContext context = new UnexpectedExceptionContext(ex,
                     "Deleting Operations files"); // NOI18N
-            new ExceptionDisplayFrame(context);
+            new ExceptionDisplayFrame(context, null).setVisible(true);
         }
     }
 

--- a/java/src/jmri/jmrit/operations/setup/RestoreDialog.java
+++ b/java/src/jmri/jmrit/operations/setup/RestoreDialog.java
@@ -233,7 +233,7 @@ public class RestoreDialog extends JDialog {
         catch (IOException ex) {
             ExceptionContext context = new ExceptionContext(ex, Bundle.getMessage("RestoreDialog.restoring")
                     + " " + setName, "Hint about checking valid names, etc."); // NOI18N
-            new ExceptionDisplayFrame(context);
+            new ExceptionDisplayFrame(context, this).setVisible(true);
 
         } catch (Exception ex) {
             log.error("Doing restore from " + setName, ex);
@@ -241,7 +241,7 @@ public class RestoreDialog extends JDialog {
             UnexpectedExceptionContext context = new UnexpectedExceptionContext(ex,
                     Bundle.getMessage("RestoreDialog.restoring") + " " + setName);
 
-            new ExceptionDisplayFrame(context);
+            new ExceptionDisplayFrame(context, this).setVisible(true);
         }
     }
 

--- a/java/src/jmri/jmrit/operations/setup/RestoreFilesAction.java
+++ b/java/src/jmri/jmrit/operations/setup/RestoreFilesAction.java
@@ -91,7 +91,7 @@ public class RestoreFilesAction extends AbstractAction {
             ExceptionContext context = new ExceptionContext(ex,
                     Bundle.getMessage("RestoreDialog.restore.files"),
                     Bundle.getMessage("RestoreDialog.makeSure"));
-            new ExceptionDisplayFrame(context);
+            new ExceptionDisplayFrame(context, null).setVisible(true);
         }
     }
 

--- a/java/test/jmri/jmrit/operations/ExceptionDisplayFrameTest.java
+++ b/java/test/jmri/jmrit/operations/ExceptionDisplayFrameTest.java
@@ -18,6 +18,7 @@ public class ExceptionDisplayFrameTest {
 
     @Test
     public void testCTor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ExceptionContext ec = new ExceptionContext(new Exception("Test"), "Test", "Test");
         ExceptionDisplayFrame dialog = new ExceptionDisplayFrame(ec, null);
         Assert.assertNotNull("exists", dialog);

--- a/java/test/jmri/jmrit/operations/ExceptionDisplayFrameTest.java
+++ b/java/test/jmri/jmrit/operations/ExceptionDisplayFrameTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.operations;
 
 import java.awt.GraphicsEnvironment;
+import javax.swing.JFrame;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -17,19 +18,32 @@ public class ExceptionDisplayFrameTest {
 
     @Test
     public void testCTor() {
+        ExceptionContext ec = new ExceptionContext(new Exception("Test"), "Test", "Test");
+        ExceptionDisplayFrame dialog = new ExceptionDisplayFrame(ec, null);
+        Assert.assertNotNull("exists", dialog);
+        Assert.assertEquals(Exception.class.getSimpleName(), dialog.getTitle());
+        JUnitUtil.dispose(dialog);
+    }
+
+    @Test
+    public void testSetVisible() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         ExceptionContext ec = new ExceptionContext(new Exception("Test"), "Test", "Test");
+        JFrame testFrame = new JFrame();
         new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(ec.getTitle());
             jdo.requestClose();
         }).start();
-        ExceptionDisplayFrame dialog = new ExceptionDisplayFrame(ec);
+        ExceptionDisplayFrame dialog = new ExceptionDisplayFrame(ec, testFrame);
+        dialog.setName(ec.getTitle());
         Assert.assertNotNull("exists", dialog);
+        dialog.setVisible(true);
         JUnitUtil.waitFor(() -> {
             return !dialog.isVisible();
         }, "Exception Frame did not close");
         JUnitUtil.dispose(dialog);
+        JUnitUtil.dispose(testFrame);
     }
 
     // The minimal setup for log4J


### PR DESCRIPTION
- Allow the ExceptionDisplayFrame to be manipulated before drawing on screen (this also avoids static analyzers from warning about unused instances being created).
- Center the ExceptionDisplayFrame over the owning window that trigger the exception (or centered in the screen if the owning window is null).
- Attempt to redo tests to prevent tests from hanging in CI environments.