### PR TITLE
Loconet throttle setSpeedSetting() options

### DIFF
--- a/java/src/jmri/Throttle.java
+++ b/java/src/jmri/Throttle.java
@@ -103,7 +103,32 @@ public interface Throttle {
      */
     public float getSpeedSetting();
 
+    /**
+     * Set the speed.
+     *
+     * @param speed - a number from 0.0 to 1.0
+     */
     public void setSpeedSetting(float speed);
+
+    /**
+     * Set the speed - on systems which normally suppress the sending of a message
+     * if the new speed won't (appear to JMRI to) make any difference, the two extra
+     * options allow the calling method to insist the message is sent under some
+     * circumstances.
+     *
+     * @param speed - the speed between 0.0 and 1.0
+     * @param allowDuplicates - if true, don't suppress messages that should have no effect
+     * @param allowDuplicatesOnStop - if true, and the new speed is idle or estop, don't suppress messages
+     */
+    public void setSpeedSetting(float speed, boolean allowDuplicates, boolean allowDuplicatesOnStop);
+
+    /**
+     * Set the speed, and on systems which normally suppress the sending of a message make sure
+     * the message gets sent.
+     *
+     * @param speed
+     */
+    public void setSpeedSettingAgain(float speed);
 
     /**
      * direction This is an bound property.

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -83,10 +83,35 @@ abstract public class AbstractThrottle implements DccThrottle {
      */
     @Override
     public void setSpeedSetting(float speed) {
+        setSpeedSetting(speed, false, false);
+    }
+
+    /**
+     * setSpeedSetting - Implementations should override this method only if they normally suppress
+     * messages to the system if, as far as JMRI can tell, the new message would make no difference
+     * to the system state (eg. the speed is the same, or effectivly the same, as the existing speed).
+     * Then, the boolean options can affect this behaviour.
+     *
+     * @param speed - the new speed
+     * @param allowDuplicates - don't suppress messages
+     * @param allowDuplicatesOnStop - don't suppress messages if the new speed is 'stop'
+     */
+    @Override
+    public void setSpeedSetting(float speed, boolean allowDuplicates, boolean allowDuplicatesOnStop) {
         if (Math.abs(this.speedSetting - speed) > 0.0001) {
             notifyPropertyChangeListener("SpeedSetting", this.speedSetting, this.speedSetting = speed);
         }
         record(speed);
+    }
+
+    /**
+     * setSpeedSettingAgain - set the speed and don't ever supress the sending of messages to the system
+     *
+     * @param speed - the new speed
+     */
+    @Override
+    public void setSpeedSettingAgain(float speed) {
+        setSpeedSetting(speed, true, true);
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -259,10 +259,37 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
      *
      * @param speed Number from 0 to 1; less than zero is emergency stop
      */
-    @SuppressFBWarnings(value = "FE_FLOATING_POINT_EQUALITY") // OK to compare floating point, notify on any change
     @Override
     public void setSpeedSetting(float speed) {
-        log.debug("setSpeedSetting: sending speed {} to LocoNet slot {}", speed, slot.getSlot());
+        setSpeedSetting(speed, false, false);
+    }
+
+    /**
+     * Set the Speed, ensuring that a Loconet message is sent to update the slot
+     * even if the new speed is effectively the same as the current speed. Note: this
+     * can cause an increase in Loconet traffic.
+     *
+     * @param speed Number from 0 to 1; less than zero is emergency stop
+     */
+    public void setSpeedSettingAgain(float speed) {
+        setSpeedSetting(speed, true, true);
+    }
+
+    /**
+     * Set the speed. No Loconet message is sent if the new speed would
+     * result in a 'duplicate' - ie. a speed setting no different to the one the slot
+     * currently has - unless the boolean paramters indicate it should be.
+     *
+     * @param speed Number from 0 to 1; less than zero is emergency stop
+     * @param allowDuplicates boolean - if true, send a Loconet message no matter what
+     * @param allowDuplicatesOnStop boolean - if true, send a Loconet message if the new speed is
+     *                              'idle' or 'emergency stop', even if that matches the
+     *                              existing speed.
+     *
+     */
+    @SuppressFBWarnings(value = "FE_FLOATING_POINT_EQUALITY") // OK to compare floating point, notify on any change
+    public void setSpeedSetting(float speed, boolean allowDuplicates, boolean allowDuplicatesOnStop) {
+        log.debug("setSpeedSetting: called with speed {} for LocoNet slot {}", speed, slot.getSlot());
         if (LnConstants.CONSIST_MID == slot.consistStatus()
                 || LnConstants.CONSIST_SUB == slot.consistStatus()) {
             // Digitrax slots use the same memory location to store the
@@ -279,13 +306,30 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         }
 
         int new_spd = intSpeed(speed);
+
+        // decide whether to send a new loconet message
+        boolean sendLoconetMessage = false;
         if (new_spd != layout_spd) {
+            // the new speed is different - send a message
+            sendLoconetMessage = true;
+        } else if (allowDuplicates) {
+            // calling method wants a new mesage sent regardless
+            sendLoconetMessage = true;
+        } else if (allowDuplicatesOnStop && new_spd <= 1) {
+            // calling method wants a new message sent if the speed is idle or estop, which it is
+            sendLoconetMessage = true;
+        }
+
+        if (sendLoconetMessage) {
+            log.debug("setSpeedSetting: sending speed {} to LocoNet slot {}", speed, slot.getSlot());
             LocoNetMessage msg = new LocoNetMessage(4);
             msg.setOpCode(LnConstants.OPC_LOCO_SPD);
             msg.setElement(1, slot.getSlot());
             log.debug("setSpeedSetting: float speed: " + speed + " LocoNet speed: " + new_spd);
             msg.setElement(2, new_spd);
             network.sendLocoNetMessage(msg);
+        } else {
+            log.debug("setSpeedSetting: not sending LocoNet message to slot {}, new speed == old speed", slot.getSlot());
         }
 
         // reset timeout

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -67,12 +67,12 @@ public class AbstractThrottleTest {
     }
 
     /**
-     * Test of setSpeedSetting method, of class AbstractThrottle.
+     * Test of setSpeedSettingAgain method, of class AbstractThrottle.
      */
     @Test
     public void testSetSpeedSettingAgain() {
         float speed = 1.0F;
-        instance.setSpeedSetting(speed);
+        instance.setSpeedSettingAgain(speed);
         Assert.assertEquals(speed, instance.getSpeedSetting(), 0.0);
     }
 

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -70,6 +70,16 @@ public class AbstractThrottleTest {
      * Test of setSpeedSetting method, of class AbstractThrottle.
      */
     @Test
+    public void testSetSpeedSettingAgain() {
+        float speed = 1.0F;
+        instance.setSpeedSetting(speed);
+        Assert.assertEquals(speed, instance.getSpeedSetting(), 0.0);
+    }
+
+    /**
+     * Test of setSpeedSetting method, of class AbstractThrottle.
+     */
+    @Test
     public void testSetSpeedSetting() {
         float speed = 1.0F;
         instance.setSpeedSetting(speed);


### PR DESCRIPTION
A suggestion on jmri-developers of making available an option for users to choose to allow 'duplicate' loconet slot speed messages met with some scepticism.

Since that option is only really useful for people controlling trains with scripts rather than (physical or on-screen) throttles, this PR takes a different approach: allow scripts to call any of three different methods on Loconet throttles:

- setSpeedSetting(float) - does exactly what it has always done
- setSpeedSettingAgain(float) - sends a loconet message even when the speed is the same as the existing speed
- setSpeedSetting(float, boolean, boolean) - allow or suppress 'duplicate' loconet messages according to options specified

Hopefully this approach avoids the potential pitfalls of the previous suggestion: extra support queries, unintentional additional loconet traffic.