### PR TITLE
Updated sub file CV372-CV399sound.xml

### DIFF
--- a/xml/decoders/zimo/CV372-CV399sound.xml
+++ b/xml/decoders/zimo/CV372-CV399sound.xml
@@ -16,8 +16,9 @@
 <!-- version 1.1 - Mark Waters Jan 30 2015 -->
 <!-- Added CVs from Nigel Cliffe's 'CV372-CV399sound_v34.xml' file, using qualifiers to combine them into a single file -->
 <!-- version 1.2 - Ronald Kuhn - add german translation 06 Jun 2016 -->
+<!-- version 1.3 - Alain Carasso - Item to increase/reduce volume in CV396/397 were inverted 05 March 2018 -->
+
 <variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  
   
   
   <!--  CV372/373 are for electric locos -->
@@ -392,7 +393,7 @@
     <label xml:lang="de">Maximale Lautstärke</label>
     <label xml:lang="cs">Maximální hlasitost</label>
   </variable>
-  <variable item="Function Key to Decrease Volume"  CV="396"  default="0" tooltip="CV396">
+  <variable item="Function Key to Increase Volume"  CV="397"  default="0" tooltip="CV397">
      <enumVal>
       <enumChoice choice="No key assigned">
         <choice>No key assigned</choice>
@@ -488,7 +489,7 @@
     <label xml:lang="de">Leiser Taste</label>
     <label xml:lang="cs">Funkční klávesa pro zvýšení hlasitosti</label>
   </variable>
-  <variable item="Function Key to Increase Volume"  CV="397"  default="0"  tooltip="CV397">
+  <variable item="Function Key to Reduce Volume"  CV="396"  default="0"  tooltip="CV396">
      <enumVal>
       <enumChoice choice="No key assigned">
         <choice>No key assigned</choice>


### PR DESCRIPTION
In my previous update 8 days ago ( https://github.com/JMRI/JMRI/pull/4957) I made a mistake changing an item name, instead of only reverting the CV numbers. Thus only half the update was OK (only one CV was showing in the pane).

So I restarted from unmodified subfile in 4.11.3, and tested the update on my ECoS
![image](https://user-images.githubusercontent.com/18462439/36980855-d3011274-208b-11e8-9d70-ccbafbf9d350.png)
![image](https://user-images.githubusercontent.com/18462439/36980870-ddc07c40-208b-11e8-81da-12e14fdd7807.png)

Thanks to validate and add in next test release

Alain