### PR TITLE
Eliminate compiler warnings

### DIFF
--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -666,7 +666,7 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
     }
 
     // ------------ variable definitions ------------
-    
+
     // Multi use variables
     ConditionalManager _conditionalManager = null;  // set when LogixAction is created
     LogixManager _logixManager = null;  // set when LogixAction is created
@@ -740,7 +740,7 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
     private HashMap<String, ArrayList<String>> _saveTargetList = new HashMap<>();
 
     // ------------ Methods for Add Logix Window ------------
-    
+
     /**
      * Respond to the Add button in Logix table Creates and/or initialize the
      * Add Logix pane.
@@ -1223,7 +1223,7 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
     }
 
     // ------------ Methods for Edit Logix Pane ------------
-    
+
     /**
      * Respond to the Edit button pressed in Logix table.
      *
@@ -1493,9 +1493,9 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
                         String[] msgs = new String[]{c.getUserName(), c.getSystemName(), cRef.getUserName(),
                             cRef.getSystemName(), xRef.getUserName(), xRef.getSystemName()};
                         JOptionPane.showMessageDialog(null,
-                                Bundle.getMessage("LogixError11", msgs), // NOI18N
-                                Bundle.getMessage("ErrorTitle"),
-                                JOptionPane.ERROR_MESSAGE);  // NOI18N
+                                Bundle.getMessage("LogixError11", (Object[]) msgs), // NOI18N
+                                Bundle.getMessage("ErrorTitle"),  // NOI18N
+                                JOptionPane.ERROR_MESSAGE);
                         return false;
                     }
                 }

--- a/java/src/jmri/jmrit/conditional/ConditionalEditBase.java
+++ b/java/src/jmri/jmrit/conditional/ConditionalEditBase.java
@@ -628,7 +628,7 @@ public class ConditionalEditBase {
                     String[] msgs = new String[]{c.getUserName(), c.getSystemName(), cRef.getUserName(),
                         cRef.getSystemName(), xRef.getUserName(), xRef.getSystemName()};
                     JOptionPane.showMessageDialog(null,
-                            Bundle.getMessage("Error11", msgs), // NOI18N
+                            Bundle.getMessage("Error11", (Object[]) msgs),  // NOI18N
                             Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE); // NOI18N
                     return false;
                 }

--- a/java/src/jmri/jmrit/conditional/ConditionalListEdit.java
+++ b/java/src/jmri/jmrit/conditional/ConditionalListEdit.java
@@ -1367,9 +1367,9 @@ public class ConditionalListEdit extends ConditionalEditBase {
         String[] msgs = _curLogix.deleteConditional(sName);
         if (msgs != null) {
             JOptionPane.showMessageDialog(_editLogixFrame,
-                    Bundle.getMessage("Error11", msgs), // NOI18N
-                    Bundle.getMessage("ErrorTitle"),
-                    JOptionPane.ERROR_MESSAGE);  // NOI18N
+                    Bundle.getMessage("Error11", (Object[]) msgs), // NOI18N
+                    Bundle.getMessage("ErrorTitle"),  // NOI18N
+                    JOptionPane.ERROR_MESSAGE);
         }
 
         // complete deletion
@@ -1379,7 +1379,7 @@ public class ConditionalListEdit extends ConditionalEditBase {
         if (_numConditionals < 1 && !_suppressReminder) {
             // warning message - last Conditional deleted
             JOptionPane.showMessageDialog(_editLogixFrame,
-                    Bundle.getMessage("Warn1"),
+                    Bundle.getMessage("Warn1"),  // NOI18N
                     Bundle.getMessage("WarningTitle"), // NOI18N
                     JOptionPane.WARNING_MESSAGE);
         }

--- a/java/src/jmri/jmrit/conditional/ConditionalTreeEdit.java
+++ b/java/src/jmri/jmrit/conditional/ConditionalTreeEdit.java
@@ -1224,9 +1224,9 @@ public class ConditionalTreeEdit extends ConditionalEditBase {
                 if (msgs != null) {
                     // Unable to delete due to existing conditional references
                     JOptionPane.showMessageDialog(_editLogixFrame,
-                            Bundle.getMessage("Error11", msgs), // NOI18N
-                            Bundle.getMessage("ErrorTitle"),
-                            JOptionPane.ERROR_MESSAGE);  // NOI18N
+                            Bundle.getMessage("Error11", (Object[]) msgs), // NOI18N
+                            Bundle.getMessage("ErrorTitle"),  // NOI18N
+                            JOptionPane.ERROR_MESSAGE);
                     return;
                 }
                 updateWhereUsed(oldTargetNames, newTargetNames, _curNodeName);


### PR DESCRIPTION
Bundle.getMessage(String, String[]) requires explicit cast to Object[].

warning: non-varargs call of varargs method with inexact argument type for last parameter