### PR TITLE
WIP: Use the NX UUID for Conditional References

### DIFF
--- a/java/src/jmri/ConditionalAction.java
+++ b/java/src/jmri/ConditionalAction.java
@@ -36,6 +36,19 @@ public interface ConditionalAction {
      */
     String getDeviceName();
 
+     /**
+     * @since 4.11.4
+     * @return the GUI name for the NX Pair.
+     */
+    String getGuiName();
+
+    /**
+     * Set the GUI name for the NX Pair.
+     * @since 4.11.4
+     * @param guiName The referenced Conditional user name.
+     */
+    void setGuiName(String guiName);
+
     /**
      * Options on when action is taken.
      *

--- a/java/src/jmri/ConditionalVariable.java
+++ b/java/src/jmri/ConditionalVariable.java
@@ -52,7 +52,7 @@ public class ConditionalVariable {
     private String _dataString = "";
     private int _num1 = 0;
     private int _num2 = 0;
-    private String _guiName = "";       // Contains the user name of the referenced conditional
+    private String _guiName = "";       // Contains the user name of the referenced conditional or NX Pair
     private NamedBeanHandle<?> _namedBean = null;
     //private NamedBeanHandle<Sensor> _namedSensorBean = null;
     protected jmri.NamedBeanHandleManager nbhm = jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class);
@@ -333,14 +333,14 @@ public class ConditionalVariable {
 
      /**
      * @since 4.7.4
-     * @return the GUI name for the referenced conditional.
+     * @return the GUI name for the referenced conditional or NX Pair.
      */
     public String getGuiName() {
         return _guiName;
     }
 
     /**
-     * Set the GUI name for the conditional state variable.
+     * Set the GUI name for the conditional state variable or NX Pair.
      * @since 4.7.4
      * @param guiName The referenced Conditional user name.
      */
@@ -1087,7 +1087,7 @@ public class ConditionalVariable {
                         new Object[]{rbx.getString("OBlockStatus"), getName(), _dataString});
             case Conditional.ITEM_TYPE_ENTRYEXIT:
                 return java.text.MessageFormat.format(rbx.getString("VarStateDescrpt"),
-                        new Object[]{Bundle.getMessage("EntryExit"), getBean().getUserName(), type}); // NOI18N
+                        new Object[]{Bundle.getMessage("EntryExit"), getGuiName(), type}); // NOI18N
             case Conditional.TYPE_NONE:
                 return getName() + " type " + type;
             default:

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -302,6 +304,10 @@ public interface Manager<E extends NamedBean> {
     public @Nonnull
     String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException;
 
+    static final Pattern UUID = Pattern.compile(
+        "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",   // NOI18N
+        Pattern.CASE_INSENSITIVE);
+
     /**
      * Provides length of the system prefix of the given system name.
      * <p>
@@ -320,7 +326,9 @@ public interface Manager<E extends NamedBean> {
             throw new NamedBean.BadSystemNameException();
         }
         if (!Character.isLetter(inputName.charAt(0))) {
-            throw new NamedBean.BadSystemNameException();
+            if (!UUID.matcher(inputName).find()) {
+                throw new NamedBean.BadSystemNameException();
+            }
         }
 
         // As a very special case, check for legacy prefixs - to be removed

--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -210,6 +210,7 @@ public class DefaultConditional extends AbstractNamedBean
             clone.setDeviceName(action.getDeviceName());
             clone.setActionData(action.getActionData());
             clone.setActionString(action.getActionString());
+            clone.setGuiName(action.getGuiName());
             actionList.add(clone);
         }
         return actionList;

--- a/java/src/jmri/implementation/DefaultConditionalAction.java
+++ b/java/src/jmri/implementation/DefaultConditionalAction.java
@@ -43,6 +43,7 @@ public class DefaultConditionalAction implements ConditionalAction {
     private String _deviceName = " ";
     private int _actionData = 0;
     private String _actionString = "";
+    private String _guiName = "";       // Contains the user name of the NX Pair
     private NamedBeanHandle<?> _namedBean = null;
 
     private Timer _timer = null;
@@ -63,6 +64,7 @@ public class DefaultConditionalAction implements ConditionalAction {
         _deviceName = name;
         _actionData = actionData;
         _actionString = actionStr;
+        _guiName = "";
 
         NamedBean bean = getIndirectBean(_deviceName);
         if (bean == null) {
@@ -316,6 +318,25 @@ public class DefaultConditionalAction implements ConditionalAction {
             return getNamedBean().getBean();
         }
         return null;
+    }
+
+     /**
+     * @since 4.11.4
+     * @return the GUI name for the NX Pair.
+     */
+    @Override
+    public String getGuiName() {
+        return _guiName;
+    }
+
+    /**
+     * Set the GUI name for the NX Pair.
+     * @since 4.11.4
+     * @param guiName The referenced Conditional user name.
+     */
+    @Override
+    public void setGuiName(String guiName) {
+        _guiName = guiName;
     }
 
     /**
@@ -866,10 +887,12 @@ public class DefaultConditionalAction implements ConditionalAction {
                 case Conditional.ACTION_DEALLOCATE_BLOCK:
                 case Conditional.ACTION_SET_BLOCK_OUT_OF_SERVICE:
                 case Conditional.ACTION_SET_BLOCK_IN_SERVICE:
+                    str = str + ", \"" + _deviceName + "\".";
+                    break;
                 case Conditional.ACTION_SET_NXPAIR_ENABLED:
                 case Conditional.ACTION_SET_NXPAIR_DISABLED:
                 case Conditional.ACTION_SET_NXPAIR_SEGMENT:
-                    str = str + ", \"" + _deviceName + "\".";
+                    str = str + ", \"" + getGuiName() + "\".";
                     break;
                 case Conditional.ACTION_SET_ROUTE_TURNOUTS:
                 case Conditional.ACTION_AUTO_RUN_WARRANT:

--- a/java/src/jmri/jmrit/conditional/ConditionalEditBase.java
+++ b/java/src/jmri/jmrit/conditional/ConditionalEditBase.java
@@ -352,7 +352,7 @@ public class ConditionalEditBase {
         }
 
         PickSinglePanel _pickSingle;
-        
+
         switch (itemType) {
             case Conditional.ITEM_TYPE_SENSOR:      // 1
                 _pickSingle = new PickSinglePanel<Sensor>(PickListModel.sensorPickModelInstance());
@@ -1222,16 +1222,17 @@ public class ConditionalEditBase {
      * Show a message if not found.
      *
      * @param name the name to look for
-     * @return the system name of the corresponding EntryExit pair, null if not
+     * @return the system name (UUID) of the corresponding EntryExit pair, null if not
      *         found
      */
     String validateEntryExitReference(String name) {
         NamedBean nb = null;
         if (name != null) {
             if (name.length() > 0) {
-                nb = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean(name);
-                if (nb != null) {
-                    return name;
+                jmri.jmrit.entryexit.DestinationPoints dp = InstanceManager.
+                        getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean(name);
+                if (dp != null) {
+                    return dp.getUniqueId();
                 }
             }
         }

--- a/java/src/jmri/jmrit/conditional/ConditionalListEdit.java
+++ b/java/src/jmri/jmrit/conditional/ConditionalListEdit.java
@@ -2584,6 +2584,13 @@ public class ConditionalListEdit extends ConditionalEditBase {
                 if (name == null) {
                     return false;
                 }
+                jmri.jmrit.entryexit.DestinationPoints dp = InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).
+                        getNamedBean(name);
+                if (dp == null) {
+                    return false;
+                }
+                _curVariable.setName(dp.getUniqueId());
+                _curVariable.setGuiName(dp.getDisplayName());
                 break;
             default:
                 javax.swing.JOptionPane.showMessageDialog(_editConditionalFrame,
@@ -3916,9 +3923,15 @@ public class ConditionalListEdit extends ConditionalEditBase {
                         return false;
                     }
                 }
+                jmri.jmrit.entryexit.DestinationPoints dp = InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).
+                        getNamedBean(name);
+                if (dp == null) {
+                    return false;
+                }
                 actionType = Conditional.ITEM_TO_ENTRYEXIT_ACTION[selection - 1];
-                _actionNameField.setText(name);
-                _curAction.setDeviceName(name);
+                _actionNameField.setText(dp.getDisplayName());
+                _curAction.setDeviceName(dp.getUniqueId());
+                _curAction.setGuiName(dp.getDisplayName());
                 break;
             case Conditional.ITEM_TYPE_CLOCK:
                 actionType = Conditional.ITEM_TO_CLOCK_ACTION[selection - 1];

--- a/java/src/jmri/jmrit/conditional/ConditionalTreeEdit.java
+++ b/java/src/jmri/jmrit/conditional/ConditionalTreeEdit.java
@@ -3089,6 +3089,13 @@ public class ConditionalTreeEdit extends ConditionalEditBase {
                 if (name == null) {
                     return false;
                 }
+                jmri.jmrit.entryexit.DestinationPoints dp = InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).
+                        getNamedBean(name);
+                if (dp == null) {
+                    return false;
+                }
+                _curVariable.setName(dp.getUniqueId());
+                _curVariable.setGuiName(dp.getDisplayName());
                 break;
             default:
                 javax.swing.JOptionPane.showMessageDialog(_editLogixFrame,
@@ -4576,9 +4583,15 @@ public class ConditionalTreeEdit extends ConditionalEditBase {
                         return false;
                     }
                 }
+                jmri.jmrit.entryexit.DestinationPoints dp = InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).
+                        getNamedBean(name);
+                if (dp == null) {
+                    return false;
+                }
                 actionType = Conditional.ITEM_TO_ENTRYEXIT_ACTION[selection - 1];
-                _actionNameField.setText(name);
-                _curAction.setDeviceName(name);
+                _actionNameField.setText(dp.getDisplayName());
+                _curAction.setDeviceName(dp.getUniqueId());
+                _curAction.setGuiName(dp.getDisplayName());
                 break;
             case Conditional.ITEM_TYPE_CLOCK:
                 actionType = Conditional.ITEM_TO_CLOCK_ACTION[selection - 1];

--- a/java/src/jmri/jmrit/entryexit/DestinationPoints.java
+++ b/java/src/jmri/jmrit/entryexit/DestinationPoints.java
@@ -106,7 +106,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
         return getSystemName();
     }
 
-    String getUniqueId() {
+    public String getUniqueId() {
         return getSystemName();
     }
 


### PR DESCRIPTION
NX user names are derived and subject to change.  To prevent Logix Conditional reference issues, use the NX system name, UUID, as the State Variable and Action names.  The current NX user name will be used for user visible display.

Modify Manager#getSystemPrefixLength() to tolerate UUID system names.  This currently affects the creation of Pick Lists.  See issue #4951.