### PR TITLE
Ignore unreliable test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,8 @@
                         <exclude>%regex[jmri/jmrix/nce/(boosterprog|cab|clockmon|consist|macro|ncemon|networkdriver|packetgen|simulator|swing|usbdriver|usbinterface)/.*/Nce.*]</exclude>
                         <!-- ignore until #3492 is resolved -->
                         <exclude>%regex[jmri.jmrix.loconet.locormi.LnMessage[Client|Server]Test]</exclude>
+                        <!-- ignore as unreliable on CI services -->
+                        <exclude>jmri.jmrit.logix.MergePromptTest</exclude>
                         <!-- ignore to avoid duplicate test runs -->
                         <exclude>apps.tests.AllTest</exclude>
                         <exclude>jmri.HeadLessTest</exclude>


### PR DESCRIPTION
The MergePromptTest is incredibly unreliable on CI services. This PR disables it since it, as it stands, does nothing but reduce trust in the entire unit testing concept.