### PR TITLE
Include HTML scan in Travis CI

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1873,6 +1873,16 @@
              includes="xml/decoders/*.xml"/>
     </target>
 
+    <target name="scanhelp"
+            description="scan English-language help for HTML errors">
+        <exec executable="./scripts/tidy-check.sh"
+              osFamily="unix"
+              failonerror="true">
+            <arg value="help/en/*/*/"/>
+        </exec>
+            
+    </target>
+    
     <target name="remakedecoderindex"
             depends="debug"
             description="rebuild the decoder index into the preferences directory">

--- a/help/en/html/doc/Technical/Help.shtml
+++ b/help/en/html/doc/Technical/Help.shtml
@@ -143,6 +143,18 @@ confuses JavaHelp.
         web browser.</li>
       </ul><a name="web" id="web"></a>
 
+      <a id="check"></a>
+      <h3>Checking Your Changes</h3>
+      
+      The 
+      <a href="">Continuous Integration</a>
+      process checks all changes to JMRI Help files to make
+      sure they're OK.  If you'd like to run that same check
+      while you're working, do:
+<pre style="font-family: monospace;">   
+    ant scanhelp   
+</pre>
+
       <h2>Web access to help</h2>
       It's inconvenient to have to
       maintain two separate web pages for the main web site and the

--- a/scripts/tidy-check.sh
+++ b/scripts/tidy-check.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+# scan the help files for HMTL errors, used in 'ant html'
+# if an argument is provided, i.e. "help/en/*/" scan there, otherwise scan all the help
+
+if [[ "$@" == "" ]] ; then
+    WHERE=help/*/*/
+else
+    WHERE=$@
+fi
+
+# first, scan for whether there's an issue
+find ${WHERE} -name \*html ! -exec tidy -eq -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | awk -f scripts/tidy.awk | grep Warning
+
+if [ $? -eq 0 ]; then
+    exit 1
+fi
+if [ $? -eq 1 ]; then
+    exit 0
+fi
+# leave error codes as-is
+

--- a/scripts/tidy-scan.sh
+++ b/scripts/tidy-scan.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
-# scan the help files for HMTL errors, used in Jenkins
+# scan the help files for HMTL errors, used in Jenkins as "tidy-scan.sh help/en/*/*"
+# formats output for Jenkins presentation
 # if an argument is provided, i.e. "help/en/*/" scan there, otherwise scan all the help
 
 if [[ "$@" == "" ]] ; then

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -20,6 +20,8 @@ if [[ "${HEADLESS}" == "true" ]] ; then
         mvn clean test -U -P travis-spotbugs --batch-mode
         # run Javadoc
         mvn javadoc:javadoc -U --batch-mode
+        # scan HTML
+        ant scanhelp
     else
         # run headless tests
         mvn test -U -P travis-headless --batch-mode \


### PR DESCRIPTION
Script and control file changes to include the HTML scan (already one in Jenkins) in Travis static headless CI runs.

This first run will fail, due to an intentionally-bad HTML file.  That'll be fixed via an additional commit.