### PR TITLE
Fix audio schema validation problem in JMRI 4.11.4

### DIFF
--- a/xml/schema/types/audio-2-9-6.xsd
+++ b/xml/schema/types/audio-2-9-6.xsd
@@ -119,7 +119,7 @@
                   <xs:attribute name="out" type="xs:integer" />
                 </xs:complexType>
               </xs:element>
-              <xs:element name="dopplerfactor" type="xs:float" minOccurs="1" maxOccurs="1">
+              <xs:element name="dopplerfactor" type="xs:float" minOccurs="0" maxOccurs="1">
                 <xs:annotation><xs:documentation>No longer written as of JMRI 4.11.4</xs:documentation></xs:annotation>
               </xs:element>
               <xs:element name="positionrelative" type="yesNoType" minOccurs="0" maxOccurs="1" />


### PR DESCRIPTION
See issue #5163 for background

Changed:
- dopplerfactor attribute in audiosource element no longer required

Closes #5163