### PR TITLE
Eliminate duplicate named bean handles

### DIFF
--- a/java/src/jmri/NamedBeanHandleManager.java
+++ b/java/src/jmri/NamedBeanHandleManager.java
@@ -61,9 +61,12 @@ public class NamedBeanHandleManager extends AbstractManager implements InstanceM
             throw new IllegalArgumentException("name cannot be empty in getNamedBeanHandle");
         }
         NamedBeanHandle<T> temp = new NamedBeanHandle<>(name, bean);
-
-        if (! namedBeanHandles.contains(temp)) namedBeanHandles.add(temp);
-
+        for (NamedBeanHandle<T> h : namedBeanHandles) {
+            if (temp.equals(h)) {
+                return h;
+            }
+        }
+        namedBeanHandles.add(temp);
         return temp;
     }
 


### PR DESCRIPTION
Duplicate named bean handles were being returned for each request but only the first one was retained for subsequent change processing.

This PR fixes issue #5362.
