### PR TITLE
Web server providing directory listings again

### DIFF
--- a/java/acceptancetest/features/web/WebServer.feature
+++ b/java/acceptancetest/features/web/WebServer.feature
@@ -33,5 +33,5 @@ Scenario Outline: Basic Http requests
    | chrome  | http://localhost:12080/web/webThrottle.html | JMRI Web Throttle |
    | chrome  | http://localhost:12080/prefs/ | Directory: /prefs/ \| My JMRI Railroad |
    | chrome  | http://localhost:12080/dist/ | Directory: /dist/ \| My JMRI Railroad |
-   | chrome  | http://localhost:12080/image/ | Directory: /images/ \| My JMRI Railroad |
+   | chrome  | http://localhost:12080/images/ | Directory: /images/ \| My JMRI Railroad |
    | chrome  | http://localhost:12080/xml/signals/ | Directory: /xml/signals/ \| My JMRI Railroad |

--- a/java/acceptancetest/features/web/WebServer.feature
+++ b/java/acceptancetest/features/web/WebServer.feature
@@ -16,6 +16,10 @@ Scenario Outline: Basic Http requests
    | firefox | http://localhost:12080/operations | Trains \| My JMRI Railroad |
    | firefox | http://localhost:12080/frame | Panels \| My JMRI Railroad |
    | firefox | http://localhost:12080/web/webThrottle.html | JMRI Web Throttle |
+   | firefox | http://localhost:12080/prefs/ | Directory: /prefs/ \| My JMRI Railroad |
+   | firefox | http://localhost:12080/dist/ | Directory: /dist/ \| My JMRI Railroad |
+   | firefox | http://localhost:12080/image/ | Directory: /images/ \| My JMRI Railroad |
+   | firefox | http://localhost:12080/xml/signals/ | Directory: /xml/signals/ \| My JMRI Railroad |
 
    @chrome
    Examples: Chrome Tests
@@ -27,3 +31,7 @@ Scenario Outline: Basic Http requests
    | chrome  | http://localhost:12080/operations | Trains \| My JMRI Railroad |
    | chrome  | http://localhost:12080/frame | Panels \| My JMRI Railroad |
    | chrome  | http://localhost:12080/web/webThrottle.html | JMRI Web Throttle |
+   | chrome  | http://localhost:12080/prefs/ | Directory: /prefs/ \| My JMRI Railroad |
+   | chrome  | http://localhost:12080/dist/ | Directory: /dist/ \| My JMRI Railroad |
+   | chrome  | http://localhost:12080/image/ | Directory: /images/ \| My JMRI Railroad |
+   | chrome  | http://localhost:12080/xml/signals/ | Directory: /xml/signals/ \| My JMRI Railroad |

--- a/java/acceptancetest/features/web/WebServer.feature
+++ b/java/acceptancetest/features/web/WebServer.feature
@@ -18,7 +18,7 @@ Scenario Outline: Basic Http requests
    | firefox | http://localhost:12080/web/webThrottle.html | JMRI Web Throttle |
    | firefox | http://localhost:12080/prefs/ | Directory: /prefs/ \| My JMRI Railroad |
    | firefox | http://localhost:12080/dist/ | Directory: /dist/ \| My JMRI Railroad |
-   | firefox | http://localhost:12080/image/ | Directory: /images/ \| My JMRI Railroad |
+   | firefox | http://localhost:12080/images/ | Directory: /images/ \| My JMRI Railroad |
    | firefox | http://localhost:12080/xml/signals/ | Directory: /xml/signals/ \| My JMRI Railroad |
 
    @chrome

--- a/java/src/jmri/web/servlet/directory/DirectoryService.java
+++ b/java/src/jmri/web/servlet/directory/DirectoryService.java
@@ -27,10 +27,15 @@ public class DirectoryService extends ResourceService {
     @Override
     protected void sendDirectory(HttpServletRequest request, HttpServletResponse response, Resource resource, String pathInContext) throws IOException {
         if (this.isDirAllowed()) {
-            log.error("Sending {} for {} in context {}", request.getRequestURI(), resource.getName(), pathInContext);
+            log.debug("Sending !! {} for {} in context {}", request.getRequestURI(), resource.getName(), pathInContext);
             response.setStatus(HttpServletResponse.SC_OK);
             response.setContentType(ServletUtil.UTF8_TEXT_HTML);
-            response.getWriter().print((new DirectoryResource(request.getLocale(), resource)).getListHTML(request.getRequestURI(), request.getPathInfo().lastIndexOf('/') > 0)); // NOI18N
+
+            String dir = (new DirectoryResource(request.getLocale(), resource)).getListHTML(request.getRequestURI(), request.getPathInfo().lastIndexOf('/') > 0);
+            
+            byte[] data = dir.getBytes("utf-8");
+            response.setContentLength(data.length);
+            response.getOutputStream().write(data);
         } else {
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
         }


### PR DESCRIPTION
Restores the ability to provide directory listings.  Resolves #5245. Note that this code has only ctor tests,  so the coverage numbers are quite misleading.