### PR TITLE
EcosLocoToRoster should not retain decoderindex

### DIFF
--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -1059,7 +1059,7 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
                         break;
                     case 1:
                         if (deletePanel()) { // disposes everything
-                            dispose(true);
+                            dispose();
                         }
                         break;
                     case 2:

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -1114,7 +1114,7 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
 //            ed.pack();
             ed.setVisible(true);
             InstanceManager.getDefault(PanelMenu.class).addEditorPanel(ed);
-            dispose(true);
+            dispose();
             return ed;
         } catch (ClassNotFoundException cnfe) {
             log.error("changeView exception {}", cnfe.toString());

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -441,7 +441,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
         _fileMenu.add(deleteItem);
         deleteItem.addActionListener((ActionEvent event) -> {
             if (deletePanel()) {
-                dispose(true);
+                dispose();
             }
         });
         _fileMenu.addSeparator();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -575,7 +575,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         fileMenu.add(deleteItem);
         deleteItem.addActionListener((ActionEvent event) -> {
             if (deletePanel()) {
-                dispose(true);
+                dispose();
             }
         });
         setJMenuBar(menuBar);

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
@@ -196,7 +196,7 @@ public class PanelEditor extends Editor implements ItemListener {
             @Override
             public void actionPerformed(ActionEvent event) {
                 if (deletePanel()) {
-                    dispose(true);
+                    dispose();
                 }
             }
         });
@@ -556,7 +556,7 @@ public class PanelEditor extends Editor implements ItemListener {
             @Override
             public void actionPerformed(ActionEvent e) {
                 if (deletePanel()) {
-                    dispose(true);
+                    dispose();
                 }
             }
         });

--- a/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
@@ -667,7 +667,7 @@ public class SwitchboardEditor extends Editor {
         _fileMenu.add(deleteItem);
         deleteItem.addActionListener((ActionEvent event) -> {
             if (deletePanel()) {
-                dispose(true);
+                dispose();
             }
         });
         _fileMenu.addSeparator();

--- a/java/src/jmri/jmrix/ecos/utilities/EcosLocoToRoster.java
+++ b/java/src/jmri/jmrix/ecos/utilities/EcosLocoToRoster.java
@@ -65,7 +65,6 @@ public class EcosLocoToRoster implements EcosListener {
     RosterEntry re;
     String filename = null;
     DecoderFile pDecoderFile = null;
-    DecoderIndexFile decoderind = InstanceManager.getDefault(DecoderIndexFile.class);
     String _ecosObject;
     int _ecosObjectInt;
     Label _statusLabel = null;
@@ -251,7 +250,7 @@ public class EcosLocoToRoster implements EcosListener {
         }
         re = new RosterEntry();
         re.setId(rosterId);
-        List<DecoderFile> decoder = decoderind.matchingDecoderList(null, null, ecosLoco.getCVAsString(8), ecosLoco.getCVAsString(7), null, null);
+        List<DecoderFile> decoder = InstanceManager.getDefault(DecoderIndexFile.class).matchingDecoderList(null, null, ecosLoco.getCVAsString(8), ecosLoco.getCVAsString(7), null, null);
         if (decoder.size() == 1) {
             pDecoderFile = decoder.get(0);
             selectedDecoder(pDecoderFile);

--- a/java/test/jmri/jmrit/display/IconEditorWindowTest.java
+++ b/java/test/jmri/jmrit/display/IconEditorWindowTest.java
@@ -404,12 +404,12 @@ public class IconEditorWindowTest {
     @After
     public void tearDown() throws Exception {
 
-        // Delete the editor by calling dispose(true) defined in PanelEditor
+        // Delete the editor by calling dispose() defined in PanelEditor
         // directly instead of closing the window through a WindowClosing()
         // event - this is the method called to delete a panel if a user
         // selects that in the Hide/Delete dialog triggered by WindowClosing().
         if (_editor != null) {
-            _editor.dispose(true);
+            _editor.dispose();
         }
 
         JUnitUtil.resetWindows(false, false); // don't log existing windows here, should just be from this class

--- a/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorTest.java
+++ b/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorTest.java
@@ -90,7 +90,7 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase {
     @After
     public void tearDown() {
         if (swe != null) {
-            swe.dispose(true);
+            swe.dispose();
             e = swe = null;
         }
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/logix/LearnWarrantTest.java
+++ b/java/test/jmri/jmrit/logix/LearnWarrantTest.java
@@ -153,7 +153,7 @@ public class LearnWarrantTest {
         JFrameOperator jfo2 = new JFrameOperator(tableFrame);
         jfo2.requestClose();
         ControlPanelEditor panel = (ControlPanelEditor)jmri.util.JmriJFrame.getFrame("LearnWarrantTest");
-        panel.dispose(true);    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
     }
 
     private void pressButton(WindowOperator frame, String text) {

--- a/java/test/jmri/jmrit/logix/NXFrameTest.java
+++ b/java/test/jmri/jmrit/logix/NXFrameTest.java
@@ -209,7 +209,7 @@ public class NXFrameTest {
         jfo.requestClose();
         // we may want to use jemmy to close the panel as well.
         ControlPanelEditor panel = (ControlPanelEditor) jmri.util.JmriJFrame.getFrame("NXWarrantTest");
-        panel.dispose(true);    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+        panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
     }
 
     private void pressButton(WindowOperator frame, String text) {

--- a/java/test/jmri/jmrix/rps/RpsPositionIconTest.java
+++ b/java/test/jmri/jmrix/rps/RpsPositionIconTest.java
@@ -38,7 +38,7 @@ public class RpsPositionIconTest {
         Editor e = Editor.getEditor("RPS Location Test Editor");
         Assert.assertNotNull("has target frame", e.getTargetFrame());
         Assert.assertEquals("RPS Location Test", e.getTargetFrame().getTitle());
-        e.dispose(true);
+        e.dispose();
     }
 
     @Before


### PR DESCRIPTION
The EcosLocoToRoster objects are retained in memory at the end of JUnit tests, apparently (at least) because they've registered shut-down objects.  

The memory impact of this can be greatly reduced by having them _not_ retain a DecoderIndex object. That's what's in this PR.

Still to be done in some other PR is resolving what's retaining the EcosLocoToRoster objects.

![skitch](https://user-images.githubusercontent.com/2774117/38215807-cd7ff9ac-367d-11e8-8379-7739b6ef0b59.png)
