### PR TITLE
Set locale from profile earlier

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1044,7 +1044,7 @@
     <target name="locale"
             description="check DecoderPro I8N"
             depends="debug, runtime-library-selection">
-        <java classname="apps.DecoderPro.DecoderPro" dir="." fork="yes">
+        <java classname="apps.PanelPro.PanelPro" dir="." fork="yes">
             <classpath refid="project.class.path"/>
             <sysproperty key="java.security.policy"
                          value="${libdir}/security.policy"/>

--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -178,6 +178,9 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
             System.setProperty("org.jmri.Apps.configFilename", Profile.CONFIG_FILENAME);
             Profile profile = ProfileManager.getDefault().getActiveProfile();
             log.info("Starting with profile {}", (profile != null ? profile.getId() : "<none>"));
+            
+            // rapid language set; must follow up later with full setting as part of preferences
+            apps.gui.GuiLafPreferencesManager.setLocaleMinimally(profile);
         } catch (IOException ex) {
             log.info("Profiles not configurable. Using fallback per-application configuration. Error: {}", ex.getMessage());
         }
@@ -249,10 +252,12 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         
         // ensure the UserPreferencesManager has loaded. Done on GUI
         // thread as it can modify GUI objects
+        log.debug("*** About to getDefault(jmri.UserPreferencesManager.class)");
         ThreadingUtil.runOnGUI(() -> {
             InstanceManager.getDefault(jmri.UserPreferencesManager.class);
         });
-        
+        log.debug("*** Done");
+
         // now (attempt to) load the config file
         log.debug("Using config file(s) {}", file.getPath());
         if (file.exists()) {

--- a/java/src/apps/configurexml/GuiLafConfigPaneXml.java
+++ b/java/src/apps/configurexml/GuiLafConfigPaneXml.java
@@ -94,6 +94,7 @@ public class GuiLafConfigPaneXml extends jmri.configurexml.AbstractXmlAdapter {
         if (countryAttr != null && langAttr != null && varAttr != null) {
             Locale locale = new Locale(langAttr.getValue(), countryAttr.getValue(), varAttr.getValue());
             
+            log.debug("About to setDefault Locale", new Exception(""));
             Locale.setDefault(locale);
             javax.swing.JComponent.setDefaultLocale(locale);
             javax.swing.JOptionPane.setDefaultLocale(locale);

--- a/java/src/apps/gui/GuiLafPreferencesManager.java
+++ b/java/src/apps/gui/GuiLafPreferencesManager.java
@@ -102,6 +102,7 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesManager
             this.setGraphicTableState(preferences.getBoolean(GRAPHICTABLESTATE, this.isGraphicTableState()));
             this.setToolTipDismissDelay(preferences.getInt(SHOW_TOOL_TIP_TIME, this.getToolTipDismissDelay()));
 
+            log.debug("About to setDefault Locale", new Exception(""));
             Locale.setDefault(this.getLocale());
             javax.swing.JComponent.setDefaultLocale(this.getLocale());
             javax.swing.JOptionPane.setDefaultLocale(this.getLocale());

--- a/java/src/apps/gui/GuiLafPreferencesManager.java
+++ b/java/src/apps/gui/GuiLafPreferencesManager.java
@@ -459,6 +459,21 @@ public class GuiLafPreferencesManager extends Bean implements PreferencesManager
             }
         }
     }
+    
+    /**
+     * Stand-alone service routine to 
+     * set the default Locale.
+     *
+     * Intended to be invoked early, as soon as a profile is
+     * available, to ensure the correct language is set as 
+     * startup proceeds. Must be followed eventually
+     * by a complete {@link #setLocale}.
+     */
+    public static void setLocaleMinimally(Profile profile) {
+        String name = ProfileUtils.getPreferences(profile, GuiLafPreferencesManager.class, true).get("locale","en"); // "en" is default if not found
+        log.debug("language found {}", name);
+        Locale.setDefault(new Locale(name));
+    }
 
     /**
      * @return a new calculated font size based on difference between default

--- a/java/src/jmri/Bundle.java
+++ b/java/src/jmri/Bundle.java
@@ -142,6 +142,7 @@ public class Bundle {
      * @throws MissingResourceException if message cannot be found
      */
     public String handleGetMessage(Locale locale, String key) {
+        log.trace("handleGetMessage for key {}", key);
         if (bundleName() != null) {
             ResourceBundle rb = ResourceBundle.getBundle(bundleName(), locale);
             if (rb.containsKey(key)) {
@@ -211,4 +212,7 @@ public class Bundle {
     //           log.error("Failed to load defaults because of missing bundle");
     //           return;
     //        }
+    
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Bundle.class);
+
 }

--- a/java/translate.sh
+++ b/java/translate.sh
@@ -21,7 +21,7 @@
 # 2) Insertion keys, e.g. {0}, are not preserved in the strings.
 
 # Make list of properties classes, removing a couple that are intended not for translation
-VALS=`find classes -name \*.properties ! -name \*_\?\?.properties ! -name \*_\?\?\?.properties -print \
+VALS=`find target/classes -name \*.properties ! -name \*_\?\?.properties ! -name \*_\?\?\?.properties -print \
 | grep -v apps/AppsStructureBundle.properties \
 | grep -v jmri/web/server/Services.properties \
 | grep -v jmri/web/server/FilePaths.properties`


### PR DESCRIPTION
Currently, the user-specified Locale is being set after a number of resources have been loaded and objects created.  They therefore appear in the GUI in the machine-default language, not what the user has requested. 

This moves setting of the Locale earlier in startup to reduce (but not eliminate) the number of cases.