### PR TITLE
Update AppVeyor build status badge to point to correct project

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ Jenkins: [![Build Status](http://jmri.tagadab.com/jenkins/buildStatus/icon?job=D
 [![Build Status](http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/Separate_Tests)](http://jmri.tagadab.com/jenkins/job/Development/job/Separate_Tests/)
 
 Travis: [![Build Status](https://travis-ci.org/JMRI/JMRI.svg?branch=master)](https://travis-ci.org/JMRI/JMRI)
-AppVeyor: [![Build status](https://ci.appveyor.com/api/projects/status/1wa25bdftg5241hk/branch/master?svg=true)](https://ci.appveyor.com/project/JMRI/jmri/branch/master)
+AppVeyor: [![Build status](https://ci.appveyor.com/api/projects/status/lmdrtxjxf62xym0p/branch/master?svg=true)](https://ci.appveyor.com/project/JMRI/jmri/branch/master)
 Coveralls: [![Coverage Status](https://coveralls.io/repos/github/JMRI/JMRI/badge.svg?branch=master)](https://coveralls.io/github/JMRI/JMRI?branch=master)


### PR DESCRIPTION
It was necessary to change the JMRI project on AppVeyor which meant that the unique identifier was changed.

This PR ensures that the AppVeyor build status badge for `master` points at the currently maintained AppVeyor project.