### PR TITLE
Change order of DP3 OpsFrame startup to better handle programming modes

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrame.java
@@ -461,28 +461,6 @@ abstract public class PaneProgFrame extends JmriJFrame
                 resetMenu.setEnabled(true);
             }
         }
-        // and build the GUI
-        loadProgrammerFile(pRosterEntry);
-
-        // optionally, add extra panes from the decoder file
-        Attribute a;
-        if ((a = programmerRoot.getChild("programmer").getAttribute("decoderFilePanes")) != null
-                && a.getValue().equals("yes")) {
-            if (decoderRoot != null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("will process " + decoderPaneList.size() + " pane definitions from decoder file");
-                }
-                for (int i = 0; i < decoderPaneList.size(); i++) {
-                    // load each pane
-                    String pname = jmri.util.jdom.LocaleSelector.getAttribute(decoderPaneList.get(i), "name");
-
-                    // handle include/exclude
-                    if (isIncludedFE(decoderPaneList.get(i), modelElem, _rosterEntry, "", "")) {
-                        newPane(pname, decoderPaneList.get(i), modelElem, true, false);  // show even if empty not a programmer pane
-                    }
-                }
-            }
-        }
 
         // set the programming mode
         if (pProg != null) {
@@ -527,12 +505,35 @@ abstract public class PaneProgFrame extends JmriJFrame
             }
         }
 
+        // and build the GUI (after programmer mode because it depends on what's available)
+        loadProgrammerFile(pRosterEntry);
+
+        // optionally, add extra panes from the decoder file
+        Attribute a;
+        if ((a = programmerRoot.getChild("programmer").getAttribute("decoderFilePanes")) != null
+                && a.getValue().equals("yes")) {
+            if (decoderRoot != null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("will process " + decoderPaneList.size() + " pane definitions from decoder file");
+                }
+                for (int i = 0; i < decoderPaneList.size(); i++) {
+                    // load each pane
+                    String pname = jmri.util.jdom.LocaleSelector.getAttribute(decoderPaneList.get(i), "name");
+
+                    // handle include/exclude
+                    if (isIncludedFE(decoderPaneList.get(i), modelElem, _rosterEntry, "", "")) {
+                        newPane(pname, decoderPaneList.get(i), modelElem, true, false);  // show even if empty not a programmer pane
+                    }
+                }
+            }
+        }
+
         // now that programmer is configured, set the programming GUI
-        setProgrammingGui(tempPane);
+        setProgrammingGui(tempPane);        
 
         pack();
 
-        if (log.isDebugEnabled()) {
+        if (log.isDebugEnabled()) {  // because size elements take time
             log.debug("PaneProgFrame \"" + pFrameTitle
                     + "\" constructed for file " + _rosterEntry.getFileName()
                     + ", unconstrained size is " + super.getPreferredSize()

--- a/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
@@ -501,7 +501,7 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
      */
     @Override
     public boolean getCanRead() {
-        if (getMode().equals(ProgrammingMode.OPSBYTEMODE)) return mSlotMgr.getTranspondingAvailable();
+        if (getMode().equals(ProgrammingMode.OPSBYTEMODE)) return mSlotMgr.getTranspondingAvailable(); // only way can be false
         return true;
      }
 

--- a/java/test/jmri/jmrit/symbolicprog/CsvImporterTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CsvImporterTest.java
@@ -42,8 +42,9 @@ public class CsvImporterTest {
         CsvImporter t = new CsvImporter(f,tm);
         Assert.assertNotNull("exists",t);
         
-        jmri.util.JUnitAppender.assertWarnMessage("CV1 was in import file, but not defined by the decoder definition");
-        jmri.util.JUnitAppender.assertWarnMessage("CV2 was in import file, but not defined by the decoder definition");
+        // following messages don't seem to always happen in AppVeyor and Travis CI
+        // jmri.util.JUnitAppender.assertWarnMessage("CV1 was in import file, but not defined by the decoder definition");
+        // jmri.util.JUnitAppender.assertWarnMessage("CV2 was in import file, but not defined by the decoder definition");
         
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/CsvImporterTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CsvImporterTest.java
@@ -41,6 +41,10 @@ public class CsvImporterTest {
         CvTableModel tm = new CvTableModel(new JLabel(), null);
         CsvImporter t = new CsvImporter(f,tm);
         Assert.assertNotNull("exists",t);
+        
+        jmri.util.JUnitAppender.assertWarnMessage("CV1 was in import file, but not defined by the decoder definition");
+        jmri.util.JUnitAppender.assertWarnMessage("CV2 was in import file, but not defined by the decoder definition");
+        
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrit/symbolicprog/QuantumCvMgrImporterTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/QuantumCvMgrImporterTest.java
@@ -41,6 +41,9 @@ public class QuantumCvMgrImporterTest {
         CvTableModel tm = new CvTableModel(new JLabel(), null);
         QuantumCvMgrImporter t = new QuantumCvMgrImporter(f,tm);
         Assert.assertNotNull("exists",t);
+
+        jmri.util.JUnitAppender.assertWarnMessage("Adding CV 1 description \"\", which was in import file but not defined by the decoder definition");
+        jmri.util.JUnitAppender.assertWarnMessage("Adding CV 2 description \"\", which was in import file but not defined by the decoder definition");
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneSetTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneSetTest.java
@@ -31,6 +31,8 @@ public class PaneSetTest {
         };
         PaneSet t = new PaneSet(pc,re,p);
         Assert.assertNotNull("exists",t);
+        new org.netbeans.jemmy.QueueTool().waitEmpty(500);
+        pc.dispose();
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneSetTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneSetTest.java
@@ -31,7 +31,7 @@ public class PaneSetTest {
         };
         PaneSet t = new PaneSet(pc,re,p);
         Assert.assertNotNull("exists",t);
-        new org.netbeans.jemmy.QueueTool().waitEmpty(500);
+        new org.netbeans.jemmy.QueueTool().waitEmpty(10);
         pc.dispose();
     }
 


### PR DESCRIPTION
Move selection of programming mode in DP3 Ops Frame earlier, so that it's complete by the time that the GUI creation starts.   Related to #5223 but not clear if it's a complete resolution

Also, reduce verbose test output, close a dangling test window.