### PR TITLE
Eclipse: remove annotations.jar from classpath as its nolonger used

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -39,7 +39,6 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="lib/annotations.jar"/>
 	<classpathentry kind="lib" path="lib/commons-lang3-3.7.jar"/>
 	<classpathentry kind="lib" path="lib/ecj.jar"/>
 	<classpathentry kind="lib" path="lib/gluegen-rt.jar"/>


### PR DESCRIPTION
remove annotations.jar from .classpath as its no longer used or  exists in lib.