### PR TITLE
remove apparently extraneous waitfor

### DIFF
--- a/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
@@ -243,7 +243,6 @@ public class OlcbSensorTest extends TestCase {
         t.tc.rcvMessage = null;
         s.requestUpdateFromLayout();
         t.flush();
-        JUnitUtil.waitFor( ()->{ return(t.tc.rcvMessage != null); });
         t.assertSentMessage(":X198F4C4CN0102030405060708;");
     }
 


### PR DESCRIPTION
This was prompted by #5335.  This is the only place we have been using a waitfor in conjunction with the assertSentMessage method.