### PR TITLE
JSON services sanity improvements.

### DIFF
--- a/java/src/jmri/jmris/json/JsonServer.java
+++ b/java/src/jmri/jmris/json/JsonServer.java
@@ -113,7 +113,7 @@ public class JsonServer extends JmriServer implements InstanceManagerAutoDefault
                 // Read the command from the client
             } catch (IOException e) {
                 // attempt to close the connection and throw the exception
-                handler.dispose();
+                handler.onClose();
                 throw e;
             } catch (NoSuchElementException nse) {
                 // we get an NSE when we are finished with this client
@@ -121,7 +121,7 @@ public class JsonServer extends JmriServer implements InstanceManagerAutoDefault
                 break;
             }
         }
-        handler.dispose();
+        handler.onClose();
     }
 
     @Override

--- a/java/src/jmri/jmrit/operations/trains/JsonManifest.java
+++ b/java/src/jmri/jmrit/operations/trains/JsonManifest.java
@@ -63,7 +63,7 @@ public class JsonManifest extends TrainCommon {
         }
         root.put(JSON.NAME, StringEscapeUtils.escapeHtml4(this.train.getName()));
         root.put(JSON.DESCRIPTION, StringEscapeUtils.escapeHtml4(this.train.getDescription()));
-        root.put(JsonOperations.LOCATIONS, this.getLocations());
+        root.set(JsonOperations.LOCATIONS, this.getLocations());
         if (!this.train.getManifestLogoURL().equals(Train.NONE)) {
             // The operationsServlet will need to change this to a usable URL
             root.put(JSON.IMAGE, this.train.getManifestLogoURL());
@@ -98,7 +98,7 @@ public class JsonManifest extends TrainCommon {
             ObjectNode locationNode = this.mapper.createObjectNode();
             locationNode.put(JSON.COMMENT, StringEscapeUtils.escapeHtml4(routeLocation.getLocation().getComment()));
             locationNode.put(JSON.ID, routeLocation.getLocation().getId());
-            jsonLocation.put(JsonOperations.LOCATION, locationNode);
+            jsonLocation.set(JsonOperations.LOCATION, locationNode);
             jsonLocation.put(JSON.COMMENT, StringEscapeUtils.escapeHtml4(routeLocation.getComment()));
             // engine change or helper service?
             if (train.getSecondLegOptions() != Train.NO_CABOOSE_OR_FRED) {
@@ -116,7 +116,7 @@ public class JsonManifest extends TrainCommon {
                 if (routeLocation == train.getSecondLegEndLocation()) {
                     options.add(JSON.REMOVE_HELPERS);
                 }
-                jsonLocation.put(JSON.OPTIONS, options);
+                jsonLocation.set(JSON.OPTIONS, options);
             }
             if (train.getThirdLegOptions() != Train.NO_CABOOSE_OR_FRED) {
                 ArrayNode options = this.mapper.createArrayNode();
@@ -133,13 +133,13 @@ public class JsonManifest extends TrainCommon {
                 if (routeLocation == train.getThirdLegEndLocation()) {
                     options.add(JSON.ADD_HELPERS);
                 }
-                jsonLocation.put(JSON.OPTIONS, options);
+                jsonLocation.set(JSON.OPTIONS, options);
             }
 
             ObjectNode engines = this.mapper.createObjectNode();
-            engines.put(JSON.ADD, pickupEngines(engineList, routeLocation));
-            engines.put(JSON.REMOVE, dropEngines(engineList, routeLocation));
-            jsonLocation.put(JSON.ENGINES, engines);
+            engines.set(JSON.ADD, pickupEngines(engineList, routeLocation));
+            engines.set(JSON.REMOVE, dropEngines(engineList, routeLocation));
+            jsonLocation.set(JSON.ENGINES, engines);
 
             // block cars by destination
             ArrayNode pickups = this.mapper.createArrayNode();
@@ -150,7 +150,7 @@ public class JsonManifest extends TrainCommon {
                     }
                 }
             }
-            jsonCars.put(JSON.ADD, pickups);
+            jsonCars.set(JSON.ADD, pickups);
             // car set outs
             ArrayNode setouts = this.mapper.createArrayNode();
             for (Car car : carList) {
@@ -158,15 +158,15 @@ public class JsonManifest extends TrainCommon {
                     setouts.add(this.utilities.getCar(car));
                 }
             }
-            jsonCars.put(JSON.REMOVE, setouts);
+            jsonCars.set(JSON.REMOVE, setouts);
 
             if (routeLocation != train.getRoute().getTerminatesRouteLocation()) {
-                jsonLocation.put(JsonOperations.TRACK, this.getTrackComments(routeLocation, carList));
+                jsonLocation.set(JsonOperations.TRACK, this.getTrackComments(routeLocation, carList));
                 jsonLocation.put(JSON.DIRECTION, routeLocation.getTrainDirection());
                 ObjectNode length = this.mapper.createObjectNode();
                 length.put(JSON.LENGTH, train.getTrainLength(routeLocation));
                 length.put(JSON.UNIT, Setup.getLengthUnit());
-                jsonLocation.put(JSON.LENGTH, length);
+                jsonLocation.set(JSON.LENGTH, length);
                 jsonLocation.put(JsonOperations.WEIGHT, train.getTrainWeight(routeLocation));
                 int cars = train.getNumberCarsInTrain(routeLocation);
                 int emptyCars = train.getNumberEmptyCarsInTrain(routeLocation);
@@ -177,7 +177,7 @@ public class JsonManifest extends TrainCommon {
                 log.debug("Train terminates in {}", locationName);
                 jsonLocation.put("TrainTerminatesIn", StringEscapeUtils.escapeHtml4(locationName));
             }
-            jsonLocation.put(JsonOperations.CARS, jsonCars);
+            jsonLocation.set(JsonOperations.CARS, jsonCars);
             locations.add(jsonLocation);
         }
         return locations;
@@ -233,7 +233,7 @@ public class JsonManifest extends TrainCommon {
                 }
                 if (pickup || setout) {
                     jsonTrack.put(JSON.COMMENT, StringEscapeUtils.escapeHtml4(track.getComment()));
-                    comments.put(track.getId(), jsonTrack);
+                    comments.set(track.getId(), jsonTrack);
                 }
             }
         }

--- a/java/src/jmri/server/json/Bundle.properties
+++ b/java/src/jmri/server/json/Bundle.properties
@@ -1,5 +1,6 @@
 #HTTP 405 Method Not Allowed
 DeleteNotAllowed=Deleting {0} is not allowed.
+GetNotAllowed=Getting {0} is not allowed.
 PostNotAllowed=Posting {0} is not allowed.
 PutNotAllowed=Putting {0} is not allowed.
 #HTTP 400 Bad Request

--- a/java/src/jmri/server/json/JsonClientHandler.java
+++ b/java/src/jmri/server/json/JsonClientHandler.java
@@ -132,9 +132,11 @@ public class JsonClientHandler {
                 return;
             }
             if (root.path(METHOD).isValueNode()) {
+                // if method is specified, use it, setting it to "get" if not explicitly null
                 method = root.path(METHOD).asText(JSON.GET);
             } else {
                 // at one point, we used method within data, so check there also
+                // if method was not specified, set it to "post"
                 method = data.path(METHOD).asText(JSON.POST);
             }
             log.debug("Processing {} with {}", type, data);

--- a/java/src/jmri/server/json/JsonHttpService.java
+++ b/java/src/jmri/server/json/JsonHttpService.java
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.util.Locale;
+import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletResponse;
 
 /**
  * Provide HTTP method handlers for JSON RESTful messages
- *
+ * <p>
  * It is recommended that this class be as lightweight as possible, by relying
  * either on a helper stored in the InstanceManager, or a helper with static
  * methods.
@@ -26,10 +27,10 @@ public abstract class JsonHttpService {
 
     /**
      * Respond to an HTTP GET request for the requested name.
-     *
+     * <p>
      * If name is null, return a list of all objects for the given type, if
      * appropriate.
-     *
+     * <p>
      * This method should throw a 500 Internal Server Error if type is not
      * recognized.
      *
@@ -40,11 +41,11 @@ public abstract class JsonHttpService {
      * @throws jmri.server.json.JsonException if the named object does not exist
      *                                        or other error occurs
      */
-    public abstract JsonNode doGet(String type, String name, Locale locale) throws JsonException;
+    public abstract JsonNode doGet(@Nonnull String type, @Nonnull String name, @Nonnull Locale locale) throws JsonException;
 
     /**
      * Respond to an HTTP POST request for the requested name.
-     *
+     * <p>
      * This method should throw a 400 Invalid Request error if the named object
      * does not exist.
      *
@@ -58,11 +59,11 @@ public abstract class JsonHttpService {
      * @throws jmri.server.json.JsonException if the named object does not exist
      *                                        or other error occurs
      */
-    public abstract JsonNode doPost(String type, String name, JsonNode data, Locale locale) throws JsonException;
+    public abstract JsonNode doPost(@Nonnull String type, @Nonnull String name, @Nonnull JsonNode data, @Nonnull Locale locale) throws JsonException;
 
     /**
      * Respond to an HTTP PUT request for the requested name.
-     *
+     * <p>
      * Throw an HTTP 405 Method Not Allowed exception if new objects of the type
      * are not intended to be addable.
      *
@@ -75,16 +76,16 @@ public abstract class JsonHttpService {
      * @throws jmri.server.json.JsonException if the method is not allowed or
      *                                        other error occurs
      */
-    public JsonNode doPut(String type, String name, JsonNode data, Locale locale) throws JsonException {
+    public JsonNode doPut(@Nonnull String type, @Nonnull String name, @Nonnull JsonNode data, @Nonnull Locale locale) throws JsonException {
         throw new JsonException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, Bundle.getMessage(locale, "PutNotAllowed", type));
     }
 
     /**
      * Respond to an HTTP DELETE request for the requested name.
-     *
+     * <p>
      * Throw an HTTP 405 Method Not Allowed exception if the object is not
      * intended to be removable.
-     *
+     * <p>
      * Do not throw an error if the requested object does not exist.
      *
      * @param type   the type of the deleted object
@@ -93,13 +94,13 @@ public abstract class JsonHttpService {
      * @throws jmri.server.json.JsonException if this method is not allowed or
      *                                        other error occurs
      */
-    public void doDelete(String type, String name, Locale locale) throws JsonException {
+    public void doDelete(@Nonnull String type, @Nonnull String name, @Nonnull Locale locale) throws JsonException {
         throw new JsonException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, Bundle.getMessage(locale, "DeleteNotAllowed", type));
     }
 
     /**
      * Respond to an HTTP GET request for a list of items of type.
-     *
+     * <p>
      * This is called by the {@link jmri.web.servlet.json.JsonServlet} to handle
      * get requests for a type, but no name. Services that do not have named
      * objects, such as the {@link jmri.server.json.time.JsonTimeHttpService}
@@ -113,5 +114,14 @@ public abstract class JsonHttpService {
      * @throws jmri.server.json.JsonException may be thrown by concrete
      *                                        implementations
      */
-    public abstract ArrayNode doGetList(String type, Locale locale) throws JsonException;
+    public abstract @Nonnull ArrayNode doGetList(String type, Locale locale) throws JsonException;
+
+    /**
+     * Get the in-use ObjectMapper for this service.
+     *
+     * @return the object mapper
+     */
+    public @Nonnull ObjectMapper getObjectMapper() {
+        return this.mapper;
+    }
 }

--- a/java/src/jmri/server/json/JsonSocketService.java
+++ b/java/src/jmri/server/json/JsonSocketService.java
@@ -3,19 +3,24 @@ package jmri.server.json;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.util.Locale;
+import javax.annotation.Nonnull;
 import jmri.JmriException;
 
 /**
  * Interface for all JSON Services.
  *
- * @author Randall Wood
+ * @param <H> The supporting JsonHttpService implementing class
+ * @author Randall Wood Copyright 2016, 2018
  */
-public abstract class JsonSocketService {
+public abstract class JsonSocketService<H extends JsonHttpService> {
 
     protected final JsonConnection connection;
+    protected final H service;
+    private Locale locale;
 
-    protected JsonSocketService(JsonConnection connection) {
+    protected JsonSocketService(@Nonnull JsonConnection connection, @Nonnull H service) {
         this.connection = connection;
+        this.service = service;
     }
 
     /**
@@ -39,7 +44,7 @@ public abstract class JsonSocketService {
      * @throws JsonException       Thrown if the service needs to pass an error
      *                             message back to the client.
      */
-    public abstract void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException;
+    public abstract void onMessage(@Nonnull String type, @Nonnull JsonNode data, @Nonnull String method, @Nonnull Locale locale) throws IOException, JmriException, JsonException;
 
     /**
      * Handle a request for a list of objects.
@@ -61,7 +66,7 @@ public abstract class JsonSocketService {
      * @throws JsonException       If the service needs to pass an error message
      *                             back to the client.
      */
-    public abstract void onList(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException;
+    public abstract void onList(@Nonnull String type, @Nonnull JsonNode data, @Nonnull Locale locale) throws IOException, JmriException, JsonException;
 
     /**
      * Perform any teardown required when closing a connection.
@@ -69,9 +74,38 @@ public abstract class JsonSocketService {
     public abstract void onClose();
 
     /**
+     * Get the connection to the client.
+     *
      * @return the connection
      */
-    public JsonConnection getConnection() {
+    public @Nonnull JsonConnection getConnection() {
         return connection;
+    }
+
+    /**
+     * Get the supporting {@link JsonHttpService}.
+     *
+     * @return the supporting service
+     */
+    public @Nonnull H getHttpService() {
+        return service;
+    }
+
+    /**
+     * Get the in-use locale
+     *
+     * @return the locale
+     */
+    protected @Nonnull Locale getLocale() {
+        return locale;
+    }
+
+    /**
+     * Set the in-use locale
+     *
+     * @param locale the new locale
+     */
+    protected void setLocale(@Nonnull Locale locale) {
+        this.locale = locale;
     }
 }

--- a/java/src/jmri/server/json/JsonSocketService.java
+++ b/java/src/jmri/server/json/JsonSocketService.java
@@ -26,6 +26,7 @@ public abstract class JsonSocketService {
      *               correctly.
      * @param data   JSON data. The contents of this will depend on the
      *               implementing service.
+     * @param method The HTTP method to handle in this message.
      * @param locale The locale of the client, which may be different than the
      *               locale of the JMRI server.
      * @throws java.io.IOException Thrown if the service cannot send a response.
@@ -38,7 +39,7 @@ public abstract class JsonSocketService {
      * @throws JsonException       Thrown if the service needs to pass an error
      *                             message back to the client.
      */
-    public abstract void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException;
+    public abstract void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException;
 
     /**
      * Handle a request for a list of objects.

--- a/java/src/jmri/server/json/JsonWebSocket.java
+++ b/java/src/jmri/server/json/JsonWebSocket.java
@@ -59,7 +59,7 @@ public class JsonWebSocket {
     @OnWebSocketClose
     public void onClose(int i, String string) {
         log.debug("Closing connection because {} ({})", string, i);
-        this.handler.dispose();
+        this.handler.onClose();
         InstanceManager.getDefault(jmri.ShutDownManager.class).deregister(this.shutDownTask);
     }
 

--- a/java/src/jmri/server/json/block/JsonBlockServiceFactory.java
+++ b/java/src/jmri/server/json/block/JsonBlockServiceFactory.java
@@ -5,18 +5,16 @@ import static jmri.server.json.block.JsonBlock.BLOCKS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
  *
- * @author mstevetodd Copyright (C) 2016 (copied from JsonMemoryServiceFactory)
- * @author Randall Wood
+ * @author mstevetodd Copyright (C) 2016
+ * @author Randall Wood Copyright 2018
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonBlockServiceFactory implements JsonServiceFactory {
+public class JsonBlockServiceFactory implements JsonServiceFactory<JsonBlockHttpService, JsonBlockSocketService> {
 
 
     @Override
@@ -25,12 +23,12 @@ public class JsonBlockServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonBlockSocketService getSocketService(JsonConnection connection) {
         return new JsonBlockSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
+    public JsonBlockHttpService getHttpService(ObjectMapper mapper) {
         return new JsonBlockHttpService(mapper);
     }
 

--- a/java/src/jmri/server/json/block/JsonBlockSocketService.java
+++ b/java/src/jmri/server/json/block/JsonBlockSocketService.java
@@ -1,6 +1,5 @@
 package jmri.server.json.block;
 
-import static jmri.server.json.JSON.METHOD;
 import static jmri.server.json.JSON.NAME;
 import static jmri.server.json.JSON.PUT;
 import static jmri.server.json.block.JsonBlock.BLOCK;
@@ -36,10 +35,10 @@ public class JsonBlockSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         this.locale = locale;
         String name = data.path(NAME).asText();
-        if (data.path(METHOD).asText().equals(PUT)) {
+        if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
         } else {
             this.connection.sendMessage(this.service.doPost(type, name, data, locale));

--- a/java/src/jmri/server/json/block/JsonBlockSocketService.java
+++ b/java/src/jmri/server/json/block/JsonBlockSocketService.java
@@ -23,20 +23,17 @@ import jmri.server.json.JsonSocketService;
  * @author mstevetodd Copyright (C) 2016 (copied from JsonMemorySocketService)
  * @author Randall Wood
  */
-public class JsonBlockSocketService extends JsonSocketService {
+public class JsonBlockSocketService extends JsonSocketService<JsonBlockHttpService> {
 
-    private final JsonBlockHttpService service;
     private final HashMap<String, BlockListener> blocks = new HashMap<>();
-    private Locale locale;
 
     public JsonBlockSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonBlockHttpService(connection.getObjectMapper());
+        super(connection, new JsonBlockHttpService(connection.getObjectMapper()));
     }
 
     @Override
     public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         String name = data.path(NAME).asText();
         if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
@@ -55,7 +52,7 @@ public class JsonBlockSocketService extends JsonSocketService {
 
     @Override
     public void onList(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         this.connection.sendMessage(this.service.doGetList(type, locale));
     }
 
@@ -80,7 +77,7 @@ public class JsonBlockSocketService extends JsonSocketService {
             if (e.getPropertyName().equals("value")) {
                 try {
                     try {
-                        connection.sendMessage(service.doGet(BLOCK, this.block.getSystemName(), locale));
+                        connection.sendMessage(service.doGet(BLOCK, this.block.getSystemName(), getLocale()));
                     } catch (JsonException ex) {
                         connection.sendMessage(ex.getJsonMessage());
                     }

--- a/java/src/jmri/server/json/consist/JsonConsistHttpService.java
+++ b/java/src/jmri/server/json/consist/JsonConsistHttpService.java
@@ -19,9 +19,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Locale;
 import jmri.Consist;
-import jmri.LocoAddress;
 import jmri.DccLocoAddress;
 import jmri.InstanceManager;
+import jmri.LocoAddress;
 import jmri.jmrit.consisttool.ConsistFile;
 import jmri.server.json.JsonException;
 import jmri.server.json.JsonHttpService;
@@ -192,7 +192,7 @@ public class JsonConsistHttpService extends JsonHttpService {
      * @throws JsonException This exception has code 404 if the consist does not
      *                       exist.
      */
-    public JsonNode getConsist(Locale locale, DccLocoAddress address) throws JsonException {
+    public JsonNode getConsist(Locale locale, LocoAddress address) throws JsonException {
         if (this.manager.getConsistList().contains(address)) {
             ObjectNode root = mapper.createObjectNode();
             root.put(TYPE, CONSIST);

--- a/java/src/jmri/server/json/consist/JsonConsistHttpService.java
+++ b/java/src/jmri/server/json/consist/JsonConsistHttpService.java
@@ -54,7 +54,7 @@ public class JsonConsistHttpService extends JsonHttpService {
      * Change the properties and locomotives of a consist.
      *
      * This method takes as input the JSON representation of a consist as
-     * provided by {@link #getConsist(Locale, jmri.DccLocoAddress) }.
+     * provided by {@link #getConsist(Locale, jmri.LocoAddress) }.
      *
      * If present in the JSON, this method sets the following consist
      * properties:
@@ -85,7 +85,7 @@ public class JsonConsistHttpService extends JsonHttpService {
         if (!this.manager.isConsistManager()) {
             throw new JsonException(503, Bundle.getMessage(locale, "ErrorNoConsistManager")); // NOI18N
         }
-        DccLocoAddress address;
+        LocoAddress address;
         if (data.path(ADDRESS).canConvertToInt()) {
             address = new DccLocoAddress(data.path(ADDRESS).asInt(), data.path(IS_LONG_ADDRESS).asBoolean(false));
         } else {
@@ -102,7 +102,7 @@ public class JsonConsistHttpService extends JsonHttpService {
             consist.setConsistType(data.path(TYPE).asInt());
         }
         if (data.path(ENGINES).isArray()) {
-            ArrayList<DccLocoAddress> engines = new ArrayList<>();
+            ArrayList<LocoAddress> engines = new ArrayList<>();
             // add every engine
             for (JsonNode engine : data.path(ENGINES)) {
                 DccLocoAddress engineAddress = new DccLocoAddress(engine.path(ADDRESS).asInt(), engine.path(IS_LONG_ADDRESS).asBoolean());
@@ -131,7 +131,7 @@ public class JsonConsistHttpService extends JsonHttpService {
         if (!this.manager.isConsistManager()) {
             throw new JsonException(503, Bundle.getMessage(locale, "ErrorNoConsistManager")); // NOI18N
         }
-        DccLocoAddress address;
+        LocoAddress address;
         if (data.path(ADDRESS).canConvertToInt()) {
             address = new DccLocoAddress(data.path(ADDRESS).asInt(), data.path(IS_LONG_ADDRESS).asBoolean(false));
         } else {
@@ -159,7 +159,7 @@ public class JsonConsistHttpService extends JsonHttpService {
         }
         ArrayNode root = mapper.createArrayNode();
         for (LocoAddress address : this.manager.getConsistList()) {
-            root.add(getConsist(locale, (DccLocoAddress) address));
+            root.add(getConsist(locale, address));
         }
         return root;
     }

--- a/java/src/jmri/server/json/consist/JsonConsistServiceFactory.java
+++ b/java/src/jmri/server/json/consist/JsonConsistServiceFactory.java
@@ -10,7 +10,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood Copyright (C) 2016
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonConsistServiceFactory implements JsonServiceFactory {
+public class JsonConsistServiceFactory implements JsonServiceFactory<JsonConsistHttpService, JsonConsistSocketService> {
 
 
     @Override

--- a/java/src/jmri/server/json/layoutblock/JsonLayoutBlockServiceFactory.java
+++ b/java/src/jmri/server/json/layoutblock/JsonLayoutBlockServiceFactory.java
@@ -5,18 +5,16 @@ import static jmri.server.json.layoutblock.JsonLayoutBlock.LAYOUTBLOCKS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
  *
- * @author mstevetodd Copyright (C) 2016 (copied from JsonMemoryServiceFactory)
- * @author Randall Wood
+ * @author mstevetodd Copyright (C) 2016
+ * @author Randall Wood Copyright 2018
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonLayoutBlockServiceFactory implements JsonServiceFactory {
+public class JsonLayoutBlockServiceFactory implements JsonServiceFactory<JsonLayoutBlockHttpService, JsonLayoutBlockSocketService> {
 
 
     @Override
@@ -25,12 +23,12 @@ public class JsonLayoutBlockServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonLayoutBlockSocketService getSocketService(JsonConnection connection) {
         return new JsonLayoutBlockSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
+    public JsonLayoutBlockHttpService getHttpService(ObjectMapper mapper) {
         return new JsonLayoutBlockHttpService(mapper);
     }
 

--- a/java/src/jmri/server/json/layoutblock/JsonLayoutBlockSocketService.java
+++ b/java/src/jmri/server/json/layoutblock/JsonLayoutBlockSocketService.java
@@ -25,21 +25,18 @@ import org.slf4j.LoggerFactory;
  * @author mstevetodd Copyright (C) 2016 (copied from JsonMemorySocketService)
  * @author Randall Wood
  */
-public class JsonLayoutBlockSocketService extends JsonSocketService {
+public class JsonLayoutBlockSocketService extends JsonSocketService<JsonLayoutBlockHttpService> {
 
-    private final JsonLayoutBlockHttpService service;
     private final HashMap<String, LayoutBlockListener> layoutBlocks = new HashMap<>();
-    private Locale locale;
     private static final Logger log = LoggerFactory.getLogger(JsonLayoutBlockServiceFactory.class);
 
     public JsonLayoutBlockSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonLayoutBlockHttpService(connection.getObjectMapper());
+        super(connection, new JsonLayoutBlockHttpService(connection.getObjectMapper()));
     }
 
     @Override
     public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         String name = data.path(NAME).asText();
         if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
@@ -58,7 +55,7 @@ public class JsonLayoutBlockSocketService extends JsonSocketService {
 
     @Override
     public void onList(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         this.connection.sendMessage(this.service.doGetList(type, locale));
     }
 
@@ -85,7 +82,7 @@ public class JsonLayoutBlockSocketService extends JsonSocketService {
                         e.getPropertyName(), e.getOldValue(), e.getNewValue());
                 try {
                     try {
-                        connection.sendMessage(service.doGet(LAYOUTBLOCK, this.layoutBlock.getSystemName(), locale));
+                        connection.sendMessage(service.doGet(LAYOUTBLOCK, this.layoutBlock.getSystemName(), getLocale()));
                     } catch (JsonException ex) {
                         connection.sendMessage(ex.getJsonMessage());
                     }

--- a/java/src/jmri/server/json/layoutblock/JsonLayoutBlockSocketService.java
+++ b/java/src/jmri/server/json/layoutblock/JsonLayoutBlockSocketService.java
@@ -1,6 +1,5 @@
 package jmri.server.json.layoutblock;
 
-import static jmri.server.json.JSON.METHOD;
 import static jmri.server.json.JSON.NAME;
 import static jmri.server.json.JSON.PUT;
 import static jmri.server.json.layoutblock.JsonLayoutBlock.LAYOUTBLOCK;
@@ -39,19 +38,21 @@ public class JsonLayoutBlockSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         this.locale = locale;
         String name = data.path(NAME).asText();
-        if (data.path(METHOD).asText().equals(PUT)) {
+        if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
         } else {
             this.connection.sendMessage(this.service.doPost(type, name, data, locale));
         }
         if (!this.layoutBlocks.containsKey(name)) {
             LayoutBlock layoutblock = InstanceManager.getDefault(LayoutBlockManager.class).getLayoutBlock(name);
-            LayoutBlockListener listener = new LayoutBlockListener(layoutblock);
-            layoutblock.addPropertyChangeListener(listener);
-            this.layoutBlocks.put(name, listener);
+            if (layoutblock != null) {
+                LayoutBlockListener listener = new LayoutBlockListener(layoutblock);
+                layoutblock.addPropertyChangeListener(listener);
+                this.layoutBlocks.put(name, listener);
+            }
         }
     }
 

--- a/java/src/jmri/server/json/light/JsonLightHttpService.java
+++ b/java/src/jmri/server/json/light/JsonLightHttpService.java
@@ -37,7 +37,7 @@ public class JsonLightHttpService extends JsonNamedBeanHttpService {
         root.put(TYPE, LIGHT);
         Light light = InstanceManager.lightManagerInstance().getLight(name);
         ObjectNode data = this.getNamedBean(light, name, type, locale);
-        root.put(DATA, data);
+        root.set(DATA, data);
         if (light != null) {
             switch (light.getState()) {
                 case Light.ON:

--- a/java/src/jmri/server/json/light/JsonLightServiceFactory.java
+++ b/java/src/jmri/server/json/light/JsonLightServiceFactory.java
@@ -5,8 +5,6 @@ import static jmri.server.json.light.JsonLight.LIGHTS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -15,7 +13,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonLightServiceFactory implements JsonServiceFactory {
+public class JsonLightServiceFactory implements JsonServiceFactory<JsonLightHttpService, JsonLightSocketService> {
 
 
     @Override
@@ -24,12 +22,12 @@ public class JsonLightServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonLightSocketService getSocketService(JsonConnection connection) {
         return new JsonLightSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
+    public JsonLightHttpService getHttpService(ObjectMapper mapper) {
         return new JsonLightHttpService(mapper);
     }
 

--- a/java/src/jmri/server/json/light/JsonLightSocketService.java
+++ b/java/src/jmri/server/json/light/JsonLightSocketService.java
@@ -22,20 +22,17 @@ import jmri.server.json.JsonSocketService;
  *
  * @author Randall Wood
  */
-public class JsonLightSocketService extends JsonSocketService {
+public class JsonLightSocketService extends JsonSocketService<JsonLightHttpService> {
 
-    private final JsonLightHttpService service;
-    private final HashMap<String, LightListener> lights = new HashMap<>();
-    private Locale locale;
+    protected final HashMap<String, LightListener> lights = new HashMap<>();
 
     public JsonLightSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonLightHttpService(connection.getObjectMapper());
+        super(connection, new JsonLightHttpService(connection.getObjectMapper()));
     }
 
     @Override
     public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         String name = data.path(NAME).asText();
         if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
@@ -54,7 +51,7 @@ public class JsonLightSocketService extends JsonSocketService {
 
     @Override
     public void onList(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         this.connection.sendMessage(this.service.doGetList(type, locale));
     }
 
@@ -80,7 +77,7 @@ public class JsonLightSocketService extends JsonSocketService {
             if (e.getPropertyName().equals("KnownState")) {
                 try {
                     try {
-                        connection.sendMessage(service.doGet(LIGHT, this.light.getSystemName(), locale));
+                        connection.sendMessage(service.doGet(LIGHT, this.light.getSystemName(), getLocale()));
                     } catch (JsonException ex) {
                         connection.sendMessage(ex.getJsonMessage());
                     }

--- a/java/src/jmri/server/json/light/JsonLightSocketService.java
+++ b/java/src/jmri/server/json/light/JsonLightSocketService.java
@@ -1,6 +1,5 @@
 package jmri.server.json.light;
 
-import static jmri.server.json.JSON.METHOD;
 import static jmri.server.json.JSON.NAME;
 import static jmri.server.json.JSON.PUT;
 import static jmri.server.json.light.JsonLight.LIGHT;
@@ -35,10 +34,10 @@ public class JsonLightSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         this.locale = locale;
         String name = data.path(NAME).asText();
-        if (data.path(METHOD).asText().equals(PUT)) {
+        if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
         } else {
             this.connection.sendMessage(this.service.doPost(type, name, data, locale));

--- a/java/src/jmri/server/json/memory/JsonMemoryHttpService.java
+++ b/java/src/jmri/server/json/memory/JsonMemoryHttpService.java
@@ -33,7 +33,7 @@ public class JsonMemoryHttpService extends JsonNamedBeanHttpService {
         ObjectNode data = this.getNamedBean(memory, name, type, locale);
         ObjectNode root = mapper.createObjectNode();
         root.put(TYPE, MEMORY);
-        root.put(DATA, data);
+        root.set(DATA, data);
         if (memory != null) {
             if (memory.getValue() == null) {
                 data.putNull(VALUE);

--- a/java/src/jmri/server/json/memory/JsonMemoryServiceFactory.java
+++ b/java/src/jmri/server/json/memory/JsonMemoryServiceFactory.java
@@ -5,8 +5,6 @@ import static jmri.server.json.memory.JsonMemory.MEMORY;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -15,7 +13,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonMemoryServiceFactory implements JsonServiceFactory {
+public class JsonMemoryServiceFactory implements JsonServiceFactory<JsonMemoryHttpService, JsonMemorySocketService> {
 
 
     @Override
@@ -24,12 +22,12 @@ public class JsonMemoryServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonMemorySocketService getSocketService(JsonConnection connection) {
         return new JsonMemorySocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
+    public JsonMemoryHttpService getHttpService(ObjectMapper mapper) {
         return new JsonMemoryHttpService(mapper);
     }
 

--- a/java/src/jmri/server/json/memory/JsonMemorySocketService.java
+++ b/java/src/jmri/server/json/memory/JsonMemorySocketService.java
@@ -1,6 +1,5 @@
 package jmri.server.json.memory;
 
-import static jmri.server.json.JSON.METHOD;
 import static jmri.server.json.JSON.NAME;
 import static jmri.server.json.JSON.PUT;
 import static jmri.server.json.memory.JsonMemory.MEMORY;
@@ -35,10 +34,10 @@ public class JsonMemorySocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         this.locale = locale;
         String name = data.path(NAME).asText();
-        if (data.path(METHOD).asText().equals(PUT)) {
+        if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
         } else {
             this.connection.sendMessage(this.service.doPost(type, name, data, locale));

--- a/java/src/jmri/server/json/memory/JsonMemorySocketService.java
+++ b/java/src/jmri/server/json/memory/JsonMemorySocketService.java
@@ -22,20 +22,17 @@ import jmri.server.json.JsonSocketService;
  *
  * @author Randall Wood
  */
-public class JsonMemorySocketService extends JsonSocketService {
+public class JsonMemorySocketService extends JsonSocketService<JsonMemoryHttpService> {
 
-    private final JsonMemoryHttpService service;
     private final HashMap<String, MemoryListener> memories = new HashMap<>();
-    private Locale locale;
 
     public JsonMemorySocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonMemoryHttpService(connection.getObjectMapper());
+        super(connection,new JsonMemoryHttpService(connection.getObjectMapper()));
     }
 
     @Override
     public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         String name = data.path(NAME).asText();
         if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
@@ -54,7 +51,7 @@ public class JsonMemorySocketService extends JsonSocketService {
 
     @Override
     public void onList(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         this.connection.sendMessage(this.service.doGetList(type, locale));
     }
 
@@ -80,7 +77,7 @@ public class JsonMemorySocketService extends JsonSocketService {
             if (e.getPropertyName().equals("value")) {
                 try {
                     try {
-                        connection.sendMessage(service.doGet(MEMORY, this.memory.getSystemName(), locale));
+                        connection.sendMessage(service.doGet(MEMORY, this.memory.getSystemName(), getLocale()));
                     } catch (JsonException ex) {
                         connection.sendMessage(ex.getJsonMessage());
                     }

--- a/java/src/jmri/server/json/message/JsonMessage.java
+++ b/java/src/jmri/server/json/message/JsonMessage.java
@@ -170,7 +170,7 @@ public class JsonMessage {
         ObjectNode data = root.putObject(JSON.DATA);
         data.put(JsonMessage.MESSAGE, this.getMessage());
         if (this.getContext() != null) {
-            data.put(JsonMessage.CONTEXT, this.getContext());
+            data.set(JsonMessage.CONTEXT, this.getContext());
         } else {
             data.putNull(JsonMessage.CONTEXT);
         }

--- a/java/src/jmri/server/json/message/JsonMessageHttpService.java
+++ b/java/src/jmri/server/json/message/JsonMessageHttpService.java
@@ -1,0 +1,36 @@
+package jmri.server.json.message;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.util.Locale;
+import javax.servlet.http.HttpServletResponse;
+import jmri.server.json.JsonException;
+import jmri.server.json.JsonHttpService;
+
+/**
+ *
+ * @author Randall Wood Copyright 2018
+ */
+public class JsonMessageHttpService extends JsonHttpService {
+
+    public JsonMessageHttpService(ObjectMapper mapper) {
+        super(mapper);
+    }
+
+    @Override
+    public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
+        throw new JsonException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, Bundle.getMessage(locale, "GetNotAllowed", type));
+    }
+
+    @Override
+    public JsonNode doPost(String type, String name, JsonNode data, Locale locale) throws JsonException {
+        throw new JsonException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, Bundle.getMessage(locale, "PostNotAllowed", type));
+    }
+
+    @Override
+    public ArrayNode doGetList(String type, Locale locale) throws JsonException {
+        throw new JsonException(HttpServletResponse.SC_BAD_REQUEST, Bundle.getMessage(locale, "UnlistableService", type));
+    }
+
+}

--- a/java/src/jmri/server/json/message/JsonMessageServiceFactory.java
+++ b/java/src/jmri/server/json/message/JsonMessageServiceFactory.java
@@ -3,8 +3,6 @@ package jmri.server.json.message;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JSON;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -14,7 +12,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood Copyright 2017
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonMessageServiceFactory implements JsonServiceFactory {
+public class JsonMessageServiceFactory implements JsonServiceFactory<JsonMessageHttpService, JsonMessageSocketService> {
 
     @Override
     public String[] getTypes() {
@@ -22,13 +20,13 @@ public class JsonMessageServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonMessageSocketService getSocketService(JsonConnection connection) {
         return new JsonMessageSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
-        return null;
+    public JsonMessageHttpService getHttpService(ObjectMapper mapper) {
+        return new JsonMessageHttpService(mapper);
     }
 
 }

--- a/java/src/jmri/server/json/message/JsonMessageSocketService.java
+++ b/java/src/jmri/server/json/message/JsonMessageSocketService.java
@@ -19,12 +19,12 @@ import jmri.server.json.JsonSocketService;
  *
  * @author Randall Wood Copyright 2017
  */
-public class JsonMessageSocketService extends JsonSocketService {
+public class JsonMessageSocketService extends JsonSocketService<JsonMessageHttpService> {
 
     private JsonMessageClientManager messageClientManager = null;
 
     public JsonMessageSocketService(JsonConnection connection) {
-        super(connection);
+        super(connection, new JsonMessageHttpService(connection.getObjectMapper()));
         messageClientManager = InstanceManager.getDefault(JsonMessageClientManager.class);
     }
 

--- a/java/src/jmri/server/json/message/JsonMessageSocketService.java
+++ b/java/src/jmri/server/json/message/JsonMessageSocketService.java
@@ -29,7 +29,7 @@ public class JsonMessageSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         switch (type) {
             case JSON.HELLO:
                 if (!data.path(CLIENT).isMissingNode()) {
@@ -40,7 +40,7 @@ public class JsonMessageSocketService extends JsonSocketService {
                 }
                 break;
             case JsonMessage.CLIENT:
-                switch (data.path(JSON.METHOD).asText()) {
+                switch (method) {
                     case JSON.DELETE:
                         // remove client id
                         if (!data.path(CLIENT).isMissingNode()) {

--- a/java/src/jmri/server/json/operations/JsonOperationsServiceFactory.java
+++ b/java/src/jmri/server/json/operations/JsonOperationsServiceFactory.java
@@ -8,18 +8,16 @@ import static jmri.server.json.operations.JsonOperations.TRAINS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
  * Service factory for the JSON Operations services.
- * 
- * @author Randall Wood (c) 2016
+ *
+ * @author Randall Wood Copyright 2016, 2018
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonOperationsServiceFactory implements JsonServiceFactory {
+public class JsonOperationsServiceFactory implements JsonServiceFactory<JsonOperationsHttpService, JsonOperationsSocketService> {
 
     @Override
     public String[] getTypes() {
@@ -27,13 +25,13 @@ public class JsonOperationsServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonOperationsSocketService getSocketService(JsonConnection connection) {
         return new JsonOperationsSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
+    public JsonOperationsHttpService getHttpService(ObjectMapper mapper) {
         return new JsonOperationsHttpService(mapper);
     }
-    
+
 }

--- a/java/src/jmri/server/json/operations/JsonOperationsSocketService.java
+++ b/java/src/jmri/server/json/operations/JsonOperationsSocketService.java
@@ -37,7 +37,7 @@ public class JsonOperationsSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         this.locale = locale;
         String id = data.path(JSON.ID).asText(); // Operations uses ID attribute instead of name attribute
         switch (type) {

--- a/java/src/jmri/server/json/operations/JsonOperationsSocketService.java
+++ b/java/src/jmri/server/json/operations/JsonOperationsSocketService.java
@@ -23,22 +23,19 @@ import org.slf4j.LoggerFactory;
  *
  * @author Randall Wood (C) 2016
  */
-public class JsonOperationsSocketService extends JsonSocketService {
+public class JsonOperationsSocketService extends JsonSocketService<JsonOperationsHttpService> {
 
-    private Locale locale;
-    private final JsonOperationsHttpService service;
     private final HashMap<String, TrainListener> trainListeners = new HashMap<>();
     private final TrainsListener trainsListener = new TrainsListener();
     private final static Logger log = LoggerFactory.getLogger(JsonOperationsSocketService.class);
 
     public JsonOperationsSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonOperationsHttpService(connection.getObjectMapper());
+        super(connection, new JsonOperationsHttpService(connection.getObjectMapper()));
     }
 
     @Override
     public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         String id = data.path(JSON.ID).asText(); // Operations uses ID attribute instead of name attribute
         switch (type) {
             case TRAIN:
@@ -57,7 +54,7 @@ public class JsonOperationsSocketService extends JsonSocketService {
 
     @Override
     public void onList(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         this.connection.sendMessage(this.service.doGetList(type, locale));
         log.debug("adding TrainsListener");
         TrainManager.instance().addPropertyChangeListener(trainsListener); //add parent listener
@@ -96,7 +93,7 @@ public class JsonOperationsSocketService extends JsonSocketService {
             log.debug("in SensorListener for '{}' '{}' ('{}'=>'{}')", this.train.getId(), evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
             try {
                 try {
-                    connection.sendMessage(service.doGet(TRAIN, this.train.getId(), locale));
+                    connection.sendMessage(service.doGet(TRAIN, this.train.getId(), getLocale()));
                 } catch (JsonException ex) {
                     connection.sendMessage(ex.getJsonMessage());
                 }
@@ -115,7 +112,7 @@ public class JsonOperationsSocketService extends JsonSocketService {
             log.debug("in TrainsListener for '{}' ('{}' => '{}')", evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
             try {
                 try {
-                    connection.sendMessage(service.doGetList(TRAINS, locale));
+                    connection.sendMessage(service.doGetList(TRAINS, getLocale()));
                     //child added or removed, reset listeners
                     if (evt.getPropertyName().equals("length")) { // NOI18N
                         addListenersToChildren();

--- a/java/src/jmri/server/json/operations/JsonUtil.java
+++ b/java/src/jmri/server/json/operations/JsonUtil.java
@@ -62,7 +62,7 @@ public class JsonUtil {
     public JsonNode getCar(Locale locale, String id) {
         ObjectNode root = mapper.createObjectNode();
         root.put(TYPE, CAR);
-        root.put(DATA, this.getCar(InstanceManager.getDefault(CarManager.class).getById(id)));
+        root.set(DATA, this.getCar(InstanceManager.getDefault(CarManager.class).getById(id)));
         return root;
     }
 
@@ -82,7 +82,7 @@ public class JsonUtil {
     public JsonNode getEngine(Locale locale, String id) {
         ObjectNode root = mapper.createObjectNode();
         root.put(TYPE, ENGINE);
-        root.put(DATA, this.getEngine(InstanceManager.getDefault(EngineManager.class).getById(id)));
+        root.set(DATA, this.getEngine(InstanceManager.getDefault(EngineManager.class).getById(id)));
         return root;
     }
 
@@ -101,14 +101,14 @@ public class JsonUtil {
         node.put(JSON.KERNEL, car.getKernelName());
         node.put(JSON.UTILITY, car.isUtility());
         if (car.getFinalDestinationTrack() != null) {
-            node.put(JSON.FINAL_DESTINATION, this.getLocationAndTrack(car.getFinalDestinationTrack(), null));
+            node.set(JSON.FINAL_DESTINATION, this.getLocationAndTrack(car.getFinalDestinationTrack(), null));
         } else if (car.getFinalDestination() != null) {
-            node.put(JSON.FINAL_DESTINATION, this.getLocation(car.getFinalDestination(), null));
+            node.set(JSON.FINAL_DESTINATION, this.getLocation(car.getFinalDestination(), null));
         }
         if (car.getReturnWhenEmptyDestTrack() != null) {
-            node.put(JSON.RETURN_WHEN_EMPTY, this.getLocationAndTrack(car.getReturnWhenEmptyDestTrack(), null));
+            node.set(JSON.RETURN_WHEN_EMPTY, this.getLocationAndTrack(car.getReturnWhenEmptyDestTrack(), null));
         } else if (car.getReturnWhenEmptyDestination() != null) {
-            node.put(JSON.RETURN_WHEN_EMPTY, this.getLocation(car.getReturnWhenEmptyDestination(), null));
+            node.set(JSON.RETURN_WHEN_EMPTY, this.getLocation(car.getReturnWhenEmptyDestination(), null));
         }
         return node;
     }
@@ -142,7 +142,7 @@ public class JsonUtil {
 
     private ObjectNode getLocationAndTrack(Track track, RouteLocation routeLocation) {
         ObjectNode node = this.getLocation(track.getLocation(), routeLocation);
-        node.put(TRACK, this.getTrack(track));
+        node.set(TRACK, this.getTrack(track));
         return node;
     }
 
@@ -166,14 +166,14 @@ public class JsonUtil {
         node.put(OWNER, rs.getOwner());
         node.put(COMMENT, rs.getComment());
         if (rs.getTrack() != null) {
-            node.put(LOCATION, this.getLocationAndTrack(rs.getTrack(), rs.getRouteLocation()));
+            node.set(LOCATION, this.getLocationAndTrack(rs.getTrack(), rs.getRouteLocation()));
         } else if (rs.getLocation() != null) {
-            node.put(LOCATION, this.getLocation(rs.getLocation(), rs.getRouteLocation()));
+            node.set(LOCATION, this.getLocation(rs.getLocation(), rs.getRouteLocation()));
         }
         if (rs.getDestinationTrack() != null) {
-            node.put(DESTINATION, this.getLocationAndTrack(rs.getDestinationTrack(), rs.getRouteDestination()));
+            node.set(DESTINATION, this.getLocationAndTrack(rs.getDestinationTrack(), rs.getRouteDestination()));
         } else if (rs.getDestination() != null) {
-            node.put(DESTINATION, this.getLocation(rs.getDestination(), rs.getRouteDestination()));
+            node.set(DESTINATION, this.getLocation(rs.getDestination(), rs.getRouteDestination()));
         }
         return node;
     }
@@ -193,10 +193,10 @@ public class JsonUtil {
             if (train.getRoute() != null) {
                 data.put(ROUTE, train.getRoute().getName());
                 data.put(JSON.ROUTE_ID, train.getRoute().getId());
-                data.put(JsonOperations.LOCATIONS, this.getRouteLocationsForTrain(locale, train));
+                data.set(JsonOperations.LOCATIONS, this.getRouteLocationsForTrain(locale, train));
             }
-            data.put(JSON.ENGINES, this.getEnginesForTrain(locale, train));
-            data.put(JsonOperations.CARS, this.getCarsForTrain(locale, train));
+            data.set(JSON.ENGINES, this.getEnginesForTrain(locale, train));
+            data.set(JsonOperations.CARS, this.getCarsForTrain(locale, train));
             if (train.getTrainDepartsName() != null) {
                 data.put(JSON.DEPARTURE_LOCATION, train.getTrainDepartsName());
             }
@@ -263,7 +263,7 @@ public class JsonUtil {
             rln.put(SEQUENCE, rl.getSequenceId());
             rln.put(EXPECTED_ARRIVAL, train.getExpectedArrivalTime(rl));
             rln.put(EXPECTED_DEPARTURE, train.getExpectedDepartureTime(rl));
-            rln.put(LOCATION, getLocation(locale, rl.getLocation().getId()).get(DATA));
+            rln.set(LOCATION, getLocation(locale, rl.getLocation().getId()).get(DATA));
             rlan.add(rln); //add this routeLocation to the routeLocation array
         }
         return rlan;  //return array of routeLocations

--- a/java/src/jmri/server/json/operations/JsonUtil.java
+++ b/java/src/jmri/server/json/operations/JsonUtil.java
@@ -215,8 +215,8 @@ public class JsonUtil {
                 data.put(JsonOperations.LEAD_ENGINE, train.getLeadEngine().toString());
             }
             data.put(JsonOperations.CABOOSE, train.getCabooseRoadAndNumber());
-        } catch (NullPointerException e) {
-            log.error("Unable to get train id [{}].", id);
+        } catch (NullPointerException ex) {
+            log.error("Unable to get train id [{}].", id, ex);
             throw new JsonException(404, Bundle.getMessage(locale, "ErrorObject", JsonOperations.TRAIN, id));
         }
         return root;

--- a/java/src/jmri/server/json/package-info.java
+++ b/java/src/jmri/server/json/package-info.java
@@ -3,7 +3,7 @@
  * elements.
  *
  * <h2>Requests</h2>
- *
+ * <p>
  * JSON messages in four different forms from the client are handled by the JSON
  * services:
  * <ul>
@@ -19,23 +19,21 @@
  * Optionally a <strong>method</strong> node with the value <em>post</em> is
  * included in the message:
  * <code>{"type":"<em>type</em>","method":"post","data":{"name":"<em>name</em>",...}}</code>.
- * The <em>method</em> node may be included in the <em>data</em> node:
+ * For historical reasons, the <em>method</em> node may be included in the
+ * <em>data</em> node:
  * <code>{"type":"<em>type</em>","data":{"name":"<em>name</em>","method":"post",...}}</code>
- * Note that not all types support this.</li>
+ * Note that this is discouraged and not all types support this.</li>
  * <li>individual types can be created if a <strong>method</strong> node with
  * the value <em>put</em> is included in message:
- * <code>{"type":"<em>type</em>","method":"put","data":{"name":"<em>name</em>"}}</code>.
- * The <em>method</em> node may be included in the <em>data</em> node:
- * <code>{"type":"turnout","data":{"name":"LT14","method":"put"}}</code> Note
- * that not all types support this.</li>
+ * <code>{"type":"<em>type</em>","method":"put","data":{"name":"<em>name</em>"}}</code>.</li>
  * </ul></li>
  * <li>a heartbeat in the form <code>{"type":"ping"}</code>. The heartbeat gets
  * a <code>{"type":"pong"}</code> response.</li>
  * <li>a sign off in the form: <code>{"type":"goodbye"}</code> to which an
  * identical response is sent before the connection gets closed.</li></ul>
- *
+ * <p>
  * <h2>Responses</h2>
- *
+ * <p>
  * JSON messages sent to the client will be in the form:
  * <ul>
  * <li><code>{"type":"<em>type</em>","data":{"name":"<em>name</em>",...}}</code>

--- a/java/src/jmri/server/json/package-info.java
+++ b/java/src/jmri/server/json/package-info.java
@@ -8,6 +8,7 @@
  * services:
  * <ul>
  * <li>list requests in the form:
+ * <code>{"type":"<em>type</em>","method":"list"}</code> or
  * <code>{"type":"list","list":"<em>type</em>"}</code> or
  * <code>{"list":"<em>type</em>"}</code>.</li>
  * <li>individual item state requests in the form:

--- a/java/src/jmri/server/json/power/JsonPowerServiceFactory.java
+++ b/java/src/jmri/server/json/power/JsonPowerServiceFactory.java
@@ -2,8 +2,6 @@ package jmri.server.json.power;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -12,15 +10,15 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonPowerServiceFactory implements JsonServiceFactory {
+public class JsonPowerServiceFactory implements JsonServiceFactory<JsonPowerHttpService, JsonPowerSocketService> {
 
     /**
      * Token for type and name for power status messages.
-     * 
+     *
      * {@value #POWER}
      */
     public static final String POWER = "power";
-    
+
     @Override
     public String[] getTypes() {
         String[] types = {POWER};
@@ -28,13 +26,13 @@ public class JsonPowerServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonPowerSocketService getSocketService(JsonConnection connection) {
         return new JsonPowerSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
+    public JsonPowerHttpService getHttpService(ObjectMapper mapper) {
         return new JsonPowerHttpService(mapper);
     }
-    
+
 }

--- a/java/src/jmri/server/json/power/JsonPowerSocketService.java
+++ b/java/src/jmri/server/json/power/JsonPowerSocketService.java
@@ -19,14 +19,12 @@ import jmri.server.json.JsonSocketService;
  *
  * @author Randall Wood
  */
-public class JsonPowerSocketService extends JsonSocketService implements PropertyChangeListener {
+public class JsonPowerSocketService extends JsonSocketService<JsonPowerHttpService> implements PropertyChangeListener {
 
     private boolean listening = false;
-    private final JsonPowerHttpService service;
 
     public JsonPowerSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonPowerHttpService(connection.getObjectMapper());
+        super(connection, new JsonPowerHttpService(connection.getObjectMapper()));
     }
 
     @Override

--- a/java/src/jmri/server/json/power/JsonPowerSocketService.java
+++ b/java/src/jmri/server/json/power/JsonPowerSocketService.java
@@ -30,7 +30,7 @@ public class JsonPowerSocketService extends JsonSocketService implements Propert
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         if (!this.listening) {
             InstanceManager.getList(PowerManager.class).forEach((manager) -> {
                 manager.addPropertyChangeListener(this);

--- a/java/src/jmri/server/json/reporter/JsonReporterServiceFactory.java
+++ b/java/src/jmri/server/json/reporter/JsonReporterServiceFactory.java
@@ -5,8 +5,6 @@ import static jmri.server.json.reporter.JsonReporter.REPORTERS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -15,7 +13,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood (C) 2016
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonReporterServiceFactory implements JsonServiceFactory {
+public class JsonReporterServiceFactory implements JsonServiceFactory<JsonReporterHttpService, JsonReporterSocketService> {
 
     @Override
     public String[] getTypes() {
@@ -23,12 +21,12 @@ public class JsonReporterServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonReporterSocketService getSocketService(JsonConnection connection) {
         return new JsonReporterSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
+    public JsonReporterHttpService getHttpService(ObjectMapper mapper) {
         return new JsonReporterHttpService(mapper);
     }
 

--- a/java/src/jmri/server/json/reporter/JsonReporterSocketService.java
+++ b/java/src/jmri/server/json/reporter/JsonReporterSocketService.java
@@ -1,6 +1,5 @@
 package jmri.server.json.reporter;
 
-import static jmri.server.json.JSON.METHOD;
 import static jmri.server.json.JSON.NAME;
 import static jmri.server.json.JSON.PUT;
 import static jmri.server.json.reporter.JsonReporter.REPORTER;
@@ -35,10 +34,10 @@ public class JsonReporterSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         this.locale = locale;
         String name = data.path(NAME).asText();
-        if (data.path(METHOD).asText().equals(PUT)) {
+        if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
         } else {
             this.connection.sendMessage(this.service.doPost(type, name, data, locale));

--- a/java/src/jmri/server/json/reporter/JsonReporterSocketService.java
+++ b/java/src/jmri/server/json/reporter/JsonReporterSocketService.java
@@ -22,20 +22,17 @@ import jmri.server.json.JsonSocketService;
  *
  * @author Randall Wood (C) 2016
  */
-public class JsonReporterSocketService extends JsonSocketService {
+public class JsonReporterSocketService extends JsonSocketService<JsonReporterHttpService> {
 
-    private final JsonReporterHttpService service;
     private final HashMap<String, ReporterListener> reporters = new HashMap<>();
-    private Locale locale;
 
     public JsonReporterSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonReporterHttpService(connection.getObjectMapper());
+        super(connection, new JsonReporterHttpService(connection.getObjectMapper()));
     }
 
     @Override
     public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         String name = data.path(NAME).asText();
         if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
@@ -54,7 +51,7 @@ public class JsonReporterSocketService extends JsonSocketService {
 
     @Override
     public void onList(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         this.connection.sendMessage(this.service.doGetList(type, locale));
     }
 
@@ -80,7 +77,7 @@ public class JsonReporterSocketService extends JsonSocketService {
             if (e.getPropertyName().equals("currentReport")) {
                 try {
                     try {
-                        connection.sendMessage(service.doGet(REPORTER, this.reporter.getSystemName(), locale));
+                        connection.sendMessage(service.doGet(REPORTER, this.reporter.getSystemName(), getLocale()));
                     } catch (JsonException ex) {
                         connection.sendMessage(ex.getJsonMessage());
                     }

--- a/java/src/jmri/server/json/roster/JsonRosterServiceFactory.java
+++ b/java/src/jmri/server/json/roster/JsonRosterServiceFactory.java
@@ -10,7 +10,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonRosterServiceFactory implements JsonServiceFactory {
+public class JsonRosterServiceFactory implements JsonServiceFactory<JsonRosterHttpService, JsonRosterSocketService> {
 
     @Override
     public String[] getTypes() {

--- a/java/src/jmri/server/json/roster/JsonRosterSocketService.java
+++ b/java/src/jmri/server/json/roster/JsonRosterSocketService.java
@@ -4,7 +4,6 @@ import static jmri.server.json.JSON.ADD;
 import static jmri.server.json.JSON.DATA;
 import static jmri.server.json.JSON.DELETE;
 import static jmri.server.json.JSON.GET;
-import static jmri.server.json.JSON.METHOD;
 import static jmri.server.json.JSON.NAME;
 import static jmri.server.json.JSON.POST;
 import static jmri.server.json.JSON.PUT;
@@ -61,8 +60,7 @@ public class JsonRosterSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
-        String method = data.path(METHOD).asText();
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         switch (method) {
             case DELETE:
                 throw new JsonException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, Bundle.getMessage("DeleteNotAllowed", type));

--- a/java/src/jmri/server/json/roster/JsonRosterSocketService.java
+++ b/java/src/jmri/server/json/roster/JsonRosterSocketService.java
@@ -144,11 +144,11 @@ public class JsonRosterSocketService extends JsonSocketService<JsonRosterHttpSer
             try {
                 try {
                     if (evt.getPropertyName().equals(Roster.ADD)) {
-                        root.putObject(DATA).put(ADD, service.getRosterEntry(connection.getLocale(), (RosterEntry) evt.getNewValue()));
+                        root.putObject(DATA).set(ADD, service.getRosterEntry(connection.getLocale(), (RosterEntry) evt.getNewValue()));
                         ((PropertyChangeProvider) evt.getNewValue()).addPropertyChangeListener(rosterEntryListener);
                         connection.sendMessage(root);
                     } else if (evt.getPropertyName().equals(Roster.REMOVE)) {
-                        root.putObject(DATA).put(REMOVE, service.getRosterEntry(connection.getLocale(), (RosterEntry) evt.getOldValue()));
+                        root.putObject(DATA).set(REMOVE, service.getRosterEntry(connection.getLocale(), (RosterEntry) evt.getOldValue()));
                         connection.sendMessage(root);
                     } else if (!evt.getPropertyName().equals(Roster.SAVED)
                             && !evt.getPropertyName().equals(Roster.ROSTER_GROUP_ADDED)

--- a/java/src/jmri/server/json/roster/JsonRosterSocketService.java
+++ b/java/src/jmri/server/json/roster/JsonRosterSocketService.java
@@ -33,18 +33,16 @@ import org.slf4j.LoggerFactory;
  *
  * @author Randall Wood Copyright (C) 2014, 2016
  */
-public class JsonRosterSocketService extends JsonSocketService {
+public class JsonRosterSocketService extends JsonSocketService<JsonRosterHttpService> {
 
     private final static Logger log = LoggerFactory.getLogger(JsonRosterSocketService.class);
     private final JsonRosterListener rosterListener = new JsonRosterListener();
     private final JsonRosterEntryListener rosterEntryListener = new JsonRosterEntryListener();
     private final JsonRosterGroupsListener rosterGroupsListener = new JsonRosterGroupsListener();
-    private final JsonRosterHttpService service;
     private boolean listening = false;
 
     public JsonRosterSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonRosterHttpService(connection.getObjectMapper());
+        super(connection, new JsonRosterHttpService(connection.getObjectMapper()));
     }
 
     public void listen() {

--- a/java/src/jmri/server/json/route/JsonRouteHttpService.java
+++ b/java/src/jmri/server/json/route/JsonRouteHttpService.java
@@ -32,7 +32,7 @@ public class JsonRouteHttpService extends JsonNamedBeanHttpService {
         Route route = InstanceManager.getDefault(RouteManager.class).getRoute(name);
         root.put(JSON.TYPE, ROUTE);
         ObjectNode data = this.getNamedBean(route, name, type, locale); // throws JsonException if route == null
-        root.put(JSON.DATA, data);
+        root.set(JSON.DATA, data);
         if (route != null) {
             switch (route.getState()) {
                 case Sensor.ACTIVE:

--- a/java/src/jmri/server/json/route/JsonRouteServiceFactory.java
+++ b/java/src/jmri/server/json/route/JsonRouteServiceFactory.java
@@ -2,8 +2,6 @@ package jmri.server.json.route;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -13,7 +11,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonRouteServiceFactory implements JsonServiceFactory {
+public class JsonRouteServiceFactory implements JsonServiceFactory<JsonRouteHttpService, JsonRouteSocketService> {
 
     public static final String ROUTE = "route"; // NOI18N
     public static final String ROUTES = "routes"; // NOI18N
@@ -24,12 +22,12 @@ public class JsonRouteServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonRouteSocketService getSocketService(JsonConnection connection) {
         return new JsonRouteSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
+    public JsonRouteHttpService getHttpService(ObjectMapper mapper) {
         return new JsonRouteHttpService(mapper);
     }
 

--- a/java/src/jmri/server/json/route/JsonRouteSocketService.java
+++ b/java/src/jmri/server/json/route/JsonRouteSocketService.java
@@ -26,24 +26,21 @@ import org.slf4j.LoggerFactory;
  *
  * @author Randall Wood
  */
-public class JsonRouteSocketService extends JsonSocketService {
+public class JsonRouteSocketService extends JsonSocketService<JsonRouteHttpService> {
 
-    private final JsonRouteHttpService service;
     private final HashMap<String, RouteListener> routeListeners = new HashMap<>();
     private final RoutesListener routesListener = new RoutesListener();
-    private Locale locale;
     private final static Logger log = LoggerFactory.getLogger(JsonRouteSocketService.class);
     private RouteManager routeManager = null;
 
     public JsonRouteSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonRouteHttpService(connection.getObjectMapper());
+        super(connection, new JsonRouteHttpService(connection.getObjectMapper()));
         routeManager = InstanceManager.getDefault(RouteManager.class);
     }
 
     @Override
     public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         String name = data.path(JSON.NAME).asText();
         if (method.equals(JSON.PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
@@ -65,7 +62,7 @@ public class JsonRouteSocketService extends JsonSocketService {
 
     @Override
     public void onList(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         this.connection.sendMessage(this.service.doGetList(type, locale));
         log.debug("adding RoutesListener");
         routeManager.addPropertyChangeListener(routesListener); //add parent listener
@@ -112,7 +109,7 @@ public class JsonRouteSocketService extends JsonSocketService {
             log.debug("in RouteListener for '{}' '{}' ('{}'=>'{}')", this.route.getSystemName(), evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
             try {
                 try {
-                    getConnection().sendMessage(service.doGet(ROUTE, this.route.getSystemName(), locale));
+                    getConnection().sendMessage(service.doGet(ROUTE, this.route.getSystemName(), getLocale()));
                 } catch (JsonException ex) {
                     getConnection().sendMessage(ex.getJsonMessage());
                 }
@@ -135,7 +132,7 @@ public class JsonRouteSocketService extends JsonSocketService {
             try {
                 try {
                  // send the new list
-                    connection.sendMessage(service.doGetList(ROUTES, locale));
+                    connection.sendMessage(service.doGetList(ROUTES, getLocale()));
                     //child added or removed, reset listeners
                     if (evt.getPropertyName().equals("length")) { // NOI18N
                         addListenersToChildren();

--- a/java/src/jmri/server/json/route/JsonRouteSocketService.java
+++ b/java/src/jmri/server/json/route/JsonRouteSocketService.java
@@ -42,10 +42,10 @@ public class JsonRouteSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         this.locale = locale;
         String name = data.path(JSON.NAME).asText();
-        if (data.path(JSON.METHOD).asText().equals(JSON.PUT)) {
+        if (method.equals(JSON.PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
         } else {
             this.connection.sendMessage(this.service.doPost(type, name, data, locale));
@@ -109,7 +109,7 @@ public class JsonRouteSocketService extends JsonSocketService {
 
         @Override
         public void propertyChange(PropertyChangeEvent evt) {
-            log.debug("in RouteListener for '{}' '{}' ('{}'=>'{}')", this.route.getSystemName(), evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());            
+            log.debug("in RouteListener for '{}' '{}' ('{}'=>'{}')", this.route.getSystemName(), evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
             try {
                 try {
                     getConnection().sendMessage(service.doGet(ROUTE, this.route.getSystemName(), locale));
@@ -135,9 +135,9 @@ public class JsonRouteSocketService extends JsonSocketService {
             try {
                 try {
                  // send the new list
-                    connection.sendMessage(service.doGetList(ROUTES, locale)); 
+                    connection.sendMessage(service.doGetList(ROUTES, locale));
                     //child added or removed, reset listeners
-                    if (evt.getPropertyName().equals("length")) { // NOI18N 
+                    if (evt.getPropertyName().equals("length")) { // NOI18N
                         addListenersToChildren();
                     }
                 } catch (JsonException ex) {

--- a/java/src/jmri/server/json/sensor/JsonSensorHttpService.java
+++ b/java/src/jmri/server/json/sensor/JsonSensorHttpService.java
@@ -34,7 +34,7 @@ public class JsonSensorHttpService extends JsonNamedBeanHttpService {
         Sensor sensor = InstanceManager.getDefault(SensorManager.class).getSensor(name);
         ObjectNode data = this.getNamedBean(sensor, name, type, locale); // throws JsonException if sensor == null
         if (sensor != null) {
-            root.put(JSON.DATA, data);
+            root.set(JSON.DATA, data);
             switch (sensor.getKnownState()) {
                 case Sensor.ACTIVE:
                     data.put(JSON.STATE, JSON.ACTIVE);

--- a/java/src/jmri/server/json/sensor/JsonSensorServiceFactory.java
+++ b/java/src/jmri/server/json/sensor/JsonSensorServiceFactory.java
@@ -5,18 +5,16 @@ import static jmri.server.json.sensor.JsonSensor.SENSORS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
  * Factory for JSON services for {@link jmri.Sensor}s.
- * 
+ *
  * @author Randall Wood
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonSensorServiceFactory implements JsonServiceFactory {
+public class JsonSensorServiceFactory implements JsonServiceFactory<JsonSensorHttpService, JsonSensorSocketService> {
 
 
     @Override
@@ -25,12 +23,12 @@ public class JsonSensorServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonSensorSocketService getSocketService(JsonConnection connection) {
         return new JsonSensorSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
+    public JsonSensorHttpService getHttpService(ObjectMapper mapper) {
         return new JsonSensorHttpService(mapper);
     }
 

--- a/java/src/jmri/server/json/sensor/JsonSensorSocketService.java
+++ b/java/src/jmri/server/json/sensor/JsonSensorSocketService.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * JSON Socket service for {@link jmri.Sensor}s.
- * 
+ *
  * @author Randall Wood
  */
 public class JsonSensorSocketService extends JsonSocketService {
@@ -40,10 +40,10 @@ public class JsonSensorSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         this.locale = locale;
         String name = data.path(JSON.NAME).asText();
-        if (data.path(JSON.METHOD).asText().equals(JSON.PUT)) {
+        if (method.equals(JSON.PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
         } else {
             this.connection.sendMessage(this.service.doPost(type, name, data, locale));
@@ -122,9 +122,9 @@ public class JsonSensorSocketService extends JsonSocketService {
             try {
                 try {
                  // send the new list
-                    connection.sendMessage(service.doGetList(SENSORS, locale)); 
+                    connection.sendMessage(service.doGetList(SENSORS, locale));
                     //child added or removed, reset listeners
-                    if (evt.getPropertyName().equals("length")) { // NOI18N 
+                    if (evt.getPropertyName().equals("length")) { // NOI18N
                         addListenersToChildren();
                     }
                 } catch (JsonException ex) {

--- a/java/src/jmri/server/json/sensor/JsonSensorSocketService.java
+++ b/java/src/jmri/server/json/sensor/JsonSensorSocketService.java
@@ -25,23 +25,20 @@ import org.slf4j.LoggerFactory;
  *
  * @author Randall Wood
  */
-public class JsonSensorSocketService extends JsonSocketService {
+public class JsonSensorSocketService extends JsonSocketService<JsonSensorHttpService> {
 
-    private final JsonSensorHttpService service;
     private final HashMap<String, SensorListener> sensorListeners = new HashMap<>();
     private final SensorsListener sensorsListener = new SensorsListener();
-    private Locale locale;
     private final static Logger log = LoggerFactory.getLogger(JsonSensorSocketService.class);
 
 
     public JsonSensorSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonSensorHttpService(connection.getObjectMapper());
+        super(connection, new JsonSensorHttpService(connection.getObjectMapper()));
     }
 
     @Override
     public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         String name = data.path(JSON.NAME).asText();
         if (method.equals(JSON.PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
@@ -60,7 +57,7 @@ public class JsonSensorSocketService extends JsonSocketService {
 
     @Override
     public void onList(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         this.connection.sendMessage(this.service.doGetList(type, locale));
         log.debug("adding SensorsListener");
         InstanceManager.getDefault(SensorManager.class).addPropertyChangeListener(sensorsListener); //add parent listener
@@ -102,7 +99,7 @@ public class JsonSensorSocketService extends JsonSocketService {
             log.debug("in SensorListener for '{}' '{}' ('{}'=>'{}')", this.sensor.getSystemName(), evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
             try {
                 try {
-                    connection.sendMessage(service.doGet(SENSOR, this.sensor.getSystemName(), locale));
+                    connection.sendMessage(service.doGet(SENSOR, this.sensor.getSystemName(), getLocale()));
                 } catch (JsonException ex) {
                     connection.sendMessage(ex.getJsonMessage());
                 }
@@ -122,7 +119,7 @@ public class JsonSensorSocketService extends JsonSocketService {
             try {
                 try {
                  // send the new list
-                    connection.sendMessage(service.doGetList(SENSORS, locale));
+                    connection.sendMessage(service.doGetList(SENSORS, getLocale()));
                     //child added or removed, reset listeners
                     if (evt.getPropertyName().equals("length")) { // NOI18N
                         addListenersToChildren();

--- a/java/src/jmri/server/json/signalHead/JsonSignalHeadHttpService.java
+++ b/java/src/jmri/server/json/signalHead/JsonSignalHeadHttpService.java
@@ -37,7 +37,7 @@ public class JsonSignalHeadHttpService extends JsonNamedBeanHttpService {
         root.put(TYPE, SIGNAL_HEAD);
         SignalHead signalHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(name);
         ObjectNode data = this.getNamedBean(signalHead, name, type, locale);
-        root.put(DATA, data);
+        root.set(DATA, data);
         if (signalHead != null) {
             data.put(LIT, signalHead.getLit());
             data.put(APPEARANCE, signalHead.getAppearance());
@@ -61,7 +61,7 @@ public class JsonSignalHeadHttpService extends JsonNamedBeanHttpService {
             if (data.path(STATE).isIntegralNumber()) {
                 int state = data.path(STATE).asInt();
                 if (state == SignalHead.HELD) {
-                    signalHead.setHeld(true);                    
+                    signalHead.setHeld(true);
                 } else {
                     boolean isValid = false;
                     for (int validState : signalHead.getValidStates()) {

--- a/java/src/jmri/server/json/signalHead/JsonSignalHeadServiceFactory.java
+++ b/java/src/jmri/server/json/signalHead/JsonSignalHeadServiceFactory.java
@@ -5,8 +5,6 @@ import static jmri.server.json.signalHead.JsonSignalHead.SIGNAL_HEADS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -15,7 +13,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood (C) 2016
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonSignalHeadServiceFactory implements JsonServiceFactory {
+public class JsonSignalHeadServiceFactory implements JsonServiceFactory<JsonSignalHeadHttpService, JsonSignalHeadSocketService> {
 
     @Override
     public String[] getTypes() {
@@ -23,12 +21,12 @@ public class JsonSignalHeadServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonSignalHeadSocketService getSocketService(JsonConnection connection) {
         return new JsonSignalHeadSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
+    public JsonSignalHeadHttpService getHttpService(ObjectMapper mapper) {
         return new JsonSignalHeadHttpService(mapper);
     }
 

--- a/java/src/jmri/server/json/signalHead/JsonSignalHeadSocketService.java
+++ b/java/src/jmri/server/json/signalHead/JsonSignalHeadSocketService.java
@@ -1,6 +1,5 @@
 package jmri.server.json.signalHead;
 
-import static jmri.server.json.JSON.METHOD;
 import static jmri.server.json.JSON.NAME;
 import static jmri.server.json.JSON.PUT;
 import static jmri.server.json.signalHead.JsonSignalHead.SIGNAL_HEAD;
@@ -35,10 +34,10 @@ public class JsonSignalHeadSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         this.locale = locale;
         String name = data.path(NAME).asText();
-        if (data.path(METHOD).asText().equals(PUT)) {
+        if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
         } else {
             this.connection.sendMessage(this.service.doPost(type, name, data, locale));

--- a/java/src/jmri/server/json/signalHead/JsonSignalHeadSocketService.java
+++ b/java/src/jmri/server/json/signalHead/JsonSignalHeadSocketService.java
@@ -22,20 +22,17 @@ import jmri.server.json.JsonSocketService;
  *
  * @author Randall Wood (C) 2016
  */
-public class JsonSignalHeadSocketService extends JsonSocketService {
+public class JsonSignalHeadSocketService extends JsonSocketService<JsonSignalHeadHttpService> {
 
-    private final JsonSignalHeadHttpService service;
     private final HashMap<String, SignalHeadListener> signalHeads = new HashMap<>();
-    private Locale locale;
 
     public JsonSignalHeadSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonSignalHeadHttpService(connection.getObjectMapper());
+        super(connection, new JsonSignalHeadHttpService(connection.getObjectMapper()));
     }
 
     @Override
     public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         String name = data.path(NAME).asText();
         if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
@@ -54,7 +51,7 @@ public class JsonSignalHeadSocketService extends JsonSocketService {
 
     @Override
     public void onList(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         this.connection.sendMessage(this.service.doGetList(type, locale));
     }
 
@@ -79,7 +76,7 @@ public class JsonSignalHeadSocketService extends JsonSocketService {
             if (e.getPropertyName().equals("Appearance") || e.getPropertyName().equals("Held")) {
                 try {
                     try {
-                        connection.sendMessage(service.doGet(SIGNAL_HEAD, this.signalHead.getSystemName(), locale));
+                        connection.sendMessage(service.doGet(SIGNAL_HEAD, this.signalHead.getSystemName(), getLocale()));
                     } catch (JsonException ex) {
                         connection.sendMessage(ex.getJsonMessage());
                     }

--- a/java/src/jmri/server/json/signalMast/JsonSignalMastHttpService.java
+++ b/java/src/jmri/server/json/signalMast/JsonSignalMastHttpService.java
@@ -39,11 +39,11 @@ public class JsonSignalMastHttpService extends JsonNamedBeanHttpService {
         root.put(TYPE, SIGNAL_MAST);
         SignalMast signalMast = InstanceManager.getDefault(jmri.SignalMastManager.class).getSignalMast(name);
         ObjectNode data = this.getNamedBean(signalMast, name, type, locale);
-        root.put(DATA, data);
+        root.set(DATA, data);
         if (signalMast != null) {
             String aspect = signalMast.getAspect();
             if (aspect == null) {
-                aspect = ASPECT_UNKNOWN; //if null, set aspect to "Unknown"   
+                aspect = ASPECT_UNKNOWN; //if null, set aspect to "Unknown"
             }
             data.put(ASPECT, aspect);
             data.put(LIT, signalMast.getLit());

--- a/java/src/jmri/server/json/signalMast/JsonSignalMastServiceFactory.java
+++ b/java/src/jmri/server/json/signalMast/JsonSignalMastServiceFactory.java
@@ -5,8 +5,6 @@ import static jmri.server.json.signalMast.JsonSignalMast.SIGNAL_MASTS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -15,7 +13,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood (C) 2016
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonSignalMastServiceFactory implements JsonServiceFactory {
+public class JsonSignalMastServiceFactory implements JsonServiceFactory<JsonSignalMastHttpService, JsonSignalMastSocketService> {
 
     @Override
     public String[] getTypes() {
@@ -23,12 +21,12 @@ public class JsonSignalMastServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonSignalMastSocketService getSocketService(JsonConnection connection) {
         return new JsonSignalMastSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
+    public JsonSignalMastHttpService getHttpService(ObjectMapper mapper) {
         return new JsonSignalMastHttpService(mapper);
     }
 

--- a/java/src/jmri/server/json/signalMast/JsonSignalMastSocketService.java
+++ b/java/src/jmri/server/json/signalMast/JsonSignalMastSocketService.java
@@ -1,6 +1,5 @@
 package jmri.server.json.signalMast;
 
-import static jmri.server.json.JSON.METHOD;
 import static jmri.server.json.JSON.NAME;
 import static jmri.server.json.JSON.PUT;
 import static jmri.server.json.signalMast.JsonSignalMast.SIGNAL_MAST;
@@ -35,10 +34,10 @@ public class JsonSignalMastSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         this.locale = locale;
         String name = data.path(NAME).asText();
-        if (data.path(METHOD).asText().equals(PUT)) {
+        if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
         } else {
             this.connection.sendMessage(this.service.doPost(type, name, data, locale));

--- a/java/src/jmri/server/json/signalMast/JsonSignalMastSocketService.java
+++ b/java/src/jmri/server/json/signalMast/JsonSignalMastSocketService.java
@@ -22,20 +22,17 @@ import jmri.server.json.JsonSocketService;
  *
  * @author Randall Wood (C) 2016
  */
-public class JsonSignalMastSocketService extends JsonSocketService {
+public class JsonSignalMastSocketService extends JsonSocketService<JsonSignalMastHttpService> {
 
-    private final JsonSignalMastHttpService service;
     private final HashMap<String, SignalMastListener> signalMasts = new HashMap<>();
-    private Locale locale;
 
     public JsonSignalMastSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonSignalMastHttpService(connection.getObjectMapper());
+        super(connection, new JsonSignalMastHttpService(connection.getObjectMapper()));
     }
 
     @Override
     public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         String name = data.path(NAME).asText();
         if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
@@ -54,7 +51,7 @@ public class JsonSignalMastSocketService extends JsonSocketService {
 
     @Override
     public void onList(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
-        this.locale = locale;
+        this.setLocale(locale);
         this.connection.sendMessage(this.service.doGetList(type, locale));
     }
 
@@ -81,7 +78,7 @@ public class JsonSignalMastSocketService extends JsonSocketService {
                     || e.getPropertyName().equals("Lit")) {
                 try {
                     try {
-                        connection.sendMessage(service.doGet(SIGNAL_MAST, this.signalMast.getSystemName(), locale));
+                        connection.sendMessage(service.doGet(SIGNAL_MAST, this.signalMast.getSystemName(), getLocale()));
                     } catch (JsonException ex) {
                         connection.sendMessage(ex.getJsonMessage());
                     }

--- a/java/src/jmri/server/json/throttle/JsonThrottleHttpService.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottleHttpService.java
@@ -1,0 +1,36 @@
+package jmri.server.json.throttle;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.util.Locale;
+import javax.servlet.http.HttpServletResponse;
+import jmri.server.json.JsonException;
+import jmri.server.json.JsonHttpService;
+
+/**
+ *
+ * @author Randall Wood Copyright 2018
+ */
+public class JsonThrottleHttpService extends JsonHttpService {
+
+    public JsonThrottleHttpService(ObjectMapper mapper) {
+        super(mapper);
+    }
+
+    @Override
+    public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
+        throw new JsonException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, Bundle.getMessage(locale, "GetNotAllowed", type));
+    }
+
+    @Override
+    public JsonNode doPost(String type, String name, JsonNode data, Locale locale) throws JsonException {
+        throw new JsonException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, Bundle.getMessage(locale, "PostNotAllowed", type));
+    }
+
+    @Override
+    public ArrayNode doGetList(String type, Locale locale) throws JsonException {
+        throw new JsonException(HttpServletResponse.SC_BAD_REQUEST, Bundle.getMessage(locale, "UnlistableService", type));
+    }
+
+}

--- a/java/src/jmri/server/json/throttle/JsonThrottleServiceFactory.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottleServiceFactory.java
@@ -2,8 +2,6 @@ package jmri.server.json.throttle;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -12,8 +10,8 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonThrottleServiceFactory implements JsonServiceFactory {
-    
+public class JsonThrottleServiceFactory implements JsonServiceFactory<JsonThrottleHttpService, JsonThrottleSocketService> {
+
     @Override
     public String[] getTypes() {
         String[] types = {JsonThrottle.THROTTLE};
@@ -21,13 +19,13 @@ public class JsonThrottleServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonThrottleSocketService getSocketService(JsonConnection connection) {
         return new JsonThrottleSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
-        return null;
+    public JsonThrottleHttpService getHttpService(ObjectMapper mapper) {
+        return new JsonThrottleHttpService(mapper);
     }
-    
+
 }

--- a/java/src/jmri/server/json/throttle/JsonThrottleSocketService.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottleSocketService.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import javax.servlet.http.HttpServletResponse;
 import jmri.JmriException;
@@ -21,14 +22,14 @@ import org.slf4j.LoggerFactory;
  *
  * @author Randall Wood
  */
-public class JsonThrottleSocketService extends JsonSocketService {
+public class JsonThrottleSocketService extends JsonSocketService<JsonThrottleHttpService> {
 
     private final HashMap<String, JsonThrottle> throttles = new HashMap<>();
     private final HashMap<JsonThrottle, String> throttleIds = new HashMap<>();
     private final static Logger log = LoggerFactory.getLogger(JsonThrottleSocketService.class);
 
     public JsonThrottleSocketService(JsonConnection connection) {
-        super(connection);
+        super(connection, new JsonThrottleHttpService(connection.getObjectMapper()));
     }
 
     @Override
@@ -55,10 +56,10 @@ public class JsonThrottleSocketService extends JsonSocketService {
 
     @Override
     public void onClose() {
-        for (String throttleId : this.throttles.keySet()) {
+        new HashSet<>(this.throttles.keySet()).stream().forEach((throttleId) -> {
             this.throttles.get(throttleId).close(this, false);
             this.throttles.remove(throttleId);
-        }
+        });
         this.throttleIds.clear();
     }
 
@@ -74,7 +75,7 @@ public class JsonThrottleSocketService extends JsonSocketService {
             ObjectNode root = this.connection.getObjectMapper().createObjectNode();
             root.put(TYPE, THROTTLE);
             data.put(THROTTLE, id);
-            root.put(DATA, data);
+            root.set(DATA, data);
             this.connection.sendMessage(root);
         }
     }

--- a/java/src/jmri/server/json/throttle/JsonThrottleSocketService.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottleSocketService.java
@@ -32,7 +32,7 @@ public class JsonThrottleSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         log.debug("Processing {}", data);
         String id = data.path(THROTTLE).asText();
         if (id.isEmpty()) {

--- a/java/src/jmri/server/json/time/JsonTimeHttpService.java
+++ b/java/src/jmri/server/json/time/JsonTimeHttpService.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import java.text.ParseException;
 import java.util.Locale;
+import javax.annotation.Nullable;
 import jmri.InstanceManager;
 import jmri.server.json.JsonException;
 import jmri.server.json.JsonHttpService;
@@ -30,7 +31,8 @@ public class JsonTimeHttpService extends JsonHttpService {
     }
 
     @Override
-    public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
+    // using @Nullable to override @Nonnull in super class
+    public JsonNode doGet(String type, @Nullable String name, Locale locale) throws JsonException {
         ObjectNode root = this.mapper.createObjectNode();
         root.put(TYPE, TIME);
         ObjectNode data = root.putObject(DATA);
@@ -41,7 +43,8 @@ public class JsonTimeHttpService extends JsonHttpService {
     }
 
     @Override
-    public JsonNode doPost(String type, String name, JsonNode data, Locale locale) throws JsonException {
+    // using @Nullable to override @Nonnull in super class
+    public JsonNode doPost(String type, @Nullable String name, JsonNode data, Locale locale) throws JsonException {
         try {
             if (data.path(TIME).isTextual()) {
                 InstanceManager.getDefault(jmri.Timebase.class).setTime(new ISO8601DateFormat().parse(data.path(TIME).asText()));

--- a/java/src/jmri/server/json/time/JsonTimeServiceFactory.java
+++ b/java/src/jmri/server/json/time/JsonTimeServiceFactory.java
@@ -10,7 +10,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonTimeServiceFactory implements JsonServiceFactory {
+public class JsonTimeServiceFactory implements JsonServiceFactory<JsonTimeHttpService, JsonTimeSocketService> {
 
     public final static String TIME = "time";
 

--- a/java/src/jmri/server/json/time/JsonTimeSocketService.java
+++ b/java/src/jmri/server/json/time/JsonTimeSocketService.java
@@ -30,7 +30,7 @@ public class JsonTimeSocketService extends JsonSocketService implements Property
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         if (!this.listening) {
             Timebase manager = InstanceManager.getDefault(Timebase.class);
             manager.addMinuteChangeListener(this);

--- a/java/src/jmri/server/json/time/JsonTimeSocketService.java
+++ b/java/src/jmri/server/json/time/JsonTimeSocketService.java
@@ -19,14 +19,12 @@ import jmri.server.json.JsonSocketService;
  *
  * @author Randall Wood
  */
-public class JsonTimeSocketService extends JsonSocketService implements PropertyChangeListener {
+public class JsonTimeSocketService extends JsonSocketService<JsonTimeHttpService> implements PropertyChangeListener {
 
     private boolean listening = false;
-    private final JsonTimeHttpService service;
 
     public JsonTimeSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonTimeHttpService(connection.getObjectMapper());
+        super(connection, new JsonTimeHttpService(connection.getObjectMapper()));
     }
 
     @Override

--- a/java/src/jmri/server/json/turnout/JsonTurnoutHttpService.java
+++ b/java/src/jmri/server/json/turnout/JsonTurnoutHttpService.java
@@ -37,7 +37,7 @@ public class JsonTurnoutHttpService extends JsonNamedBeanHttpService {
         root.put(JSON.TYPE, TURNOUT);
         Turnout turnout = InstanceManager.turnoutManagerInstance().getTurnout(name);
         ObjectNode data = this.getNamedBean(turnout, name, type, locale); // throws JsonException if turnout == null
-        root.put(JSON.DATA, data);
+        root.set(JSON.DATA, data);
         if (turnout != null) {
             data.put(INVERTED, turnout.getInverted());
             switch (turnout.getKnownState()) {

--- a/java/src/jmri/server/json/turnout/JsonTurnoutServiceFactory.java
+++ b/java/src/jmri/server/json/turnout/JsonTurnoutServiceFactory.java
@@ -2,8 +2,6 @@ package jmri.server.json.turnout;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
-import jmri.server.json.JsonSocketService;
 import jmri.spi.JsonServiceFactory;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -12,7 +10,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonTurnoutServiceFactory implements JsonServiceFactory {
+public class JsonTurnoutServiceFactory implements JsonServiceFactory<JsonTurnoutHttpService, JsonTurnoutSocketService> {
 
     public static final String TURNOUT = "turnout"; // NOI18N
     public static final String TURNOUTS = "turnouts"; // NOI18N
@@ -23,12 +21,12 @@ public class JsonTurnoutServiceFactory implements JsonServiceFactory {
     }
 
     @Override
-    public JsonSocketService getSocketService(JsonConnection connection) {
+    public JsonTurnoutSocketService getSocketService(JsonConnection connection) {
         return new JsonTurnoutSocketService(connection);
     }
 
     @Override
-    public JsonHttpService getHttpService(ObjectMapper mapper) {
+    public JsonTurnoutHttpService getHttpService(ObjectMapper mapper) {
         return new JsonTurnoutHttpService(mapper);
     }
 

--- a/java/src/jmri/server/json/turnout/JsonTurnoutSocketService.java
+++ b/java/src/jmri/server/json/turnout/JsonTurnoutSocketService.java
@@ -1,6 +1,5 @@
 package jmri.server.json.turnout;
 
-import static jmri.server.json.JSON.METHOD;
 import static jmri.server.json.JSON.NAME;
 import static jmri.server.json.JSON.PUT;
 import static jmri.server.json.turnout.JsonTurnoutServiceFactory.TURNOUT;
@@ -31,7 +30,7 @@ public class JsonTurnoutSocketService extends JsonSocketService {
 
     private final JsonTurnoutHttpService service;
     private final HashMap<String, TurnoutListener> turnoutListeners = new HashMap<>();
-    private final TurnoutsListener turnoutsListener = new TurnoutsListener();   
+    private final TurnoutsListener turnoutsListener = new TurnoutsListener();
     private Locale locale;
     private final static Logger log = LoggerFactory.getLogger(JsonTurnoutSocketService.class);
 
@@ -42,10 +41,10 @@ public class JsonTurnoutSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         this.locale = locale;
         String name = data.path(NAME).asText();
-        if (data.path(METHOD).asText().equals(PUT)) {
+        if (method.equals(PUT)) {
             this.connection.sendMessage(this.service.doPut(type, name, data, locale));
         } else {
             this.connection.sendMessage(this.service.doPost(type, name, data, locale));
@@ -68,7 +67,7 @@ public class JsonTurnoutSocketService extends JsonSocketService {
 
         InstanceManager.getDefault(TurnoutManager.class).addPropertyChangeListener(turnoutsListener); //add parent listener
         addListenersToChildren();
-        
+
     }
 
     private void addListenersToChildren() {
@@ -108,7 +107,7 @@ public class JsonTurnoutSocketService extends JsonSocketService {
             if (evt.getPropertyName().equals("KnownState")  //only send changes for values which are sent
                     || evt.getPropertyName().equals("inverted")
                     || evt.getPropertyName().equals("UserName")
-                    || evt.getPropertyName().equals("Comment")) { 
+                    || evt.getPropertyName().equals("Comment")) {
                 try {
                     try {
                         connection.sendMessage(service.doGet(TURNOUT, this.turnout.getSystemName(), locale));
@@ -131,9 +130,9 @@ public class JsonTurnoutSocketService extends JsonSocketService {
             try {
                 try {
                  // send the new list
-                    connection.sendMessage(service.doGetList(TURNOUTS, locale)); 
+                    connection.sendMessage(service.doGetList(TURNOUTS, locale));
                     //child added or removed, reset listeners
-                    if (evt.getPropertyName().equals("length")) { // NOI18N 
+                    if (evt.getPropertyName().equals("length")) { // NOI18N
                         addListenersToChildren();
                     }
                 } catch (JsonException ex) {

--- a/java/src/jmri/server/json/util/JsonUtilHttpService.java
+++ b/java/src/jmri/server/json/util/JsonUtilHttpService.java
@@ -15,10 +15,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.awt.Container;
+import java.awt.Frame;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.Locale;
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletResponse;
 import jmri.DccLocoAddress;
 import jmri.InstanceManager;
@@ -54,10 +56,11 @@ public class JsonUtilHttpService extends JsonHttpService {
     }
 
     @Override
-    public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
+    // use @Nullable to override @Nonnull specified in superclass
+    public JsonNode doGet(String type, @Nullable String name, Locale locale) throws JsonException {
         switch (type) {
             case JSON.HELLO:
-                return this.getHello(locale, JsonServerPreferences.getDefault().getHeartbeatInterval());
+                return this.getHello(locale, InstanceManager.getDefault(JsonServerPreferences.class).getHeartbeatInterval());
             case JSON.METADATA:
                 if (name == null) {
                     return this.getMetadata(locale);
@@ -237,7 +240,7 @@ public class JsonUtilHttpService extends JsonHttpService {
         NodeIdentity.formerIdentities().stream().forEach((node) -> {
             nodes.add(node);
         });
-        data.put(JSON.FORMER_NODES, nodes);
+        data.set(JSON.FORMER_NODES, nodes);
         return root;
     }
 
@@ -245,7 +248,7 @@ public class JsonUtilHttpService extends JsonHttpService {
         if (editor.getAllowInFrameServlet()) {
             Container container = editor.getTargetPanel().getTopLevelAncestor();
             if (container instanceof JmriJFrame) {
-                String title = ((JmriJFrame) container).getTitle();
+                String title = ((Frame) container).getTitle();
                 if (!title.isEmpty() && !Arrays.asList(InstanceManager.getDefault(WebServerPreferences.class).getDisallowedFrames()).contains(title)) {
                     String type = PANEL;
                     String name = "Panel";

--- a/java/src/jmri/server/json/util/JsonUtilHttpService.java
+++ b/java/src/jmri/server/json/util/JsonUtilHttpService.java
@@ -128,7 +128,7 @@ public class JsonUtilHttpService extends JsonHttpService {
         data.put(JSON.JMRI, jmri.Version.name());
         data.put(JSON.JSON, JSON.JSON_PROTOCOL_VERSION);
         data.put(JSON.HEARTBEAT, Math.round(heartbeat * 0.9f));
-        data.put(JSON.RAILROAD, WebServerPreferences.getDefault().getRailroadName());
+        data.put(JSON.RAILROAD, InstanceManager.getDefault(WebServerPreferences.class).getRailroadName());
         data.put(JSON.NODE, NodeIdentity.identity());
         data.put(JSON.ACTIVE_PROFILE, ProfileManager.getDefault().getActiveProfileName());
         return root;
@@ -246,7 +246,7 @@ public class JsonUtilHttpService extends JsonHttpService {
             Container container = editor.getTargetPanel().getTopLevelAncestor();
             if (container instanceof JmriJFrame) {
                 String title = ((JmriJFrame) container).getTitle();
-                if (!title.isEmpty() && !Arrays.asList(WebServerPreferences.getDefault().getDisallowedFrames()).contains(title)) {
+                if (!title.isEmpty() && !Arrays.asList(InstanceManager.getDefault(WebServerPreferences.class).getDisallowedFrames()).contains(title)) {
                     String type = PANEL;
                     String name = "Panel";
                     if (editor instanceof ControlPanelEditor) {
@@ -312,7 +312,7 @@ public class JsonUtilHttpService extends JsonHttpService {
         ObjectNode root = mapper.createObjectNode();
         root.put(JSON.TYPE, JSON.RAILROAD);
         ObjectNode data = root.putObject(JSON.DATA);
-        data.put(JSON.NAME, WebServerPreferences.getDefault().getRailroadName());
+        data.put(JSON.NAME, InstanceManager.getDefault(WebServerPreferences.class).getRailroadName());
         return root;
     }
 

--- a/java/src/jmri/server/json/util/JsonUtilServiceFactory.java
+++ b/java/src/jmri/server/json/util/JsonUtilServiceFactory.java
@@ -12,7 +12,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Randall Wood
  */
 @ServiceProvider(service = JsonServiceFactory.class)
-public class JsonUtilServiceFactory implements JsonServiceFactory {
+public class JsonUtilServiceFactory implements JsonServiceFactory<JsonUtilHttpService, JsonUtilSocketService> {
 
     @Override
     public String[] getTypes() {

--- a/java/src/jmri/server/json/util/JsonUtilSocketService.java
+++ b/java/src/jmri/server/json/util/JsonUtilSocketService.java
@@ -5,6 +5,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.util.Locale;
+import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.server.json.JSON;
 import jmri.server.json.JsonConnection;
@@ -16,14 +17,13 @@ import jmri.web.server.WebServerPreferences;
  *
  * @author Randall Wood
  */
-public class JsonUtilSocketService extends JsonSocketService {
+public class JsonUtilSocketService extends JsonSocketService<JsonUtilHttpService> {
 
-    private final JsonUtilHttpService service;
     private PropertyChangeListener rrNameListener;
+    private WebServerPreferences webServerPreferences = InstanceManager.getDefault(WebServerPreferences.class);
 
     public JsonUtilSocketService(JsonConnection connection) {
-        super(connection);
-        this.service = new JsonUtilHttpService(connection.getObjectMapper());
+        super(connection, new JsonUtilHttpService(connection.getObjectMapper()));
     }
 
     @Override
@@ -49,10 +49,10 @@ public class JsonUtilSocketService extends JsonSocketService {
                             this.connection.sendMessage(ex.getJsonMessage());
                         }
                     } catch (IOException ex) {
-                        WebServerPreferences.getDefault().removePropertyChangeListener(this.rrNameListener);
+                        webServerPreferences.removePropertyChangeListener(this.rrNameListener);
                     }
                 };
-                WebServerPreferences.getDefault().addPropertyChangeListener(this.rrNameListener);
+                webServerPreferences.addPropertyChangeListener(this.rrNameListener);
                 break;
             default:
                 this.connection.sendMessage(this.service.doPost(type, name, data, locale));
@@ -67,7 +67,7 @@ public class JsonUtilSocketService extends JsonSocketService {
 
     @Override
     public void onClose() {
-        WebServerPreferences.getDefault().removePropertyChangeListener(this.rrNameListener);
+        webServerPreferences.removePropertyChangeListener(this.rrNameListener);
     }
 
 }

--- a/java/src/jmri/server/json/util/JsonUtilSocketService.java
+++ b/java/src/jmri/server/json/util/JsonUtilSocketService.java
@@ -27,7 +27,7 @@ public class JsonUtilSocketService extends JsonSocketService {
     }
 
     @Override
-    public void onMessage(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
         String name = data.path(JSON.NAME).asText();
         switch (type) {
             case JSON.LOCALE:
@@ -40,7 +40,7 @@ public class JsonUtilSocketService extends JsonSocketService {
                 this.connection.sendMessage(this.connection.getObjectMapper().createObjectNode().put(JSON.TYPE, JSON.GOODBYE));
                 break;
             case JSON.RAILROAD:
-                this.connection.sendMessage(this.service.doPost(type, name, data, locale));
+                this.connection.sendMessage(this.service.doGet(type, name, locale));
                 this.rrNameListener = (PropertyChangeEvent evt) -> {
                     try {
                         try {

--- a/java/src/jmri/spi/JsonServiceFactory.java
+++ b/java/src/jmri/spi/JsonServiceFactory.java
@@ -1,33 +1,36 @@
 package jmri.spi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.annotation.Nonnull;
 import jmri.server.json.JsonConnection;
 import jmri.server.json.JsonHttpService;
 import jmri.server.json.JsonSocketService;
 
 /**
  * Factory interface for JSON services.
- *
+ * <p>
  * A JSON service is a service provided by the
  * {@link jmri.jmris.json.JsonServer}. This API allows JSON services to be
  * defined in a modular manner. The factory pattern is used since each
  * connection gets a unique instance of each service.
  *
- * @author Randall Wood
+ * @param <H> the specific supported HTTP service
+ * @param <S> the specific supported (Web)Socket service
+ * @author Randall Wood Copyright 2016, 2018
  */
-public interface JsonServiceFactory extends JmriServiceProviderInterface {
+public interface JsonServiceFactory<H extends JsonHttpService, S extends JsonSocketService<H>> extends JmriServiceProviderInterface {
 
     /**
      * Get the service type(s) for services created by this factory respond to.
-     *
+     * <p>
      * Types should be single words, in camelCase if needed, unless supporting a
      * plural noun exposed in the JSON 3.0 protocol.
-     *
+     * <p>
      * If a service returns no types, it will never be used.
      *
      * @return An array of types this service responds to.
      */
-    public String[] getTypes();
+    public @Nonnull String[] getTypes();
 
     /**
      * Create a JSON service for the given connection. This connection can be a
@@ -36,7 +39,7 @@ public interface JsonServiceFactory extends JmriServiceProviderInterface {
      * @param connection The connection for this service to respond to.
      * @return A service or null if the service does not support sockets.
      */
-    public JsonSocketService getSocketService(JsonConnection connection);
+    public @Nonnull S getSocketService(JsonConnection connection);
 
     /**
      * Create a JSON HTTP service.
@@ -44,5 +47,5 @@ public interface JsonServiceFactory extends JmriServiceProviderInterface {
      * @param mapper The object mapper for the HTTP service to use.
      * @return A servlet or null if the service does not support HTTP.
      */
-    public JsonHttpService getHttpService(ObjectMapper mapper);
+    public @Nonnull H getHttpService(ObjectMapper mapper);
 }

--- a/java/src/jmri/web/servlet/json/JsonServlet.java
+++ b/java/src/jmri/web/servlet/json/JsonServlet.java
@@ -42,10 +42,10 @@ import org.slf4j.LoggerFactory;
 /**
  * Provide JSON formatted responses for requests to requests for information
  * from the JMRI Web Server.
- *
+ * <p>
  * This server supports long polling in some GET requests, but also provides a
  * WebSocket to provide a more extensive control and monitoring capability.
- *
+ * <p>
  * This server responds to HTTP requests for objects in following manner:
  * <table>
  * <caption>HTTP methods handled by this servlet.</caption>
@@ -73,17 +73,15 @@ public class JsonServlet extends WebSocketServlet {
     public void init() throws ServletException {
         super.init();
         this.mapper = new ObjectMapper();
-        for (JsonServiceFactory factory : ServiceLoader.load(JsonServiceFactory.class)) {
+        for (JsonServiceFactory<?, ?> factory : ServiceLoader.load(JsonServiceFactory.class)) {
             JsonHttpService service = factory.getHttpService(this.mapper);
-            if (service != null) {
-                for (String type : factory.getTypes()) {
-                    HashSet<JsonHttpService> set = this.services.get(type);
-                    if (set == null) {
-                        this.services.put(type, new HashSet<>());
-                        set = this.services.get(type);
-                    }
-                    set.add(factory.getHttpService(this.mapper));
+            for (String type : factory.getTypes()) {
+                HashSet<JsonHttpService> set = this.services.get(type);
+                if (set == null) {
+                    this.services.put(type, new HashSet<>());
+                    set = this.services.get(type);
                 }
+                set.add(factory.getHttpService(this.mapper));
             }
         }
     }

--- a/java/test/jmri/server/json/JsonClientHandlerTest.java
+++ b/java/test/jmri/server/json/JsonClientHandlerTest.java
@@ -1,6 +1,22 @@
 package jmri.server.json;
 
+import static jmri.server.json.JsonTestServiceFactory.TEST;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import jmri.InstanceManager;
+import jmri.Version;
+import jmri.jmris.json.JsonServerPreferences;
+import jmri.profile.NullProfile;
+import jmri.profile.Profile;
+import jmri.profile.ProfileManager;
+import jmri.util.FileUtil;
 import jmri.util.JUnitUtil;
+import jmri.util.node.NodeIdentity;
+import jmri.web.server.WebServerPreferences;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -8,29 +24,23 @@ import org.junit.Test;
 
 /**
  *
- * @author Paul Bender Copyright (C) 2017	
+ * @author Paul Bender Copyright (C) 2017
+ * @author Randall Wood Copyright 2018
  */
 public class JsonClientHandlerTest {
 
     @Test
     public void testCTor() {
-        java.io.DataOutputStream output = new java.io.DataOutputStream(
-                new java.io.OutputStream() {
-                    // null output string drops characters
-                    // could be replaced by one that checks for specific outputs
-                    @Override
-                    public void write(int b) throws java.io.IOException {
-                    }
-                });
-        JsonMockConnection mc = new JsonMockConnection(output);
+        JsonMockConnection mc = new JsonMockConnection((DataOutputStream) null);
         JsonClientHandler t = new JsonClientHandler(mc);
-        Assert.assertNotNull("exists",t);
+        Assert.assertNotNull("exists", t);
     }
 
     // The minimal setup for log4J
     @Before
-    public void setUp() {
+    public void setUp() throws IOException {
         JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager(new NullProfile("JsonClientHandlerTest", "12345678", FileUtil.getFile("program:test")));
     }
 
     @After
@@ -38,6 +48,116 @@ public class JsonClientHandlerTest {
         JUnitUtil.tearDown();
     }
 
-    // private final static Logger log = LoggerFactory.getLogger(JsonClientHandlerTest.class);
+    /**
+     * Test of onClose method, of class JsonClientHandler.
+     */
+    @Test
+    public void testOnClose() {
+        JsonClientHandler instance = new TestJsonClientHandler();
+        Assert.assertFalse(instance.getServices().isEmpty());
+        instance.onClose();
+        Assert.assertTrue(instance.getServices().isEmpty());
+    }
 
+    /**
+     * Test of onMessage method, of class JsonClientHandler.
+     */
+    @Test
+    public void testOnMessage_String() throws Exception {
+        String string = "{\"type\":\"test\",\"method\":\"list\"}";
+        JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
+        JsonClientHandler instance = new TestJsonClientHandler(connection);
+        instance.onMessage(string);
+        Assert.assertTrue("Response is an array", connection.getMessage().isArray());
+        Assert.assertEquals("Response array contains two elements", 2, connection.getMessage().size());
+        Assert.assertTrue("Response array element 0 is an object", connection.getMessage().get(0).isObject());
+        Assert.assertEquals("Response array element 0 is empty", 0, connection.getMessage().get(0).size());
+        Assert.assertTrue("Response array element 1 is an object", connection.getMessage().get(1).isObject());
+        Assert.assertEquals("Response array element 1 is empty", 0, connection.getMessage().get(1).size());
+    }
+
+    /**
+     * Test of onMessage method, of class JsonClientHandler.
+     */
+    @Test
+    public void testOnMessage_JsonNode_Method_list() throws Exception {
+        testOnMessage_JsonNode_Method_list("{\"type\":\"test\",\"method\":\"list\"}");
+        testOnMessage_JsonNode_Method_list("{\"type\":\"list\",\"list\":\"test\"}");
+        testOnMessage_JsonNode_Method_list("{\"list\":\"test\"}");
+    }
+
+    private void testOnMessage_JsonNode_Method_list(String message) throws Exception {
+        JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
+        JsonClientHandler instance = new TestJsonClientHandler(connection);
+        JsonNode node = connection.getObjectMapper().readTree(message);
+        instance.onMessage(node);
+        Assert.assertTrue("Response is an array", connection.getMessage().isArray());
+        Assert.assertEquals("Response array contains two elements", 2, connection.getMessage().size());
+        Assert.assertTrue("Response array element 0 is an object", connection.getMessage().get(0).isObject());
+        Assert.assertEquals("Response array element 0 is empty", 0, connection.getMessage().get(0).size());
+        Assert.assertTrue("Response array element 1 is an object", connection.getMessage().get(1).isObject());
+        Assert.assertEquals("Response array element 1 is empty", 0, connection.getMessage().get(1).size());
+    }
+
+    /**
+     * Test of onMessage method, of class JsonClientHandler.
+     */
+    @Test
+    public void testOnMessage_JsonNode_Method_get() throws Exception {
+        testOnMessage_JsonNode_Method_get("{\"type\":\"test\",\"data\":{\"name\":\"test\"},\"method\":\"get\"}");
+        testOnMessage_JsonNode_Method_get("{\"type\":\"test\",\"data\":{\"name\":\"test\",\"method\":\"get\"}}");
+    }
+
+    private void testOnMessage_JsonNode_Method_get(String message) throws Exception {
+        JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
+        JsonClientHandler instance = new TestJsonClientHandler(connection);
+        JsonNode node = connection.getObjectMapper().readTree(message);
+        instance.onMessage(node);
+        JsonNode root = connection.getMessage();
+        JsonNode data = root.path(JSON.DATA);
+        Assert.assertTrue("Response is an object", root.isObject());
+        Assert.assertEquals("Response object contains two elements", 2, root.size());
+        Assert.assertEquals("Response object type is test", TEST, root.path(JSON.TYPE).asText());
+        Assert.assertEquals("Response object data name is test", TEST, data.path(JSON.NAME).asText());
+        Assert.assertEquals("Response object data size is 1", 1, data.size());
+    }
+
+    /**
+     * Test of sendHello method, of class JsonClientHandler.
+     */
+    @Test
+    public void testSendHello() throws Exception {
+        JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
+        JsonClientHandler instance = new TestJsonClientHandler(connection);
+        instance.sendHello(1000);
+        JsonNode root = connection.getMessage();
+        JsonNode data = root.path(JSON.DATA);
+        Assert.assertEquals("Hello type", JSON.HELLO, root.path(JSON.TYPE).asText());
+        Assert.assertEquals("JMRI Version", Version.name(), data.path(JSON.JMRI).asText());
+        Assert.assertEquals("JSON Verson", JSON.JSON_PROTOCOL_VERSION, data.path(JSON.JSON).asText());
+        Assert.assertEquals("Heartbeat", Math.round(InstanceManager.getDefault(JsonServerPreferences.class).getHeartbeatInterval() * 0.9f), data.path(JSON.HEARTBEAT).asInt());
+        Assert.assertEquals("RR Name", InstanceManager.getDefault(WebServerPreferences.class).getRailroadName(), data.path(JSON.RAILROAD).asText());
+        Assert.assertEquals("Node Identity", NodeIdentity.identity(), data.path(JSON.NODE).asText());
+        Profile profile = ProfileManager.getDefault().getActiveProfile();
+        Assert.assertNotNull(profile);
+        Assert.assertEquals("Profile", profile.getName(), data.path(JSON.ACTIVE_PROFILE).asText());
+        Assert.assertEquals("Message has 2 elements", 2, root.size());
+        Assert.assertEquals("Message data has 6 elements", 6, data.size());
+    }
+
+    private class TestJsonClientHandler extends JsonClientHandler {
+
+        public TestJsonClientHandler(JsonConnection connection) {
+            super(connection);
+        }
+
+        public TestJsonClientHandler() {
+            this(new JsonMockConnection((DataOutputStream) null));
+        }
+
+        @Override
+        public HashMap<String, HashSet<JsonSocketService<?>>> getServices() {
+            return super.getServices();
+        }
+    }
 }

--- a/java/test/jmri/server/json/JsonTestHttpService.java
+++ b/java/test/jmri/server/json/JsonTestHttpService.java
@@ -1,0 +1,45 @@
+package jmri.server.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Locale;
+
+/**
+ * JSON Test HTTP service.
+ *
+ * @author Randall Wood Copyright 2018
+ */
+public class JsonTestHttpService extends JsonHttpService {
+
+    public JsonTestHttpService(ObjectMapper mapper) {
+        super(mapper);
+    }
+
+    @Override
+    public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
+        ObjectNode root = mapper.createObjectNode();
+        root.put(JSON.TYPE, type);
+        ObjectNode data = root.putObject(JSON.DATA);
+        data.put(JSON.NAME, name);
+        return root;
+    }
+
+    @Override
+    public JsonNode doPost(String type, String name, JsonNode data, Locale locale) throws JsonException {
+        ObjectNode root = mapper.createObjectNode();
+        root.put(JSON.TYPE, type);
+        root.set(JSON.DATA, data);
+        return root;
+    }
+
+    @Override
+    public ArrayNode doGetList(String type, Locale locale) throws JsonException {
+        ArrayNode array = mapper.createArrayNode();
+        array.add(mapper.createObjectNode());
+        array.add(mapper.createObjectNode());
+        return array;
+    }
+
+}

--- a/java/test/jmri/server/json/JsonTestServiceFactory.java
+++ b/java/test/jmri/server/json/JsonTestServiceFactory.java
@@ -1,0 +1,33 @@
+package jmri.server.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jmri.spi.JsonServiceFactory;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * JsonServiceFactory for a JsonService supporting testing of the
+ * JsonClientHandler.
+ *
+ * @author Randall Wood Copyright 2018
+ */
+@ServiceProvider(service = JsonServiceFactory.class)
+public class JsonTestServiceFactory implements JsonServiceFactory<JsonTestHttpService, JsonTestSocketService> {
+
+    public static final String TEST = "test";
+
+    @Override
+    public String[] getTypes() {
+        return new String[]{TEST};
+    }
+
+    @Override
+    public JsonTestSocketService getSocketService(JsonConnection connection) {
+        return new JsonTestSocketService(connection);
+    }
+
+    @Override
+    public JsonTestHttpService getHttpService(ObjectMapper mapper) {
+        return new JsonTestHttpService(mapper);
+    }
+
+}

--- a/java/test/jmri/server/json/JsonTestSocketService.java
+++ b/java/test/jmri/server/json/JsonTestSocketService.java
@@ -1,0 +1,51 @@
+package jmri.server.json;
+
+import static jmri.server.json.JsonTestServiceFactory.TEST;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.Locale;
+import javax.servlet.http.HttpServletResponse;
+import jmri.JmriException;
+
+/**
+ * JSON Test Socket service.
+ *
+ * @author Randall Wood Copyright 2018
+ */
+public class JsonTestSocketService extends JsonSocketService<JsonTestHttpService> {
+
+    public JsonTestSocketService(JsonConnection connection) {
+        super(connection, new JsonTestHttpService(connection.getObjectMapper()));
+    }
+
+    @Override
+    public void onMessage(String type, JsonNode data, String method, Locale locale) throws IOException, JmriException, JsonException {
+        switch (method) {
+            case JSON.GET:
+                connection.sendMessage(service.doGet(type, data.path(JSON.NAME).asText(), locale));
+                break;
+            case JSON.POST:
+                connection.sendMessage(service.doPost(type, data.path(JSON.NAME).asText(), data, locale));
+                break;
+            default:
+                throw new JsonException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, Bundle.getMessage(locale, "ErrorObject", TEST, data.path(JSON.NAME).asText()));
+        }
+    }
+
+    /**
+     * Return an array of two empty objects.
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public void onList(String type, JsonNode data, Locale locale) throws IOException, JmriException, JsonException {
+        connection.sendMessage(service.doGetList(type, locale));
+    }
+
+    @Override
+    public void onClose() {
+        // nothing to do
+    }
+
+}

--- a/java/test/jmri/server/json/block/JsonBlockServiceFactoryTest.java
+++ b/java/test/jmri/server/json/block/JsonBlockServiceFactoryTest.java
@@ -1,5 +1,9 @@
 package jmri.server.json.block;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.DataOutputStream;
+import jmri.server.json.JsonConnection;
+import jmri.server.json.JsonMockConnection;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -8,17 +12,31 @@ import org.junit.Test;
 
 /**
  *
- * @author Paul Bender Copyright (C) 2017	
+ * @author Paul Bender Copyright (C) 2017
+ * @author Randall Wood Copyright 2018
  */
 public class JsonBlockServiceFactoryTest {
 
     @Test
-    public void testCTor() {
-        JsonBlockServiceFactory t = new JsonBlockServiceFactory();
-        Assert.assertNotNull("exists",t);
+    public void testGetTypes() {
+        JsonBlockServiceFactory instance = new JsonBlockServiceFactory();
+        Assert.assertArrayEquals(new String[]{JsonBlock.BLOCK, JsonBlock.BLOCKS}, instance.getTypes());
     }
 
-    // The minimal setup for log4J
+    @Test
+    public void testGetSocketService() {
+        JsonConnection connection = new JsonMockConnection((DataOutputStream) null);
+        JsonBlockServiceFactory instance = new JsonBlockServiceFactory();
+        Assert.assertNotNull(instance.getSocketService(connection));
+    }
+
+    @Test
+    public void testGetHttpService() {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonBlockServiceFactory instance = new JsonBlockServiceFactory();
+        Assert.assertNotNull(instance.getHttpService(mapper));
+    }
+
     @Before
     public void setUp() {
         JUnitUtil.setUp();
@@ -28,7 +46,5 @@ public class JsonBlockServiceFactoryTest {
     public void tearDown() {
         JUnitUtil.tearDown();
     }
-
-    // private final static Logger log = LoggerFactory.getLogger(JsonBlockServiceFactoryTest.class);
 
 }

--- a/java/test/jmri/server/json/light/JsonLightSocketServiceTest.java
+++ b/java/test/jmri/server/json/light/JsonLightSocketServiceTest.java
@@ -39,7 +39,7 @@ public class JsonLightSocketServiceTest extends TestCase {
             JsonLightSocketService service = new JsonLightSocketService(connection);
             LightManager manager = InstanceManager.getDefault(LightManager.class);
             Light light1 = manager.provideLight("IL1");
-            service.onMessage(JsonLight.LIGHT, message, Locale.ENGLISH);
+            service.onMessage(JsonLight.LIGHT, message, JSON.POST, Locale.ENGLISH);
             // TODO: test that service is listener in LightManager
             Assert.assertEquals(JSON.OFF, connection.getMessage().path(JSON.DATA).path(JSON.STATE).asInt());
             light1.setState(Light.ON);
@@ -69,21 +69,21 @@ public class JsonLightSocketServiceTest extends TestCase {
             Light light1 = manager.provideLight("IL1");
             // Light OFF
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IL1").put(JSON.STATE, JSON.OFF);
-            service.onMessage(JsonLight.LIGHT, message, Locale.ENGLISH);
+            service.onMessage(JsonLight.LIGHT, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(Light.OFF, light1.getState());
             // Light ON
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IL1").put(JSON.STATE, JSON.ON);
-            service.onMessage(JsonLight.LIGHT, message, Locale.ENGLISH);
+            service.onMessage(JsonLight.LIGHT, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(Light.ON, light1.getState());
             // Light UNKNOWN - remains ON
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IL1").put(JSON.STATE, JSON.UNKNOWN);
-            service.onMessage(JsonLight.LIGHT, message, Locale.ENGLISH);
+            service.onMessage(JsonLight.LIGHT, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(Light.ON, light1.getState());
             // Light Invalid State
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IL1").put(JSON.STATE, 42); // invalid state
             JsonException exception = null;
             try {
-                service.onMessage(JsonLight.LIGHT, message, Locale.ENGLISH);
+                service.onMessage(JsonLight.LIGHT, message, JSON.POST, Locale.ENGLISH);
             } catch (JsonException ex) {
                 exception = ex;
             }

--- a/java/test/jmri/server/json/memory/JsonMemorySocketServiceTest.java
+++ b/java/test/jmri/server/json/memory/JsonMemorySocketServiceTest.java
@@ -38,7 +38,7 @@ public class JsonMemorySocketServiceTest extends TestCase {
             JsonMemorySocketService service = new JsonMemorySocketService(connection);
             MemoryManager manager = InstanceManager.getDefault(MemoryManager.class);
             Memory memory1 = manager.provideMemory("IM1");
-            service.onMessage(JsonMemory.MEMORY, message, Locale.ENGLISH);
+            service.onMessage(JsonMemory.MEMORY, message, JSON.POST, Locale.ENGLISH);
             // TODO: test that service is listener in MemoryManager
             // default null value of memory1 has text representation "null" in JSON
             Assert.assertEquals("null", connection.getMessage().path(JSON.DATA).path(JSON.VALUE).asText());
@@ -69,22 +69,22 @@ public class JsonMemorySocketServiceTest extends TestCase {
             Memory memory1 = manager.provideMemory("IM1");
             // Memory "close"
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IM1").put(JSON.VALUE, "close");
-            service.onMessage(JsonMemory.MEMORY, message, Locale.ENGLISH);
+            service.onMessage(JsonMemory.MEMORY, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals("close", memory1.getValue());
             // Memory "throw"
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IM1").put(JSON.VALUE, "throw");
-            service.onMessage(JsonMemory.MEMORY, message, Locale.ENGLISH);
+            service.onMessage(JsonMemory.MEMORY, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals("throw", memory1.getValue());
             // Memory UNKNOWN - remains ON
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IM1").putNull(JSON.VALUE);
-            service.onMessage(JsonMemory.MEMORY, message, Locale.ENGLISH);
+            service.onMessage(JsonMemory.MEMORY, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(null, memory1.getValue());
             memory1.setValue("throw");
             // Memory no value
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IM1");
             JsonException exception = null;
             try {
-                service.onMessage(JsonMemory.MEMORY, message, Locale.ENGLISH);
+                service.onMessage(JsonMemory.MEMORY, message, JSON.POST, Locale.ENGLISH);
             } catch (JsonException ex) {
                 exception = ex;
             }

--- a/java/test/jmri/server/json/message/JsonMessageServiceFactoryTest.java
+++ b/java/test/jmri/server/json/message/JsonMessageServiceFactoryTest.java
@@ -49,7 +49,7 @@ public class JsonMessageServiceFactoryTest {
     public void testGetHttpService() {
         ObjectMapper mapper = new ObjectMapper();
         JsonMessageServiceFactory instance = new JsonMessageServiceFactory();
-        Assert.assertNull(instance.getHttpService(mapper));
+        Assert.assertNotNull(instance.getHttpService(mapper));
     }
 
 }

--- a/java/test/jmri/server/json/message/JsonMessageSocketServiceTest.java
+++ b/java/test/jmri/server/json/message/JsonMessageSocketServiceTest.java
@@ -42,7 +42,7 @@ public class JsonMessageSocketServiceTest {
         JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
         JsonMessageSocketService instance = new JsonMessageSocketService(connection);
         try {
-            instance.onMessage(type, data, locale);
+            instance.onMessage(type, data, JSON.POST, locale);
             Assert.assertNull(connection.getMessage());
         } catch (IOException | JmriException | JsonException ex) {
             Assert.fail("Unexpected exception thrown.");

--- a/java/test/jmri/server/json/power/JsonPowerSocketServiceTest.java
+++ b/java/test/jmri/server/json/power/JsonPowerSocketServiceTest.java
@@ -42,7 +42,7 @@ public class JsonPowerSocketServiceTest extends TestCase {
             JsonPowerSocketService service = new JsonPowerSocketService(connection);
             PowerManager power = InstanceManager.getDefault(PowerManager.class);
             power.setPower(PowerManager.UNKNOWN);
-            service.onMessage(JsonPowerServiceFactory.POWER, message, Locale.ENGLISH);
+            service.onMessage(JsonPowerServiceFactory.POWER, message, JSON.POST, Locale.ENGLISH);
             // TODO: test that service is listener in PowerManager
             Assert.assertEquals(JSON.UNKNOWN, connection.getMessage().path(JSON.DATA).path(JSON.STATE).asInt());
             power.setPower(PowerManager.ON);
@@ -64,18 +64,18 @@ public class JsonPowerSocketServiceTest extends TestCase {
             JsonPowerSocketService service = new JsonPowerSocketService(connection);
             PowerManager power = InstanceManager.getDefault(PowerManager.class);
             power.setPower(PowerManager.UNKNOWN);
-            service.onMessage(JsonPowerServiceFactory.POWER, message, Locale.ENGLISH);
+            service.onMessage(JsonPowerServiceFactory.POWER, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(PowerManager.ON, power.getPower());
             message = connection.getObjectMapper().readTree("{\"state\":4}"); // Power OFF
-            service.onMessage(JsonPowerServiceFactory.POWER, message, Locale.ENGLISH);
+            service.onMessage(JsonPowerServiceFactory.POWER, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(PowerManager.OFF, power.getPower());
             message = connection.getObjectMapper().readTree("{\"state\":0}"); // JSON Power UNKNOWN
-            service.onMessage(JsonPowerServiceFactory.POWER, message, Locale.ENGLISH);
+            service.onMessage(JsonPowerServiceFactory.POWER, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(PowerManager.OFF, power.getPower()); // did not change
             message = connection.getObjectMapper().readTree("{\"state\":1}"); // JSON Invalid
             JsonException exception = null;
             try {
-                service.onMessage(JsonPowerServiceFactory.POWER, message, Locale.ENGLISH);
+                service.onMessage(JsonPowerServiceFactory.POWER, message, JSON.POST, Locale.ENGLISH);
             } catch (JsonException ex) {
                 exception = ex;
             }

--- a/java/test/jmri/server/json/reporter/JsonReporterSocketServiceTest.java
+++ b/java/test/jmri/server/json/reporter/JsonReporterSocketServiceTest.java
@@ -38,7 +38,7 @@ public class JsonReporterSocketServiceTest {
             JsonReporterSocketService service = new JsonReporterSocketService(connection);
             ReporterManager manager = InstanceManager.getDefault(ReporterManager.class);
             Reporter memory1 = manager.provideReporter("IR1");
-            service.onMessage(JsonReporter.REPORTER, message, Locale.ENGLISH);
+            service.onMessage(JsonReporter.REPORTER, message, JSON.POST, Locale.ENGLISH);
             // TODO: test that service is listener in ReporterManager
             // default null value of memory1 has text representation "null" in JSON
             Assert.assertEquals("null", connection.getMessage().path(JSON.DATA).path(JsonReporter.REPORT).asText());
@@ -70,22 +70,22 @@ public class JsonReporterSocketServiceTest {
             Reporter memory1 = manager.provideReporter("IR1");
             // Reporter "close"
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1").put(JsonReporter.REPORT, "close");
-            service.onMessage(JsonReporter.REPORTER, message, Locale.ENGLISH);
+            service.onMessage(JsonReporter.REPORTER, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals("close", memory1.getCurrentReport());
             // Reporter "throw"
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1").put(JsonReporter.REPORT, "throw");
-            service.onMessage(JsonReporter.REPORTER, message, Locale.ENGLISH);
+            service.onMessage(JsonReporter.REPORTER, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals("throw", memory1.getCurrentReport());
             // Reporter UNKNOWN - remains ON
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1").putNull(JsonReporter.REPORT);
-            service.onMessage(JsonReporter.REPORTER, message, Locale.ENGLISH);
+            service.onMessage(JsonReporter.REPORTER, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(null, memory1.getCurrentReport());
             memory1.setReport("throw");
             // Reporter no value
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1");
             JsonException exception = null;
             try {
-                service.onMessage(JsonReporter.REPORTER, message, Locale.ENGLISH);
+                service.onMessage(JsonReporter.REPORTER, message, JSON.POST, Locale.ENGLISH);
             } catch (JsonException ex) {
                 exception = ex;
             }

--- a/java/test/jmri/server/json/roster/JsonRosterSocketServiceTest.java
+++ b/java/test/jmri/server/json/roster/JsonRosterSocketServiceTest.java
@@ -70,12 +70,12 @@ public class JsonRosterSocketServiceTest {
      */
     @Test
     public void testOnMessageDeleteRoster() throws IOException, JmriException {
-        JsonNode data = this.connection.getObjectMapper().createObjectNode().put(JSON.METHOD, JSON.DELETE);
+        JsonNode data = this.connection.getObjectMapper().createObjectNode();
         Locale locale = Locale.ENGLISH;
         JsonException exception = null;
         JsonRosterSocketService instance = new JsonRosterSocketService(this.connection);
         try {
-            instance.onMessage(JsonRoster.ROSTER, data, locale);
+            instance.onMessage(JsonRoster.ROSTER, data, JSON.DELETE, locale);
         } catch (JsonException ex) {
             exception = ex;
         }
@@ -96,7 +96,7 @@ public class JsonRosterSocketServiceTest {
         JsonException exception = null;
         JsonRosterSocketService instance = new JsonRosterSocketService(this.connection);
         try {
-            instance.onMessage(JsonRoster.ROSTER, data, locale);
+            instance.onMessage(JsonRoster.ROSTER, data, JSON.POST, locale);
         } catch (JsonException ex) {
             exception = ex;
         }
@@ -117,7 +117,7 @@ public class JsonRosterSocketServiceTest {
         JsonException exception = null;
         JsonRosterSocketService instance = new JsonRosterSocketService(this.connection);
         try {
-            instance.onMessage(JsonRoster.ROSTER, data, locale);
+            instance.onMessage(JsonRoster.ROSTER, data, JSON.POST, locale);
         } catch (JsonException ex) {
             exception = ex;
         }
@@ -137,7 +137,7 @@ public class JsonRosterSocketServiceTest {
      */
     @Test
     public void testOnMessageGetRoster() throws IOException, JmriException, JsonException {
-        JsonNode data = this.connection.getObjectMapper().createObjectNode().put(JSON.METHOD, JSON.GET);
+        JsonNode data = this.connection.getObjectMapper().createObjectNode();
         Locale locale = Locale.ENGLISH;
         JsonRosterSocketService instance = new JsonRosterSocketService(this.connection);
         // assert we have not been listening
@@ -146,7 +146,7 @@ public class JsonRosterSocketServiceTest {
             Assert.assertEquals(1, entry.getPropertyChangeListeners().length);
         });
         // onMessage should cause listening to start if it hasn't already
-        instance.onMessage(JsonRoster.ROSTER, data, locale);
+        instance.onMessage(JsonRoster.ROSTER, data, JSON.GET, locale);
         Assert.assertEquals(Roster.getDefault().numEntries(), this.connection.getMessage().size());
         // assert we are listening
         Assert.assertEquals(2, Roster.getDefault().getPropertyChangeListeners().length);
@@ -167,10 +167,10 @@ public class JsonRosterSocketServiceTest {
      */
     @Test
     public void testOnMessageInvalidRoster() throws IOException, JmriException, JsonException {
-        JsonNode data = this.connection.getObjectMapper().createObjectNode().put(JSON.METHOD, "Invalid");
+        JsonNode data = this.connection.getObjectMapper().createObjectNode();
         Locale locale = Locale.ENGLISH;
         JsonRosterSocketService instance = new JsonRosterSocketService(this.connection);
-        instance.onMessage(JsonRoster.ROSTER, data, locale);
+        instance.onMessage(JsonRoster.ROSTER, data, "Invalid", locale);
         Assert.assertNotNull(this.connection.getMessage());
         Assert.assertEquals(Roster.getDefault().numEntries(), this.connection.getMessage().size());
     }

--- a/java/test/jmri/server/json/route/JsonRouteSocketServiceTest.java
+++ b/java/test/jmri/server/json/route/JsonRouteSocketServiceTest.java
@@ -48,7 +48,7 @@ public class JsonRouteSocketServiceTest extends TestCase {
             Sensor sensor1 = InstanceManager.getDefault(SensorManager.class).provideSensor("IS1");
             sensor1.setKnownState(Sensor.UNKNOWN);
             route1.setTurnoutsAlignedSensor(sensor1.getSystemName());
-            service.onMessage(JsonRouteServiceFactory.ROUTE, message, Locale.ENGLISH);
+            service.onMessage(JsonRouteServiceFactory.ROUTE, message, JSON.POST, Locale.ENGLISH);
             // TODO: test that service is listener in RouteManager
             Assert.assertEquals(JSON.UNKNOWN, connection.getMessage().path(JSON.DATA).path(JSON.STATE).asInt());
             sensor1.setKnownState(Sensor.ACTIVE);
@@ -87,25 +87,25 @@ public class JsonRouteSocketServiceTest extends TestCase {
             Assert.assertNotNull(route1.getTurnoutsAlgdSensor());
             // Route ACTIVE - becomes ACTIVE
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1").put(JSON.STATE, JSON.ACTIVE);
-            service.onMessage(JsonRouteServiceFactory.ROUTE, message, Locale.ENGLISH);
+            service.onMessage(JsonRouteServiceFactory.ROUTE, message, JSON.POST, Locale.ENGLISH);
             JUnitUtil.waitFor(() -> {
                 return route1.getState() == Sensor.ACTIVE;
             }, "Route to activate");
             Assert.assertEquals(Sensor.ACTIVE, route1.getState());
             // Route INACTIVE - remains ACTIVE
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1").put(JSON.STATE, JSON.INACTIVE);
-            service.onMessage(JsonRouteServiceFactory.ROUTE, message, Locale.ENGLISH);
+            service.onMessage(JsonRouteServiceFactory.ROUTE, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(Sensor.ACTIVE, route1.getState());
             // Route UNKNOWN - remains ACTIVE
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1").put(JSON.STATE, JSON.UNKNOWN);
-            service.onMessage(JsonRouteServiceFactory.ROUTE, message, Locale.ENGLISH);
+            service.onMessage(JsonRouteServiceFactory.ROUTE, message, JSON.POST, Locale.ENGLISH);
             JUnitUtil.waitFor(() -> {
                 return route1.getState() == Sensor.ACTIVE;
             }, "Route to activate");
             Assert.assertEquals(Sensor.ACTIVE, route1.getState());
             // Route TOGGLE - remains ACTIVE
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1").put(JSON.STATE, JSON.TOGGLE);
-            service.onMessage(JsonRouteServiceFactory.ROUTE, message, Locale.ENGLISH);
+            service.onMessage(JsonRouteServiceFactory.ROUTE, message, JSON.POST, Locale.ENGLISH);
             JUnitUtil.waitFor(() -> {
                 return route1.getState() == Sensor.ACTIVE;
             }, "Route to activate");
@@ -113,7 +113,7 @@ public class JsonRouteSocketServiceTest extends TestCase {
             // Route TOGGLE - becomes ACTIVE
             sensor1.setKnownState(Sensor.INACTIVE);
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1").put(JSON.STATE, JSON.TOGGLE);
-            service.onMessage(JsonRouteServiceFactory.ROUTE, message, Locale.ENGLISH);
+            service.onMessage(JsonRouteServiceFactory.ROUTE, message, JSON.POST, Locale.ENGLISH);
             JUnitUtil.waitFor(() -> {
                 return route1.getState() == Sensor.ACTIVE;
             }, "Route to activate");
@@ -122,7 +122,7 @@ public class JsonRouteSocketServiceTest extends TestCase {
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1").put(JSON.STATE, 42); // invalid state
             JsonException exception = null;
             try {
-                service.onMessage(JsonRouteServiceFactory.ROUTE, message, Locale.ENGLISH);
+                service.onMessage(JsonRouteServiceFactory.ROUTE, message, JSON.POST, Locale.ENGLISH);
             } catch (JsonException ex) {
                 exception = ex;
             }

--- a/java/test/jmri/server/json/sensor/JsonSensorSocketServiceTest.java
+++ b/java/test/jmri/server/json/sensor/JsonSensorSocketServiceTest.java
@@ -38,7 +38,7 @@ public class JsonSensorSocketServiceTest extends TestCase {
             JsonSensorSocketService service = new JsonSensorSocketService(connection);
             SensorManager manager = InstanceManager.getDefault(SensorManager.class);
             Sensor sensor1 = manager.provideSensor("IS1");
-            service.onMessage(JsonSensor.SENSOR, message, Locale.ENGLISH);
+            service.onMessage(JsonSensor.SENSOR, message, JSON.POST, Locale.ENGLISH);
             // TODO: test that service is listener in SensorManager
             Assert.assertEquals(JSON.UNKNOWN, connection.getMessage().path(JSON.DATA).path(JSON.STATE).asInt(-1)); // -1 not possible value
             sensor1.setKnownState(Sensor.ACTIVE);
@@ -68,27 +68,27 @@ public class JsonSensorSocketServiceTest extends TestCase {
             Sensor sensor1 = manager.provideSensor("IS1");
             // Sensor INACTIVE
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IS1").put(JSON.STATE, JSON.INACTIVE);
-            service.onMessage(JsonSensor.SENSOR, message, Locale.ENGLISH);
+            service.onMessage(JsonSensor.SENSOR, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(Sensor.INACTIVE, sensor1.getKnownState());
             // Sensor ACTIVE
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IS1").put(JSON.STATE, JSON.ACTIVE);
-            service.onMessage(JsonSensor.SENSOR, message, Locale.ENGLISH);
+            service.onMessage(JsonSensor.SENSOR, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(Sensor.ACTIVE, sensor1.getKnownState());
             // Sensor UNKNOWN - remains ACTIVE
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IS1").put(JSON.STATE, JSON.UNKNOWN);
-            service.onMessage(JsonSensor.SENSOR, message, Locale.ENGLISH);
+            service.onMessage(JsonSensor.SENSOR, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(Sensor.ACTIVE, sensor1.getKnownState());
             sensor1.setKnownState(Sensor.ACTIVE);
             // Sensor INCONSISTENT - remains ACTIVE
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IS1").put(JSON.STATE, JSON.INCONSISTENT);
-            service.onMessage(JsonSensor.SENSOR, message, Locale.ENGLISH);
+            service.onMessage(JsonSensor.SENSOR, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(Sensor.ACTIVE, sensor1.getKnownState());
             sensor1.setKnownState(Sensor.ACTIVE);
             // Sensor no value
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IS1");
             JsonException exception = null;
             try {
-                service.onMessage(JsonSensor.SENSOR, message, Locale.ENGLISH);
+                service.onMessage(JsonSensor.SENSOR, message, JSON.POST, Locale.ENGLISH);
             } catch (JsonException ex) {
                 exception = ex;
             }

--- a/java/test/jmri/server/json/signalHead/JsonSignalHeadSocketServiceTest.java
+++ b/java/test/jmri/server/json/signalHead/JsonSignalHeadSocketServiceTest.java
@@ -34,7 +34,7 @@ public class JsonSignalHeadSocketServiceTest {
         try {
             //create a signalhead for testing
             String sysName = "IH1";
-            String userName = "SH1";        
+            String userName = "SH1";
             SignalHead s = new jmri.implementation.VirtualSignalHead(sysName, userName);
             jmri.InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
             Assert.assertNotNull(s);
@@ -42,8 +42,8 @@ public class JsonSignalHeadSocketServiceTest {
             JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
             JsonNode message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, sysName);
             JsonSignalHeadSocketService service = new JsonSignalHeadSocketService(connection);
-            service.onMessage(JsonSignalHead.SIGNAL_HEAD, message, Locale.ENGLISH);
-            
+            service.onMessage(JsonSignalHead.SIGNAL_HEAD, message, JSON.POST, Locale.ENGLISH);
+
             //signalhead defaults to Dark
             Assert.assertEquals(SignalHead.DARK, connection.getMessage().path(JSON.DATA).path(JSON.STATE).asInt());
 
@@ -53,14 +53,14 @@ public class JsonSignalHeadSocketServiceTest {
                 return s.getState() == SignalHead.GREEN;
             }, "SignalHead is now GREEN");
             Assert.assertEquals(SignalHead.GREEN, connection.getMessage().path(JSON.DATA).path(JSON.STATE).asInt());
-            
+
             //change to Red, and wait for change to show up, then verify
             s.setAppearance(SignalHead.RED);
             JUnitUtil.waitFor(() -> {
                 return s.getState() == SignalHead.RED;
             }, "SignalHead is now RED");
             Assert.assertEquals(SignalHead.RED, connection.getMessage().path(JSON.DATA).path(JSON.STATE).asInt());
-            
+
             service.onClose();
 
         } catch (IOException | JmriException | JsonException ex) {
@@ -76,7 +76,7 @@ public class JsonSignalHeadSocketServiceTest {
 
         //create a signalhead for testing
         String sysName = "IH1";
-        String userName = "SH1";        
+        String userName = "SH1";
         SignalHead s = new jmri.implementation.VirtualSignalHead(sysName, userName);
         jmri.InstanceManager.getDefault(jmri.SignalHeadManager.class).register(s);
         Assert.assertNotNull(s);
@@ -85,7 +85,7 @@ public class JsonSignalHeadSocketServiceTest {
             // SignalHead Yellow
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, userName)
                     .put(JSON.STATE, SignalHead.YELLOW);
-            service.onMessage(JsonSignalHead.SIGNAL_HEAD, message, Locale.ENGLISH);           
+            service.onMessage(JsonSignalHead.SIGNAL_HEAD, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(SignalHead.YELLOW, s.getState()); //state should be Yellow
         } catch (IOException | JmriException | JsonException ex) {
             Assert.fail(ex.getMessage());
@@ -96,13 +96,13 @@ public class JsonSignalHeadSocketServiceTest {
         try {
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, userName)
                     .put(JSON.STATE, SignalHead.FLASHLUNAR);
-            service.onMessage(JsonSignalHead.SIGNAL_HEAD, message, Locale.ENGLISH);
+            service.onMessage(JsonSignalHead.SIGNAL_HEAD, message, JSON.POST, Locale.ENGLISH);
         } catch (IOException | JmriException | JsonException ex) {
             exception = ex;
         }
         Assert.assertNotNull(exception);
         Assert.assertEquals(SignalHead.YELLOW, s.getAppearance()); //state should be Yellow
-        
+
     }
 
 

--- a/java/test/jmri/server/json/signalMast/JsonSignalMastSocketServiceTest.java
+++ b/java/test/jmri/server/json/signalMast/JsonSignalMastSocketServiceTest.java
@@ -38,7 +38,7 @@ public class JsonSignalMastSocketServiceTest {
         try {
             //create a signalmast for testing
             String sysName = "IF$shsm:basic:one-searchlight:SM2";
-            String userName = "SM2";        
+            String userName = "SM2";
             SignalMastManager manager = InstanceManager.getDefault(SignalMastManager.class);
             SignalMast s = manager.provideSignalMast(sysName);
             s.setUserName(userName);
@@ -47,7 +47,7 @@ public class JsonSignalMastSocketServiceTest {
             JsonNode message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, sysName);
             JsonSignalMastSocketService service = new JsonSignalMastSocketService(connection);
 
-            service.onMessage(JsonSignalMast.SIGNAL_MAST, message, Locale.ENGLISH);
+            service.onMessage(JsonSignalMast.SIGNAL_MAST, message, JSON.POST, Locale.ENGLISH);
             // TODO: test that service is listener in SignalMastManager
             Assert.assertEquals(JSON.ASPECT_UNKNOWN, connection.getMessage().path(JSON.DATA).path(JSON.STATE).asText());
 
@@ -57,14 +57,14 @@ public class JsonSignalMastSocketServiceTest {
                 return s.getAspect().equals("Approach");
             }, "SignalMast is now Approach");
             Assert.assertEquals("Approach", connection.getMessage().path(JSON.DATA).path(JSON.STATE).asText());
-            
+
             //change to Stop, and wait for change to show up
             s.setAspect("Stop");
             JUnitUtil.waitFor(() -> {
                 return s.getAspect().equals("Stop");
             }, "SignalMast is now Stop");
             Assert.assertEquals("Stop", connection.getMessage().path(JSON.DATA).path(JSON.STATE).asText());
-            
+
             service.onClose();
 //            // TODO: test that service is no longer a listener in SignalMastManager
         } catch (IOException | JmriException | JsonException ex) {
@@ -81,7 +81,7 @@ public class JsonSignalMastSocketServiceTest {
 
         //create a signalmast for testing
         String sysName = "IF$shsm:basic:one-searchlight:SM2";
-        String userName = "SM2";        
+        String userName = "SM2";
         SignalMastManager manager = InstanceManager.getDefault(SignalMastManager.class);
         SignalMast s = manager.provideSignalMast(sysName);
         s.setUserName(userName);
@@ -89,7 +89,7 @@ public class JsonSignalMastSocketServiceTest {
         try {
             // SignalMast Stop
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, userName).put(JSON.STATE, "Stop");
-            service.onMessage(JsonSignalMast.SIGNAL_MAST, message, Locale.ENGLISH);           
+            service.onMessage(JsonSignalMast.SIGNAL_MAST, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals("Stop", s.getAspect()); //aspect should be Stop
         } catch (IOException | JmriException | JsonException ex) {
             Assert.fail(ex.getMessage());
@@ -99,18 +99,18 @@ public class JsonSignalMastSocketServiceTest {
         Exception exception = null;
         try {
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, userName).put(JSON.STATE, JSON.ASPECT_UNKNOWN);
-            service.onMessage(JsonSignalMast.SIGNAL_MAST, message, Locale.ENGLISH);
+            service.onMessage(JsonSignalMast.SIGNAL_MAST, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals("Stop", s.getAspect());
         } catch (IOException | JmriException | JsonException ex) {
             exception = ex;
         }
         Assert.assertNotNull(exception);
-        
+
         // set SignalMast no value, should throw error, remain at Stop
         message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, sysName);
         exception = null;
         try {
-            service.onMessage(JsonSignalMast.SIGNAL_MAST, message, Locale.ENGLISH);
+            service.onMessage(JsonSignalMast.SIGNAL_MAST, message, JSON.POST, Locale.ENGLISH);
         } catch (JsonException ex) {
             exception = ex;
         } catch (IOException | JmriException ex) {

--- a/java/test/jmri/server/json/throttle/JsonThrottleServiceFactoryTest.java
+++ b/java/test/jmri/server/json/throttle/JsonThrottleServiceFactoryTest.java
@@ -3,9 +3,7 @@ package jmri.server.json.throttle;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.DataOutputStream;
 import jmri.server.json.JsonConnection;
-import jmri.server.json.JsonHttpService;
 import jmri.server.json.JsonMockConnection;
-import jmri.server.json.JsonSocketService;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,9 +32,8 @@ public class JsonThrottleServiceFactoryTest {
     public void testGetSocketService() {
         JsonConnection connection = new JsonMockConnection((DataOutputStream) null);
         JsonThrottleServiceFactory instance = new JsonThrottleServiceFactory();
-        JsonSocketService result = instance.getSocketService(connection);
+        JsonThrottleSocketService result = instance.getSocketService(connection);
         Assert.assertNotNull(result);
-        Assert.assertTrue(JsonSocketService.class.isInstance(result));
     }
 
     /**
@@ -45,8 +42,8 @@ public class JsonThrottleServiceFactoryTest {
     @Test
     public void testGetHttpService() {
         JsonThrottleServiceFactory instance = new JsonThrottleServiceFactory();
-        JsonHttpService result = instance.getHttpService(new ObjectMapper());
-        Assert.assertNull(result);
+        JsonThrottleHttpService result = instance.getHttpService(new ObjectMapper());
+        Assert.assertNotNull(result);
     }
 
 }

--- a/java/test/jmri/server/json/turnout/JsonTurnoutSocketServiceTest.java
+++ b/java/test/jmri/server/json/turnout/JsonTurnoutSocketServiceTest.java
@@ -40,7 +40,7 @@ public class JsonTurnoutSocketServiceTest extends TestCase {
             TurnoutManager manager = InstanceManager.getDefault(TurnoutManager.class);
             Turnout turnout1 = manager.provideTurnout("IT1");
             turnout1.setCommandedState(Turnout.UNKNOWN);
-            service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, Locale.ENGLISH);
+            service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
             // TODO: test that service is listener in TurnoutManager
             Assert.assertEquals(JSON.UNKNOWN, connection.getMessage().path(JSON.DATA).path(JSON.STATE).asInt());
             turnout1.setCommandedState(Turnout.CLOSED);
@@ -71,21 +71,21 @@ public class JsonTurnoutSocketServiceTest extends TestCase {
             turnout1.setCommandedState(Turnout.UNKNOWN);
             // Turnout CLOSED
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1").put(JSON.STATE, JSON.CLOSED);
-            service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, Locale.ENGLISH);
+            service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(Turnout.CLOSED, turnout1.getState());
             // Turnout THROWN
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1").put(JSON.STATE, JSON.THROWN);
-            service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, Locale.ENGLISH);
+            service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(Turnout.THROWN, turnout1.getState());
             // Turnout UNKNOWN - remains THROWN
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1").put(JSON.STATE, JSON.UNKNOWN);
-            service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, Locale.ENGLISH);
+            service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(Turnout.THROWN, turnout1.getState());
             // Turnout Invalid State
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1").put(JSON.STATE, 42); // invalid state
             JsonException exception = null;
             try {
-                service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, Locale.ENGLISH);
+                service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
             } catch (JsonException ex) {
                 exception = ex;
             }

--- a/java/test/jmri/server/json/util/JsonUtilHttpServiceTest.java
+++ b/java/test/jmri/server/json/util/JsonUtilHttpServiceTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Locale;
 import javax.servlet.http.HttpServletResponse;
+import jmri.InstanceManager;
 import jmri.Metadata;
 import jmri.jmris.json.JsonServerPreferences;
 import jmri.profile.ProfileManager;
@@ -151,7 +152,7 @@ public class JsonUtilHttpServiceTest {
         Assert.assertEquals(jmri.Version.name(), data.path(JSON.JMRI).asText());
         Assert.assertEquals(JSON.JSON_PROTOCOL_VERSION, data.path(JSON.JSON).asText());
         Assert.assertEquals(Math.round(heartbeat * 0.9f), data.path(JSON.HEARTBEAT).asInt());
-        Assert.assertEquals(WebServerPreferences.getDefault().getRailroadName(), data.path(JSON.RAILROAD).asText());
+        Assert.assertEquals(InstanceManager.getDefault(WebServerPreferences.class).getRailroadName(), data.path(JSON.RAILROAD).asText());
         Assert.assertEquals(NodeIdentity.identity(), data.path(JSON.NODE).asText());
         Assert.assertEquals(ProfileManager.getDefault().getActiveProfile().getName(), data.path(JSON.ACTIVE_PROFILE).asText());
     }
@@ -226,7 +227,7 @@ public class JsonUtilHttpServiceTest {
         Assert.assertEquals(JSON.NETWORK_SERVICE, result.get(0).path(JSON.TYPE).asText());
         JsonNode data = result.get(0).path(JSON.DATA);
         Assert.assertFalse(data.isMissingNode());
-        Assert.assertEquals(WebServerPreferences.getDefault().getRailroadName(), data.path(JSON.NAME).asText());
+        Assert.assertEquals(InstanceManager.getDefault(WebServerPreferences.class).getRailroadName(), data.path(JSON.NAME).asText());
         Assert.assertEquals(9999, data.path(JSON.PORT).asInt());
         Assert.assertEquals(JSON.ZEROCONF_SERVICE_TYPE, data.path(JSON.TYPE).asText());
         Assert.assertEquals(NodeIdentity.identity(), data.path(JSON.NODE).asText());
@@ -299,7 +300,7 @@ public class JsonUtilHttpServiceTest {
         Assert.assertEquals(JSON.NETWORK_SERVICE, result.path(JSON.TYPE).asText());
         JsonNode data = result.path(JSON.DATA);
         Assert.assertFalse(data.isMissingNode());
-        Assert.assertEquals(WebServerPreferences.getDefault().getRailroadName(), data.path(JSON.NAME).asText());
+        Assert.assertEquals(InstanceManager.getDefault(WebServerPreferences.class).getRailroadName(), data.path(JSON.NAME).asText());
         Assert.assertEquals(9999, data.path(JSON.PORT).asInt());
         Assert.assertEquals(JSON.ZEROCONF_SERVICE_TYPE, data.path(JSON.TYPE).asText());
         Assert.assertEquals(NodeIdentity.identity(), data.path(JSON.NODE).asText());
@@ -318,7 +319,7 @@ public class JsonUtilHttpServiceTest {
         JsonNode result = instance.getRailroad(locale);
         Assert.assertEquals(JSON.RAILROAD, result.path(JSON.TYPE).asText());
         JsonNode data = result.path(JSON.DATA);
-        Assert.assertEquals(WebServerPreferences.getDefault().getRailroadName(), data.path(JSON.NAME).asText());
+        Assert.assertEquals(InstanceManager.getDefault(WebServerPreferences.class).getRailroadName(), data.path(JSON.NAME).asText());
     }
 
 }

--- a/java/test/jmri/server/json/util/JsonUtilSocketServiceTest.java
+++ b/java/test/jmri/server/json/util/JsonUtilSocketServiceTest.java
@@ -69,16 +69,16 @@ public class JsonUtilSocketServiceTest {
         JsonNode empty = connection.getObjectMapper().createObjectNode();
         JsonUtilSocketService instance = new JsonUtilSocketService(connection);
         // JSON.LOCALE
-        instance.onMessage(JSON.LOCALE, empty, locale);
+        instance.onMessage(JSON.LOCALE, empty, JSON.POST, locale);
         assertNull(connection.getMessage());
         // JSON.PING
-        instance.onMessage(JSON.PING, empty, locale);
+        instance.onMessage(JSON.PING, empty, JSON.POST, locale);
         JsonNode result = connection.getMessage().path(JSON.TYPE);
         assertNotNull(result);
         assertTrue(JsonNode.class.isInstance(result));
         assertEquals(JSON.PONG, result.asText());
         // JSON.GOODBYE
-        instance.onMessage(JSON.GOODBYE, empty, locale);
+        instance.onMessage(JSON.GOODBYE, empty, JSON.POST, locale);
         result = connection.getMessage().path(JSON.TYPE);
         assertNotNull(result);
         assertTrue(JsonNode.class.isInstance(result));


### PR DESCRIPTION
- JSON messages include a type (to help determine what should handle the message), data, and a method defining the action that should be taken on the data by the handler. The method would be embedded within the data before passing to the handler, although clients did not need to do so. This PR changes this to explicitly pass a non-null method to the handler as a separate parameter, and to `get` the handler to get if the data is empty or `post` if the data is not empty.
- Improve DRYness by using Generics for JsonSocketServices. This both reduces warnings in the code, and reduces code duplication.
- Clean up use of deprecated methods in JSON-handling code.
- Name, and allow the cleanup of, a thread in the WebAppManager