### PR TITLE
Move javadoc step from Travis graphic job to headless job

### DIFF
--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -259,7 +259,7 @@ First JMRI 4.11.2 files are available in the usual way at:
 
 http://jmri.tagadab.com/jenkins/job/TestReleases/job/4.11.2
 
-Feedback appreciated. I would like to release this later today or tomorrow morning. 
+Feedback appreciated. I would like to release this later today or tomorrow morning if the files are OK.
 
 - *Wait for some replies* before proceeding
 

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -18,7 +18,7 @@ if [[ "${HEADLESS}" == "true" ]] ; then
     # SpotBugs configuration is in pom.xml
     mvn clean test -U -P travis-spotbugs --batch-mode
     # run headless tests
-    mvn test -U -P travis-headless --batch-mode \
+    mvn test javadoc:javadoc  -U -P travis-headless --batch-mode \
         -Dsurefire.printSummary=${PRINT_SUMMARY} \
         -Dsurefire.runOrder=${RUN_ORDER} \
         -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" \
@@ -26,7 +26,7 @@ if [[ "${HEADLESS}" == "true" ]] ; then
         -Dcucumber.options="--tags 'not @Ignore' --tags 'not @firefox'"
 else
     # run full GUI test suite and fail on coverage issues
-    mvn javadoc:javadoc verify -U -P travis-coverage --batch-mode \
+    mvn verify -U -P travis-coverage --batch-mode \
         -Dsurefire.printSummary=${PRINT_SUMMARY} \
         -Dsurefire.runOrder=${RUN_ORDER} \
         -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" \

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -17,10 +17,8 @@ if [[ "${HEADLESS}" == "true" ]] ; then
     # run SpotBugs only on headless, failing build if bugs are found
     # SpotBugs configuration is in pom.xml
     mvn clean test -U -P travis-spotbugs --batch-mode
-    # run javadoc only on headless
-    mvn javadoc:javadoc  --batch-mode
-    # run headless tests
-    mvn test -U -P travis-headless --batch-mode \
+    # run javadoc, headless tests
+    mvn javadoc:javadoc test -U -P travis-headless --batch-mode \
         -Dsurefire.printSummary=${PRINT_SUMMARY} \
         -Dsurefire.runOrder=${RUN_ORDER} \
         -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" \

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -17,8 +17,10 @@ if [[ "${HEADLESS}" == "true" ]] ; then
     # run SpotBugs only on headless, failing build if bugs are found
     # SpotBugs configuration is in pom.xml
     mvn clean test -U -P travis-spotbugs --batch-mode
+    # run javadoc only on headless
+    mvn javadoc:javadoc  --batch-mode
     # run headless tests
-    mvn test javadoc:javadoc  -U -P travis-headless --batch-mode \
+    mvn test -U -P travis-headless --batch-mode \
         -Dsurefire.printSummary=${PRINT_SUMMARY} \
         -Dsurefire.runOrder=${RUN_ORDER} \
         -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" \


### PR DESCRIPTION
To balance the duration of the jobs a bit, this moves the `javadoc` step from the Travis CI graphical job to the headless job. See Issue #4703 for background.