### PR TITLE
Tweak max row count calculations

### DIFF
--- a/java/src/jmri/util/swing/JComboBoxUtil.java
+++ b/java/src/jmri/util/swing/JComboBoxUtil.java
@@ -35,6 +35,9 @@ public class JComboBoxUtil {
             Component c = renderer.getListCellRendererComponent(list, value, i, false, false);
             maxItemHeight = Math.max(maxItemHeight, c.getPreferredSize().height);
         }
+        // Compensate for slightly undersized cell height for macOS
+        // The last rows will be off the screen if the dock is hidden
+        if (jmri.util.SystemType.isMacOSX()) maxItemHeight++;
 
         int itemsPerScreen = inComboBox.getItemCount();
         // calculate the number of items that will fit on the screen
@@ -45,7 +48,8 @@ public class JComboBoxUtil {
             itemsPerScreen = (int) maxWindowBounds.getHeight() / maxItemHeight;
         }
 
-        int c = Math.min(itemsPerScreen, inComboBox.getItemCount());
+        // Set the minimum size to 8 rows
+        int c = Math.max(Math.min(itemsPerScreen - 1, inComboBox.getItemCount()), 8);
         inComboBox.setMaximumRowCount(c);
     }
 

--- a/java/test/jmri/util/swing/JComboBoxUtilTest.java
+++ b/java/test/jmri/util/swing/JComboBoxUtilTest.java
@@ -3,12 +3,13 @@ package jmri.util.swing;
 import javax.swing.*;
 import jmri.util.JUnitUtil;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 /**
  *
- * @author Bob Jacobsen Copyright (C) 2017	
+ * @author Bob Jacobsen Copyright (C) 2017
  */
 public class JComboBoxUtilTest {
 
@@ -16,6 +17,7 @@ public class JComboBoxUtilTest {
     public void testCall() {
         JComboBox<String> c = new JComboBox<>(new String[]{"A", "B"});
         JComboBoxUtil.setupComboBoxMaxRows(c);
+        Assert.assertEquals("Max row count", 8, c.getMaximumRowCount());  // NOI18N
     }
 
     // The minimal setup for log4J


### PR DESCRIPTION
Fix screen overflow for macOS.
Set the minimum row count to 8 to prevent very short lists for new projects.