### PR TITLE
Add missing properties

### DIFF
--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -10,6 +10,8 @@
 BeanStateInconsistent   = Inconsistent
 BeanStateUnknown        = Unknown
 BeanStateUnexpected     = Unexpected value: {0}
+BeanStateThrown         = Thrown
+BeanStateClosed         = Closed
 
 BeanNameTurnout         = Turnout
 BeanNameSensor          = Sensor

--- a/java/src/jmri/jmrix/loconet/ds64/Ds64TabbedPanel.java
+++ b/java/src/jmri/jmrix/loconet/ds64/Ds64TabbedPanel.java
@@ -374,7 +374,8 @@ public class Ds64TabbedPanel extends AbstractBoardProgPanel {
                 localSensorType.setSelectedIndex(opsw[21] ? 1 : 0);
                 break;
             default:
-                log.warn("Unhandled state code: {}", state);
+                // we are only interested in the states above. Ignore the rest
+                log.debug("Unhandled state code: {}", state);
                 break;
         }
         updateUI();


### PR DESCRIPTION
#5513 Add in the missing beanstate properties. Make log.warn on ignoring of states that we do not process log.debug. 