### PR TITLE
Ecos direction change

### DIFF
--- a/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
@@ -569,13 +569,18 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
             return;
         }
 
-        // Need to send current speed as well as direction, otherwise
-        // speed will be set to zero on direction change
-        int speedValue = (int) ((127 - 1) * this.speedSetting);     // -1 for rescale to avoid estop
-        if (speedValue > 128) {
-            speedValue = 126;    // max possible speed
+        String message;
+        if (this.speedSetting > 0.0f) {
+            // Need to send current speed as well as direction, otherwise
+            // speed will be set to zero on direction change
+            int speedValue = (int) ((127 - 1) * this.speedSetting);     // -1 for rescale to avoid estop
+            if (speedValue > 128) {
+                speedValue = 126;    // max possible speed
+            }
+            message = "set(" + this.objectNumber + ", dir[" + (forward ? 0 : 1) + "], speed[" + speedValue + "])";
+        } else {
+            message = "set(" + this.objectNumber + ", dir[" + (forward ? 0 : 1) + ")";
         }
-        String message = "set(" + this.objectNumber + ", dir[" + (forward ? 0 : 1) + "], speed[" + speedValue + "])";
         EcosMessage m = new EcosMessage(message);
         tc.sendEcosMessage(m, this);
     }

--- a/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
@@ -569,7 +569,13 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
             return;
         }
 
-        String message = "set(" + this.objectNumber + ", dir[" + (forward ? 0 : 1) + "])";
+        // Need to send current speed as well as direction, otherwise
+        // speed will be set to zero on direction change
+        int speedValue = (int) ((127 - 1) * this.speedSetting);     // -1 for rescale to avoid estop
+        if (speedValue > 128) {
+            speedValue = 126;    // max possible speed
+        }
+        String message = "set(" + this.objectNumber + ", dir[" + (forward ? 0 : 1) + "], speed[" + speedValue + "])";
         EcosMessage m = new EcosMessage(message);
         tc.sendEcosMessage(m, this);
     }


### PR DESCRIPTION
This fixes the issue #4891 where an ECoS does not retain the current speed setting if a direction change is made by a JMRI Throttle (or WiThrottle) with a non-zero speed.