### PR TITLE
More SPROG Command Station Fixes

### DIFF
--- a/java/src/jmri/jmrix/sprog/SprogConstants.java
+++ b/java/src/jmri/jmrix/sprog/SprogConstants.java
@@ -40,13 +40,13 @@ public final class SprogConstants {
      * 
      * Worst case DCC packet transmission time is ~10 ms, which equates to 100
      * packets/s. Wait for a somewhat arbitrary time before reporting a possible
-     * issue with the system performance. A delay of 33 ms equates to 30 packets/s
+     * issue with the system performance. A delay of 50 ms equates to 20 packets/s
      * if sustained.
      * 
      * Slower systems such as Raspberry Pi with flash based file systems are
      * more likely to exhibit longer delays between packets.
      */
-    public static int PACKET_DELAY_WARN_THRESHOLD = 33;
+    public static int PACKET_DELAY_WARN_THRESHOLD = 50;
 
     /**
      * Timeout for command station to wait for reply from hardware.
@@ -64,7 +64,8 @@ public final class SprogConstants {
      * reading a high value from a CV. Therefore we set a very long timeout,
      * which should longer than the programmer timeout.
      */
-    public static int TC_REPLY_TIMEOUT = 70*1000;
+    public static int TC_PROG_REPLY_TIMEOUT = 70*1000;
+    public static int TC_OPS_REPLY_TIMEOUT = 200;
 
     
     /* The following should be altered only if you know what you are doing */

--- a/java/src/jmri/jmrix/sprog/SprogPowerManager.java
+++ b/java/src/jmri/jmrix/sprog/SprogPowerManager.java
@@ -3,6 +3,8 @@ package jmri.jmrix.sprog;
 import jmri.JmriException;
 import jmri.PowerManager;
 import jmri.jmrix.AbstractMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * PowerManager implementation for controlling SPROG layout power.
@@ -32,6 +34,7 @@ public class SprogPowerManager extends jmri.managers.AbstractPowerManager
         checkTC();
         if (v == ON) {
             // configure to wait for reply
+            log.debug("setPower ON");
             waiting = true;
             onReply = PowerManager.ON;
             // send "Enable main track"
@@ -39,9 +42,10 @@ public class SprogPowerManager extends jmri.managers.AbstractPowerManager
             trafficController.sendSprogMessage(l, this);
         } else if (v == OFF) {
             // configure to wait for reply
+            log.debug("setPower OFF");
             waiting = true;
             onReply = PowerManager.OFF;
-            firePropertyChange("Power", null, null);
+//            firePropertyChange("Power", null, null);
             // send "Kill main track"
             SprogMessage l = SprogMessage.getKillMain();
             for (int i = 0; i < 3; i++) {
@@ -86,6 +90,7 @@ public class SprogPowerManager extends jmri.managers.AbstractPowerManager
     @Override
     public void notifyReply(SprogReply m) {
         if (waiting) {
+            log.debug("Reply while waiting");
             power = onReply;
             firePropertyChange("Power", null, null);
         }
@@ -96,10 +101,12 @@ public class SprogPowerManager extends jmri.managers.AbstractPowerManager
     public void notifyMessage(SprogMessage m) {
         if (m.isKillMain()) {
             // configure to wait for reply
+            log.debug("Seen Kill Main");
             waiting = true;
             onReply = PowerManager.OFF;
         } else if (m.isEnableMain()) {
             // configure to wait for reply
+            log.debug("Seen Enable Main");
             waiting = true;
             onReply = PowerManager.ON;
         }
@@ -113,4 +120,7 @@ public class SprogPowerManager extends jmri.managers.AbstractPowerManager
         }
     }
 
+
+    // initialize logging
+    private final static Logger log = LoggerFactory.getLogger(SprogPowerManager.class);
 }

--- a/java/src/jmri/jmrix/sprog/SprogSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/sprog/SprogSystemConnectionMemo.java
@@ -145,7 +145,7 @@ public class SprogSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
             case OPS:
                 slotThread = new Thread(commandStation);
                 slotThread.setName("SPROG slot thread");
-                slotThread.setPriority(Thread.MAX_PRIORITY-1);
+                slotThread.setPriority(Thread.MAX_PRIORITY-2);
                 slotThread.start();
                 break;
             case SERVICE:

--- a/java/src/jmri/jmrix/sprog/SprogTrafficController.java
+++ b/java/src/jmri/jmrix/sprog/SprogTrafficController.java
@@ -25,10 +25,12 @@ import purejavacomm.SerialPortEventListener;
  * via a pair of *Streams, which then carry sequences of characters for
  * transmission. Note that this processing is handled in an independent thread.
  * <p>
- * Updated January 2010 for gnu io (RXTX) - Andrew Berridge.
- * Removed Runnable implementation and methods for it.
- *
+ * Rewritten during 4.11.x series. Create a high priority thread for the TC to
+ * move everything off the swing thread. Use a blocking queue to handle
+ * asynchronous messages from multiple sources.
+ * 
  * @author	Bob Jacobsen Copyright (C) 2001
+ * @author	Andrew Crosland Copyright (C) 2018
  */
 public class SprogTrafficController implements SprogInterface, SerialPortEventListener,
         Runnable {
@@ -41,6 +43,8 @@ public class SprogTrafficController implements SprogInterface, SerialPortEventLi
     private Thread tcThread;
     private final Object lock = new Object();
     private boolean replyAvailable = false;
+    // MAke this public so it can be overridden by a script for debug
+    public static int timeout = SprogConstants.TC_PROG_REPLY_TIMEOUT;
     
     /**
      * Create a new SprogTrafficController instance.
@@ -53,6 +57,12 @@ public class SprogTrafficController implements SprogInterface, SerialPortEventLi
         tcThread.setName("TC thread");
         tcThread.setPriority(Thread.MAX_PRIORITY-1);
         tcThread.start();
+        // Set the timeout for communcation with hardware
+        if (memo.getSprogMode() == SprogConstants.SprogMode.OPS) {
+            timeout = SprogConstants.TC_OPS_REPLY_TIMEOUT;
+        } else {
+            timeout = SprogConstants.TC_PROG_REPLY_TIMEOUT;
+        }
     }
 
     // Methods to implement the Sprog Interface
@@ -215,7 +225,7 @@ public class SprogTrafficController implements SprogInterface, SerialPortEventLi
      * @param m The message to be forwarded
      */
     public void sendSprogMessage(SprogMessage m) {
-        log.debug("sendSprogMessage message: [{}] id: {}", m.toString(isSIIBootMode()), m.getId());
+        log.debug("Add message to queue: [{}] id: {}", m.toString(isSIIBootMode()), m.getId());
         try {
             sendQueue.add(new MessageTuple(m, null));
         } catch (Exception e) {
@@ -231,7 +241,7 @@ public class SprogTrafficController implements SprogInterface, SerialPortEventLi
      */
     @Override
     public synchronized void sendSprogMessage(SprogMessage m, SprogListener replyTo) {
-        log.debug("sendSprogMessage message: [{}] id: {}", m.toString(isSIIBootMode()), m.getId());
+        log.debug("Add message to queue: [{}] id: {}", m.toString(isSIIBootMode()), m.getId());
         try {
             sendQueue.add(new MessageTuple(m, replyTo));
         } catch (Exception e) {
@@ -265,30 +275,21 @@ public class SprogTrafficController implements SprogInterface, SerialPortEventLi
             if (messageToSend.listener != null) {
                 notifyMessage(messageToSend.message, messageToSend.listener);
             }
+            replyAvailable = false;
             sendToInterface(messageToSend.message);
             log.debug("Waiting for a reply");
             try {
                 synchronized (lock) {
-                    lock.wait(SprogConstants.TC_REPLY_TIMEOUT); // Wait for notify
+                    lock.wait(timeout); // Wait for notify
                 }
             } catch (InterruptedException e) {
                 log.debug("waitingForReply interrupted");
             }
             if (!replyAvailable) {
-                log.error("Timeout waiting for reply from hardware");
-                PowerManager pm = InstanceManager.getNullableDefault(jmri.PowerManager.class);
-                try {
-                    pm.setPower(PowerManager.OFF);
-                } catch (JmriException ex) {
-                    log.error("Exception when turning power off {}", ex);
-                }
-                if (!GraphicsEnvironment.isHeadless()) {
-                    JOptionPane.showMessageDialog(null, Bundle.getMessage("CSErrorFrameDialogString"),
-                        Bundle.getMessage("SprogCSTitle"), JOptionPane.ERROR_MESSAGE);
-                }
+                // Timed out
+                log.warn("Timeout waiting for reply from hardware");
             } else {
-                replyAvailable = false;
-                log.debug("Notified");
+                log.debug("Notified of reply");
             }
         }
     }


### PR DESCRIPTION
Traffic Controller: Make timout dep[end on SPROG mode, don't manipulate power from here.
ConnectionMemo: Launch slot thread at slightly lower priority, traffic controller will be higher
Power Manager: Added logging. Removed one property change firing. to avoid too many repeats.
SprogConstants: Increased packet delay threshold to reduce console output on R-Pi. Split Traffic Controller timeout into two values.
Command Station: Some thread locking no longer needed after recent changes to traffic controller.