### PR TITLE
CBUS Event Table Fixes + OPC Update

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusBundle.properties
+++ b/java/src/jmri/jmrix/can/cbus/CbusBundle.properties
@@ -2,6 +2,7 @@
 #
 # Default properties for the jmri.jmrix.can.cbus package
 
+
 # menu items
 MenuTools               = Systems
 
@@ -112,16 +113,18 @@ TypeColTip              = Type of Event
 ColumnComment           = Comment
 CommentColTip           = Enter comments in this column
 EmptyTableDialogString  = Your Event Table is empty and\ncan not be saved to a file.
+ColumnEventID           = Event ID
+ColumnEventIDTip        = Event Table Internal ID
 
 # Cbus configure pane items
 ToolTipNodeNumber       = Enter Node number from 256 to 65535 (decimal)
 
 
 # CbusTurnout (Add to table pane) items
-AddOutputEntryToolTip = +18 (Event 18 On Thrown; 18 Off Closed)<br>\
+AddOutputEntryToolTip = <html>+18 (Event 18 On Thrown; 18 Off Closed)<br>\
 +18;-21 (Event 18 On Thrown; 21 Off Closed)<br>\
 +N2E18 (Node 2 Event 18; On Thrown; Off Closed)<br>\
-See JMRI CBUS Support for more options
+See JMRI CBUS Support for more options</html>
 
 AddInputEntryToolTip = <html>+18 (Event 18 On Active; 18 Off Inactive)<br>\
 +18;-21 ( Event 18 On Active; 21 Off Closed )<br>\

--- a/java/src/jmri/jmrix/can/cbus/CbusMessage.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusMessage.java
@@ -55,16 +55,51 @@ public class CbusMessage {
     }
 
     public static int getEventType(CanMessage m) {
-        if ((m.getElement(0) == 0x91) || (m.getElement(0) == 0x99)) {
+        if (
+           (m.getElement(0) == 0x91)
+        || (m.getElement(0) == 0x94)
+        || (m.getElement(0) == 0x99)
+        || (m.getElement(0) == 0x9E)
+        || (m.getElement(0) == 0xB1)
+        || (m.getElement(0) == 0xB4)
+        || (m.getElement(0) == 0xB9)
+        || (m.getElement(0) == 0xBE)
+        || (m.getElement(0) == 0xD1)
+        || (m.getElement(0) == 0xD5)
+        || (m.getElement(0) == 0xD9)
+        || (m.getElement(0) == 0xDE)
+        || (m.getElement(0) == 0xF1)
+        || (m.getElement(0) == 0xF4)
+        || (m.getElement(0) == 0xF9)
+        || (m.getElement(0) == 0xFE)
+        ) {
             return CbusConstants.EVENT_OFF;
         } else {
             return CbusConstants.EVENT_ON;
         }
     }
 
+    // this adheres to cbus spec, ie on off responses to an AREQ are events
+    // D4 D5 not typo
     public static boolean isEvent(CanMessage m) {
-        if ((m.getElement(0) == 0x90) || (m.getElement(0) == 0x91)
-         || (m.getElement(0) == 0x98) || (m.getElement(0) == 0x99)) {
+        if 
+          ((m.getElement(0) == 0x90) || (m.getElement(0) == 0x91)
+        || (m.getElement(0) == 0x93) || (m.getElement(0) == 0x94)
+        || (m.getElement(0) == 0x98) || (m.getElement(0) == 0x99)
+        || (m.getElement(0) == 0x9D) || (m.getElement(0) == 0x9E)
+        || (m.getElement(0) == 0xB0) || (m.getElement(0) == 0xB1)
+        || (m.getElement(0) == 0xB3) || (m.getElement(0) == 0xB4)
+        || (m.getElement(0) == 0xB8) || (m.getElement(0) == 0xB9)
+        || (m.getElement(0) == 0xBD) || (m.getElement(0) == 0xBE)
+        || (m.getElement(0) == 0xD0) || (m.getElement(0) == 0xD1)
+        || (m.getElement(0) == 0xD4) || (m.getElement(0) == 0xD5) 
+        || (m.getElement(0) == 0xD8) || (m.getElement(0) == 0xD9)
+        || (m.getElement(0) == 0xDD) || (m.getElement(0) == 0xDE)
+        || (m.getElement(0) == 0xF0) || (m.getElement(0) == 0xF1)
+        || (m.getElement(0) == 0xF3) || (m.getElement(0) == 0xF4)
+        || (m.getElement(0) == 0xF8) || (m.getElement(0) == 0xF9)
+        || (m.getElement(0) == 0xFD) || (m.getElement(0) == 0xFE)
+     ) {
             return true;
         } else {
             return false;
@@ -176,7 +211,24 @@ public class CbusMessage {
     }
 
     public static int getEventType(CanReply r) {
-        if ((r.getElement(0) == 0x91) || (r.getElement(0) == 0x99)) {
+        if (
+           (r.getElement(0) == 0x91)
+        || (r.getElement(0) == 0x94)
+        || (r.getElement(0) == 0x99)
+        || (r.getElement(0) == 0x9E)
+        || (r.getElement(0) == 0xB1)
+        || (r.getElement(0) == 0xB4)
+        || (r.getElement(0) == 0xB9)
+        || (r.getElement(0) == 0xBE)
+        || (r.getElement(0) == 0xD1)
+        || (r.getElement(0) == 0xD5)
+        || (r.getElement(0) == 0xD9)
+        || (r.getElement(0) == 0xDE)
+        || (r.getElement(0) == 0xF1)
+        || (r.getElement(0) == 0xF4)
+        || (r.getElement(0) == 0xF9)
+        || (r.getElement(0) == 0xFE)
+        ) {
             return CbusConstants.EVENT_OFF;
         } else {
             return CbusConstants.EVENT_ON;
@@ -184,8 +236,24 @@ public class CbusMessage {
     }
 
     public static boolean isEvent(CanReply r) {
-        if ((r.getElement(0) == 0x90) || (r.getElement(0) == 0x91)
-         || (r.getElement(0) == 0x98) || (r.getElement(0) == 0x99)) {
+        if (
+           (r.getElement(0) == 0x90) || (r.getElement(0) == 0x91)
+        || (r.getElement(0) == 0x93) || (r.getElement(0) == 0x94)
+        || (r.getElement(0) == 0x98) || (r.getElement(0) == 0x99)
+        || (r.getElement(0) == 0x9D) || (r.getElement(0) == 0x9E)
+        || (r.getElement(0) == 0xB0) || (r.getElement(0) == 0xB1)
+        || (r.getElement(0) == 0xB3) || (r.getElement(0) == 0xB4)
+        || (r.getElement(0) == 0xB8) || (r.getElement(0) == 0xB9)
+        || (r.getElement(0) == 0xBD) || (r.getElement(0) == 0xBE)
+        || (r.getElement(0) == 0xD0) || (r.getElement(0) == 0xD1)
+        || (r.getElement(0) == 0xD4) || (r.getElement(0) == 0xD5) 
+        || (r.getElement(0) == 0xD8) || (r.getElement(0) == 0xD9)
+        || (r.getElement(0) == 0xDD) || (r.getElement(0) == 0xDE)
+        || (r.getElement(0) == 0xF0) || (r.getElement(0) == 0xF1)
+        || (r.getElement(0) == 0xF3) || (r.getElement(0) == 0xF4)
+        || (r.getElement(0) == 0xF8) || (r.getElement(0) == 0xF9)
+        || (r.getElement(0) == 0xFD) || (r.getElement(0) == 0xFE)
+        ) {
             return true;
         } else {
             return false;

--- a/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTableDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTableDataModel.java
@@ -157,7 +157,9 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
             case EVENTIDCOLUMN:
                 return _eventid[row];
             case NODECOLUMN:
-                return _node[row];
+                if (_node[row]>0) {
+                    return _node[row];
+                }
             case EVENTCOLUMN:
                 return _event[row];
 

--- a/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTableDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTableDataModel.java
@@ -159,6 +159,8 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
             case NODECOLUMN:
                 if (_node[row]>0) {
                     return _node[row];
+                } else {
+                    return null;
                 }
             case EVENTCOLUMN:
                 return _event[row];

--- a/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTableDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTableDataModel.java
@@ -1,16 +1,19 @@
 package jmri.jmrix.can.cbus.swing.eventtable;
 
 import java.awt.Font;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+
 import javax.swing.JComboBox;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+
 import jmri.jmrix.can.CanInterface;
 import jmri.jmrix.can.CanListener;
 import jmri.jmrix.can.CanMessage;
@@ -18,8 +21,10 @@ import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.CbusConstants;
 import jmri.jmrix.can.cbus.CbusMessage;
+
 import jmri.util.FileUtil;
 import jmri.util.davidflanagan.HardcopyWriter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,28 +32,32 @@ import org.slf4j.LoggerFactory;
  * Table data model for display of Cbus events
  *
  * @author Andrew Crosland (C) 2009
+ * @author Steve Young (c) 2018
+ * 
  */
 public class CbusEventTableDataModel extends javax.swing.table.AbstractTableModel implements CanListener {
+    
 
-    static public final int IDCOLUMN = 0;
-    static public final int NODECOLUMN = IDCOLUMN + 1;
-    static public final int NAMECOLUMN = NODECOLUMN + 1;
-    static public final int EVENTCOLUMN = NAMECOLUMN + 1;
-    static public final int TYPECOLUMN = EVENTCOLUMN + 1;
-    static public final int COMMENTCOLUMN = TYPECOLUMN + 1;
-
-    static public final int NUMCOLUMN = 6;
+    static public final int EVENTIDCOLUMN = 0; 
+    static public final int NODECOLUMN = 1; 
+    static public final int EVENTCOLUMN = 2; 
+    static public final int TYPECOLUMN = 3; 
+    static public final int NAMECOLUMN = 4; 
+    static public final int CANIDCOLUMN =5; 
+    static public final int COMMENTCOLUMN = 6; 
+    static public final int NUMCOLUMN = 7;
 
     final JFileChooser fileChooser = new JFileChooser(FileUtil.getUserFilesPath());
 
     CanSystemConnectionMemo memo;
 
     CbusEventTableDataModel(CanSystemConnectionMemo memo, int row, int column) {
-        _id = new int[CbusConstants.MAX_TABLE_EVENTS];
+        _eventid = new int[CbusConstants.MAX_TABLE_EVENTS];
+        _canid = new int[CbusConstants.MAX_TABLE_EVENTS];
         _node = new int[CbusConstants.MAX_TABLE_EVENTS];
         _name = new String[CbusConstants.MAX_TABLE_EVENTS];
         _event = new int[CbusConstants.MAX_TABLE_EVENTS];
-        _type = new boolean[CbusConstants.MAX_TABLE_EVENTS];
+        _type = new int[CbusConstants.MAX_TABLE_EVENTS];
         _comment = new String[CbusConstants.MAX_TABLE_EVENTS];
         // connect to the CanInterface
         tc = memo.getTrafficController();
@@ -69,9 +78,11 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
     }
 
     @Override
-    public String getColumnName(int col) {
+    public String getColumnName(int col) { // not in any order
         switch (col) {
-            case IDCOLUMN:
+            case EVENTIDCOLUMN:
+                return Bundle.getMessage("ColumnEventID");
+            case CANIDCOLUMN:
                 return Bundle.getMessage("ColumnID");
             case NODECOLUMN:
                 return Bundle.getMessage("ColumnNode");
@@ -80,7 +91,7 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
             case EVENTCOLUMN:
                 return Bundle.getMessage("ColumnEvent");
             case TYPECOLUMN:
-                return Bundle.getMessage("ColumnType");
+                return Bundle.getMessage("CbusEventOnOrOff");
             case COMMENTCOLUMN:
                 return Bundle.getMessage("ColumnComment");
             default:
@@ -90,18 +101,20 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
 
     public int getColumnWidth(int col) {
         switch (col) {
-            case IDCOLUMN:
-                return 7;
+            case EVENTIDCOLUMN:
+                return 6;
+            case CANIDCOLUMN:
+                return 3;
             case NODECOLUMN:
                 return 7;
             case NAMECOLUMN:
-                return 20;
+                return 12;
             case EVENTCOLUMN:
                 return 7;
-            case TYPECOLUMN:
-                return 7;
+            case TYPECOLUMN: // on off
+                return 8;
             case COMMENTCOLUMN:
-                return 0; // to get writer recognize it as the last column, will fill with spaces
+                return 10; // was 0 to get writer recognize it as the last column, will fill with spaces
             default:
                 return -1;
         }
@@ -110,7 +123,8 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
     @Override
     public Class<?> getColumnClass(int col) {
         switch (col) {
-            case IDCOLUMN:
+            case EVENTIDCOLUMN:
+            case CANIDCOLUMN:
             case NODECOLUMN:
             case EVENTCOLUMN:
                 return Integer.class;
@@ -140,19 +154,24 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
     @Override
     public Object getValueAt(int row, int col) {
         switch (col) {
-            case IDCOLUMN:
-                return _id[row];
+            case EVENTIDCOLUMN:
+                return _eventid[row];
             case NODECOLUMN:
                 return _node[row];
-            case NAMECOLUMN:
-                return _name[row];
             case EVENTCOLUMN:
                 return _event[row];
-            case TYPECOLUMN:
-                if (_type[row]) {
+
+            case NAMECOLUMN:
+                return _name[row];
+            case CANIDCOLUMN:
+                return _canid[row];
+            case TYPECOLUMN:  // on or off event  1 is on, 0 is off, null unknown
+                if (_type[row]==1) { 
+                    return Bundle.getMessage("PowerStateOff");
+                } else if (_type[row]==0) {
                     return Bundle.getMessage("PowerStateOn");
                 } else {
-                    return Bundle.getMessage("PowerStateOff");
+                    return("Unknown");
                 }
             case COMMENTCOLUMN:
                 return _comment[row];
@@ -162,21 +181,29 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
                 return null;
         }
     }
+    
+    
+    
+    
 
     public int getPreferredWidth(int col) {
         switch (col) {
-            case IDCOLUMN:
-                return new JTextField(5).getPreferredSize().width;
-            case NODECOLUMN:
-                return new JTextField(5).getPreferredSize().width;
-            case NAMECOLUMN:
-                return new JTextField(18).getPreferredSize().width;
-            case EVENTCOLUMN:
-                return new JTextField(5).getPreferredSize().width;
-            case TYPECOLUMN:
+            case EVENTIDCOLUMN:
                 return new JTextField(3).getPreferredSize().width;
+            case NODECOLUMN:
+                return new JTextField(4).getPreferredSize().width;
+            case EVENTCOLUMN:
+                return new JTextField(4).getPreferredSize().width;
+            case TYPECOLUMN:
+                return new JTextField(4).getPreferredSize().width;
+            case NAMECOLUMN:
+                return new JTextField(10).getPreferredSize().width;
+            
+            case CANIDCOLUMN:
+                return new JTextField(4).getPreferredSize().width;
+
             case COMMENTCOLUMN:
-                return new JTextField(30).getPreferredSize().width;
+                return new JTextField(10).getPreferredSize().width;
             default:
                 return new JLabel(" <unknown> ").getPreferredSize().width; // NOI18N
         }
@@ -206,9 +233,25 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
             _comment[row] = (String) value;
             fireTableRowsUpdated(row, row);
         }
+        
+        if (col == TYPECOLUMN) {
+            // log.debug("243 updating event on or off");
+            _type[row] = (int) value;
+            fireTableRowsUpdated(row, row);
+        }
+        
         // table is dirty
         _saved = false;
     }
+
+    
+    
+    
+    
+    
+    
+    
+    
 
     /**
      * Configure a table to have our standard rows and columns.
@@ -241,48 +284,106 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
     }
 
     /**
-     * Capture node and event and add to table.
+     * Capture node and event, check isevent and send to parse from message.
      */
     @Override
     public void message(CanMessage m) {
-        log.debug("Received new message event: {}", m);
-        _id[_rowCount] = CbusMessage.getId(m);
-        _node[_rowCount] = m.getElement(1) * 256 + m.getElement(2);
-        _event[_rowCount] = m.getElement(3) * 256 + m.getElement(4);
-        _type[_rowCount] = (m.getOpCode() & 1) == 0;
-        addEvent();
+        // log.debug("296 Received new message: {} getevent: {} ", m, CbusMessage.getEvent(m) );
+        if (( CbusMessage.getEvent(m))>0) {
+            parseMessage(
+            CbusMessage.getId(m), 
+            (m.getElement(1) * 256 + m.getElement(2)),
+            (m.getElement(3) * 256 + m.getElement(4)),
+            CbusMessage.getEventType(m)); 
+        }
     }
 
     /**
-     * Capture node and event and add to table.
+     * Capture node and event, check isevent and send to parse from reply.
      */
     @Override
     public void reply(CanReply m) {
-        log.debug("Received new reply event: {}", m);
-        _id[_rowCount] = CbusMessage.getId(m);
-        _node[_rowCount] = m.getElement(1) * 256 + m.getElement(2);
-        _event[_rowCount] = m.getElement(3) * 256 + m.getElement(4);
-        _type[_rowCount] = (m.getOpCode() & 1) == 0;
-        addEvent();
+        // log.debug("311 Received new reply : {} getevent: {} ", m, CbusMessage.getEvent(m) );
+        if (( CbusMessage.getEvent(m))>0) {
+            parseMessage(
+            CbusMessage.getId(m), 
+            (m.getElement(1) * 256 + m.getElement(2)),
+            (m.getElement(3) * 256 + m.getElement(4)),
+            CbusMessage.getEventType(m));
+        }
     }
 
+    
     /**
-     * Register new event.
+     * If new event add to table, else update table.
+     * takes canid, node, event, onoroff
+     */
+    public synchronized void parseMessage( int canid, int node, int event, int eventOnOrOff) {
+        log.debug("304 parseMessage  ");
+        // log.debug(" 310 event: {}  node: {}  canid: {} ", event, node, canid);
+        // log.debug(" 326 event onoroff 1 is off, 0 is on : {} ", eventOnOrOff);
+        int existingRow = seeIfEventOnTable( event, node);
+        // log.debug(" 339 existing event: {} ", existingRow);
+        if (existingRow<0) {
+            _canid[_rowCount] = canid;
+            _event[_rowCount] = event;
+            _node[_rowCount] = node;
+            _type[_rowCount] = eventOnOrOff;
+            addEvent(); 
+        } else {
+            updateEventfromNetwork(existingRow, eventOnOrOff);
+        }
+    }
+    
+    
+    /**
+     * Do Node + Event check, returns -1 if not on table, otherwise the row id
+     */
+    public synchronized int seeIfEventOnTable( int event, int node) {
+        for (int i = 0; i < getRowCount(); i++) { // todo - check if quicker to do 3 lookups?
+            int testnode = (_node[i]);
+            int testevent = (_event[i]);
+            // log.warn(" 343 testevent: {}  tetsnode: {} row {} ", testevent, testnode, i);
+            if ((event==testevent) && (node == testnode)) {
+                // log.debug(" 398 match found {} ", i);
+                return i;
+            }
+        }
+        return -1;
+    }
+    
+    
+    
+    
+    /**
+     * Updates the table if event already on table
+     */    
+    public synchronized void updateEventfromNetwork( int existingRow, int eventOnOrOff ) {
+        // log.debug(" 393 updating row {} with status {} ", existingRow, eventOnOrOff);        
+        setValueAt(eventOnOrOff, existingRow, TYPECOLUMN);
+    }
+    
+    
+    
+    /**
+     * Register new event to table
      */
     public synchronized void addEvent() {
+        // log.debug(" adding event ");
         if (_rowCount < CbusConstants.MAX_TABLE_EVENTS) {
+            _eventid[_rowCount]=_rowCount+1;
+            
             // notify the JTable object that a row has changed; do that in the Swing thread!
             Runnable r = new Notify(_rowCount, this);   // -1 in first arg means all
             javax.swing.SwingUtilities.invokeLater(r);
             _rowCount++;
         }
     }
+    
 
     static class Notify implements Runnable {
-
         private int _row;
         javax.swing.table.AbstractTableModel _model;
-
         public Notify(int row, javax.swing.table.AbstractTableModel model) {
             _row = row;
             _model = model;
@@ -290,12 +391,15 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
 
         @Override
         public void run() {
+            // log.debug("Table added row: {}", _row);
             // notify that row is added
-            log.debug("Table added row: {}", _row);
             _model.fireTableRowsInserted(_row, _row);
         }
     }
 
+    /**
+     * Does Nothing
+     */
     public void dispose() {
         // table.removeAllElements();
         // table = null;
@@ -374,7 +478,9 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
         p.println(this.getColumnName(getColumnCount() - 1)); // last column, without comma
         // print rows
         for (int i = 0; i < this.getRowCount(); i++) {
-            p.print(_id[i]);
+            p.print(_eventid[i]);
+            p.print(",");
+            p.print(_canid[i]);
             p.print(",");
             p.print(_node[i]);
             p.print(",");
@@ -382,10 +488,10 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
             p.print(",");
             p.print(_event[i]);
             p.print(",");
-            if (_type[i]) {
-                p.print(Bundle.getMessage("PowerStateOn"));
+            if (_type[i]>0) {
+                p.print(Bundle.getMessage("CbusEventOn"));
             } else {
-                p.print(Bundle.getMessage("PowerStateOff"));
+                p.print(Bundle.getMessage("CbusEventOff"));
             }
             p.print(",");
             if (_comment[i] == null) {
@@ -444,6 +550,8 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
         for (int i = 0; i < this.getColumnCount(); i++) {
             columnStrings[i] = this.getColumnName(i);
         }
+        
+        
         w.setFontStyle(Font.BOLD);
         printColumns(w, columnStrings, columnWidth);
         w.setFontStyle(0);
@@ -453,18 +561,17 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
         // now print each row of data
         // create a base string the width of the column
         String spaces;
-        StringBuffer buf = new StringBuffer();
-        for (int i = 0; i < this.getRowCount() - 1; i++) {
-            //spaces = "";
-            for (int j = 0; j < columnWidth[i]; j++) {
-                //spaces = spaces + " ";
+
+        for (int i = 0; i < this.getRowCount(); i++) {
+            StringBuffer buf = new StringBuffer();
+            for (int j = 0; j < columnWidth[j]; j++) {
                 buf.append(" ");
             }
-            spaces = buf.toString();
+            
             for (int j = 0; j < this.getColumnCount(); j++) {
                 //check for special, non string contents
                 if (this.getValueAt(i, j) == null) {
-                    columnStrings[j] = spaces;
+                    columnStrings[j] = buf.toString();
                 } else if (this.getValueAt(i, j) instanceof JComboBox) {
                     columnStrings[j] = (String) ((JComboBox<String>) this.getValueAt(i, j)).getSelectedItem();
                 } else if (this.getValueAt(i, j) instanceof Boolean) {
@@ -474,7 +581,9 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
                 } else {
                     columnStrings[j] = (String) this.getValueAt(i, j);
                 }
+                // log.debug("588 columnStrings :{}:", columnStrings[j]);
             }
+            
             printColumns(w, columnStrings, columnWidth);
             w.write(w.getCurrentLineNumber(), 0, w.getCurrentLineNumber(),
                     w.getCharactersPerLine());
@@ -549,11 +658,12 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
     // private data
     private CanInterface tc = null;
     private int _rowCount = 0;
-    private int[] _id = null;
+    private int[] _canid = null;
+    private int[] _eventid = null;
     private int[] _node = null;
     private String[] _name = null;
     private int[] _event = null;
-    private boolean[] _type = null;
+    private int[] _type = null;
     private String[] _comment = null;
     private File _saveFile = null;
     private String _saveFileName = null;

--- a/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePane.java
@@ -1,23 +1,31 @@
 package jmri.jmrix.can.cbus.swing.eventtable;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.awt.FlowLayout;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
+
+import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JTextArea;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.table.JTableHeader;
+
 import jmri.jmrix.can.CanSystemConnectionMemo;
+
 import jmri.util.davidflanagan.HardcopyWriter;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +34,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Andrew Crosland (C) 2009
  * @author Kevin Dickerson (C) 2012
+ * @author Steve Young (C) 2018
  *
  * @since 2.99.2
  */
@@ -36,11 +45,12 @@ public class CbusEventTablePane extends jmri.jmrix.can.swing.CanPanel {
     JScrollPane eventScroll;
 
     protected String[] columnToolTips = {
-            Bundle.getMessage("IDColTip"),
-            Bundle.getMessage("NodeColTip"), // "Last Name" assumed obvious
-            Bundle.getMessage("NameColTip"),
+            Bundle.getMessage("ColumnEventIDTip"),
+            Bundle.getMessage("NodeColTip"), 
             Bundle.getMessage("EventColTip"),
             Bundle.getMessage("TypeColTip"),
+            Bundle.getMessage("NameColTip"),
+            Bundle.getMessage("IDColTip"),
             Bundle.getMessage("CommentColTip")
     }; // Length = number of items in array should (at least) match number of columns
 
@@ -48,15 +58,16 @@ public class CbusEventTablePane extends jmri.jmrix.can.swing.CanPanel {
     public String getTitle() {
         if (memo != null) {
             return (memo.getUserName() + " " + Bundle.getMessage("MenuItemEventTable"));
+        } else {
+            return Bundle.getMessage("MenuItemEventTable");
         }
-        return Bundle.getMessage("MenuItemEventTable");
     }
 
     @Override
     public void initComponents(CanSystemConnectionMemo memo) {
         super.initComponents(memo);
         eventModel = new CbusEventTableDataModel(memo, 20,
-                CbusEventTableDataModel.NUMCOLUMN);
+                CbusEventTableDataModel.NUMCOLUMN); // controller, row, column
         init();
     }
 
@@ -77,17 +88,30 @@ public class CbusEventTablePane extends jmri.jmrix.can.swing.CanPanel {
 
                     @Override
                     public String getToolTipText(MouseEvent e) {
-                        java.awt.Point p = e.getPoint();
-                        int index = columnModel.getColumnIndexAtX(p.x);
-                        int realIndex
+                        
+                        try {
+                            java.awt.Point p = e.getPoint();
+                            int index = columnModel.getColumnIndexAtX(p.x);
+                            int realIndex
                                 = columnModel.getColumn(index).getModelIndex();
-                        return columnToolTips[realIndex];
+                            return columnToolTips[realIndex];
+                            
+                        } catch (RuntimeException e1) {
+                            //catch null pointer exception if mouse is over an empty line
+                        }
+                        return null;
+
                     }
                 };
             }
         };
 
-// breaks build        eventTable.setAutoCreateRowSorter(false);
+        
+        
+        
+        
+        
+//      eventTable.setAutoCreateRowSorter(false);
         eventScroll = new JScrollPane(eventTable);
 
         // Allow selection of a single interval of columns
@@ -102,11 +126,45 @@ public class CbusEventTablePane extends jmri.jmrix.can.swing.CanPanel {
         //setTitle("CBUS Event table"); // TODO I18N
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
 
+        
+       
+        
+        /*
+        
+        
+        
+        JPanel paneTopAcross = new JPanel();
+        paneTopAcross.setLayout(new BoxLayout(paneTopAcross, BoxLayout.Y_AXIS));
+
+        JPanel topPane = new JPanel();
+        // Add a nice border
+        topPane.setBorder(BorderFactory.createTitledBorder(
+        BorderFactory.createEtchedBorder(), (" dfgh dfgh fgh fgh gfh ")));
+        add(topPane);
+        
+        JTextArea myTextarea = new JTextArea();
+        myTextarea.setText("Total events + options + space to drag to create new turnout sensor light");
+        myTextarea.setVisible(true);
+
+        topPane.add(myTextarea);
+        
+        */
+        
+        
+        
+        
         // add file menu items
         // install items in GUI
         JPanel pane1 = new JPanel();
         pane1.setLayout(new FlowLayout());
 
+        
+        
+        
+        
+        
+        
+        
         add(pane1);
         add(eventScroll);
 
@@ -115,10 +173,14 @@ public class CbusEventTablePane extends jmri.jmrix.can.swing.CanPanel {
         //pack();
     }
 
+    
+    
     @Override
     public String getHelpTarget() {
         return "package.jmri.jmrix.can.cbus.swing.eventtable.EventTablePane";
     }
+    
+    
 
     @Override
     public List<JMenu> getMenus() {
@@ -170,6 +232,8 @@ public class CbusEventTablePane extends jmri.jmrix.can.swing.CanPanel {
                 eventModel.printTable(writer); // close() is taken care of in printTable()
             }
         });
+        
+        
         JMenuItem previewItem = new JMenuItem(rb.getString("PreviewTable"));
         fileMenu.add(previewItem);
         previewItem.addActionListener(new ActionListener() {
@@ -190,26 +254,16 @@ public class CbusEventTablePane extends jmri.jmrix.can.swing.CanPanel {
         return menuList;
     }
 
-    @Override
-    public void initComponents() {
 
-    }
-
-    /**
-     * Find the existing CBUS event table object.
-     * @deprecated JMRI Since 4.4 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated
-    static public final CbusEventTablePane instance() {
-        return self;
-    }
     static private CbusEventTablePane self = null;
 
+    
     public void update() {
         eventModel.fireTableDataChanged();
         // TODO disable menuItem if table was saved and has not changed since
         // replacing menuItem by a new getMenus(). Note saveItem.setEnabled(eventModel.isTableDirty());
     }
+
 
     private boolean mShown = false;
 
@@ -234,11 +288,20 @@ public class CbusEventTablePane extends jmri.jmrix.can.swing.CanPanel {
 
     @Override
     public void dispose() {
+        
+        
+        String className = this.getClass().getSimpleName();
+        log.debug("dispose called {} ",className);
+        
+        
         eventModel.dispose();
         eventModel = null;
         eventTable = null;
         eventScroll = null;
         super.dispose();
+        
+        
+        
     }
 
     /**


### PR DESCRIPTION
Fixes #5563 Now each event is checked for duplicates before adding or updating.
Both on + off events are on same row.
New column for event status, updated when heard on network.
Fixes #5559 Better filtering of which Opscodes to use in table.
Fixes #5550 Print Preview on multi pages working + expanding row height issue sorted.

Added full list of event Opscodes  , does not change S / T / L operation.