### PR TITLE
VSDecoder: Update Help and Manual

### DIFF
--- a/help/en/manual/DecoderPro/Main_Debug.shtml
+++ b/help/en/manual/DecoderPro/Main_Debug.shtml
@@ -209,6 +209,17 @@
 
       <div style="margin-left: 2em">
         <ul>
+          <li><a href="Main_VSD.shtml"><strong>VSDecoder
+          </strong></a></li>
+        </ul>
+      </div>
+
+      <div style="margin-left: 120px;">
+        Main page and introduction
+      </div>
+
+      <div style="margin-left: 2em">
+        <ul>
           <li><a href="VSD_Manager.shtml"><strong>VSDecoder
           Manager</strong></a></li>
         </ul>
@@ -239,6 +250,13 @@
 
       <div style="margin-left: 120px;">
         Manage VSD Preferences elements.
+      </div>
+
+      <div style="margin-left: 2em">
+        <ul>
+          <li><a href="VSD_File_and_Config.shtml"><strong>VSD File
+          and Configuration</strong></a></li>
+        </ul>
       </div>
 
       <p><img src="images/separator.png" alt="sep" height="4"

--- a/help/en/manual/DecoderPro/Main_VSD.shtml
+++ b/help/en/manual/DecoderPro/Main_VSD.shtml
@@ -43,7 +43,7 @@
 
       <h4>How it works</h4>
 
-      <p><span id="product-desc">Locomotive sound "Profiles" are
+      <p>Locomotive sound "Profiles" are
       stored in a file called a "VSD File". When the Virtual Sound
       Decoder ("VSDecoder" or "VSD") is launched, the user chooses
       the desired Profile, and then assigns the VSDecoder an
@@ -51,12 +51,15 @@
       pressing function buttons or changing the speed, the Virtual
       Sound Decoder responds just like a hardware sound decoder
       installed in the locomotive would by playing sounds through
-      the computer speakers.</span></p>
+      the computer speakers.</p>
 
       <p>An example VSD file is included with the package, 
       more examples are available for download
       <a href="https://github.com/JMRI/vsdecoder">on the web</a>
       and you can make (and share!) your own.</p>
+
+      <p>See <a href="VSD_File_and_Config.shtml">more details</a>
+      on the VSD File and its Configuration.</p>
 
       <h4>OpenAL Required</h4>
 
@@ -65,7 +68,7 @@
       on the Mac, but must be installed on Windows.</p>
 
       <p>OpenAL is available free from Creative Labs. You can
-      <a target="_blank" href="http://www.openal.org/downloads/">
+      <a href="http://www.openal.org/downloads/">
       download the installer for your operating system</a> from the
       OpenAL site.</p>
 
@@ -252,10 +255,6 @@
       <p>For more information on Operations, see the JMRI&reg;
       Operating User's Guide.</p>
 
-      <p><em>Note:</em> Operations Locations following is
-      temporarily disabled in version 3.1.6. It will be re-enabled
-      in 3.1.7.</p>
-
       <h5>Menu Items</h5>
 
       <h6>File-&gt;Load VSD File</h6>
@@ -282,6 +281,9 @@
       <p>If checked, the Engine sounds will react immediately to
       Throttle changes, without the Engine Start button first
       having to be pressed.</p>
+      <p><em>Note:</em> Diesel engines normaly have a starting-sound. 
+      Throttle changes will be processed not util the starting-sound
+      has been finished.</p>
 
       <h5>Auto-Load VSD File</h5>
 

--- a/help/en/manual/DecoderPro/Main_VSD.shtml
+++ b/help/en/manual/DecoderPro/Main_VSD.shtml
@@ -68,7 +68,7 @@
       on the Mac, but must be installed on Windows.</p>
 
       <p>OpenAL is available free from Creative Labs. You can
-      <a href="http://www.openal.org/downloads/">
+      <a target="_blank" href="http://www.openal.org/downloads/">
       download the installer for your operating system</a> from the
       OpenAL site.</p>
 
@@ -281,9 +281,9 @@
       <p>If checked, the Engine sounds will react immediately to
       Throttle changes, without the Engine Start button first
       having to be pressed.</p>
-      <p><em>Note:</em> Diesel engines normaly have a starting-sound. 
-      Throttle changes will be processed not util the starting-sound
-      has been finished.</p>
+      <p><em>Note:</em> Diesel engines normally have a starting-sound. 
+      Throttle changes will not be processed util the starting-sound
+      has finished.</p>
 
       <h5>Auto-Load VSD File</h5>
 

--- a/help/en/manual/DecoderPro/Main_VSD.shtml
+++ b/help/en/manual/DecoderPro/Main_VSD.shtml
@@ -282,7 +282,7 @@
       Throttle changes, without the Engine Start button first
       having to be pressed.</p>
       <p><em>Note:</em> Diesel engines normally have a starting-sound. 
-      Throttle changes will not be processed util the starting-sound
+      Throttle changes will not be processed until the starting-sound
       has finished.</p>
 
       <h5>Auto-Load VSD File</h5>

--- a/help/en/manual/DecoderPro/VSD_File_and_Config.shtml
+++ b/help/en/manual/DecoderPro/VSD_File_and_Config.shtml
@@ -1,0 +1,132 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+
+<html lang="en">
+<head>
+  <meta name="generator" content=
+  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.17), see www.w3.org">
+
+  <title>DecoderPro&reg; Main Window</title><!-- Style -->
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=us-ascii">
+  <link rel="stylesheet" type="text/css" href="/css/default.css"
+  media="screen">
+  <link rel="stylesheet" type="text/css" href="/css/print.css"
+  media="print">
+  <link rel="icon" href="/images/jmri.ico" type="image/png">
+  <link rel="home" title="Home" href="/"><!-- /Style -->
+</head>
+
+<body>
+  <!--#include virtual="/Header" -->
+
+  <div id="mBody">
+    <!--#include virtual="Sidebar" -->
+
+    <div id="mainContent">
+      <h1>DecoderPro&reg; Debug Menu</h1>
+
+      <h2>Virtual Sound Decoder</h2>
+
+      <div align="right">
+        <p><a href="Main_Debug.shtml#vsdecoder">Back</a></p>
+      </div>
+      <hr>
+
+      <h4>VSD File and Configuration</h4>
+
+      <p><span id="product-desc">The <strong>VSD File</strong> is a 
+        ZIP archive containing all of the source audio
+        files, plus a Configuration File that tells
+        the Virtual Sound Decoder when and how to use the sound
+        files, plus a License information file license.txt</span>.
+      </p>
+      <p>An example VSD file is included with the package, 
+        more examples are available for download
+        <a href="https://github.com/JMRI/vsdecoder">on the web</a>
+        and you can make (and share!) your own.</p>
+      <p>To open a VSD File you may have to rename the file extension
+       "vsd" to "zip" first.
+      </p>
+
+      <h4>Configuration File</h4>
+
+      <p>The config.xml file can be created or edited using a
+       standard text editor or a
+        <a href="http://jmri.org/help/en/html/doc/Technical/XmlEditors.shtml">
+        XML editor</a>.
+	  </p>
+      <p>A value in XML is described as a <strong>tag</strong>, e.g.
+	    <code>&lt;gain&gt;0.8&lt;/gain&gt;</code>.
+      </p>
+      <p>The following sections present some optional configuration features.
+        They are documented as tags, so you can copy and paste it into your 
+        config.xml file, if desired.
+      </p>
+
+      <h5>Auto-Start Engine</h5>
+
+      <p>Description:<br>
+        Beside the "Auto Start Engine" option in VSD Preferences you
+        may want to use this advanced option in your config.xml.
+        Since this option is allowed per Engine, you could have
+        auto-start-engines and non-auto-start-engines side by
+        side.<br>
+        Optional. Must be declared in the tag <strong>sound
+        name="ENGINE"</strong>. Default value: "no"<br>
+        <em>Since JMRI 4.11.3</em>
+      </p>
+
+      <p>Example:
+      <pre>
+      &lt;auto-start&gt;yes&lt;/auto-start&gt;
+      </pre>
+      </p>
+
+      <h5><a name="engine-startstop">
+        Engine Start and Stop by a throttle key</a>
+      </h5>
+
+      <p>Description:<br>
+      If desired, you may define a throttle button to start and to
+      stop the engine sound.<br>
+      Optional. Must be declared in the tag
+      <strong>sound-event name="ENGINE"</strong>.<br>
+      <em>Since JMRI 4.11.4</em></p>
+
+      <p>Example:
+      <pre>
+      &lt;trigger name="ENGINE_STARTSTOP" type="THROTTLE"&gt;
+          &lt;event-name&gt;F4&lt;/event-name&gt;
+          &lt;target-name>ENGINE&lt;/target-name&gt;
+          &lt;action>NOTHING&lt;/action&gt;
+      &lt;/trigger&gt;
+      </pre>
+      </p>
+
+      <h5>Reference Distance</h5
+
+      <p>Description:<br>
+      It's recommended to setup this value for each sound tag.
+      The reason for this is the sound attenuation model of OpenAL.
+      Sounds with distance to listener position lower than 
+      reference-distance will not have any attenuation and the
+      volume of the Audio Source will be as defined by the gain
+      setting.<br>
+      Optional. Must be declared in the tag <strong>sound</strong>
+	  previous to a gain value. Default value: 1.0<br>
+      <em>Since JMRI 4.11.4</em></p>
+
+      <p>Example:
+      <pre>
+      &lt;reference-distance&gt;3.0&lt;/reference-distance&gt;
+      </pre>
+      </p>
+
+      <div align="right">
+        <p><a href="Main_Debug.shtml#vsdecoder">Back</a></p>
+      </div><!--#include virtual="/Footer" -->
+    </div><!-- closes #mainContent-->
+  </div><!-- closes #mBody-->
+</body>
+</html>

--- a/help/en/manual/DecoderPro/VSD_LocationsMgr.shtml
+++ b/help/en/manual/DecoderPro/VSD_LocationsMgr.shtml
@@ -39,9 +39,9 @@
       Locations</strong> window provides a consolidated location to
       manage and set the apparent physical location of sounds for
       trains using Virtual Sound Decoder</span></p>The
-      <strong>Manage VSD Locations</strong> window has three tabs:
-      Reporters, Operations Locations, and Listeners. Each tab
-      shows a list of objects, each with a check-box to
+      <strong>Manage VSD Locations</strong> window has four tabs:
+      Reporters, Blocks, Operations Locations, and Listeners. Each
+      tab shows a list of objects, each with a check-box to
       enable/disable use (for VSD purposes, not for other JMRI
       purposes), and entry cells for X, Y, and Z location
       coordinates.

--- a/help/en/manual/DecoderPro/VSD_Manager.shtml
+++ b/help/en/manual/DecoderPro/VSD_Manager.shtml
@@ -133,7 +133,7 @@
       activated</a> by a throttle key, if desired.</p>
       <p><em>Note 1:</em> To start the Engine the throttle speed must be 0.<br>
       <em>Note 2:</em> Diesel engines normally have a starting-sound. 
-      Throttle changes will not be processed util the starting-sound
+      Throttle changes will not be processed until the starting-sound
       has finished.</p>
 
       <h5>Volume / Mute control</h5>

--- a/help/en/manual/DecoderPro/VSD_Manager.shtml
+++ b/help/en/manual/DecoderPro/VSD_Manager.shtml
@@ -132,9 +132,9 @@
       <a href="VSD_File_and_Config.shtml#engine-startstop">can be
       activated</a> by a throttle key, if desired.</p>
       <p><em>Note 1:</em> To start the Engine the throttle speed must be 0.<br>
-      <em>Note 2:</em> Diesel engines normaly have a starting-sound. 
-      Throttle changes will be processed not util the starting-sound
-      has been finished.</p>
+      <em>Note 2:</em> Diesel engines normally have a starting-sound. 
+      Throttle changes will not be processed util the starting-sound
+      has finished.</p>
 
       <h5>Volume / Mute control</h5>
 

--- a/help/en/manual/DecoderPro/VSD_Manager.shtml
+++ b/help/en/manual/DecoderPro/VSD_Manager.shtml
@@ -128,6 +128,13 @@
 
       <p>Sounds can also be activated by a throttle assigned to the
       same address as the VSDecoder.</p>
+	  <p>And similar the "Engine Start" button 
+      <a href="VSD_File_and_Config.shtml#engine-startstop">can be
+      activated</a> by a throttle key, if desired.</p>
+      <p><em>Note 1:</em> To start the Engine the throttle speed must be 0.<br>
+      <em>Note 2:</em> Diesel engines normaly have a starting-sound. 
+      Throttle changes will be processed not util the starting-sound
+      has been finished.</p>
 
       <h5>Volume / Mute control</h5>
 

--- a/help/en/manual/DecoderPro/index.shtml
+++ b/help/en/manual/DecoderPro/index.shtml
@@ -608,7 +608,11 @@
                 <li><a href="VSD_LocationsMgr.shtml">Manage VSD
                 Locations</a></li>
 
-                <li>VSDecoder Preferences</li>
+                <li><a href="Main_VSD.shtml#preferences">VSDecoder
+                Preferences</li>
+
+                <li><a href="VSD_File_and_Config.shtml">VSDFile and
+                Configuration</li>
               </ul>
             </li>
 

--- a/help/en/package/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.shtml
+++ b/help/en/package/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.shtml
@@ -150,8 +150,7 @@
       operation. If you would prefer to have your engine sounds
       start immediately when you advance the throttle, without
       first pressing "Engine Start", there is a setting in the
-      VSDecoder Preferences to change this. (This feature is
-      currently not active ...)<br>
+      VSDecoder Preferences to change this.<br>
       <hr>
 
       <h3>Options Dialog</h3>
@@ -235,23 +234,31 @@
         Roster entry</li>
       </ul>To store the current VSDecoder profile setting to a
       Roster Entry, select the Roster Entry and click the "Save"
-      button.<br>
-
+      button.
       <hr>
-      <h2>Bugs and other notes</h2>A few notes on limitations
-      (bugs, mostly):
+
+      <h2>Bugs and other notes</h2>
+      <hr>
+      A few notes on limitations and bug reporting:
 
       <ul>
-        <li>All of the sounds are still "rough". Expect odd
-        transitions between speed settings, strange effects when
-        you press buttons rapidly (and sometimes not), and so
-        on.</li>
+        <li>Some of the sounds are still "rough". Expect odd
+          transitions between speed settings, strange effects when
+          you press buttons rapidly (and sometimes not), and so on.
+        </li>
 
-        <li>Not all of the sound buttons are functional.</li>
+        <li>
+          Not all of the sound buttons in example.vsd are functional.
+        </li>
 
-        <li>Many other things are buggy or broken. Please log a bug
-        report if something appears truly broken.</li>
+        <li>Please post a bug report on the
+          <a href="https://groups.yahoo.com/neo/groups/jmriusers/info">
+          JMRIUsers Yahoo! Group</a> or open an issue
+          <a href="https://github.com/JMRI/JMRI/issues">on github</a>
+          if something appears truly broken.
+        </li>
       </ul>
+
       <hr>
       <a id="prefs" name="prefs">(This is the
       jmri.jmrit.vsdecoder.swing.VSDManagerFrame help page) 


### PR DESCRIPTION
This PR covers a documentation update around my last changes like ```Throttle button for Engine Start-Stop``` and ```OpenAL Reference Distance```.
