### PR TITLE
VSDecoder: listener attribute check

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsFrame.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsFrame.java
@@ -33,7 +33,6 @@ import jmri.jmrit.operations.OperationsXml;
 import jmri.jmrit.operations.locations.Location;
 import jmri.jmrit.operations.locations.LocationManager;
 import jmri.jmrit.operations.setup.Setup;
-import jmri.jmrit.vsdecoder.LoadVSDFileAction;
 import jmri.jmrit.vsdecoder.VSDecoderManager;
 import jmri.jmrit.vsdecoder.listener.ListeningSpot;
 import jmri.util.JmriJFrame;
@@ -252,20 +251,14 @@ public class ManageLocationsFrame extends JmriJFrame {
     }
 
     private void buildMenu() {
-        JMenu fileMenu = new JMenu(Bundle.getMessage("MenuFile"));
-
-        fileMenu.add(new LoadVSDFileAction(Bundle.getMessage("VSDecoderFileMenuLoadVSDFile")));
-
         JMenu editMenu = new JMenu(Bundle.getMessage("MenuEdit"));
         editMenu.add(new VSDPreferencesAction(Bundle.getMessage("VSDecoderFileMenuPreferences")));
 
         menuList = new ArrayList<>();
 
-        menuList.add(fileMenu);
         menuList.add(editMenu);
 
         this.setJMenuBar(new JMenuBar());
-        this.getJMenuBar().add(fileMenu);
         this.getJMenuBar().add(editMenu);
         this.addHelpMenu("package.jmri.jmrit.vsdecoder.swing.ManageLocationsFrame", true); // NOI18N
     }

--- a/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsFrame.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsFrame.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
 public class ManageLocationsFrame extends JmriJFrame {
 
     // Map of Mnemonic KeyEvent values to GUI Components
-    private static final Map<String, Integer> Mnemonics = new HashMap<String, Integer>();
+    private static final Map<String, Integer> Mnemonics = new HashMap<>();
 
     static {
         Mnemonics.put("RoomMode", KeyEvent.VK_R); // NOI18N
@@ -254,7 +254,7 @@ public class ManageLocationsFrame extends JmriJFrame {
         JMenu editMenu = new JMenu(Bundle.getMessage("MenuEdit"));
         editMenu.add(new VSDPreferencesAction(Bundle.getMessage("VSDecoderFileMenuPreferences")));
 
-        menuList = new ArrayList<>();
+        menuList = new ArrayList<>(1);
 
         menuList.add(editMenu);
 
@@ -351,7 +351,7 @@ public class ManageLocationsFrame extends JmriJFrame {
 
         public HashMap<String, PhysicalLocation> getDataMap() {
             // Includes only the ones with the checkbox made
-            HashMap<String, PhysicalLocation> retv = new HashMap<String, PhysicalLocation>();
+            HashMap<String, PhysicalLocation> retv = new HashMap<>();
             for (Object[] row : rowData) {
                 if ((Boolean) row[1]) {
                     if (row[2] == null) { 
@@ -443,7 +443,7 @@ public class ManageLocationsFrame extends JmriJFrame {
         @SuppressWarnings("unused")
         public HashMap<String, ListeningSpot> getDataMap() {
             // Includes only the ones with the checkbox made
-            HashMap<String, ListeningSpot> retv = new HashMap<String, ListeningSpot>();
+            HashMap<String, ListeningSpot> retv = new HashMap<>();
             ListeningSpot spot = null;
             for (Object[] row : rowData) {
                 if ((Boolean) row[1]) {

--- a/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsFrame.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/ManageLocationsFrame.java
@@ -286,13 +286,19 @@ public class ManageLocationsFrame extends JmriJFrame {
     @SuppressFBWarnings(value = "WMI_WRONG_MAP_ITERATOR", justification = "only in slow debug")
     private void saveTableValues() {
         if ((Boolean) locModel.getValueAt(0, 1)) {
-            listenerLoc.setLocation((Double) locModel.getValueAt(0, 2),
-                    (Double) locModel.getValueAt(0, 3),
-                    (Double) locModel.getValueAt(0, 4));
-            listenerLoc.setOrientation((Double) locModel.getValueAt(0, 5),
-                    (Double) locModel.getValueAt(0, 6));
-            VSDecoderManager.instance().getVSDecoderPreferences().save();
-            VSDecoderManager.instance().getVSDecoderPreferences().setListenerPosition(listenerLoc);
+            // Don't accept Azimuth value 90 or -90 (they are not in the domain of definition)
+            if ((Double) locModel.getValueAt(0, 6) != null 
+                    && ((Double) locModel.getValueAt(0, 6) == 90.0d || (Double) locModel.getValueAt(0, 6) == -90.0d)) {
+                JOptionPane.showMessageDialog(null, Bundle.getMessage("FieldTableAzimuthInvalidValue"));
+            } else {
+                listenerLoc.setLocation((Double) locModel.getValueAt(0, 2),
+                        (Double) locModel.getValueAt(0, 3),
+                        (Double) locModel.getValueAt(0, 4));
+                listenerLoc.setOrientation((Double) locModel.getValueAt(0, 5),
+                        (Double) locModel.getValueAt(0, 6));
+                VSDecoderManager.instance().getVSDecoderPreferences().save();
+                VSDecoderManager.instance().getVSDecoderPreferences().setListenerPosition(listenerLoc);
+            }
         }
 
         HashMap<String, PhysicalLocation> data = reporterModel.getDataMap();

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle.properties
@@ -86,6 +86,7 @@ FieldTableZColumn = Z
 FieldTableIsTunnelColumn = Is Tunnel?
 FieldTableBearingColumn = Bearing
 FieldTableAzimuthColumn = Azimuth
+FieldTableAzimuthInvalidValue = Value is not in the domain of definition
 
 # DieselPane
 ToolTipDP_ThrottleSpinner = Shows current Engine Notch (Information only. Not clickable)

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_ca.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_ca.properties
@@ -87,6 +87,7 @@ FieldTableZColumn = Z
 FieldTableIsTunnelColumn = \u00c9s un t\u00fanel?
 FieldTableBearingColumn = Coixinet
 FieldTableAzimuthColumn = Azimut
+FieldTableAzimuthInvalidValue = Value is not in the domain of definition
 
 # DieselPane
 ToolTipDP_ThrottleSpinner = Mostra l'osca del motor (Nom\u00e9s informaci\u00f3)

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_da.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_da.properties
@@ -84,6 +84,7 @@ FieldTableZColumn = Z
 FieldTableIsTunnelColumn = Is Tunnel?
 FieldTableBearingColumn = Bearing
 FieldTableAzimuthColumn = Azimuth
+FieldTableAzimuthInvalidValue = Value is not in the domain of definition
 
 # DieselPane
 ToolTipDP_ThrottleSpinner = Shows current Engine Notch (Information only. Not clickable)

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_de.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_de.properties
@@ -73,6 +73,7 @@ FieldTableUseColumn=Nutze Ort
 FieldTableIsTunnelColumn=Im Tunnel
 FieldTableBearingColumn=Richtung
 FieldTableAzimuthColumn=Azimutwinkel
+FieldTableAzimuthInvalidValue=Wert liegt nicht im Definitionsbereich
 
 # DieselPane
 ToolTipDP_ThrottleSpinner=Zeigt die aktuelle Lokgeschwindigkeitsstufe (nur informativ, nicht anpassbar)

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_fr.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_fr.properties
@@ -117,6 +117,7 @@ FieldTableZColumn = Z
 FieldTableIsTunnelColumn = Est-ce un Tunnel?
 FieldTableBearingColumn = Support
 FieldTableAzimuthColumn = Azimuth
+FieldTableAzimuthInvalidValue = Value is not in the domain of definition
 
 # DieselPane
 ToolTipDP_ThrottleSpinner = SMontrer les Machines Coch&#233;es actuellement. (Information seulement. Non cliquable)

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_it.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_it.properties
@@ -86,6 +86,7 @@ FieldTableZColumn = Z
 FieldTableIsTunnelColumn = E' un Tunnel?
 FieldTableBearingColumn = Cuscinetto
 FieldTableAzimuthColumn = Azimut
+FieldTableAzimuthInvalidValue = Value is not in the domain of definition
 
 # DieselPane
 ToolTipDP_ThrottleSpinner = Visualizza Notch Loco corrente (Non cliccabile)


### PR DESCRIPTION
This PR is a follow-up to #5211 and handle the special case for Azimuth values of 90 and -90 (singularity points).
The Bearing and Azimuth values set the orientation of the Listener, or the direction the Listener is facing. Both an atVector and an upVector are provided. The value 90 gives an zero upVector ```(0,0,0)```, which breaks the rule that the atVector and the upVector must always be at right angles to one another.
The value -90 gives a wrong result (```NaN```) for the Bearing value and a ```audio.JoalAudioListener WARN```.
The Azimuth values are set manually by a ```VSD``` user. If a user enters a value of 90 or -90, now a message shows up.