### PR TITLE
When loading preferences, don't call the deprecated setScale method.

### DIFF
--- a/java/src/jmri/jmrit/logix/WarrantPreferences.java
+++ b/java/src/jmri/jmrit/logix/WarrantPreferences.java
@@ -181,9 +181,9 @@ public class WarrantPreferences extends AbstractPreferencesManager {
         Attribute a;
         if ((a = layoutParm.getAttribute(LAYOUT_SCALE)) != null) {
             try {
-                setScale(a.getFloatValue());
+                setLayoutScale(a.getFloatValue());
             } catch (DataConversionException ex) {
-                setScale(87.1f);
+                setLayoutScale(87.1f);
                 log.error("Unable to read layout scale. Setting to default value.", ex);
             }
         }


### PR DESCRIPTION
This appears to be the cause of the failures I saw that lead me to create #5034.  

An error message was introduced to the deprecated setScale method as part of #5032.

Assuming this passes tests without issue, #5034 will be closed.