### PR TITLE
Fix JavaDoc and Java warnings from Jenkins build 2276

### DIFF
--- a/java/src/jmri/Throttle.java
+++ b/java/src/jmri/Throttle.java
@@ -106,7 +106,7 @@ public interface Throttle {
     /**
      * Set the speed.
      *
-     * @param speed - a number from 0.0 to 1.0
+     * @param speed a number from 0.0 to 1.0
      */
     public void setSpeedSetting(float speed);
 
@@ -116,9 +116,9 @@ public interface Throttle {
      * options allow the calling method to insist the message is sent under some
      * circumstances.
      *
-     * @param speed - the speed between 0.0 and 1.0
-     * @param allowDuplicates - if true, don't suppress messages that should have no effect
-     * @param allowDuplicatesOnStop - if true, and the new speed is idle or estop, don't suppress messages
+     * @param speed a number from 0.0 to 1.0
+     * @param allowDuplicates if true, don't suppress messages that should have no effect
+     * @param allowDuplicatesOnStop if true, and the new speed is idle or estop, don't suppress messages
      */
     public void setSpeedSetting(float speed, boolean allowDuplicates, boolean allowDuplicatesOnStop);
 
@@ -126,7 +126,7 @@ public interface Throttle {
      * Set the speed, and on systems which normally suppress the sending of a message make sure
      * the message gets sent.
      *
-     * @param speed
+     * @param speed a number from 0.0 to 1.0
      */
     public void setSpeedSettingAgain(float speed);
 
@@ -257,7 +257,7 @@ public interface Throttle {
 
     public void setF28(boolean f28);
 
-    // functions momentary status - note that we use the naming for DCC, 
+    // functions momentary status - note that we use the naming for DCC,
     // though that's not the implication;
     // see also DccThrottle interface
     public boolean getF0Momentary();

--- a/java/src/jmri/server/json/package-info.java
+++ b/java/src/jmri/server/json/package-info.java
@@ -32,7 +32,7 @@
  * a <code>{"type":"pong"}</code> response.</li>
  * <li>a sign off in the form: <code>{"type":"goodbye"}</code> to which an
  * identical response is sent before the connection gets closed.</li></ul>
- * <p>
+ *
  * <h2>Responses</h2>
  * <p>
  * JSON messages sent to the client will be in the form:


### PR DESCRIPTION
Fix JavaDoc and Java warnings that crept into the code and were only caught by Jenkins in build 2276.