### PR TITLE
Updates to SPROG bootloader

### DIFF
--- a/help/en/html/hardware/sprog/SPROG.shtml
+++ b/help/en/html/hardware/sprog/SPROG.shtml
@@ -61,24 +61,9 @@
         <li>SPROG II USB</li>
         <li>SPROG 3 (USB)</li>
         <li>SPROG Nano (only as Command Station, using an external Booster)</li>
-        <li>Pi SPROG</li>
+        <li>Pi SPROG One</li>
         <li>Pi SPROG Nano</li>
       </ul>
-
-      <a name="limitations" id="limitations"></a>
-      <h2>Limitations</h2>
-
-      <p class="important">On some earlier SPROG versions the
-      <a href="#update">Firmware Update tool</a> is not completely functional
-      and the firmware update tools in JMRI should NOT be used without first
-      checking the current firmware version (see <a href="#update">
-      below</a>) and contacting <a href="#documentation">SPROG DCC</a>
-      to ascertain if that version can be updated by the user.<br>
-      Under no circumstances should you experiment
-      with the Firmware Update tool if you do not have a valid update file
-      available. Doing so could result in your SPROG becoming
-      non-responsive. It will then need to be returned to the
-      manufacturer (or local representative) for unlocking.</p>
 
       <a name="connecting" id="connecting"></a>
       <h2>Connecting</h2>
@@ -249,14 +234,11 @@
 
       <p>SPROG includes a "Firmware Update" tool that allows the
       SPROG firmware (the internal software that operates the SPROG) to
-      be updated by the user. The tool is only functional in
-      <a href=
-      "../../../package/jmri/jmrix/sprog/update/SprogIIUpdateFrame.shtml">
-      USB SPROG II version 2.2 to 3</a> and the newer <a href=
-      "../../../package/jmri/jmrix/sprog/update/Sprogv4UpdateFrame.shtml">
-      version 4 SPROG</a>.<br>
-      <strong>Warning: see <a href="#limitations">Limitations</a>
-      above.</strong></p>
+      be updated by the user. The  
+      <a href="../../../package/jmri/jmrix/sprog/update/SprogIIUpdateFrame.shtml">
+      update tool</a>.<br> supports USB SPROG II (from version 2.2), SPROG 3 (all versions)
+	  and Pi-SPROG One (from version 2.5). For more information contact the manufacturer
+	  <a href="http://www.sprog-dcc.co.uk/">SPROG DCC</a>
 
       <a name="documentation" id="documentation"></a>
       <h2>Documentation</h2>

--- a/java/src/jmri/jmrix/sprog/SPROGCSMenu.java
+++ b/java/src/jmri/jmrix/sprog/SPROGCSMenu.java
@@ -23,8 +23,10 @@ public class SPROGCSMenu extends JMenu {
         add(new jmri.jmrix.sprog.console.SprogConsoleAction(Bundle.getMessage("SprogConsoleTitle"), _memo));
         add(new javax.swing.JSeparator());
         add(new jmri.jmrix.sprog.update.SprogVersionAction(Bundle.getMessage("GetSprogFirmwareVersion"), _memo));
-        add(new jmri.jmrix.sprog.update.Sprogv4UpdateAction(Bundle.getMessage("SprogXFirmwareUpdate", " v3/v4"), _memo));
-        add(new jmri.jmrix.sprog.update.SprogIIUpdateAction(Bundle.getMessage("SprogXFirmwareUpdate", " II"), _memo));
+        // Removed to avoid confusion with newer SPROG II and 3 that have now reached v3 and v4:
+        //add(new jmri.jmrix.sprog.update.Sprogv4UpdateAction(Bundle.getMessage("SprogXFirmwareUpdate", " v3/v4"), _memo));
+        // Removed as attempting a firmware update in command station mode is not expected to work
+        //add(new jmri.jmrix.sprog.update.SprogIIUpdateAction(Bundle.getMessage("SprogXFirmwareUpdate", " II"), _memo));
     }
 
 }

--- a/java/src/jmri/jmrix/sprog/SPROGMenu.java
+++ b/java/src/jmri/jmrix/sprog/SPROGMenu.java
@@ -26,7 +26,7 @@ public class SPROGMenu extends JMenu {
             add(new jmri.jmrix.sprog.update.SprogVersionAction(Bundle.getMessage("GetSprogFirmwareVersion"), memo));
             // Removed to avoid confusion with newer SPROG II and 3 that have now reached v3 and v4:
             //add(new jmri.jmrix.sprog.update.Sprogv4UpdateAction(Bundle.getMessage("SprogXFirmwareUpdate", " v3/v4"), memo));
-            add(new jmri.jmrix.sprog.update.SprogIIUpdateAction(Bundle.getMessage("SprogXFirmwareUpdate", " II/SPROG 3"), memo));
+            add(new jmri.jmrix.sprog.update.SprogIIUpdateAction(Bundle.getMessage("SprogXFirmwareUpdate"), memo));
         }
     }
 

--- a/java/src/jmri/jmrix/sprog/SprogBundle.properties
+++ b/java/src/jmri/jmrix/sprog/SprogBundle.properties
@@ -3,11 +3,7 @@
 # Default properties for the jmri.jmrix.sprog classes
 
 GetSprogFirmwareVersion = Get SPROG Firmware Version
-SprogXFirmwareUpdate = SPROG{0} Firmware Update
-#Sprog4FirmwareUpdate = SPROG v3/v4 Firmware Update
-#Sprog3FirmwareUpdate = SPROG II/SPROG 3 Firmware Update
-#Sprog2FirmwareUpdate = SPROG II Firmware Update
-#SprogFirmwareUpdate = SPROG Firmware Update
+SprogXFirmwareUpdate = SPROGII/SPROG 3/Pi-SPROG Firmware Update
 SprogConsoleTitle = SPROG Console
 SprogProgrammerTitle = SPROG Programmer
 SprogSimulatorTitle = SPROG Sim

--- a/java/src/jmri/jmrix/sprog/SprogBundle_nl.properties
+++ b/java/src/jmri/jmrix/sprog/SprogBundle_nl.properties
@@ -4,10 +4,7 @@
 # Translation Egbert Broerse 2017
 
 GetSprogFirmwareVersion=Lees SPROG firmware versie uit
-#Sprog4FirmwareUpdate=SPROG v3/v4 firmware bijwerken
-#Sprog3FirmwareUpdate=SPROG II/SPROG 3 firmware bijwerken
-#Sprog2FirmwareUpdate=SPROG II firmware bijwerken
-SprogXFirmwareUpdate=SPROG{0} firmware bijwerken
+SprogXFirmwareUpdate=SPROG II/SPROG 3/Pi-SPROG firmware bijwerken
 SprogConsoleTitle = SPROG Console
 SprogProgrammerTitle = SPROG Programmeerunit
 SprogSimulatorTitle = SPROG Sim

--- a/java/src/jmri/jmrix/sprog/SprogMessage.java
+++ b/java/src/jmri/jmrix/sprog/SprogMessage.java
@@ -125,7 +125,9 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         _dataChars[1] = i;
     }
 
-    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    /**
+     * @deprecated 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+     */
     @Deprecated
     private void setV4Length(int i) {
         _dataChars[0] = hexDigit((i & 0xf0) >> 4);
@@ -138,7 +140,9 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         _dataChars[4] = i >> 16;
     }
 
-    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    /**
+     * @deprecated 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+     */
     @Deprecated
     private void setV4Address(int i) {
         _dataChars[2] = hexDigit((i & 0xf000) >> 12);
@@ -147,7 +151,9 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         _dataChars[5] = hexDigit(i & 0xf);
     }
 
-    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    /**
+     * @deprecated 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+     */
     @Deprecated
     private void setV4RecType(int i) {
         _dataChars[6] = hexDigit((i & 0xf0) >> 4);
@@ -160,7 +166,9 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         }
     }
 
-    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    /**
+     * @deprecated 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+     */
     @Deprecated
     private void setV4Data(int[] d) {
         int j = 8;
@@ -182,7 +190,9 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         _dataChars[_nDataChars - 1] = checksum;
     }
 
-    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    /**
+     * @deprecated 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+     */
     @Deprecated
     private void setV4Checksum(int length, int addr, int type, int[] data) {
         int checksum = length + ((addr & 0xff00) >> 8) + (addr & 0xff) + type;
@@ -226,7 +236,9 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         return f;
     }
 
-    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    /**
+     * @deprecated 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+     */
     @Deprecated
     private SprogMessage v4frame() {
         int i = 0;
@@ -322,8 +334,9 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         return m;
     }
 
-    // [AC] 23/01/17 This was never actually required by a SPROG. Was copied
-    // from some other interface type. No longer used by SprogProgrammer
+    /**
+     * @deprecated 4.11.2 as bootloading old sprogs is no longer supported in JMRI
+     */
     @Deprecated
     static public SprogMessage getProgMode() {
         SprogMessage m = new SprogMessage(1);
@@ -331,10 +344,9 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         return m;
     }
 
-    // [AC] 11/09/2002 Leave SPROG in programmer mode. Don't want to go
-    // to booster mode as this would power up the track.
-    // [AC] 23/01/17 This was never actually required by a SPROG. Was copied
-    // from some other interface type. No longer used by SprogProgrammer
+    /**
+     * @deprecated 4.11.2 as bootloading old sprogs is no longer supported in JMRI
+     */
     @Deprecated
     static public SprogMessage getExitProgMode() {
         SprogMessage m = new SprogMessage(1);
@@ -457,7 +469,9 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         return m.frame();
     }
 
-    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    /**
+     * @deprecated 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+     */
     @Deprecated
     static public SprogMessage getV4WriteFlash(int addr, int[] data, int type) {
         // Create a v4 bootloader message which is same format as a record
@@ -472,7 +486,9 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         return m.v4frame();
     }
 
-    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    /**
+     * @deprecated 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+     */
     @Deprecated
     static public SprogMessage getV4EndOfFile() {
         // Create a v4 bootloader end of file message
@@ -485,7 +501,9 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         return m.v4frame();
     }
 
-    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    /**
+     * @deprecated 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+     */
     @Deprecated
     static public SprogMessage getv4ExtAddr() {
         // Create a v4 bootloader extended address message

--- a/java/src/jmri/jmrix/sprog/SprogMessage.java
+++ b/java/src/jmri/jmrix/sprog/SprogMessage.java
@@ -69,9 +69,10 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
      */
     public SprogMessage(byte[] packet) {
         this(1 + (packet.length * 3));
-        int i = 0; // counter of byte in output message
-        int j = 0; // counter of byte in input packet
+        int i; // counter of byte in output message
+        int j; // counter of byte in input packet
 
+        i = 0;
         this.setElement(i++, 'O');  // "O " starts output packet
 
         // add each byte of the input message
@@ -124,6 +125,8 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         _dataChars[1] = i;
     }
 
+    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    @Deprecated
     private void setV4Length(int i) {
         _dataChars[0] = hexDigit((i & 0xf0) >> 4);
         _dataChars[1] = hexDigit(i & 0xf);
@@ -135,6 +138,8 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         _dataChars[4] = i >> 16;
     }
 
+    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    @Deprecated
     private void setV4Address(int i) {
         _dataChars[2] = hexDigit((i & 0xf000) >> 12);
         _dataChars[3] = hexDigit((i & 0xf00) >> 8);
@@ -142,6 +147,8 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         _dataChars[5] = hexDigit(i & 0xf);
     }
 
+    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    @Deprecated
     private void setV4RecType(int i) {
         _dataChars[6] = hexDigit((i & 0xf0) >> 4);
         _dataChars[7] = hexDigit(i & 0xf);
@@ -153,6 +160,8 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         }
     }
 
+    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    @Deprecated
     private void setV4Data(int[] d) {
         int j = 8;
         for (int i = 0; i < d.length; i++) {
@@ -173,6 +182,8 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         _dataChars[_nDataChars - 1] = checksum;
     }
 
+    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    @Deprecated
     private void setV4Checksum(int length, int addr, int type, int[] data) {
         int checksum = length + ((addr & 0xff00) >> 8) + (addr & 0xff) + type;
         for (int i = 0; i < data.length; i++) {
@@ -215,6 +226,8 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         return f;
     }
 
+    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    @Deprecated
     private SprogMessage v4frame() {
         int i = 0;
         // Create new message to hold the framed one
@@ -369,25 +382,12 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
 
     // [AC] 11/09/2002 SPROG doesn't currently support registered mode
     static public SprogMessage getReadRegister(int reg) { //Vx
-//        if (reg>8) log.error("register number too large: "+reg);
-//        SprogMessage m = new SprogMessage(2);
-//        m.setOpCode('V');
-//        String s = ""+reg;
-//        m.setElement(1, s.charAt(s.length()-1));
-//        return m;
         SprogMessage m = new SprogMessage(1);
         m.setOpCode(' ');
         return m;
     }
 
     static public SprogMessage getWriteRegister(int reg, int val) { //Sx xx
-//        if (reg>8) log.error("register number too large: "+reg);
-//        SprogMessage m = new SprogMessage(4);
-//        m.setOpCode('S');
-//        String s = ""+reg;
-//        m.setElement(1, s.charAt(s.length()-1));
-//        addIntAsTwoHex(val, m, 2);
-//        return m;
         SprogMessage m = new SprogMessage(1);
         m.setOpCode(' ');
         return m;
@@ -457,6 +457,8 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         return m.frame();
     }
 
+    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    @Deprecated
     static public SprogMessage getV4WriteFlash(int addr, int[] data, int type) {
         // Create a v4 bootloader message which is same format as a record
         // in the hex file
@@ -470,6 +472,8 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         return m.v4frame();
     }
 
+    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    @Deprecated
     static public SprogMessage getV4EndOfFile() {
         // Create a v4 bootloader end of file message
         int l = 10;
@@ -481,6 +485,8 @@ public class SprogMessage extends jmri.jmrix.AbstractMRMessage {
         return m.v4frame();
     }
 
+    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    @Deprecated
     static public SprogMessage getv4ExtAddr() {
         // Create a v4 bootloader extended address message
         int l = 14;

--- a/java/src/jmri/jmrix/sprog/SprogReply.java
+++ b/java/src/jmri/jmrix/sprog/SprogReply.java
@@ -282,7 +282,12 @@ public class SprogReply extends AbstractMRReply {
         }
     }
 
-    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    /**
+     * @param sprogState the current SPROG state
+     * 
+     * @return true if end of bootloader reply is found
+     * @deprecated 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+     */
     @Deprecated
     public boolean endBootloaderReply(SprogState sprogState) {
         // Detect that the reply buffer ends with "L>" or "." from a SPROG v4

--- a/java/src/jmri/jmrix/sprog/SprogReply.java
+++ b/java/src/jmri/jmrix/sprog/SprogReply.java
@@ -77,20 +77,26 @@ public class SprogReply extends AbstractMRReply {
 
     /**
      * Is this reply indicating that an overload condition was detected?
+     * 
+     * @return boolean true for overload
      */
     public boolean isOverload() {
-        return (this.toString().indexOf("!O") >= 0);
+        return (this.toString().contains("!O"));
     }
 
     /**
      * Is this reply indicating that a general error has occurred?
+     *
+     * @return boolean true for error message
      */
     public boolean isError() {
-        return (this.toString().indexOf("!E") >= 0);
+        return (this.toString().contains("!E"));
     }
 
     /**
      * Check and strip framing characters and DLE from a SPROG bootloader reply.
+     * 
+     * @return boolean result of message validation
      */
     public boolean strip() {
         char tmp[] = new char[_nDataChars];
@@ -127,6 +133,8 @@ public class SprogReply extends AbstractMRReply {
      * Check and strip checksum from a SPROG bootloader reply.
      * <p>
      * Assumes framing and DLE chars have been stripped
+     * 
+     * @return boolean result of checksum validation
      */
     public boolean getChecksum() {
         int checksum = 0;
@@ -139,6 +147,8 @@ public class SprogReply extends AbstractMRReply {
 
     /**
      * Return a string representation of this SprogReply.
+     * 
+     * @return String The string representation
      */
     @Override
     public String toString() {
@@ -180,8 +190,8 @@ public class SprogReply extends AbstractMRReply {
         String s2 = "" + (char) getElement(index + 1);
         int val = -1;
         try {
-            int sum = Integer.valueOf(s2, 16).intValue();
-            sum += 16 * Integer.valueOf(s1, 16).intValue();
+            int sum = Integer.valueOf(s2, 16);
+            sum += 16 * Integer.valueOf(s1, 16);
             val = sum;  // don't do this assign until now in case the conversion throws
         } catch (NumberFormatException e) {
             log.error("Unable to get number from reply: \"{}{}\" index: {} message: \"{}\"", s1, s2, index, toString());
@@ -215,9 +225,8 @@ public class SprogReply extends AbstractMRReply {
 
     /**
      * Normal SPROG replies will end with the prompt for the next command.
-     * Bootloader will end with ETX with no preceding DLE.
-     * SPROG v4 bootloader replies "L{@literal >}" on entry and replies "." at other
-     * times.
+     * 
+     * @return true if end of normal reply is found
      */
     public boolean endNormalReply() {
         // Detect that the reply buffer ends with "P> " or "R> " (note ending space)
@@ -248,6 +257,11 @@ public class SprogReply extends AbstractMRReply {
         }
     }
 
+    /**
+     * Bootloader will end with ETX with no preceding DLE.
+     * 
+     * @return true if end of bootloader reply is found
+     */
     public boolean endBootReply() {
         // Detect that the reply buffer ends with ETX with no preceding DLE.
         // This is the end of a SPROG II bootloader reply or the end of
@@ -268,6 +282,8 @@ public class SprogReply extends AbstractMRReply {
         }
     }
 
+    // deprecated since 4.11.4 as bootloading old sprogs is no longer supported in JMRI
+    @Deprecated
     public boolean endBootloaderReply(SprogState sprogState) {
         // Detect that the reply buffer ends with "L>" or "." from a SPROG v4
         // bootloader
@@ -282,10 +298,7 @@ public class SprogReply extends AbstractMRReply {
             if (this.getElement(ptr) != '>') {
                 return false;
             }
-            if (this.getElement(ptr - 1) != 'L') {
-                return false;
-            }
-            return true;
+            return this.getElement(ptr - 1) == 'L';
         } else {
             return false;
         }

--- a/java/src/jmri/jmrix/sprog/update/SprogIIUpdateFrame.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogIIUpdateFrame.java
@@ -41,6 +41,7 @@ public class SprogIIUpdateFrame
 
     /** 
      * {@inheritDoc}
+     * @param v SPROG version to be decoded
      */
     @SuppressFBWarnings(value = "SWL_SLEEP_WITH_LOCK_HELD")
     @Override
@@ -124,7 +125,6 @@ public class SprogIIUpdateFrame
                 if (blockLen != SprogType.getBlockLen(bootVer)) {
                     log.error("Bootloader version does not match SPROG type");
                     bootState = BootState.IDLE;
-                    return;
                 }
             } else {
                 // Don't yet have correct SPROG version
@@ -145,7 +145,6 @@ public class SprogIIUpdateFrame
             JOptionPane.showMessageDialog(this, Bundle.getMessage("StatusUnableToConnectBootloader"),
                     Bundle.getMessage("SprogXFirmwareUpdate", " II"), JOptionPane.ERROR_MESSAGE);
             statusBar.setText(Bundle.getMessage("StatusUnableToConnectBootloader"));
-            return;
         }
     }
 
@@ -172,7 +171,6 @@ public class SprogIIUpdateFrame
             statusBar.setText(Bundle.getMessage("StatusBadReplyWriteRequest"));
             bootState = BootState.IDLE;
             tc.setSprogState(SprogState.NORMAL);
-            return;
         }
     }
 
@@ -212,7 +210,6 @@ public class SprogIIUpdateFrame
             log.error("Bad reply to erase request");
             bootState = BootState.IDLE;
             tc.setSprogState(SprogState.NORMAL);
-            return;
         }
     }
 
@@ -238,7 +235,6 @@ public class SprogIIUpdateFrame
             log.error("Bad reply to SPROG Mode request");
             bootState = BootState.IDLE;
             tc.setSprogState(SprogState.NORMAL);
-            return;
         }
     }
 

--- a/java/src/jmri/jmrix/sprog/update/SprogType.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogType.java
@@ -50,10 +50,7 @@ public class SprogType {
      * @return true if this object holds a SPROG type
      */
     public boolean isSprog() {
-        if (sprogType < SPROGV4) {
-            return false;
-        }
-        return true;
+        return sprogType >= SPROGV4;
     }
 
     /**
@@ -62,10 +59,7 @@ public class SprogType {
      * @return true if this object holds a SPROG II type
      */
     public boolean isSprogII() {
-        if ((sprogType >= SPROGII) && (sprogType <= SPROGIIv4)) {
-            return true;
-        }
-        return false;
+        return (sprogType >= SPROGII) && (sprogType <= SPROGIIv4);
     }
 
     /**
@@ -176,7 +170,7 @@ public class SprogType {
                 break;
                 
             case PISPROGONE:
-                if ((addr >= 0x1000) && (addr < 0x3F00)) {
+                if ((addr >= 0x1000) && (addr < 0x3E00)) {
                     return true;
                 }
                 break;
@@ -225,7 +219,8 @@ public class SprogType {
     }
 
     /**
-     *
+     * @param t Numeric SPROG type
+     * 
      * @return String representation of a SPROG type
      */
     public String toString(int t) {

--- a/java/src/jmri/jmrix/sprog/update/SprogUpdateFrame.java
+++ b/java/src/jmri/jmrix/sprog/update/SprogUpdateFrame.java
@@ -152,25 +152,16 @@ abstract public class SprogUpdateFrame
 
         getContentPane().add(paneA);
 
-        openFileChooserButton.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                openFileChooserButtonActionPerformed(e);
-            }
+        openFileChooserButton.addActionListener((java.awt.event.ActionEvent e) -> {
+            openFileChooserButtonActionPerformed(e);
         });
 
-        programButton.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                programButtonActionPerformed(e);
-            }
+        programButton.addActionListener((java.awt.event.ActionEvent e) -> {
+            programButtonActionPerformed(e);
         });
 
-        setSprogModeButton.addActionListener(new java.awt.event.ActionListener() {
-            @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                setSprogModeButtonActionPerformed(e);
-            }
+        setSprogModeButton.addActionListener((java.awt.event.ActionEvent e) -> {
+            setSprogModeButtonActionPerformed(e);
         });
 
         // connect to data source
@@ -288,7 +279,7 @@ abstract public class SprogUpdateFrame
             if (log.isDebugEnabled()) {
                 log.debug("hex file chosen: " + hexFile.getName());
             }
-            if ((hexFile.getName().indexOf("sprog") < 0)) {
+            if ((!hexFile.getName().contains("sprog"))) {
                 JOptionPane.showMessageDialog(this, Bundle.getMessage("HexFileSelectDialogString"),
                         Bundle.getMessage("HexFileSelectTitle"), JOptionPane.ERROR_MESSAGE);
                 hexFile = null;
@@ -386,14 +377,13 @@ abstract public class SprogUpdateFrame
 
     /**
      * Internal routine to handle timer starts {@literal &} restarts.
+     * 
+     * @param delay
      */
     synchronized protected void restartTimer(int delay) {
         if (timer == null) {
-            timer = new javax.swing.Timer(delay, new java.awt.event.ActionListener() {
-                @Override
-                public void actionPerformed(java.awt.event.ActionEvent e) {
-                    timeout();
-                }
+            timer = new javax.swing.Timer(delay, (java.awt.event.ActionEvent e) -> {
+                timeout();
             });
         }
         timer.stop();


### PR DESCRIPTION
Removed bootloader completely from command station as it is not expected to work. Deprecated code for old SPROG bootloader no longer supported. Tidy up following Netbeans code hints.