### PR TITLE
Change Entry/Exit system name and NX Conditional references

### DIFF
--- a/java/src/jmri/implementation/DefaultConditionalAction.java
+++ b/java/src/jmri/implementation/DefaultConditionalAction.java
@@ -866,10 +866,12 @@ public class DefaultConditionalAction implements ConditionalAction {
                 case Conditional.ACTION_DEALLOCATE_BLOCK:
                 case Conditional.ACTION_SET_BLOCK_OUT_OF_SERVICE:
                 case Conditional.ACTION_SET_BLOCK_IN_SERVICE:
+                    str = str + ", \"" + _deviceName + "\".";
+                    break;
                 case Conditional.ACTION_SET_NXPAIR_ENABLED:
                 case Conditional.ACTION_SET_NXPAIR_DISABLED:
                 case Conditional.ACTION_SET_NXPAIR_SEGMENT:
-                    str = str + ", \"" + _deviceName + "\".";
+                    str = str + ", \"" + getBean().getUserName() + "\".";
                     break;
                 case Conditional.ACTION_SET_ROUTE_TURNOUTS:
                 case Conditional.ACTION_AUTO_RUN_WARRANT:

--- a/java/src/jmri/jmrit/conditional/ConditionalEditBase.java
+++ b/java/src/jmri/jmrit/conditional/ConditionalEditBase.java
@@ -352,7 +352,7 @@ public class ConditionalEditBase {
         }
 
         PickSinglePanel _pickSingle;
-        
+
         switch (itemType) {
             case Conditional.ITEM_TYPE_SENSOR:      // 1
                 _pickSingle = new PickSinglePanel<Sensor>(PickListModel.sensorPickModelInstance());
@@ -1231,7 +1231,7 @@ public class ConditionalEditBase {
             if (name.length() > 0) {
                 nb = jmri.InstanceManager.getDefault(jmri.jmrit.entryexit.EntryExitPairs.class).getNamedBean(name);
                 if (nb != null) {
-                    return name;
+                    return nb.getSystemName();
                 }
             }
         }

--- a/java/src/jmri/jmrit/conditional/ConditionalListEdit.java
+++ b/java/src/jmri/jmrit/conditional/ConditionalListEdit.java
@@ -3002,6 +3002,7 @@ public class ConditionalListEdit extends ConditionalEditBase {
             case Conditional.ITEM_TYPE_ENTRYEXIT:
                 _actionTypeBox.setSelectedIndex(DefaultConditional.getIndexInTable(
                         Conditional.ITEM_TO_ENTRYEXIT_ACTION, actionType) + 1);
+                _actionNameField.setText(_curAction.getBean().getUserName());
                 break;
 
             case Conditional.ITEM_TYPE_AUDIO:

--- a/java/src/jmri/jmrit/conditional/ConditionalTreeEdit.java
+++ b/java/src/jmri/jmrit/conditional/ConditionalTreeEdit.java
@@ -3673,6 +3673,7 @@ public class ConditionalTreeEdit extends ConditionalEditBase {
                 break;
 
             case Conditional.ITEM_TYPE_ENTRYEXIT:
+                _actionNameField.setText(_curAction.getBean().getUserName());
                 _actionTypeBox.setSelectedIndex(DefaultConditional.getIndexInTable(
                         Conditional.ITEM_TO_ENTRYEXIT_ACTION, actionType) + 1);
                 break;

--- a/java/src/jmri/jmrit/entryexit/DestinationPoints.java
+++ b/java/src/jmri/jmrit/entryexit/DestinationPoints.java
@@ -84,7 +84,7 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
     transient Source src = null;
 
     DestinationPoints(PointDetails point, String id, Source src) {
-        super(id != null ? id : UUID.randomUUID().toString());
+        super(id != null ? id : "IN:" + UUID.randomUUID().toString());
         this.src = src;
         this.point = point;
         setUserName(src.getPoint().getDisplayName() + " to " + this.point.getDisplayName());

--- a/java/src/jmri/jmrit/entryexit/configurexml/EntryExitPairsXml.java
+++ b/java/src/jmri/jmrit/entryexit/configurexml/EntryExitPairsXml.java
@@ -227,6 +227,9 @@ public class EntryExitPairsXml extends AbstractXmlAdapter {
                         String id = null;
                         if (destinationList.get(j).getAttribute("uniqueid") != null) {  // NOI18N
                             id = destinationList.get(j).getAttribute("uniqueid").getValue();  // NOI18N
+                            if (id.length() > 3 && !id.startsWith("IN:")) {     // NOI18N
+                                id = "IN:" + id;    // NOI18N
+                            }
                         }
                         String destType = destinationList.get(j).getAttribute("type").getValue();  // NOI18N
                         String destItem = destinationList.get(j).getAttribute("item").getValue();  // NOI18N

--- a/java/src/jmri/jmrit/entryexit/configurexml/EntryExitPairsXml.java
+++ b/java/src/jmri/jmrit/entryexit/configurexml/EntryExitPairsXml.java
@@ -227,7 +227,7 @@ public class EntryExitPairsXml extends AbstractXmlAdapter {
                         String id = null;
                         if (destinationList.get(j).getAttribute("uniqueid") != null) {  // NOI18N
                             id = destinationList.get(j).getAttribute("uniqueid").getValue();  // NOI18N
-                            if (id.length() > 3 && !id.startsWith("IN:")) {     // NOI18N
+                            if (!id.startsWith("IN:")) {     // NOI18N
                                 id = "IN:" + id;    // NOI18N
                             }
                         }


### PR DESCRIPTION
Make the Entry/Exit system name valid by adding the "IN:" prefix to the Entry/Exit UUID.
Change Logix Conditional State Variable and Action Entry/Exit references to use only the Entry/Exit system name.