### PR TITLE
Warrant MaxBlocks fix, added OBlock table column

### DIFF
--- a/java/src/jmri/jmrit/beantable/OBlockTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/OBlockTableBundle.properties
@@ -21,6 +21,7 @@ Last            = Last
 PermissionCol   = Permit?
 Permissive      = Permissive
 Absolute        = Absolute
+WarrantCol		= Allocated To
 SpeedCol        = Speed Notch
 ButtonEditTO    = Turnouts
 OpenMenu        = Tables

--- a/java/src/jmri/jmrit/beantable/oblock/TableFrames.java
+++ b/java/src/jmri/jmrit/beantable/oblock/TableFrames.java
@@ -488,7 +488,7 @@ public class TableFrames extends jmri.util.JmriJFrame implements InternalFrameLi
         tcm.setColumnVisible(tcm.getColumnByModelIndex(OBlockTableModel.REPORTERCOL), false);
         tcm.setColumnVisible(tcm.getColumnByModelIndex(OBlockTableModel.REPORT_CURRENTCOL), false);
         tcm.setColumnVisible(tcm.getColumnByModelIndex(OBlockTableModel.PERMISSIONCOL), false);
-//        tcm.setColumnVisible(tcm.getColumnByModelIndex(OBlockTableModel.SPEEDCOL), false);
+        tcm.setColumnVisible(tcm.getColumnByModelIndex(OBlockTableModel.WARRANTCOL), false);
 //        tcm.setColumnVisible(tcm.getColumnByModelIndex(OBlockTableModel.ERR_SENSORCOL), false);
         tcm.setColumnVisible(tcm.getColumnByModelIndex(OBlockTableModel.CURVECOL), false);
 

--- a/java/src/jmri/jmrit/logix/Engineer.java
+++ b/java/src/jmri/jmrit/logix/Engineer.java
@@ -44,14 +44,14 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
     private int _syncIdx;           // block order index of current command
     protected DccThrottle _throttle;
     private final Warrant _warrant;
-    private List<ThrottleSetting> _commands;
+    private final List<ThrottleSetting> _commands;
     private Sensor _waitSensor;
     private int _sensorWaitState;
     private ThrottleRamp _ramp;
     final ReentrantLock _lock = new ReentrantLock(true);    // Ramp needs to block script speeds
     private boolean _atHalt = false;
     private boolean _atClear = false;
-    private SpeedUtil _speedUtil;
+    private final SpeedUtil _speedUtil;
 
     Engineer(Warrant warrant, DccThrottle throttle) {
         _warrant = warrant;
@@ -1099,7 +1099,13 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
                             log.debug("Ramp down ends in block \"{}\" at command #{}", name, _idxCurrentCommand);
                         // if there is a ramp overrun to another block, skip commands in previous blocks.
                         // Look back i index for NOOP into current block
-                        for (int idx = _idxCurrentCommand - 1; idx < _commands.size(); idx++) {
+                        int start;
+                        if (_idxCurrentCommand > 0) {
+                            start = _idxCurrentCommand - 1;
+                        } else {
+                            start = 0;
+                        }
+                        for (int idx = start; idx < _commands.size(); idx++) {
                             ThrottleSetting ts = _commands.get(idx);
                             NamedBean bean = ts.getNamedBeanHandle().getBean();
                             if (bean instanceof OBlock ) {

--- a/java/src/jmri/jmrit/logix/NXFrame.java
+++ b/java/src/jmri/jmrit/logix/NXFrame.java
@@ -94,7 +94,6 @@ public class NXFrame extends WarrantRoute {
     private void init() {
         if (log.isDebugEnabled()) log.debug("newInstance");
         WarrantPreferences preferences = updatePreferences();
-        setDepth(preferences.getSearchDepth());
         makeMenus();
 
         _routePanel = new JPanel();

--- a/java/src/jmri/jmrit/logix/OBlock.java
+++ b/java/src/jmri/jmrit/logix/OBlock.java
@@ -80,8 +80,8 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
 //    static final public int DARK = 0x01;        // Block has no Sensor, same as UNKNOWN
     static final public int TRACK_ERROR = 0x80; // Block has Error
 
-    private static final HashMap<String, Integer> _statusMap = new HashMap<String, Integer>();
-    private static final HashMap<String, String> _statusNameMap = new HashMap<String, String>();
+    private static final HashMap<String, Integer> _statusMap = new HashMap<>();
+    private static final HashMap<String, String> _statusNameMap = new HashMap<>();
 
     static final Color DEFAULT_FILL_COLOR = new Color(200, 0, 200);
 
@@ -126,7 +126,7 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
         }
         return _statusNameMap.get(str);
     }
-    ArrayList<Portal> _portals = new ArrayList<Portal>();     // portals to this block
+    ArrayList<Portal> _portals = new ArrayList<>();     // portals to this block
 
     private Warrant _warrant;       // when not null, block is allocated to this warrant
     private String _pathName;      // when not null, this is the allocated path
@@ -135,8 +135,8 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
     private NamedBeanHandle<Sensor> _errNamedSensor;
     // path keys a list of Blocks whose paths conflict with the path.  These Blocks key 
     // a list of their conflicting paths.
-    private HashMap<String, List<HashMap<OBlock, List<OPath>>>> _sharedTO
-            = new HashMap<String, List<HashMap<OBlock, List<OPath>>>>();
+    private final HashMap<String, List<HashMap<OBlock, List<OPath>>>> _sharedTO
+            = new HashMap<>();
     private boolean _ownsTOs = false;
     private Color _markerForeground = Color.WHITE;
     private Color _markerBackground = DEFAULT_FILL_COLOR;
@@ -327,25 +327,25 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
                             return true;
                         }
                     } else {
-                        List<OPath> pathList = new ArrayList<OPath>();
+                        List<OPath> pathList = new ArrayList<>();
                         pathList.add(path);
                         map.put(block, pathList);
                         return true;
                     }
                 }
             }
-            HashMap<OBlock, List<OPath>> map = new HashMap<OBlock, List<OPath>>();
-            List<OPath> pathList = new ArrayList<OPath>();
+            HashMap<OBlock, List<OPath>> map = new HashMap<>();
+            List<OPath> pathList = new ArrayList<>();
             pathList.add(path);
             map.put(block, pathList);
             blockList.add(map);
             return true;
         } else {
-            List<OPath> pathList = new ArrayList<OPath>();
+            List<OPath> pathList = new ArrayList<>();
             pathList.add(path);
-            HashMap<OBlock, List<OPath>> map = new HashMap<OBlock, List<OPath>>();
+            HashMap<OBlock, List<OPath>> map = new HashMap<>();
             map.put(block, pathList);
-            blockList = new ArrayList<HashMap<OBlock, List<OPath>>>();
+            blockList = new ArrayList<>();
             blockList.add(map);
             _sharedTO.put(key.getName(), blockList);
             return true;
@@ -417,7 +417,7 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
         return msg;
     }
 
-    protected Warrant getWarrant() {
+    public Warrant getWarrant() {
         return _warrant;
     }
     
@@ -512,7 +512,7 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
      * @return name of block if block is already allocated to another warrant or
      *         block is OUT_OF_SERVICE
      */
-    protected String allocate(Warrant warrant) {
+    public String allocate(Warrant warrant) {
         if (warrant == null) {
             return "ERROR! allocate called with null warrant in block \"" + getDisplayName() + "\"!";
         }

--- a/java/src/jmri/jmrit/logix/WarrantFrame.java
+++ b/java/src/jmri/jmrit/logix/WarrantFrame.java
@@ -262,10 +262,6 @@ public class WarrantFrame extends WarrantRoute {
             }
         });
 
-        int numBlocks = InstanceManager.getDefault(OBlockManager.class).getSystemNameList().size();
-        if (numBlocks / 6 > getDepth()) {
-            setDepth(numBlocks / 6);
-        }
         panel.add(searchDepthPanel(true));
 
         JPanel p = new JPanel();

--- a/java/src/jmri/jmrit/logix/WarrantRoute.java
+++ b/java/src/jmri/jmrit/logix/WarrantRoute.java
@@ -8,7 +8,6 @@ import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
-import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.List;
@@ -89,7 +88,7 @@ public abstract class WarrantRoute extends jmri.util.JmriJFrame implements Actio
     private final JComboBox<String> _rosterBox = new JComboBox<>();
     private final JTextField _dccNumBox = new JTextField();
     private final JTextField _trainNameBox = new JTextField(6);
-    private JButton _viewProfile = new JButton(Bundle.getMessage("ViewProfile"));
+    private final JButton _viewProfile = new JButton(Bundle.getMessage("ViewProfile"));
     private SpeedProfileTable _spTable = null;
     private JmriJFrame _pickListFrame;
 
@@ -99,18 +98,13 @@ public abstract class WarrantRoute extends jmri.util.JmriJFrame implements Actio
      */
     protected WarrantRoute() {
         super(false, true);
+        if (log.isDebugEnabled()) log.debug("newInstance");
+        WarrantPreferences preferences = WarrantPreferences.getDefault();
+        setDepth(preferences.getSearchDepth());
+
         _routeModel = new RouteTableModel();
         _speedUtil = new SpeedUtil(null);
         getRoster();
-        WarrantPreferences.getDefault().addPropertyChangeListener((PropertyChangeEvent evt) -> {
-            switch (evt.getPropertyName()) {
-                case WarrantPreferences.SEARCH_DEPTH:
-                    this.setDepth((int) evt.getNewValue());
-                    break;
-                default:
-                    // do nothing
-            }
-        });
     }
 
     public abstract void selectedRoute(ArrayList<BlockOrder> orders);

--- a/java/src/jmri/jmrit/logix/WarrantTableModel.java
+++ b/java/src/jmri/jmrit/logix/WarrantTableModel.java
@@ -56,7 +56,7 @@ class WarrantTableModel extends jmri.jmrit.beantable.BeanTableDataModel // Abstr
     WarrantManager _manager;
     WarrantTableFrame _frame;
     private ArrayList<Warrant> _warList;
-    private ArrayList<Warrant> _warNX; // temporary warrants appended to table
+    private final ArrayList<Warrant> _warNX; // temporary warrants appended to table
     static Color myGreen = new Color(0, 100, 0);
     static Color myGold = new Color(200, 100, 0);
 
@@ -66,8 +66,8 @@ class WarrantTableModel extends jmri.jmrit.beantable.BeanTableDataModel // Abstr
         _manager = InstanceManager
                 .getDefault(jmri.jmrit.logix.WarrantManager.class);
         // _manager.addPropertyChangeListener(this); // for adds and deletes
-        _warList = new ArrayList<Warrant>();
-        _warNX = new ArrayList<Warrant>();
+        _warList = new ArrayList<>();
+        _warNX = new ArrayList<>();
     }
 
     public void addHeaderListener(JTable table) {
@@ -114,7 +114,7 @@ class WarrantTableModel extends jmri.jmrit.beantable.BeanTableDataModel // Abstr
      * propertyChange
      */
     public synchronized void init() {
-        ArrayList<Warrant> tempList = new ArrayList<Warrant>();
+        ArrayList<Warrant> tempList = new ArrayList<>();
         List<String> systemNameList = _manager.getSystemNameList();
         Iterator<String> iter = systemNameList.iterator();
         // copy over warrants still listed
@@ -142,7 +142,7 @@ class WarrantTableModel extends jmri.jmrit.beantable.BeanTableDataModel // Abstr
     }
 
     protected void haltAllTrains() {
-        ArrayList<Warrant> abortList = new ArrayList<Warrant>();
+        ArrayList<Warrant> abortList = new ArrayList<>();
         Iterator<Warrant> iter = _warList.iterator();
         while (iter.hasNext()) {
             Warrant w = iter.next();
@@ -402,7 +402,7 @@ class WarrantTableModel extends jmri.jmrit.beantable.BeanTableDataModel // Abstr
                 return new NamedIcon(
                         "resources/icons/smallschematics/tracksegments/circuit-green.gif",
                         "off");
-            } else if (/*w.hasRouteSet() &&*/ w.isAllocated()) {
+            } else if (w.hasRouteSet() && w.isAllocated()) {
                 return new NamedIcon(
                         "resources/icons/smallschematics/tracksegments/circuit-occupied.gif",
                         "occupied");
@@ -488,15 +488,17 @@ class WarrantTableModel extends jmri.jmrit.beantable.BeanTableDataModel // Abstr
             }
             break;
         case SET_COLUMN:
-            msg = w.setRoute(1, null);
-            if (msg == null) {
-                _frame.setStatusText(
-                        Bundle.getMessage("pathsSet", w.getDisplayName()),
-                        myGreen, false);
-            } else {
-                w.deAllocate();
-                _frame.setStatusText(msg, myGold, false);
-                msg = null;
+            if (w.getRunMode() == Warrant.MODE_NONE) {
+                msg = w.setRoute(1, null);
+                if (msg == null) {
+                    _frame.setStatusText(
+                            Bundle.getMessage("pathsSet", w.getDisplayName()),
+                            myGreen, false);
+                } else {
+                    w.deAllocate();
+                    _frame.setStatusText(msg, myGold, false);
+                    msg = null;
+                }
             }
             break;
         case AUTO_RUN_COLUMN:

--- a/java/test/jmri/jmrit/beantable/oblock/TableFramesTest.java
+++ b/java/test/jmri/jmrit/beantable/oblock/TableFramesTest.java
@@ -19,6 +19,7 @@ public class TableFramesTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         TableFrames t = new TableFrames();
         Assert.assertNotNull("exists",t);
+        t.initComponents();
     }
 
     // The minimal setup for log4J


### PR DESCRIPTION
Fix default MaxBlocks from Preferences.
Running warrant will not allocate or throw turnouts beyond signal stop
aspect or occupied block.
Add column to OBlock table enabling allocate/deAllocate block to a
warrrant.