### PR TITLE
JmriColorChooser improvements

### DIFF
--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -2,7 +2,7 @@
 #
 # Default properties for the jmri package of JMRI
 #
-# This resource bundle should only be referenced via the Bundle class tree, 
+# This resource bundle should only be referenced via the Bundle class tree,
 # see http://jmri.org/help/en/html/doc/Technical/I8N.shtml
 # for more information.  At some later date
 # the name of this bundle will change
@@ -69,9 +69,9 @@ TurnoutStateThrown      = Thrown
 StateThrownShort        = T
 
 TurnoutOperationOff     = Off
-TurnoutOperationDefault = Use Global Default 
-TurnoutOperationRaw     = Raw 
-TurnoutOperationSensor  = Sensor 
+TurnoutOperationDefault = Use Global Default
+TurnoutOperationRaw     = Raw
+TurnoutOperationSensor  = Sensor
 TurnoutOperationNoFeedback = NoFeedback
 UseGlobal               = Use {0}
 
@@ -121,7 +121,7 @@ TrackAllocated          = Allocated
 TrackCurrentPosition    = Current Position
 TrackDoNotUse           = Out Of Service
 TrackError              = Track Power Error
-        
+
 # very simple default signal system definitions
 SignalAspectDefaultRed  = Stop
 SignalAspectDefaultYellow = Approach
@@ -315,7 +315,7 @@ PullResistanceUp        = Pullup Resistor Enabled
 PullResistanceDown      = Pulldown Resistor Enabled
 PullResistanceOff       = No Pullup/Pulldown.
 
-# Specifically for AbstractLoaderPane 
+# Specifically for AbstractLoaderPane
 StatusFileNotFound      = File Not Found
 
 # server preferences, key used in jmris, jmrit and jmrix
@@ -353,3 +353,4 @@ Blue            = Blue
 Magenta         = Magenta
 Cyan            = Cyan
 ColorClear      = Clear
+Brown           = Brown

--- a/java/src/jmri/jmrit/display/PositionablePopupUtil.java
+++ b/java/src/jmri/jmrit/display/PositionablePopupUtil.java
@@ -315,12 +315,12 @@ public class PositionablePopupUtil {
             setHasBackground(true);
             _textComponent.setBackground(color);
             _parent.setBackground(color);
+            JmriColorChooser.addRecentColor(color);
         }
         if (hasBackground()) {
             setMargin(margin);  //This rebuilds margin and sets it colour.
         }
         _parent.updateSize();
-        JmriColorChooser.addRecentColor(color);
     }
 
     public void setHasBackground(boolean set) {

--- a/java/src/jmri/util/ColorUtil.java
+++ b/java/src/jmri/util/ColorUtil.java
@@ -33,9 +33,11 @@ public class ColorUtil {
     public final static String ColorMagenta = "magenta";
     public final static String ColorCyan = "cyan";
     public final static String ColorClear = "clear";
+    public final static String ColorBrown = "brown";
 
     public final static Color clear = setAlpha(Color.BLACK, 0);
     public final static Color CLEAR = clear;
+    public final static Color BROWN = new Color(102, 51, 0);
 
     /**
      * Handles known colors plus special value for track.
@@ -130,6 +132,8 @@ public class ColorUtil {
                    return Color.magenta;
                case ColorCyan:
                    return Color.cyan;
+               case ColorBrown:
+                   return BROWN;
                case ColorTrack:
                    return null;
                default:
@@ -237,6 +241,8 @@ public class ColorUtil {
             return ColorMagenta;
         } else if (color.equals(Color.cyan)) {
             return ColorCyan;
+        } else if (color.equals(BROWN)) {
+            return ColorBrown;
         }
         return null;
     }

--- a/java/src/jmri/util/swing/ColorListPopupMenu.java
+++ b/java/src/jmri/util/swing/ColorListPopupMenu.java
@@ -17,7 +17,7 @@ import javax.swing.JMenuItem;
  * java colors.
  *
  * @author Paul Bender Copyright (C) 2018
- * @since 4.12.1
+ * @since 4.13.1
  */
 public class ColorListPopupMenu extends JPopupMenu {
 
@@ -26,8 +26,9 @@ public class ColorListPopupMenu extends JPopupMenu {
     // Standard Colors
     private Color[] colorCode = {Color.black, Color.darkGray, Color.gray,
        Color.lightGray, Color.white, Color.red, Color.pink, Color.orange,
-       Color.yellow, Color.green, Color.blue, Color.magenta, Color.cyan};
-    private int numColors = 13; //number of entries in the above arrays
+       Color.yellow, Color.green, Color.blue, Color.magenta, Color.cyan,
+       jmri.util.ColorUtil.BROWN};
+    private int numColors = 14; //number of entries in the above arrays
     private ColorSelectionModel model;
 
     public ColorListPopupMenu(ColorSelectionModel m){
@@ -57,11 +58,11 @@ public class ColorListPopupMenu extends JPopupMenu {
     private JMenuItem createMenuItem(Color swatchColor, boolean isStdColor){
         // update the Swatch to have the right color showing.
         BufferedImage image = new BufferedImage(ICON_DIMENSION, ICON_DIMENSION,
-             BufferedImage.TYPE_INT_RGB);
+             BufferedImage.TYPE_INT_ARGB);
 
         Graphics g = image.getGraphics();
         // fill it with its representative color
-        g.setColor(swatchColor);
+        g.setColor(new Color(swatchColor.getRed(), swatchColor.getGreen(), swatchColor.getBlue(), swatchColor.getAlpha()));
         g.fillRect(0, 0, ICON_DIMENSION, ICON_DIMENSION);
         // draw a black border around it
         g.setColor(Color.black);
@@ -71,14 +72,17 @@ public class ColorListPopupMenu extends JPopupMenu {
 
         g.dispose();
 
-        String colorName;
+        String colorName = "";
+        String colorTip = String.format("r=%d, g=%d, b=%d, a=%d",
+                swatchColor.getRed(), swatchColor.getGreen(), swatchColor.getBlue(), swatchColor.getAlpha());
         if (isStdColor) {
             colorName = jmri.util.ColorUtil.colorToLocalizedName(swatchColor);
         } else {
-            colorName = swatchColor.toString().substring(14);
+            colorName = colorTip;
         }
 
         JMenuItem colorMenuItem = new JMenuItem(colorName,icon);
+        if (isStdColor) colorMenuItem.setToolTipText(colorTip);
         colorMenuItem.addActionListener((ActionEvent e) -> {
            model.setSelectedColor(swatchColor);
         });

--- a/java/src/jmri/util/swing/JmriColorChooser.java
+++ b/java/src/jmri/util/swing/JmriColorChooser.java
@@ -32,7 +32,11 @@ public class JmriColorChooser {
      * @param color The color object to be added.
      */
     static public void addRecentColor(Color color) {
-        if (color != null && !recentColors.contains(color)) {
+        if (color == null || !color.toString().contains("java.awt.Color")) {
+            // Ignore null or default system colors
+            return;
+        }
+        if (!recentColors.contains(color)) {
             recentColors.add(color);
         }
     }

--- a/java/src/jmri/util/swing/JmriColorChooserPanel.java
+++ b/java/src/jmri/util/swing/JmriColorChooserPanel.java
@@ -6,6 +6,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.image.BufferedImage;
+import java.util.ArrayList;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.Icon;
@@ -27,18 +28,23 @@ public class JmriColorChooserPanel extends AbstractColorChooserPanel {
 
     private Color[] colors = {Color.black, Color.darkGray, Color.gray,
        Color.lightGray, Color.white, Color.red, Color.pink, Color.orange,
-       Color.yellow, Color.green, Color.blue, Color.magenta, Color.cyan};
-    private int numColors = 13; //number of entries in the above array
+       Color.yellow, Color.green, Color.blue, Color.magenta, Color.cyan,
+       jmri.util.ColorUtil.BROWN};
+    private int numColors = 14; //number of entries in the above array
     private JPanel recentPanel = new JPanel(new GridBagLayout());
 
     @Override
     public void updateChooser(){
         GridBagConstraints c = new GridBagConstraints();
         c.anchor = java.awt.GridBagConstraints.WEST;
+        recentPanel.removeAll();
+
+        ArrayList<Color> colors = JmriColorChooser.getRecentColors();
+        int cols = Math.max(3, (int) Math.ceil((double)colors.size() / 7));
         int idx = 0;
-        for (Color recent : JmriColorChooser.getRecentColors()) {
-            c.gridx = idx % 2;
-            c.gridy = idx / 2;
+        for (Color recent : colors) {
+            c.gridx = idx % cols;
+            c.gridy = idx / cols;
             recentPanel.add(createColorButton(recent, false), c);
             idx++;
         }
@@ -61,10 +67,12 @@ public class JmriColorChooserPanel extends AbstractColorChooserPanel {
         stdColors.setVisible(true);
 
         recentPanel.setBorder(BorderFactory.createTitledBorder(Bundle.getMessage("RecentColorLabel")));  // NOI18N
+        ArrayList<Color> colors = JmriColorChooser.getRecentColors();
+        int cols = Math.max(3, (int) Math.ceil((double)colors.size() / 7));
         int idx = 0;
-        for (Color recent : JmriColorChooser.getRecentColors()) {
-            c.gridx = idx % 2;
-            c.gridy = idx / 2;
+        for (Color recent : colors) {
+            c.gridx = idx % cols;
+            c.gridy = idx / cols;
             recentPanel.add(createColorButton(recent, false), c);
             idx++;
         }
@@ -82,24 +90,25 @@ public class JmriColorChooserPanel extends AbstractColorChooserPanel {
      */
     JButton createColorButton(Color color, boolean stdcolor) {
         BufferedImage image = new BufferedImage(40, 15,
-                BufferedImage.TYPE_INT_RGB);
+                BufferedImage.TYPE_INT_ARGB);
         Graphics g = image.getGraphics();
         // fill it with its representative color
-        g.setColor(color);
+        g.setColor(new Color(color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha()));
         g.fillRect(0, 0, 40, 15);
         // draw a black border around it
         g.setColor(Color.black);
         g.drawRect(0, 0, 40 - 1, 15 - 1);
         ImageIcon icon = new ImageIcon(image);
 
-        String colorName;
+        String colorName = "";
         if (stdcolor) {
             colorName = jmri.util.ColorUtil.colorToLocalizedName(color);
-        } else {
-            colorName = color.toString().substring(14);
         }
+        String colorTip = String.format("r=%d, g=%d, b=%d, a=%d",
+                color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha());
 
         JButton colorButton = new JButton(colorName, icon);
+        colorButton.setToolTipText(colorTip);
         colorButton.addActionListener((ActionEvent e) -> {
             getColorSelectionModel().setSelectedColor(color);
         });


### PR DESCRIPTION
Changes:
- Add Brown as a semi-standard color with arbitrary RGB values.
- Ignore OS default colors caused by positional labels without a background specified.
- Added support for Alpha values.  Note:  This does not change application support for Alpha values.
- Display the RGBA values as tool tips.
- Changed the JMRI chooser tab to dynamically adjust the column count for recent colors to support large collections.