### PR TITLE
re-throw AssumptionViolatedExceptions in RetryRule

### DIFF
--- a/java/test/jmri/util/junit/rules/RetryRule.java
+++ b/java/test/jmri/util/junit/rules/RetryRule.java
@@ -10,6 +10,7 @@ package jmri.util.junit.rules;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.junit.AssumptionViolatedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +37,9 @@ public class RetryRule implements TestRule {
                     try {
                         base.evaluate();
                         return;
+                    } catch (AssumptionViolatedException ave) {
+                        // an assumption was violated, so just re-throw ave.
+                        throw ave;
                     } catch (Throwable t) {
                         caughtThrowable = t;
                         log.info("{} : run  {} failed",description.getDisplayName(), (i + 1));


### PR DESCRIPTION
This addresses #5114 by handling an AssumptionViolatedException differently than any other Throwable.