### PR TITLE
use queuetool to wait for AWT to settle before constructing the object under test.

### DIFF
--- a/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitFrameTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/EditCircuitFrameTest.java
@@ -21,6 +21,7 @@ public class EditCircuitFrameTest {
         ControlPanelEditor frame = new ControlPanelEditor();
         CircuitBuilder cb = new CircuitBuilder(frame);
         OBlock ob = new OBlock("OB01");
+        new org.netbeans.jemmy.QueueTool().waitEmpty(100);
         EditCircuitFrame t = new EditCircuitFrame("Edit Circuit Frame", cb, ob);
         Assert.assertNotNull("exists", t);
         JUnitUtil.dispose(frame);


### PR DESCRIPTION
Attempt to address #5294 