### PR TITLE
Windows installer will backup "classes" subdirectory

### DIFF
--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -1507,7 +1507,7 @@ Function RemoveOldJMRI
   Rename "$PROFILE\JMRI_backup" "$PROFILE\JMRI_backup_old"
   CreateDirectory "$PROFILE\JMRI_backup"
   CopyFiles "$PROFILE\JMRI\*.*" "$PROFILE\JMRI_backup"
-  CopyFiles "$INSTDIR\classes\" "$PROFILE\JMRI_backup"
+  CopyFiles "$INSTDIR\classes" "$PROFILE\JMRI_backup"
 
   ; -- Check if uninstall required
   StrCmp $REMOVEOLDJMRI.BACKUPONLY "1" Done


### PR DESCRIPTION
@bobjacobsen
This is related to PR #5113, where I overlooked to remove a backslash in the ```CopyFiles``` command.
So, no version change in ```InstallJMRI.nsi```.