### PR TITLE
Reply parser was not honouring replies with multiple items

### DIFF
--- a/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
@@ -125,6 +125,8 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
 
     /**
      * Convert an Ecos speed integer to a float speed value.
+     * @param lSpeed speed value as an integer
+     * @return speed value as a float
      */
     protected float floatSpeed(int lSpeed) {
         if (lSpeed == 0) {
@@ -643,10 +645,11 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
                     if (line.contains("speed") && !line.contains("speedstep")) {
                         speedMessageSent--;
                         if (speedMessageSent <= 0) {
-                            Float newSpeed = Float.valueOf(floatSpeed(Integer.parseInt(EcosReply.getContentDetails(line, "speed"))));
+                            Float newSpeed = floatSpeed(Integer.parseInt(EcosReply.getContentDetails(line, "speed")));
                             super.setSpeedSetting(newSpeed);
                         }
-                    } else if (line.contains("dir")) {
+                    }
+                    if (line.contains("dir")) {
                         boolean newDirection = false;
                         if (EcosReply.getContentDetails(line, "dir").equals("0")) {
                             newDirection = true;
@@ -659,10 +662,11 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
                     if (m.toString().contains("speed") && !m.toString().contains("speedstep")) {
                         speedMessageSent--;
                         if (speedMessageSent <= 0) {
-                            Float newSpeed = Float.valueOf(floatSpeed(Integer.parseInt(EcosReply.getContentDetails(m.toString(), "speed"))));
+                            Float newSpeed = floatSpeed(Integer.parseInt(EcosReply.getContentDetails(m.toString(), "speed")));
                             super.setSpeedSetting(newSpeed);
                         }
-                    } else if (m.toString().contains("dir")) {
+                    }
+                    if (m.toString().contains("dir")) {
                         boolean newDirection = false;
                         if (EcosReply.getContentDetails(m.toString(), "dir").equals("0")) {
                             newDirection = true;
@@ -678,7 +682,7 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
                     if (speedMessageSent > 0 && m.isUnsolicited() && line.contains("speed")) {
                         //We want to ignore these messages.
                     } else if (speedMessageSent <= 0 && line.contains("speed") && !line.contains("speedstep")) {
-                        Float newSpeed = Float.valueOf(floatSpeed(Integer.parseInt(EcosReply.getContentDetails(line, "speed"))));
+                        Float newSpeed = floatSpeed(Integer.parseInt(EcosReply.getContentDetails(line, "speed")));
                         super.setSpeedSetting(newSpeed);
                     } else if (line.contains("dir")) {
                         boolean newDirection = false;


### PR DESCRIPTION
ECoS state machine is updated on replies from the command station.

The response parser was only considering single item responses.

As a result of the change introduced in #4945 we now generate messages containing multiple items (speed and dir).

This PR fixes the reply parser to correctly update the state machine from such messages. Without this change, only speed was being updated by these multi-item responses.

In addition, there is some clean-up of unnecessary Float boxing and additions to some missing JavaDoc - both highlighted by NetBeans.