### PR TITLE
Fix Drag and Drop of Files

### DIFF
--- a/java/src/jmri/util/iharder/dnd/FileDrop.java
+++ b/java/src/jmri/util/iharder/dnd/FileDrop.java
@@ -26,53 +26,40 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class makes it easy to drag and drop files from the operating system to
- * a Java program. Any <tt>Component</tt> can be dropped onto, but only
- * <tt>JComponent</tt>s will indicate the drop event with a changed border.
+ * a Java program. Any {@code Component} can be dropped onto, but only
+ * {@code JComponent}s will indicate the drop event with a changed border.
  * <p>
- * To use this class, construct a new <tt>FileDrop</tt> by passing it the target
- * component and a <tt>Listener</tt> to receive notification when file(s) have
+ * To use this class, construct a new {@code FileDrop} by passing it the target
+ * component and a {@code Listener} to receive notification when file(s) have
  * been dropped. Here is an example:
- * </p>
- * <pre><code>
+ * <p>
+ * <code>
  *      JPanel myPanel = new JPanel();
  *      new FileDrop( myPanel, new FileDrop.Listener()
  *      {   public void filesDropped( java.io.File[] files )
  *          {
  *              // handle file drop
  *              ...
- *          }   // end filesDropped
- *      }); // end FileDrop.Listener
- * </code></pre>
+ *          }
+ *      });
+ * </code>
  * <p>
  * You can specify the border that will appear when files are being dragged by
- * calling the constructor with a <tt>border.Border</tt>. Only
- * <tt>JComponent</tt>s will show any indication with a border.
+ * calling the constructor with a {@code border.Border}. Only
+ * {@code JComponent}s will show any indication with a border.
  * <p>
- * You can turn on some debugging features by passing a <tt>PrintStream</tt>
- * object (such as <tt>System.out</tt>) into the full constructor. A
- * <tt>null</tt>
+ * You can turn on some debugging features by passing a {@code PrintStream}
+ * object (such as {@code System.out}) into the full constructor. A {@code null}
  * value will result in no extra debugging information being output.
- * <p>
- * I'm releasing this code into the Public Domain. Enjoy.
- * </p>
- * <p>
- * <em>Original author: Robert Harder, rharder@usa.net</em></p>
- * <p>
- * 2007-09-12 Nathan Blomquist -- Linux (KDE/Gnome) support added.</p>
  *
- * @author Robert Harder
- * @author rharder@users.sf.net
+ * @author Robert Harder rharder@users.sf.net
+ * @author Nathan Blomquist
  * @version 1.0.1
  */
 public class FileDrop {
 
     private transient Border normalBorder;
     private transient DropTargetListener dropListener;
-
-    /**
-     * Discover if the running JVM is modern enough to have drag and drop.
-     */
-    private static Boolean supportsDnD;
 
     // Default border color
     private static Color defaultBorderColor = new Color(0f, 0f, 1f, 0.25f);
@@ -84,7 +71,7 @@ public class FileDrop {
      * will change borders.
      *
      * @param c        Component on which files will be dropped.
-     * @param listener Listens for <tt>filesDropped</tt>.
+     * @param listener Listens for {@code filesDropped}.
      * @since 1.0
      */
     public FileDrop(
@@ -95,17 +82,17 @@ public class FileDrop {
                 BorderFactory.createMatteBorder(2, 2, 2, 2, defaultBorderColor), // Drag border
                 true, // Recursive
                 listener);
-    }   // end constructor
+    }
 
     /**
      * Constructor with a default border and the option to recursively set drop
-     * targets. If your component is a <tt>Container</tt>, then each of its
+     * targets. If your component is a {@code Container}, then each of its
      * children components will also listen for drops, though only the parent
      * will change borders.
      *
      * @param c         Component on which files will be dropped.
      * @param recursive Recursively set children as drop targets.
-     * @param listener  Listens for <tt>filesDropped</tt>.
+     * @param listener  Listens for {@code filesDropped}.
      * @since 1.0
      */
     public FileDrop(
@@ -117,23 +104,23 @@ public class FileDrop {
                 BorderFactory.createMatteBorder(2, 2, 2, 2, defaultBorderColor), // Drag border
                 recursive, // Recursive
                 listener);
-    }   // end constructor
+    }
 
     /**
      * Constructor with a default border, debugging optionally turned on and the
      * option to recursively set drop targets. If your component is a
-     * <tt>Container</tt>, then each of its children components will also listen
+     * {@code Container}, then each of its children components will also listen
      * for drops, though only the parent will change borders. With Debugging
-     * turned on, more status messages will be displayed to
-     * <tt>out</tt>. A common way to use this constructor is with
-     * <tt>System.out</tt> or <tt>System.err</tt>. A <tt>null</tt> value for the
-     * parameter <tt>out</tt> will result in no debugging output.
+     * turned on, more status messages will be displayed to {@code out}. A
+     * common way to use this constructor is with {@code System.out} or
+     * {@code System.err}. A {@code null} value for the parameter {@code out}
+     * will result in no debugging output.
      *
      * @param out       PrintStream to record debugging info or null for no
      *                  debugging.
      * @param c         Component on which files will be dropped.
      * @param recursive Recursively set children as drop targets.
-     * @param listener  Listens for <tt>filesDropped</tt>.
+     * @param listener  Listens for {@code filesDropped}.
      * @since 1.0
      */
     public FileDrop(
@@ -146,15 +133,15 @@ public class FileDrop {
                 BorderFactory.createMatteBorder(2, 2, 2, 2, defaultBorderColor), // Drag border
                 recursive, // Recursive
                 listener);
-    }   // end constructor
+    }
 
     /**
      * Constructor with a specified border
      *
      * @param c          Component on which files will be dropped.
-     * @param dragBorder Border to use on <tt>JComponent</tt> when dragging
+     * @param dragBorder Border to use on {@code JComponent} when dragging
      *                   occurs.
-     * @param listener   Listens for <tt>filesDropped</tt>.
+     * @param listener   Listens for {@code filesDropped}.
      * @since 1.0
      */
     public FileDrop(
@@ -167,19 +154,19 @@ public class FileDrop {
                 dragBorder, // Drag border
                 false, // Recursive
                 listener);
-    }   // end constructor
+    }
 
     /**
      * Constructor with a specified border and the option to recursively set
-     * drop targets. If your component is a <tt>Container</tt>, then each of its
+     * drop targets. If your component is a {@code Container}, then each of its
      * children components will also listen for drops, though only the parent
      * will change borders.
      *
      * @param c          Component on which files will be dropped.
-     * @param dragBorder Border to use on <tt>JComponent</tt> when dragging
+     * @param dragBorder Border to use on {@code JComponent} when dragging
      *                   occurs.
      * @param recursive  Recursively set children as drop targets.
-     * @param listener   Listens for <tt>filesDropped</tt>.
+     * @param listener   Listens for {@code filesDropped}.
      * @since 1.0
      */
     public FileDrop(
@@ -193,21 +180,21 @@ public class FileDrop {
                 dragBorder,
                 recursive,
                 listener);
-    }   // end constructor
+    }
 
     /**
      * Constructor with a specified border and debugging optionally turned on.
      * With Debugging turned on, more status messages will be displayed to
-     * <tt>out</tt>. A common way to use this constructor is with
-     * <tt>System.out</tt> or <tt>System.err</tt>. A <tt>null</tt> value for the
-     * parameter <tt>out</tt> will result in no debugging output.
+     * {@code out}. A common way to use this constructor is with
+     * {@code System.out} or {@code System.err}. A {@code null} value for the
+     * parameter {@code out} will result in no debugging output.
      *
      * @param out        PrintStream to record debugging info or null for no
      *                   debugging.
      * @param c          Component on which files will be dropped.
-     * @param dragBorder Border to use on <tt>JComponent</tt> when dragging
+     * @param dragBorder Border to use on {@code JComponent} when dragging
      *                   occurs.
-     * @param listener   Listens for <tt>filesDropped</tt>.
+     * @param listener   Listens for {@code filesDropped}.
      * @since 1.0
      */
     public FileDrop(
@@ -221,22 +208,22 @@ public class FileDrop {
                 dragBorder, // Drag border
                 false, // Recursive
                 listener);
-    }   // end constructor
+    }
 
     /**
      * Full constructor with a specified border and debugging optionally turned
      * on. With Debugging turned on, more status messages will be displayed to
-     * <tt>out</tt>. A common way to use this constructor is with
-     * <tt>System.out</tt> or <tt>System.err</tt>. A <tt>null</tt> value for the
-     * parameter <tt>out</tt> will result in no debugging output.
+     * {@code out}. A common way to use this constructor is with
+     * {@code System.out} or {@code System.err}. A {@code null} value for the
+     * parameter {@code out} will result in no debugging output.
      *
      * @param out        PrintStream to record debugging info or null for no
      *                   debugging.
      * @param c          Component on which files will be dropped.
-     * @param dragBorder Border to use on <tt>JComponent</tt> when dragging
+     * @param dragBorder Border to use on {@code JComponent} when dragging
      *                   occurs.
      * @param recursive  Recursively set children as drop targets.
-     * @param listener   Listens for <tt>filesDropped</tt>.
+     * @param listener   Listens for {@code filesDropped}.
      * @since 1.0
      */
     public FileDrop(
@@ -246,165 +233,139 @@ public class FileDrop {
             final boolean recursive,
             final Listener listener) {
 
-        if (supportsDnD()) {   // Make a drop listener
-            dropListener = new DropTargetListener() {
-                @Override
-                public void dragEnter(DropTargetDragEvent evt) {
-                    log.debug("FileDrop: dragEnter event.");
+        dropListener = new DropTargetListener() {
+            @Override
+            public void dragEnter(DropTargetDragEvent evt) {
+                log.debug("FileDrop: dragEnter event.");
 
-                    // Is this an acceptable drag event?
-                    if (isDragOk(evt)) {
-                        // If it's a Swing component, set its border
-                        if (c instanceof JComponent) {
-                            JComponent jc = (JComponent) c;
-                            normalBorder = jc.getBorder();
-                            log.debug("FileDrop: normal border saved.");
-                            jc.setBorder(dragBorder);
-                            log.debug("FileDrop: drag border set.");
-                        }   // end if: JComponent
+                // Is this an acceptable drag event?
+                if (isDragOk(evt)) {
+                    // If it's a Swing component, set its border
+                    if (c instanceof JComponent) {
+                        JComponent jc = (JComponent) c;
+                        normalBorder = jc.getBorder();
+                        log.debug("FileDrop: normal border saved.");
+                        jc.setBorder(dragBorder);
+                        log.debug("FileDrop: drag border set.");
+                    }
 
-                        // Acknowledge that it's okay to enter
-                        //evt.acceptDrag( DnDConstants.ACTION_COPY_OR_MOVE );
-                        evt.acceptDrag(DnDConstants.ACTION_COPY);
-                        log.debug("FileDrop: event accepted.");
-                    } // end if: drag ok
-                    else {   // Reject the drag event
-                        evt.rejectDrag();
-                        log.debug("FileDrop: event rejected.");
-                    }   // end else: drag not ok
-                }   // end dragEnter
+                    // Acknowledge that it's okay to enter
+                    //evt.acceptDrag( DnDConstants.ACTION_COPY_OR_MOVE );
+                    evt.acceptDrag(DnDConstants.ACTION_COPY);
+                    log.debug("FileDrop: event accepted.");
+                } else {   // Reject the drag event
+                    evt.rejectDrag();
+                    log.debug("FileDrop: event rejected.");
+                }
+            }
 
-                @Override
-                public void dragOver(DropTargetDragEvent evt) {   // This is called continually as long as the mouse is
-                    // over the drag target.
-                }   // end dragOver
+            @Override
+            public void dragOver(DropTargetDragEvent evt) {   // This is called continually as long as the mouse is
+                // over the drag target.
+            }
 
-                @SuppressWarnings("unchecked")
-                @Override
-                public void drop(DropTargetDropEvent evt) {
-                    log.debug("FileDrop: drop event.");
-                    try {   // Get whatever was dropped
-                        Transferable tr = evt.getTransferable();
+            @SuppressWarnings("unchecked")
+            @Override
+            public void drop(DropTargetDropEvent evt) {
+                log.debug("FileDrop: drop event.");
+                try {   // Get whatever was dropped
+                    Transferable tr = evt.getTransferable();
 
-                        // Is it a file list?
-                        if (tr.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
-                            // Say we'll take it.
-                            //evt.acceptDrop ( DnDConstants.ACTION_COPY_OR_MOVE );
-                            evt.acceptDrop(DnDConstants.ACTION_COPY);
-                            log.debug("FileDrop: file list accepted.");
+                    // Is it a file list?
+                    if (tr.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+                        // Say we'll take it.
+                        //evt.acceptDrop ( DnDConstants.ACTION_COPY_OR_MOVE );
+                        evt.acceptDrop(DnDConstants.ACTION_COPY);
+                        log.debug("FileDrop: file list accepted.");
 
-                            // Get a useful list
-                            List<File> fileList = (List<File>) tr.getTransferData(DataFlavor.javaFileListFlavor);
+                        // Get a useful list
+                        List<File> fileList = (List<File>) tr.getTransferData(DataFlavor.javaFileListFlavor);
 
-                            // Convert list to array
-                            java.io.File[] filesTemp = new java.io.File[fileList.size()];
-                            fileList.toArray(filesTemp);
-                            final java.io.File[] files = filesTemp;
+                        // Convert list to array
+                        java.io.File[] filesTemp = new java.io.File[fileList.size()];
+                        fileList.toArray(filesTemp);
+                        final java.io.File[] files = filesTemp;
 
-                            // Alert listener to drop.
-                            if (listener != null) {
-                                listener.filesDropped(files);
-                            }
+                        // Alert listener to drop.
+                        if (listener != null) {
+                            listener.filesDropped(files);
+                        }
 
-                            // Mark that drop is completed.
-                            evt.getDropTargetContext().dropComplete(true);
-                            log.debug("FileDrop: drop complete.");
-                        } // end if: file list
-                        else // this section will check for a reader flavor.
-                        {
-                            // Thanks, Nathan!
-                            // BEGIN 2007-09-12 Nathan Blomquist -- Linux (KDE/Gnome) support added.
-                            DataFlavor[] flavors = tr.getTransferDataFlavors();
-                            boolean handled = false;
-                            for (DataFlavor flavor : flavors) {
-                                if (flavor.isRepresentationClassReader()) {
-                                    // Say we'll take it.
-                                    //evt.acceptDrop ( DnDConstants.ACTION_COPY_OR_MOVE );
-                                    evt.acceptDrop(DnDConstants.ACTION_COPY);
-                                    log.debug("FileDrop: reader accepted.");
-                                    Reader reader = flavor.getReaderForText(tr);
-                                    BufferedReader br = new BufferedReader(reader);
-                                    if (listener != null) {
-                                        listener.filesDropped(createFileArray(br));
-                                    }
-                                    // Mark that drop is completed.
-                                    evt.getDropTargetContext().dropComplete(true);
-                                    log.debug("FileDrop: drop complete.");
-                                    handled = true;
-                                    break;
+                        // Mark that drop is completed.
+                        evt.getDropTargetContext().dropComplete(true);
+                        log.debug("FileDrop: drop complete.");
+                    } else // this section will check for a reader flavor.
+                    {
+                        DataFlavor[] flavors = tr.getTransferDataFlavors();
+                        boolean handled = false;
+                        for (DataFlavor flavor : flavors) {
+                            if (flavor.isRepresentationClassReader()) {
+                                // Say we'll take it.
+                                //evt.acceptDrop ( DnDConstants.ACTION_COPY_OR_MOVE );
+                                evt.acceptDrop(DnDConstants.ACTION_COPY);
+                                log.debug("FileDrop: reader accepted.");
+                                Reader reader = flavor.getReaderForText(tr);
+                                BufferedReader br = new BufferedReader(reader);
+                                if (listener != null) {
+                                    listener.filesDropped(createFileArray(br));
                                 }
+                                // Mark that drop is completed.
+                                evt.getDropTargetContext().dropComplete(true);
+                                log.debug("FileDrop: drop complete.");
+                                handled = true;
+                                break;
                             }
-                            if (!handled) {
-                                log.debug("FileDrop: not a file list or reader - abort.");
-                                evt.rejectDrop();
-                            }
-                            // END 2007-09-12 Nathan Blomquist -- Linux (KDE/Gnome) support added.
-                        }   // end else: not a file list
-                    } catch (java.io.IOException io) {
-                        log.error("FileDrop: IOException - abort:", io);
-                        evt.rejectDrop();
-                    } catch (UnsupportedFlavorException ufe) {
-                        log.error("FileDrop: UnsupportedFlavorException - abort:", ufe);
-                        evt.rejectDrop();
-                    } finally {
-                        // If it's a Swing component, reset its border
-                        if (c instanceof JComponent) {
-                            JComponent jc = (JComponent) c;
-                            jc.setBorder(normalBorder);
-                            log.debug("FileDrop: normal border restored.");
-                        }   // end if: JComponent
-                    }   // end finally
-                }   // end drop
-
-                @Override
-                public void dragExit(DropTargetEvent evt) {
-                    log.debug("FileDrop: dragExit event.");
+                        }
+                        if (!handled) {
+                            log.debug("FileDrop: not a file list or reader - abort.");
+                            evt.rejectDrop();
+                        }
+                    }
+                } catch (java.io.IOException io) {
+                    log.error("FileDrop: IOException - abort:", io);
+                    evt.rejectDrop();
+                } catch (UnsupportedFlavorException ufe) {
+                    log.error("FileDrop: UnsupportedFlavorException - abort:", ufe);
+                    evt.rejectDrop();
+                } finally {
                     // If it's a Swing component, reset its border
                     if (c instanceof JComponent) {
                         JComponent jc = (JComponent) c;
                         jc.setBorder(normalBorder);
                         log.debug("FileDrop: normal border restored.");
-                    }   // end if: JComponent
-                }   // end dragExit
-
-                @Override
-                public void dropActionChanged(DropTargetDragEvent evt) {
-                    log.debug("FileDrop: dropActionChanged event.");
-                    // Is this an acceptable drag event?
-                    if (isDragOk(evt)) {   //evt.acceptDrag( DnDConstants.ACTION_COPY_OR_MOVE );
-                        evt.acceptDrag(DnDConstants.ACTION_COPY);
-                        log.debug("FileDrop: event accepted.");
-                    } // end if: drag ok
-                    else {
-                        evt.rejectDrag();
-                        log.debug("FileDrop: event rejected.");
-                    }   // end else: drag not ok
-                }   // end dropActionChanged
-            }; // end DropTargetListener
-
-            // Make the component (and possibly children) drop targets
-            makeDropTarget(c, recursive);
-        } // end if: supports dnd
-        else {
-            log.debug("FileDrop: Drag and drop is not supported with this JVM");
-        }   // end else: does not support DnD
-    }   // end constructor
-
-    private static boolean supportsDnD() {   // Static Boolean
-        if (supportsDnD == null) {
-            boolean support = false;
-            try {
-                Class.forName("DnDConstants");
-                support = true;
-            } catch (Exception e) {
-                support = false;
+                    }
+                }
             }
-            supportsDnD = support;
-        }   // end if: first time through
-        return supportsDnD;
-    }   // end supportsDnD
 
-    // BEGIN 2007-09-12 Nathan Blomquist -- Linux (KDE/Gnome) support added.
+            @Override
+            public void dragExit(DropTargetEvent evt) {
+                log.debug("FileDrop: dragExit event.");
+                // If it's a Swing component, reset its border
+                if (c instanceof JComponent) {
+                    JComponent jc = (JComponent) c;
+                    jc.setBorder(normalBorder);
+                    log.debug("FileDrop: normal border restored.");
+                }
+            }
+
+            @Override
+            public void dropActionChanged(DropTargetDragEvent evt) {
+                log.debug("FileDrop: dropActionChanged event.");
+                // Is this an acceptable drag event?
+                if (isDragOk(evt)) {   //evt.acceptDrag( DnDConstants.ACTION_COPY_OR_MOVE );
+                    evt.acceptDrag(DnDConstants.ACTION_COPY);
+                    log.debug("FileDrop: event accepted.");
+                } else {
+                    evt.rejectDrag();
+                    log.debug("FileDrop: event rejected.");
+                }
+            }
+        };
+
+        // Make the component (and possibly children) drop targets
+        makeDropTarget(c, recursive);
+    }
+
     private static String ZERO_CHAR_STRING = "" + (char) 0;
 
     private static File[] createFileArray(BufferedReader bReader) {
@@ -431,7 +392,6 @@ public class FileDrop {
         }
         return new File[0];
     }
-    // END 2007-09-12 Nathan Blomquist -- Linux (KDE/Gnome) support added.
 
     private void makeDropTarget(final Component c, boolean recursive) {
         // Make drop target
@@ -469,8 +429,8 @@ public class FileDrop {
             for (Component comp : comps) {
                 makeDropTarget(comp, recursive);
             }
-        }   // end if: recursively set components as listener
-    }   // end dropListener
+        }
+    }
 
     /**
      * Determine if the dragged data is a file list.
@@ -484,16 +444,14 @@ public class FileDrop {
         // See if any of the flavors are a file list
         int i = 0;
         while (!ok && i < flavors.length) {
-            // BEGIN 2007-09-12 Nathan Blomquist -- Linux (KDE/Gnome) support added.
             // Is the flavor a file list?
             final DataFlavor curFlavor = flavors[i];
             if (curFlavor.equals(DataFlavor.javaFileListFlavor)
                     || curFlavor.isRepresentationClassReader()) {
                 ok = true;
             }
-            // END 2007-09-12 Nathan Blomquist -- Linux (KDE/Gnome) support added.
             i++;
-        }   // end while: through flavors
+        }
 
         // If logging is enabled, show data flavors
         if (log.isDebugEnabled()) {
@@ -503,10 +461,10 @@ public class FileDrop {
             for (i = 0; i < flavors.length; i++) {
                 log.debug(flavors[i].toString());
             }
-        }   // end if: logging enabled
+        }
 
         return ok;
-    }   // end isDragOk
+    }
 
     /**
      * Removes the drag-and-drop hooks from the component and optionally from
@@ -521,7 +479,7 @@ public class FileDrop {
      */
     public static boolean remove(Component c) {
         return remove(c, true);
-    }   // end remove
+    }
 
     /**
      * Removes the drag-and-drop hooks from the component and optionally from
@@ -533,23 +491,19 @@ public class FileDrop {
      * @return true if any components were unregistered
      * @since 1.0
      */
-    public static boolean remove(Component c, boolean recursive) {   // Make sure we support
-        if (supportsDnD()) {
-            log.debug("FileDrop: Removing drag-and-drop hooks.");
-            c.setDropTarget(null);
-            if (recursive && (c instanceof Container)) {
-                Component[] comps = ((Container) c).getComponents();
-                for (Component comp : comps) {
-                    remove(comp, recursive);
-                }
-                return true;
-            } else {
-                return false;
+    public static boolean remove(Component c, boolean recursive) {
+        log.debug("FileDrop: Removing drag-and-drop hooks.");
+        c.setDropTarget(null);
+        if (recursive && (c instanceof Container)) {
+            Component[] comps = ((Container) c).getComponents();
+            for (Component comp : comps) {
+                remove(comp, recursive);
             }
+            return true;
         } else {
             return false;
         }
-    }   // end remove
+    }
 
     /* ********  I N N E R   I N T E R F A C E   L I S T E N E R  ******** */
     /**
@@ -561,7 +515,7 @@ public class FileDrop {
      *      public void filesDropped( java.io.File[] files )
      *      {
      *          ...
-     *      }   // end filesDropped
+     *      }
      *      ...
      * </code></pre>
      *
@@ -572,11 +526,11 @@ public class FileDrop {
         /**
          * This method is called when files have been successfully dropped.
          *
-         * @param files An array of <tt>File</tt>s that were dropped.
+         * @param files An array of {@code File}s that were dropped.
          * @since 1.0
          */
         public abstract void filesDropped(java.io.File[] files);
-    }   // end inner-interface Listener
+    }
 
     private final static Logger log = LoggerFactory.getLogger(FileDrop.class);
 }


### PR DESCRIPTION
Remove no longer needed checks for Java 1.0 and 1.1 compatibility and cleanup Javadocs.
Fixes #4846.