### PR TITLE
Modify SML and NX path checking

### DIFF
--- a/java/src/jmri/SignalMastLogicManager.java
+++ b/java/src/jmri/SignalMastLogicManager.java
@@ -32,15 +32,6 @@ public interface SignalMastLogicManager extends Manager<SignalMastLogic> {
     public void automaticallyDiscoverSignallingPairs() throws JmriException;
 
     /**
-     * Use the Layout Editor to check if the destination signal mast is
-     * reachable from the source signal mast.
-     *
-     * @param sourceMast Source Signal Mast
-     * @param destMast   Destination Signal Mast
-     * @return true if valid, false if not valid
-     */
-    // public boolean checkValidDest(SignalMast sourceMast, SignalMast destMast) throws JmriException;
-    /**
      * Discover valid destination signal masts for a given source Signal Mast on
      * a given Layout Editor Panel.
      *


### PR DESCRIPTION
Extend the block path method to include both inverted route hops and extended route hops.  Previously the hops had to be ascending sequential for the normal case but inverted sequence was handled by a special case.  The special case is now used for hop gaps.

Update Javadoc to reflect the functions for the 4 checkValidDest methods.
