### PR TITLE
make sure terminology used to describe debounce delays in help matches the application

### DIFF
--- a/help/en/package/jmri/jmrit/beantable/BlockEdit.shtml
+++ b/help/en/package/jmri/jmrit/beantable/BlockEdit.shtml
@@ -92,8 +92,8 @@
         to select if the sensor will use the default sensor
         debounce values if configured.</li>
 
-        <li><b>Sensor Inactive Debounce</b> and <b>Sensor Active
-        Debounce</b> allow you to specify the amount of time in
+        <li><b>Inactive Delay</b> and <b>Active
+        Delay</b> allow you to specify the amount of time in
         milliseconds that the system waits before registering the
         state change of a sensor.</li>
       </ul>

--- a/help/en/package/jmri/jmrit/beantable/SensorTable.shtml
+++ b/help/en/package/jmri/jmrit/beantable/SensorTable.shtml
@@ -75,7 +75,7 @@
           <p><a href="#Debounce">See Sensor Debounce below</a></p>
         </dd>
 
-        <dt>Active Delay/ InActive Delay</dt>
+        <dt>Active Delay/ Inactive Delay</dt>
 
         <dd>
           Specify the amount of time in milliseconds that the

--- a/help/en/package/jmri/jmrit/display/EditLayoutBlock.shtml
+++ b/help/en/package/jmri/jmrit/display/EditLayoutBlock.shtml
@@ -114,8 +114,8 @@
       electrical interference. <b>Use Global Debounce Values</b>
       check box, allows you to select if the sensor will use the
       default sensor debounce values if configured.<br>
-      <b>Sensor Inactive Debounce</b> and <b>Sensor Active
-      Debounce</b> allow you to specify the amount of time in
+      <b>Inactive Delay</b> and <b>Active
+      Delay</b> allow you to specify the amount of time in
       milliSeconds that the system waits before registering the
       state change of a sensor.
 


### PR DESCRIPTION
This addresses the user documentation inconsistencies noted in #5529 