### PR TITLE
Revert CommandDelay thread to previous implementation to fix Bug

### DIFF
--- a/java/src/jmri/jmrit/logix/Engineer.java
+++ b/java/src/jmri/jmrit/logix/Engineer.java
@@ -361,7 +361,8 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
         }
         float newSpeed = _speedUtil.modifySpeed(_normalSpeed, endSpeedType, _isForward);
         // if already at requested speed or ramping to it return;
-        if (Math.abs(newSpeed - getSpeedSetting()) < 0.002f || Math.abs(newSpeed - _rampEndSpeed) < 0.002f) {
+        if (Math.abs(newSpeed - getSpeedSetting()) < 0.002f || 
+                (_rampEndSpeed >= 0.0 && Math.abs(newSpeed - _rampEndSpeed) < 0.002f)) {
             if (log.isDebugEnabled()) log.debug("rampSpeedTo type= {}, throttle= {} _endSpeed= {} _rampEndSpeed= {}. warrant {}",
                     endSpeedType, getSpeedSetting(), newSpeed, _rampEndSpeed, _warrant.getDisplayName());
             return;
@@ -392,7 +393,7 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
             log.debug("ThrottleRamp {} for \"{}\" at speed= {}. _waitForClear= {} _halt= {} on warrant {}",
                     (stop?"stopped":"completed"), type, _rampEndSpeed, _waitForClear, _halt, _warrant.getDisplayName());        
         _ramp = null;
-        _rampEndSpeed = -0.5f;
+        _rampEndSpeed = -0.5f;      // indicates not ramping
         ThreadingUtil.runOnLayoutEventually(() -> {
             _warrant.fireRunStatus("Command", _idxCurrentCommand - 1, _idxCurrentCommand);
         });
@@ -456,7 +457,7 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
     }
 
     protected void setSpeedToType(String speedType) {
-        if (log.isTraceEnabled()) log.trace("setSpeedToType({})", speedType);
+        if (log.isDebugEnabled()) log.debug("setSpeedToType({})", speedType);
         if (!setSpeedRatio(speedType)) {
             return;
         }

--- a/java/src/jmri/server/json/JsonHttpService.java
+++ b/java/src/jmri/server/json/JsonHttpService.java
@@ -97,7 +97,6 @@ public abstract class JsonHttpService {
      * @param locale the requesting client's Locale
      * @throws JsonException if this method is not allowed or other error occurs
      */
-    @Nonnull
     public void doDelete(@Nonnull String type, @Nonnull String name, @Nonnull Locale locale) throws JsonException {
         throw new JsonException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, Bundle.getMessage(locale, "DeleteNotAllowed", type));
     }

--- a/java/src/jmri/server/json/JsonHttpService.java
+++ b/java/src/jmri/server/json/JsonHttpService.java
@@ -97,6 +97,7 @@ public abstract class JsonHttpService {
      * @param locale the requesting client's Locale
      * @throws JsonException if this method is not allowed or other error occurs
      */
+    @Nonnull
     public void doDelete(@Nonnull String type, @Nonnull String name, @Nonnull Locale locale) throws JsonException {
         throw new JsonException(HttpServletResponse.SC_METHOD_NOT_ALLOWED, Bundle.getMessage(locale, "DeleteNotAllowed", type));
     }


### PR DESCRIPTION
1. Revert CommandDelay thread in Warrant to previous implementation to fix java.util.concurrent.CancellationException bug.  Cancelling FutureTask on a SwingWorker throws a CancellationException.  Occasional cancelling is a normal operation. Also an interrupt on the Wait is all that is wanted.  Cancelling a speed ramp is done elsewhere.  SwingWorker was an experiment to see if getting a thread from a thread pool might improve performance - it didn't.
2. Improve Resume control after losing occupation for better recovery from
flakey hardware, dirty track, wheels etc.