### PR TITLE
clean up Throttled Transmitter threads in LocoNet tests

### DIFF
--- a/java/test/jmri/jmrix/loconet/CsOpSwAccessTest.java
+++ b/java/test/jmri/jmrix/loconet/CsOpSwAccessTest.java
@@ -36,6 +36,7 @@ public class CsOpSwAccessTest {
 
     @After
     public void tearDown() {
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/Ib1ThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib1ThrottleManagerTest.java
@@ -12,6 +12,8 @@ import org.junit.Test;
  */
 public class Ib1ThrottleManagerTest extends jmri.managers.AbstractThrottleManagerTestBase {
 
+    private LocoNetSystemConnectionMemo memo;
+
     @Test
     public void testCTor() {
         Assert.assertNotNull("exists",tm);
@@ -21,12 +23,14 @@ public class Ib1ThrottleManagerTest extends jmri.managers.AbstractThrottleManage
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        memo = new LocoNetSystemConnectionMemo();
         tm = new Ib1ThrottleManager(new LocoNetSystemConnectionMemo());
     }
 
     @After
     public void tearDown() {
         ((Ib1ThrottleManager)tm).dispose();
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/Ib1ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib1ThrottleTest.java
@@ -13,6 +13,8 @@ import org.junit.Test;
  */
 public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
+    private LocoNetSystemConnectionMemo memo; 
+
     @Test
     public void testCTor() {
         Assert.assertNotNull("exists",instance);
@@ -407,7 +409,7 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         JUnitUtil.setUp();
         LnTrafficController lnis = new LocoNetInterfaceScaffold();
         SlotManager slotmanager = new SlotManager(lnis);
-        LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo(lnis,slotmanager);
+        memo = new LocoNetSystemConnectionMemo(lnis,slotmanager);
         memo.setThrottleManager(new Ib1ThrottleManager(memo));
         jmri.InstanceManager.setDefault(jmri.ThrottleManager.class,memo.getThrottleManager());
         instance = new Ib1Throttle(memo,new LocoNetSlot(5));
@@ -417,6 +419,7 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void tearDown() {
         ((Ib1ThrottleManager)jmri.InstanceManager.getDefault(jmri.ThrottleManager.class)).dispose();
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/Ib2ThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib2ThrottleManagerTest.java
@@ -12,6 +12,8 @@ import org.junit.Test;
  */
 public class Ib2ThrottleManagerTest extends jmri.managers.AbstractThrottleManagerTestBase {
 
+    private LocoNetSystemConnectionMemo memo;
+
     @Test
     public void testCTor() {
         Assert.assertNotNull("exists",tm);
@@ -21,12 +23,14 @@ public class Ib2ThrottleManagerTest extends jmri.managers.AbstractThrottleManage
     @Before
     public void setUp() {
         JUnitUtil.setUp();
-        tm = new Ib2ThrottleManager(new LocoNetSystemConnectionMemo());
+        memo = new LocoNetSystemConnectionMemo();
+        tm = new Ib2ThrottleManager(memo);
     }
 
     @After
     public void tearDown() {
         ((Ib2ThrottleManager)tm).dispose();
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/Ib2ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib2ThrottleTest.java
@@ -13,6 +13,8 @@ import org.junit.Test;
  */
 public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
+    private LocoNetSystemConnectionMemo memo; 
+
     @Test
     public void testCTor() {
         Assert.assertNotNull("exists",instance);
@@ -408,7 +410,7 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         JUnitUtil.setUp();
         LnTrafficController lnis = new LocoNetInterfaceScaffold();
         SlotManager slotmanager = new SlotManager(lnis);
-        LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo(lnis,slotmanager);
+        memo = new LocoNetSystemConnectionMemo(lnis,slotmanager);
         memo.setThrottleManager(new Ib2ThrottleManager(memo));
         jmri.InstanceManager.setDefault(jmri.ThrottleManager.class,memo.getThrottleManager());
         instance = new Ib2Throttle(memo,new LocoNetSlot(5));
@@ -418,6 +420,7 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void tearDown() {
         ((Ib2ThrottleManager)jmri.InstanceManager.getDefault(jmri.ThrottleManager.class)).dispose();
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/LnCommandStationTypeTest.java
+++ b/java/test/jmri/jmrix/loconet/LnCommandStationTypeTest.java
@@ -31,6 +31,7 @@ public class LnCommandStationTypeTest {
         jmri.ThrottleManager tm = LnCommandStationType.COMMAND_STATION_DCS200.getThrottleManager(memo);
         Assert.assertEquals(LnThrottleManager.class, tm.getClass());
         ((LnThrottleManager)tm).dispose();
+        memo.dispose();
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/loconet/LnNetworkPortControllerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnNetworkPortControllerTest.java
@@ -12,11 +12,13 @@ import org.junit.Before;
  */
 public class LnNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortControllerTestBase {
 
+    private LocoNetSystemConnectionMemo memo;
+ 
     @Override
     @Before
     public void setUp(){
        JUnitUtil.setUp();
-       LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo();
+       memo = new LocoNetSystemConnectionMemo();
        apc = new LnNetworkPortController(memo){
             @Override
             public void configure(){
@@ -27,6 +29,7 @@ public class LnNetworkPortControllerTest extends jmri.jmrix.AbstractNetworkPortC
     @Override
     @After
     public void tearDown(){
+       memo.dispose();
        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
@@ -417,6 +417,7 @@ public class LnOpsModeProgrammerTest extends TestCase {
 
     @Override
     protected void tearDown() {
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/loconet/LnPortControllerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnPortControllerTest.java
@@ -12,11 +12,13 @@ import org.junit.Before;
  */
 public class LnPortControllerTest extends jmri.jmrix.AbstractSerialPortControllerTestBase {
 
+    private LocoNetSystemConnectionMemo memo;
+
     @Override
     @Before
     public void setUp(){
        JUnitUtil.setUp();
-       LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo();
+       memo = new LocoNetSystemConnectionMemo();
        new LocoNetInterfaceScaffold();
        apc = new LnPortController(memo){
             @Override
@@ -58,6 +60,7 @@ public class LnPortControllerTest extends jmri.jmrix.AbstractSerialPortControlle
     @Override
     @After
     public void tearDown(){
+       memo.dispose();
        JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/LnPowerManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnPowerManagerTest.java
@@ -12,6 +12,8 @@ import org.junit.Before;
  */
 public class LnPowerManagerTest extends AbstractPowerManagerTestBase {
 
+    private LocoNetSystemConnectionMemo memo;
+
     /**
      * service routines to simulate receiving on, off from interface
      */
@@ -66,12 +68,14 @@ public class LnPowerManagerTest extends AbstractPowerManagerTestBase {
     @Override
     public void setUp() {
         controller = new LocoNetInterfaceScaffold();
-        p = pwr = new LnPowerManager(new LocoNetSystemConnectionMemo(controller, null));
+        memo = new LocoNetSystemConnectionMemo(controller, null);
+        p = pwr = new LnPowerManager(memo);
     }
 
     @After
     public void tearDown() {
         pwr.dispose();
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/LnPr2ThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnPr2ThrottleManagerTest.java
@@ -12,6 +12,8 @@ import org.junit.Test;
  */
 public class LnPr2ThrottleManagerTest extends jmri.managers.AbstractThrottleManagerTestBase {
 
+    private LocoNetSystemConnectionMemo memo;
+
     @Test
     public void testSetAndGettActiveAddress() { 
         ((LnPr2ThrottleManager)tm).requestThrottleSetup(new jmri.DccLocoAddress(3,false));
@@ -23,11 +25,13 @@ public class LnPr2ThrottleManagerTest extends jmri.managers.AbstractThrottleMana
     @Before
     public void setUp() {
         JUnitUtil.setUp();
-        tm = new LnPr2ThrottleManager(new LocoNetSystemConnectionMemo());
+        memo = new LocoNetSystemConnectionMemo();
+        tm = new LnPr2ThrottleManager(memo);
     }
 
     @After
     public void tearDown() {
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/LnProgrammerManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnProgrammerManagerTest.java
@@ -19,6 +19,7 @@ public class LnProgrammerManagerTest {
         LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo(lnis,slotmanager);
         LnProgrammerManager t = new LnProgrammerManager(slotmanager,memo);
         Assert.assertNotNull("exists",t);
+        memo.dispose();
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
@@ -1053,6 +1053,7 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
     @After
     public void tearDown() {
         ((LnThrottleManager)tm).dispose();
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/LocoNetConsistManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetConsistManagerTest.java
@@ -39,6 +39,7 @@ public class LocoNetConsistManagerTest extends jmri.implementation.AbstractConsi
     public void tearDown() {
         cm = null;
         ((LnThrottleManager)memo.getThrottleManager()).dispose();
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/LocoNetConsistTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetConsistTest.java
@@ -151,6 +151,7 @@ public class LocoNetConsistTest extends jmri.implementation.AbstractConsistTestB
     public void tearDown() {
         ltm.dispose();
         c = null;
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/LocoNetSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetSystemConnectionMemoTest.java
@@ -12,12 +12,14 @@ import org.junit.Before;
  */
 public class LocoNetSystemConnectionMemoTest extends jmri.jmrix.SystemConnectionMemoTestBase {
 
+    private LocoNetSystemConnectionMemo memo; 
+
     @Override
     @Before
     public void setUp(){
        JUnitUtil.setUp();
        LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold();
-       LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo();
+       memo = new LocoNetSystemConnectionMemo();
        memo.setLnTrafficController(lnis);
        memo.configureCommandStation(LnCommandStationType.COMMAND_STATION_DCS100,false,false);
        memo.configureManagers();
@@ -27,6 +29,7 @@ public class LocoNetSystemConnectionMemoTest extends jmri.jmrix.SystemConnection
     @Override
     @After
     public void tearDown(){
+       memo.dispose();
        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/loconet/LocoNetThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetThrottleTest.java
@@ -517,6 +517,7 @@ public class LocoNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void tearDown() {
         ((LnThrottleManager)memo.getThrottleManager()).dispose();
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/Pr2ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Pr2ThrottleTest.java
@@ -13,6 +13,8 @@ import org.junit.Test;
  */
 public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
+    private LocoNetSystemConnectionMemo memo;
+ 
     @Test
     public void testCTor() {
         Assert.assertNotNull("exists",instance);
@@ -417,7 +419,7 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         JUnitUtil.setUp();
         LnTrafficController lnis = new LocoNetInterfaceScaffold();
         SlotManager slotmanager = new SlotManager(lnis);
-        LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo(lnis,slotmanager);
+        memo = new LocoNetSystemConnectionMemo(lnis,slotmanager);
         jmri.InstanceManager.setDefault(jmri.ThrottleManager.class,new LnPr2ThrottleManager(memo));
         instance = new Pr2Throttle(memo,new jmri.DccLocoAddress(5,false));
     }
@@ -425,6 +427,7 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @After
     @Override
     public void tearDown() {
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/SE8cSignalHeadTest.java
+++ b/java/test/jmri/jmrix/loconet/SE8cSignalHeadTest.java
@@ -24,7 +24,7 @@ public class SE8cSignalHeadTest {
         JUnitUtil.setUp();
         LnTrafficController lnis = new LocoNetInterfaceScaffold();
         SlotManager slotmanager = new SlotManager(lnis);
-        new LocoNetSystemConnectionMemo(lnis,slotmanager);
+        //new LocoNetSystemConnectionMemo(lnis,slotmanager);
         jmri.InstanceManager.setDefault(LnTrafficController.class,lnis);
     }
 

--- a/java/test/jmri/jmrix/loconet/downloader/LoaderPaneTest.java
+++ b/java/test/jmri/jmrix/loconet/downloader/LoaderPaneTest.java
@@ -47,6 +47,7 @@ public class LoaderPaneTest extends jmri.util.swing.JmriPanelTest {
 
     @After
     public void tearDown() {
+        memo.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnDplxGrpInfoImplTest.java
+++ b/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnDplxGrpInfoImplTest.java
@@ -12,11 +12,15 @@ import org.junit.Test;
  * @author	Paul Bender Copyright (C) 2016
  */
 public class LnDplxGrpInfoImplTest {
+    
+    private jmri.jmrix.loconet.LocoNetSystemConnectionMemo memo;
 
     @Test
     public void testCtor() {
-        LnDplxGrpInfoImpl action = new LnDplxGrpInfoImpl(new jmri.jmrix.loconet.LocoNetSystemConnectionMemo());
+        jmri.jmrix.loconet.LocoNetSystemConnectionMemo memo = new jmri.jmrix.loconet.LocoNetSystemConnectionMemo();
+        LnDplxGrpInfoImpl action = new LnDplxGrpInfoImpl(memo);
         Assert.assertNotNull("exists", action);
+        memo.dispose();
     }
 
     @Before

--- a/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnIPLImplementationTest.java
+++ b/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnIPLImplementationTest.java
@@ -12,11 +12,13 @@ import org.junit.Test;
  * @author	Paul Bender Copyright (C) 2016
  */
 public class LnIPLImplementationTest {
-
+        
     @Test
     public void testCtor() {
-        LnIPLImplementation action = new LnIPLImplementation(new jmri.jmrix.loconet.LocoNetSystemConnectionMemo());
+        jmri.jmrix.loconet.LocoNetSystemConnectionMemo memo = new jmri.jmrix.loconet.LocoNetSystemConnectionMemo();
+        LnIPLImplementation action = new LnIPLImplementation(memo);
         Assert.assertNotNull("exists", action);
+        memo.dispose();
     }
 
     @Before

--- a/java/test/jmri/jmrix/loconet/hexfile/LocoNetSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/hexfile/LocoNetSystemConnectionMemoTest.java
@@ -28,6 +28,7 @@ public class LocoNetSystemConnectionMemoTest extends jmri.jmrix.SystemConnection
     @Override
     @After
     public void tearDown() {
+        ((LocoNetSystemConnectionMemo)scm).dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/locoio/LocoIOPanelTest.java
+++ b/java/test/jmri/jmrix/loconet/locoio/LocoIOPanelTest.java
@@ -37,6 +37,7 @@ public class LocoIOPanelTest extends jmri.util.swing.JmriPanelTest {
 
         // dispose and end operation
         f.dispose();
+        memo.dispose();
     }
 
     @Test
@@ -65,6 +66,7 @@ public class LocoIOPanelTest extends jmri.util.swing.JmriPanelTest {
 
         // dispose and end operation
         f.dispose();
+        memo.dispose();
     }
 
     @Test
@@ -94,6 +96,7 @@ public class LocoIOPanelTest extends jmri.util.swing.JmriPanelTest {
 
         // dispose and end operation
         f.dispose();
+        memo.dispose();
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/loconet/locostats/LocoStatsFuncTest.java
+++ b/java/test/jmri/jmrix/loconet/locostats/LocoStatsFuncTest.java
@@ -23,6 +23,7 @@ public class LocoStatsFuncTest {
         LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo(lnis,slotmanager);
         LocoStatsFunc t = new LocoStatsFunc(memo);
         Assert.assertNotNull("exists",t);
+        memo.dispose();
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/loconet/pr3/PR3SystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/pr3/PR3SystemConnectionMemoTest.java
@@ -28,6 +28,7 @@ public class PR3SystemConnectionMemoTest extends jmri.jmrix.SystemConnectionMemo
     @Override
     @After
     public void tearDown() {
+        ((PR3SystemConnectionMemo)scm).dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/slotmon/SlotMonDataModelTest.java
+++ b/java/test/jmri/jmrix/loconet/slotmon/SlotMonDataModelTest.java
@@ -22,6 +22,7 @@ public class SlotMonDataModelTest {
         LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo(lnis,slotmanager);
         SlotMonDataModel t = new SlotMonDataModel(1,19,memo);
         Assert.assertNotNull("exists",t);
+        memo.dispose();
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/loconet/slotmon/SlotMonPaneTest.java
+++ b/java/test/jmri/jmrix/loconet/slotmon/SlotMonPaneTest.java
@@ -24,6 +24,7 @@ public class SlotMonPaneTest extends jmri.util.swing.JmriPanelTest {
         LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo(lnis,slotmanager);
         // we are just making sure that initComponents doesn't cause an exception.
         t.initComponents(memo);
+        memo.dispose();
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/loconet/streamport/LnStreamPortControllerTest.java
+++ b/java/test/jmri/jmrix/loconet/streamport/LnStreamPortControllerTest.java
@@ -13,12 +13,14 @@ import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
  * @author      Paul Bender Copyright (C) 2016,2018
  */
 public class LnStreamPortControllerTest extends jmri.jmrix.AbstractStreamPortControllerTestBase {
+       
+    private LocoNetSystemConnectionMemo memo;
 
     @Override
     @Before
     public void setUp(){
        JUnitUtil.setUp();
-       LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo();
+       memo = new LocoNetSystemConnectionMemo();
        memo.setLnTrafficController(new LnStreamPortPacketizer());
        apc = new LnStreamPortController(memo,null,null,"Test Stream Port");
     }
@@ -26,6 +28,7 @@ public class LnStreamPortControllerTest extends jmri.jmrix.AbstractStreamPortCon
     @Override
     @After
     public void tearDown(){
+       memo.dispose();
        JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/swing/LnComponentFactoryTest.java
+++ b/java/test/jmri/jmrix/loconet/swing/LnComponentFactoryTest.java
@@ -23,6 +23,7 @@ public class LnComponentFactoryTest {
         LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo(lnis,slotmanager);
         LnComponentFactory t = new LnComponentFactory(memo);
         Assert.assertNotNull("exists",t);
+        memo.dispose();
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/loconet/swing/LnNamedPaneActionTest.java
+++ b/java/test/jmri/jmrix/loconet/swing/LnNamedPaneActionTest.java
@@ -28,6 +28,7 @@ public class LnNamedPaneActionTest {
         LnNamedPaneAction t = new LnNamedPaneAction("Test Action",jf,"test",memo);
         Assert.assertNotNull("exists",t);
         jf.dispose();
+        memo.dispose();
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/loconet/swing/LocoNetMenuTest.java
+++ b/java/test/jmri/jmrix/loconet/swing/LocoNetMenuTest.java
@@ -23,6 +23,7 @@ public class LocoNetMenuTest {
         LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo(lnis,slotmanager);
         LocoNetMenu t = new LocoNetMenu(memo);
         Assert.assertNotNull("exists",t);
+        memo.dispose();
     }
 
     // The minimal setup for log4J


### PR DESCRIPTION
This  cleans most of the Subject threads by calling dispose on the system connection memo objects.