### PR TITLE
Fix CondtionalTreeEditTest button push timeout

### DIFF
--- a/java/test/jmri/jmrit/conditional/ConditionalTreeEditTest.java
+++ b/java/test/jmri/jmrit/conditional/ConditionalTreeEditTest.java
@@ -129,7 +129,10 @@ public class ConditionalTreeEditTest {
         new JComboBoxOperator(editFrame, 2).selectItem("Sensor 4");  // NOI18N
 
         // Cancel and end the edit
-        new JButtonOperator(editFrame, Bundle.getMessage("ButtonCancel")).push();  // NOI18N
+        JButtonOperator jbo = new JButtonOperator(editFrame, Bundle.getMessage("ButtonCancel"));  // NOI18N
+        if (jbo.isEnabled()) {
+            jbo.push();
+        }
         new JButtonOperator(editFrame, Bundle.getMessage("ButtonDone")).push();  // NOI18N
     }
 
@@ -145,4 +148,6 @@ public class ConditionalTreeEditTest {
     public void tearDown() {
         JUnitUtil.tearDown();
     }
+
+//     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ConditionalTreeEditTest.class);
 }


### PR DESCRIPTION
There is a small probability that a JComboBoxOperator **select** does not create a focus event.  This can leave two buttons in a disabled state which causes a JButtonOperator **push** timeout failure.

This change addresses issue #5026.