### PR TITLE
Improve LocoNet initialization of turnouts from layout messages

### DIFF
--- a/java/src/jmri/jmrix/loconet/LnTurnoutManager.java
+++ b/java/src/jmri/jmrix/loconet/LnTurnoutManager.java
@@ -159,7 +159,7 @@ public class LnTurnoutManager extends jmri.managers.AbstractTurnoutManager imple
                 lastSWREQ = null;
                 return;
         }
-        // reach here for loconet switch command; make sure we know about this one
+        // reach here for loconet switch command; make sure that a Turnout with this name exists
         String s = prefix + "T" + addr; // NOI18N
         if (getBySystemName(s) == null) {
             // no turnout with this address, is there a light?
@@ -167,6 +167,21 @@ public class LnTurnoutManager extends jmri.managers.AbstractTurnoutManager imple
             if (jmri.InstanceManager.lightManagerInstance().getBySystemName(sx) == null) {
                 // no light, create a turnout
                 LnTurnout t = (LnTurnout) provideTurnout(s);
+                
+                // if this is an OPC_SW_REP INPUT message for the AUX input,
+                // then the actual turnout must be in EXACT feedback mode
+                if (l.getOpCode() == LnConstants.OPC_SW_REP) {
+                    if ( (l.getElement(2) & LnConstants.OPC_SW_REP_INPUTS) != 0) {
+                        // INPUT
+                        if ( (l.getElement(2) & LnConstants.OPC_SW_REP_SW) == 0) {
+                            // AUX - set exact feedback
+                            log.debug("setting EXACT based on initial message: {}", l);
+                            t.setFeedbackMode(LnTurnout.EXACT);
+                        } 
+                    }
+                }
+                
+                // process the message to put the turnout in the right state
                 t.message(l);
             }
         }

--- a/java/src/jmri/jmrix/loconet/LnTurnoutManager.java
+++ b/java/src/jmri/jmrix/loconet/LnTurnoutManager.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.loconet;
 
+import javax.annotation.*;
 import jmri.Turnout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -167,19 +168,6 @@ public class LnTurnoutManager extends jmri.managers.AbstractTurnoutManager imple
             if (jmri.InstanceManager.lightManagerInstance().getBySystemName(sx) == null) {
                 // no light, create a turnout
                 LnTurnout t = (LnTurnout) provideTurnout(s);
-                
-                // if this is an OPC_SW_REP INPUT message for the AUX input,
-                // then the actual turnout must be in EXACT feedback mode
-                if (l.getOpCode() == LnConstants.OPC_SW_REP) {
-                    if ( (l.getElement(2) & LnConstants.OPC_SW_REP_INPUTS) != 0) {
-                        // INPUT
-                        if ( (l.getElement(2) & LnConstants.OPC_SW_REP_SW) == 0) {
-                            // AUX - set exact feedback
-                            log.debug("setting EXACT based on initial message: {}", l);
-                            t.setFeedbackMode(LnTurnout.EXACT);
-                        } 
-                    }
-                }
                 
                 // process the message to put the turnout in the right state
                 t.message(l);

--- a/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
@@ -3,7 +3,6 @@ package jmri.jmrix.loconet;
 import java.util.ArrayList;
 import java.util.List;
 import jmri.Turnout;
-import jmri.TurnoutManager;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -75,16 +74,44 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBa
         Assert.assertTrue(null != l.getBySystemName("LT22"));
 
         // check the list
-        List<String> testList = new ArrayList<String>(2);
+        List<String> testList = new ArrayList<>(2);
         testList.add("LT21");
         testList.add("LT22");
         Assert.assertEquals("system name list", testList, l.getSystemNameList());
     }
 
     @Test
+    public void testCreateFromMessage1 () {
+        // Turnout LT61 () Switch input is Closed (input off).
+        LocoNetMessage m = new LocoNetMessage(new int[]{0xb1, 0x3C, 0x70, 0x02});
+        lnis.sendTestMessage(m);
+        Assert.assertTrue(null != l.getBySystemName("LT61"));
+        Assert.assertEquals(Turnout.CLOSED, l.getBySystemName("LT61").getKnownState());
+    }
+    
+    @Test
+    public void testCreateFromMessage2 () {
+        // Turnout LT62 () Switch input is Thrown (input on).
+        LocoNetMessage m = new LocoNetMessage(new int[]{0xb1, 0x3D, 0x60, 0x13});
+        lnis.sendTestMessage(m);
+        Assert.assertTrue(null != l.getBySystemName("LT62"));
+        Assert.assertEquals(Turnout.THROWN, l.getBySystemName("LT62").getKnownState());
+    }
+    
+    @Test
+    public void testCreateFromMessage3 () {
+        // Turnout LT63 () Aux input is Thrown (input ).
+        LocoNetMessage m = new LocoNetMessage(new int[]{0xb1, 0x3E, 0x40, 0x30});
+        lnis.sendTestMessage(m);
+        Assert.assertTrue(null != l.getBySystemName("LT63"));
+        Assert.assertEquals("EXACT", l.getBySystemName("LT63").getFeedbackModeName());
+        Assert.assertEquals(Turnout.INCONSISTENT, l.getBySystemName("LT63").getKnownState());
+    }
+    
+    @Test
     public void testCreateFromMessage4 () {
         // Turnout LT64 () Aux input is Closed (input off).
-        LocoNetMessage m = new LocoNetMessage(new int[]{0xb1, 0x3F, 0x50, 0x2F, 0});
+        LocoNetMessage m = new LocoNetMessage(new int[]{0xb1, 0x3F, 0x50, 0x21});
         lnis.sendTestMessage(m);
         Assert.assertTrue(null != l.getBySystemName("LT64"));
         Assert.assertEquals("EXACT", l.getBySystemName("LT64").getFeedbackModeName());

--- a/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
@@ -82,6 +82,16 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBa
     }
 
     @Test
+    public void testCreateFromMessage4 () {
+        // Turnout LT64 () Aux input is Closed (input off).
+        LocoNetMessage m = new LocoNetMessage(new int[]{0xb1, 0x3F, 0x50, 0x2F, 0});
+        lnis.sendTestMessage(m);
+        Assert.assertTrue(null != l.getBySystemName("LT64"));
+        Assert.assertEquals("EXACT", l.getBySystemName("LT64").getFeedbackModeName());
+        Assert.assertEquals(Turnout.THROWN, l.getBySystemName("LT64").getKnownState());
+    }
+    
+    @Test
     public void testAsAbstractFactory() {
         // ask for a Turnout, and check type
         Turnout o = l.newTurnout("LT21", "my name");


### PR DESCRIPTION
See Issue #5143 for background.

Briefly, OPC_SW_REP messages received from the layout during initialization can now set automatically-created layouts to EXACT mode, and will be more aggressively interpreted when setting the turnout state.