### PR TITLE
Updated sub file CV372-399sound.xml

### DIFF
--- a/xml/decoders/zimo/CV372-CV399sound.xml
+++ b/xml/decoders/zimo/CV372-CV399sound.xml
@@ -392,7 +392,7 @@
     <label xml:lang="de">Maximale Lautstärke</label>
     <label xml:lang="cs">Maximální hlasitost</label>
   </variable>
-  <variable item="Function Key to Increase Volume"  CV="396"  default="0" tooltip="CV396">
+  <variable item="Function Key to Decrease Volume"  CV="396"  default="0" tooltip="CV396">
      <enumVal>
       <enumChoice choice="No key assigned">
         <choice>No key assigned</choice>
@@ -488,7 +488,7 @@
     <label xml:lang="de">Leiser Taste</label>
     <label xml:lang="cs">Funkční klávesa pro zvýšení hlasitosti</label>
   </variable>
-  <variable item="Function Key to Reduce Volume"  CV="397"  default="0"  tooltip="CV397">
+  <variable item="Function Key to Increase Volume"  CV="397"  default="0"  tooltip="CV397">
      <enumVal>
       <enumChoice choice="No key assigned">
         <choice>No key assigned</choice>


### PR DESCRIPTION
The displayed texts in the pane to increase or decrease volumes are inversed
>> CV to decrease sound volume is  CV396 and CV to increase sound volume is 397

So I replaced texts in lines 395 (Increase replaced by Decrease) and 491 (decrease replaced by Increase) in the updated file

Extract from zimo manual
![image](https://user-images.githubusercontent.com/18462439/36644803-d2cc2c6c-1a5f-11e8-84c2-3b4b3ea80461.png)
