### PR TITLE
Removing one bad character in an italian label

### DIFF
--- a/xml/decoders/MTH_PS3_Full.xml
+++ b/xml/decoders/MTH_PS3_Full.xml
@@ -25,7 +25,7 @@
         <decVal/>
         <label>PWM Start voltage</label>
         <label xml:lang="it">PWM Volt Partenza</label>
-    <label xml:lang="fr">PWM V dÃ©marr.</label>
+    <label xml:lang="fr">PWM V demarr.</label>
     <label xml:lang="de">PWM Anfahrspannung</label>
       </variable>
       <!-- CV 3-4 -->
@@ -34,7 +34,7 @@
         <decVal/>
         <label>PWM max voltage</label>
         <label xml:lang="it">PWM Volt Massimi (0-255):</label>
-        <label xml:lang="de">PWM HÃ¶chstgeschwindigkeit</label>
+        <label xml:lang="de">PWM Hachstgeschwindigkeit</label>
       </variable>
       <!-- CV 7-8 -->
       <xi:include href="http://jmri.org/xml/decoders/nmra/mfgVersionId.xml"/>


### PR DESCRIPTION
My local (on my PC) file validation didn't work on my PC, finding bad character sets in an italian label >> Thus replaced the bad characters by standard characters