### PR TITLE
Report out legacy system names

### DIFF
--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -405,6 +405,12 @@ public interface Manager<E extends NamedBean> {
         int p = startsWithLegacySystemPrefix(inputName);
         if (p > 0) {
             if (legacyNameSet.size() == 0) {
+                if (InstanceManager.getNullableDefault(ShutDownManager.class) == null) {
+                // for migration purposes, we don't insist that apps (and tests)
+                // be preconfigured with a shutdown manager before getting here
+                    InstanceManager.setDefault(ShutDownManager.class, new jmri.managers.DefaultShutDownManager());
+                }
+                // register our own shutdown
                 InstanceManager.getDefault(ShutDownManager.class)
                                 .register(legacyReportTask);
             }

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -404,6 +404,12 @@ public interface Manager<E extends NamedBean> {
         // This is also quite a bit slower than the tuned implementation below
         int p = startsWithLegacySystemPrefix(inputName);
         if (p > 0) {
+            if (legacyNameSet.size() == 0) {
+                InstanceManager.getDefault(ShutDownManager.class)
+                                .register(legacyReportTask);
+            }
+            legacyNameSet.add(inputName);
+            
             return p;
         }
 
@@ -417,6 +423,18 @@ public interface Manager<E extends NamedBean> {
         return i;
     }
 
+    @Deprecated
+    static Set<String> legacyNameSet = Collections.synchronizedSet(new HashSet(200)); // want fast search and insert
+    @Deprecated
+    static ShutDownTask legacyReportTask = new jmri.implementation.AbstractShutDownTask("Legacy Name List"){
+                            public boolean execute() {
+                                org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Manager.class);
+                                log.warn("The following legacy names need to be migrated:");
+                                for (String name : legacyNameSet) log.warn("    {}", name);
+                                return true;
+                            }
+                };
+                        
     /**
      * Provides the system prefix of the given system name.
      * <p>
@@ -435,6 +453,7 @@ public interface Manager<E extends NamedBean> {
         return inputName.substring(0, getSystemPrefixLength(inputName));
     }
 
+    
     /**
      * Indicate whether a system-prefix is one of the legacy non-parsable ones
      * that are being removed during the JMRI 4.11 cycle.

--- a/java/src/jmri/jmrix/mrc/MrcTrafficController.java
+++ b/java/src/jmri/jmrix/mrc/MrcTrafficController.java
@@ -181,7 +181,7 @@ public abstract class MrcTrafficController implements MrcInterface {
 
     public String getSystemPrefix() {
         if (adaptermemo == null) {
-            return "MR"; //IN18N
+            return "M"; //IN18N
         }
         return adaptermemo.getSystemPrefix();
     }

--- a/java/test/jmri/ManagerTest.java
+++ b/java/test/jmri/ManagerTest.java
@@ -37,6 +37,23 @@ public class ManagerTest {
     }
 
     @Test
+    public void testLegacyLog() {
+        jmri.Manager.legacyNameSet.clear(); // clean start
+
+        // start actual test
+        Assert.assertEquals("Empty at first", 0, Manager.legacyNameSet.size());
+
+        Manager.getSystemPrefix("DCCPPS01");
+        Assert.assertEquals("Didn't catch reference", 1, Manager.legacyNameSet.size());
+
+        Manager.getSystemPrefix("IS01");
+        Assert.assertEquals("Logged one in error", 1, Manager.legacyNameSet.size());
+
+        // there should be a ShutDownTask registered, remove it
+        InstanceManager.getDefault(jmri.ShutDownManager.class).deregister(Manager.legacyReportTask);
+    }
+    
+    @Test
     public void testGetSystemPrefixLengthThrow2() {
         try {
             Manager.getSystemPrefixLength("1T1");

--- a/jython/test/LegacyNameTest.py
+++ b/jython/test/LegacyNameTest.py
@@ -1,0 +1,18 @@
+# Test access to legacy names
+import jmri
+
+jmri.util.JUnitUtil.initShutDownManager()
+
+jmri.Manager.legacyNameSet.clear() # just in case
+
+# start actual test
+if (jmri.Manager.legacyNameSet.size() != 0) : raise AssertionError('Not empty at first')
+
+jmri.Manager.getSystemPrefix("DCCPPS01")
+if (jmri.Manager.legacyNameSet.size() != 1) : raise AssertionError('Didn\'t catch a reference')
+
+jmri.Manager.getSystemPrefix("IS01")
+if (jmri.Manager.legacyNameSet.size() != 1) : raise AssertionError('Tagged one in error')
+
+# there should be a ShutDownTask registered, remove it
+jmri.InstanceManager.getDefault(jmri.ShutDownManager).deregister(jmri.Manager.legacyReportTask)


### PR DESCRIPTION
Adds code to Managers to keep a record of non-parsable system names, and report them out to the log at the end of program execution.  

This is to help migrate those names for users, so that in turn we can complete that migration during the 4.15.* release series.