### PR TITLE
Fix for loco stopping during low speed Roster Profiling steps.

### DIFF
--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
@@ -991,7 +991,7 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
     }
 
     TreeMap<Integer, SpeedStep> speeds = new TreeMap<>();
-
+    
     static class SpeedStep {
 
         float forward = 0.0f;

--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
@@ -40,6 +40,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * JOD Feb18 BugFix
+ * To fix slow running locos stopping dead as they exit timed block.
+ * caused by (speedProfile/2) throttle setting which may be < the loco is capable of, so it stops.
+ * create a var profileSpeedAtStart
+ * populate with profileSpeed at start of a profile in notifyThrottleFound()
+ * in stopCurrentSpeedStep() test that current speed /2 > profileSpeedAtStart 
+ * if not, profileSpeedAtStart will be our minimum otherwise default behav half speed. 
+ * JOD
+ *   
  * Set up and run automated speed table calibration.
  * <p>
  * Uses three sensors in a row (see diagram in window help):
@@ -303,6 +312,10 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
     protected float profileBlockLength;
     RosterSpeedProfile rosterSpeedProfile;
 
+    // JOD Feb18 adding var
+    protected float profileSpeedAtStart;
+    // JOD
+    
     void setupProfile() {
         String text;
         finishSpeedStep = 0;
@@ -493,6 +506,10 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
         log.debug("Speed step mode {}", profileSpeedStepMode);
         profileSpeed = profileIncrement * profileStep;
 
+        // JOD Feb18  store the starting speed
+        profileSpeedAtStart = profileSpeed;
+        // JOD
+        
         if (profile) {
             startSensor = middleBlockSensor.getSensor();
             finishSensor = sensorB.getSensor();
@@ -668,9 +685,19 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
         stepCalculated = true;
         finishSensor.removePropertyChangeListener(finishListener);
         sourceLabel.setText(Bundle.getMessage("StatusLabelCalculating"));
-        if (profileStep >= 4) {
+
+        //JOD Feb18
+        //  if (profileStep >= 4) {
+        //    t.setSpeedSetting(profileSpeed / 2);
+        //  }
+        // replace the above with ...
+        if (profileSpeed/2 > profileSpeedAtStart) {
             t.setSpeedSetting(profileSpeed / 2);
+        } else {
+            t.setSpeedSetting(profileSpeedAtStart);
         }
+        // JOD
+        
         calculateSpeed();
         sourceLabel.setText(Bundle.getMessage("StatusLabelWaitingToClear"));
     }
@@ -925,8 +952,8 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
     long startTime;
     long finishTime;
 
-    ArrayList<Double> forwardOverRuns = new ArrayList<Double>();
-    ArrayList<Double> reverseOverRuns = new ArrayList<Double>();
+    ArrayList<Double> forwardOverRuns = new ArrayList<>();
+    ArrayList<Double> reverseOverRuns = new ArrayList<>();
 
     JPanel update;
 
@@ -962,7 +989,7 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
 
     }
 
-    TreeMap<Integer, SpeedStep> speeds = new TreeMap<Integer, SpeedStep>();
+    TreeMap<Integer, SpeedStep> speeds = new TreeMap<>();
 
     static class SpeedStep {
 

--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
@@ -39,16 +39,16 @@ import org.jdom2.JDOMException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// JOD Feb18 BugFix
+// To fix slow running locos stopping dead as they exit timed block.
+// caused by (speedProfile/2) throttle setting which may be < the loco is capable of, so it stops.
+// create a var profileSpeedAtStart
+// populate with profileSpeed at start of a profile in notifyThrottleFound()
+// in stopCurrentSpeedStep() test that current speed /2 > profileSpeedAtStart 
+// if not, profileSpeedAtStart will be our minimum otherwise default behav half speed. 
+// JOD
+
 /**
- * JOD Feb18 BugFix
- * To fix slow running locos stopping dead as they exit timed block.
- * caused by (speedProfile/2) throttle setting which may be < the loco is capable of, so it stops.
- * create a var profileSpeedAtStart
- * populate with profileSpeed at start of a profile in notifyThrottleFound()
- * in stopCurrentSpeedStep() test that current speed /2 > profileSpeedAtStart 
- * if not, profileSpeedAtStart will be our minimum otherwise default behav half speed. 
- * JOD
- *   
  * Set up and run automated speed table calibration.
  * <p>
  * Uses three sensors in a row (see diagram in window help):

--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
@@ -687,6 +687,7 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
         sourceLabel.setText(Bundle.getMessage("StatusLabelCalculating"));
 
         //JOD Feb18
+        //
         //  if (profileStep >= 4) {
         //    t.setSpeedSetting(profileSpeed / 2);
         //  }


### PR DESCRIPTION
Change such that; loco usually halves current throttle setting as it exits timed block as it does now, but if half current throttle setting < the starting throttle setting use that starting throttle setting as the reduced throttle setting.