### PR TITLE
More work to reduce test verbosity

### DIFF
--- a/java/src/jmri/profile/ProfileManager.java
+++ b/java/src/jmri/profile/ProfileManager.java
@@ -133,6 +133,7 @@ public class ProfileManager extends Bean {
      *
      * @return the in use Profile or null if there is no Profile in use
      */
+    @Nonnull
     public Profile getActiveProfile() {
         if (activeProfile == null) {
             throw new NullPointerException("activeProfile is null");
@@ -150,6 +151,7 @@ public class ProfileManager extends Bean {
      * @return the name of the active profile or null if there is no active
      *         profile
      */
+    @Nonnull
     public String getActiveProfileName() {
         if (activeProfile == null) {
             throw new NullPointerException("activeProfile is null");

--- a/java/src/jmri/util/node/NodeIdentity.java
+++ b/java/src/jmri/util/node/NodeIdentity.java
@@ -413,13 +413,14 @@ public class NodeIdentity {
         String uniqueId = "-";
         try {
             uniqueId += ProfileManager.getDefault().getActiveProfile().getUniqueId();
-        } catch (NullPointerException ex) {
+        } catch (NullPointerException ex) { // because there is no active profile
             uniqueId += ProfileManager.createUniqueId();
+            log.debug("created uniqueID \"{}\" because of there (probably) is no active profile", uniqueId);
         }
         List<String> formerIdList = NodeIdentity.formerIdentities();
         int listSize = formerIdList.size();
         if (listSize < 1) {
-            log.warn("Unable to copy from a former identity; no former identities found.");
+            log.debug("Unable to copy from a former identity; no former identities found.");
             return false;
         }
         log.debug("{} former identies found", listSize);

--- a/java/src/jmri/util/prefs/AbstractConfigurationProvider.java
+++ b/java/src/jmri/util/prefs/AbstractConfigurationProvider.java
@@ -38,11 +38,13 @@ public abstract class AbstractConfigurationProvider {
             if (!shared) {
                 File nodeDir = new File(dir, NodeIdentity.identity());
                 if (!nodeDir.exists()) {
-                    NodeIdentity.copyFormerIdentity(dir, nodeDir);
+                    boolean success = NodeIdentity.copyFormerIdentity(dir, nodeDir);
+                    if (! success) log.debug("copyFormerIdentity({}, {}) did not copy", dir, nodeDir);
                 }
                 dir = new File(dir, NodeIdentity.identity());
             }
         }
+        log.debug("createDirectory(\"{}\")", dir);
         FileUtil.createDirectory(dir);
         return dir;
     }
@@ -75,4 +77,5 @@ public abstract class AbstractConfigurationProvider {
         this.sharedBackedUp = sharedBackedUp;
     }
 
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(AbstractConfigurationProvider.class);
 }

--- a/java/src/jmri/util/prefs/JmriPreferencesProvider.java
+++ b/java/src/jmri/util/prefs/JmriPreferencesProvider.java
@@ -21,8 +21,6 @@ import jmri.profile.Profile;
 import jmri.util.FileUtil;
 import jmri.util.OrderedProperties;
 import jmri.util.node.NodeIdentity;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Provides instances of {@link java.util.prefs.Preferences} backed by a
@@ -53,9 +51,7 @@ public final class JmriPreferencesProvider {
 
     private static final HashMap<File, JmriPreferencesProvider> SHARED_PROVIDERS = new HashMap<>();
     private static final HashMap<File, JmriPreferencesProvider> PRIVATE_PROVIDERS = new HashMap<>();
-    //private static final String INVALID_KEY_CHARACTERS = "_.";
-    private static final Logger log = LoggerFactory.getLogger(JmriPreferencesProvider.class);
-
+ 
     /**
      * Get the JmriPreferencesProvider for the specified profile path. Use of
      *
@@ -261,11 +257,13 @@ public final class JmriPreferencesProvider {
             if (!this.shared) {
                 File nodeDir = new File(dir, NodeIdentity.identity());
                 if (!nodeDir.exists()) {
-                    NodeIdentity.copyFormerIdentity(dir, nodeDir);
+                    boolean success = NodeIdentity.copyFormerIdentity(dir, nodeDir);
+                    if (! success) log.debug("copyFormerIdentity({}, {}) did not copy", dir, nodeDir);
                 }
                 dir = new File(dir, NodeIdentity.identity());
-                }
             }
+        }
+        log.debug("createDirectory(\"{}\")", dir);
         FileUtil.createDirectory(dir);
         return dir;
     }
@@ -285,9 +283,7 @@ public final class JmriPreferencesProvider {
     }
 
     private class JmriPreferences extends AbstractPreferences {
-
-        private final Logger log = LoggerFactory.getLogger(JmriPreferences.class);
-
+    
         private Map<String, String> root;
         private Map<String, JmriPreferences> children;
         private boolean isRemoved = false;
@@ -466,6 +462,8 @@ public final class JmriPreferencesProvider {
                 }
             }
         }
+        private final  org.slf4j.Logger log =  org.slf4j.LoggerFactory.getLogger(JmriPreferences.class);
     }
 
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(JmriPreferencesProvider.class);
 }

--- a/java/test/jmri/jmrix/rps/swing/AffineEntryPanelTest.java
+++ b/java/test/jmri/jmrix/rps/swing/AffineEntryPanelTest.java
@@ -3,10 +3,9 @@ package jmri.jmrix.rps.swing;
 import java.awt.GraphicsEnvironment;
 import java.awt.geom.AffineTransform;
 import javax.swing.JFrame;
+import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.*;
 
 /**
  * Tests for the jmri.jmrix.rps.swing.AffineEntryPanel class
@@ -53,4 +52,14 @@ public class AffineEntryPanelTest {
         Assert.assertTrue(p.getTransform().equals(t));
     }
 
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
 }

--- a/java/test/jmri/jmrix/secsi/SerialMessageTest.java
+++ b/java/test/jmri/jmrix/secsi/SerialMessageTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.secsi;
 
+import jmri.util.JUnitUtil;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -43,4 +44,12 @@ public class SerialMessageTest extends TestCase {
         return suite;
     }
 
+    // The minimal setup for log4J
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
 }

--- a/java/test/jmri/jmrix/secsi/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/secsi/SerialTurnoutTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.secsi;
 
 import jmri.implementation.AbstractTurnoutTestBase;
+import jmri.util.JUnitUtil;
 import org.junit.Before;
 
 /**
@@ -15,6 +16,7 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
     @Before
     @Override
     public void setUp() {
+        JUnitUtil.setUp();
         // prepare an interface
         SecsiSystemConnectionMemo memo = new SecsiSystemConnectionMemo();
         tcis = new SerialTrafficControlScaffold(memo);

--- a/java/test/jmri/jmrix/tmcc/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/tmcc/SerialTurnoutTest.java
@@ -18,6 +18,7 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
     @Before
     @Override
     public void setUp() {
+        JUnitUtil.setUp();
         // prepare an interface
         memo = new TmccSystemConnectionMemo("T", "TMCC Test");
         tcis = new SerialTrafficControlScaffold(memo);
@@ -49,6 +50,7 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
     @After
     public void tearDown() {
         t.dispose();
+        t = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -90,7 +90,7 @@ public class JUnitUtil {
         // ideally this would be false, true to force an error if an earlier
         // test left a window open, but different platforms seem to have just
         // enough differences that this is, for now, only emitting a warning
-        resetWindows(true, false);
+        resetWindows(false, false);
         resetInstanceManager();
     }
 
@@ -99,7 +99,7 @@ public class JUnitUtil {
      * annotated method.
      */
     public static void tearDown() {
-        resetWindows(true, false); // warn
+        resetWindows(false, false);
         resetInstanceManager();
         Log4JFixture.tearDown();
     }


### PR DESCRIPTION
- routine WARN messages due to left-open windows now omitted; can easily be turned back on if people want to work on that
- WARN messages about no previous profile are benign in any case, set to debug