### PR TITLE
Add Fast Clock to WiThrottle Protocol

### DIFF
--- a/java/src/jmri/jmrit/withrottle/DeviceServer.java
+++ b/java/src/jmri/jmrit/withrottle/DeviceServer.java
@@ -52,6 +52,12 @@ package jmri.jmrit.withrottle;
  * turnouts Format:
  * PTL]\[SysName}|{UsrName}|{CurrentState]\[SysName}|{UsrName}|{CurrentState
  * States: 1 - UNKNOWN, 2 - CLOSED, 4 - THROWN
+ * 
+ * Send time or time&rate:
+ * 'PFT' + UTCAdjustedTimeSeconds
+ *     -OR-
+ * 'PFT' + UTCAdjustedTimeSeconds + "<;>" + RateMultipier
+ * Set rate to 0.0 for stop, float value to run.
  *
  * Web server port: 'PW' + {port#}
  *
@@ -124,6 +130,8 @@ public class DeviceServer implements Runnable, ThrottleControllerListener, Contr
     final boolean isRouteAllowed = InstanceManager.getDefault(WiThrottlePreferences.class).isAllowRoute();
     private ConsistController consistC = null;
     private boolean isConsistAllowed;
+    private FastClockController fastClockC = null;
+    final boolean isClockDisplayed = InstanceManager.getDefault(WiThrottlePreferences.class).isDisplayFastClock();
 
     private DeviceManager manager;
 
@@ -413,6 +421,9 @@ public class DeviceServer implements Runnable, ThrottleControllerListener, Contr
         if (consistC != null) {
             consistC.removeControllerListener(this);
         }
+        if (fastClockC != null) {
+            fastClockC.removeControllerListener(this);
+        }
 
         closeSocket();
         for (int i = 0; i < listeners.size(); i++) {
@@ -538,7 +549,16 @@ public class DeviceServer implements Runnable, ThrottleControllerListener, Contr
 
             consistC.sendAllConsistData();
         }
-
+        if (isClockDisplayed) {
+            fastClockC = InstanceManager.getDefault(WiThrottleManager.class).getFastClockController();
+            if (fastClockC.verifyCreation()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Fast Clock Controller valid.");
+                }
+                fastClockC.addControllerListener(this);
+                fastClockC.sendFastRate();
+            }
+        }
     }
 
     public String getUDID() {

--- a/java/src/jmri/jmrit/withrottle/FastClockController.java
+++ b/java/src/jmri/jmrit/withrottle/FastClockController.java
@@ -1,0 +1,139 @@
+
+package jmri.jmrit.withrottle;
+
+import java.beans.PropertyChangeListener;
+import java.util.TimeZone;
+import jmri.InstanceManager;
+import jmri.Timebase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Fast Clock interface for Wi-Fi throttles.
+ * <P>
+ * Fast Clock display on devices will be synchronized with hardware or software
+ * clock. Time is UTC seconds on Wi-Fi devices, Local milliseconds in JMRI.
+ * <P>
+ * @author Brett Hoffman Copyright (C) 2018
+ */
+public class FastClockController extends AbstractController {
+
+    private final Timebase fastClock;
+    //  To correct for local time
+    private final int timeZoneOffset;
+    private final PropertyChangeListener minuteListener;
+    private final PropertyChangeListener rateListener;
+    
+    //  Number of real minutes between re-sync of time
+    private static final short UPDATE_MINUTES = 5;
+    //  Essentially, rate times minutes desired between re-sync
+    private static short updateMinsSetpoint;
+    private short updateMinuteCount = 0;
+
+    public FastClockController() {
+        
+        fastClock = InstanceManager.getDefault(jmri.Timebase.class);
+        timeZoneOffset = TimeZone.getDefault().getOffset(System.currentTimeMillis());
+        minuteListener = new PropertyChangeListener() {
+            @Override
+            public void propertyChange(java.beans.PropertyChangeEvent e) {
+                sendFastTime();
+            }
+        };
+        rateListener = new PropertyChangeListener() {
+            @Override
+            public void propertyChange(java.beans.PropertyChangeEvent e) {
+                setReSyncSetpoint();
+                sendFastRate();
+            }
+        };
+        
+        if (fastClock == null) {
+            log.info("No fast clock manager instance.");
+            isValid = false;
+            return;
+        } else {
+            isValid = true;
+        }
+        updateMinsSetpoint = (short)(fastClock.userGetRate() * UPDATE_MINUTES);
+        setReSyncSetpoint();
+        // request callback to update time
+        fastClock.addMinuteChangeListener(minuteListener);
+        fastClock.addPropertyChangeListener(rateListener);
+    }
+    
+    @Override
+    boolean verifyCreation() {
+        return isValid;
+    }
+
+    @Override
+    void handleMessage(String message) {
+        throw new UnsupportedOperationException("Not used.");
+    }
+
+    @Override
+    void register() {
+        throw new UnsupportedOperationException("Not used.");
+    }
+
+    @Override
+    void deregister() {
+        // cancel callback to update time
+        fastClock.removeMinuteChangeListener(minuteListener);
+        fastClock.removePropertyChangeListener(rateListener);
+    }
+    
+    
+    /**
+     * Fast clock should not have a time zone.
+     * <P>
+     * Remove the offset to give straight UTC value.
+     * @return Time with offset removed
+     */
+    private long getAdjustedTime() {
+        return ((fastClock.getTime().getTime() + timeZoneOffset) / 1000);
+    }
+    
+    /**
+     * Send just time.
+     * <P>
+     * Use to synchronize time on Wi-Fi devices to nearest second. Send no rate.
+     */
+    public void sendFastTime() {
+        updateMinuteCount++;
+        if (updateMinuteCount >= updateMinsSetpoint) {
+            for (ControllerInterface listener : listeners) {
+                listener.sendPacketToDevice("PFT" + getAdjustedTime());
+            }
+            updateMinuteCount = 0;
+        }
+    }
+    
+    /**
+     * Send Time and Rate.
+     * <P>
+     * Time on device will update to the value that is sent and rate will allow 
+     * Fast Clock to keep its own time. A rate == 0 will tell the device to 
+     * stop the clock.
+     */
+    public void sendFastRate() {
+        //  Send the time and run rate whether running or not
+        for (ControllerInterface listener : listeners) {
+            listener.sendPacketToDevice("PFT" + getAdjustedTime() + "<;>" + fastClock.userGetRate());
+        }
+        if (fastClock.getRun() == false) {
+            //  Not running, send rate of 0
+            //  This will stop a running clock without changing stored rate
+            for (ControllerInterface listener : listeners) {
+                listener.sendPacketToDevice("PFT" + getAdjustedTime() + "<;>" + 0.0);
+            }
+        }
+    }
+    
+    private void setReSyncSetpoint() {
+        updateMinsSetpoint = (short)(fastClock.userGetRate() * UPDATE_MINUTES);
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(FastClockController.class);
+}

--- a/java/src/jmri/jmrit/withrottle/WiThrottleBundle.properties
+++ b/java/src/jmri/jmrit/withrottle/WiThrottleBundle.properties
@@ -49,6 +49,9 @@ ToolTipTurnout = Allow Wi-Fi devices to control turnouts
 LabelRoute = Routes
 ToolTipRoute = Allow Wi-Fi devices to control routes
 
+LabelFastClockDisplayed = Display Fast Clock
+ToolTipFastClockDisplayed = Send Fast Clock time to Wi-Fi devices
+
 LabelConsist = Consists
 LabelWiFiConsist = NMRA Format
 LabelDCCConsist = DCC Brand-Specific

--- a/java/src/jmri/jmrit/withrottle/WiThrottleManager.java
+++ b/java/src/jmri/jmrit/withrottle/WiThrottleManager.java
@@ -12,6 +12,7 @@ public class WiThrottleManager implements InstanceManagerAutoDefault {
     private TurnoutController turnoutController = null;
     private RouteController routeController = null;
     private ConsistController consistController = null;
+    private FastClockController fastClockController = null;
 
     public WiThrottleManager() {
     }
@@ -42,6 +43,13 @@ public class WiThrottleManager implements InstanceManagerAutoDefault {
             consistController = new ConsistController();
         }
         return consistController;
+    }
+    
+    public FastClockController getFastClockController() {
+        if (fastClockController == null) {
+            fastClockController = new FastClockController();
+        }
+        return fastClockController;
     }
 
     /**

--- a/java/src/jmri/jmrit/withrottle/WiThrottlePreferences.java
+++ b/java/src/jmri/jmrit/withrottle/WiThrottlePreferences.java
@@ -34,6 +34,7 @@ public class WiThrottlePreferences extends AbstractWiThrottlePreferences {
     private boolean allowRoute = true;
     private boolean allowConsist = true;
     private boolean useWiFiConsist = true;
+    private boolean displayFastClock = true;
 
     // track as loaded / as saved state
     private boolean asLoadedUseEStop = true;
@@ -48,6 +49,7 @@ public class WiThrottlePreferences extends AbstractWiThrottlePreferences {
     private boolean asLoadedAllowRoute = true;
     private boolean asLoadedAllowConsist = true;
     private boolean asLoadedUseWiFiConsist = true;
+    private boolean asLoadedDisplayFastClock = true;
 
     public WiThrottlePreferences(String fileName) {
         super.openFile(fileName);
@@ -104,36 +106,24 @@ public class WiThrottlePreferences extends AbstractWiThrottlePreferences {
             setUseWiFiConsist(a.getValue().equalsIgnoreCase("true"));
             this.asLoadedUseWiFiConsist = this.isUseWiFiConsist();
         }
+        if ((a = child.getAttribute("isDisplayFastClock")) != null) {
+            setDisplayFastClock(a.getValue().equalsIgnoreCase("true"));
+            this.asLoadedDisplayFastClock = this.isDisplayFastClock();
+        }
 
     }
 
     public boolean compareValuesDifferent(WiThrottlePreferences prefs) {
-        if (isAllowTrackPower() != prefs.isAllowTrackPower()) {
-            return true;
-        }
-        if (isAllowTurnout() != prefs.isAllowTurnout()) {
-            return true;
-        }
-        if (isAllowRoute() != prefs.isAllowRoute()) {
-            return true;
-        }
-        if (isAllowConsist() != prefs.isAllowConsist()) {
-            return true;
-        }
-        if (isUseWiFiConsist() != prefs.isUseWiFiConsist()) {
-            return true;
-        }
-
-        if (isUseEStop() != prefs.isUseEStop()) {
-            return true;
-        }
-        if (getEStopDelay() != prefs.getEStopDelay()) {
-            return true;
-        }
-        if (isUseMomF2() != prefs.isUseMomF2()) {
-            return true;
-        }
-        return getPort() != prefs.getPort();
+                return prefs.isUseEStop() != this.isUseEStop()
+                || prefs.getEStopDelay() != this.getEStopDelay()
+                || prefs.isUseMomF2() != this.isUseMomF2()
+                || prefs.getPort() != this.getPort()
+                || prefs.isAllowTrackPower() != this.isAllowTrackPower()
+                || prefs.isAllowTurnout() != this.isAllowTurnout()
+                || prefs.isAllowRoute() != this.isAllowRoute()
+                || prefs.isAllowConsist() != this.isAllowConsist()
+                || prefs.isUseWiFiConsist() != this.isUseWiFiConsist()
+                || prefs.isDisplayFastClock() != this.isDisplayFastClock();
     }
 
     public void apply(WiThrottlePreferences prefs) {
@@ -146,6 +136,7 @@ public class WiThrottlePreferences extends AbstractWiThrottlePreferences {
         setAllowRoute(prefs.isAllowRoute());
         setAllowConsist(prefs.isAllowConsist());
         setUseWiFiConsist(prefs.isUseWiFiConsist());
+        setDisplayFastClock(prefs.isDisplayFastClock());
     }
 
     @Override
@@ -172,6 +163,8 @@ public class WiThrottlePreferences extends AbstractWiThrottlePreferences {
         this.asLoadedAllowConsist = this.isAllowConsist();
         element.setAttribute("isUseWiFiConsist", "" + isUseWiFiConsist());
         this.asLoadedUseWiFiConsist = this.isUseWiFiConsist();
+        element.setAttribute("isDisplayFastClock", "" + isDisplayFastClock());
+        this.asLoadedDisplayFastClock = this.isDisplayFastClock();
         return element;
     }
 
@@ -185,7 +178,8 @@ public class WiThrottlePreferences extends AbstractWiThrottlePreferences {
                 || this.asLoadedAllowTurnout != this.isAllowTurnout()
                 || this.asLoadedAllowRoute != this.isAllowRoute()
                 || this.asLoadedAllowConsist != this.isAllowConsist()
-                || this.asLoadedUseWiFiConsist != this.isUseWiFiConsist();
+                || this.asLoadedUseWiFiConsist != this.isUseWiFiConsist()
+                || this.asLoadedDisplayFastClock != this.isDisplayFastClock();
     }
 
     public boolean isRestartRequired() {
@@ -262,6 +256,14 @@ public class WiThrottlePreferences extends AbstractWiThrottlePreferences {
 
     public void setUseWiFiConsist(boolean value) {
         useWiFiConsist = value;
+    }
+    
+    public boolean isDisplayFastClock() {
+        return displayFastClock;
+    }
+
+    public void setDisplayFastClock(boolean value) {
+        displayFastClock = value;
     }
 
     private final static Logger log = LoggerFactory.getLogger(WiThrottlePreferences.class);

--- a/java/src/jmri/jmrit/withrottle/WiThrottlePrefsPanel.java
+++ b/java/src/jmri/jmrit/withrottle/WiThrottlePrefsPanel.java
@@ -2,6 +2,9 @@ package jmri.jmrit.withrottle;
 
 import apps.PerformActionModel;
 import apps.StartupActionsManager;
+import java.awt.FlowLayout;
+import java.awt.GridLayout;
+import java.awt.Insets;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.beans.PropertyChangeEvent;
@@ -42,6 +45,7 @@ public class WiThrottlePrefsPanel extends JPanel implements PreferencesPanel {
     JCheckBox routeCB;
     JCheckBox consistCB;
     JCheckBox startupCB;
+    JCheckBox fastClockDisplayCB;
     ItemListener startupItemListener;
     int startupActionPosition = -1;
     JRadioButton wifiRB;
@@ -80,6 +84,7 @@ public class WiThrottlePrefsPanel extends JPanel implements PreferencesPanel {
         powerCB.setSelected(localPrefs.isAllowTrackPower());
         turnoutCB.setSelected(localPrefs.isAllowTurnout());
         routeCB.setSelected(localPrefs.isAllowRoute());
+        fastClockDisplayCB.setSelected(localPrefs.isDisplayFastClock());
         consistCB.setSelected(localPrefs.isAllowConsist());
         InstanceManager.getDefault(StartupActionsManager.class).addPropertyChangeListener((PropertyChangeEvent evt) -> {
             startupCB.setSelected(isStartUpAction());
@@ -120,6 +125,7 @@ public class WiThrottlePrefsPanel extends JPanel implements PreferencesPanel {
         localPrefs.setAllowTrackPower(powerCB.isSelected());
         localPrefs.setAllowTurnout(turnoutCB.isSelected());
         localPrefs.setAllowRoute(routeCB.isSelected());
+        localPrefs.setDisplayFastClock(fastClockDisplayCB.isSelected());
         localPrefs.setAllowConsist(consistCB.isSelected());
         localPrefs.setUseWiFiConsist(wifiRB.isSelected());
 
@@ -189,22 +195,19 @@ public class WiThrottlePrefsPanel extends JPanel implements PreferencesPanel {
 
         powerCB = new JCheckBox(Bundle.getMessage("LabelTrackPower"));
         powerCB.setToolTipText(Bundle.getMessage("ToolTipTrackPower"));
-        panel.add(powerCB);
 
         turnoutCB = new JCheckBox(Bundle.getMessage("Turnouts"));
         turnoutCB.setToolTipText(Bundle.getMessage("ToolTipTurnout"));
-        panel.add(turnoutCB);
 
         routeCB = new JCheckBox(Bundle.getMessage("LabelRoute"));
         routeCB.setToolTipText(Bundle.getMessage("ToolTipRoute"));
-        panel.add(routeCB);
+
+        fastClockDisplayCB = new JCheckBox(Bundle.getMessage("LabelFastClockDisplayed"));
+        fastClockDisplayCB.setToolTipText(Bundle.getMessage("ToolTipFastClockDisplayed"));
 
         consistCB = new JCheckBox(Bundle.getMessage("LabelConsist"));
         consistCB.setToolTipText(Bundle.getMessage("ToolTipConsist"));
-        panel.add(consistCB);
-
-        JPanel conPanel = new JPanel();
-        conPanel.setLayout(new BoxLayout(conPanel, BoxLayout.Y_AXIS));
+        
         wifiRB = new JRadioButton(Bundle.getMessage("LabelWiFiConsist"));
         wifiRB.setToolTipText(Bundle.getMessage("ToolTipWiFiConsist"));
         dccRB = new JRadioButton(Bundle.getMessage("LabelDCCConsist"));
@@ -213,8 +216,24 @@ public class WiThrottlePrefsPanel extends JPanel implements PreferencesPanel {
         ButtonGroup group = new ButtonGroup();
         group.add(wifiRB);
         group.add(dccRB);
+        
+        JPanel gridPanel = new JPanel(new GridLayout(0, 2));
+        JPanel conPanel = new JPanel();
+        
+        gridPanel.add(powerCB);
+        gridPanel.add(fastClockDisplayCB);
+        gridPanel.add(turnoutCB);
+        gridPanel.add(routeCB);
+        
+        conPanel.setLayout(new BoxLayout(conPanel, BoxLayout.Y_AXIS));
+        wifiRB.setMargin(new Insets(0, 20, 0, 0));
+        dccRB.setMargin(new Insets(0, 20, 0, 0));
+        conPanel.add(consistCB);
         conPanel.add(wifiRB);
         conPanel.add(dccRB);
+        
+        panel.setLayout(new FlowLayout(FlowLayout.CENTER, 40, 0));
+        panel.add(gridPanel);
         panel.add(conPanel);
 
         return panel;
@@ -234,7 +253,7 @@ public class WiThrottlePrefsPanel extends JPanel implements PreferencesPanel {
 
     @Override
     public String getTabbedPreferencesTitle() {
-        return null;
+        return getPreferencesItemText();
     }
 
     @Override
@@ -282,11 +301,5 @@ public class WiThrottlePrefsPanel extends JPanel implements PreferencesPanel {
     private boolean isStartUpAction() {
         return InstanceManager.getDefault(StartupActionsManager.class).getActions(PerformActionModel.class).stream()
                 .anyMatch((model) -> (WiThrottleCreationAction.class.getName().equals(model.getClassName())));
-//        for (PerformActionModel model : InstanceManager.getDefault(StartupActionsManager.class).getActions(PerformActionModel.class)) {
-//            if (WiThrottleCreationAction.class.getName().equals(model.getClassName()))) {
-//                return true;
-//            }
-//        }
-//        return false;
     }
 }

--- a/java/test/jmri/jmrit/withrottle/FastClockControllerTest.java
+++ b/java/test/jmri/jmrit/withrottle/FastClockControllerTest.java
@@ -1,0 +1,31 @@
+
+package jmri.jmrit.withrottle;
+
+import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Brett Hoffman Copyright (C) 2018
+ */
+public class FastClockControllerTest {
+    
+    @Test
+    public void testCtor() {
+        FastClockController panel = new FastClockController();
+        Assert.assertNotNull("exists", panel );
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        JUnitUtil.setUp();
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        JUnitUtil.tearDown();
+    }
+}

--- a/java/test/jmri/jmrit/withrottle/PackageTest.java
+++ b/java/test/jmri/jmrit/withrottle/PackageTest.java
@@ -10,6 +10,7 @@ import org.junit.runners.Suite;
         ConsistFunctionControllerTest.class,
         DeviceServerTest.class,
         FacelessServerTest.class,
+        FastClockControllerTest.class,
         MultiThrottleControllerTest.class,
         MultiThrottleTest.class,
         RouteControllerTest.class,


### PR DESCRIPTION
Add send of Fast Clock to devices connected through WiThrottle Server and preference to disable send. This works with code already implemented in WiThrottle and Engine Driver apps.