### PR TITLE
VSDecoder: add engine-gain for steam1 and diesel3

### DIFF
--- a/help/en/manual/DecoderPro/VSD_File_and_Config.shtml
+++ b/help/en/manual/DecoderPro/VSD_File_and_Config.shtml
@@ -120,6 +120,23 @@
       &lt;reference-distance&gt;3.0&lt;/reference-distance&gt;
       </pre>
 
+      <h5>Engine Gain</h5>
+
+      <p>Description:<br>
+      This element allows to adjust the engine gain for steam1
+      and diesel3 engine types.<br>
+      For engine type steam1 the gain value must be in the 
+      range of 0.4 and 1.0.<br>
+      Optional. Must be declared in the tag
+      <strong>sound name="ENGINE"</strong>.
+      Default value: 0.8<br>
+      <em>Since JMRI 4.11.7</em></p>
+
+      <p>Example:</p>
+      <pre>
+      &lt;engine-gain&gt;0.6&lt;/engine-gain&gt;
+      </pre>
+
       <div align="right">
         <p><a href="Main_Debug.shtml#vsdecoder">Back</a></p>
       </div><!--#include virtual="/Footer" -->

--- a/java/src/jmri/jmrit/vsdecoder/Diesel3Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Diesel3Sound.java
@@ -48,6 +48,7 @@ class Diesel3Sound extends EngineSound {
     AudioBuffer stop_buffer;
     AudioBuffer transition_buf;
     float engine_rd;
+    float engine_gain;
 
     // Common variables
     Float throttle_setting; // used for handling speed changes
@@ -143,7 +144,7 @@ class Diesel3Sound extends EngineSound {
     @Override
     public void setXml(Element e, VSDFile vf) {
         Element el;
-        String fn;
+        String fn, in;
         D3Notch sb;
 
         // Handle the common stuff.
@@ -153,7 +154,7 @@ class Diesel3Sound extends EngineSound {
         _soundName = this.getName() + ":LoopSound";
         log.debug("get name: {}, soundName: {}, name: {}", this.getName(), _soundName, name);
         notch_sounds = new HashMap<Integer, D3Notch>();
-        String in = e.getChildText("idle-notch");
+        in = e.getChildText("idle-notch");
         Integer idle_notch = null;
         if (in != null) {
             idle_notch = Integer.parseInt(in);
@@ -170,6 +171,16 @@ class Diesel3Sound extends EngineSound {
         // Sounds with distance to listener position lower than reference-distance will not have attenuation
         engine_rd = setXMLReferenceDistance(e); // Handle reference distance
         log.debug("engine-sound referenceDistance: {}", engine_rd);
+
+        // Optional value
+        // Allows to adjust the engine gain
+        in = e.getChildText("engine-gain");
+        if ((in != null) && (!in.isEmpty())) {
+            engine_gain = Float.parseFloat(in);
+        } else {
+            engine_gain = default_gain;
+        }
+        log.debug("engine gain: {}", engine_gain);
 
         // Get the notch sounds
         Iterator<Element> itr = (e.getChildren("notch-sound")).iterator();
@@ -520,7 +531,7 @@ class Diesel3Sound extends EngineSound {
             is_dying = false;
             _notch = n;
             _sound = new SoundBite(s);
-            _sound.setGain(0.8f);
+            _sound.setGain(_parent.engine_gain);
             _parent = d;
             _throttle = 0.0f;
             if (r) {

--- a/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
@@ -57,6 +57,7 @@ class Steam1Sound extends EngineSound {
     private SoundBite brake_sound;
     private SoundBite pre_arrival_sound;
     float engine_rd;
+    float engine_gain;
 
     // Common variables
     boolean is_looping = false;
@@ -190,6 +191,21 @@ class Steam1Sound extends EngineSound {
         // Sounds with distance to listener position lower than reference-distance will not have attenuation
         engine_rd = setXMLReferenceDistance(e); // Handle reference distance
         log.debug("engine-sound referenceDistance: {}", engine_rd);
+
+        // Optional value
+        // Allows to adjust the engine gain
+        n = e.getChildText("engine-gain");
+        if ((n != null) && (!n.isEmpty())) {
+            engine_gain = Float.parseFloat(n);
+            // Make some restrictions, since engine_gain is used for calculations later
+            if ((engine_gain < default_gain - 0.4f) || (engine_gain > default_gain + 0.2f)) {
+                log.info("Invalid engine gain {} was set to default {}", engine_gain, default_gain);
+                engine_gain = default_gain;
+            }
+        } else {
+            engine_gain = default_gain;
+        }
+        log.debug("engine gain: {}", engine_gain);
 
         // Optional value
         // Defines how many rpms in 0.5 seconds will trigger decel actions like braking.
@@ -626,6 +642,7 @@ class Steam1Sound extends EngineSound {
         public S1LoopThread(Steam1Sound d, String s, int ts, float dd, 
                 int nc, float e, int dtr, boolean r) {
             super();
+            _parent = d;
             is_running = r;
             is_looping = false;
             is_dying = false;
@@ -642,8 +659,7 @@ class Steam1Sound extends EngineSound {
             helper_notch = null;
             // Sound for queueing.
             _sound = new SoundBite(s + "_QUEUE");
-            _sound.setGain(VSDSound.default_gain); // All chuff sounds will have this gain
-            _parent = d;
+            _sound.setGain(_parent.engine_gain); // All chuff sounds will have this gain
             _top_speed = ts;
             _driver_diameter_float = dd;
             _num_cylinders = nc;


### PR DESCRIPTION
The gain of the engine sound is 0.8 by default and cannot be changed for steam1 and diesel3 by the user (steam already has an adjustable engine gain).
The new element engine-gain allows to adjust the engine gain individually in config.xml.