### PR TITLE
Set connecting track block assignment

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -6086,6 +6086,9 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                     if ((ft.getTurnoutType() == LayoutTurnout.RH_TURNOUT) || (ft.getTurnoutType() == LayoutTurnout.LH_TURNOUT)) {
                         rotateTurnout(ft);
                     }
+
+                    // Assign a block to the new zero length track segment.
+                    ft.setTrackSegmentBlock(foundPointType, true);
                     break;
                 }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
@@ -1530,6 +1530,7 @@ public class LayoutTurnout extends LayoutTrack {
                     && ((block == blockB) || (block == blockC) || (block == blockD))) {
                 block.decrementUse();
             }
+            setTrackSegmentBlocks();
         }
     }
 
@@ -1558,6 +1559,7 @@ public class LayoutTurnout extends LayoutTrack {
                         && ((blockB == block) || (blockB == blockC) || (blockB == blockD))) {
                     blockB.decrementUse();
                 }
+                setTrackSegmentBlocks();
             }
         } else {
             log.error("Attempt to set block B, but not a crossover");
@@ -1589,6 +1591,7 @@ public class LayoutTurnout extends LayoutTrack {
                         && ((blockC == block) || (blockC == blockB) || (blockC == blockD))) {
                     blockC.decrementUse();
                 }
+                setTrackSegmentBlocks();
             }
         } else {
             log.error("Attempt to set block C, but not a crossover");
@@ -1620,6 +1623,7 @@ public class LayoutTurnout extends LayoutTrack {
                         && ((blockD == block) || (blockD == blockB) || (blockD == blockC))) {
                     blockD.decrementUse();
                 }
+                setTrackSegmentBlocks();
             }
         } else {
             log.error("Attempt to set block D, but not a crossover");
@@ -1663,6 +1667,110 @@ public class LayoutTurnout extends LayoutTrack {
             blockDName = name;
         } else {
             log.error("Attempt to set block D name ('{}') on Layout Turnout {}, but not a crossover or slip", name, getName());
+        }
+    }
+
+    /**
+     * Check each connection point and update the block value for very short track segments.
+     * @since 4.11.6
+     */
+    void setTrackSegmentBlocks() {
+        setTrackSegmentBlock(TURNOUT_A, false);
+        setTrackSegmentBlock(TURNOUT_B, false);
+        setTrackSegmentBlock(TURNOUT_C, false);
+        if (getTurnoutType() > WYE_TURNOUT) {
+            setTrackSegmentBlock(TURNOUT_D, false);
+        }
+    }
+
+    /**
+     * Update the block for a track segment that provides a short connection
+     * between a turnout and another object, normally another turnout.
+     * These are hard to see and are frequently missed.
+     * <p>
+     * Skip block changes if signal heads, masts or sensors have been assigned.
+     * Only track segments with a length less than the turnout circle radius will be changed.
+     * @since 4.11.6
+     * @param pointType The point type which indicates which turnout connection.
+     * @param isAutomatic True for the automatically generated track segment created
+     * by the drag-n-drop process.  False for existing connections which require
+     * a track segment length calculation.
+     */
+    void setTrackSegmentBlock(int pointType, boolean isAutomatic) {
+        TrackSegment trkSeg;
+        Point2D pointCoord;
+        LayoutBlock currBlk = block;
+        boolean xOver = getTurnoutType() > WYE_TURNOUT && getTurnoutType() < SINGLE_SLIP;
+        switch (pointType) {
+            case TURNOUT_A:
+            case SLIP_A:
+                if (signalA1HeadNamed != null) return;
+                if (signalA2HeadNamed != null) return;
+                if (signalA3HeadNamed != null) return;
+                if (getSignalAMast() != null) return;
+                if (getSensorA() != null) return;
+                trkSeg = (TrackSegment) connectA;
+                pointCoord = getCoordsA();
+                break;
+            case TURNOUT_B:
+            case SLIP_B:
+                if (signalB1HeadNamed != null) return;
+                if (signalB2HeadNamed != null) return;
+                if (getSignalBMast() != null) return;
+                if (getSensorB() != null) return;
+                trkSeg = (TrackSegment) connectB;
+                pointCoord = getCoordsB();
+                if (xOver) {
+                    currBlk = blockB != null ? blockB : block;
+                }
+                break;
+            case TURNOUT_C:
+            case SLIP_C:
+                if (signalC1HeadNamed != null) return;
+                if (signalC2HeadNamed != null) return;
+                if (getSignalCMast() != null) return;
+                if (getSensorC() != null) return;
+                trkSeg = (TrackSegment) connectC;
+                pointCoord = getCoordsC();
+                if (xOver) {
+                    currBlk = blockC != null ? blockC : block;
+                }
+                break;
+            case TURNOUT_D:
+            case SLIP_D:
+                if (signalD1HeadNamed != null) return;
+                if (signalD2HeadNamed != null) return;
+                if (getSignalDMast() != null) return;
+                if (getSensorD() != null) return;
+                trkSeg = (TrackSegment) connectD;
+                pointCoord = getCoordsD();
+                if (xOver) {
+                    currBlk = blockD != null ? blockD : block;
+                }
+                break;
+            default:
+                log.error("setTrackSegmentBlock: Invalid pointType: {}", pointType);
+                return;
+        }
+        if (trkSeg != null) {
+            double chkSize = LayoutEditor.SIZE * layoutEditor.getTurnoutCircleSize();
+            double segLength = 0;
+            if (!isAutomatic) {
+                Point2D segCenter = trkSeg.getCoordsCenter();
+                segLength = MathUtil.distance(pointCoord, segCenter) * 2;
+            }
+            if (segLength < chkSize) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Set block:");
+                    log.debug("    seg: {}", trkSeg);
+                    log.debug("    cor: {}", pointCoord);
+                    log.debug("    blk: {}", (currBlk == null) ? "null" : currBlk.getDisplayName());
+                    log.debug("    len: {}", segLength);
+                }
+
+                trkSeg.setLayoutBlock(currBlk);
+                layoutEditor.getLEAuxTools().setBlockConnectivityChanged();
+            }
         }
     }
 


### PR DESCRIPTION
Assign the target turnout block to the automatically created track segment when using the Layout Editor drag-n-drop method for joining turnouts.

Update the block assignment for very short track segments attached to a turnout when the turnout block assignment is changed.