### PR TITLE
Windows installer will remove classes\ subdirectory

### DIFF
--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -152,7 +152,9 @@ We roll some general code maintenance items into the release process.  They can 
 
 - This is a good place to make sure CATS still builds, see the (doc page)[http://jmri.org/help/en/html/doc/Technical/CATS.shtml] - note that CATS has not been updated to compile cleanly with JMRI 4.*
         
-- If you fixed anything, commit it back. Also commit the current copy of these notes. Push directly back to master on GitHub.
+- If you fixed anything, commit it back. 
+
+- Commit the current copy of these notes. Push directly back to master on GitHub.
 
 ```
 git commit -m"for 4.11.4" scripts/HOWTO-distribution.md

--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -469,6 +469,11 @@ SectionGroup "JMRI Core Files" SEC_CORE
     ; -- Clean up of JMRI folder
     SetOutPath "$INSTDIR"
 
+    ; -- Recursively delete classes folder, which historically contained 
+    ; -- individual .properties and .classes patch files
+    ; -- that might not be consistent with this new version
+    RMDir /R "$OUTDIR\classes"
+
     ; -- Delete insecure jackson jar files as of JMRI 4.11.3
     Delete "$OUTDIR\lib\jackson-annotations-2.8.5.jar"
     Delete "$OUTDIR\lib\jackson-core-2.8.5.jar"

--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -1507,7 +1507,7 @@ Function RemoveOldJMRI
   Rename "$PROFILE\JMRI_backup" "$PROFILE\JMRI_backup_old"
   CreateDirectory "$PROFILE\JMRI_backup"
   CopyFiles "$PROFILE\JMRI\*.*" "$PROFILE\JMRI_backup"
-  CopyFiles "$OUTDIR\classes\" "$PROFILE\JMRI_backup"
+  CopyFiles "$INSTDIR\classes\" "$PROFILE\JMRI_backup"
 
   ; -- Check if uninstall required
   StrCmp $REMOVEOLDJMRI.BACKUPONLY "1" Done

--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -50,6 +50,9 @@
 ; -------------------------------------------------------------------------
 ; - Version History
 ; -------------------------------------------------------------------------
+; - Version 0.1.22.15
+; - Backup and remove classes folder
+; -------------------------------------------------------------------------
 ; - Version 0.1.22.14
 ; - Remove insecure Jackson libraries to address CVE-2017-17485
 ; -------------------------------------------------------------------------
@@ -295,7 +298,7 @@
   ; -- usually, this will be determined by the build.xml ant script
   !define JRE_VER   "1.8"                       ; Required JRE version
 !endif
-!define INST_VER  "0.1.22.11"                   ; Installer version
+!define INST_VER  "0.1.22.15"                   ; Installer version
 !define PNAME     "${APP}.${JMRI_VER}"          ; Name of installer.exe
 !define SRCDIR    "."                           ; Path to head of sources
 InstallDir        "$PROGRAMFILES\JMRI"          ; Default install directory
@@ -1504,6 +1507,7 @@ Function RemoveOldJMRI
   Rename "$PROFILE\JMRI_backup" "$PROFILE\JMRI_backup_old"
   CreateDirectory "$PROFILE\JMRI_backup"
   CopyFiles "$PROFILE\JMRI\*.*" "$PROFILE\JMRI_backup"
+  CopyFiles "$OUTDIR\classes\" "$PROFILE\JMRI_backup"
 
   ; -- Check if uninstall required
   StrCmp $REMOVEOLDJMRI.BACKUPONLY "1" Done


### PR DESCRIPTION
This updates the Windows installer to remove any "classes\" subdirectory and it's contents.  This can have left-over .class and .properties files from the previous version.  if needed, the old versions are part of the backup done earlier.