### PR TITLE
Block tracking: improve value restoration behaviour

### DIFF
--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -726,10 +726,16 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                             log.debug("Sensor ACTIVE came out of nowhere, no neighbors active for block {}. Restoring previous value.", getDisplayName());
                             infoMessageCount++;
                         }
-                    } else {
-                        log.debug("not restoring previous value, block {} has been inactive for too long ("
-                                + (tn.toEpochMilli() - _timeLastInactive.toEpochMilli()) + "ms) and layout power has not just been restored ("
-                                + bm.timeSinceLastLayoutPowerOn() + "ms ago)", getDisplayName());
+                    } else if (log.isDebugEnabled()) {
+                        if (null != _timeLastInactive) {
+                            log.debug("not restoring previous value, block {} has been inactive for too long ("
+                                    + (tn.toEpochMilli() - _timeLastInactive.toEpochMilli()) + "ms) and layout power has not just been restored ("
+                                    + bm.timeSinceLastLayoutPowerOn() + "ms ago)", getDisplayName());
+                        } else {
+                            log.debug("not restoring previous value, block {} has been inactive since the start " +
+                                    "of this session and layout power has not just been restored ("
+                                    + bm.timeSinceLastLayoutPowerOn() + "ms ago)", getDisplayName());
+                        }
                     }
                 } else {
                     if (infoMessageCount < maxInfoMessages) {

--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -720,16 +720,16 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                     // 2. power has just come back on
                     Instant tn = Instant.now();
                     BlockManager bm = jmri.InstanceManager.getDefault(jmri.BlockManager.class);
-                    if (bm.timeSinceLastLayoutPowerOn() < 5000 || tn.toEpochMilli() - _timeLastInactive.toEpochMilli() < 2000) {
+                    if (bm.timeSinceLastLayoutPowerOn() < 5000 || (_timeLastInactive != null && tn.toEpochMilli() - _timeLastInactive.toEpochMilli() < 2000)) {
                         setValue(_previousValue);
                         if (infoMessageCount < maxInfoMessages) {
                             log.debug("Sensor ACTIVE came out of nowhere, no neighbors active for block {}. Restoring previous value.", getDisplayName());
                             infoMessageCount++;
                         }
                     } else {
-                        log.debug("not restoring previous value, block has been inactive for too long ("
+                        log.debug("not restoring previous value, block {} has been inactive for too long ("
                                 + (tn.toEpochMilli() - _timeLastInactive.toEpochMilli()) + "ms) and layout power has not just been restored ("
-                                + bm.timeSinceLastLayoutPowerOn() + "ms ago)");
+                                + bm.timeSinceLastLayoutPowerOn() + "ms ago)", getDisplayName());
                     }
                 } else {
                     if (infoMessageCount < maxInfoMessages) {

--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -652,7 +652,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         }
     }
 
-    private Instant timeLastInactive;
+    private Instant _timeLastInactive;
     /**
      * Handles Block sensor going INACTIVE: this block is empty
      */
@@ -668,7 +668,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         setValue(null);
         setDirection(Path.NONE);
         setState(UNOCCUPIED);
-        timeLastInactive = Instant.now();
+        _timeLastInactive = Instant.now();
     }
 
     private final int maxInfoMessages = 5;
@@ -720,15 +720,15 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                     // 2. power has just come back on
                     Instant tn = Instant.now();
                     PowerManager pm = jmri.InstanceManager.getDefault(jmri.PowerManager.class);
-                    if (pm.timeSinceLastPowerOn() < 5000 || tn.toEpochMilli() - timeLastInactive.toEpochMilli() < 2000) {
+                    if (pm.timeSinceLastPowerOn() < 5000 || tn.toEpochMilli() - _timeLastInactive.toEpochMilli() < 2000) {
                         setValue(_previousValue);
                         if (infoMessageCount < maxInfoMessages) {
-                            log.info("Sensor ACTIVE came out of nowhere, no neighbors active for block {}. Restoring previous value.", getDisplayName());
+                            log.debug("Sensor ACTIVE came out of nowhere, no neighbors active for block {}. Restoring previous value.", getDisplayName());
                             infoMessageCount++;
                         }
                     } else {
-                        log.info("not restoring previous value, block has been inactive for too long + ("
-                                + (tn.toEpochMilli() - timeLastInactive.toEpochMilli()) + "ms and power has been on for " + pm.timeSinceLastPowerOn() + "ms");
+                        log.debug("not restoring previous value, block has been inactive for too long + ("
+                                + (tn.toEpochMilli() - _timeLastInactive.toEpochMilli()) + "ms and power has been on for " + pm.timeSinceLastPowerOn() + "ms");
                     }
                 } else {
                     if (infoMessageCount < maxInfoMessages) {

--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -727,8 +727,9 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                             infoMessageCount++;
                         }
                     } else {
-                        log.debug("not restoring previous value, block has been inactive for too long + ("
-                                + (tn.toEpochMilli() - _timeLastInactive.toEpochMilli()) + "ms and power has been on for " + pm.timeSinceLastPowerOn() + "ms");
+                        log.debug("not restoring previous value, block has been inactive for too long ("
+                                + (tn.toEpochMilli() - _timeLastInactive.toEpochMilli()) + "ms) and layout power has not just been restored ("
+                                + pm.timeSinceLastPowerOn() + "ms ago)");
                     }
                 } else {
                     if (infoMessageCount < maxInfoMessages) {

--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -719,8 +719,8 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                     // 1. the block has been 'unoccupied' only very briefly
                     // 2. power has just come back on
                     Instant tn = Instant.now();
-                    PowerManager pm = jmri.InstanceManager.getDefault(jmri.PowerManager.class);
-                    if (pm.timeSinceLastPowerOn() < 5000 || tn.toEpochMilli() - _timeLastInactive.toEpochMilli() < 2000) {
+                    BlockManager bm = jmri.InstanceManager.getDefault(jmri.BlockManager.class);
+                    if (bm.timeSinceLastLayoutPowerOn() < 5000 || tn.toEpochMilli() - _timeLastInactive.toEpochMilli() < 2000) {
                         setValue(_previousValue);
                         if (infoMessageCount < maxInfoMessages) {
                             log.debug("Sensor ACTIVE came out of nowhere, no neighbors active for block {}. Restoring previous value.", getDisplayName());
@@ -729,7 +729,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
                     } else {
                         log.debug("not restoring previous value, block has been inactive for too long ("
                                 + (tn.toEpochMilli() - _timeLastInactive.toEpochMilli()) + "ms) and layout power has not just been restored ("
-                                + pm.timeSinceLastPowerOn() + "ms ago)");
+                                + bm.timeSinceLastLayoutPowerOn() + "ms ago)");
                     }
                 } else {
                     if (infoMessageCount < maxInfoMessages) {

--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -327,16 +327,15 @@ public class BlockManager extends AbstractManager<Block> implements PropertyChan
     @Override
     public void propertyChange(PropertyChangeEvent e) {
         super.propertyChange(e);
-        if ("Power".equals(e.getPropertyName())) {
-            InstanceManager.getList(PowerManager.class).forEach((pm) -> {
-                try {
-                    if (pm.getPower() == jmri.PowerManager.ON) {
-                        lastTimeLayoutPowerOn = Instant.now();
-                    }
-                } catch (JmriException xe) {
-                    // do nothing
+        if (jmri.PowerManager.POWER.equals(e.getPropertyName())) {
+            try {
+                PowerManager pm = (PowerManager) e.getSource();
+                if (pm.getPower() == jmri.PowerManager.ON) {
+                    lastTimeLayoutPowerOn = Instant.now();
                 }
-            });
+            } catch (JmriException | NoSuchMethodError xe) {
+                // do nothing
+            }
         }
     }
 

--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -45,7 +45,7 @@ public class BlockManager extends AbstractManager<Block> implements PropertyChan
         InstanceManager.sensorManagerInstance().addVetoableChangeListener(this);
         InstanceManager.getDefault(ReporterManager.class).addVetoableChangeListener(this);
         InstanceManager.getList(PowerManager.class).forEach((pm) -> {
-            pm.addProperyChangeListener(this);
+            pm.addPropertyChangeListener(this);
         });
     }
 
@@ -314,7 +314,6 @@ public class BlockManager extends AbstractManager<Block> implements PropertyChan
 
 
     private Instant lastTimeLayoutPowerOn; // the most recent time any power manager had a power ON event
-    private int powerState = jmri.PowerManager.UNKNOWN; // the current power state
 
     /**
      * Listen for changes to the power state from any power managers
@@ -327,16 +326,18 @@ public class BlockManager extends AbstractManager<Block> implements PropertyChan
 
     @Override
     public void propertyChange(PropertyChangeEvent e) {
+        super.propertyChange(e);
         if ("Power".equals(e.getPropertyName())) {
-            int newPowerState = jmri.PowerManager.OFF;
-            Instance.getList(PowerManager.class).forEach((pm) -> {
-               if (pm.getPower() == jmri.PowerManager.ON) {
-                    lastTimeLayoutPowerOn = Instant.now();
-                    break;
+            InstanceManager.getList(PowerManager.class).forEach((pm) -> {
+                try {
+                    if (pm.getPower() == jmri.PowerManager.ON) {
+                        lastTimeLayoutPowerOn = Instant.now();
+                    }
+                } catch (JmriException xe) {
+                    // do nothing
                 }
             });
         }
-        super(e);
     }
 
 

--- a/java/src/jmri/PowerManager.java
+++ b/java/src/jmri/PowerManager.java
@@ -54,5 +54,4 @@ public interface PowerManager {
     @CheckReturnValue
     @Nonnull public String getUserName();
 
-    public long timeSinceLastPowerOn();
 }

--- a/java/src/jmri/PowerManager.java
+++ b/java/src/jmri/PowerManager.java
@@ -53,5 +53,4 @@ public interface PowerManager {
 
     @CheckReturnValue
     @Nonnull public String getUserName();
-
 }

--- a/java/src/jmri/PowerManager.java
+++ b/java/src/jmri/PowerManager.java
@@ -53,4 +53,6 @@ public interface PowerManager {
 
     @CheckReturnValue
     @Nonnull public String getUserName();
+
+    public long timeSinceLastPowerOn();
 }

--- a/java/src/jmri/managers/AbstractPowerManager.java
+++ b/java/src/jmri/managers/AbstractPowerManager.java
@@ -83,6 +83,5 @@ abstract public class AbstractPowerManager implements PowerManager {
         }
         return Instant.now().toEpochMilli() - lastOn.toEpochMilli();
     }
-
-    private final static Logger log = LoggerFactory.getLogger(PowerManager.class);
+    
 }

--- a/java/src/jmri/managers/AbstractPowerManager.java
+++ b/java/src/jmri/managers/AbstractPowerManager.java
@@ -2,8 +2,6 @@ package jmri.managers;
 
 import jmri.JmriException;
 import jmri.PowerManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;

--- a/java/src/jmri/managers/AbstractPowerManager.java
+++ b/java/src/jmri/managers/AbstractPowerManager.java
@@ -24,7 +24,7 @@ abstract public class AbstractPowerManager implements PowerManager {
         addPropertyChangeListener(tk);
     }
 
-    int power = UNKNOWN;
+    private int powerState = UNKNOWN;
     private Instant lastOn;
 
     @Override
@@ -51,6 +51,7 @@ abstract public class AbstractPowerManager implements PowerManager {
         pcs.removePropertyChangeListener(l);
     }
 
+    // a class for listening for power state changes
     public class TimeKeeper implements PropertyChangeListener {
         @Override
         public void propertyChange(PropertyChangeEvent e) {
@@ -61,18 +62,12 @@ abstract public class AbstractPowerManager implements PowerManager {
                 } catch (JmriException ex) {
                     return;
                 }
-                if (newPowerState != power) {
-                    power = newPowerState;
+                if (newPowerState != powerState) {
+                    powerState = newPowerState;
                     if (newPowerState == ON) {
                         lastOn = Instant.now();
                     }
-                    if (newPowerState == OFF) {
-                        log.info("power has been on for " + timeSinceLastPowerOn() + " millisecs");
-                    }
-
                 }
-            } else {
-                log.info("property changed: " + e.getPropertyName());
             }
         }
     }


### PR DESCRIPTION
When a block becomes occupied JMRI attempts to copy the value of an adjacent occupied block.

When a block's sensor becomes active 'out of nowhere' JMRI restores its previous value, if there is one. This makes sense but only in the following circumstances:

* if the block went unoccupied very recently (to allow for sensor flicker or other momentary loss of contact)
* if power to the layout has just been restored

Otherwise, the new value of the block is probably not the same as it was previously. This PR modifies the behaviour such that the last value is not restored unless one of the above criteria are met. It is better, particularly on automated layouts, not to have a value than to have the wrong value.