### PR TITLE
Fix incorrect toString() methods in some named beans

### DIFF
--- a/java/src/jmri/implementation/AbstractIdTag.java
+++ b/java/src/jmri/implementation/AbstractIdTag.java
@@ -57,6 +57,10 @@ public abstract class AbstractIdTag extends AbstractNamedBean implements IdTag {
         }
     }
 
+    // note that this doesn't properly implement the 
+    // contract in {@link NamedBean.toString()}, 
+    // which means things like tables and persistance 
+    // might not behave properly.
     @Override
     public String toString() {
         String userName = getUserName();

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -60,23 +60,18 @@ public abstract class AbstractNamedBean implements NamedBean {
     }
 
     /**
-     * Get associated comment text.
+     * {@inheritDoc}
      */
     @Override
-    public String getComment() {
+    final public String getComment() {
         return this.comment;
     }
 
     /**
-     * Set associated comment text.
-     * <p>
-     * Comments can be any valid text.
-     *
-     * @param comment 'nulln means no comment associated.
+     * {@inheritDoc}
      */
     @Override
-    @OverridingMethodsMustInvokeSuper
-    public void setComment(String comment) {
+    final public void setComment(String comment) {
         String old = this.comment;
         if (comment == null || comment.trim().isEmpty()) {
             this.comment = null;
@@ -88,8 +83,12 @@ public abstract class AbstractNamedBean implements NamedBean {
     private String comment;
 
     /**
-     * Get the name string of this object.
-     *
+     * {@inheritDoc}
+     * <p>
+     * It would be good to eventually make this final to 
+     * keep it consistent system-wide, but 
+     * we have some existing classes to update first.
+     * 
      * @return user name if not null or empty, else return system name
      */
     @Override
@@ -102,6 +101,12 @@ public abstract class AbstractNamedBean implements NamedBean {
         }
     }
 
+    /**
+     * <p>
+     * It would be good to eventually make this final to 
+     * keep it consistent system-wide, but 
+     * we have some existing classes to update first.
+     */
     @Override
     public String getFullyFormattedDisplayName() {
         String name = getUserName();
@@ -203,12 +208,16 @@ public abstract class AbstractNamedBean implements NamedBean {
     }
 
     @Override
-    public String getSystemName() {
+    final public String getSystemName() {
         return mSystemName;
     }
 
     /**
      * {@inheritDoc}
+     * <p>
+     * It would be good to eventually make this final to 
+     * keep it consistent system-wide, but 
+     * we have some existing classes to update first.
      */
     @Nonnull
     @Override
@@ -217,7 +226,7 @@ public abstract class AbstractNamedBean implements NamedBean {
     }
 
     @Override
-    public String getUserName() {
+    final public String getUserName() {
         return mUserName;
     }
 

--- a/java/src/jmri/implementation/AbstractReporter.java
+++ b/java/src/jmri/implementation/AbstractReporter.java
@@ -31,12 +31,6 @@ public abstract class AbstractReporter extends AbstractNamedBean implements Repo
         return Bundle.getMessage("BeanNameReporter");
     }
     
-    // for combo boxes
-    @Override
-    public String toString() {
-        return getDisplayName();
-    }
-
     @Override
     public Object getCurrentReport() {
         return _currentReport;

--- a/java/src/jmri/implementation/DefaultRailCom.java
+++ b/java/src/jmri/implementation/DefaultRailCom.java
@@ -284,6 +284,10 @@ public class DefaultRailCom extends DefaultIdTag implements jmri.RailCom {
 
     Hashtable<Integer, Integer> cvValues = new Hashtable<>();
 
+    // note that this doesn't properly implement the 
+    // contract in {@link NamedBean.toString()}, 
+    // which means things like tables and persistance 
+    // might not behave properly.
     @Override
     public String toString() {
         String comment;

--- a/java/src/jmri/implementation/DefaultSignalSystem.java
+++ b/java/src/jmri/implementation/DefaultSignalSystem.java
@@ -178,6 +178,10 @@ public class DefaultSignalSystem extends AbstractNamedBean implements SignalSyst
 
     protected java.util.Vector<String> imageTypes = new java.util.Vector<>();
 
+    // note that this doesn't properly implement the 
+    // contract in {@link NamedBean.toString()}, 
+    // which means things like tables and persistance 
+    // might not behave properly.
     @Override
     public String toString() {
         StringBuilder retval = new StringBuilder();

--- a/java/src/jmri/implementation/SE8cSignalHead.java
+++ b/java/src/jmri/implementation/SE8cSignalHead.java
@@ -46,7 +46,6 @@ public class SE8cSignalHead extends DefaultSignalHead {
         super(makeSystemName(lowTO, highTO), userName);
         this.lowTurnout = lowTO;
         this.highTurnout = highTO;
-        systemName = makeSystemName(lowTO, highTO);
         init();
     }
 
@@ -62,7 +61,6 @@ public class SE8cSignalHead extends DefaultSignalHead {
         super(makeSystemName(lowTO, highTO));
         this.lowTurnout = lowTO;
         this.highTurnout = highTO;
-        systemName = makeSystemName(lowTO, highTO);
         init();
     }
 
@@ -81,7 +79,6 @@ public class SE8cSignalHead extends DefaultSignalHead {
         super(sname, userName);
         this.lowTurnout = lowTO;
         this.highTurnout = highTO;
-        systemName = sname;
         init();
     }
 
@@ -98,7 +95,6 @@ public class SE8cSignalHead extends DefaultSignalHead {
         super(sname);
         this.lowTurnout = lowTO;
         this.highTurnout = highTO;
-        systemName = sname;
         init();
     }
 
@@ -112,7 +108,6 @@ public class SE8cSignalHead extends DefaultSignalHead {
         super("LH" + pNumber, userName);
         this.lowTurnout = makeHandle(pNumber);
         this.highTurnout = makeHandle(pNumber + 1);
-        systemName = "LH" + pNumber;
         init();
     }
 
@@ -156,7 +151,6 @@ public class SE8cSignalHead extends DefaultSignalHead {
         super("LH" + pNumber);
         this.lowTurnout = makeHandle(pNumber);
         this.highTurnout = makeHandle(pNumber + 1);
-        systemName = "LH" + pNumber;
         init();
     }
 
@@ -172,12 +166,6 @@ public class SE8cSignalHead extends DefaultSignalHead {
         mAppearance = DARK;  // start turned off
         updateOutput();
     }
-
-    @Override
-    public String getSystemName() {
-        return systemName;
-    }
-    String systemName;
 
     /**
      * Type-specific routine to handle output to the layout hardware.

--- a/java/src/jmri/jmrit/audio/AbstractAudioSource.java
+++ b/java/src/jmri/jmrit/audio/AbstractAudioSource.java
@@ -832,6 +832,10 @@ public abstract class AbstractAudioSource extends AbstractAudio implements Audio
         return this.fading;
     }
 
+    // note that this doesn't properly implement the 
+    // contract in {@link NamedBean.toString()}, 
+    // which means things like tables and persistance 
+    // might not behave properly.
     @Override
     public String toString() {
         return "Pos: " + this.getPosition().toString()

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -212,12 +212,6 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
         });
     }
 
-    // this should only be used for debugging...
-    @Override
-    public String toString() {
-        return "LayoutBlock " + getDisplayName();
-    }
-
     /*
      * Accessor methods
      */

--- a/java/src/jmri/jmrit/logix/OBlock.java
+++ b/java/src/jmri/jmrit/logix/OBlock.java
@@ -948,11 +948,6 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
     }
 
     @Override
-    public String toString() {
-        return getDisplayName();
-    }
-
-    @Override
     public String getBeanType() {
         return Bundle.getMessage("BeanNameOBlock");
     }

--- a/java/src/jmri/jmrit/logix/Portal.java
+++ b/java/src/jmri/jmrit/logix/Portal.java
@@ -625,6 +625,10 @@ public class Portal extends jmri.implementation.AbstractNamedBean {
     }
 
     @Override
+    // note that this doesn't properly implement the 
+    // contract in {@link NamedBean.toString()}, 
+    // which means things like tables and persistance 
+    // might not behave properly.
     public String toString() {
         StringBuilder sb = new StringBuilder("Portal \"");
         sb.append(getUserName());

--- a/java/src/jmri/jmrix/loconet/SE8cSignalHead.java
+++ b/java/src/jmri/jmrix/loconet/SE8cSignalHead.java
@@ -63,11 +63,6 @@ public class SE8cSignalHead extends DefaultSignalHead implements LocoNetListener
         return mNumber;
     }
 
-    @Override
-    public String getSystemName() {
-        return "LH" + getNumber(); // NOI18N
-    }
-
     // Handle a request to change state by sending a LocoNet command
     @Override
     protected void updateOutput() {

--- a/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
+++ b/java/test/jmri/jmrit/entryexit/AddEntryExitPairPanelTest.java
@@ -60,6 +60,8 @@ public class AddEntryExitPairPanelTest {
         // Open the Options window
         String[] optionPath = {"Options", "Options"};  // NOI18N
         JMenuBarOperator nxMenu = new JMenuBarOperator(nxFrame);
+        
+        nxMenu.getTimeouts().setTimeout("JMenuOperator.WaitBeforePopupTimeout", 30L);
         nxMenu.pushMenu(optionPath);
 
         // Close the options window


### PR DESCRIPTION
Fixes Issue #5180: Reporter table shows wrong names.

The NamedBean class documents toString() as providing the system name, and lots of code counts on that.  But some classes re-implement the AbstractNamedBean method to do their own thing.

- Fix that in Reporter and several others
- Set several AbstractNamedBean methods final to prevent more of this in the future.

Unfortunately, several other classes fail tests when their toString methods are converted back to what's required. That's not addressed here, to get #5180 fixed, but a new Issue (#5216) has been opened for it. 