### PR TITLE
Add LocoNet transponding option

### DIFF
--- a/help/en/html/hardware/loconet/Digitrax.shtml
+++ b/help/en/html/hardware/loconet/Digitrax.shtml
@@ -388,8 +388,15 @@
 
             <li>The <a href="#TurnoutCmdHandling">"Command Station
             Turnout Command Rejection and JMRI Turnout Command
-            Handling"</a> setting is described <a href=
+            Handling"</a> settings are described <a href=
             "#TurnoutCmdHandling">below</a>.</li>
+
+            <li>The "Transponding Present" allows you indicate whether
+                certain special hardware is present and configured.
+                If you have LocoNet-attached boards that configure 
+                in "ops mode", or if you have Digitrax Transponding
+                installed, set this to "Yes". Otherwise, set it to 
+                "No". </li>
 
             <li>The "Connection Uses" selection determines how
             "flow control" is implemented in software. This

--- a/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableTableModel.java
@@ -286,22 +286,13 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
         boolean opsOnly = e.getAttribute("opsOnly") != null
                 ? e.getAttribute("opsOnly").getValue().equals("yes") : false;
 
-        // Ops mode doesn't allow reads, therefore we must disable read buttons
+        // Handle special case of opsOnly mode & specific programmer type
         if (_cvModel.getProgrammer() != null) {
             if (opsOnly && !AddressedProgrammer.class.isAssignableFrom(_cvModel.getProgrammer().getClass())) {
                 // opsOnly but not Ops mode, so adjust
                 readOnly = false;
                 writeOnly = false;
                 infoOnly = true;
-            } else if (!_cvModel.getProgrammer().getCanRead()) {
-                // can't read, so adjust
-                if (readOnly) {
-                    readOnly = false;
-                    infoOnly = true;
-                }
-                if (!infoOnly) {
-                    writeOnly = true;
-                }
             }
         }
 
@@ -630,6 +621,12 @@ public class VariableTableModel extends AbstractTableModel implements ActionList
                 br.setActionCommand("R" + row);
                 br.addActionListener(this);
             }
+        }
+    }
+
+    public void setButtonModeFromProgrammer() {
+        if (!_cvModel.getProgrammer().getCanRead()) {
+            for (JButton b : _readButtons) b.setEnabled(false);
         }
     }
 

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
@@ -516,6 +516,8 @@ abstract public class PaneProgFrame extends JmriJFrame
                 // done after setting facades in case new possibilities appear
                 if (programming != null) {
                     pickProgrammerMode(programming);
+                    // reset the read buttons if the mode changes
+                    enableReadButtons();
                 } else {
                     log.debug("Skipping programmer setup because found no programmer element");
                 }

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPane.java
@@ -2188,6 +2188,7 @@ public class PaneProgPane extends javax.swing.JPanel
         for (int j = 0; j < _cvModel.getRowCount(); j++) {
             cvList.add(j);
         }
+        _varModel.setButtonModeFromProgrammer();
     }
 
     /**

--- a/java/src/jmri/jmrix/JmrixBundle.properties
+++ b/java/src/jmri/jmrix/JmrixBundle.properties
@@ -70,10 +70,12 @@ BroadcastPortLabel      = Broadcast Port:
 XconnectionUsesLabel    = {0} connection uses:
 CommandStationTypeLabel = Command station type:
 
-PacketizerTypeLabel              = Packetizer stype:
+PacketizerTypeLabel              = Packetizer type:
 PacketizerTypelnPacketizer       = Normal (recommended)
 PacketizerTypelnPacketizerStrict = Strict
 
+TurnoutHandling         = Turnout command handling:
+TranspondingPresent     = Transponding present:
 
 #JmrixAbstractConnectionConfig (item on the above ConfigPane)
 AdditionalConnectionSettings = Additional Connection Settings

--- a/java/src/jmri/jmrix/loconet/Intellibox/IntelliboxAdapter.java
+++ b/java/src/jmri/jmrix/loconet/Intellibox/IntelliboxAdapter.java
@@ -44,7 +44,7 @@ public class IntelliboxAdapter extends LocoBufferAdapter {
         this.getSystemConnectionMemo().setLnTrafficController(packets);
         // do the common manager config
         this.getSystemConnectionMemo().configureCommandStation(commandStationType,
-                mTurnoutNoRetry, mTurnoutExtraSpace);
+                mTurnoutNoRetry, mTurnoutExtraSpace, mTranspondingAvailable);
         this.getSystemConnectionMemo().configureManagers();
 
         // start operation

--- a/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
@@ -445,6 +445,7 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
     public List<ProgrammingMode> getSupportedModes() {
         List<ProgrammingMode> ret = new ArrayList<>(4);
         ret.add(ProgrammingMode.OPSBYTEMODE);
+        ret.add(LnProgrammerManager.LOCONETOPSBOARD);
         ret.add(LnProgrammerManager.LOCONETSV1MODE);
         ret.add(LnProgrammerManager.LOCONETSV2MODE);
         ret.add(LnProgrammerManager.LOCONETBDOPSWMODE);
@@ -495,14 +496,15 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
 
     /**
      * Can this ops-mode programmer read back values? Yes, if transponding
-     * hardware is present, but we don't check that here.
+     * hardware is present and regular ops mode, or if in any other mode.
      *
      * @return always true
      */
     @Override
     public boolean getCanRead() {
-        return mSlotMgr.getTranspondingAvailable();
-    }
+        if (getMode().equals(ProgrammingMode.OPSBYTEMODE)) return mSlotMgr.getTranspondingAvailable();
+        return true;
+     }
 
     @Override
     public boolean getCanRead(String addr) {

--- a/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
@@ -501,7 +501,7 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
      */
     @Override
     public boolean getCanRead() {
-        return true;
+        return mSlotMgr.getTranspondingAvailable();
     }
 
     @Override

--- a/java/src/jmri/jmrix/loconet/LnPortController.java
+++ b/java/src/jmri/jmrix/loconet/LnPortController.java
@@ -50,6 +50,8 @@ public abstract class LnPortController extends jmri.jmrix.AbstractSerialPortCont
     protected boolean mTurnoutNoRetry = false;
     protected boolean mTurnoutExtraSpace = false;
 
+    protected boolean mTranspondingAvailable = false;
+
     protected LnCommandStationType[] commandStationTypes = {
         LnCommandStationType.COMMAND_STATION_DCS100,
         LnCommandStationType.COMMAND_STATION_DCS240,
@@ -89,7 +91,7 @@ public abstract class LnPortController extends jmri.jmrix.AbstractSerialPortCont
         if (value == null) {
             return;  // can happen while switching protocols
         }
-        log.debug("setCommandStationType: " + value); // NOI18N
+        log.debug("setCommandStationType: {}", value); // NOI18N
         commandStationType = value;
     }
 
@@ -100,10 +102,16 @@ public abstract class LnPortController extends jmri.jmrix.AbstractSerialPortCont
         if (value.equals("Spread") || value.equals("Both")) { // NOI18N
             mTurnoutExtraSpace = true;
         }
-        log.debug("turnout no retry: " + mTurnoutNoRetry); // NOI18N
-        log.debug("turnout extra space: " + mTurnoutExtraSpace); // NOI18N
+        log.debug("turnout no retry: {}", mTurnoutNoRetry); // NOI18N
+        log.debug("turnout extra space: {}", mTurnoutExtraSpace); // NOI18N
     }
 
+    public void setTranspondingAvailable(String value) {
+        // default (most common state) is off, so just check for Yes
+        mTranspondingAvailable = value.equals("Yes");
+        log.debug("transponding available: {}", mTranspondingAvailable); // NOI18N
+    }
+    
     @Override
     public LocoNetSystemConnectionMemo getSystemConnectionMemo() {
         return (LocoNetSystemConnectionMemo) super.getSystemConnectionMemo();

--- a/java/src/jmri/jmrix/loconet/LnProgrammerManager.java
+++ b/java/src/jmri/jmrix/loconet/LnProgrammerManager.java
@@ -44,6 +44,7 @@ public class LnProgrammerManager extends DefaultProgrammerManager {
         return null;
     }
 
+    static final ProgrammingMode LOCONETOPSBOARD    = new ProgrammingMode("LOCONETOPSBOARD", Bundle.getMessage("LOCONETOPSBOARD"));
     static final ProgrammingMode LOCONETSV1MODE    = new ProgrammingMode("LOCONETSV1MODE", Bundle.getMessage("LOCONETSV1MODE"));
     static final ProgrammingMode LOCONETSV2MODE    = new ProgrammingMode("LOCONETSV2MODE", Bundle.getMessage("LOCONETSV2MODE"));
     static final ProgrammingMode LOCONETBDOPSWMODE = new ProgrammingMode("LOCONETBDOPSWMODE", Bundle.getMessage("LOCONETBDOPSWMODE"));
@@ -56,6 +57,7 @@ public class LnProgrammerManager extends DefaultProgrammerManager {
     public List<ProgrammingMode> getDefaultModes() {
         List<ProgrammingMode> ret = new ArrayList<ProgrammingMode>();
         ret.add(ProgrammingMode.OPSBYTEMODE);
+        ret.add(LOCONETOPSBOARD);
         ret.add(LOCONETSV2MODE);
         ret.add(LOCONETSV1MODE); // the show in interface in order listed here
         return ret;

--- a/java/src/jmri/jmrix/loconet/LocoNetBundle.properties
+++ b/java/src/jmri/jmrix/loconet/LocoNetBundle.properties
@@ -62,6 +62,7 @@ TextSlotMonShowSystem       = Show system slots
 TooltipSlotMonShowUnused    = if checked, even empty/idle slots will appear
 TooltipSlotMonShowSystem    = if checked, slots reserved for system use will be shown
 
+LOCONETOPSBOARD             = LocoNet-Attached Board
 LOCONETSV1MODE              = System Variable Type 1
 LOCONETSV2MODE              = System Variable Type 2
 LOCONETCSOPSWMODE           = Command Station Op Switches

--- a/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
@@ -119,7 +119,8 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
      * @param mTurnoutExtraSpace Is the user configuration set for extra time
      *                           between turnout operations?
      */
-    public void configureCommandStation(LnCommandStationType type, boolean mTurnoutNoRetry, boolean mTurnoutExtraSpace) {
+    public void configureCommandStation(LnCommandStationType type, boolean mTurnoutNoRetry, 
+                                            boolean mTurnoutExtraSpace, boolean mTranspondingAvailable) {
 
         // store arguments
         this.mTurnoutNoRetry = mTurnoutNoRetry;
@@ -135,6 +136,7 @@ public class LocoNetSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo
 
             sm.setCommandStationType(type);
             sm.setSystemConnectionMemo(this);
+            sm.setTranspondingAvailable(mTranspondingAvailable);
 
             // store as CommandStation object
             InstanceManager.store(sm, jmri.CommandStation.class);

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -1532,6 +1532,10 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
         return adaptermemo.getSystemPrefix();
     }
 
+    boolean transpondingAvailable = false;
+    public void setTranspondingAvailable(boolean val) { transpondingAvailable = val; }
+    public boolean getTranspondingAvailable() { return transpondingAvailable; }
+    
     /**
      * Returns the memo
      * <p>

--- a/java/src/jmri/jmrix/loconet/bluetooth/LocoNetBluetoothAdapter.java
+++ b/java/src/jmri/jmrix/loconet/bluetooth/LocoNetBluetoothAdapter.java
@@ -194,7 +194,7 @@ public class LocoNetBluetoothAdapter extends LnPortController implements jmri.jm
         // do the common manager config
 
         this.getSystemConnectionMemo().configureCommandStation(commandStationType,
-                mTurnoutNoRetry, mTurnoutExtraSpace);
+                mTurnoutNoRetry, mTurnoutExtraSpace, mTranspondingAvailable);
         this.getSystemConnectionMemo().configureManagers();
 
         // start operation

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileFrame.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileFrame.java
@@ -166,7 +166,7 @@ public class HexFileFrame extends JmriJFrame {
 
         // do the common manager config
         port.getSystemConnectionMemo().configureCommandStation(LnCommandStationType.COMMAND_STATION_DCS100, // full featured by default
-                false, false);
+                false, false, false);
         port.getSystemConnectionMemo().configureManagers();
         if (port.getSystemConnectionMemo().getSensorManager() instanceof LnSensorManager) {
             LnSensorManager LnSensorManager = (LnSensorManager) port.getSystemConnectionMemo().getSensorManager();

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileServer.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileServer.java
@@ -44,7 +44,7 @@ public class HexFileServer {
 
         // do the common manager config
         port.getSystemConnectionMemo().configureCommandStation(LnCommandStationType.COMMAND_STATION_DCS100, // full featured by default
-                false, false);
+                false, false, false);
         port.getSystemConnectionMemo().configureManagers();
 
         // Install a debug programmer, replacing the existing LocoNet one

--- a/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
@@ -39,11 +39,13 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
         option2Name = "CommandStation"; // NOI18N
         option3Name = "TurnoutHandle"; // NOI18N
         option4Name = "PacketizerType"; //NOI18N
-        options.put(option1Name, new Option(Bundle.getMessage("XconnectionUsesLabel", Bundle.getMessage("TypeSerial")), validOption1));
-        options.put(option2Name, new Option(Bundle.getMessage("CommandStationTypeLabel"), getCommandStationListWithStandaloneLN(), false));
-        options.put(option3Name, new Option("Turnout command handling:", new String[]{"Normal", "Spread", "One Only", "Both"})); // TODO I18N
-        options.put(option4Name, new Option(Bundle.getMessage("PacketizerTypeLabel"),packetizerOptions()));
-        options.put("TranspondingPresent", new Option("Transponding present:", new String[]{"No", "Yes"})); // TODO I18N
+        options.put(option1Name, new Option(Bundle.getMessage("XconnectionUsesLabel", Bundle.getMessage("TypeSerial")), validOption1));  // NOI18N
+        options.put(option2Name, new Option(Bundle.getMessage("CommandStationTypeLabel"), getCommandStationListWithStandaloneLN(), false));  // NOI18N
+        options.put(option3Name, new Option(Bundle.getMessage("TurnoutHandling"), 
+                new String[]{"Normal", "Spread", "One Only", "Both"})); // TODO I18N
+        options.put(option4Name, new Option(Bundle.getMessage("PacketizerTypeLabel"),packetizerOptions()));  // NOI18N
+        options.put("TranspondingPresent", new Option(Bundle.getMessage("TranspondingPresent"), 
+                new String[]{Bundle.getMessage("ButtonNo"), Bundle.getMessage("ButtonYes")})); // NOI18N
     }
     
     /**

--- a/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
@@ -45,7 +45,7 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
                 new String[]{"Normal", "Spread", "One Only", "Both"})); // TODO I18N
         options.put(option4Name, new Option(Bundle.getMessage("PacketizerTypeLabel"),packetizerOptions()));  // NOI18N
         options.put("TranspondingPresent", new Option(Bundle.getMessage("TranspondingPresent"), 
-                new String[]{Bundle.getMessage("ButtonNo"), Bundle.getMessage("ButtonYes")})); // NOI18N
+                new String[]{Bundle.getMessage("ButtonYes"), Bundle.getMessage("ButtonNo")} )); // NOI18N
     }
     
     /**

--- a/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
@@ -43,6 +43,7 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
         options.put(option2Name, new Option(Bundle.getMessage("CommandStationTypeLabel"), getCommandStationListWithStandaloneLN(), false));
         options.put(option3Name, new Option("Turnout command handling:", new String[]{"Normal", "Spread", "One Only", "Both"})); // TODO I18N
         options.put(option4Name, new Option(Bundle.getMessage("PacketizerTypeLabel"),packetizerOptions()));
+        options.put("TranspondingPresent", new Option("Transponding present:", new String[]{"No", "Yes"})); // TODO I18N
     }
     
     /**
@@ -173,6 +174,7 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
 
         setCommandStationType(getOptionState(option2Name));
         setTurnoutHandling(getOptionState(option3Name));
+        setTranspondingAvailable(getOptionState("TranspondingPresent"));
         // connect to a packetizing traffic controller
         LnPacketizer packets = getPacketizer(getOptionState(option4Name));
         packets.connectPort(this);
@@ -182,7 +184,7 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
         // do the common manager config
 
         this.getSystemConnectionMemo().configureCommandStation(commandStationType,
-                mTurnoutNoRetry, mTurnoutExtraSpace);
+                mTurnoutNoRetry, mTurnoutExtraSpace, mTranspondingAvailable);
         this.getSystemConnectionMemo().configureManagers();
 
         // start operation

--- a/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
@@ -45,7 +45,7 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
                 new String[]{"Normal", "Spread", "One Only", "Both"})); // TODO I18N
         options.put(option4Name, new Option(Bundle.getMessage("PacketizerTypeLabel"),packetizerOptions()));  // NOI18N
         options.put("TranspondingPresent", new Option(Bundle.getMessage("TranspondingPresent"), 
-                new String[]{Bundle.getMessage("ButtonYes"), Bundle.getMessage("ButtonNo")} )); // NOI18N
+                new String[]{Bundle.getMessage("ButtonNo"), Bundle.getMessage("ButtonYes")} )); // NOI18N
     }
     
     /**

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpDriverAdapter.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpDriverAdapter.java
@@ -42,7 +42,7 @@ public class LnTcpDriverAdapter extends LnNetworkPortController {
         this.getSystemConnectionMemo().setLnTrafficController(packets);
         // do the common manager config
         this.getSystemConnectionMemo().configureCommandStation(commandStationType,
-                mTurnoutNoRetry, mTurnoutExtraSpace);
+                mTurnoutNoRetry, mTurnoutExtraSpace, false); // never transponding
         this.getSystemConnectionMemo().configureManagers();
 
         // start operation

--- a/java/src/jmri/jmrix/loconet/locormi/LnMessageClient.java
+++ b/java/src/jmri/jmrix/loconet/locormi/LnMessageClient.java
@@ -106,7 +106,7 @@ public class LnMessageClient extends LnTrafficRouter {
         clientMemo.setLnTrafficController(this);
         // do the common manager config
         clientMemo.configureCommandStation(LnCommandStationType.COMMAND_STATION_DCS100, // for now, assume full capability
-                false, false);
+                false, false, false);
         clientMemo.configureManagers();
 
         // the serial connections (LocoBuffer et al) start

--- a/java/src/jmri/jmrix/loconet/ms100/MS100Adapter.java
+++ b/java/src/jmri/jmrix/loconet/ms100/MS100Adapter.java
@@ -138,7 +138,7 @@ public class MS100Adapter extends LnPortController implements jmri.jmrix.SerialP
         this.getSystemConnectionMemo().setLnTrafficController(packets);
         // do the common manager config
         this.getSystemConnectionMemo().configureCommandStation(commandStationType,
-                mTurnoutNoRetry, mTurnoutExtraSpace);
+                mTurnoutNoRetry, mTurnoutExtraSpace, mTranspondingAvailable);
         this.getSystemConnectionMemo().configureManagers();
 
         // start operation

--- a/java/src/jmri/jmrix/loconet/pr2/PR2Adapter.java
+++ b/java/src/jmri/jmrix/loconet/pr2/PR2Adapter.java
@@ -70,7 +70,7 @@ public class PR2Adapter extends LocoBufferAdapter {
         this.getSystemConnectionMemo().setLnTrafficController(packets);
         // do the common manager config
         this.getSystemConnectionMemo().configureCommandStation(commandStationType,
-                mTurnoutNoRetry, mTurnoutExtraSpace);
+                mTurnoutNoRetry, mTurnoutExtraSpace, mTranspondingAvailable);
         this.getSystemConnectionMemo().configureManagers();
 
         // start operation

--- a/java/src/jmri/jmrix/loconet/pr3/PR3Adapter.java
+++ b/java/src/jmri/jmrix/loconet/pr3/PR3Adapter.java
@@ -81,7 +81,7 @@ public class PR3Adapter extends LocoBufferAdapter {
             this.getSystemConnectionMemo().setLnTrafficController(packets);
             // do the common manager config
             this.getSystemConnectionMemo().configureCommandStation(commandStationType,
-                    mTurnoutNoRetry, mTurnoutExtraSpace);
+                    mTurnoutNoRetry, mTurnoutExtraSpace, mTranspondingAvailable);  // never transponding!
             this.getSystemConnectionMemo().configureManagersPR2();
 
             // start operation
@@ -109,7 +109,7 @@ public class PR3Adapter extends LocoBufferAdapter {
             this.getSystemConnectionMemo().setLnTrafficController(packets);
             // do the common manager config
             this.getSystemConnectionMemo().configureCommandStation(commandStationType,
-                    mTurnoutNoRetry, mTurnoutExtraSpace);
+                    mTurnoutNoRetry, mTurnoutExtraSpace, mTranspondingAvailable);
 
             this.getSystemConnectionMemo().configureManagersMS100();
 

--- a/java/src/jmri/jmrix/loconet/streamport/LnStreamPortController.java
+++ b/java/src/jmri/jmrix/loconet/streamport/LnStreamPortController.java
@@ -49,7 +49,7 @@ public class LnStreamPortController extends jmri.jmrix.AbstractStreamPortControl
         this.getSystemConnectionMemo().setLnTrafficController(packets);
         // do the common manager config
         this.getSystemConnectionMemo().configureCommandStation(commandStationType,
-                mTurnoutNoRetry, mTurnoutExtraSpace);
+                mTurnoutNoRetry, mTurnoutExtraSpace, false); // never transponding
         this.getSystemConnectionMemo().configureManagers();
 
         // start operation

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockAdapter.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockAdapter.java
@@ -53,7 +53,7 @@ public class UhlenbrockAdapter extends LocoBufferAdapter {
         this.getSystemConnectionMemo().setLnTrafficController(packets);
         // do the common manager config
         this.getSystemConnectionMemo().configureCommandStation(commandStationType,
-                mTurnoutNoRetry, mTurnoutExtraSpace);
+                mTurnoutNoRetry, mTurnoutExtraSpace, mTranspondingAvailable);
         this.getSystemConnectionMemo().configureManagers();
 
         // start operation

--- a/java/test/apps/gui3/paned/PanelProFrameTest.java
+++ b/java/test/apps/gui3/paned/PanelProFrameTest.java
@@ -30,14 +30,14 @@ public class PanelProFrameTest {
         jmri.jmrix.loconet.LocoNetInterfaceScaffold lnis = new jmri.jmrix.loconet.LocoNetInterfaceScaffold();
         jmri.jmrix.loconet.LocoNetSystemConnectionMemo memo = new jmri.jmrix.loconet.LocoNetSystemConnectionMemo();
         memo.setLnTrafficController(lnis);
-        memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100,false,false);
+        memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100,false,false,false);
         memo.configureManagers();
         jmri.InstanceManager.store(memo,jmri.jmrix.loconet.LocoNetSystemConnectionMemo.class);
 
         jmri.jmrix.loconet.LocoNetInterfaceScaffold lnis2 = new jmri.jmrix.loconet.LocoNetInterfaceScaffold();
         jmri.jmrix.loconet.LocoNetSystemConnectionMemo memo2 = new jmri.jmrix.loconet.LocoNetSystemConnectionMemo();
         memo2.setLnTrafficController(lnis2);
-        memo2.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100,false,false);
+        memo2.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100,false,false,false);
         memo2.configureManagers();
         jmri.InstanceManager.store(memo2,jmri.jmrix.loconet.LocoNetSystemConnectionMemo.class);
     }

--- a/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
@@ -33,10 +33,20 @@ public class LnOpsModeProgrammerTest extends TestCase {
         Assert.assertEquals("OpsByteMode", ProgrammingMode.OPSBYTEMODE, intRet);
     }
 
-    public void testGetCanRead() {
+    public void testGetCanReadDefault() {
         LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(sm, memo, 1, true);
 
-        Assert.assertEquals("ops mode always can read", true,
+        Assert.assertEquals("ops mode by default can;t read", false,
+                lnopsmodeprogrammer.getCanRead());
+    }
+
+    public void testGetCanReadWithTransponding() {
+        // allow transponding
+        sm.setTranspondingAvailable(true);
+        
+        LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(sm, memo, 1, true);
+
+        Assert.assertEquals("ops mode can read with transponding", true,
                 lnopsmodeprogrammer.getCanRead());
     }
 

--- a/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
@@ -401,6 +401,75 @@ public class LnOpsModeProgrammerTest extends TestCase {
 
      }
 
+     public void testOpsReadDecoderTransponding() throws ProgrammerException {
+        // allow transponding
+        sm.setTranspondingAvailable(true);
+
+        LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(sm, memo, 4, true);
+
+        lnopsmodeprogrammer.setMode(ProgrammingMode.OPSBYTEMODE);
+        lnopsmodeprogrammer.readCV("12", pl);
+
+        // should have written
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+
+        Assert.assertEquals("sent", "EF 0E 7C 2F 00 00 04 00 00 0B 00 7F 7F 00", lnis.outbound.get(0).toString());
+
+        // check echo of sent message has no effect
+        LocoNetMessage m = lnis.outbound.get(0);
+        lnopsmodeprogrammer.message(m);
+        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+
+        // LACK followed by Known-good message in reply
+        m = new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25});
+        lnopsmodeprogrammer.message(m);
+        sm.message(m);
+        m = new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x2B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1C, 0x23, 0x7F, 0x7F, 0x3B});
+        lnopsmodeprogrammer.message(m);
+        sm.message(m);
+        JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"getRcvdInvoked not set");
+        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("Reply status OK", 0, pl.getRcvdStatus());
+
+     }
+
+     public void testOpsReadLocoNetMode() throws ProgrammerException {
+        // allow transponding
+        sm.setTranspondingAvailable(false);
+
+        LnOpsModeProgrammer lnopsmodeprogrammer = new LnOpsModeProgrammer(sm, memo, 4, true);
+
+        lnopsmodeprogrammer.setMode(LnProgrammerManager.LOCONETOPSBOARD);
+        lnopsmodeprogrammer.readCV("12", pl);
+
+        // should have written
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+
+        Assert.assertEquals("sent", "EF 0E 7C 2F 00 00 04 00 00 0B 00 7F 7F 00", lnis.outbound.get(0).toString());
+
+        // check echo of sent message has no effect
+        LocoNetMessage m = lnis.outbound.get(0);
+        lnopsmodeprogrammer.message(m);
+        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("No programming reply", 0, pl.getRcvdInvoked());
+
+        // LACK followed by Known-good message in reply
+        m = new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25});
+        lnopsmodeprogrammer.message(m);
+        sm.message(m);
+
+        m = new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x2B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1C, 0x23, 0x7F, 0x7F, 0x3B});
+        lnopsmodeprogrammer.message(m);
+        sm.message(m);
+        JUnitUtil.waitFor(()->{return pl.getRcvdInvoked() == 1;},"getRcvdInvoked not set");
+        Assert.assertEquals("still one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("Reply status OK", 0, pl.getRcvdStatus());
+
+     }
+
 
     // from here down is testing infrastructure
     public LnOpsModeProgrammerTest(String s) {

--- a/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
@@ -1041,7 +1041,7 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         lnis = new LocoNetInterfaceScaffold();
         memo = new LocoNetSystemConnectionMemo();
         memo.setLnTrafficController(lnis);
-        memo.configureCommandStation(LnCommandStationType.COMMAND_STATION_DCS100,false,false);
+        memo.configureCommandStation(LnCommandStationType.COMMAND_STATION_DCS100,false,false,false);
         memo.configureManagers();
         tm = new LnThrottleManager(memo);
         log.debug("new throttle manager is {}", tm.toString());

--- a/java/test/jmri/jmrix/loconet/LocoNetSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetSystemConnectionMemoTest.java
@@ -21,7 +21,7 @@ public class LocoNetSystemConnectionMemoTest extends jmri.jmrix.SystemConnection
        LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold();
        memo = new LocoNetSystemConnectionMemo();
        memo.setLnTrafficController(lnis);
-       memo.configureCommandStation(LnCommandStationType.COMMAND_STATION_DCS100,false,false);
+       memo.configureCommandStation(LnCommandStationType.COMMAND_STATION_DCS100,false,false,false);
        memo.configureManagers();
        scm = memo;
     }

--- a/java/test/jmri/jmrix/loconet/hexfile/LocoNetSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/hexfile/LocoNetSystemConnectionMemoTest.java
@@ -20,7 +20,7 @@ public class LocoNetSystemConnectionMemoTest extends jmri.jmrix.SystemConnection
        LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold();
        LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo();
        memo.setLnTrafficController(lnis);
-       memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100,false,false);
+       memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100,false,false,false);
        memo.configureManagers();
        scm = memo;
     }

--- a/java/test/jmri/jmrix/loconet/pr2/PR2SystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/pr2/PR2SystemConnectionMemoTest.java
@@ -19,7 +19,7 @@ public class PR2SystemConnectionMemoTest extends jmri.jmrix.SystemConnectionMemo
        LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold();
        PR2SystemConnectionMemo memo = new PR2SystemConnectionMemo();
        memo.setLnTrafficController(lnis);
-       memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100,false,false);
+       memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100,false,false,false);
        memo.configureManagers();
        scm = memo;
     }

--- a/java/test/jmri/jmrix/loconet/pr3/PR3SystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/pr3/PR3SystemConnectionMemoTest.java
@@ -20,7 +20,7 @@ public class PR3SystemConnectionMemoTest extends jmri.jmrix.SystemConnectionMemo
        LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold();
        PR3SystemConnectionMemo memo = new PR3SystemConnectionMemo();
        memo.setLnTrafficController(lnis);
-       memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100,false,false);
+       memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100,false,false,false);
        memo.configureManagers();
        scm = memo;
     }

--- a/java/test/jmri/jmrix/loconet/uhlenbrock/UhlenbrockSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/uhlenbrock/UhlenbrockSystemConnectionMemoTest.java
@@ -20,7 +20,7 @@ public class UhlenbrockSystemConnectionMemoTest extends jmri.jmrix.SystemConnect
        LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold();
        UhlenbrockSystemConnectionMemo memo = new UhlenbrockSystemConnectionMemo();
        memo.setLnTrafficController(lnis);
-       memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_IBX_TYPE_2,false,false);
+       memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_IBX_TYPE_2,false,false,false);
        memo.configureManagers();
        scm = memo;
     }

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <!--Written by JMRI version 4.11.4ish+jake+20180316T0456Z+R76e3ad8db2 on Thu Mar 15 21:56:28 PDT 2018-->
-  <decoderIndex version="892">
+  <!--Written by JMRI version 4.11.5ish+jake+20180325T2139Z+R5e0fc842e3 on Sun Mar 25 14:39:48 PDT 2018-->
+  <decoderIndex version="894">
     <mfgList nmraListDate="2015-03-06" updated="2015-03-25" lastadd="107,124,126,128,134">
       <manufacturer mfg="NMRA" mfgID="999" />
       <manufacturer mfg="A-Train Electronics" mfgID="137" />
@@ -14265,7 +14265,41 @@
         </functionlabels>
       </family>
       <family name="Econami Diesel OEM Athearn" mfg="SoundTraxx (Throttle-Up)" file="SoundTraxx_Eco_Diesel_OEM_Athearn.xml">
-        <model model="ECO-200 SD38" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="774" comment="Model E9900.001B">
+        <model model="ECO-RTR F59PHI" numOuts="4" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="825" comment="Model E5000.001BR">
+          <versionCV lowVersionID="70" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="10" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="14" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="ECO-200 SD38" numOuts="4" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="774" comment="Model E9900.001B">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -14300,7 +14334,144 @@
           </output>
           <size length="35" width="18" height="6" units="mm" />
         </model>
-        <model model="ECO-200 SD38 w/DB" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="775" comment="Model E9900.002B">
+        <model model="ECO-200 SD38 w/DB" numOuts="4" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="775" comment="Model E9900.002B">
+          <versionCV lowVersionID="70" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="10" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="14" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+          <size length="35" width="18" height="6" units="mm" />
+        </model>
+        <model model="ECO-RTR SD38 w/strobe" numOuts="4" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="780" comment="Model E0101.004B">
+          <versionCV lowVersionID="70" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="10" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="14" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="ECO-RTR SD40-2 w/DB" numOuts="4" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="789" comment="Model E0102.002B">
+          <versionCV lowVersionID="70" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="10" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="14" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="ECO-RTR SD45 w/DB" numOuts="4" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="781" comment="Model E0103.001B">
+          <versionCV lowVersionID="70" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="10" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="14" label="|" />
+          <!-- Not used for for this decoder -->
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="ECO-200 SD45 w/DB" numOuts="4" numFns="30" maxMotorCurrent="2A" connector="9pin" productID="773" comment="Model E9901.001B">
           <versionCV lowVersionID="70" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -16199,6 +16370,96 @@
         </functionlabels>
       </family>
       <family name="Tsunami2 Diesel OEM Genesis" mfg="SoundTraxx (Throttle-Up)" file="SoundTraxx_Tsu2_Diesel_OEM_Genesis.xml">
+        <model model="TSU-GN2200 F3/7 w/DB" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="782" comment="Model T0102.006B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 F3/7 w/DB/gyra" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="783" comment="Model T0102.008B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 F3/7 w/DB/gyra2" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="806" comment="Model T0102.015B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
         <model model="TSU-GN2200 GP7" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="770" comment="Model T0102.001B">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
@@ -16259,6 +16520,366 @@
             <label xml:lang="it">Accoppiatore| </label>
           </output>
         </model>
+        <model model="TSU-GN2200 GP7/GP9" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="793" comment="Model T0102.003B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP7/GP9 w/mars" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="788" comment="Model T0102.016B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP7/GP9 w/beacon" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="824" comment="Model T0102.017B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP9 w/DB" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="772" comment="Model T0102.004B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP9 w/DB,gyra" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="794" comment="Model T0102.009B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP9 w/beacon" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="795" comment="Model T0102.010B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP9 w/beacon2" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="796" comment="Model T0102.011B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP9 w/mars" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="787" comment="Model T0102.014B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP15T" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="797" comment="Model T0200.001B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP15-1 w/beacon" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="798" comment="Model T0201.001B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP15-1 w/beacon2" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="799" comment="Model T0201.002B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP15-1 w/ditch" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="800" comment="Model T0201.003B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
         <model model="TSU-GN2200 GP38-2" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="776" comment="Model T0203.001B">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
@@ -16290,6 +16911,486 @@
           </output>
         </model>
         <model model="TSU-GN2200 GP38-2 w/ beacon/strobe" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="777" comment="Model T0203.003B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP40-2L/W w/mars" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="784" comment="Model T0204.001B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP40-2L/W w/ditch" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="785" comment="Model T0204.002B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 GP40-2L/W w/gyra" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="786" comment="Model T0204.003B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 SDP40F w/gyra" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="813" comment="Model T0207.001B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 SDF40-2 w/beacon" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="814" comment="Model T0207.002B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 SD60I" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="804" comment="Model T0302.003B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 SD60I w/ditch" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="803" comment="Model T0302.002B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 SD60M" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="802" comment="Model T0302.001B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 SD60M w/ditch" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="805" comment="Model T0302.004B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 SD70M/75M" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="778" comment="Model T0301.001B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 SD70M w/ditch" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="779" comment="Model T0301.002B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 SD70ACe" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="791" comment="Model T0303.001B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 SD70ACe w/ditch" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="792" comment="Model T0303.002B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 ES40DC w/ditch" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="816" comment="Model T1004.002B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 ES44DC" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="815" comment="Model T1004.001B">
+          <versionCV lowVersionID="71" />
+          <output name="3" label="  FX3  " />
+          <output name="4" label="  FX4  " />
+          <output name="5" label="Airhorn| ">
+            <label xml:lang="it">Tromba| </label>
+          </output>
+          <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+          </output>
+          <output name="7" label="Dynamic|Brakes">
+            <label xml:lang="it">Freni|Dinamici</label>
+          </output>
+          <output name="8" label="Short|Horn">
+            <label xml:lang="it">Breve|Tromba</label>
+          </output>
+          <output name="9" label="Straight|to 8" />
+          <output name="10" label="General|Service" />
+          <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+          </output>
+          <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+          </output>
+          <output name="13" label="HEP|Mode" />
+          <output name="14" label="Ind/Train|Brake" />
+          <output name="15" label="Coupler| ">
+            <label xml:lang="it">Accoppiatore| </label>
+          </output>
+        </model>
+        <model model="TSU-GN2200 ES44DC w/ditch" numOuts="6" numFns="30" maxMotorCurrent="2A" connector="DropIn" productID="817" comment="Model T1004.003B">
           <versionCV lowVersionID="71" />
           <output name="3" label="  FX3  " />
           <output name="4" label="  FX4  " />
@@ -26287,6 +27388,1845 @@
           <functionlabel num="5" lockable="true">Dimming lights</functionlabel>
         </functionlabels>
       </family>
+      <family name="Märklin mLD" mfg="Trix Modelleisenbahn" lowVersionID="1" highVersionID="255" comment="Märklin HO Locomotive Decoders - no sound" file="Trix_mLD.xml">
+        <model model="60942" numOuts="6" numFns="36" maxMotorCurrent="1.1A" productID="60942" connector="21MTC" comment="Non sound decoder for Märklin HO locomotives, with MTC21 plug">
+          <output name="1" label="LV|Gray" connection="solder">
+            <label xml:lang="de">LV|Grau</label>
+          </output>
+          <output name="2" label="LR|Yellow" connection="solder">
+            <label xml:lang="de">LR|Gelb</label>
+          </output>
+          <output name="3" label="Aux 1|Brown/Red" connection="solder">
+            <label xml:lang="de">Aux 1|Braun/Rot</label>
+          </output>
+          <output name="4" label="Aux 2|Brown/Green" connection="solder">
+            <label xml:lang="de">Aux 2|Braun/Grün</label>
+          </output>
+          <output name="5" label="Aux 3|Brown/Yellow" connection="solder">
+            <label xml:lang="de">Aux 3|Braun/Gelb</label>
+          </output>
+          <output name="6" label="Aux 4|Brown/White" connection="solder">
+            <label xml:lang="de">Aux 4|Braun/Weiß</label>
+          </output>
+          <output name="7" label="Aux 5|Green Mot.1" connection="solder">
+            <label xml:lang="de">Aux 5|Grün Mot.1</label>
+          </output>
+          <output name="8" label="Aux 6|Blue Mot.2" connection="solder">
+            <label xml:lang="de">Aux 6|Blau Mot.2</label>
+          </output>
+          <output name="ABV" label="deactivate">
+            <label xml:lang="de">ausschalten</label>
+          </output>
+          <output name="RG" label="Switching">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <protocols>
+            <protocol>mfx</protocol>
+            <protocol>dcc</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <model model="60962" numOuts="4" numFns="36" maxMotorCurrent="1.1A" productID="60962" connector="Wires/NEM652" comment="Non sound decoder for Märklin HO locomotives, with NEM652 8-pin plug">
+          <output name="1" label="LV|White" connection="wire">
+            <label xml:lang="de">LV|Weiß</label>
+          </output>
+          <output name="2" label="LR|Yellow" connection="wire">
+            <label xml:lang="de">LR|Gelb</label>
+          </output>
+          <output name="3" label="Aux 1|Green" connection="wire">
+            <label xml:lang="de">Aux 1|Grün</label>
+          </output>
+          <output name="4" label="Aux 2|Violet" connection="wire">
+            <label xml:lang="de">Aux 2|Violett</label>
+          </output>
+          <output name="7" label="Aux 5|Green Mot.1" connection="solder">
+            <label xml:lang="de">Aux 5|Grün Mot.1</label>
+          </output>
+          <output name="8" label="Aux 6|Blue Mot.2" connection="solder">
+            <label xml:lang="de">Aux 6|Blau Mot.2</label>
+          </output>
+          <output name="ABV" label="deactivate">
+            <label xml:lang="de">ausschalten</label>
+          </output>
+          <output name="RG" label="Switching">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <protocols>
+            <protocol>mfx</protocol>
+            <protocol>dcc</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+        </model>
+        <functionlabels>
+          <functionlabel num="0" lockable="true">
+            <text>Headlights</text>
+            <text xml:lang="de">Spitzensignal</text>
+          </functionlabel>
+          <functionlabel num="3" lockable="true">
+            <text>Switching</text>
+            <text xml:lang="de">Rangiergang</text>
+          </functionlabel>
+          <functionlabel num="4" lockable="true">
+            <text>Deactivate ABV</text>
+            <text xml:lang="de">ABV ausschalten</text>
+          </functionlabel>
+        </functionlabels>
+      </family>
+      <family name="Märklin mSD" mfg="Trix Modelleisenbahn" lowVersionID="1" highVersionID="255" comment="Märklin HO Locomotive Sound Decoders" file="Trix_mSD.xml">
+        <model model="60940" numOuts="6" numFns="36" maxMotorCurrent="1.1A" productID="60940" connector="21MTC" comment="Sound decoder for Märklin HO 'Special' locomotives, with MTC21 plug">
+          <output name="1" label="LV|Gray" connection="solder">
+            <label xml:lang="de">LV|Grau</label>
+          </output>
+          <output name="2" label="LR|Yellow" connection="solder">
+            <label xml:lang="de">LR|Gelb</label>
+          </output>
+          <output name="3" label="Aux 1|Brown/Red" connection="solder">
+            <label xml:lang="de">Aux 1|Braun/Rot</label>
+          </output>
+          <output name="4" label="Aux 2|Brown/Green" connection="solder">
+            <label xml:lang="de">Aux 2|Braun/Grün</label>
+          </output>
+          <output name="5" label="Aux 3|Brown/Yellow" connection="solder">
+            <label xml:lang="de">Aux 3|Braun/Gelb</label>
+          </output>
+          <output name="6" label="Aux 4|Brown/White" connection="solder">
+            <label xml:lang="de">Aux 4|Braun/Weiß</label>
+          </output>
+          <output name="7" label="Aux 5|Green Mot.1" connection="solder">
+            <label xml:lang="de">Aux 5|Grün Mot.1</label>
+          </output>
+          <output name="8" label="Aux 6|Blue Mot.2" connection="solder">
+            <label xml:lang="de">Aux 6|Blau Mot.2</label>
+          </output>
+          <output name="ABV" label="deactivate">
+            <label xml:lang="de">ausschalten</label>
+          </output>
+          <output name="RG" label="Switching">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <output name="SndBrk" label="Brake Squeal">
+            <label xml:lang="de">Bremsenquietschen</label>
+          </output>
+          <output name="SndDrv" label="Operating Snd">
+            <label xml:lang="de">Betriebsgeräusch</label>
+          </output>
+          <output name="Sound1" label="Whistle">
+            <label xml:lang="de">Pfeife</label>
+          </output>
+          <output name="Sound2" label="Sound 2">
+            <label xml:lang="de">Sound 2</label>
+          </output>
+          <output name="Sound3" label="Sound 3">
+            <label xml:lang="de">Sound 3</label>
+          </output>
+          <output name="Sound4" label="Announce.">
+            <label xml:lang="de">Ansage</label>
+          </output>
+          <output name="Sound5" label="Doors">
+            <label xml:lang="de">Türe</label>
+          </output>
+          <output name="Sound6" label="Tickets">
+            <label xml:lang="de">Fahrkart.</label>
+          </output>
+          <output name="Sound7" label="Cond. Whistle">
+            <label xml:lang="de">Schaf.pfiff</label>
+          </output>
+          <output name="Sound8" label="Uncoupling">
+            <label xml:lang="de">Abkuppeln</label>
+          </output>
+          <output name="Sound9" label="Coupling">
+            <label xml:lang="de">Ankuppeln</label>
+          </output>
+          <output name="Sound10" label="Sound 10">
+            <label xml:lang="de">Sound 10</label>
+          </output>
+          <output name="Sound11" label="Sand">
+            <label xml:lang="de">Sanden</label>
+          </output>
+          <output name="Sound12" label="Sound 12">
+            <label xml:lang="de">Sound 12</label>
+          </output>
+          <output name="Sound13" label="Destin. 1">
+            <label xml:lang="de">Zielbhf 1</label>
+          </output>
+          <output name="Sound14" label="Destin. 2">
+            <label xml:lang="de">Zielbhf 2</label>
+          </output>
+          <output name="Sound15" label="Train Ends">
+            <label xml:lang="de">Zug endet</label>
+          </output>
+          <output name="Sound16" label="Rail Joints">
+            <label xml:lang="de">Schienenstoß</label>
+          </output>
+          <protocols>
+            <protocol>mfx</protocol>
+            <protocol>dcc</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+          <functionlabels>
+            <functionlabel num="1" lockable="true">
+              <text>Physical Functions (Aux1)</text>
+              <text xml:lang="de">Physikalisch Funktion (Aux 1)</text>
+            </functionlabel>
+            <functionlabel num="2" lockable="true">
+              <text>Station Announcements</text>
+              <text xml:lang="de">Bahnhofsansage</text>
+            </functionlabel>
+            <functionlabel num="3" lockable="true">
+              <text>Whistle</text>
+              <text xml:lang="de">Pfeife</text>
+            </functionlabel>
+            <functionlabel num="5" lockable="true">
+              <text>Doors Opened/Closed</text>
+              <text xml:lang="de">Türe öffnen/schließen</text>
+            </functionlabel>
+            <functionlabel num="6" lockable="true">
+              <text>Switching</text>
+              <text xml:lang="de">Rangiergang</text>
+            </functionlabel>
+            <functionlabel num="7" lockable="true">
+              <text>Conductor Whistle</text>
+              <text xml:lang="de">Schaffnerpfiff</text>
+            </functionlabel>
+            <functionlabel num="9" lockable="true">
+              <text>Coupling</text>
+              <text xml:lang="de">Ankuppeln</text>
+            </functionlabel>
+            <functionlabel num="10" lockable="true">
+              <text>Checking Train Tickets</text>
+              <text xml:lang="de">Fahrkartenkontrolle</text>
+            </functionlabel>
+            <functionlabel num="11" lockable="true">
+              <text>Sand</text>
+              <text xml:lang="de">Sanden</text>
+            </functionlabel>
+            <functionlabel num="12" lockable="true">
+              <text>Rail Joints</text>
+              <text xml:lang="de">Schienenstoß</text>
+            </functionlabel>
+            <functionlabel num="13" lockable="true">
+              <text>Destination Station 1</text>
+              <text xml:lang="de">Zielbahnhof 1</text>
+            </functionlabel>
+            <functionlabel num="14" lockable="true">
+              <text>Destination Station 2</text>
+              <text xml:lang="de">Zielbahnhof 2</text>
+            </functionlabel>
+            <functionlabel num="15" lockable="true">
+              <text>Train Ends</text>
+              <text xml:lang="de">Zug endet</text>
+            </functionlabel>
+          </functionlabels>
+          <soundlabels>
+            <soundlabel num="1">
+              <text>Whistle</text>
+              <text xml:lang="de">Pfeife</text>
+            </soundlabel>
+            <soundlabel num="2">
+              <text>Unused Sound 2</text>
+              <text xml:lang="de">Unbenutzter Sound 2</text>
+            </soundlabel>
+            <soundlabel num="3">
+              <text>Unused Sound 3</text>
+              <text xml:lang="de">Unbenutzter Sound 3</text>
+            </soundlabel>
+            <soundlabel num="4">
+              <text>Station Announcements</text>
+              <text xml:lang="de">Bahnhofsansage</text>
+            </soundlabel>
+            <soundlabel num="5">
+              <text>Doors Opened/Closed</text>
+              <text xml:lang="de">Türe öffnen/schließen</text>
+            </soundlabel>
+            <soundlabel num="6">
+              <text>Checking Train Tickets</text>
+              <text xml:lang="de">Fahrkartenkontrolle</text>
+            </soundlabel>
+            <soundlabel num="7">
+              <text>Conductor Whistle</text>
+              <text xml:lang="de">Schaffnerpfiff</text>
+            </soundlabel>
+            <soundlabel num="8">
+              <text>Uncoupling</text>
+              <text xml:lang="de">Abkuppeln</text>
+            </soundlabel>
+            <soundlabel num="9">
+              <text>Coupling</text>
+              <text xml:lang="de">Ankuppeln</text>
+            </soundlabel>
+            <soundlabel num="10">
+              <text>Unused Sound 10</text>
+              <text xml:lang="de">Unbenutzter Sound 10</text>
+            </soundlabel>
+            <soundlabel num="11">
+              <text>Sand</text>
+              <text xml:lang="de">Sanden</text>
+            </soundlabel>
+            <soundlabel num="12">
+              <text>Unused Sound 12</text>
+              <text xml:lang="de">Unbenutzter Sound 12</text>
+            </soundlabel>
+            <soundlabel num="13">
+              <text>Destination Station 1</text>
+              <text xml:lang="de">Zielbahnhof 1</text>
+            </soundlabel>
+            <soundlabel num="14">
+              <text>Destination Station 2</text>
+              <text xml:lang="de">Zielbahnhof 2</text>
+            </soundlabel>
+            <soundlabel num="15">
+              <text>Train Ends</text>
+              <text xml:lang="de">Zug endet</text>
+            </soundlabel>
+            <soundlabel num="16">
+              <text>Rail Joints</text>
+              <text xml:lang="de">Schienenstoß</text>
+            </soundlabel>
+          </soundlabels>
+        </model>
+        <model model="60945" numOuts="6" numFns="36" maxMotorCurrent="1.1A" productID="60945" connector="21MTC" comment="Sound decoder for Märklin HO Steam locomotives, with MTC21 plug">
+          <output name="1" label="LV|Gray" connection="solder">
+            <label xml:lang="de">LV|Grau</label>
+          </output>
+          <output name="2" label="LR|Yellow" connection="solder">
+            <label xml:lang="de">LR|Gelb</label>
+          </output>
+          <output name="3" label="Aux 1|Brown/Red" connection="solder">
+            <label xml:lang="de">Aux 1|Braun/Rot</label>
+          </output>
+          <output name="4" label="Aux 2|Brown/Green" connection="solder">
+            <label xml:lang="de">Aux 2|Braun/Grün</label>
+          </output>
+          <output name="5" label="Aux 3|Brown/Yellow" connection="solder">
+            <label xml:lang="de">Aux 3|Braun/Gelb</label>
+          </output>
+          <output name="6" label="Aux 4|Brown/White" connection="solder">
+            <label xml:lang="de">Aux 4|Braun/Weiß</label>
+          </output>
+          <output name="7" label="Aux 5|Green Mot.1" connection="solder">
+            <label xml:lang="de">Aux 5|Grün Mot.1</label>
+          </output>
+          <output name="8" label="Aux 6|Blue Mot.2" connection="solder">
+            <label xml:lang="de">Aux 6|Blau Mot.2</label>
+          </output>
+          <output name="ABV" label="deactivate">
+            <label xml:lang="de">ausschalten</label>
+          </output>
+          <output name="RG" label="Switching">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <output name="SndBrk" label="Brake Squeal">
+            <label xml:lang="de">Bremsenquietschen</label>
+          </output>
+          <output name="SndDrv" label="Operating Snd">
+            <label xml:lang="de">Betriebsgeräusch</label>
+          </output>
+          <output name="Sound1" label="Whistle">
+            <label xml:lang="de">Pfeife</label>
+          </output>
+          <output name="Sound2" label="Bell">
+            <label xml:lang="de">Glocke</label>
+          </output>
+          <output name="Sound3" label="Short Whistle">
+            <label xml:lang="de">Pfeife kurz</label>
+          </output>
+          <output name="Sound4" label="Announce.">
+            <label xml:lang="de">Ansage</label>
+          </output>
+          <output name="Sound5" label="Cond. Whistle">
+            <label xml:lang="de">Schaf.pfiff</label>
+          </output>
+          <output name="Sound6" label="Sound 6">
+            <label xml:lang="de">Sound 6</label>
+          </output>
+          <output name="Sound7" label="Sound 7">
+            <label xml:lang="de">Sound 7</label>
+          </output>
+          <output name="Sound8" label="Sound 8">
+            <label xml:lang="de">Sound 8</label>
+          </output>
+          <output name="Sound9" label="Coal">
+            <label xml:lang="de">Kohle</label>
+          </output>
+          <output name="Sound10" label="Rocker Grate">
+            <label xml:lang="de">Schüttelrost</label>
+          </output>
+          <output name="Sound11" label="Sound 11">
+            <label xml:lang="de">Sound 11</label>
+          </output>
+          <output name="Sound12" label="Sound 12">
+            <label xml:lang="de">Sound 12</label>
+          </output>
+          <output name="Sound13" label="Sound 13">
+            <label xml:lang="de">Sound 13</label>
+          </output>
+          <output name="Sound14" label="Rail Joints">
+            <label xml:lang="de">Schienenstoß</label>
+          </output>
+          <output name="Sound15" label="Sound 15">
+            <label xml:lang="de">Sound 15</label>
+          </output>
+          <output name="Sound16" label="Sound 16">
+            <label xml:lang="de">Sound 16</label>
+          </output>
+          <protocols>
+            <protocol>mfx</protocol>
+            <protocol>dcc</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+          <functionlabels>
+            <functionlabel num="1" lockable="true">
+              <text>Smoke generator (Aux1)</text>
+              <text xml:lang="de">Rauchgenerator (Aux 1)</text>
+            </functionlabel>
+            <functionlabel num="3" lockable="true">
+              <text>Whistle</text>
+              <text xml:lang="de">Pfeife</text>
+            </functionlabel>
+            <functionlabel num="5" lockable="true">
+              <text>Physical Functions (Aux 3)</text>
+              <text xml:lang="de">Physikalisch Funktion (Aux3)</text>
+            </functionlabel>
+            <functionlabel num="6" lockable="true">
+              <text>Physical Functions (Aux 4)</text>
+              <text xml:lang="de">Physikalisch Funktion (Aux4)</text>
+            </functionlabel>
+            <functionlabel num="7" lockable="true">
+              <text>Bell</text>
+              <text xml:lang="de">Glocke</text>
+            </functionlabel>
+            <functionlabel num="10" lockable="true">
+              <text>Coal Shoveling</text>
+              <text xml:lang="de">Kohle schaufeln</text>
+            </functionlabel>
+            <functionlabel num="11" lockable="true">
+              <text>Short Whistle</text>
+              <text xml:lang="de">Pfeife kurz</text>
+            </functionlabel>
+            <functionlabel num="13" lockable="true">
+              <text>Rocker Grate</text>
+              <text xml:lang="de">Schüttelrost</text>
+            </functionlabel>
+          </functionlabels>
+          <soundlabels>
+            <soundlabel num="1">
+              <text>Whistle</text>
+              <text xml:lang="de">Pfeife</text>
+            </soundlabel>
+            <soundlabel num="2">
+              <text>Bell</text>
+              <text xml:lang="de">Glocke</text>
+            </soundlabel>
+            <soundlabel num="3">
+              <text>Short Whistle</text>
+              <text xml:lang="de">Pfeife kurz</text>
+            </soundlabel>
+            <soundlabel num="4">
+              <text>Station Announcements</text>
+              <text xml:lang="de">Bahnhofsansage</text>
+            </soundlabel>
+            <soundlabel num="5">
+              <text>Conductor Whistle</text>
+              <text xml:lang="de">Schaffnerpfiff</text>
+            </soundlabel>
+            <soundlabel num="6">
+              <text>Unused Sound</text>
+              <text xml:lang="de">Unbenutzter Sound</text>
+            </soundlabel>
+            <soundlabel num="7">
+              <text>Unused Sound 7</text>
+              <text xml:lang="de">Unbenutzter Sound 7</text>
+            </soundlabel>
+            <soundlabel num="8">
+              <text>Unused Sound 8</text>
+              <text xml:lang="de">Unbenutzter Sound 8</text>
+            </soundlabel>
+            <soundlabel num="9">
+              <text>Coal Shoveling</text>
+              <text xml:lang="de">Kohle schaufeln</text>
+            </soundlabel>
+            <soundlabel num="10">
+              <text>Rocker Grate</text>
+              <text xml:lang="de">Schüttelrost</text>
+            </soundlabel>
+            <soundlabel num="11">
+              <text>Unused Sound 11</text>
+              <text xml:lang="de">Unbenutzter Sound 11</text>
+            </soundlabel>
+            <soundlabel num="12">
+              <text>Unused Sound 12</text>
+              <text xml:lang="de">Unbenutzter Sound 12</text>
+            </soundlabel>
+            <soundlabel num="13">
+              <text>Unused Sound 13</text>
+              <text xml:lang="de">Unbenutzter Sound 13</text>
+            </soundlabel>
+            <soundlabel num="15">
+              <text>Unused Sound 15</text>
+              <text xml:lang="de">Unbenutzter Sound 15</text>
+            </soundlabel>
+            <soundlabel num="16">
+              <text>Unused Sound 16</text>
+              <text xml:lang="de">Unbenutzter Sound 16</text>
+            </soundlabel>
+          </soundlabels>
+        </model>
+        <model model="60946" numOuts="6" numFns="36" maxMotorCurrent="1.1A" productID="60946" connector="21MTC" comment="Sound decoder for Märklin HO Diesel locomotives, with MTC21 plug">
+          <output name="1" label="LV|Gray" connection="solder">
+            <label xml:lang="de">LV|Grau</label>
+          </output>
+          <output name="2" label="LR|Yellow" connection="solder">
+            <label xml:lang="de">LR|Gelb</label>
+          </output>
+          <output name="3" label="Aux 1|Brown/Red" connection="solder">
+            <label xml:lang="de">Aux 1|Braun/Rot</label>
+          </output>
+          <output name="4" label="Aux 2|Brown/Green" connection="solder">
+            <label xml:lang="de">Aux 2|Braun/Grün</label>
+          </output>
+          <output name="5" label="Aux 3|Brown/Yellow" connection="solder">
+            <label xml:lang="de">Aux 3|Braun/Gelb</label>
+          </output>
+          <output name="6" label="Aux 4|Brown/White" connection="solder">
+            <label xml:lang="de">Aux 4|Braun/Weiß</label>
+          </output>
+          <output name="7" label="Aux 5|Green Mot.1" connection="solder">
+            <label xml:lang="de">Aux 5|Grün Mot.1</label>
+          </output>
+          <output name="8" label="Aux 6|Blue Mot.2" connection="solder">
+            <label xml:lang="de">Aux 6|Blau Mot.2</label>
+          </output>
+          <output name="ABV" label="deactivate">
+            <label xml:lang="de">ausschalten</label>
+          </output>
+          <output name="RG" label="Switching">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <output name="SndBrk" label="Brake Squeal">
+            <label xml:lang="de">Bremsenquietschen</label>
+          </output>
+          <output name="SndDrv" label="Operating Snd">
+            <label xml:lang="de">Betriebsgeräusch</label>
+          </output>
+          <output name="Sound1" label="Horn 1">
+            <label xml:lang="de">Horn 1</label>
+          </output>
+          <output name="Sound2" label="Horn 2">
+            <label xml:lang="de">Horn 2</label>
+          </output>
+          <output name="Sound3" label="Bell">
+            <label xml:lang="de">Glocke</label>
+          </output>
+          <output name="Sound4" label="Sound 4">
+            <label xml:lang="de">Sound 4</label>
+          </output>
+          <output name="Sound5" label="Announce.">
+            <label xml:lang="de">Ansage</label>
+          </output>
+          <output name="Sound6" label="Cond. Whistle">
+            <label xml:lang="de">Schaf.pfiff</label>
+          </output>
+          <output name="Sound7" label="Aux. Diesel">
+            <label xml:lang="de">Hilfsdiesel</label>
+          </output>
+          <output name="Sound8" label="Sound 8">
+            <label xml:lang="de">Sound 8</label>
+          </output>
+          <output name="Sound9" label="Blower">
+            <label xml:lang="de">Lüfter</label>
+          </output>
+          <output name="Sound10" label="Sound 10">
+            <label xml:lang="de">Sound 10</label>
+          </output>
+          <output name="Sound11" label="Sound 11">
+            <label xml:lang="de">Sound 11</label>
+          </output>
+          <output name="Sound12" label="Sound 12">
+            <label xml:lang="de">Sound 12</label>
+          </output>
+          <output name="Sound13" label="Sound 13">
+            <label xml:lang="de">Sound 13</label>
+          </output>
+          <output name="Sound14" label="Rail Joints">
+            <label xml:lang="de">Schienenstoß</label>
+          </output>
+          <output name="Sound15" label="Sound 15">
+            <label xml:lang="de">Sound 15</label>
+          </output>
+          <output name="Sound16" label="Sound 16">
+            <label xml:lang="de">Sound 16</label>
+          </output>
+          <protocols>
+            <protocol>mfx</protocol>
+            <protocol>dcc</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+          <functionlabels>
+            <functionlabel num="1" lockable="true">
+              <text>Engineer‘s Cab Lighting (Aux 1)</text>
+              <text xml:lang="de">Führerstandsbeleuchtung (Aux 1)</text>
+            </functionlabel>
+            <functionlabel num="3" lockable="true">
+              <text>Horn 1</text>
+              <text xml:lang="de">Horn 1</text>
+            </functionlabel>
+            <functionlabel num="5" lockable="true">
+              <text>Physical Functions (Aux 3)</text>
+              <text xml:lang="de">Physikalisch Funktion (Aux3)</text>
+            </functionlabel>
+            <functionlabel num="6" lockable="true">
+              <text>Physical Functions (Aux 4)</text>
+              <text xml:lang="de">Physikalisch Funktion (Aux4)</text>
+            </functionlabel>
+            <functionlabel num="7" lockable="true">
+              <text>Horn 2</text>
+              <text xml:lang="de">Horn 2</text>
+            </functionlabel>
+            <functionlabel num="10" lockable="true">
+              <text>Blower</text>
+              <text xml:lang="de">Lüfter</text>
+            </functionlabel>
+            <functionlabel num="11" lockable="true">
+              <text>Bell</text>
+              <text xml:lang="de">Glocke</text>
+            </functionlabel>
+            <functionlabel num="13" lockable="true">
+              <text>Auxiliary Diesel</text>
+              <text xml:lang="de">Hilfsdiesel</text>
+            </functionlabel>
+          </functionlabels>
+          <soundlabels>
+            <soundlabel num="1">
+              <text>Horn 1</text>
+              <text xml:lang="de">Horn 1</text>
+            </soundlabel>
+            <soundlabel num="2">
+              <text>Horn 2</text>
+              <text xml:lang="de">Horn 2</text>
+            </soundlabel>
+            <soundlabel num="3">
+              <text>Bell</text>
+              <text xml:lang="de">Glocke</text>
+            </soundlabel>
+            <soundlabel num="4">
+              <text>Unused Sound 4</text>
+              <text xml:lang="de">Unbenutzter Sound 4</text>
+            </soundlabel>
+            <soundlabel num="5">
+              <text>Station Announcements</text>
+              <text xml:lang="de">Bahnhofsansage</text>
+            </soundlabel>
+            <soundlabel num="6">
+              <text>Conductor Whistle</text>
+              <text xml:lang="de">Schaffnerpfiff</text>
+            </soundlabel>
+            <soundlabel num="7">
+              <text>Auxiliary Diesel</text>
+              <text xml:lang="de">Hilfsdiesel</text>
+            </soundlabel>
+            <soundlabel num="8">
+              <text>Unused Sound 8</text>
+              <text xml:lang="de">Unbenutzter Sound 8</text>
+            </soundlabel>
+            <soundlabel num="9">
+              <text>Blower</text>
+              <text xml:lang="de">Lüfter</text>
+            </soundlabel>
+            <soundlabel num="10">
+              <text>Unused Sound 10</text>
+              <text xml:lang="de">Unbenutzter Sound 10</text>
+            </soundlabel>
+            <soundlabel num="11">
+              <text>Unused Sound 11</text>
+              <text xml:lang="de">Unbenutzter Sound 11</text>
+            </soundlabel>
+            <soundlabel num="12">
+              <text>Unused Sound 12</text>
+              <text xml:lang="de">Unbenutzter Sound 12</text>
+            </soundlabel>
+            <soundlabel num="13">
+              <text>Unused Sound 13</text>
+              <text xml:lang="de">Unbenutzter Sound 13</text>
+            </soundlabel>
+            <soundlabel num="15">
+              <text>Unused Sound 15</text>
+              <text xml:lang="de">Unbenutzter Sound 15</text>
+            </soundlabel>
+            <soundlabel num="16">
+              <text>Unused Sound 16</text>
+              <text xml:lang="de">Unbenutzter Sound 16</text>
+            </soundlabel>
+          </soundlabels>
+        </model>
+        <model model="60947" numOuts="6" numFns="36" maxMotorCurrent="1.1A" productID="60947" connector="21MTC" comment="Sound decoder for Märklin HO Electric locomotives, with MTC21 plug">
+          <output name="1" label="LV|Gray" connection="solder">
+            <label xml:lang="de">LV|Grau</label>
+          </output>
+          <output name="2" label="LR|Yellow" connection="solder">
+            <label xml:lang="de">LR|Gelb</label>
+          </output>
+          <output name="3" label="Aux 1|Brown/Red" connection="solder">
+            <label xml:lang="de">Aux 1|Braun/Rot</label>
+          </output>
+          <output name="4" label="Aux 2|Brown/Green" connection="solder">
+            <label xml:lang="de">Aux 2|Braun/Grün</label>
+          </output>
+          <output name="5" label="Aux 3|Brown/Yellow" connection="solder">
+            <label xml:lang="de">Aux 3|Braun/Gelb</label>
+          </output>
+          <output name="6" label="Aux 4|Brown/White" connection="solder">
+            <label xml:lang="de">Aux 4|Braun/Weiß</label>
+          </output>
+          <output name="7" label="Aux 5|Green Mot.1" connection="solder">
+            <label xml:lang="de">Aux 5|Grün Mot.1</label>
+          </output>
+          <output name="8" label="Aux 6|Blue Mot.2" connection="solder">
+            <label xml:lang="de">Aux 6|Blau Mot.2</label>
+          </output>
+          <output name="ABV" label="deactivate">
+            <label xml:lang="de">ausschalten</label>
+          </output>
+          <output name="RG" label="Switching">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <output name="SndBrk" label="Brake Squeal">
+            <label xml:lang="de">Bremsenquietschen</label>
+          </output>
+          <output name="SndDrv" label="Operating Snd">
+            <label xml:lang="de">Betriebsgeräusch</label>
+          </output>
+          <output name="Sound1" label="Horn 1">
+            <label xml:lang="de">Horn 1</label>
+          </output>
+          <output name="Sound2" label="Horn 2">
+            <label xml:lang="de">Horn 2</label>
+          </output>
+          <output name="Sound3" label="Short Whistle">
+            <label xml:lang="de">Pfeife kurz</label>
+          </output>
+          <output name="Sound4" label="Sound 4">
+            <label xml:lang="de">Sound 4</label>
+          </output>
+          <output name="Sound5" label="Announce.">
+            <label xml:lang="de">Ansage</label>
+          </output>
+          <output name="Sound6" label="Cond. Whistle">
+            <label xml:lang="de">Schaf.pfiff</label>
+          </output>
+          <output name="Sound7" label="Sound 7">
+            <label xml:lang="de">Sound 7</label>
+          </output>
+          <output name="Sound8" label="Sound 8">
+            <label xml:lang="de">Sound 8</label>
+          </output>
+          <output name="Sound9" label="Blower">
+            <label xml:lang="de">Lüfter</label>
+          </output>
+          <output name="Sound10" label="Sound 10">
+            <label xml:lang="de">Sound 10</label>
+          </output>
+          <output name="Sound11" label="Compressor">
+            <label xml:lang="de">Luftpresser</label>
+          </output>
+          <output name="Sound12" label="Sound 12">
+            <label xml:lang="de">Sound 12</label>
+          </output>
+          <output name="Sound13" label="Sound 13">
+            <label xml:lang="de">Sound 13</label>
+          </output>
+          <output name="Sound14" label="Rail Joints">
+            <label xml:lang="de">Schienenstoß</label>
+          </output>
+          <output name="Sound15" label="Sound 15">
+            <label xml:lang="de">Sound 15</label>
+          </output>
+          <output name="Sound16" label="Sound 16">
+            <label xml:lang="de">Sound 16</label>
+          </output>
+          <protocols>
+            <protocol>mfx</protocol>
+            <protocol>dcc</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+          <functionlabels>
+            <functionlabel num="1" lockable="true">
+              <text>Long Distance Headlights (Aux1)</text>
+              <text xml:lang="de">Fernlicht (Aux 1)</text>
+            </functionlabel>
+            <functionlabel num="3" lockable="true">
+              <text>Horn 1</text>
+              <text xml:lang="de">Horn 1</text>
+            </functionlabel>
+            <functionlabel num="5" lockable="true">
+              <text>Physical Functions (Aux 3)</text>
+              <text xml:lang="de">Physikalisch Funktion (Aux3)</text>
+            </functionlabel>
+            <functionlabel num="6" lockable="true">
+              <text>Physical Functions (Aux 4)</text>
+              <text xml:lang="de">Physikalisch Funktion (Aux4)</text>
+            </functionlabel>
+            <functionlabel num="7" lockable="true">
+              <text>Horn 2</text>
+              <text xml:lang="de">Horn 2</text>
+            </functionlabel>
+            <functionlabel num="10" lockable="true">
+              <text>Blower</text>
+              <text xml:lang="de">Lüfter</text>
+            </functionlabel>
+            <functionlabel num="11" lockable="true">
+              <text>Short Whistle</text>
+              <text xml:lang="de">Pfeife kurz</text>
+            </functionlabel>
+            <functionlabel num="13" lockable="true">
+              <text>Compressor</text>
+              <text xml:lang="de">Luftpresser</text>
+            </functionlabel>
+          </functionlabels>
+          <soundlabels>
+            <soundlabel num="1">
+              <text>Horn 1</text>
+              <text xml:lang="de">Horn 1</text>
+            </soundlabel>
+            <soundlabel num="2">
+              <text>Horn 2</text>
+              <text xml:lang="de">Horn 2</text>
+            </soundlabel>
+            <soundlabel num="3">
+              <text>Short Whistle</text>
+              <text xml:lang="de">Pfeife kurz</text>
+            </soundlabel>
+            <soundlabel num="4">
+              <text>Unused Sound 4</text>
+              <text xml:lang="de">Unbenutzter Sound 4</text>
+            </soundlabel>
+            <soundlabel num="5">
+              <text>Station Announcements</text>
+              <text xml:lang="de">Bahnhofsansage</text>
+            </soundlabel>
+            <soundlabel num="6">
+              <text>Conductor Whistle</text>
+              <text xml:lang="de">Schaffnerpfiff</text>
+            </soundlabel>
+            <soundlabel num="7">
+              <text>Unused Sound 7</text>
+              <text xml:lang="de">Unbenutzter Sound 7</text>
+            </soundlabel>
+            <soundlabel num="8">
+              <text>Unused Sound 8</text>
+              <text xml:lang="de">Unbenutzter Sound 8</text>
+            </soundlabel>
+            <soundlabel num="9">
+              <text>Blower</text>
+              <text xml:lang="de">Lüfter</text>
+            </soundlabel>
+            <soundlabel num="10">
+              <text>Unused Sound 10</text>
+              <text xml:lang="de">Unbenutzter Sound 10</text>
+            </soundlabel>
+            <soundlabel num="11">
+              <text>Compressor</text>
+              <text xml:lang="de">Luftpresser</text>
+            </soundlabel>
+            <soundlabel num="12">
+              <text>Unused Sound 12</text>
+              <text xml:lang="de">Unbenutzter Sound 12</text>
+            </soundlabel>
+            <soundlabel num="13">
+              <text>Unused Sound 13</text>
+              <text xml:lang="de">Unbenutzter Sound 13</text>
+            </soundlabel>
+            <soundlabel num="15">
+              <text>Unused Sound 15</text>
+              <text xml:lang="de">Unbenutzter Sound 15</text>
+            </soundlabel>
+            <soundlabel num="16">
+              <text>Unused Sound 16</text>
+              <text xml:lang="de">Unbenutzter Sound 16</text>
+            </soundlabel>
+          </soundlabels>
+        </model>
+        <model model="60948" numOuts="6" numFns="36" maxMotorCurrent="1.1A" productID="60948" connector="21MTC" comment="Sound decoder for Märklin HO Diesel (Herkules) locomotives, with MTC21 plug">
+          <output name="1" label="LV|Gray" connection="solder">
+            <label xml:lang="de">LV|Grau</label>
+          </output>
+          <output name="2" label="LR|Yellow" connection="solder">
+            <label xml:lang="de">LR|Gelb</label>
+          </output>
+          <output name="3" label="Aux 1|Brown/Red" connection="solder">
+            <label xml:lang="de">Aux 1|Braun/Rot</label>
+          </output>
+          <output name="4" label="Aux 2|Brown/Green" connection="solder">
+            <label xml:lang="de">Aux 2|Braun/Grün</label>
+          </output>
+          <output name="5" label="Aux 3|Brown/Yellow" connection="solder">
+            <label xml:lang="de">Aux 3|Braun/Gelb</label>
+          </output>
+          <output name="6" label="Aux 4|Brown/White" connection="solder">
+            <label xml:lang="de">Aux 4|Braun/Weiß</label>
+          </output>
+          <output name="7" label="Aux 5|Green Mot.1" connection="solder">
+            <label xml:lang="de">Aux 5|Grün Mot.1</label>
+          </output>
+          <output name="8" label="Aux 6|Blue Mot.2" connection="solder">
+            <label xml:lang="de">Aux 6|Blau Mot.2</label>
+          </output>
+          <output name="ABV" label="deactivate">
+            <label xml:lang="de">ausschalten</label>
+          </output>
+          <output name="RG" label="Switching">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <output name="SndBrk" label="Brake Squeal">
+            <label xml:lang="de">Bremsenquietschen</label>
+          </output>
+          <output name="SndDrv" label="Operating Snd">
+            <label xml:lang="de">Betriebsgeräusch</label>
+          </output>
+          <output name="Sound1" label="Horn 1">
+            <label xml:lang="de">Horn 1</label>
+          </output>
+          <output name="Sound2" label="Horn 2">
+            <label xml:lang="de">Horn 2</label>
+          </output>
+          <output name="Sound3" label="Cond. Whistle">
+            <label xml:lang="de">Schaf.pfiff</label>
+          </output>
+          <output name="Sound4" label="Doors">
+            <label xml:lang="de">Türe</label>
+          </output>
+          <output name="Sound5" label="Announce.">
+            <label xml:lang="de">Ansage</label>
+          </output>
+          <output name="Sound6" label="Tickets">
+            <label xml:lang="de">Fahrkart.</label>
+          </output>
+          <output name="Sound7" label="Sound 7">
+            <label xml:lang="de">Sound 7</label>
+          </output>
+          <output name="Sound8" label="Sound 8">
+            <label xml:lang="de">Sound 8</label>
+          </output>
+          <output name="Sound9" label="Blower">
+            <label xml:lang="de">Lüfter</label>
+          </output>
+          <output name="Sound10" label="Sound 10">
+            <label xml:lang="de">Sound 10</label>
+          </output>
+          <output name="Sound11" label="Sound 11">
+            <label xml:lang="de">Sound 11</label>
+          </output>
+          <output name="Sound12" label="Buffer">
+            <label xml:lang="de">Puffer</label>
+          </output>
+          <output name="Sound13" label="Sound 13">
+            <label xml:lang="de">Sound 13</label>
+          </output>
+          <output name="Sound14" label="Rail Joints">
+            <label xml:lang="de">Schienenstoß</label>
+          </output>
+          <output name="Sound15" label="Coupling">
+            <label xml:lang="de">Ankuppeln</label>
+          </output>
+          <output name="Sound16" label="Uncoupling">
+            <label xml:lang="de">Abkuppeln</label>
+          </output>
+          <protocols>
+            <protocol>mfx</protocol>
+            <protocol>dcc</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+          <functionlabels>
+            <functionlabel num="1" lockable="true">
+              <text>Buffer to Buffer</text>
+              <text xml:lang="de">Puffer an Puffer</text>
+            </functionlabel>
+            <functionlabel num="3" lockable="true">
+              <text>Horn 1</text>
+              <text xml:lang="de">Horn 1</text>
+            </functionlabel>
+            <functionlabel num="5" lockable="true">
+              <text>Coupling</text>
+              <text xml:lang="de">Ankuppeln</text>
+            </functionlabel>
+            <functionlabel num="6" lockable="true">
+              <text>Uncoupling</text>
+              <text xml:lang="de">Abkuppeln</text>
+            </functionlabel>
+            <functionlabel num="7" lockable="true">
+              <text>Horn 2</text>
+              <text xml:lang="de">Horn 2</text>
+            </functionlabel>
+            <functionlabel num="8" lockable="true">
+              <text>Compressed Air</text>
+              <text xml:lang="de">Pressluft ablassen</text>
+            </functionlabel>
+            <functionlabel num="10" lockable="true">
+              <text>Blower</text>
+              <text xml:lang="de">Lüfter</text>
+            </functionlabel>
+            <functionlabel num="11" lockable="true">
+              <text>Conductor Whistle</text>
+              <text xml:lang="de">Schaffnerpfiff</text>
+            </functionlabel>
+            <functionlabel num="12" lockable="true">
+              <text>Departure Announcement</text>
+              <text xml:lang="de">Ansage</text>
+            </functionlabel>
+            <functionlabel num="13" lockable="true">
+              <text>Doors Opened/Closed</text>
+              <text xml:lang="de">Türe öffnen/schließen</text>
+            </functionlabel>
+            <functionlabel num="15" lockable="true">
+              <text>Checking Train Tickets</text>
+              <text xml:lang="de">Fahrkartenkontrolle</text>
+            </functionlabel>
+          </functionlabels>
+          <soundlabels>
+            <soundlabel num="1">
+              <text>Horn 1</text>
+              <text xml:lang="de">Horn 1</text>
+            </soundlabel>
+            <soundlabel num="2">
+              <text>Horn 2</text>
+              <text xml:lang="de">Horn 2</text>
+            </soundlabel>
+            <soundlabel num="3">
+              <text>Conductor Whistle</text>
+              <text xml:lang="de">Schaffnerpfiff</text>
+            </soundlabel>
+            <soundlabel num="4">
+              <text>Doors Opened/Closed</text>
+              <text xml:lang="de">Türe öffnen/schließen</text>
+            </soundlabel>
+            <soundlabel num="5">
+              <text>Departure Announcement</text>
+              <text xml:lang="de">Ansage</text>
+            </soundlabel>
+            <soundlabel num="6">
+              <text>Checking Train Tickets</text>
+              <text xml:lang="de">Fahrkartenkontrolle</text>
+            </soundlabel>
+            <soundlabel num="7">
+              <text>Unused Sound 7</text>
+              <text xml:lang="de">Unbenutzter Sound 7</text>
+            </soundlabel>
+            <soundlabel num="8">
+              <text>Unused Sound 8</text>
+              <text xml:lang="de">Unbenutzter Sound 8</text>
+            </soundlabel>
+            <soundlabel num="9">
+              <text>Blower</text>
+              <text xml:lang="de">Lüfter</text>
+            </soundlabel>
+            <soundlabel num="10">
+              <text>Unused Sound 10</text>
+              <text xml:lang="de">Unbenutzter Sound 10</text>
+            </soundlabel>
+            <soundlabel num="11">
+              <text>Unused Sound 11</text>
+              <text xml:lang="de">Unbenutzter Sound 11</text>
+            </soundlabel>
+            <soundlabel num="12">
+              <text>Buffer to Buffer</text>
+              <text xml:lang="de">Puffer an Puffer</text>
+            </soundlabel>
+            <soundlabel num="13">
+              <text>Unused Sound 13</text>
+              <text xml:lang="de">Unbenutzter Sound 13</text>
+            </soundlabel>
+            <soundlabel num="15">
+              <text>Coupling</text>
+              <text xml:lang="de">Ankuppeln</text>
+            </soundlabel>
+            <soundlabel num="16">
+              <text>Uncoupling</text>
+              <text xml:lang="de">Abkuppeln</text>
+            </soundlabel>
+          </soundlabels>
+        </model>
+        <model model="60949" numOuts="6" numFns="36" maxMotorCurrent="1.1A" productID="60949" connector="21MTC" comment="Sound decoder for Märklin HO Electric (TRAXX) locomotives, with MTC21 plug">
+          <output name="1" label="LV|Gray" connection="solder">
+            <label xml:lang="de">LV|Grau</label>
+          </output>
+          <output name="2" label="LR|Yellow" connection="solder">
+            <label xml:lang="de">LR|Gelb</label>
+          </output>
+          <output name="3" label="Aux 1|Brown/Red" connection="solder">
+            <label xml:lang="de">Aux 1|Braun/Rot</label>
+          </output>
+          <output name="4" label="Aux 2|Brown/Green" connection="solder">
+            <label xml:lang="de">Aux 2|Braun/Grün</label>
+          </output>
+          <output name="5" label="Aux 3|Brown/Yellow" connection="solder">
+            <label xml:lang="de">Aux 3|Braun/Gelb</label>
+          </output>
+          <output name="6" label="Aux 4|Brown/White" connection="solder">
+            <label xml:lang="de">Aux 4|Braun/Weiß</label>
+          </output>
+          <output name="7" label="Aux 5|Green Mot.1" connection="solder">
+            <label xml:lang="de">Aux 5|Grün Mot.1</label>
+          </output>
+          <output name="8" label="Aux 6|Blue Mot.2" connection="solder">
+            <label xml:lang="de">Aux 6|Blau Mot.2</label>
+          </output>
+          <output name="ABV" label="deactivate">
+            <label xml:lang="de">ausschalten</label>
+          </output>
+          <output name="RG" label="Switching">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <output name="SndBrk" label="Brake Squeal">
+            <label xml:lang="de">Bremsenquietschen</label>
+          </output>
+          <output name="SndDrv" label="Operating Snd">
+            <label xml:lang="de">Betriebsgeräusch</label>
+          </output>
+          <output name="Sound1" label="Horn 1">
+            <label xml:lang="de">Horn 1</label>
+          </output>
+          <output name="Sound2" label="Horn 2">
+            <label xml:lang="de">Horn 2</label>
+          </output>
+          <output name="Sound3" label="Cond. Whistle">
+            <label xml:lang="de">Schaf.pfiff</label>
+          </output>
+          <output name="Sound4" label="Doors">
+            <label xml:lang="de">Türe</label>
+          </output>
+          <output name="Sound5" label="Announce.">
+            <label xml:lang="de">Ansage</label>
+          </output>
+          <output name="Sound6" label="Tickets">
+            <label xml:lang="de">Fahrkart.</label>
+          </output>
+          <output name="Sound7" label="Sound 7">
+            <label xml:lang="de">Sound 7</label>
+          </output>
+          <output name="Sound8" label="Sound 8">
+            <label xml:lang="de">Sound 8</label>
+          </output>
+          <output name="Sound9" label="Blower">
+            <label xml:lang="de">Lüfter</label>
+          </output>
+          <output name="Sound10" label="Sound 10">
+            <label xml:lang="de">Sound 10</label>
+          </output>
+          <output name="Sound11" label="Sound 11">
+            <label xml:lang="de">Sound 11</label>
+          </output>
+          <output name="Sound12" label="Buffer">
+            <label xml:lang="de">Puffer</label>
+          </output>
+          <output name="Sound13" label="Sound 13">
+            <label xml:lang="de">Sound 13</label>
+          </output>
+          <output name="Sound14" label="Rail Joints">
+            <label xml:lang="de">Schienenstoß</label>
+          </output>
+          <output name="Sound15" label="Coupling">
+            <label xml:lang="de">Ankuppeln</label>
+          </output>
+          <output name="Sound16" label="Uncoupling">
+            <label xml:lang="de">Abkuppeln</label>
+          </output>
+          <protocols>
+            <protocol>mfx</protocol>
+            <protocol>dcc</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+          <functionlabels>
+            <functionlabel num="1" lockable="true">
+              <text>Buffer to Buffer</text>
+              <text xml:lang="de">Puffer an Puffer</text>
+            </functionlabel>
+            <functionlabel num="3" lockable="true">
+              <text>Horn 1</text>
+              <text xml:lang="de">Horn 1</text>
+            </functionlabel>
+            <functionlabel num="5" lockable="true">
+              <text>Coupling</text>
+              <text xml:lang="de">Ankuppeln</text>
+            </functionlabel>
+            <functionlabel num="6" lockable="true">
+              <text>Uncoupling</text>
+              <text xml:lang="de">Abkuppeln</text>
+            </functionlabel>
+            <functionlabel num="7" lockable="true">
+              <text>Horn 2</text>
+              <text xml:lang="de">Horn 2</text>
+            </functionlabel>
+            <functionlabel num="8" lockable="true">
+              <text>Compressed Air</text>
+              <text xml:lang="de">Pressluft ablassen</text>
+            </functionlabel>
+            <functionlabel num="10" lockable="true">
+              <text>Blower</text>
+              <text xml:lang="de">Lüfter</text>
+            </functionlabel>
+            <functionlabel num="11" lockable="true">
+              <text>Conductor Whistle</text>
+              <text xml:lang="de">Schaffnerpfiff</text>
+            </functionlabel>
+            <functionlabel num="12" lockable="true">
+              <text>Departure Announcement</text>
+              <text xml:lang="de">Ansage</text>
+            </functionlabel>
+            <functionlabel num="13" lockable="true">
+              <text>Doors Opened/Closed</text>
+              <text xml:lang="de">Türe öffnen/schließen</text>
+            </functionlabel>
+            <functionlabel num="15" lockable="true">
+              <text>Checking Train Tickets</text>
+              <text xml:lang="de">Fahrkartenkontrolle</text>
+            </functionlabel>
+          </functionlabels>
+          <soundlabels>
+            <soundlabel num="1">
+              <text>Horn 1</text>
+              <text xml:lang="de">Horn 1</text>
+            </soundlabel>
+            <soundlabel num="2">
+              <text>Horn 2</text>
+              <text xml:lang="de">Horn 2</text>
+            </soundlabel>
+            <soundlabel num="3">
+              <text>Conductor Whistle</text>
+              <text xml:lang="de">Schaffnerpfiff</text>
+            </soundlabel>
+            <soundlabel num="4">
+              <text>Doors Opened/Closed</text>
+              <text xml:lang="de">Türe öffnen/schließen</text>
+            </soundlabel>
+            <soundlabel num="5">
+              <text>Departure Announcement</text>
+              <text xml:lang="de">Ansage</text>
+            </soundlabel>
+            <soundlabel num="6">
+              <text>Checking Train Tickets</text>
+              <text xml:lang="de">Fahrkartenkontrolle</text>
+            </soundlabel>
+            <soundlabel num="7">
+              <text>Unused Sound 7</text>
+              <text xml:lang="de">Unbenutzter Sound 7</text>
+            </soundlabel>
+            <soundlabel num="8">
+              <text>Unused Sound 8</text>
+              <text xml:lang="de">Unbenutzter Sound 8</text>
+            </soundlabel>
+            <soundlabel num="9">
+              <text>Blower</text>
+              <text xml:lang="de">Lüfter</text>
+            </soundlabel>
+            <soundlabel num="10">
+              <text>Unused Sound 10</text>
+              <text xml:lang="de">Unbenutzter Sound 10</text>
+            </soundlabel>
+            <soundlabel num="11">
+              <text>Unused Sound 11</text>
+              <text xml:lang="de">Unbenutzter Sound 11</text>
+            </soundlabel>
+            <soundlabel num="12">
+              <text>Buffer to Buffer</text>
+              <text xml:lang="de">Puffer an Puffer</text>
+            </soundlabel>
+            <soundlabel num="13">
+              <text>Unused Sound 13</text>
+              <text xml:lang="de">Unbenutzter Sound 13</text>
+            </soundlabel>
+            <soundlabel num="15">
+              <text>Coupling</text>
+              <text xml:lang="de">Ankuppeln</text>
+            </soundlabel>
+            <soundlabel num="16">
+              <text>Uncoupling</text>
+              <text xml:lang="de">Abkuppeln</text>
+            </soundlabel>
+          </soundlabels>
+        </model>
+        <model model="60965" numOuts="4" numFns="36" maxMotorCurrent="1.1A" productID="60965" connector="Wires/NEM652" comment="Sound decoder for Märklin HO Steam locomotives, with NEM652 8-pin plug">
+          <output name="1" label="LV|Gray" connection="solder">
+            <label xml:lang="de">LV|Grau</label>
+          </output>
+          <output name="2" label="LR|Yellow" connection="solder">
+            <label xml:lang="de">LR|Gelb</label>
+          </output>
+          <output name="3" label="Aux 1|Brown/Red" connection="solder">
+            <label xml:lang="de">Aux 1|Braun/Rot</label>
+          </output>
+          <output name="4" label="Aux 2|Brown/Green" connection="solder">
+            <label xml:lang="de">Aux 2|Braun/Grün</label>
+          </output>
+          <output name="7" label="Aux 5|Green Mot.1" connection="solder">
+            <label xml:lang="de">Aux 5|Grün Mot.1</label>
+          </output>
+          <output name="8" label="Aux 6|Blue Mot.2" connection="solder">
+            <label xml:lang="de">Aux 6|Blau Mot.2</label>
+          </output>
+          <output name="ABV" label="deactivate">
+            <label xml:lang="de">ausschalten</label>
+          </output>
+          <output name="RG" label="Switching">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <output name="SndBrk" label="Brake Squeal">
+            <label xml:lang="de">Bremsenquietschen</label>
+          </output>
+          <output name="SndDrv" label="Operating Snd">
+            <label xml:lang="de">Betriebsgeräusch</label>
+          </output>
+          <output name="Sound1" label="Whistle">
+            <label xml:lang="de">Pfeife</label>
+          </output>
+          <output name="Sound2" label="Bell">
+            <label xml:lang="de">Glocke</label>
+          </output>
+          <output name="Sound3" label="Short Whistle">
+            <label xml:lang="de">Pfeife kurz</label>
+          </output>
+          <output name="Sound4" label="Announce.">
+            <label xml:lang="de">Ansage</label>
+          </output>
+          <output name="Sound5" label="Cond. Whistle">
+            <label xml:lang="de">Schaf.pfiff</label>
+          </output>
+          <output name="Sound6" label="Sound 6">
+            <label xml:lang="de">Sound 6</label>
+          </output>
+          <output name="Sound7" label="Sound 7">
+            <label xml:lang="de">Sound 7</label>
+          </output>
+          <output name="Sound8" label="Sound 8">
+            <label xml:lang="de">Sound 8</label>
+          </output>
+          <output name="Sound9" label="Coal">
+            <label xml:lang="de">Kohle</label>
+          </output>
+          <output name="Sound10" label="Rocker Grate">
+            <label xml:lang="de">Schüttelrost</label>
+          </output>
+          <output name="Sound11" label="Sound 11">
+            <label xml:lang="de">Sound 11</label>
+          </output>
+          <output name="Sound12" label="Sound 12">
+            <label xml:lang="de">Sound 12</label>
+          </output>
+          <output name="Sound13" label="Sound 13">
+            <label xml:lang="de">Sound 13</label>
+          </output>
+          <output name="Sound14" label="Rail Joints">
+            <label xml:lang="de">Schienenstoß</label>
+          </output>
+          <output name="Sound15" label="Sound 15">
+            <label xml:lang="de">Sound 15</label>
+          </output>
+          <output name="Sound16" label="Buffer">
+            <label xml:lang="de">Puffer</label>
+          </output>
+          <protocols>
+            <protocol>mfx</protocol>
+            <protocol>dcc</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+          <functionlabels>
+            <functionlabel num="1" lockable="true">
+              <text>Smoke generator (Aux1)</text>
+              <text xml:lang="de">Rauchgenerator (Aux 1)</text>
+            </functionlabel>
+            <functionlabel num="3" lockable="true">
+              <text>Whistle</text>
+              <text xml:lang="de">Pfeife</text>
+            </functionlabel>
+            <functionlabel num="5" lockable="true">
+              <text>Buffer to Buffer</text>
+              <text xml:lang="de">Puffer an Puffer</text>
+            </functionlabel>
+            <functionlabel num="6" lockable="true">
+              <text>Switching + double A light</text>
+              <text xml:lang="de">Rangiergang + Doppel A</text>
+            </functionlabel>
+            <functionlabel num="7" lockable="true">
+              <text>Bell</text>
+              <text xml:lang="de">Glocke</text>
+            </functionlabel>
+            <functionlabel num="10" lockable="true">
+              <text>Coal Shoveling</text>
+              <text xml:lang="de">Kohle schaufeln</text>
+            </functionlabel>
+            <functionlabel num="11" lockable="true">
+              <text>Short Whistle</text>
+              <text xml:lang="de">Pfeife kurz</text>
+            </functionlabel>
+            <functionlabel num="13" lockable="true">
+              <text>Rocker Grate</text>
+              <text xml:lang="de">Schüttelrost</text>
+            </functionlabel>
+          </functionlabels>
+          <soundlabels>
+            <soundlabel num="1">
+              <text>Whistle</text>
+              <text xml:lang="de">Pfeife</text>
+            </soundlabel>
+            <soundlabel num="2">
+              <text>Bell</text>
+              <text xml:lang="de">Glocke</text>
+            </soundlabel>
+            <soundlabel num="3">
+              <text>Short Whistle</text>
+              <text xml:lang="de">Pfeife kurz</text>
+            </soundlabel>
+            <soundlabel num="4">
+              <text>Station Announcements</text>
+              <text xml:lang="de">Bahnhofsansage</text>
+            </soundlabel>
+            <soundlabel num="5">
+              <text>Conductor Whistle</text>
+              <text xml:lang="de">Schaffnerpfiff</text>
+            </soundlabel>
+            <soundlabel num="6">
+              <text>Unused Sound 6</text>
+              <text xml:lang="de">Unbenutzter Sound 6</text>
+            </soundlabel>
+            <soundlabel num="7">
+              <text>Unused Sound 7</text>
+              <text xml:lang="de">Unbenutzter Sound 7</text>
+            </soundlabel>
+            <soundlabel num="8">
+              <text>Unused Sound 8</text>
+              <text xml:lang="de">Unbenutzter Sound 8</text>
+            </soundlabel>
+            <soundlabel num="9">
+              <text>Coal Shoveling</text>
+              <text xml:lang="de">Kohle schaufeln</text>
+            </soundlabel>
+            <soundlabel num="10">
+              <text>Rocker Grate</text>
+              <text xml:lang="de">Schüttelrost</text>
+            </soundlabel>
+            <soundlabel num="11">
+              <text>Unused Sound 11</text>
+              <text xml:lang="de">Unbenutzter Sound 11</text>
+            </soundlabel>
+            <soundlabel num="12">
+              <text>Unused Sound 12</text>
+              <text xml:lang="de">Unbenutzter Sound 12</text>
+            </soundlabel>
+            <soundlabel num="13">
+              <text>Unused Sound 13</text>
+              <text xml:lang="de">Unbenutzter Sound 13</text>
+            </soundlabel>
+            <soundlabel num="15">
+              <text>Unused Sound 15</text>
+              <text xml:lang="de">Unbenutzter Sound 15</text>
+            </soundlabel>
+            <soundlabel num="16">
+              <text>Buffer to Buffer</text>
+              <text xml:lang="de">Puffer an Puffer</text>
+            </soundlabel>
+          </soundlabels>
+        </model>
+        <model model="60966" numOuts="4" numFns="36" maxMotorCurrent="1.1A" productID="60966" connector="Wires/NEM652" comment="Sound decoder for Märklin HO Diesel locomotives, with NEM652 8-pin plug">
+          <output name="1" label="LV|Gray" connection="solder">
+            <label xml:lang="de">LV|Grau</label>
+          </output>
+          <output name="2" label="LR|Yellow" connection="solder">
+            <label xml:lang="de">LR|Gelb</label>
+          </output>
+          <output name="3" label="Aux 1|Brown/Red" connection="solder">
+            <label xml:lang="de">Aux 1|Braun/Rot</label>
+          </output>
+          <output name="4" label="Aux 2|Brown/Green" connection="solder">
+            <label xml:lang="de">Aux 2|Braun/Grün</label>
+          </output>
+          <output name="7" label="Aux 5|Green Mot.1" connection="solder">
+            <label xml:lang="de">Aux 5|Grün Mot.1</label>
+          </output>
+          <output name="8" label="Aux 6|Blue Mot.2" connection="solder">
+            <label xml:lang="de">Aux 6|Blau Mot.2</label>
+          </output>
+          <output name="ABV" label="deactivate">
+            <label xml:lang="de">ausschalten</label>
+          </output>
+          <output name="RG" label="Switching">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <output name="SndBrk" label="Brake Squeal">
+            <label xml:lang="de">Bremsenquietschen</label>
+          </output>
+          <output name="SndDrv" label="Operating Snd">
+            <label xml:lang="de">Betriebsgeräusch</label>
+          </output>
+          <output name="Sound1" label="Horn 1">
+            <label xml:lang="de">Horn 1</label>
+          </output>
+          <output name="Sound2" label="Horn 2">
+            <label xml:lang="de">Horn 2</label>
+          </output>
+          <output name="Sound3" label="Bell">
+            <label xml:lang="de">Glocke</label>
+          </output>
+          <output name="Sound4" label="Sound 4">
+            <label xml:lang="de">Sound 4</label>
+          </output>
+          <output name="Sound5" label="Announce.">
+            <label xml:lang="de">Ansage</label>
+          </output>
+          <output name="Sound6" label="Cond. Whistle">
+            <label xml:lang="de">Schaf.pfiff</label>
+          </output>
+          <output name="Sound7" label="Aux. Diesel">
+            <label xml:lang="de">Hilfsdiesel</label>
+          </output>
+          <output name="Sound8" label="Coupling">
+            <label xml:lang="de">Ankuppeln</label>
+          </output>
+          <output name="Sound9" label="Blower">
+            <label xml:lang="de">Lüfter</label>
+          </output>
+          <output name="Sound10" label="Uncoupling">
+            <label xml:lang="de">Abkuppeln</label>
+          </output>
+          <output name="Sound11" label="Sound 11">
+            <label xml:lang="de">Sound 11</label>
+          </output>
+          <output name="Sound12" label="Sound 12">
+            <label xml:lang="de">Sound 12</label>
+          </output>
+          <output name="Sound13" label="Sound 13">
+            <label xml:lang="de">Sound 13</label>
+          </output>
+          <output name="Sound14" label="Rail Joints">
+            <label xml:lang="de">Schienenstoß</label>
+          </output>
+          <output name="Sound15" label="Sound 15">
+            <label xml:lang="de">Sound 15</label>
+          </output>
+          <output name="Sound16" label="Sound 16">
+            <label xml:lang="de">Sound 16</label>
+          </output>
+          <protocols>
+            <protocol>mfx</protocol>
+            <protocol>dcc</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+          <functionlabels>
+            <functionlabel num="1" lockable="true">
+              <text>Engineer‘s Cab Lighting (Aux 1)</text>
+              <text xml:lang="de">Führerstandsbeleuchtung (Aux 1)</text>
+            </functionlabel>
+            <functionlabel num="3" lockable="true">
+              <text>Horn 1</text>
+              <text xml:lang="de">Horn 1</text>
+            </functionlabel>
+            <functionlabel num="5" lockable="true">
+              <text>Coupling</text>
+              <text xml:lang="de">Ankuppeln</text>
+            </functionlabel>
+            <functionlabel num="6" lockable="true">
+              <text>Uncoupling</text>
+              <text xml:lang="de">Abkuppeln</text>
+            </functionlabel>
+            <functionlabel num="7" lockable="true">
+              <text>Horn 2</text>
+              <text xml:lang="de">Horn 2</text>
+            </functionlabel>
+            <functionlabel num="10" lockable="true">
+              <text>Blower</text>
+              <text xml:lang="de">Lüfter</text>
+            </functionlabel>
+            <functionlabel num="11" lockable="true">
+              <text>Bell</text>
+              <text xml:lang="de">Glocke</text>
+            </functionlabel>
+            <functionlabel num="13" lockable="true">
+              <text>Auxiliary Diesel</text>
+              <text xml:lang="de">Hilfsdiesel</text>
+            </functionlabel>
+          </functionlabels>
+          <soundlabels>
+            <soundlabel num="1">
+              <text>Horn 1</text>
+              <text xml:lang="de">Horn 1</text>
+            </soundlabel>
+            <soundlabel num="2">
+              <text>Horn 2</text>
+              <text xml:lang="de">Horn 2</text>
+            </soundlabel>
+            <soundlabel num="3">
+              <text>Bell</text>
+              <text xml:lang="de">Glocke</text>
+            </soundlabel>
+            <soundlabel num="4">
+              <text>Unused Sound 4</text>
+              <text xml:lang="de">Unbenutzter Sound 4</text>
+            </soundlabel>
+            <soundlabel num="5">
+              <text>Station Announcements</text>
+              <text xml:lang="de">Bahnhofsansage</text>
+            </soundlabel>
+            <soundlabel num="6">
+              <text>Conductor Whistle</text>
+              <text xml:lang="de">Schaffnerpfiff</text>
+            </soundlabel>
+            <soundlabel num="7">
+              <text>Auxiliary Diesel</text>
+              <text xml:lang="de">Hilfsdiesel</text>
+            </soundlabel>
+            <soundlabel num="8">
+              <text>Coupling</text>
+              <text xml:lang="de">Ankuppeln</text>
+            </soundlabel>
+            <soundlabel num="9">
+              <text>Blower</text>
+              <text xml:lang="de">Lüfter</text>
+            </soundlabel>
+            <soundlabel num="10">
+              <text>Uncoupling</text>
+              <text xml:lang="de">Abkuppeln</text>
+            </soundlabel>
+            <soundlabel num="11">
+              <text>Unused Sound 11</text>
+              <text xml:lang="de">Unbenutzter Sound 11</text>
+            </soundlabel>
+            <soundlabel num="12">
+              <text>Unused Sound 12</text>
+              <text xml:lang="de">Unbenutzter Sound 12</text>
+            </soundlabel>
+            <soundlabel num="13">
+              <text>Unused Sound 13</text>
+              <text xml:lang="de">Unbenutzter Sound 13</text>
+            </soundlabel>
+            <soundlabel num="15">
+              <text>Unused Sound 15</text>
+              <text xml:lang="de">Unbenutzter Sound 15</text>
+            </soundlabel>
+            <soundlabel num="16">
+              <text>Unused Sound 16</text>
+              <text xml:lang="de">Unbenutzter Sound 16</text>
+            </soundlabel>
+          </soundlabels>
+        </model>
+        <model model="60967" numOuts="4" numFns="36" maxMotorCurrent="1.1A" productID="60967" connector="Wires/NEM652" comment="Sound decoder for Märklin HO Electric locomotives, with NEM652 8-pin plug">
+          <output name="1" label="LV|Gray" connection="solder">
+            <label xml:lang="de">LV|Grau</label>
+          </output>
+          <output name="2" label="LR|Yellow" connection="solder">
+            <label xml:lang="de">LR|Gelb</label>
+          </output>
+          <output name="3" label="Aux 1|Brown/Red" connection="solder">
+            <label xml:lang="de">Aux 1|Braun/Rot</label>
+          </output>
+          <output name="4" label="Aux 2|Brown/Green" connection="solder">
+            <label xml:lang="de">Aux 2|Braun/Grün</label>
+          </output>
+          <output name="7" label="Aux 5|Green Mot.1" connection="solder">
+            <label xml:lang="de">Aux 5|Grün Mot.1</label>
+          </output>
+          <output name="8" label="Aux 6|Blue Mot.2" connection="solder">
+            <label xml:lang="de">Aux 6|Blau Mot.2</label>
+          </output>
+          <output name="ABV" label="deactivate">
+            <label xml:lang="de">ausschalten</label>
+          </output>
+          <output name="RG" label="Switching">
+            <label xml:lang="de">Rangiergang</label>
+          </output>
+          <output name="SndBrk" label="Brake Squeal">
+            <label xml:lang="de">Bremsenquietschen</label>
+          </output>
+          <output name="SndDrv" label="Operating Snd">
+            <label xml:lang="de">Betriebsgeräusch</label>
+          </output>
+          <output name="Sound1" label="Horn 1">
+            <label xml:lang="de">Horn 1</label>
+          </output>
+          <output name="Sound2" label="Horn 2">
+            <label xml:lang="de">Horn 2</label>
+          </output>
+          <output name="Sound3" label="Short Whistle">
+            <label xml:lang="de">Pfeife kurz</label>
+          </output>
+          <output name="Sound4" label="Sound 4">
+            <label xml:lang="de">Sound 4</label>
+          </output>
+          <output name="Sound5" label="Announce.">
+            <label xml:lang="de">Ansage</label>
+          </output>
+          <output name="Sound6" label="Cond. Whistle">
+            <label xml:lang="de">Schaf.pfiff</label>
+          </output>
+          <output name="Sound7" label="Sound 7">
+            <label xml:lang="de">Sound 7</label>
+          </output>
+          <output name="Sound8" label="Sound 8">
+            <label xml:lang="de">Sound 8</label>
+          </output>
+          <output name="Sound9" label="Blower">
+            <label xml:lang="de">Lüfter</label>
+          </output>
+          <output name="Sound10" label="Sound 10">
+            <label xml:lang="de">Sound 10</label>
+          </output>
+          <output name="Sound11" label="Compressor">
+            <label xml:lang="de">Luftpresser</label>
+          </output>
+          <output name="Sound12" label="Sound 12">
+            <label xml:lang="de">Sound 12</label>
+          </output>
+          <output name="Sound13" label="Sound 13">
+            <label xml:lang="de">Sound 13</label>
+          </output>
+          <output name="Sound14" label="Rail Joints">
+            <label xml:lang="de">Schienenstoß</label>
+          </output>
+          <output name="Sound15" label="Tickets">
+            <label xml:lang="de">Fahrkart.</label>
+          </output>
+          <output name="Sound16" label="Buffer">
+            <label xml:lang="de">Puffer</label>
+          </output>
+          <protocols>
+            <protocol>mfx</protocol>
+            <protocol>dcc</protocol>
+            <protocol>motorola</protocol>
+          </protocols>
+          <functionlabels>
+            <functionlabel num="1" lockable="true">
+              <text>Long Distance Headlights (Aux1)</text>
+              <text xml:lang="de">Fernlicht (Aux 1)</text>
+            </functionlabel>
+            <functionlabel num="3" lockable="true">
+              <text>Horn 1</text>
+              <text xml:lang="de">Horn 1</text>
+            </functionlabel>
+            <functionlabel num="5" lockable="true">
+              <text>Buffer to Buffer</text>
+              <text xml:lang="de">Puffer an Puffer</text>
+            </functionlabel>
+            <functionlabel num="6" lockable="true">
+              <text>Checking Train Tickets</text>
+              <text xml:lang="de">Fahrkartenkontrolle</text>
+            </functionlabel>
+            <functionlabel num="7" lockable="true">
+              <text>Horn 2</text>
+              <text xml:lang="de">Horn 2</text>
+            </functionlabel>
+            <functionlabel num="10" lockable="true">
+              <text>Blower</text>
+              <text xml:lang="de">Lüfter</text>
+            </functionlabel>
+            <functionlabel num="11" lockable="true">
+              <text>Short Whistle</text>
+              <text xml:lang="de">Pfeife kurz</text>
+            </functionlabel>
+            <functionlabel num="13" lockable="true">
+              <text>Compressor</text>
+              <text xml:lang="de">Luftpresser</text>
+            </functionlabel>
+          </functionlabels>
+          <soundlabels>
+            <soundlabel num="1">
+              <text>Horn 1</text>
+              <text xml:lang="de">Horn 1</text>
+            </soundlabel>
+            <soundlabel num="2">
+              <text>Horn 2</text>
+              <text xml:lang="de">Horn 2</text>
+            </soundlabel>
+            <soundlabel num="3">
+              <text>Short Whistle</text>
+              <text xml:lang="de">Pfeife kurz</text>
+            </soundlabel>
+            <soundlabel num="4">
+              <text>Unused Sound 4</text>
+              <text xml:lang="de">Unbenutzter Sound 4</text>
+            </soundlabel>
+            <soundlabel num="5">
+              <text>Station Announcements</text>
+              <text xml:lang="de">Bahnhofsansage</text>
+            </soundlabel>
+            <soundlabel num="6">
+              <text>Conductor Whistle</text>
+              <text xml:lang="de">Schaffnerpfiff</text>
+            </soundlabel>
+            <soundlabel num="7">
+              <text>Unused Sound 7</text>
+              <text xml:lang="de">Unbenutzter Sound 7</text>
+            </soundlabel>
+            <soundlabel num="8">
+              <text>Unused Sound 8</text>
+              <text xml:lang="de">Unbenutzter Sound 8</text>
+            </soundlabel>
+            <soundlabel num="9">
+              <text>Blower</text>
+              <text xml:lang="de">Lüfter</text>
+            </soundlabel>
+            <soundlabel num="10">
+              <text>Unused Sound 10</text>
+              <text xml:lang="de">Unbenutzter Sound 10</text>
+            </soundlabel>
+            <soundlabel num="11">
+              <text>Compressor</text>
+              <text xml:lang="de">Luftpresser</text>
+            </soundlabel>
+            <soundlabel num="12">
+              <text>Unused Sound 12</text>
+              <text xml:lang="de">Unbenutzter Sound 12</text>
+            </soundlabel>
+            <soundlabel num="13">
+              <text>Unused Sound 13</text>
+              <text xml:lang="de">Unbenutzter Sound 13</text>
+            </soundlabel>
+            <soundlabel num="15">
+              <text>Checking Train Tickets</text>
+              <text xml:lang="de">Fahrkartenkontrolle</text>
+            </soundlabel>
+            <soundlabel num="16">
+              <text>Buffer to Buffer</text>
+              <text xml:lang="de">Puffer an Puffer</text>
+            </soundlabel>
+          </soundlabels>
+        </model>
+        <functionlabels>
+          <functionlabel num="0" lockable="true">
+            <text>Headlights</text>
+            <text xml:lang="de">Spitzensignal</text>
+          </functionlabel>
+          <functionlabel num="2" lockable="true">
+            <text>Operating Sounds</text>
+            <text xml:lang="de">Betriebsgeräusch</text>
+          </functionlabel>
+          <functionlabel num="4" lockable="true">
+            <text>Deactivate ABV</text>
+            <text xml:lang="de">ABV ausschalten</text>
+          </functionlabel>
+          <functionlabel num="8" lockable="true">
+            <text>Telex coupler (Aux2)</text>
+            <text xml:lang="de">Telexkupplung (Aux 2)</text>
+          </functionlabel>
+          <functionlabel num="9" lockable="true">
+            <text>Squealing Brakes off</text>
+            <text xml:lang="de">Bremsenquietschen aus</text>
+          </functionlabel>
+          <functionlabel num="12" lockable="true">
+            <text>Station Announcements</text>
+            <text xml:lang="de">Bahnhofsansage</text>
+          </functionlabel>
+          <functionlabel num="14" lockable="true">
+            <text>Rail Joints</text>
+            <text xml:lang="de">Schienenstoß</text>
+          </functionlabel>
+          <functionlabel num="15" lockable="true">
+            <text>Conductor Whistle</text>
+            <text xml:lang="de">Schaffnerpfiff</text>
+          </functionlabel>
+        </functionlabels>
+        <soundlabels>
+          <soundlabel num="14">
+            <text>Rail Joints</text>
+            <text xml:lang="de">Schienenstoß</text>
+          </soundlabel>
+        </soundlabels>
+      </family>
       <family name="IntelliSound Module" mfg="Uhlenbrock Elektronik" comment="Auxiliary Sound module for all locomotive decoders with SUSI connector" file="Uhlenbrock_32100.xml">
         <model model="32100">
           <size length="20.8" width="10.8" height="5" units="mm" />
@@ -26564,19 +29504,19 @@
       </family>
       <family name="Umelec ATLPlus Engine Module" mfg="Umelec Ing Buero" file="Umelec_ATL2066.xml">
         <model model="ATL2066" lowVersionID="21" highVersionID="40" maxInputVolts="21V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" formFactor="H0" connector="Wires/NEM652" numOuts="9" numFns="13" productID="NEM652">
-          <output name="1" label="Pad A">
+          <output name="1" label="Output A">
             <label xml:lang="de">Ausgang A</label>
             <label xml:lang="nl">Uitgang A</label>
           </output>
-          <output name="2" label="Pad B">
+          <output name="2" label="Output B">
             <label xml:lang="de">Ausgang B</label>
             <label xml:lang="nl">Uitgang B</label>
           </output>
-          <output name="3" label="Pad C">
+          <output name="3" label="Output C">
             <label xml:lang="de">Ausgang C</label>
             <label xml:lang="nl">Uitgang C</label>
           </output>
-          <output name="4" label="Pad D">
+          <output name="4" label="Output D">
             <label xml:lang="de">Ausgang D</label>
             <label xml:lang="nl">Uitgang D</label>
           </output>
@@ -26602,19 +29542,19 @@
           <size length="24" width="10" height="4" units="mm" />
         </model>
         <model model="ATL2066 (21MTC)" lowVersionID="25" highVersionID="40" maxInputVolts="21V" maxMotorCurrent="1.5A" maxTotalCurrent="1.5A" formFactor="H0" connector="21MTC" numOuts="9" numFns="13" productID="21MTC">
-          <output name="1" label="Pad A">
+          <output name="1" label="Output A">
             <label xml:lang="de">Ausgang A</label>
             <label xml:lang="nl">Uitgang A</label>
           </output>
-          <output name="2" label="Pad B">
+          <output name="2" label="Output B">
             <label xml:lang="de">Ausgang B</label>
             <label xml:lang="nl">Uitgang B</label>
           </output>
-          <output name="3" label="Pad C">
+          <output name="3" label="Output C">
             <label xml:lang="de">Ausgang C</label>
             <label xml:lang="nl">Uitgang C</label>
           </output>
-          <output name="4" label="Pad D">
+          <output name="4" label="Output D">
             <label xml:lang="de">Ausgang D</label>
             <label xml:lang="nl">Uitgang D</label>
           </output>
@@ -26639,19 +29579,19 @@
           </output>
         </model>
         <model model="ATL2066p" lowVersionID="21" highVersionID="40" maxInputVolts="21V" maxMotorCurrent="3A" maxTotalCurrent="3A" formFactor="HO" connector="Wires/NEM652" numOuts="9" numFns="13" productID="NEM652">
-          <output name="1" label="Pad A">
+          <output name="1" label="Output A">
             <label xml:lang="de">Ausgang A</label>
             <label xml:lang="nl">Uitgang A</label>
           </output>
-          <output name="2" label="Pad B">
+          <output name="2" label="Output B">
             <label xml:lang="de">Ausgang B</label>
             <label xml:lang="nl">Uitgang B</label>
           </output>
-          <output name="3" label="Pad C">
+          <output name="3" label="Output C">
             <label xml:lang="de">Ausgang C</label>
             <label xml:lang="nl">Uitgang C</label>
           </output>
-          <output name="4" label="Pad D">
+          <output name="4" label="Output D">
             <label xml:lang="de">Ausgang D</label>
             <label xml:lang="nl">Uitgang D</label>
           </output>
@@ -26677,19 +29617,19 @@
           <size length="24" width="10" height="4" units="mm" />
         </model>
         <model model="ATL2066p (21MTC)" lowVersionID="25" highVersionID="40" maxInputVolts="21V" maxMotorCurrent="3A" maxTotalCurrent="3A" formFactor="HO" connector="21MTC" numOuts="9" numFns="13" productID="21MTC">
-          <output name="1" label="Pad A">
+          <output name="1" label="Output A">
             <label xml:lang="de">Ausgang A</label>
             <label xml:lang="nl">Uitgang A</label>
           </output>
-          <output name="2" label="Pad B">
+          <output name="2" label="Output B">
             <label xml:lang="de">Ausgang B</label>
             <label xml:lang="nl">Uitgang B</label>
           </output>
-          <output name="3" label="Pad C">
+          <output name="3" label="Output C">
             <label xml:lang="de">Ausgang C</label>
             <label xml:lang="nl">Uitgang C</label>
           </output>
-          <output name="4" label="Pad D">
+          <output name="4" label="Output D">
             <label xml:lang="de">Ausgang D</label>
             <label xml:lang="nl">Uitgang D</label>
           </output>

--- a/xml/decoders/RR-CirKits-LNCP-basic.xml
+++ b/xml/decoders/RR-CirKits-LNCP-basic.xml
@@ -27,13 +27,14 @@
     <family name="Control Point" mfg="RR-CirKits" type="stationary" comment="The Control Point is normally programmed in OPs mode">
       <model model="LNCP" comment="LocoNet Control Point" lowVersionID="01"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes">
+    <programming direct="no" paged="yes" register="no" ops="no">
       <capability>
         <name>Indexed CV access</name>
         <parameter name="PI">32</parameter>
         <parameter name="SI">00</parameter> <!-- not used, but needs to be specified -->
         <parameter name="cvFirst">true</parameter> <!-- 257.1 is write 1 to PICV, then access CV 257 -->
       </capability>
+      <mode>LOCONETOPSBOARD</mode>
     </programming>
     <variables>
       <!--		<variable label="Address" CV="9" item="Extended Address"  -->

--- a/xml/decoders/RR-CirKits-MotorMan.xml
+++ b/xml/decoders/RR-CirKits-MotorMan.xml
@@ -26,7 +26,9 @@
       <model model="MotorMan" comment="8 Line Output Driver"/>
       <model model="MotorMan-II" comment="8 Line Output Driver"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes"/>
+    <programming direct="no" paged="yes" register="no" ops="no">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable label="Primary Address" CV="1" comment="Short address">
         <shortAddressVal/>

--- a/xml/decoders/RR-CirKits-SignalMan-basic.xml
+++ b/xml/decoders/RR-CirKits-SignalMan-basic.xml
@@ -22,7 +22,9 @@
     <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The SignalMan is normally programmed in OPs mode">
       <model model="SignalMan" comment="Signal Mast Driver" lowVersionID="10"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes"/>
+    <programming direct="no" paged="yes" register="no" ops="no">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <!--		<variable label="Address" CV="9" item="Extended Address"  -->
       <variable item="Primary Address" CV="1" comment="Short address">

--- a/xml/decoders/RR-CirKits-SwitchMan.xml
+++ b/xml/decoders/RR-CirKits-SwitchMan.xml
@@ -22,7 +22,9 @@
     <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The SwitchMan is normally programmed in OPs mode">
       <model model="SwitchMan" comment="16 Line I/O Driver" lowVersionID="10"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes"/>
+    <programming direct="no" paged="yes" register="no" ops="no">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable item="Primary Address" CV="1" comment="Short address">
         <shortAddressVal/>

--- a/xml/decoders/RR-CirKits-TC-64-basic.xml
+++ b/xml/decoders/RR-CirKits-TC-64-basic.xml
@@ -27,7 +27,9 @@
     <family name="Tower Controller" mfg="RR-CirKits" type="stationary" comment="The Tower Controller is normally programmed in OPs mode">
       <model model="TC-64" comment="64 line I/O" lowVersionID="06"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes"/>
+    <programming direct="no" paged="yes" register="no" ops="no">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable item="P1 Base Address" CV="1" mask="VVVVVVVV" default="0">
         <splitVal highCV="2" upperMask="XXXXXVVV"/>

--- a/xml/decoders/RR-CirKits-TowerController-Mark-II.xml
+++ b/xml/decoders/RR-CirKits-TowerController-Mark-II.xml
@@ -22,7 +22,9 @@
     <family name="Tower Controller" mfg="RR-CirKits" type="stationary" comment="The TowerController Mark-II is normally programmed in OPs mode">
       <model model="Mark-II" comment="64 Line I/O Driver" lowVersionID="11"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes"/>
+    <programming direct="no" paged="yes" register="no" ops="no">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable item="Primary Address" CV="1" comment="Short address">
         <shortAddressVal/>

--- a/xml/decoders/RR-CirKits-TowerMan-basic.xml
+++ b/xml/decoders/RR-CirKits-TowerMan-basic.xml
@@ -22,7 +22,9 @@
     <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The TowerMan is programmed in OPs mode">
       <model model="TowerMan" comment="16 Line I/O Driver" lowVersionID="10"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes"/>
+    <programming direct="no" paged="yes" register="no" ops="no">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable item="Primary Address" CV="1" comment="Short address">
         <shortAddressVal/>

--- a/xml/decoders/RR-CirKits-WatchMan-basic.xml
+++ b/xml/decoders/RR-CirKits-WatchMan-basic.xml
@@ -23,7 +23,9 @@
     <family name="Decoders" mfg="RR-CirKits" type="stationary" comment="The WatchMan is normally programmed in OPs mode">
       <model model="WatchMan" comment="8 block detector plus 8 Line I/O Driver" lowVersionID="11"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes"/>
+    <programming direct="no" paged="yes" register="no" ops="no">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable item="Primary Address" CV="1" comment="Short address">
         <shortAddressVal/>

--- a/xml/schema/decoder.xsd
+++ b/xml/schema/decoder.xsd
@@ -925,6 +925,7 @@
       <xs:enumeration value="REGISTERMODE"/>
       <xs:enumeration value="DIRECTBITMODE"/>
       <xs:enumeration value="DIRECTMODE"/>
+      <xs:enumeration value="LOCONETOPSBOARD"/>
       <xs:enumeration value="LOCONETSV1MODE"/>
       <xs:enumeration value="LOCONETSV2MODE"/>
       <xs:enumeration value="LOCONETBDOPSWMODE"/>


### PR DESCRIPTION
This addresses configuring JMRI for the presence or absence of LocoNet transponding read back of decoders. For background, see Issue #5128. There was also relevant discussion in #3314 and some parts of #5130.

This PR adds a new option to LocoNet connections that allows the user to specify whether transponding is present:

![preferences](https://user-images.githubusercontent.com/2774117/37879582-1c8076a2-3030-11e8-8e2f-18c7eeb3ffbf.png)

 - Transponding on: Current behavior
 - Transponding off: Ops mode read shows as not available.  

Note that some LocoNet-attached boards use transponding-like connections to do their read back. This PR defines a new `LOCONETOPSBOARD` programming mode that's available when using a LocoNet connection.  Using this mode ignores the transponding on/off option as to whether ops-mode read is possible:  It's assumed that the board has been properly connected to the LocoNet, so Ops mode read of the Board is possible.

The RR-CirKits decoder definitions were updated to use this new support.  If there are others with the same character, please open a new PR/Issue.

Includes changes to the `jmrit.symbolicprog` support to properly handle alternative ops-mode programming modes.  This now selects the best mode from among those available, preferring the one identified in the decoder definition.

Closes #3314 and #5128 