### PR TITLE
Provide success/fail return from sendPacket.

### DIFF
--- a/java/src/jmri/CommandStation.java
+++ b/java/src/jmri/CommandStation.java
@@ -26,8 +26,10 @@ public interface CommandStation {
      * @param packet  Byte array representing the packet, including the
      *                error-correction byte.
      * @param repeats Number of times to repeat the transmission.
+     *
+     * @return {@code true} if the operation succeeds, {@code false} otherwise.
      */
-    public void sendPacket(@Nonnull byte[] packet, int repeats);
+    public boolean sendPacket(@Nonnull byte[] packet, int repeats);
 
     public String getUserName();
 

--- a/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
+++ b/java/src/jmri/implementation/AccessoryOpsModeProgrammerFacade.java
@@ -170,7 +170,12 @@ public class AccessoryOpsModeProgrammerFacade extends AbstractProgrammerFacade i
                 programmingOpReply(val, ProgListener.UnknownError);
                 return;
         }
-        InstanceManager.getDefault(CommandStation.class).sendPacket(b, 2); // send two packets
+        boolean ret = InstanceManager.getDefault(CommandStation.class).sendPacket(b, 2); // send two packets
+        if (!ret) {
+                log.error("Unable to program cv={}, value={}: Operation not implemented in command station", Integer.parseInt(cv), val);
+                programmingOpReply(val, ProgListener.NotImplemented);
+                return;
+        }
 
         // set up a delayed completion reply
         new Thread(new Runnable() {

--- a/java/src/jmri/jmrix/can/cbus/CbusCommandStation.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusCommandStation.java
@@ -37,7 +37,7 @@ public class CbusCommandStation implements CommandStation, CanListener {
      *                in the current implementation
      */
     @Override
-    public void sendPacket(byte[] packet, int repeats) {
+    public boolean sendPacket(byte[] packet, int repeats) {
 
         if (repeats != 1) {
             log.warn("Only single transmissions currently available");
@@ -55,6 +55,7 @@ public class CbusCommandStation implements CommandStation, CanListener {
         }
 
         tc.sendCanMessage(m, null);
+        return true;
     }
 
     /**

--- a/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
@@ -140,11 +140,11 @@ public class DCCppCommandStation implements jmri.CommandStation {
      * @param repeats Number of times to repeat the transmission.
      */
     @Override
-    public void sendPacket(byte[] packet, int repeats) {
+    public boolean sendPacket(byte[] packet, int repeats) {
 
         if (_tc == null) {
             log.error("Send Packet Called without setting traffic controller");
-            return;
+            return false;
         }
 
         int reg = 0;  // register 0, so this doesn't repeat
@@ -153,6 +153,7 @@ public class DCCppCommandStation implements jmri.CommandStation {
         for (int i = 0; i < repeats; i++) {
             _tc.sendDCCppMessage(msg, null);
         }
+        return true;
     }
 
     /*

--- a/java/src/jmri/jmrix/direct/TrafficController.java
+++ b/java/src/jmri/jmrix/direct/TrafficController.java
@@ -54,7 +54,7 @@ public class TrafficController implements jmri.CommandStation {
      *                in the current implementation
      */
     @Override
-    public void sendPacket(byte[] packet, int repeats) {
+    public boolean sendPacket(byte[] packet, int repeats) {
 
         if (repeats != 1) {
             log.warn("Only single transmissions currently available");
@@ -66,7 +66,7 @@ public class TrafficController implements jmri.CommandStation {
         if (msgAsInt[0] == 0) {
             // failed to make packet
             log.error("Failed to convert packet to transmitable form: {}", java.util.Arrays.toString(packet));
-            return;
+            return false;
         }
 
         // have to recopy & reformat, as there's only a byte write in Java 1
@@ -94,6 +94,7 @@ public class TrafficController implements jmri.CommandStation {
         } catch (IOException e) {
             log.warn("sendMessage: Exception: {}", e.getMessage());
         }
+        return true;
     }
 
     // methods to connect/disconnect to a source of data in an AbstractSerialPortController

--- a/java/src/jmri/jmrix/easydcc/EasyDccCommandStation.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccCommandStation.java
@@ -23,7 +23,7 @@ public class EasyDccCommandStation implements CommandStation {
      * @param repeats Number of times to repeat the transmission, capped at 9
      */
     @Override
-    public void sendPacket(byte[] packet, int repeats) {
+    public boolean sendPacket(byte[] packet, int repeats) {
 
         if (repeats > 9) {
             repeats = 9;
@@ -54,6 +54,7 @@ public class EasyDccCommandStation implements CommandStation {
 
         memo.getTrafficController().sendEasyDccMessage(m, null);
 
+        return true;
     }
 
     EasyDccSystemConnectionMemo memo = null;

--- a/java/src/jmri/jmrix/lenz/LenzCommandStation.java
+++ b/java/src/jmri/jmrix/lenz/LenzCommandStation.java
@@ -182,17 +182,18 @@ public class LenzCommandStation implements jmri.CommandStation {
      * @param repeats Number of times to repeat the transmission.
      */
     @Override
-    public void sendPacket(byte[] packet, int repeats) {
+    public boolean sendPacket(byte[] packet, int repeats) {
 
         if (_tc == null) {
             log.error("Send Packet Called without setting traffic controller");
-            return;
+            return false;
         }
 
         XNetMessage msg = XNetMessage.getNMRAXNetMsg(packet);
         for (int i = 0; i < repeats; i++) {
             _tc.sendXNetMessage(msg, null);
         }
+        return true;
     }
 
     /*

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -119,7 +119,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
      *          is outside of this range.
      */
     @Override
-    public void sendPacket(byte[] packet, int sendCount) {
+    public boolean sendPacket(byte[] packet, int sendCount) {
         if (sendCount > 8) {
             log.warn("Ops Mode Accessory Packet 'Send count' reduced from {} to 8.", sendCount); // NOI18N
             sendCount = 8;
@@ -176,6 +176,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
         } else {
             tc.sendLocoNetMessage(m);
         }
+        return true;
     }
 
     final static protected int NUM_SLOTS = 128;

--- a/java/src/jmri/jmrix/marklin/MarklinTrafficController.java
+++ b/java/src/jmri/jmrix/marklin/MarklinTrafficController.java
@@ -65,8 +65,9 @@ public class MarklinTrafficController extends AbstractMRTrafficController implem
      * CommandStation implementation, not yet supported.
      */
     @Override
-    public void sendPacket(byte[] packet, int count) {
+    public boolean sendPacket(byte[] packet, int count) {
 
+        return true;
     }
 
     /**

--- a/java/src/jmri/jmrix/nce/NceTrafficController.java
+++ b/java/src/jmri/jmrix/nce/NceTrafficController.java
@@ -55,7 +55,7 @@ public class NceTrafficController extends AbstractMRTrafficController implements
      * CommandStation implementation
      */
     @Override
-    public void sendPacket(byte[] packet, int count) {
+    public boolean sendPacket(byte[] packet, int count) {
         NceMessage m;
 
         boolean isUsb = ((getUsbSystem() == NceTrafficController.USB_SYSTEM_POWERCAB
@@ -87,8 +87,12 @@ public class NceTrafficController extends AbstractMRTrafficController implements
             m = NceMessage.createAccDecoderPktOpsMode(this, accyAddr, cvAddr, cvData);
         } else {
             m = NceMessage.sendPacketMessage(this, packet);
+            if (m == null) {
+                return false;
+            }
         }
         this.sendNceMessage(m, null);
+        return true;
     }
 
     /**

--- a/java/src/jmri/jmrix/sprog/SprogCommandStation.java
+++ b/java/src/jmri/jmrix/sprog/SprogCommandStation.java
@@ -105,7 +105,7 @@ public class SprogCommandStation implements CommandStation, SprogListener, Runna
      * @param repeats number of times to repeat the packet
      */
     @Override
-    public void sendPacket(byte[] packet, int repeats) {
+    public boolean sendPacket(byte[] packet, int repeats) {
         if (packet.length <= 1) {
             log.error("Invalid DCC packet length: {}", packet.length);
         }
@@ -114,6 +114,7 @@ public class SprogCommandStation implements CommandStation, SprogListener, Runna
         }
         final SprogMessage m = new SprogMessage(packet);
         sendMessage(m);
+        return true;
     }
 
     /**

--- a/java/src/jmri/jmrix/tams/TamsTrafficController.java
+++ b/java/src/jmri/jmrix/tams/TamsTrafficController.java
@@ -94,8 +94,9 @@ public class TamsTrafficController extends AbstractMRTrafficController implement
      * @param count  ignored, but needed for API compatibility
      */
     @Override
-    public void sendPacket(byte[] packet, int count) {
+    public boolean sendPacket(byte[] packet, int count) {
         log.trace("*** sendPacket ***");
+        return true;
     }
 
     /**

--- a/java/test/jmri/implementation/AccessoryOpsModeProgrammerFacadeTest.java
+++ b/java/test/jmri/implementation/AccessoryOpsModeProgrammerFacadeTest.java
@@ -142,8 +142,9 @@ public class AccessoryOpsModeProgrammerFacadeTest {
     class MockCommandStation implements CommandStation {
 
         @Override
-        public void sendPacket(byte[] packet, int repeats) {
+        public boolean sendPacket(byte[] packet, int repeats) {
             lastPacket = packet;
+            return true;
         }
 
         @Override

--- a/java/test/jmri/implementation/DccSignalHeadTest.java
+++ b/java/test/jmri/implementation/DccSignalHeadTest.java
@@ -166,9 +166,10 @@ public class DccSignalHeadTest extends AbstractSignalHeadTestBase {
 
         CommandStation c = new CommandStation() {
             @Override
-            public void sendPacket(byte[] packet, int repeats) {
+            public boolean sendPacket(byte[] packet, int repeats) {
                 lastSentPacket = packet;
                 sentPacketCount++;
+                return true;
             }
 
             @Override

--- a/java/test/jmri/implementation/DccSignalMastTest.java
+++ b/java/test/jmri/implementation/DccSignalMastTest.java
@@ -50,9 +50,10 @@ public class DccSignalMastTest {
 
         CommandStation c = new CommandStation() {
             @Override
-            public void sendPacket(byte[] packet, int repeats) {
+            public boolean sendPacket(byte[] packet, int repeats) {
                 lastSentPacket = packet;
                 sentPacketCount++;
+                return true;
             }
 
             @Override

--- a/java/test/jmri/jmrix/dcc/DccTurnoutTest.java
+++ b/java/test/jmri/jmrix/dcc/DccTurnoutTest.java
@@ -48,8 +48,9 @@ public class DccTurnoutTest extends AbstractTurnoutTestBase {
         java.util.ArrayList<byte[]> outbound = new java.util.ArrayList<byte[]>();
 
         @Override
-        public void sendPacket(byte[] packet, int repeats) {
+        public boolean sendPacket(byte[] packet, int repeats) {
             outbound.add(packet);
+            return true;
         }
 
         @Override

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -416,7 +416,8 @@ public class JUnitUtil {
     public static void initDebugCommandStation() {
         jmri.CommandStation cs = new jmri.CommandStation() {
             @Override
-            public void sendPacket(@Nonnull byte[] packet, int repeats) {
+            public boolean sendPacket(@Nonnull byte[] packet, int repeats) {
+            return true;
             }
 
             @Override


### PR DESCRIPTION
Some implementations of sendPacket log errors (for various reasons) in the System Console. But there was no mechanism for feedback to the user that an operation (e.g. programming) had failed.

Calling methods can now check the return status. A return value of true indicates that at least the packet was queued.