### PR TITLE
Fix two entity-resolution problems

### DIFF
--- a/java/src/jmri/util/JmriLocalEntityResolver.java
+++ b/java/src/jmri/util/JmriLocalEntityResolver.java
@@ -51,7 +51,7 @@ public class JmriLocalEntityResolver implements EntityResolver {
                     path = "/xml/schema/xinclude.xsd";
                 }
                 // type 3 - find local file if we can
-                String filename = path.substring(1);  // drop leading slash
+                String filename = path.substring(1).trim();  // drop leading slash
                 log.trace("http finds filename: {}", filename);
                 stream = FileUtil.findInputStream(filename);
                 if (stream != null) {
@@ -116,7 +116,7 @@ public class JmriLocalEntityResolver implements EntityResolver {
                         if (path.lastIndexOf(realSeparator + "DTD" + realSeparator) >= 0) {
                             log.trace("file not exist, DTD in name, insert xml directory");
                             String modifiedPath = realSeparator + "xml"
-                                    + path.substring(path.lastIndexOf(realSeparator + "DTD" + realSeparator), path.length());
+                                    + path.substring(path.lastIndexOf(realSeparator + "DTD" + realSeparator), path.length()).trim();
                             path = modifiedPath;
                         } else {
                             log.trace("file not exist, no DTD, insert xml/DTD directory");

--- a/java/test/jmri/jmrit/XmlFileTest.java
+++ b/java/test/jmri/jmrit/XmlFileTest.java
@@ -45,7 +45,7 @@ public class XmlFileTest extends TestCase {
         final String docTypeInvalid = "<!DOCTYPE layout-config SYSTEM \"layout-config-2-5-4.dtd\">";
 
         final String contentSchemaValid = "<decoderIndex-config xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://jmri.org/xml/schema/decoder.xsd\">";
-        final String contentSchemaInvalid = "<decoderIndex-config xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://jmri.org/xml/schema/layout-2-9-6.xsd \">";
+        final String contentSchemaInvalid = "<decoderIndex-config xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://jmri.org/xml/schema/layout-2-9-6.xsd\">";
         final String contentSchemaAbsent = "<decoderIndex-config>";
         
         final String ending = "<decoderIndex><mfgList nmraListDate=\"\" updated=\"\"><manufacturer mfg=\"\"/></mfgList><familyList><family mfg=\"\" name=\"\" file=\"\"/></familyList></decoderIndex></decoderIndex-config>";


### PR DESCRIPTION
Fix two problems that, together, were causing recent CI problems:
- remove an extraneous space from Schema reference in XmlFIleTest
- Fix local entity resolver so that it gracefully handles extra spaces (when jmri.org is down, so the fallback reference fails)

(This is only visible now because jmri.org is down due to SF.net maintenance)
