### PR TITLE
Typo-fix - missed a rather important angle bracket in JMRI/JMRI#4945

### DIFF
--- a/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
@@ -579,7 +579,7 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
             }
             message = "set(" + this.objectNumber + ", dir[" + (forward ? 0 : 1) + "], speed[" + speedValue + "])";
         } else {
-            message = "set(" + this.objectNumber + ", dir[" + (forward ? 0 : 1) + ")";
+            message = "set(" + this.objectNumber + ", dir[" + (forward ? 0 : 1) + "])";
         }
         EcosMessage m = new EcosMessage(message);
         tc.sendEcosMessage(m, this);


### PR DESCRIPTION
Rather embarrassing typo snuck in which causes a problem switching direction at zero speed.

Not entirely the aim of this original change...