### PR TITLE
Fix memory label rotation issues

### DIFF
--- a/java/src/jmri/jmrit/display/MemoryIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryIcon.java
@@ -335,6 +335,17 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
         displayState(key);
     }
 
+    /**
+     * Special method to transfer a setAttributes call from the LE version of
+     * MemoryIcon.  This eliminates the need to change references to public.
+     * @since 4.11.6
+     * @param util The LE popup util object.
+     * @param that The current positional object (this).
+     */
+    public void setAttributes(PositionablePopupUtil util, Positionable that) {
+        _editor.setAttributes(util, that);
+    }
+
     protected void displayState(Object key) {
         log.debug("displayState({})", key);
         if (key != null) {

--- a/java/src/jmri/jmrit/display/layoutEditor/MemoryIcon.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/MemoryIcon.java
@@ -82,6 +82,7 @@ public class MemoryIcon extends jmri.jmrit.display.MemoryIcon {
                     setIcon(null);
                     _text = true;
                     _icon = false;
+                    setAttributes(getPopupUtility(), this);
                     updateSize();
                     return;
                 } else if (val instanceof javax.swing.ImageIcon) {


### PR DESCRIPTION
The memory content was displayed in both the horizontal and rotated positions with the rotated text truncated by the clip area still being horizontal.  Background colors were only visible in the horizontal position.
