### PR TITLE
Improve handling of certain test warnings

### DIFF
--- a/java/src/jmri/ShutDownManager.java
+++ b/java/src/jmri/ShutDownManager.java
@@ -1,5 +1,7 @@
 package jmri;
 
+import java.util.List;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -52,10 +54,19 @@ public interface ShutDownManager {
     public void deregister(@Nullable ShutDownTask task);
 
     /**
+     * Provide access to the current registered shutdown tasks.
+     */
+    public List<ShutDownTask> tasks();
+    
+    /**
      * Run the shutdown tasks, and then terminate the program with status 100 if
      * not aborted. Does not return under normal circumstances. Does return
      * false if the shutdown was aborted by the user, in which case the program
      * should continue to operate.
+     * <p>
+     * By exiting the program with status 100, the batch file (MS Windows) or
+     * shell script (Linux/Mac OS X/UNIX) can catch the exit status and restart
+     * the java program.
      * <p>
      * <b>NOTE</b> If the OS X {@literal application->quit} menu item is used,
      * this must return false to abort the shutdown.

--- a/java/src/jmri/managers/DefaultShutDownManager.java
+++ b/java/src/jmri/managers/DefaultShutDownManager.java
@@ -1,15 +1,15 @@
 package jmri.managers;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.awt.Frame;
 import java.awt.GraphicsEnvironment;
 import java.awt.event.WindowEvent;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Objects;
+import java.util.*;
+
 import jmri.ShutDownManager;
 import jmri.ShutDownTask;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,6 +69,7 @@ public class DefaultShutDownManager implements ShutDownManager {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     synchronized public void register(ShutDownTask s) {
         Objects.requireNonNull(s, "Shutdown task cannot be null.");
@@ -79,6 +80,7 @@ public class DefaultShutDownManager implements ShutDownManager {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     synchronized public void deregister(ShutDownTask s) {
         if (s == null) {
@@ -90,28 +92,19 @@ public class DefaultShutDownManager implements ShutDownManager {
         }
     }
 
-    /**
-     * Run the shutdown tasks, and then terminate the program with status 0 if
-     * not aborted. Does not return under normal circumstances. Does return if
-     * the shutdown was aborted by the user, in which case the program should
-     * continue to operate.
-     */
+    /** {@inheritDoc} */
+    public List<ShutDownTask> tasks() {
+        return java.util.Collections.unmodifiableList(tasks);
+    }
+
+    /** {@inheritDoc} */
     @SuppressFBWarnings(value = "DM_EXIT", justification = "OK to directly exit standalone main")
     @Override
     public boolean shutdown() {
         return shutdown(0, true);
     }
 
-    /**
-     * Run the shutdown tasks, and then terminate the program with status 100 if
-     * not aborted. Does not return under normal circumstances. Does return if
-     * the shutdown was aborted by the user, in which case the program should
-     * continue to operate.
-     *
-     * By exiting the program with status 100, the batch file (MS Windows) or
-     * shell script (Linux/Mac OS X/UNIX) can catch the exit status and restart
-     * the java program.
-     */
+    /** {@inheritDoc} */
     @SuppressFBWarnings(value = "DM_EXIT", justification = "OK to directly exit standalone main")
     @Override
     public boolean restart() {
@@ -239,11 +232,7 @@ public class DefaultShutDownManager implements ShutDownManager {
         return true;
     }
 
-    /**
-     * Check if application is shutting down.
-     *
-     * @return true if shutting down; false otherwise
-     */
+    /** {@inheritDoc} */
     @Override
     public boolean isShuttingDown() {
         return shuttingDown;

--- a/java/test/jmri/jmrit/log/Log4JTreePaneTest.java
+++ b/java/test/jmri/jmrit/log/Log4JTreePaneTest.java
@@ -38,6 +38,9 @@ public class Log4JTreePaneTest extends jmri.util.swing.JmriPanelTest {
     @Override
     public void setUp() {
         JUnitUtil.setUp();
+        jmri.util.JUnitUtil.resetInstanceManager();
+        jmri.util.JUnitUtil.resetProfileManager();
+
         panel = new Log4JTreePane();
         title=Bundle.getMessage("MenuItemLogTreeAction");
         helpTarget="package.jmri.jmrit.log.Log4JTreePane";
@@ -46,6 +49,10 @@ public class Log4JTreePaneTest extends jmri.util.swing.JmriPanelTest {
     @After
     @Override
     public void tearDown() {
+        panel = null;
+        title = null;
+        helpTarget = null;
+        
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/logix/OpSessionLogTest.java
+++ b/java/test/jmri/jmrit/logix/OpSessionLogTest.java
@@ -26,19 +26,21 @@ public class OpSessionLogTest {
     @Test
     public void openAndClose() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        
-        // create a thread that waits to close the dialog box opened later
-        Thread t = new Thread(() -> {
-            // constructor for jdo will wait until the dialog is visible
-            JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("logSession"));
-            jdo.close();
-        });
-        t.setName("OpSessionLog File Chooser Dialog Close Thread");
-        t.start();
-        
+                
         // create the window and make the log file on Swing thread
         jmri.util.ThreadingUtil.runOnGUI(() -> {
             f = new jmri.util.JmriJFrame("OpSessionLog Chooser Test");
+            
+            // create a thread that waits to close the dialog box opened later
+            Thread t = new Thread(() -> {
+                // constructor for jdo will wait until the dialog is visible
+                JDialogOperator jdo = new JDialogOperator(Bundle.getMessage("logSession"));
+                jdo.close();
+            });
+            t.setName("OpSessionLog File Chooser Dialog Close Thread");
+            t.start();
+
+            // get the result of closing
             retval = OpSessionLog.makeLogFile(f);
         });
         
@@ -66,6 +68,7 @@ public class OpSessionLogTest {
 
     @After
     public void tearDown() {
+        f = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/can/cbus/CbusReporterManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusReporterManagerTest.java
@@ -36,7 +36,9 @@ public class CbusReporterManagerTest extends jmri.managers.AbstractReporterMgrTe
 
     @After
     public void tearDown() {
+        l = null;
         tc = null;
+        jmri.util.JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/dccpp/DCCppLightManagerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppLightManagerTest.java
@@ -65,6 +65,12 @@ public class DCCppLightManagerTest extends jmri.managers.AbstractLightMgrTestBas
 
     @After
     public void tearDown() {
+        l.dispose();
+        l = null;
+        xnis = null;
+        jmri.util.JUnitUtil.clearShutDownManager();
+        jmri.util.JUnitUtil.resetInstanceManager();
+        apps.tests.Log4JFixture.tearDown();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/dccpp/DCCppSensorManagerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppSensorManagerTest.java
@@ -111,6 +111,11 @@ public class DCCppSensorManagerTest extends jmri.managers.AbstractSensorMgrTestB
     @After
     public void tearDown() {
         l.dispose();
+        l = null;
+        xnis = null;
+        jmri.util.JUnitUtil.clearShutDownManager();
+        jmri.util.JUnitUtil.resetInstanceManager();
+        apps.tests.Log4JFixture.tearDown();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/pi/RaspberryPiSensorManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiSensorManagerTest.java
@@ -125,8 +125,9 @@ public class RaspberryPiSensorManagerTest extends jmri.managers.AbstractSensorMg
 
     @After
     public void tearDown() {
-       jmri.util.JUnitUtil.resetInstanceManager();
-       apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.clearShutDownManager();
+        jmri.util.JUnitUtil.resetInstanceManager();
+        apps.tests.Log4JFixture.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
@@ -115,8 +115,9 @@ public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnout
 
     @After
     public void tearDown() {
+        jmri.util.JUnitUtil.clearShutDownManager();
         jmri.util.JUnitUtil.resetInstanceManager();
-        JUnitUtil.tearDown();
+        apps.tests.Log4JFixture.tearDown();
     }
 
 

--- a/java/test/jmri/managers/DefaultShutDownManagerTest.java
+++ b/java/test/jmri/managers/DefaultShutDownManagerTest.java
@@ -33,6 +33,7 @@ public class DefaultShutDownManagerTest {
         DefaultShutDownManager dsdm = new DefaultShutDownManager();
         List<?> tasks = this.exposeTasks(dsdm);
         Assert.assertEquals(0, tasks.size());
+        Assert.assertEquals(0, dsdm.tasks().size());
         ShutDownTask task = new QuietShutDownTask("task") {
             @Override
             public boolean execute() {
@@ -41,8 +42,10 @@ public class DefaultShutDownManagerTest {
         };
         dsdm.register(task);
         Assert.assertEquals(1, tasks.size());
+        Assert.assertEquals(1, dsdm.tasks().size());
         dsdm.register(task);
         Assert.assertEquals(1, tasks.size());
+        Assert.assertEquals(1, dsdm.tasks().size());
         try {
             dsdm.register(null);
             Assert.fail("Expected NullPointerException not thrown");

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -470,8 +470,11 @@ public class JUnitUtil {
     public static void clearShutDownManager() {
         ShutDownManager sm = InstanceManager.getNullableDefault(jmri.ShutDownManager.class);
         if (sm == null) return;
-        List<ShutDownTask> tasks = sm.tasks();
-        for (ShutDownTask t : tasks) sm.deregister(t);
+        List<ShutDownTask> list = sm.tasks();
+        while (list != null && list.size() > 0) {
+            sm.deregister(list.get(0));
+            list = sm.tasks();  // avoid ConcurrentModificationException
+        }
     }
 
     /**

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1,33 +1,18 @@
 package jmri.util;
 
-import apps.gui.GuiLafPreferencesManager;
-import apps.tests.Log4JFixture;
 import java.awt.Frame;
 import java.awt.Window;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
+import java.util.*;
 import javax.annotation.Nonnull;
-import jmri.ConditionalManager;
-import jmri.ConfigureManager;
-import jmri.GlobalProgrammerManager;
-import jmri.InstanceManager;
-import jmri.JmriException;
-import jmri.LogixManager;
-import jmri.MemoryManager;
-import jmri.NamedBean;
-import jmri.PowerManager;
-import jmri.PowerManagerScaffold;
-import jmri.ReporterManager;
-import jmri.RouteManager;
-import jmri.ShutDownManager;
-import jmri.SignalHeadManager;
-import jmri.SignalMastLogicManager;
-import jmri.SignalMastManager;
-import jmri.TurnoutOperationManager;
-import jmri.UserPreferencesManager;
+
+import apps.gui.GuiLafPreferencesManager;
+import apps.tests.Log4JFixture;
+
+import jmri.*;
 import jmri.implementation.JmriConfigurationManager;
 import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
 import jmri.jmrit.logix.OBlockManager;
@@ -52,6 +37,7 @@ import jmri.progdebugger.DebugProgrammerManager;
 import jmri.util.prefs.JmriConfigurationProvider;
 import jmri.util.prefs.JmriPreferencesProvider;
 import jmri.util.prefs.JmriUserInterfaceConfigurationProvider;
+
 import org.junit.Assert;
 import org.netbeans.jemmy.FrameWaiter;
 import org.netbeans.jemmy.TestOut;
@@ -476,6 +462,23 @@ public class JUnitUtil {
         }
     }
 
+    /**
+     * Leaves ShutDownManager, if any, in place,
+     * but removes its contents.
+     * {@see #initShutDownManager()}
+     */
+    public static void clearShutDownManager() {
+        ShutDownManager sm = InstanceManager.getNullableDefault(jmri.ShutDownManager.class);
+        if (sm == null) return;
+        List<ShutDownTask> tasks = sm.tasks();
+        for (ShutDownTask t : tasks) sm.deregister(t);
+    }
+
+    /**
+     * Creates a new ShutDownManager.
+     * Does not remove the contents (i.e. kill the future actions) of any existing ShutDownManager.
+     * {@see #clearShutDownManager()}
+     */
     public static void initShutDownManager() {
         if (InstanceManager.getNullableDefault(ShutDownManager.class) == null) {
             InstanceManager.setDefault(ShutDownManager.class, new MockShutDownManager());

--- a/java/test/jmri/util/MockShutDownManager.java
+++ b/java/test/jmri/util/MockShutDownManager.java
@@ -13,7 +13,7 @@ import jmri.ShutDownTask;
  * the method to test. To clear the state of shutting down, call
  * {@link #resetShuttingDown()}.</p>
  * <p>
- * The list of registered tasts is exposed via {@link #shutDownTasks()} to allow
+ * The modifiable list of registered tasts is exposed via {@link #shutDownTasks()} to allow
  * verification that a method that registers or deregisters a ShutDownTask as a
  * side effect did so correctly.</p>
  *
@@ -37,6 +37,11 @@ public class MockShutDownManager implements ShutDownManager {
         this.tasks.remove(task);
     }
 
+    @Override
+    public List<ShutDownTask> tasks() {
+        return java.util.Collections.unmodifiableList(tasks);
+    }
+    
     @Override
     public boolean restart() {
         this.isShuttingDown = true;

--- a/java/test/jmri/util/SystemNameComparatorTest.java
+++ b/java/test/jmri/util/SystemNameComparatorTest.java
@@ -87,6 +87,7 @@ public class SystemNameComparatorTest {
 
     @After
     public void tearDown() {
+        jmri.util.JUnitUtil.clearShutDownManager();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/util/swing/sdi/SdiJfcUnitTest.java
+++ b/java/test/jmri/util/swing/sdi/SdiJfcUnitTest.java
@@ -83,7 +83,9 @@ public class SdiJfcUnitTest extends jmri.util.SwingTestCase {
     protected void setUp() throws Exception {
         super.setUp();
         apps.tests.Log4JFixture.setUp();
-        //jmri.util.JUnitUtil.resetInstanceManager();
+        jmri.util.JUnitUtil.resetInstanceManager();
+        jmri.util.JUnitUtil.resetProfileManager();
+        
         //jmri.util.JUnitUtil.initInternalTurnoutManager();
         //jmri.util.JUnitUtil.initInternalSensorManager();
         jmri.util.swing.SamplePane.disposed = new java.util.ArrayList<>();


### PR DESCRIPTION
No functional changes intended.

- Adds a JUnitUtil.clearShutDownManager() method to clean up when needed post-test
- Adds a ShutDownManager#tasks() method to get an UnmodifiableList of current ShutDownTasks