### PR TITLE
LocoNetOverTCP multiple menu fix

### DIFF
--- a/.idea/ant.xml
+++ b/.idea/ant.xml
@@ -9,6 +9,9 @@
     </buildFile>
     <buildFile url="file://$PROJECT_DIR$/build.xml">
       <customJdkName value="1.8" />
+      <properties>
+        <property name="test.includes" value="jmri.jmrix.loconet.loconetovertcp.PackageTest" />
+      </properties>
     </buildFile>
   </component>
 </project>

--- a/.idea/ant.xml
+++ b/.idea/ant.xml
@@ -9,9 +9,6 @@
     </buildFile>
     <buildFile url="file://$PROJECT_DIR$/build.xml">
       <customJdkName value="1.8" />
-      <properties>
-        <property name="test.includes" value="jmri.jmrix.loconet.loconetovertcp.PackageTest" />
-      </properties>
     </buildFile>
   </component>
 </project>

--- a/java/src/jmri/jmrix/loconet/LnNetworkPortController.java
+++ b/java/src/jmri/jmrix/loconet/LnNetworkPortController.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.loconet;
 
+import jmri.jmrix.AbstractNetworkPortController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -8,11 +9,11 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kevin Dickerson Copyright (C) 2011
  */
-public abstract class LnNetworkPortController extends jmri.jmrix.AbstractNetworkPortController {
+public abstract class LnNetworkPortController extends AbstractNetworkPortController {
 
     /**
      * Base class. Implementations will provide InputStream and OutputStream
-     * objects to LnTrafficController classes, who in turn will deal in messages.
+     * objects to LnTrafficController classes, which in turn will deal in messages.
      *
      * @param connectionMemo associated memo for this connection
      */

--- a/java/src/jmri/jmrix/loconet/LnTrafficController.java
+++ b/java/src/jmri/jmrix/loconet/LnTrafficController.java
@@ -40,6 +40,16 @@ public abstract class LnTrafficController implements LocoNetInterface {
     LocoNetSystemConnectionMemo memo = null;
 
     /**
+     * Get access to the system connection memo associated with this traffic
+     * controller.
+     *
+     * @return associated systemConnectionMemo object
+     */
+    public LocoNetSystemConnectionMemo getSystemConnectionMemo() {
+        return memo;
+    }
+
+    /**
      * Set the system connection memo associated with this traffic controller.
      *
      * @param m associated systemConnectionMemo object

--- a/java/src/jmri/jmrix/loconet/locobuffer/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/ConnectionConfig.java
@@ -5,7 +5,7 @@ package jmri.jmrix.loconet.locobuffer;
  * via a LocoBufferAdapter object.
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2003, 2010
-  */
+ */
 public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig {
 
     /**

--- a/java/src/jmri/jmrix/loconet/locobuffer/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/configurexml/ConnectionConfigXml.java
@@ -6,9 +6,10 @@ import jmri.jmrix.loconet.locobuffer.LocoBufferAdapter;
 
 /**
  * Handle XML persistance of layout connections by persistening the
- * LocoBufferAdapter (and connections). Note this is named as the XML version of
- * a ConnectionConfig object, but it's actually persisting the
- * LocoBufferAdapter.
+ * LocoBufferAdapter (and connections).
+ * <p>
+ * Note this is named as the XML version of a ConnectionConfig object,
+ * but it's actually persisting the LocoBufferAdapter.
  * <p>
  * This class is invoked from jmrix.JmrixConfigPaneXml on write, as that class
  * is the one actually registered. Reads are brought here directly via the class

--- a/java/src/jmri/jmrix/loconet/locobufferusb/LocoBufferUsbAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobufferusb/LocoBufferUsbAdapter.java
@@ -63,4 +63,5 @@ public class LocoBufferUsbAdapter extends LocoBufferAdapter {
     }
 
     private final static Logger log = LoggerFactory.getLogger(LocoBufferUsbAdapter.class);
+
 }

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/Bundle.properties
@@ -21,7 +21,7 @@ StartButton=Start Server
 #Button text for stopping server
 StopButton=Stop Server
 #Server status label
-StatusLabel=Server Status: {0}  Client Count: {1}
+StatusLabel=Server Status: {0} - Client Count: {1}
 #Status label when server after server is started
 Running=Running
 #Status label when server is stopped

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/Bundle.properties
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/Bundle.properties
@@ -27,4 +27,6 @@ Running=Running
 #Status label when server is stopped
 Stopped=Stopped
 #Label for port number
+ConnectionLabel=Connection: {0}
+#Label for port number
 PortLabel=Port: {0}

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/ClientRxHandler.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/ClientRxHandler.java
@@ -36,7 +36,7 @@ public final class ClientRxHandler extends Thread implements LocoNetListener {
         setDaemon(true);
         setPriority(Thread.MAX_PRIORITY);
         remoteAddress = newRemoteAddress;
-        setName("ClientRxHandler:" + remoteAddress);
+        setName("ClientRxHandler: " + remoteAddress);
         lastSentMessage = null;
         start();
     }

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/ConnectionConfig.java
@@ -1,13 +1,11 @@
 package jmri.jmrix.loconet.loconetovertcp;
 
-
 /**
  * Definition of objects to handle configuring a LocoNetOverTcp layout
  * connection via a LnTcpDriverAdapter object.
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2003
  * @author Stephen Williams Copyright (C) 2008
- *
  */
 public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig {
 
@@ -20,7 +18,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     }
 
     /**
-     * Ctor for a functional Swing object with no preexisting adapter
+     * Ctor for a functional Swing object with no preexisting adapter.
      */
     public ConnectionConfig() {
         super();
@@ -35,6 +33,10 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
         return false;
     }
 
+    /**
+     * Load the adapter with an appropriate object
+     * <i>unless</i> it has already been set.
+     */
     @Override
     protected void setInstance() {
         if (adapter == null) {

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpDriverAdapter.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpDriverAdapter.java
@@ -29,7 +29,7 @@ public class LnTcpDriverAdapter extends LnNetworkPortController {
     }
 
     public LnTcpDriverAdapter() {
-        this(new LocoNetSystemConnectionMemo());
+        this(new LocoNetSystemConnectionMemo()); // Bug: creates an extra LocoNet connection + memo
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpDriverAdapter.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpDriverAdapter.java
@@ -29,7 +29,9 @@ public class LnTcpDriverAdapter extends LnNetworkPortController {
     }
 
     public LnTcpDriverAdapter() {
-        this(new LocoNetSystemConnectionMemo()); // Bug: creates an extra LocoNet connection + memo
+        this(new LocoNetSystemConnectionMemo());
+        // jmri.InstanceManager.getDefault(LocoNetSystemConnectionMemo.class)); requires at least 1 connection or gives NPE
+        // new LocoNetSystemConnectionMemo()); creates an extra LocoNet connection + memo
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServer.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServer.java
@@ -35,7 +35,7 @@ public class LnTcpServer {
     private LnTrafficController tc;
 
     private LnTcpServer(LocoNetSystemConnectionMemo memo) {
-        tc = memo.getLnTrafficController(); // store tc in order to known where to send messages
+        tc = memo.getLnTrafficController(); // store tc in order to know where to send messages
         LnTcpPreferences pm = LnTcpPreferences.getDefault();
         portNumber = pm.getPort();
         pm.addPropertyChangeListener((PropertyChangeEvent evt) -> {
@@ -232,6 +232,15 @@ public class LnTcpServer {
 
     public boolean removeStateListener(LnTcpServerListener l) {
         return this.stateListeners.remove(l);
+    }
+
+    /**
+     * Get the connection user name this server is using.
+     *
+     * @return the system name
+     */
+    public String getSystemName() {
+        return this.tc.getSystemConnectionMemo().getUserName();
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServer.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServer.java
@@ -60,7 +60,7 @@ public class LnTcpServer {
 
     /**
      * Get a server instance for the default  SystemConnectionMemo.
-     * Used as startup action {@link }
+     * Used as startup action {@link apps.startup.AbstractStartupModel}
      *
      * @param memo the SystemConnectionMemo to use
      */

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServer.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServer.java
@@ -34,6 +34,11 @@ public class LnTcpServer {
     private int portNumber;
     private LnTrafficController tc;
 
+    /**
+     * Get a server instance for a given SystemConnectionMemo.
+     *
+     * @param memo the SystemConnectionMemo to use
+     */
     private LnTcpServer(LocoNetSystemConnectionMemo memo) {
         tc = memo.getLnTrafficController(); // store tc in order to know where to send messages
         LnTcpPreferences pm = LnTcpPreferences.getDefault();
@@ -51,6 +56,16 @@ public class LnTcpServer {
                     break;
             }
         });
+    }
+
+    /**
+     * Get a server instance for the default  SystemConnectionMemo.
+     * Used as startup action {@link }
+     *
+     * @param memo the SystemConnectionMemo to use
+     */
+    private LnTcpServer() {
+        this(InstanceManager.getDefault(LocoNetSystemConnectionMemo.class));
     }
 
     /**
@@ -73,7 +88,7 @@ public class LnTcpServer {
      */
     public static synchronized LnTcpServer getDefault() {
         return InstanceManager.getOptionalDefault(LnTcpServer.class).orElseGet(() -> {
-            LnTcpServer server = new LnTcpServer(new LocoNetSystemConnectionMemo());
+            LnTcpServer server = new LnTcpServer(); // uses default memo, don't create an additional connection
             return InstanceManager.setDefault(LnTcpServer.class, server);
         });
     }
@@ -241,6 +256,15 @@ public class LnTcpServer {
      */
     public String getSystemName() {
         return this.tc.getSystemConnectionMemo().getUserName();
+    }
+
+    /**
+     * Get the traffic controller this server is using.
+     *
+     * @return the traffic controller
+     */
+    public LnTrafficController getTrafficController() {
+        return this.tc;
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServerAction.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServerAction.java
@@ -19,13 +19,25 @@ import jmri.jmrix.swing.SystemConnectionAction;
 public class LnTcpServerAction
         extends AbstractAction implements SystemConnectionAction {
 
+    /**
+     * Initiate a LnTcpServer for a given SystemConnectionMemo, eg. when called from a specific system connection menu.
+     * TODO allow multiple server instance for different connections
+     *
+     * @param s name for the server action
+     * @param memo the SystemConnectionMemo to connect to
+     */
     public LnTcpServerAction(String s, LocoNetSystemConnectionMemo memo) {
         super(s);
         setSystemConnectionMemo(memo);
     }
 
+    /**
+     * Initiate a LnTcpServer without a known SystemConnectionMemo, eg. as part of the auto startupAction.
+     *
+     * @param s name for the server action
+     */
     public LnTcpServerAction(String s) {
-        super(s);
+        this(s, jmri.InstanceManager.getDefault(LocoNetSystemConnectionMemo.class));
     }
 
     public LnTcpServerAction() {

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServerAction.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServerAction.java
@@ -2,7 +2,14 @@ package jmri.jmrix.loconet.loconetovertcp;
 
 import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.CheckForNull;
 import javax.swing.AbstractAction;
+import jmri.jmrix.SystemConnectionMemo;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
+import jmri.jmrix.swing.SystemConnectionAction;
 
 /**
  * Implementation of the LocoNet over TCP Server Protocol.
@@ -10,7 +17,12 @@ import javax.swing.AbstractAction;
  * @author Alex Shepherd Copyright (C) 2006
  */
 public class LnTcpServerAction
-        extends AbstractAction {
+        extends AbstractAction implements SystemConnectionAction {
+
+    public LnTcpServerAction(String s, LocoNetSystemConnectionMemo memo) {
+        super(s);
+        setSystemConnectionMemo(memo);
+    }
 
     public LnTcpServerAction(String s) {
         super(s);
@@ -20,6 +32,37 @@ public class LnTcpServerAction
         this(Bundle.getMessage("ServerAction"));
     }
 
+    private LocoNetSystemConnectionMemo memo;
+
+    /**
+     * Get the {@link jmri.jmrix.SystemConnectionMemo} this action is bound to.
+     *
+     * @return the SystemConnectionMemo or null if not bound
+     */
+    @CheckForNull
+    @Override
+    public SystemConnectionMemo getSystemConnectionMemo(){
+        return memo;
+    }
+
+    @Override
+    public void setSystemConnectionMemo(SystemConnectionMemo memo) throws IllegalArgumentException {
+        if (LocoNetSystemConnectionMemo.class.isAssignableFrom(memo.getClass())) {
+            if (memo instanceof LocoNetSystemConnectionMemo) {
+                this.memo = (LocoNetSystemConnectionMemo) memo;
+            } else {
+                throw new IllegalArgumentException();
+            }
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public Set<Class<? extends SystemConnectionMemo>> getSystemConnectionMemoClasses() {
+        return new HashSet<>(Arrays.asList(LocoNetSystemConnectionMemo.class));
+    }
+
     @Override
     public void actionPerformed(ActionEvent e) {
         LnTcpServer.getDefault().enable();
@@ -27,4 +70,5 @@ public class LnTcpServerAction
             LnTcpServerFrame.getDefault().setVisible(true);
         }
     }
+
 }

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServerFrame.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServerFrame.java
@@ -1,11 +1,14 @@
 package jmri.jmrix.loconet.loconetovertcp;
 
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
+import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.border.Border;
 import jmri.InstanceManager;
 import jmri.util.JmriJFrame;
 
@@ -56,12 +59,16 @@ public class LnTcpServerFrame extends JmriJFrame {
 
         JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+        Border panelBorder = BorderFactory.createEtchedBorder();
+        panel.setBorder(panelBorder);
         panel.add(startButton);
         panel.add(stopButton);
         panel.setAlignmentX(Component.CENTER_ALIGNMENT);
         super.getContentPane().add(panel);
 
         statusLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        statusLabel.setFont(statusLabel.getFont().deriveFont(0.9f * connectionLabel.getFont().getSize())); // a bit smaller
+        statusLabel.setForeground(Color.gray);
         super.getContentPane().add(statusLabel);
 
         startButton.addActionListener((ActionEvent a) -> {

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServerFrame.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpServerFrame.java
@@ -24,6 +24,8 @@ import jmri.util.JmriJFrame;
  */
 public class LnTcpServerFrame extends JmriJFrame {
 
+    private final JLabel connectionLabel = new JLabel(Bundle.getMessage("ConnectionLabel", "?"));
+    private final JLabel spacer = new JLabel(" - ");
     private final JLabel portNumberLabel = new JLabel(Bundle.getMessage("PortLabel", 1234));
     private final JLabel statusLabel = new JLabel(Bundle.getMessage("StatusLabel", Bundle.getMessage("Stopped"), 0));
 
@@ -44,8 +46,13 @@ public class LnTcpServerFrame extends JmriJFrame {
         super.getContentPane().setLayout(new BoxLayout(super.getContentPane(), BoxLayout.Y_AXIS));
 
         // add GUI items
-        portNumberLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
-        super.getContentPane().add(portNumberLabel);
+        JPanel panel1 = new JPanel();
+        panel1.setLayout(new BoxLayout(panel1, BoxLayout.X_AXIS));
+        panel1.add(connectionLabel);
+        panel1.add(spacer);
+        panel1.add(portNumberLabel);
+        panel1.setAlignmentX(Component.CENTER_ALIGNMENT);
+        super.getContentPane().add(panel1);
 
         JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
@@ -125,6 +132,7 @@ public class LnTcpServerFrame extends JmriJFrame {
     }
 
     private void updateServerStatus(LnTcpServer s) {
+        connectionLabel.setText(Bundle.getMessage("ConnectionLabel", s.getSystemName()));
         portNumberLabel.setText(Bundle.getMessage("PortLabel", s.getPort()));
         startButton.setEnabled(!s.isEnabled());
         stopButton.setEnabled(s.isEnabled());

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpStartupActionFactory.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/LnTcpStartupActionFactory.java
@@ -28,4 +28,3 @@ public class LnTcpStartupActionFactory extends AbstractStartupActionFactory {
     }
 
 }
-

--- a/java/src/jmri/jmrix/loconet/loconetovertcp/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/loconet/loconetovertcp/configurexml/ConnectionConfigXml.java
@@ -15,7 +15,7 @@ import jmri.jmrix.loconet.loconetovertcp.LnTcpDriverAdapter;
  * is the one actually registered. Reads are brought here directly via the class
  * attribute in the XML.
  *
- * @author Bob Jacobsen Copyright: Copyright (c) 2003
+ * @author Bob Jacobsen Copyright (c) 2003
  */
 public class ConnectionConfigXml extends AbstractNetworkConnectionConfigXml {
 
@@ -25,7 +25,9 @@ public class ConnectionConfigXml extends AbstractNetworkConnectionConfigXml {
 
     @Override
     protected void getInstance() {
-        adapter = new LnTcpDriverAdapter();
+        if (adapter == null) {
+            adapter = new LnTcpDriverAdapter();
+        }
     }
 
     @Override

--- a/java/src/jmri/jmrix/loconet/locormi/LnMessageServerAction.java
+++ b/java/src/jmri/jmrix/loconet/locormi/LnMessageServerAction.java
@@ -2,25 +2,64 @@ package jmri.jmrix.loconet.locormi;
 
 import java.awt.event.ActionEvent;
 import java.rmi.RemoteException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.CheckForNull;
 import javax.swing.AbstractAction;
+import jmri.jmrix.SystemConnectionMemo;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
+import jmri.jmrix.swing.SystemConnectionAction;
 import jmri.util.zeroconf.ZeroConfService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Start a LnMessageServer that will listen for clients wanting to use the
- * LocoNet connection on this machine. Copyright: Copyright (c) 2002
+ * LocoNet connection on this machine.
  *
- * @author Alex Shepherd
+ * @author Alex Shepherd Copyright (c) 2002
  */
-public class LnMessageServerAction extends AbstractAction {
+public class LnMessageServerAction
+        extends AbstractAction implements SystemConnectionAction {
 
     public LnMessageServerAction(String s) {
         super(s);
     }
 
     public LnMessageServerAction() {
-        super("Start LocoNet server");
+        this(Bundle.getMessage("MenuItemStartLocoNetServer"));
+    }
+
+    private LocoNetSystemConnectionMemo memo;
+
+    /**
+     * Get the {@link jmri.jmrix.SystemConnectionMemo} this action is bound to.
+     *
+     * @return the SystemConnectionMemo or null if not bound
+     */
+    @CheckForNull
+    @Override
+    public SystemConnectionMemo getSystemConnectionMemo(){
+        return memo;
+    }
+
+    @Override
+    public void setSystemConnectionMemo(SystemConnectionMemo memo) throws IllegalArgumentException {
+        if (LocoNetSystemConnectionMemo.class.isAssignableFrom(memo.getClass())) {
+            if (memo instanceof LocoNetSystemConnectionMemo) {
+                this.memo = (LocoNetSystemConnectionMemo) memo;
+            } else {
+                throw new IllegalArgumentException();
+            }
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public Set<Class<? extends SystemConnectionMemo>> getSystemConnectionMemoClasses() {
+        return new HashSet<>(Arrays.asList(LocoNetSystemConnectionMemo.class));
     }
 
     @Override

--- a/java/src/jmri/jmrix/loconet/locormi/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/loconet/locormi/configurexml/ConnectionConfigXml.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  * is the one actually registered. Reads are brought here directly via the class
  * attribute in the XML.
  *
- * @author Bob Jacobsen Copyright: Copyright (c) 2003
+ * @author Bob Jacobsen Copyright (c) 2003
  */
 public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
 
@@ -68,7 +68,7 @@ public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
 
         try {
             manufacturer = shared.getAttribute("manufacturer").getValue(); // NOI18N
-        } catch (NullPointerException ex) { //Considered normal if not present
+        } catch (NullPointerException ex) { // Considered normal if not present
         }
 
         ConnectionConfig cc = new ConnectionConfig(hostName, manufacturer);

--- a/java/src/jmri/jmrix/loconet/swing/LocoNetMenu.java
+++ b/java/src/jmri/jmrix/loconet/swing/LocoNetMenu.java
@@ -36,7 +36,7 @@ public class LocoNetMenu extends JMenu {
         add(new jmri.jmrix.loconet.locormi.LnMessageServerAction(Bundle.getMessage("MenuItemStartLocoNetServer")));
         add(new jmri.jmrix.loconet.loconetovertcp.LnTcpServerAction(Bundle.getMessage("MenuItemLocoNetOverTCPServer"), memo));
     }
-    // TODO Sort out the Loconet server menu items
+    // TODO Sort out the Loconet _server_ menu items (currently started from above lines, commented out below)
     Item[] panelItems = new Item[]{
         new Item("MenuItemLocoNetMonitor", "jmri.jmrix.loconet.locomon.LocoMonPane"), // NOI18N
         new Item("MenuItemSlotMonitor", "jmri.jmrix.loconet.slotmon.SlotMonPane"), // NOI18N

--- a/java/src/jmri/jmrix/loconet/swing/LocoNetMenu.java
+++ b/java/src/jmri/jmrix/loconet/swing/LocoNetMenu.java
@@ -34,7 +34,7 @@ public class LocoNetMenu extends JMenu {
         }
         add(new javax.swing.JSeparator());
         add(new jmri.jmrix.loconet.locormi.LnMessageServerAction(Bundle.getMessage("MenuItemStartLocoNetServer")));
-        add(new jmri.jmrix.loconet.loconetovertcp.LnTcpServerAction(Bundle.getMessage("MenuItemLocoNetOverTCPServer")));
+        add(new jmri.jmrix.loconet.loconetovertcp.LnTcpServerAction(Bundle.getMessage("MenuItemLocoNetOverTCPServer"), memo));
     }
     // TODO Sort out the Loconet server menu items
     Item[] panelItems = new Item[]{

--- a/java/src/jmri/jmrix/swing/SystemConnectionAction.java
+++ b/java/src/jmri/jmrix/swing/SystemConnectionAction.java
@@ -44,4 +44,5 @@ public interface SystemConnectionAction {
      */
     @Nonnull
     public Set<Class<? extends SystemConnectionMemo>> getSystemConnectionMemoClasses();
+
 }

--- a/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpServerActionTest.java
+++ b/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpServerActionTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.loconet.loconetovertcp;
 
 import java.awt.GraphicsEnvironment;
+import jmri.jmrix.loconet.LocoNetInterfaceScaffold;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -15,10 +17,20 @@ import org.junit.Test;
  */
 public class LnTcpServerActionTest {
 
+    private LocoNetInterfaceScaffold lnis;
+    private LocoNetSystemConnectionMemo memo;
+
+    @Test
+    public void testMemoCtor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        LnTcpServerAction action = new LnTcpServerAction("LocoNet test Action", memo);
+        Assert.assertNotNull("exists", action);
+    }
+
     @Test
     public void testStringCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        LnTcpServerAction action = new LnTcpServerAction("Loconet test Action");
+        LnTcpServerAction action = new LnTcpServerAction("LocoNet test Action");
         Assert.assertNotNull("exists", action);
     }
 
@@ -32,8 +44,17 @@ public class LnTcpServerActionTest {
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        lnis = new LocoNetInterfaceScaffold();
+        memo = new LocoNetSystemConnectionMemo();
+        lnis.setSystemConnectionMemo(memo);
+        memo.setLnTrafficController(lnis);
     }
 
     @After
-    public void tearDown() {        JUnitUtil.tearDown();    }
+    public void tearDown() {
+        memo.dispose();
+        lnis = null;
+        JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpServerFrameTest.java
+++ b/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpServerFrameTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.loconet.loconetovertcp;
 
 import java.awt.GraphicsEnvironment;
+import jmri.jmrix.loconet.LocoNetInterfaceScaffold;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -14,6 +16,9 @@ import org.junit.Test;
  * @author Paul Bender Copyright (C) 2016
  */
 public class LnTcpServerFrameTest {
+
+    private LocoNetInterfaceScaffold lnis;
+    private LocoNetSystemConnectionMemo memo;
 
     @Test
     public void testGetDefault() {
@@ -35,8 +40,17 @@ public class LnTcpServerFrameTest {
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
+        lnis = new LocoNetInterfaceScaffold();
+        memo = new LocoNetSystemConnectionMemo();
+        lnis.setSystemConnectionMemo(memo);
+        memo.setLnTrafficController(lnis);
     }
 
     @After
-    public void tearDown() {        JUnitUtil.tearDown();    }
+    public void tearDown() {
+        memo.dispose();
+        lnis = null;
+        JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpServerTest.java
+++ b/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpServerTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.loconet.loconetovertcp;
 
+import jmri.jmrix.loconet.LocoNetInterfaceScaffold;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -14,16 +16,23 @@ import org.junit.Test;
  */
 public class LnTcpServerTest {
 
+    private LocoNetInterfaceScaffold lnis;
+
     @Test
     public void getInstanceTest() {
+        LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo();
+        lnis.setSystemConnectionMemo(memo);
+        memo.setLnTrafficController(lnis);
         Assert.assertNotNull("Server getInstance", LnTcpServer.getDefault());
         LnTcpServer.getDefault().disable();  // turn the server off after enabled during creation.
+        memo.dispose();
     }
 
     @Before
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
+        lnis = new LocoNetInterfaceScaffold();
     }
 
     @After


### PR DESCRIPTION
Fix for Issue #5443
Use default LocoNet memo with server instead of a new memo
Styling of LnOverTcpServer pane, showing connection name
TODO: allow specifying which connection to use for server, currently only one can be started.
LnTcpServerAction startup is still storing an empty prefix:
```
    <startup xmlns="http://jmri.org/xml/schema/auxiliary-configuration/startup-4-3-5.xsd">
        <perform xmlns="" class="apps.configurexml.PerformActionModelXml" name="jmri.jmrix.loconet.loconetovertcp.LnTcpServerAction" type="Action">
            <property name="systemPrefix" value=""/>
        </perform>
    </startup>
```