### PR TITLE
Catalan translation files

### DIFF
--- a/java/src/jmri/jmrit/Bundle_ca.properties
+++ b/java/src/jmri/jmrit/Bundle_ca.properties
@@ -29,7 +29,7 @@ MenuItemOBlockTable = Ocupaci\u00f3 de blocs
 MenuItemBlockTable = Blocs
 MenuItemSectionTable = Seccions
 MenuItemTransitTable = Transits
-MenuItemSensorGroup = Grups de senyors
+MenuItemSensorGroup = Grups de Sensors
 MenuItemDispatcher = Dispatcher...
 MenuItemAudioTable = \u00c0udio
 MenuItemIdTagTable = Id. d'etiquetes
@@ -42,7 +42,7 @@ MastBuilderTitle    = Construeix Mast
 MenuThrottles = Regulador
 MenuItemNewThrottle = Regulador nou
 MenuItemThrottlesList = Llista de reguladors
-MenuItemSaveThrottleLayout = Guarda reguladors emprats
+MenuItemSaveThrottleLayout = Desa reguladors emprats
 MenuItemLoadThrottleLayout = Carrega reguladors emprats
 MenuItemSaveAsDefaultThrottleLayout = Desa com a reguladors emprats per defecte
 MenuItemLoadDefaultThrottleLayout = Obre reguladors emprats per defecte
@@ -133,7 +133,7 @@ ThrottleMenuPowerOn = Engegar
 ThrottleMenuPowerOff = Apagar
 
 # Pickers
-CantAddNew      = Cannot add new items to this pick panel.
+CantAddNew      = No es poden afegir nous elements a aquest panell.
 OpenToAdd       = Obre la Taula per afegir aquest tipus d'element.
 
 # Common gui strings

--- a/java/src/jmri/jmrit/roster/JmritRosterBundle_ca.properties
+++ b/java/src/jmri/jmrit/roster/JmritRosterBundle_ca.properties
@@ -1,10 +1,11 @@
 # JmritRosterBundle_ca.properties
 #
-# Translation: Joan de Castro (joan276dca@yahoo.es) 18/08/2016
 # Catalan properties for the jmri.jmrit.roster package
+# Translation: Joan de Castro (joan276dca@yahoo.es) 18/08/2016
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/05/29
 
-MenuRosterGroups = Grups de Flota
 MenuItemRoster = Flota
+MenuRosterGroups = Grups de Flota
 MenuItemCreate = Crea una entrada
 MenuItemEdit = Edita una entrada
 MenuItemImport = Importa una entrada
@@ -13,6 +14,8 @@ MenuItemCopy = Copia una entrada
 MenuItemDelete = Elimina una entrada
 MenuItemPrint = Imprimeix entrades
 MenuItemPreview = Visualitza entrades
+MenuItemPrintList = Imprimeix Llista...
+MenuItemPreviewList = Imprimeix Previsualitzaci\u00f3 de la Llista...
 MenuGroupCreate = Crea un grup
 MenuGroupDelete = Elimina un grup
 MenuGroupTable = Taula d'Associacions
@@ -32,9 +35,9 @@ FieldModel = Model
 FieldSpeedLimit = Velocitat m\u00e0xima del regulador
 FieldDCCAddress = Adre\u00e7a DCC
 FieldComment = Comentari
-FieldDecoderFamily = Fam\u00edlia del dec\u00f2der
+FieldDecoderFamily = Fam\u00edlia del decoder
 FieldDecoderModel = Model dec\u00f2der
-FieldDecoderComment = Comentari del dec\u00f2der
+FieldDecoderComment = Comentari del decoder
 FieldFilename = Nom del fitxer
 FieldDateUpdated = Data de modificaci\u00f3
 FieldIcon = Icona
@@ -46,7 +49,7 @@ AddrLocoTypeLong = Llarga
 RosterGroupTable = Taula de grups de la Flota
 SelectRosterGroup = Selecciona un grup de la Flota:
 
-ErrorNoSelection = Please select a loco from the Roster first.
+ErrorNoSelection = Si us plau, en primer lloc seleciona una locomotora de la Flota.
 ErrorSavingTitle = Error desant entrada de la flota
 ErrorSavingText = Hi ha hagut un error en desar el fitxer de la flota, potser no s'ha completat:
 DeleteTitle = Eliminar l'entrada ({0})?
@@ -57,12 +60,27 @@ ErrorReadingText = Hi ha hagut un error en llegir el fitxer de l'\u00edndex de l
 
 ToolTipID = Identifica la locomotora dins la flota
 
+#TitleDecIndexNotReady = Update Decoder Definitions
+TitleMultRepl = Actualitza les Definicions del decoder: S'han trobat diversos reempla\u00e7aments
+TitleNoDefn = Actualitza les Definicions del decoder: No s'han trobat cap definici\u00f3
+TitleReplDefn = Trieu una definici\u00f3 de reempla\u00e7 per a l'Entrada de la Flota "{0}"
+
 ToolTipDccAddress = El programa omple aquest camp autom\u00e0ticament
 ToolTipShortLong = El programa omple aquest camp autom\u00e0ticament
 ToolTipDecoderModel = El programa omple aquest camp autom\u00e0ticament amb les seleccions anteriors
 ToolTipDecoderFamily = El programa omple aquest camp autom\u00e0ticament amb les seleccions anteriors
 ToolTipFilename = El programa omple aquest camp autom\u00e0ticament
 ToolTipDateUpdated = Hora i data de l'\u00faltima modificaci\u00f3 desada
+ToolTipMultReplSelectNew = Obriu un di\u00e0leg per activar la selecci\u00f3 del reempla\u00e7 de la definici\u00f3
+ToolTipMultReplSkipThis = Omet substituir aquest per ara. Se't demanar\u00e0 de nou la propera vegada.
+ToolTipMultReplSkipAll = Omet tots els reempla\u00e7aments m\u00faltiples per ara. Se't demanar\u00e0 de nou la propera vegada.
+ToolTipShowSuggested = Mostra els suggeriments dels reempla\u00e7aments
+ToolTipNoShowSuggested = No hi ha suggeriments del reempla\u00e7aments
+ToolTipVersionMatch = Mostra coincid\u00e8ncies amb el valor CV 7 ({0}) que es troba a l'entrada de la llista "{1}"
+ToolTipNoVersionMatch = No hi ha cap coincidència amb el valor del CV 7 a l'entrada de la llista "{0}"
+ToolTipNoSelectedDecoder = No has seleccionat cap decoder
+ToolTipUseSelectedDecoder = Utilitza el decoder seleccionat
+ToolTipButtonCancel = Cancel\u00b7la per ara
 
 ErrorDuplicateID = Aquesta ID est\u00e0 duplicada, canvia-la 
 
@@ -71,14 +89,52 @@ LabelDefaultOwner = Nom del propietari per defecte\:
 
 ButtonSetDots = Estableix...
 ButtonReset = Reinicia
+ButtonMultReplSelectNew = Selecciona un Nou
+ButtonMultReplSkipThis = Omet aquest
+ButtonMultReplSkipAll = Omet Tot
+ButtonReadType = Llegeix el tipus de decoder
+ButtonAllMatched = "Tot" o "Nom\u00e8s Coincident"
+ButtonShowVersionMatch = Mostra la Versi\u00f3 Coincident
+ButtonShowSuggested = Mostra Suggerit
+ButtonUseSelected = Utilitza la Seleccionada
+
+TextMultRepl1 = L'Entrada de la Flota "{0}" que est\u00e0 essent utilitzada:\n\
+                Fam\u00edlia: "{1}"\n\
+                Model: "{2}"
+TextMultRepl1a = Aquesta definici\u00f3 \u00e9s obsoleta, per\u00f2 hi ha diversos reempla\u00e7aments possibles:
+TextNoDefn1a = No hi ha cap definici\u00f3, per\u00f2 pot haver possibles reempla\u00e7aments:
+TextMultReplFamily = La Fam\u00edlia de Reempla\u00e7ament \u00e8s
+TextMultReplFamilyOneOf = La Fam\u00edlia de Reempla\u00e7ament \u00e8s una de
+TextMultReplModel = El Model de Reempla\u00e7ament \u00e8s
+TextMultReplModelOneOf = El Model de Reempla\u00e7ament \u00e8s un de
+TextMultRepl2 = El "{0}" seg\u00fcent bot\u00f3 us ajudar\u00e0 a triar un reempla\u00e7ament.
+TextReplDefn = Reempla\u00e7ant Fam\u00edlia: "{0}" Model: "{1}" de l'entrada de la Flota "{2}"
+TextLastAction = (\u00daltima Acci\u00f3: {0})
+TextManualSelection = Selecciona Manualment
+
+ButtonReadTypeHelp1 = Aquest bot\u00f3 \u00e9s l'opci\u00f3 preferida, per\u00f2 haur\u00e0 de tenir "{0}" a la pista de programaci\u00f3.
+ButtonShowVersionMatchHelp1 = Aquest bot\u00f3 intenta utilitzar un valor de CV 7 emmagatzemat a "{0}" per trobar una coincid\u00e8ncia recomanada a
+ButtonShowVersionMatchHelp2 = partir d'una llista suggerida de reempla\u00e7aments (si est\u00e0 disponible).
+ButtonShowVersionMatchHelp3 = 
+ButtonShowVersionMatchHelp4 = ATENCI\u00d3: La coincid\u00e8ncia recomanada pot ser incorrecta si:
+ButtonShowVersionMatchHelp5 = - No heu fet cap Lectura pr\u00e8via de la programaci\u00f3 i no l'heu desada a l'entrada de la flota "{0}". 
+ButtonShowVersionMatchHelp6 = - El firmware del decoder o el programari ha estat actualitzat.
+ButtonShowVersionMatchHelp7 = - El decoder ha estat reempla\u00e7at per un altre del mateix (o diferent) model.
+ButtonShowVersionMatchHelp8 = - L'entrada de la Flota "{0}" ha estat creada duplicant un altre entrada de la flota.
+ButtonShowSuggestedHelp1 = Aquest bot\u00f3 mostra una llista suggerida de reempla\u00e7aments (si est\u00e0 disponible), per\u00f2 no es pot recomanar una millor coincid\u00e8ncia.
+ButtonAllMatchedHelp1 = Permet filtrar els resultats de qualsevol de les operacions de botons descrites anteriorment
+ButtonAllMatchedHelp2 =  per mostrar nom\u00e9s definicions combinades (desactiva la visualitzaci\u00f3).
+ButtonUseSelectedHelp1 = Aquest bot\u00f3 substitueix la definici\u00f3 de "{0}" amb l'elecci\u00f3 seleccionada.
+ButtonCancelHelp1 = Aquest bot\u00f3 cancela el procediment de reempla\u00e7ament de "{0}".
+ButtonCancelHelp2 = Se't demanar\u00e0 de nou la propera vegada que decidiu actualitzar les Definicions del decoder.
 
 DialogTitleMove = Cerca l'arxiu roster.xml desitjat
 
-DialogMsgMoveWarning = Per usar aquesta opci\u00f3, necessites un fitxer de flota secundari(a\n\
+DialogMsgMoveWarning = Per usar aquesta opci\u00f3, necessites un fitxer de flota secundari (a\n\
                        fitxer "roster.xml" i un directori de "roster") disponible en qualsevol lloc de l'ordinador\n\
                        diferent a la ubicaci\u00f3 est\u00e0ndard. Per usar la informaci\u00f3 alternativa,\n\
-                       pitja "OK" aqu\u00ed, despr\u00e9s en el seg\u00fcent panell ves al directori\n\
-                       seleccionant el fitxer roster.xml alternatiuf i pitja "Obre".
+                       prem "OK" aqu\u00ed, despr\u00e9s en el seg\u00fcent panell ves al directori\n\
+                       seleccionant el fitxer roster.xml alternatiuf i prem "Obre".
 
 DialogMsgMoveQuestion = Est\u00e0s segur qu\u00e8 vols continuar?
 
@@ -128,7 +184,7 @@ OpsModeProgOffline = Programador en via principal {0} fora de servei
 
 IdentifyError = Identifica la locomotora quan no hi ha disponible el programador en via de programaci\u00f3
 NoServiceProgrammerAvailable = Programador en via de programaci\u00f3 no disponible
-NoOpsProgrammerAvailable = Programador Pom no disponible
+NoOpsProgrammerAvailable = Programador POM no disponible
 
 Program = Programaci\u00f3
 BasicProgrammer = Programador b\u00e0sic
@@ -156,3 +212,16 @@ RosterEntryDisplayName = {1} {2} (DCC {0})
 
 # Errors
 IllegalRosterLocation = "{0}" no \u00e9s un cam\u00ed v\u00e0lid
+
+# Print roster
+TitleDecoderProRoster = Flota DecoderPro
+TitleGroup = Grup
+TitleEntries = {0} Entrades
+TitleSelectItemsToPrint = Elements seleccionats per imprimir
+ItemsLabel = Elements 
+LabelSelectLine1 = Selecciona els elements que vols que apareguin
+LabelSelectLine2 = a la impressi\u00f3.
+LabelFunctionList = Llista de Funcions
+ColumnHeadingFunction = Funci\u00f3
+ColumnHeadingDescription = Descripci\u00f3
+HeadingFunctionLabels = ETIQUETES DE FUNCIONS

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle_ca.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle_ca.properties
@@ -1,7 +1,8 @@
 # ThrottleBundle_ca.properties
 #
-# Translation: Joan de Castro (joan276dca@yahoo.es) 20160818
 # Catalan properties for the jmri.jmrit.throttle GUI elements
+# Translation: Joan de Castro (joan276dca@yahoo.es) 20160818
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/06/01
 
 # Menu
 MenuItemNewThrottle = Regulador Nou
@@ -39,7 +40,7 @@ ButtonDispatch = Envia
 ButtonRelease = Allibera
 ConsistNumberHasNotBeenAssigned = El n\u00famero de MT no ha estat assignat!
 NeedsConsistNumber = Necessita n\u00famero de MT
-SendFunctionToLead = Envia ordre de funcions a la m\u00e0quina l\u00edder?
+SendFunctionToLead = Envia ordre de funcions a la m\u00e0quina del davant?
 NCEconsistThrottle = Regulador de MT de NCE
 NoLocoSelected = <Cap Locomotora Seleccionada>
 NoConsistSelected = <Cap MT Seleccionada>
@@ -49,10 +50,8 @@ AddressInUse = Adre\u00e7a usada per un altre regulador.
 # ControlPanelPropertyEditor
 ControlPanelProperties = Propietats
 TitleEditSpeedControlPanel = Edita el panell de velocitat
-#ButtonDisplaySpeedSlider = Visualitza lliscant de velocitat (0-100)
-ButtonDisplaySpeedSliderContinuous = Visualitza lliscant de velocitat de maniobra (-100 - 0 - 100)
-#ButtonDisplaySpeedSteps = Visualitza passos de velocitat
 CheckBoxTrackSliderInRealTime = Barra lliscant en temps real
+ButtonDisplaySpeedSliderContinuous = Visualitza lliscant de velocitat de maniobra (-100 - 0 - 100)
 SwitchSliderOnFunction = Canvia a lliscant continu amb la funci\u00f3:
 
 # FunctionButtonPropertyEditor
@@ -86,6 +85,7 @@ ExThrottleHideUndefinedFunctionButtons = Amaga botons de funci\u00f3 de la flota
 ExThrottleIgnoreThrottlePosition = Ignora ajust de posici\u00f3 del regulador
 ExThrottleCleanOnDispose = Tanca regulador en tancar la finestra
 ExThrottleSaveThrottleOnLayoutSave = Desa reguladors quan es desi la disposici\u00f3 de finestres de reguladors
+ExThrottleSilentSteal = Agafa el regulador si est\u00e0 essent utilitzat per alg\u00fa altre
 ExThrottleLabelApplyWarning = Per aplicar les noves prefer\u00e8ncies cal tancar tots els reguladors.
 ThrottlesPrefsReset = Reset
 ThrottleToolBarClose = Tanca
@@ -110,6 +110,7 @@ ThrottleMenuView = Visualitza
 ThrottleMenuViewAddressPanel = Panell d'adre\u00e7a
 ThrottleMenuViewControlPanel = Panell de control
 ThrottleMenuViewFunctionPanel = Panell de funcions
+ThrottleMenuViewSpeedPanel = Panell de Velocitat
 ThrottleMenuViewAllFunctionButtons = Reset a botons de funci\u00f3
 ThrottleMenuViewMakeAllComponentsInBounds = Posar tots els components dins del marc
 ThrottleMenuViewSwitchMode = Canvia el mode de vista del marc del regulador 
@@ -119,6 +120,8 @@ ThrottleMenuEditResetFunctionButtons = Reset a botons de funci\u00f3
 ThrottleMenuEditSaveCustoms = Exporta personalitzacions de regulador a la flota
 ThrottlePreferencesFrameTitle = Prefer\u00e8ncies de reguladors
 ThrottleListFrameTile = Reguladors JMRI locals
+
+ThrottleSpeedPanelError = No est\u00e0 disponible l'Escala de Velocitat
 
 ThrottleFrameNoRosterItemMessageDialog = Selecciona locomotora usant el men\u00fa flota al panell d'adreces
 ThrottleFrameNoRosterItemTitleDialog = Cap entrada de la flota seleccionada
@@ -131,12 +134,14 @@ ThrottleAddress = Adre\u00e7a
 ThrottleNotAssigned = No assignat
 
 Use_Roster_Edit_Entry_to_save_your_function_keys = Usa Modifica entrada de la flota per desar els botons de funci\u00f3
-currently_not_used = Actualment no usat
+currently_not_used = Actualment no utilitzat
 Push_for_alternate_set_of_function_keys = Pr\u00e9mer per accedir a banc de funcions alternatiu
 Feature_still_under_development = Caracter\u00edstica en desenvolupament!
 
 FailedSetupRequestTitle = Error en la creaci\u00f3 de regulador.
+StealQuestionText = El Regulador {0} \u00e9s en \u00fas per un altre dispositiu.  Agafa'l?
+StealRequestTitle = Agafa el Regulador
 
-LayoutPowerOn = Maqueta alimentada. Pitja per apagar.
-LayoutPowerOff = Maqueta apagada. Pitja per encendre.
-LayoutPowerUnknown = Estat d'alimentaci\u00f3 de la maqueta desconegut. Pitja per apagar.
+LayoutPowerOn = Maqueta alimentada. Prem per apagar.
+LayoutPowerOff = Maqueta apagada. Prem per encendre.
+LayoutPowerUnknown = Estat d'alimentaci\u00f3 de la maqueta desconegut. Prem per apagar.

--- a/java/src/jmri/jmrix/rfid/RfidActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/rfid/RfidActionListBundle_ca.properties
@@ -1,0 +1,7 @@
+# RfidActionListBundle.properties
+#
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/05/22
+#
+# Properties listing names for "Action" classes that can appear
+# in various forms in advanced preferences
+jmri.jmrix.rfid.swing.serialmon.SerialMonPane = Obre Monitor de Lectura Rfid

--- a/java/src/jmri/jmrix/rfid/RfidBundle_ca.properties
+++ b/java/src/jmri/jmrix/rfid/RfidBundle_ca.properties
@@ -1,0 +1,7 @@
+# RfidBundle.properties
+#
+# Default properties for the jmri.jmrix.rfid menu
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/05/22
+
+MenuSystem    = RFID
+MenuItemCommandMonitor      = Monitor de Comunicacions

--- a/java/src/jmri/jmrix/rps/RpsActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/rps/RpsActionListBundle_ca.properties
@@ -5,12 +5,13 @@
 # Properties listing names for "Action" classes that can appear
 # in various forms in advanced preferences
 #
-# Translation Joan de Castro <joan276dca@yahoo.es> 20110206 
+# Translation Joan de Castro <joan276dca@yahoo.es> 20110206
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/05/22
 
-jmri.jmrix.rps.aligntable.AlignTableAction = Open RPS Receiver Control
-jmri.jmrix.rps.swing.polling.PollTableAction = Open RPS Polling Control
-jmri.jmrix.rps.swing.debugger.DebuggerAction = Open RPS Debugger
-jmri.jmrix.rps.swing.soundset.SoundSetAction = Open RPS Sound Control
-jmri.jmrix.rps.rpsmon.RpsMonAction = Open RPS Monitor
-jmri.jmrix.rps.trackingpanel.RpsTrackingFrameAction = Open RPS Tracking Display
-jmri.jmrix.rps.reversealign.AlignmentPanelAction = Open RPS Alignment Tool
+jmri.jmrix.rps.aligntable.AlignTableAction = Obre Control de Recepci\u00f3 RPS
+jmri.jmrix.rps.swing.polling.PollTableAction = Obre Control de Sondeig RPS
+jmri.jmrix.rps.swing.debugger.DebuggerAction = Obre Debugger RPS
+jmri.jmrix.rps.swing.soundset.SoundSetAction = Obre Control de S\u00f2 RPS
+jmri.jmrix.rps.rpsmon.RpsMonAction = Obre Monitor RPS
+jmri.jmrix.rps.trackingpanel.RpsTrackingFrameAction = Obre RPS Tracking Display
+jmri.jmrix.rps.reversealign.AlignmentPanelAction = Obre RPS Alignment Tool

--- a/java/src/jmri/jmrix/rps/RpsBundle_ca.properties
+++ b/java/src/jmri/jmrix/rps/RpsBundle_ca.properties
@@ -1,0 +1,20 @@
+# RpsBundle.properties
+#
+#
+#
+# Default properties for the jmri.rps package
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/05/22
+
+TitleSource         = Conexi\u00f3 RPS
+ActionSource        = Conexi\u00f3 RPS
+
+TooltipSelectPort   = Seleccio el port
+TooltipSelectBaud   = Selecciona els bauds configurats en el Pocket Tester
+TooltipOpen         = Configura programa per utilitzar el port seleccionat
+
+ButtonOpen          = Obre
+
+LabelSerialPort     = Port Serie: 
+LabelSpeed          = Velocitat: 
+
+LabelToOpen         = Obre Nou: 

--- a/java/src/jmri/jmrix/srcp/SrcpActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/srcp/SrcpActionListBundle_ca.properties
@@ -6,6 +6,9 @@
 # in various forms in advanced preferences
 #
 # Translation Joan de Castro <joan276dca@yahoo.es> 20110206 
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/05/22
 
 jmri.jmrix.srcp.swing.srcpmon.SRCPMonAction = Obre el monitor de SRCP
 jmri.jmrix.srcp.swing.packetgen.PacketGenAction = Missatges de SRCP
+
+jmri.jmris.srcp.JmriSRCPServerAction = Engega Servidor JMRI SRCP

--- a/java/src/jmri/jmrix/tams/TamsActionListBundle_ca.properties
+++ b/java/src/jmri/jmrix/tams/TamsActionListBundle_ca.properties
@@ -1,0 +1,8 @@
+# TamsActionListBundle.properties
+#
+# Properties listing names for "Action" classes that can appear
+# in various forms in advanced preferences
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/05/22
+
+jmri.jmrix.tams.swing.monitor.TamsMonPane$Default = Obre el Monitor de Tams
+jmri.jmrix.tams.swing.statusframe.StatusPanel$Default = Obre Info de Tams

--- a/java/src/jmri/jmrix/tams/TamsBundle_ca.properties
+++ b/java/src/jmri/jmrix/tams/TamsBundle_ca.properties
@@ -1,0 +1,13 @@
+# TamsBundle.properties
+#
+# Default properties for the jmri.jmrix.tams menu
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/05/22
+
+MenuTams                    = Tams
+
+MenuItemTamsMonitor         = Monitor de Comandes Tams
+MenuItemSendPacket          = Envia Comandes Tams
+MenuItemInfo                = Info de Tams
+MenuItemLocoData            = Base de dades de Locomotores Tams
+
+CommandMonitor              = Monitor de Comandes de Tams

--- a/java/src/jmri/jmrix/tams/swing/locodatabase/TamsLocoBundle_ca.properties
+++ b/java/src/jmri/jmrix/tams/swing/locodatabase/TamsLocoBundle_ca.properties
@@ -1,0 +1,21 @@
+# TamsLocoBundle.properties
+#
+# Default properties for the jmri.jmrix.tams.swing.locodatabase
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/05/22
+
+Address = Adre\u00e7a de Lomotora
+Name = Nom de Locomotora
+Steps = Passos
+Format = Format
+ColFormat = Format
+ColSteps = Passos
+ColAddress = Adre\u00e7a
+ColName = Nom
+ColDelete = Esborra
+AddLoco = Afegeix Locomotora
+DeleteLoco = Esborra
+
+ErrorNullAddress = L'Adre\u00e7a no pot estar buida
+ErrorNotNumber = Adre\u00e7a ha de ser un n\u00famero
+
+Title = Tams Loco Database

--- a/java/src/jmri/jmrix/tmcc/TmccBundle_ca.properties
+++ b/java/src/jmri/jmrix/tmcc/TmccBundle_ca.properties
@@ -1,0 +1,16 @@
+# TMCCBundle.properties
+#
+# Default properties for the jmri.jmrix.tmcc menu
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/05/22
+
+MenuTMCC                    = TMCC
+
+MenuItemCommandMonitor      = Monitor TMCC...
+MenuItemSendCommand         = Envia Comanda TMCC...
+
+SendCommandTitle            = Envia Comanda TMCC
+AdapterSerialName           = TMCC via Serie
+
+# TMCC Turnout (Add to table pane) items
+AddOutputEntryToolTip = 3 (Agulla 3)<br>\
+entra un n\u00famero des de el 1 fins 511 (inclosos).

--- a/java/src/jmri/jmrix/xpa/XpaBundle_ca.properties
+++ b/java/src/jmri/jmrix/xpa/XpaBundle_ca.properties
@@ -4,7 +4,14 @@
 #
 # Xpa specific System Menu properties
 # traducci\u00f3 al catal\u00e0: Joan de Castro Alemany [joan276dca@yahoo.es] 30/10/2016
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/05/22 
 
-MenuXpa = XPA
+MenuXpa               = XPA
 
 MenuItemXpaConfigTool = Eina de Configuraci\u00f3 de XPA
+ModemInitStringLabel  = Cadena d'Inicialitzaci\u00f3 del M\u00f2dem: 
+
+# XpaTurnout/Sensor/Light (Add to table pane) items
+AddOutputEntryToolTip = A3 (House code A + device code)<br>\
+01.2A.B4 (Insteon label 01.2A.B4)
+# No inputs for Xpa, so no key

--- a/java/src/jmri/jmrix/xpa/swing/XpaSwingBundle_ca.properties
+++ b/java/src/jmri/jmrix/xpa/swing/XpaSwingBundle_ca.properties
@@ -1,0 +1,22 @@
+# XpaSwingBundle.properties
+#
+# Default properties for the jmri.jmrix.xpa.swing package
+# Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/05/22
+
+#PacketGenFrameTitle        = Send Xpa Packet
+XpaMonFrameTitle            = Tr\u00e0fic Xpa
+SendCommandTitle            = Envia comanda Xpa+Modem
+
+# XpaConfig items
+XpAddressLabel              = Adre\u00e7a XpressNe:
+ZeroButtonLabel             = Bot\u00f3 Zero:
+MomentaryDurLabel           = Duraci\u00f3 de les Funcions Moment\u00e0nies:
+ButtonSetAddress            = Estableix l'Adre\u00e7a
+SetAddressToolTip           = Selecciona l'adre\u00e7a XpressNet
+# the next 2 are also in XpressNet bundle
+XNetCSStatusEmergencyOff    = Parada d'Emerg\u008ncia 
+XNetCSStatusEmergencyStop   = Aturada d'Emerg\u008ncia 
+ButtonSetZero               = Estableix Funci\u00f3 Zero
+ButtonSetDuration           = Estableix Durada
+SetDurationToolTip          = Selecciona la duraci\u00f3 de les Funcions moment\u00e0nies
+ButtonReset                 = Reseteja el XPA

--- a/java/src/jmri/util/swing/UtilBundle_ca.properties
+++ b/java/src/jmri/util/swing/UtilBundle_ca.properties
@@ -10,6 +10,6 @@ EnterHWaddressAsIntTooltip = Entra un enter per a l'adre\u00e7a hardware per aqu
 
 #used in the Color Chooser Panels.
 ComboBoxColorChooserName = Llista de Colors
-ButtonGroupColorChooserName = Bot\u00e9 de Colors
+ButtonGroupColorChooserName = Bot\u00f3 de Colors
 ButtonSwatchColorChooserName = Franja de Color
 SetColor = Posa...


### PR DESCRIPTION
java/src/jmri/jmrit/Bundle_ca.properties
java/src/jmri/jmrit/roster/JmritRosterBundle_ca.properties
java/src/jmri/jmrix/rfid/RfidActionListBundle_ca.properties
java/src/jmri/jmrix/rfid/RfidBundle_ca.properties
java/src/jmri/jmrix/rps/RpsActionListBundle_ca.properties
java/src/jmri/jmrix/rps/RpsBundle_ca.properties
java/src/jmri/jmrix/srcp/SrcpActionListBundle_ca.properties
java/src/jmri/jmrix/tams/TamsActionListBundle_ca.properties
java/src/jmri/jmrix/tams/TamsBundle_ca.properties
java/src/jmri/jmrix/tams/swing/locodatabase/TamsLocoBundle_ca.properties
java/src/jmri/jmrit/throttle/ThrottleBundle_ca.properties
java/src/jmri/jmrix/tmcc/TmccBundle_ca.properties
java/src/jmri/util/swing/UtilBundle_ca.properties
java/src/jmri/jmrix/xpa/XpaBundle_ca.properties
java/src/jmri/jmrix/xpa/swing/XpaSwingBundle_ca.properties