### PR TITLE
Misc Layout Editor fixes

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -1604,7 +1604,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
             if ((p != null) && (p.getLinkedEditor() != null)) {
                 return getFacingBean(facingBlock, protectedBlock, p.getLinkedEditor(), T);
             }
-            log.error(
+            log.debug(
                     "Block " + facingBlock.getDisplayName() + " is not connected to Block " + protectedBlock.getDisplayName() + " on panel "
                     + panel.getLayoutName());
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -9546,11 +9546,13 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         draw1(g2, main, block, hidden, dashed = true);
 
         //setup for drawing mainline rails
+        main = true;
         g2.setColor(ltdo.getMainRailColor());
         g2.setStroke(stroke);
         draw1(g2, main, block, hidden, dashed = false);
         g2.setStroke(dashedStroke);
-        draw1(g2, main, block, hidden, dashed = true);
+        dashed = true;
+        draw1(g2, main, block, hidden, dashed);
     }
 
     //
@@ -9620,7 +9622,8 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             g2.setStroke(new BasicStroke(ballastWidth,
                     BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
             g2.setColor(ltdo.getMainBallastColor());
-            draw1(g2, main = true, block, hidden, dashed);
+            main = true;
+            draw1(g2, main, block, hidden, dashed);
         }
     }
 
@@ -9701,7 +9704,8 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                     railWidth,
                     BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
             g2.setColor(railColor);
-            draw1(g2, main, block, hidden, dashed = false);
+            dashed = false;
+            draw1(g2, main, block, hidden, dashed);
         }
     }   // drawLayoutTracksRails
 
@@ -9768,7 +9772,8 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         //note: color is set in layout track's draw1 when isBlock is true
         draw1(g2, main = true, block, hidden, dashed = true);
         g2.setStroke(blockLineStroke);
-        draw1(g2, main, block, hidden, dashed = false);
+        dashed = false;
+        draw1(g2, main, block, hidden, dashed);
     }
 
     // isDashed defaults to false

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
@@ -2759,7 +2759,7 @@ public class LayoutTurnout extends LayoutTrack {
                             for (Map.Entry<String, LayoutBlock> entry : map.entrySet()) {
                                 String blockName = entry.getKey();
                                 LayoutBlock layoutBlock = entry.getValue();
-                                viewRouting.add(new AbstractActionImpl(getBlockBName(), blockName, layoutBlock));
+                                viewRouting.add(new AbstractActionImpl(blockName, getBlockBName(), layoutBlock));
                             }
                             popup.add(viewRouting);
                         }

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/TrackSegmentXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/TrackSegmentXml.java
@@ -61,11 +61,10 @@ public class TrackSegmentXml extends AbstractXmlAdapter {
                 element.setAttribute("hideConLines", "" + (p.hideConstructionLines() ? "yes" : "no"));
             }
         }
-        if (p.isBezier()) {
-            element.setAttribute("bezier", "yes");
-        }
 
         if (p.isBezier()) {
+            element.setAttribute("bezier", "yes");
+            element.setAttribute("hideConLines", "" + (p.hideConstructionLines() ? "yes" : "no"));
             // add control points
             Element elementControlpoints = new Element("controlpoints");
             for (int i = 0; i < p.getNumberOfBezierControlPoints(); i++) {

--- a/java/test/jmri/jmrit/display/layoutEditor/loadref/LayoutEditorTest.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/loadref/LayoutEditorTest.xml
@@ -267,7 +267,7 @@
     <tracksegment ident="T14" blockname="Yard" connect1name="TO5" type1="4" connect2name="A3" type2="1" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="T15" blockname="North" connect1name="TO6" type1="3" connect2name="TO8" type2="2" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="T17" blockname="Yard" connect1name="SL1" type1="24" connect2name="TO6" type2="4" dashed="no" mainline="no" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
-    <tracksegment ident="T18" blockname="Yard" connect1name="SL1" type1="22" connect2name="A4" type2="1" dashed="no" mainline="no" hidden="no" bezier="yes" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+    <tracksegment ident="T18" blockname="Yard" connect1name="SL1" type1="22" connect2name="A4" type2="1" dashed="no" mainline="no" hidden="no" bezier="yes" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
       <controlpoints>
         <controlpoint index="0" x="220.0" y="130.0" />
         <controlpoint index="1" x="180.0" y="170.0" />
@@ -275,7 +275,7 @@
     </tracksegment>
     <tracksegment ident="T20" blockname="East" connect1name="TO3" type1="3" connect2name="A5" type2="1" dashed="no" mainline="yes" hidden="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
     <tracksegment ident="T21" blockname="East" connect1name="TO6" type1="2" connect2name="A5" type2="1" dashed="no" mainline="yes" hidden="no" arc="yes" flip="no" circle="yes" angle="180.0" hideConLines="yes" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml" />
-    <tracksegment ident="T22" blockname="Yard" connect1name="SL1" type1="23" connect2name="A6" type2="1" dashed="no" mainline="no" hidden="no" bezier="yes" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
+    <tracksegment ident="T22" blockname="Yard" connect1name="SL1" type1="23" connect2name="A6" type2="1" dashed="no" mainline="no" hidden="no" bezier="yes" hideConLines="no" class="jmri.jmrit.display.layoutEditor.configurexml.TrackSegmentXml">
       <controlpoints>
         <controlpoint index="0" x="400.0" y="140.0" />
         <controlpoint index="1" x="420.0" y="140.0" />


### PR DESCRIPTION
- Display hidden **mainline** track in edit mode.
- Change the **View Block Routing** selection list for cross-overs to use the actual block name instead of the same name for each entry.
- Change an **error** message to **debug** that occurs during signal mast pair discovery when more than one LE panel exists.
- Include the **hideConLines** attribute for the bezier lines when storing a LE panel.
- Updated the **loadref** test file.
- Spotbugs fixes