### PR TITLE
make loconet simulator addressing match hardware addressing

### DIFF
--- a/java/src/jmri/jmrix/debugthrottle/DebugThrottleManager.java
+++ b/java/src/jmri/jmrix/debugthrottle/DebugThrottleManager.java
@@ -34,12 +34,12 @@ public class DebugThrottleManager extends AbstractThrottleManager {
     }
 
     /**
-     * Address 1 and above can be a long address
+     * Address 128 and above can be a long address
      *
      */
     @Override
     public boolean canBeLongAddress(int address) {
-        return (address >= 1);
+        return (address >= 128);
     }
 
     /**

--- a/java/src/jmri/jmrix/debugthrottle/DebugThrottleManager.java
+++ b/java/src/jmri/jmrix/debugthrottle/DebugThrottleManager.java
@@ -34,12 +34,12 @@ public class DebugThrottleManager extends AbstractThrottleManager {
     }
 
     /**
-     * Address 128 and above can be a long address
+     * Address 1 and above can be a long address
      *
      */
     @Override
     public boolean canBeLongAddress(int address) {
-        return (address >= 128);
+        return (address >= 1);
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileServer.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileServer.java
@@ -57,8 +57,19 @@ public class HexFileServer {
             jmri.InstanceManager.store(port.getSystemConnectionMemo().getProgrammerManager(), GlobalProgrammerManager.class);
         }
 
-        // Install a debug throttle manager, replacing the existing LocoNet one
-        port.getSystemConnectionMemo().setThrottleManager(new jmri.jmrix.debugthrottle.DebugThrottleManager(port.getSystemConnectionMemo()));
+        // Install a debug throttle manager, replacing the existing LocoNet one, and overriding edits
+        port.getSystemConnectionMemo().setThrottleManager(
+                new jmri.jmrix.debugthrottle.DebugThrottleManager(port.getSystemConnectionMemo() ) {
+                    /**
+                     * Address 128 and above can be a long address
+                     *
+                     */
+                    @Override
+                    public boolean canBeLongAddress(int address) {
+                        return (address >= 128);
+                    }
+
+                });
         jmri.InstanceManager.setThrottleManager(
                 port.getSystemConnectionMemo().getThrottleManager());
 


### PR DESCRIPTION
AFAICT, this member is only used for the LocoNet Simulator. I'd like for the behavior of the simulated connection to more closely match the hardware connection, particularly for use when testing EngineDriver.