### PR TITLE
Update Dispatcher Stopping Flag at Appropriate Time

### DIFF
--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -657,17 +657,17 @@ public class AutoActiveTrain implements ThrottleListener {
                 sm.addPropertyChangeListener(_conSignalMastListener = (PropertyChangeEvent e) -> {
                     if (e.getPropertyName().equals("Aspect")) {
                         // controlling signal has changed appearance
+                        setSpeedBySignal();
                         if (_stoppingForStopSignal && (_targetSpeed > 0.0)) {
                             cancelStopInCurrentSection();
                             _stoppingForStopSignal = false;
                         }
-                        setSpeedBySignal();
                     } else if (e.getPropertyName().equals("Held")) {
+                        setSpeedBySignal();
                         if (!((Boolean) e.getNewValue())) {
                             cancelStopInCurrentSection();
                             _stoppingForStopSignal = false;
                         }
-                        setSpeedBySignal();
                     }
                 });
                 log.debug("{}: new current signalmast {}({}) for section {}", _activeTrain.getTrainName(), sm.getDisplayName(),


### PR DESCRIPTION
After  a signal mast has changed its aspect check whether it is necessary to reset the stopping flag(s).  Resetting before leaves the flags set even though the signal mast indicates stop.
