### PR TITLE
dispatcher read train info bug

### DIFF
--- a/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/ActivateTrainFrame.java
@@ -1104,7 +1104,7 @@ public class ActivateTrainFrame {
             info.setDccAddress(" ");
         } else if (_TrainsFromUser) {
             info.setTrainName(trainNameField.getText());
-            info.setDccAddress((String) dccAddressSpinner.getValue());
+            info.setDccAddress(String.valueOf(dccAddressSpinner.getValue()));
         }
         info.setTrainInTransit(inTransitBox.isSelected());
         info.setStartBlockName((String) startingBlockBox.getSelectedItem());

--- a/java/src/jmri/jmrit/dispatcher/TrainInfoFile.java
+++ b/java/src/jmri/jmrit/dispatcher/TrainInfoFile.java
@@ -256,11 +256,13 @@ public class TrainInfoFile extends jmri.jmrit.XmlFile {
                         }
                     }
                     if (traininfo.getAttribute("usespeedprofile") != null) {
+                        tInfo.setUseSpeedProfile(false);
                         if (traininfo.getAttribute("usespeedprofile").getValue().equals("yes")) {
                             tInfo.setUseSpeedProfile(true);
                         }
                     }
                     if (traininfo.getAttribute("stopbyspeedprofile") != null) {
+                        tInfo.setStopBySpeedProfile(false);
                         if (traininfo.getAttribute("stopbyspeedprofile").getValue().equals("yes")) {
                             tInfo.setStopBySpeedProfile(true);
                         }

--- a/java/src/jmri/jmrit/dispatcher/TrainInfoFile.java
+++ b/java/src/jmri/jmrit/dispatcher/TrainInfoFile.java
@@ -256,13 +256,11 @@ public class TrainInfoFile extends jmri.jmrit.XmlFile {
                         }
                     }
                     if (traininfo.getAttribute("usespeedprofile") != null) {
-                        tInfo.setTerminateWhenDone(false);
                         if (traininfo.getAttribute("usespeedprofile").getValue().equals("yes")) {
                             tInfo.setUseSpeedProfile(true);
                         }
                     }
                     if (traininfo.getAttribute("stopbyspeedprofile") != null) {
-                        tInfo.setTerminateWhenDone(false);
                         if (traininfo.getAttribute("stopbyspeedprofile").getValue().equals("yes")) {
                             tInfo.setStopBySpeedProfile(true);
                         }


### PR DESCRIPTION
In dispatcher.TrainInfoFile.readTrainInfo.java terminatewhendone is set to false immediately after it has been read and set. Delete lines 259 and 265 so that setting is kept.