### PR TITLE
UUID-based NodeIdentity.

### DIFF
--- a/java/src/jmri/util/node/NodeIdentity.java
+++ b/java/src/jmri/util/node/NodeIdentity.java
@@ -1,5 +1,8 @@
 package jmri.util.node;
 
+import static java.time.ZonedDateTime.now;
+import static java.time.temporal.ChronoField.YEAR;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -9,13 +12,19 @@ import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
-import jmri.InstanceManager;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import jmri.profile.ProfileManager;
 import jmri.util.FileUtil;
-import jmri.web.server.WebServerPreferences;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -28,33 +37,43 @@ import org.slf4j.LoggerFactory;
 /**
  * Provide a unique network identity for JMRI. If a stored identity does not
  * exist, the identity is created by taking the MAC address of the first
- * {@link java.net.InetAddress} and prepending it with "jmri-". and removing all
- * colons from the address.
- *
- * If a stored identity is found, the identity is replaced if none of the
- * InetAddresses for the host match the MAC address in the identity and
- * regenerated.
- *
+ * {@link java.net.InetAddress}, generating a Type 1 UUID, storing it,
+ * compressing it into a 22 character representation and prepending it with
+ * "jmri-".
+ * <p>
+ * If a stored UUID is found, it is always used.
+ * <p>
  * A list of former identities is retained to aid in migrating from the former
  * identity to the new identity.
- *
- * If the MAC address of the localhost cannot be read, fall back on using the
- * hostname or IP address. If no local IP address is available, fall back on
- * using the railroad name.
+ * <p>
+ * If a MAC address cannot be read, fall back on generating a random multicast
+ * MAC address as per RFC 4122.
  *
  * @author Randall Wood (C) 2013, 2014, 2016
+ * @author Dave Heap (C) 2018
  */
 public class NodeIdentity {
 
     private final ArrayList<String> formerIdentities = new ArrayList<>();
     private String identity = null;
+    private String uuid = null;
 
     private static NodeIdentity instance = null;
-    private final static Logger log = LoggerFactory.getLogger(NodeIdentity.class);
+    private static final Logger log = LoggerFactory.getLogger(NodeIdentity.class);
 
-    private final static String ROOT_ELEMENT = "nodeIdentityConfig"; // NOI18N
-    private final static String NODE_IDENTITY = "nodeIdentity"; // NOI18N
-    private final static String FORMER_IDENTITIES = "formerIdentities"; // NOI18N
+    private static final String ROOT_ELEMENT = "nodeIdentityConfig"; // NOI18N
+    private static final String UUID = "uuid"; // NOI18N
+    private static final String NODE_IDENTITY = "nodeIdentity"; // NOI18N
+    private static final String FORMER_IDENTITIES = "formerIdentities"; // NOI18N
+
+    /**
+     * A string of 64 URL compatible characters.
+     * <p>
+     * Used by {@link #uuidToCompactString uuidToCompactString} and
+     * {@link #uuidFromCompactString uuidFromCompactString}.
+     */
+    protected static final String URL_SAFE_CHARACTERS
+            = "abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-0123456789"; // NOI18N
 
     private NodeIdentity() {
         init(); // init as a method so the init can be synchronized.
@@ -65,6 +84,13 @@ public class NodeIdentity {
         if (identityFile.exists()) {
             try {
                 Document doc = (new SAXBuilder()).build(identityFile);
+                Element uu = doc.getRootElement().getChild(UUID);
+                if (uu != null) {
+                    this.uuid = uu.getAttributeValue(UUID);
+                } else {
+                    this.uuid = null;
+                    this.getIdentity(true);
+                }
                 String id = doc.getRootElement().getChild(NODE_IDENTITY).getAttributeValue(NODE_IDENTITY);
                 this.formerIdentities.clear();
                 doc.getRootElement().getChild(FORMER_IDENTITIES).getChildren().stream().forEach((e) -> {
@@ -82,6 +108,7 @@ public class NodeIdentity {
                 this.getIdentity(true);
             }
         } else {
+            this.uuid = null;
             this.getIdentity(true);
         }
     }
@@ -145,7 +172,7 @@ public class NodeIdentity {
 
     /**
      * Get a node identity from the current hardware.
-     *
+     * <p>
      */
     synchronized private void getIdentity(boolean save) {
         try {
@@ -172,24 +199,19 @@ public class NodeIdentity {
                         }
                     }
                 }
-                if (this.identity == null) {
-                    try {
-                        this.identity = InetAddress.getLocalHost().getHostName();
-                    } catch (UnknownHostException ex1) {
-                        this.identity = InetAddress.getLocalHost().getHostAddress();
-                    }
-                }
             } catch (SocketException ex) {
-                try {
-                    this.identity = InetAddress.getLocalHost().getHostName();
-                } catch (UnknownHostException ex1) {
-                    this.identity = InetAddress.getLocalHost().getHostAddress();
-                }
+                this.identity = null;
             }
         } catch (UnknownHostException ex) {
-            this.identity = InstanceManager.getDefault(WebServerPreferences.class).getRailroadName().replaceAll("[^A-Za-z0-9 ]", "-"); // NOI18N
-            log.error("Cannot get host address or name {}", ex.getLocalizedMessage());
-            log.error("Using {} as a fallback.", this.identity);
+            this.identity = null;
+        }
+        if (this.identity == null) {
+            log.info("No MAC addresses found, generating a random multicast MAC address as per RFC 4122.");
+            byte[] randBytes = new byte[6];
+            Random randGen = new Random();
+            randGen.nextBytes(randBytes);
+            randBytes[0] = (byte) (randBytes[0] | 0x01); // set multicast bit in first octet
+            this.identity = this.createIdentity(randBytes);
         }
         if (save) {
             this.saveIdentity();
@@ -202,11 +224,13 @@ public class NodeIdentity {
     private void saveIdentity() {
         Document doc = new Document();
         doc.setRootElement(new Element(ROOT_ELEMENT));
+        Element uuidElement = new Element(UUID);
         Element identityElement = new Element(NODE_IDENTITY);
         Element formerIdentitiesElement = new Element(FORMER_IDENTITIES);
         if (this.identity == null) {
             this.getIdentity(false);
         }
+        uuidElement.setAttribute(UUID, this.uuid);
         identityElement.setAttribute(NODE_IDENTITY, this.identity);
         this.formerIdentities.stream().forEach((formerIdentity) -> {
             log.debug("Retaining former node identity {}", formerIdentity);
@@ -214,6 +238,7 @@ public class NodeIdentity {
             e.setAttribute(NODE_IDENTITY, formerIdentity);
             formerIdentitiesElement.addContent(e);
         });
+        doc.getRootElement().addContent(uuidElement);
         doc.getRootElement().addContent(identityElement);
         doc.getRootElement().addContent(formerIdentitiesElement);
         try (Writer w = new OutputStreamWriter(new FileOutputStream(this.identityFile()), "UTF-8")) { // NOI18N
@@ -234,14 +259,16 @@ public class NodeIdentity {
      * @return An identity or null if input is null.
      */
     private String createIdentity(byte[] mac) {
-        StringBuilder sb = new StringBuilder("jmri-"); // NOI18N
-        try {
-            for (int i = 0; i < mac.length; i++) {
-                sb.append(String.format("%02X", mac[i])); // NOI18N
-            }
-        } catch (NullPointerException ex) {
-            return null;
+        if (this.uuid == null) {
+            UUID uu = generateUuid(mac);
+            log.info("Original UUID= {}", uu.toString());
+
+            this.uuid = uuidToCompactString(uu);
+            log.info("Compact string ='{}'", this.uuid);
         }
+
+        StringBuilder sb = new StringBuilder("jmri-"); // NOI18N
+        sb.append(this.uuid);
         return sb.toString();
     }
 
@@ -250,9 +277,164 @@ public class NodeIdentity {
     }
 
     /**
+     * Generates a Version 1 Variant 2 UUID for this installation.
+     * <p>
+     * Once generated, this should be stored in {@code nodeIdentity.xml} and
+     * always used for all profiles.
+     *
+     * @param mac the MAC address of any interface on this computer.
+     * @return the UUID
+     */
+    public static UUID generateUuid(byte[] mac) {
+        long mostSigBits = 0;
+        long leastSigBits = 0;
+        long time;
+
+        for (byte b : mac) {
+            leastSigBits = leastSigBits << 8;
+            leastSigBits = leastSigBits | (b & 0xFF);
+        }
+        leastSigBits = leastSigBits & Long.parseUnsignedLong("0000FFFFFFFFFFFF", 16); // just to be sure no overflow from node
+        leastSigBits = leastSigBits | Long.parseUnsignedLong("8000000000000000", 16); // variant 2
+
+        ZonedDateTime startDate;
+        startDate = ZonedDateTime.parse("1582-10-15T00:00:00Z");
+        try {
+            TimeUnit.SECONDS.sleep(1);
+        } catch (InterruptedException ex) {
+            java.util.logging.Logger.getLogger(NodeIdentity.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        ZonedDateTime endDate = now();
+        int midYear = (endDate.get(YEAR) + startDate.get(YEAR)) / 2; // need this to avoid overflow
+        ZonedDateTime midDate = ZonedDateTime.parse(midYear + "-01-01T00:00:00Z");
+        time = (ChronoUnit.NANOS.between(startDate, midDate)) / 100;
+        time = time + (ChronoUnit.NANOS.between(midDate, endDate)) / 100;
+        log.debug("Interval={}, Hex={}, now={}", time, Long.toHexString(time),
+                now().format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL)));
+
+        mostSigBits = mostSigBits | Long.parseUnsignedLong("1000", 16); // version 1
+        long temp = time;
+        mostSigBits = mostSigBits | ((temp & Long.parseUnsignedLong("FFFFFFFF", 16)) << 32); // time_low
+        temp = temp >>> 32;
+        mostSigBits = mostSigBits | ((temp & Long.parseUnsignedLong("FFFF", 16)) << 16); // time_mid
+        temp = temp >>> 16;
+        mostSigBits = mostSigBits | (temp & Long.parseUnsignedLong("FFF", 16)); // time_mid
+
+        log.debug("mostSigBits= {}", Long.toHexString(mostSigBits));
+        log.debug("leastSigBits= {}", Long.toHexString(leastSigBits));
+
+        UUID uu = new UUID(mostSigBits, leastSigBits);
+
+        log.debug("node= {}", Long.toHexString(uu.node()));
+        log.debug("version= {}", uu.version());
+        log.debug("variant= {}", uu.variant());
+        log.debug("Generated UUID= {}", uu.toString());
+        return uu;
+    }
+
+    /**
+     * Encodes a UUID into a 22 character URL compatible string.
+     * <p>
+     * From an example by
+     * <a href="https://stackoverflow.com/">Tom Lobato</a>.
+     *
+     * @param uuid the UUID to encode
+     * @return the 22 character string
+     */
+    public static String uuidToCompactString(UUID uuid) {
+        char[] c = new char[22];
+        long buffer = 0;
+        int val6;
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 1; i <= 22; i++) {
+            switch (i) {
+                case 1:
+                    buffer = uuid.getLeastSignificantBits();
+                    break;
+                case 12:
+                    buffer = uuid.getMostSignificantBits();
+                    break;
+                default:
+                    break;
+            }
+            val6 = (int) (buffer & 0x3F);
+            c[22 - i] = URL_SAFE_CHARACTERS.charAt(val6);
+            buffer = buffer >>> 6;
+        }
+        return sb.append(c).toString();
+    }
+
+    /**
+     * Decodes the original UUID from a 22 character string generated by
+     * {@link #uuidToCompactString uuidToCompactString}.
+     *
+     * @param compact the 22 character string
+     * @return the original UUID
+     */
+    public static UUID uuidFromCompactString(String compact) {
+        long mostSigBits = 0;
+        long leastSigBits = 0;
+        long buffer = 0;
+        int val6;
+
+        for (int i = 0; i <= 21; i++) {
+            switch (i) {
+                case 0:
+                    buffer = 0;
+                    break;
+                case 11:
+                    mostSigBits = buffer;
+                    buffer = 0;
+                    break;
+                default:
+                    buffer = buffer << 6;
+                    break;
+            }
+            val6 = URL_SAFE_CHARACTERS.indexOf(compact.charAt(i));
+            buffer = buffer | (val6 & 0x3F);
+        }
+        leastSigBits = buffer;
+        return new UUID(mostSigBits, leastSigBits);
+    }
+
+    /**
+     * Creates a copy of the last-used old node identity for use with the new
+     * identity.
+     *
+     * @param oldPath the old node identity folder
+     * @param newPath the new node identity folder
+     * @return true if successful
+     */
+    public static boolean copyFormerIdentity(File oldPath, File newPath) {
+        String uniqueId = "-";
+        try {
+            uniqueId += ProfileManager.getDefault().getActiveProfile().getUniqueId();
+        } catch (NullPointerException ex) {
+            uniqueId += ProfileManager.createUniqueId();
+        }
+        List<String> temp = NodeIdentity.formerIdentities();
+        if (temp.size() < 1) {
+            log.warn("Unable to copy from a former identity; no former identities found.");
+            return false;
+        }
+        String lastIdentity = temp.get(temp.size() - 1);
+        File lastDir = new File(oldPath, lastIdentity + uniqueId);
+        try {
+            log.info("Copying from old node \"{}\"", lastDir.toString());
+            log.info("  to new node \"{}\"", newPath.toString());
+            FileUtil.copy(lastDir, newPath);
+        } catch (IOException ex) {
+            log.warn("Unable to copy \"{}\" to \"{}\"", lastDir.toString(), newPath.toString());
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * @return the identity
      */
-    synchronized public String getIdentity() {
+    public synchronized String getIdentity() {
         if (this.identity == null) {
             this.getIdentity(false);
         }

--- a/java/src/jmri/util/prefs/AbstractConfigurationProvider.java
+++ b/java/src/jmri/util/prefs/AbstractConfigurationProvider.java
@@ -11,7 +11,7 @@ import jmri.util.node.NodeIdentity;
  * @author Randall Wood
  */
 public abstract class AbstractConfigurationProvider {
-    
+
     protected final Profile project;
     private boolean privateBackedUp = false;
     private boolean sharedBackedUp = false;
@@ -36,6 +36,10 @@ public abstract class AbstractConfigurationProvider {
         } else {
             dir = new File(this.project.getPath(), Profile.PROFILE);
             if (!shared) {
+                File nodeDir = new File(dir, NodeIdentity.identity());
+                if (!nodeDir.exists()) {
+                    NodeIdentity.copyFormerIdentity(dir, nodeDir);
+                }
                 dir = new File(dir, NodeIdentity.identity());
             }
         }
@@ -70,5 +74,5 @@ public abstract class AbstractConfigurationProvider {
     protected void setSharedBackedUp(boolean sharedBackedUp) {
         this.sharedBackedUp = sharedBackedUp;
     }
-    
+
 }

--- a/java/src/jmri/util/prefs/JmriPreferencesProvider.java
+++ b/java/src/jmri/util/prefs/JmriPreferencesProvider.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Provides instances of {@link java.util.prefs.Preferences} backed by a
  * JMRI-specific storage implementation based on a Properties file.
- *
+ * <p>
  * There are two Properties files per {@link jmri.profile.Profile} and
  * {@link jmri.util.node.NodeIdentity}, both stored in the directory
  * <code>profile:profile</code>:
@@ -259,9 +259,13 @@ public final class JmriPreferencesProvider {
         } else {
             dir = new File(this.path, Profile.PROFILE);
             if (!this.shared) {
+                File nodeDir = new File(dir, NodeIdentity.identity());
+                if (!nodeDir.exists()) {
+                    NodeIdentity.copyFormerIdentity(dir, nodeDir);
+                }
                 dir = new File(dir, NodeIdentity.identity());
+                }
             }
-        }
         FileUtil.createDirectory(dir);
         return dir;
     }

--- a/java/test/jmri/util/node/NodeIdentityTest.java
+++ b/java/test/jmri/util/node/NodeIdentityTest.java
@@ -1,20 +1,49 @@
 package jmri.util.node;
 
+import static jmri.util.node.NodeIdentity.URL_SAFE_CHARACTERS;
+import static jmri.util.node.NodeIdentity.generateUuid;
+import static jmri.util.node.NodeIdentity.uuidFromCompactString;
+import static jmri.util.node.NodeIdentity.uuidToCompactString;
+
+import java.util.UUID;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
- * @author Paul Bender Copyright (C) 2017	
+ * @author Paul Bender Copyright (C) 2017
  */
 public class NodeIdentityTest {
 
     @Test
-    public void testCTor() {
-        Assert.assertNotNull("exists",NodeIdentity.identity());
+    public void testSafeCharsCount() {
+        Assert.assertEquals(64, URL_SAFE_CHARACTERS.length());
+    }
+
+    @Test
+    public void testGenerateUuid() {
+        byte mac[] = {(byte) 0x70, (byte) 0xcd, (byte) 0x60, (byte) 0xaa, (byte) 0xce, (byte) 0xa6};
+        generateUuid(mac);
+    }
+
+    @Test
+    public void testCompactUuid() {
+        byte mac[] = {(byte) 0x70, (byte) 0xcd, (byte) 0x60, (byte) 0xaa, (byte) 0xce, (byte) 0xa6};
+        UUID uu = generateUuid(mac);
+        log.debug("Original UUID= {}", uu.toString());
+
+        String compact = uuidToCompactString(uu);
+        log.debug("Compact string ='{}'", compact);
+
+        UUID uu2 = uuidFromCompactString(compact);
+        log.debug("Regenerated UUID= {}", uu2.toString());
+
+        Assert.assertEquals("UUID from Compact String identical to original UUID", true, uu2.equals(uu));
     }
 
     // The minimal setup for log4J
@@ -28,6 +57,5 @@ public class NodeIdentityTest {
         JUnitUtil.tearDown();
     }
 
-    // private final static Logger log = LoggerFactory.getLogger(NodeIdentityTest.class);
-
+    private final static Logger log = LoggerFactory.getLogger(NodeIdentityTest.class);
 }


### PR DESCRIPTION
Addresses the issues documented in #5185 and implements my proposed solution; one-time generation of a UUID for every JMRI installation, stored in `settings:nodeIdentity.xml` and using that as the unique and non-volatile basis of the nodeIdentity.

Migration of profiles should be seamless to users, being handled the first time each profile is launched after the change.

Due to #4628 I can't check this under Windows. I would appreciate someone checking out this PR, building a Windows package, testing and/or making the installer package available to me.

I'd also appreciate checking on a Raspberry Pi.