### PR TITLE
Sample script to do a clean shutdown of JMRI on Raspberry Pi

### DIFF
--- a/jython/RaspberryPiShutdown.py
+++ b/jython/RaspberryPiShutdown.py
@@ -1,0 +1,16 @@
+# Shut down an Raspberry Pi or other Linux machine cleanly
+#
+# Run this from e.g. a Logix to end JMRI and make it save to turn off the machine
+#
+# From a sequence by Dave Sand
+
+
+import java
+import jmri
+import jmri.InstanceManager
+
+# start the machine going down in one minute (requires that you can "sudo" without a password)
+java.lang.Runtime.getRuntime().exec("sudo shutdown -h +1")
+
+# do an immediate graceful shutdown of JMRI
+jmri.InstanceManager.shutDownManagerInstance().shutdown()


### PR DESCRIPTION
Jython sample script to do a clean shutdown of JMRI and then the Raspberry Pi (or other Linux machine) it's running on.

From a suggestion by Dave Sand