### PR TITLE
add releaseThrottle() to AbstractAutomaton

### DIFF
--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -1042,7 +1042,6 @@ public class AbstractAutomaton implements Runnable {
         if (tl == null) {
             log.warn("unable to find throttle listener for throttle {}", t);
         }
-        log.info("got it: {}", tl);
         t.release(tl);
     }
 

--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -936,7 +936,7 @@ public class AbstractAutomaton implements Runnable {
 
     private DccThrottle throttle;
     private boolean failedThrottleRequest = false;
-    private ArrayList<ArrayList> throttleListenerList = new ArrayList<ArrayList>();
+    private ArrayList<ThrottleMemo> throttleListenerList = new ArrayList<ThrottleMemo>();
 
     /**
      * Obtains a DCC throttle, including waiting for the command station
@@ -1004,10 +1004,10 @@ public class AbstractAutomaton implements Runnable {
             InstanceManager.getDefault(ThrottleManager.class).cancelThrottleRequest(address, throttleListener);  //kill the pending request
         } else {
             // keep the listener so we can release the throttle properly
-            ArrayList throttleAndListenerPair = new ArrayList();
-            throttleAndListenerPair.add(0, throttle);
-            throttleAndListenerPair.add(1, throttleListener);
-            throttleListenerList.add(throttleAndListenerPair);
+            ThrottleMemo tm = new ThrottleMemo();
+            tm.throttle = throttle;
+            tm.listener = throttleListener;
+            throttleListenerList.add(tm);
         }
 
         return throttle;
@@ -1081,10 +1081,10 @@ public class AbstractAutomaton implements Runnable {
             InstanceManager.getDefault(ThrottleManager.class).cancelThrottleRequest(re, throttleListener);  //kill the pending request
         }else {
             // keep the listener so we can release the throttle properly
-            ArrayList throttleAndListenerPair = new ArrayList();
-            throttleAndListenerPair.add(0, throttle);
-            throttleAndListenerPair.add(1, throttleListener);
-            throttleListenerList.add(throttleAndListenerPair);
+            ThrottleMemo tm = new ThrottleMemo();
+            tm.throttle = throttle;
+            tm.listener = throttleListener;
+            throttleListenerList.add(tm);
         }
         return throttle;
     }
@@ -1102,9 +1102,9 @@ public class AbstractAutomaton implements Runnable {
         log.debug("releasing throttle {}", t);
         // find the listener
         ThrottleListener tl = null;
-        for(ArrayList l : throttleListenerList) {
-            if (l.get(0) == t) {
-                tl = (ThrottleListener)l.get(1);
+        for(ThrottleMemo tm : throttleListenerList) {
+            if (tm.throttle == t) {
+                tl = tm.listener;
                 break;
             }
         }
@@ -1349,4 +1349,11 @@ public class AbstractAutomaton implements Runnable {
     }
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(AbstractAutomaton.class);
+
+    // internal class to match throttles with listeners so we can find
+    // the right listener to release a throttle
+    class ThrottleMemo {
+        DccThrottle throttle;
+        ThrottleListener listener;
+    }
 }

--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -1004,7 +1004,13 @@ public class AbstractAutomaton implements Runnable {
             InstanceManager.getDefault(ThrottleManager.class).cancelThrottleRequest(address, throttleListener);  //kill the pending request
         } else {
             // keep the listener so we can release the throttle properly
-            throttleListenerMap.put(throttle, throttleListener);
+            tl = throttleListenerMap.get(throttle);
+            if (tl == null) {
+                throttleListenerMap.put(throttle, throttleListener);
+            } else {
+                // we already have a listener for this throttle object
+                throttle.removePropertyChangeListener(throttleListener);
+            }
         }
 
         return throttle;

--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -1004,13 +1004,10 @@ public class AbstractAutomaton implements Runnable {
             InstanceManager.getDefault(ThrottleManager.class).cancelThrottleRequest(address, throttleListener);  //kill the pending request
         } else {
             // keep the listener so we can release the throttle properly
-            tl = throttleListenerMap.get(throttle);
+            ThrottleListener tl = throttleListenerMap.get(throttle);
             if (tl == null) {
                 throttleListenerMap.put(throttle, throttleListener);
-            } else {
-                // we already have a listener for this throttle object
-                throttle.removePropertyChangeListener(throttleListener);
-            }
+            } 
         }
 
         return throttle;

--- a/java/src/jmri/jmrit/automat/AbstractAutomaton.java
+++ b/java/src/jmri/jmrit/automat/AbstractAutomaton.java
@@ -4,7 +4,7 @@ import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -936,7 +936,7 @@ public class AbstractAutomaton implements Runnable {
 
     private DccThrottle throttle;
     private boolean failedThrottleRequest = false;
-    private ArrayList<ThrottleMemo> throttleListenerList = new ArrayList<ThrottleMemo>();
+    private HashMap<DccThrottle, ThrottleListener> throttleListenerMap =  new HashMap<DccThrottle, ThrottleListener>();
 
     /**
      * Obtains a DCC throttle, including waiting for the command station
@@ -1004,10 +1004,7 @@ public class AbstractAutomaton implements Runnable {
             InstanceManager.getDefault(ThrottleManager.class).cancelThrottleRequest(address, throttleListener);  //kill the pending request
         } else {
             // keep the listener so we can release the throttle properly
-            ThrottleMemo tm = new ThrottleMemo();
-            tm.throttle = throttle;
-            tm.listener = throttleListener;
-            throttleListenerList.add(tm);
+            throttleListenerMap.put(throttle, throttleListener);
         }
 
         return throttle;
@@ -1027,66 +1024,7 @@ public class AbstractAutomaton implements Runnable {
      * @return A usable throttle, or null if error
      */
     public DccThrottle getThrottle(BasicRosterEntry re, int waitSecs) {
-        log.debug("requesting DccThrottle for rosterEntry " + re.getId());
-        if (!inThread) {
-            log.warn("getThrottle invoked from invalid context");
-        }
-        throttle = null;
-        ThrottleListener throttleListener = new ThrottleListener() {
-            @Override
-            public void notifyThrottleFound(DccThrottle t) {
-                throttle = t;
-                synchronized (self) {
-                    self.notifyAll(); // should be only one thread waiting, but just in case
-                }
-            }
-
-            @Override
-            public void notifyFailedThrottleRequest(jmri.LocoAddress address, String reason) {
-                log.error("Throttle request failed for " + address + " because " + reason);
-                failedThrottleRequest = true;
-                synchronized (self) {
-                    self.notifyAll(); // should be only one thread waiting, but just in case
-                }
-            }
-
-            @Override
-            public void notifyStealThrottleRequired(jmri.LocoAddress address) {
-                // this is an automatically stealing impelementation.
-                InstanceManager.throttleManagerInstance().stealThrottleRequest(address, this, true);
-            }
-        };
-        boolean ok = InstanceManager.throttleManagerInstance()
-                .requestThrottle(re, throttleListener);
-
-        // check if reply is coming
-        if (!ok) {
-            log.info("Throttle for loco " + re.getId() + " not available");
-            InstanceManager.getDefault(ThrottleManager.class).cancelThrottleRequest(re, throttleListener);  //kill the pending request
-            return null;
-        }
-
-        // now wait for reply from identified throttle
-        int waited = 0;
-        while (throttle == null && failedThrottleRequest == false && waited <= waitSecs) {
-            log.debug("waiting for throttle");
-            wait(1000);  //  1 seconds
-            waited++;
-            if (throttle == null) {
-                log.warn("Still waiting for throttle " + re.getId() + "!");
-            }
-        }
-        if (throttle == null) {
-            log.debug("canceling request for Throttle " + re.getId());
-            InstanceManager.getDefault(ThrottleManager.class).cancelThrottleRequest(re, throttleListener);  //kill the pending request
-        }else {
-            // keep the listener so we can release the throttle properly
-            ThrottleMemo tm = new ThrottleMemo();
-            tm.throttle = throttle;
-            tm.listener = throttleListener;
-            throttleListenerList.add(tm);
-        }
-        return throttle;
+        return getThrottle(Integer.parseInt(re.getDccAddress()), re.isLongAddress(), waitSecs);
     }
 
     public DccThrottle getThrottle(BasicRosterEntry re) {
@@ -1100,17 +1038,11 @@ public class AbstractAutomaton implements Runnable {
      */
     public void releaseThrottle(DccThrottle t) {
         log.debug("releasing throttle {}", t);
-        // find the listener
-        ThrottleListener tl = null;
-        for(ThrottleMemo tm : throttleListenerList) {
-            if (tm.throttle == t) {
-                tl = tm.listener;
-                break;
-            }
-        }
+        ThrottleListener tl = throttleListenerMap.get(t);
         if (tl == null) {
             log.warn("unable to find throttle listener for throttle {}", t);
         }
+        log.info("got it: {}", tl);
         t.release(tl);
     }
 
@@ -1350,10 +1282,4 @@ public class AbstractAutomaton implements Runnable {
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(AbstractAutomaton.class);
 
-    // internal class to match throttles with listeners so we can find
-    // the right listener to release a throttle
-    class ThrottleMemo {
-        DccThrottle throttle;
-        ThrottleListener listener;
-    }
 }


### PR DESCRIPTION
A throttle obtained using getThrottle() in AbstractAutomaton can't be released using throttle.release(ThrottleListner) because the caller does not have the listener.

This is my attempt at a solution: keep a list of throttle/listener pairs and pull out the right listener when the new method releaseThrottle(Throttle) is called.

It works. There's something I don't understand, and this is probably my inexperience with java, but the throttleListener created by getThrottle() appears to my debugger to be an object of type AbstractAutomaton rather than ThrottleListener. 