### PR TITLE
Write legacy_bean_names.csv file

### DIFF
--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -107,7 +107,7 @@
       these "system names". JMRI code will map these to and from
       whatever information the hardware may need.</p>
 
-      <h2 id="format" name="format">System Name Format</h2>
+      <h2 id="format">System Name Format</h2>
       
       A system name is formed from a
       short "system prefix" representing the hardware system, followed by a

--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -107,7 +107,7 @@
       these "system names". JMRI code will map these to and from
       whatever information the hardware may need.</p>
 
-      <h2>System Name Format</h2>
+      <h2 id="format" name="format">System Name Format</h2>
       
       A system name is formed from a
       short "system prefix" representing the hardware system, followed by a

--- a/help/en/html/setup/MigrateSystemPrefixes.shtml
+++ b/help/en/html/setup/MigrateSystemPrefixes.shtml
@@ -1,0 +1,73 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+
+<html lang="en">
+<head>
+
+  <title>JMRI Setup - Migrating System Prefixes</title>
+  <meta name="keywords" content=
+  "java model railroad JMRI install Dropbox"><!-- Style -->
+  <meta http-equiv="Content-Type" content=
+  "text/html; charset=us-ascii">
+  <link rel="stylesheet" type="text/css" href="/css/default.css"
+  media="screen">
+  <link rel="stylesheet" type="text/css" href="/css/print.css"
+  media="print">
+  <link rel="icon" href="/images/jmri.ico" type="image/png">
+  <link rel="home" title="Home" href="/"><!-- /Style -->
+</head>
+
+<body>
+  <!--#include virtual="/Header" -->
+
+  <div id="mBody">
+    <!--#include virtual="Sidebar" -->
+
+    <div id="mainContent">
+      <!-- Page Body -->
+
+      <h1>JMRI Setup: Migrating System Prefixes</h1>
+
+      <a href="../doc/Technical/Names.shtml">JMRI system names</a>
+      are supposed to have a 
+      <a href="../doc/Technical/Names.shtml#format">specific format</a>
+      that starts with a "system prefix" consisting of a single
+      letter, optionally followed by digits.
+      Unfortunately, for a while JMRI wasn't enforcing that properly, and 
+      in a few cases JMRI set itself up with prefixes that contained
+      multiple letters.  This can cause significant 
+      long term problems, so we're getting people to migrate their 
+      configurations and panel files to the proper format.
+      
+      <h2 id="if" name="if">Does this affect me?</h2>
+      You can check if this is an issue for your setup any of a couple ways:
+      <ul>
+      <li>Open the Preferences, and look at each of the "Connection" panes.  If the connection prefix 
+            has a letter or a single letter plus digits, this doesn't affect you.
+            If it has more than a single letter, you should do this migration.
+            (With JMRI 4.13.4 or later, the background will be colored red 
+            and the tooltip will say "This is a legacy prefix that should be migrated, ask on JMRIusers" 
+            if the prefix needs to be migrated)
+      <li>Check the system log after running and quiting the program to see if there's a 
+            warning message about "The following system names need to be migrated..."
+            If it's there, you should do this migration.
+      </ul>
+      
+      <h2 id="do" name="do">How to fix the issue</h2>
+      
+      To fix this issue, you update your configuration and panel files to
+      use new prefixes.
+      <p>
+      <ul>
+      <li>First, you should be using JMRI 4.12 or later. If you're using an earlier
+            version, please update to at least JMRI 4.12 and fix any problems.
+      <li>Next, ask for help on the JMRIusers mailing list.  
+            There are people there who will happily do the necessary file modifications.
+      </ul>
+      
+      
+      <!--#include virtual="/Footer" -->
+    </div><!-- closes #mainContent-->
+  </div><!-- closes #mBody-->
+</body>
+</html>

--- a/help/en/html/setup/MigrateSystemPrefixes.shtml
+++ b/help/en/html/setup/MigrateSystemPrefixes.shtml
@@ -39,7 +39,7 @@
       long term problems, so we're getting people to migrate their 
       configurations and panel files to the proper format.
       
-      <h2 id="if" name="if">Does this affect me?</h2>
+      <h2 id="if">Does this affect me?</h2>
       You can check if this is an issue for your setup any of a couple ways:
       <ul>
       <li>Open the Preferences, and look at each of the "Connection" panes.  If the connection prefix 
@@ -53,11 +53,11 @@
             If it's there, you should do this migration.
       </ul>
       
-      <h2 id="do" name="do">How to fix the issue</h2>
+      <h2 id="do">How to fix the issue</h2>
       
       To fix this issue, you update your configuration and panel files to
       use new prefixes.
-      <p>
+
       <ul>
       <li>First, you should be using JMRI 4.12 or later. If you're using an earlier
             version, please update to at least JMRI 4.12 and fix any problems.

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -429,14 +429,23 @@ public interface Manager<E extends NamedBean> {
         return i;
     }
 
-    @Deprecated
+    @Deprecated  // as part of name migration, Issue #4670
     static Set<String> legacyNameSet = Collections.synchronizedSet(new HashSet<String>(200)); // want fast search and insert
-    @Deprecated
+    @Deprecated  // as part of name migration, Issue #4670
     static ShutDownTask legacyReportTask = new jmri.implementation.AbstractShutDownTask("Legacy Name List"){
                             public boolean execute() {
+                                if (legacyNameSet.size() == 0) return true;
+                                
                                 org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Manager.class);
                                 log.warn("The following legacy names need to be migrated:");
                                 for (String name : legacyNameSet) log.warn("    {}", name);
+                                
+                                // now create the legacy.csv file
+                                try (java.io.PrintWriter writer = new java.io.PrintWriter(jmri.util.FileUtil.getUserFilesPath()+java.io.File.separator+"legacy_bean_names.csv");) {
+                                    for (String name : legacyNameSet) writer.println(name);
+                                } catch (java.io.IOException e) {
+                                    log.error("Failed to write legacy name file", e);
+                                }
                                 return true;
                             }
                 };

--- a/java/src/jmri/jmrix/AbstractConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractConnectionConfig.java
@@ -26,8 +26,37 @@ abstract public class AbstractConnectionConfig implements ConnectionConfig {
      */
     public AbstractConnectionConfig() {
         try {
+            // The next commented-out line replacing the following when Issue #4670 is resolved; see Manager
             // systemPrefixField = new JFormattedTextField(new jmri.util.swing.RegexFormatter("[A-Za-z]\\d*"));
-            systemPrefixField = new JFormattedTextField(new SystemPrefixFormatter());
+            systemPrefixField = new JFormattedTextField(new SystemPrefixFormatter()) {
+                @Override
+                public void setValue(Object value) {
+                    log.debug("setValue {} {}", value, getBackground());
+                    if (getBackground().equals(java.awt.Color.RED)) { // only if might have set before, leaving default otherwise
+                        setBackground(java.awt.Color.WHITE); 
+                        setToolTipText(null);
+                    }
+                    super.setValue(value);
+                    // check for legacy, and if so paint red (will have not gotten here if not valid)
+                    if (jmri.Manager.isLegacySystemPrefix(value.toString())) {
+                        setBackground(java.awt.Color.RED);
+                        setToolTipText("This is a legacy prefix that should be migrated, ask on JMRIusers");
+                    }                    
+                }
+                public void setText(String value) {
+                    log.debug("setText {} {}", value, getBackground());
+                    if (getBackground().equals(java.awt.Color.RED)) { // only if might have set before, leaving default otherwise
+                        setBackground(java.awt.Color.WHITE); 
+                        setToolTipText(null);
+                    }
+                    super.setText(value);
+                    // check for legacy, and if so paint red (will have not gotten here if not valid)
+                    if (jmri.Manager.isLegacySystemPrefix(value.toString())) {
+                        setBackground(java.awt.Color.RED);
+                        setToolTipText("This is a legacy prefix that should be migrated, ask on JMRIusers");
+                    }                    
+                }
+            };
             
             systemPrefixField.setPreferredSize(new JTextField("P123").getPreferredSize());
             systemPrefixField.setFocusLostBehavior(JFormattedTextField.COMMIT_OR_REVERT);


### PR DESCRIPTION
This is the next step in the return to parsable system names, see Issue #4670