### PR TITLE
Set rail defaults

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -1131,6 +1131,11 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
 
     private final LayoutEditorComponent layoutEditorComponent = new LayoutEditorComponent(this);
 
+    public void newPanelDefaults() {
+        getLayoutTrackDrawingOptions().setMainRailWidth(2);
+        getLayoutTrackDrawingOptions().setSideRailWidth(1);
+    }
+
     private void createFloatingEditToolBox() {
         if (floatingEditToolBoxFrame == null) {
             if (floatingEditContentScrollPane == null) {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -2811,10 +2811,10 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             // integrate LayoutEditor drawing options with previous drawing options
             layoutTrackDrawingOptions.setMainBlockLineWidth((int) mainlineTrackWidth);
             layoutTrackDrawingOptions.setSideBlockLineWidth((int) sidelineTrackWidth);
-            //layoutTrackDrawingOptions.setMainRailWidth((int) mainlineTrackWidth);
-            //layoutTrackDrawingOptions.setSideRailWidth((int) sidelineTrackWidth);
-            //layoutTrackDrawingOptions.setMainRailColor(defaultTrackColor);
-            //layoutTrackDrawingOptions.setSideRailColor(defaultTrackColor);
+            layoutTrackDrawingOptions.setMainRailWidth((int) mainlineTrackWidth);
+            layoutTrackDrawingOptions.setSideRailWidth((int) sidelineTrackWidth);
+            layoutTrackDrawingOptions.setMainRailColor(defaultTrackColor);
+            layoutTrackDrawingOptions.setSideRailColor(defaultTrackColor);
         }
         return layoutTrackDrawingOptions;
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorAction.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorAction.java
@@ -36,5 +36,6 @@ public class LayoutEditorAction extends AbstractAction {
         panel.setAllEditable(true);
         panel.setCurrentPositionAndSize();
         InstanceManager.getDefault(PanelMenu.class).addEditorPanel(panel);
+        panel.newPanelDefaults();
     }
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/loadref/LayoutEditorTest.xml
+++ b/java/test/jmri/jmrit/display/layoutEditor/loadref/LayoutEditorTest.xml
@@ -209,10 +209,10 @@
       <mainBallastWidth>0</mainBallastWidth>
       <mainBlockLineDashPercentageX10>0</mainBlockLineDashPercentageX10>
       <mainBlockLineWidth>4</mainBlockLineWidth>
-      <mainRailColor>#808080</mainRailColor>
+      <mainRailColor>#000000</mainRailColor>
       <mainRailCount>1</mainRailCount>
       <mainRailGap>0</mainRailGap>
-      <mainRailWidth>2</mainRailWidth>
+      <mainRailWidth>4</mainRailWidth>
       <mainTieColor>#000000</mainTieColor>
       <mainTieGap>0</mainTieGap>
       <mainTieLength>0</mainTieLength>
@@ -221,10 +221,10 @@
       <sideBallastWidth>0</sideBallastWidth>
       <sideBlockLineDashPercentageX10>0</sideBlockLineDashPercentageX10>
       <sideBlockLineWidth>2</sideBlockLineWidth>
-      <sideRailColor>#808080</sideRailColor>
+      <sideRailColor>#000000</sideRailColor>
       <sideRailCount>1</sideRailCount>
       <sideRailGap>0</sideRailGap>
-      <sideRailWidth>1</sideRailWidth>
+      <sideRailWidth>2</sideRailWidth>
       <sideTieColor>#000000</sideTieColor>
       <sideTieGap>0</sideTieGap>
       <sideTieLength>0</sideTieLength>


### PR DESCRIPTION
Use layout editor track width and color settings for blocks **_and rails_**.

If LayoutTrackDrawingOptions does not exist in the XML file, the above settings will be the default for creating the new LayoutTrackDrawingOptions.

If it does exist, its values will then be applied to rails and blocks.
