### PR TITLE
Fix NX setup colors

### DIFF
--- a/java/src/jmri/jmrit/entryexit/DestinationPoints.java
+++ b/java/src/jmri/jmrit/entryexit/DestinationPoints.java
@@ -317,7 +317,13 @@ public class DestinationPoints extends jmri.implementation.AbstractNamedBean imp
         final List<Color> realColorXtra = new ArrayList<Color>();
         final List<LayoutBlock> routeBlocks = new ArrayList<>();
         if (manager.useDifferentColorWhenSetting()) {
+            boolean first = true;
             for (LayoutBlock lbk : routeDetails) {
+                if (first) {
+                    // Don't change the color for the facing block
+                    first = false;
+                    continue;
+                }
                 routeBlocks.add(lbk);
                 realColorXtra.add(lbk.getBlockExtraColor());
                 realColorStd.add(lbk.getBlockTrackColor());

--- a/xml/decoders/RR-CirKits-MotorMan.xml
+++ b/xml/decoders/RR-CirKits-MotorMan.xml
@@ -1161,7 +1161,7 @@
       </variable>
 
       <variable label="PB1 Output-Input" CV="195" mask="XVXXXXXX" default="0">
-        <enumVal> 
+        <enumVal>
           <enumChoice choice="Output"/>
         </enumVal>
       </variable>
@@ -1289,7 +1289,7 @@
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceMode.xml"/>
       </variable>
       <variable label="PB2 Output-Input" CV="203" mask="XVXXXXXX" default="0">
-        <enumVal> 
+        <enumVal>
           <enumChoice choice="Output"/>
         </enumVal>
       </variable>
@@ -1414,7 +1414,7 @@
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceMode.xml"/>
       </variable>
       <variable label="PB3 Output-Input" CV="211" mask="XVXXXXXX" default="0">
-        <enumVal> 
+        <enumVal>
           <enumChoice choice="Output"/>
         </enumVal>
       </variable>
@@ -1539,7 +1539,7 @@
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceMode.xml"/>
       </variable>
       <variable label="PB4 Output-Input" CV="219" mask="XVXXXXXX" default="0">
-        <enumVal> 
+        <enumVal>
           <enumChoice choice="Output"/>
         </enumVal>
       </variable>
@@ -1666,7 +1666,7 @@
       </variable>
 
       <variable label="PB5 Output-Input" CV="227" mask="XVXXXXXX" default="0">
-        <enumVal> 
+        <enumVal>
           <enumChoice choice="Output"/>
         </enumVal>
       </variable>
@@ -1794,7 +1794,7 @@
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceMode.xml"/>
       </variable>
       <variable label="PB6 Output-Input" CV="235" mask="XVXXXXXX" default="0">
-        <enumVal> 
+        <enumVal>
           <enumChoice choice="Output"/>
         </enumVal>
       </variable>
@@ -1919,7 +1919,7 @@
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceMode.xml"/>
       </variable>
       <variable label="PB7 Output-Input" CV="243" mask="XVXXXXXX" default="0">
-        <enumVal> 
+        <enumVal>
           <enumChoice choice="Output"/>
         </enumVal>
       </variable>
@@ -2044,7 +2044,7 @@
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceMode.xml"/>
       </variable>
       <variable label="PB8 Output-Input" CV="251" mask="XVXXXXXX" default="0">
-        <enumVal> 
+        <enumVal>
           <enumChoice choice="Output"/>
         </enumVal>
       </variable>
@@ -7040,7 +7040,7 @@
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceLMode.xml"/><label>LT27 Var2 Type</label></variable>
       <variable item="LT27 Var2 Event" CV="472" mask="XXXVXXXX" default="0">
         <qualifier>
-          <variableref>LT27 Var22 Mode</variableref>
+          <variableref>LT27 Var2 Mode</variableref>
           <relation>eq</relation>
           <value>0</value>
         </qualifier>
@@ -7957,9 +7957,9 @@
           <value>1</value>
         </qualifier>
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceAspect.xml"/><label>LT32 Var2 Aspect</label></variable>
- 
+
       <!-- End of Logic Table Variables -->
- 
+
 
       <!-- Presets for Composite Variables -->
       <variable label="IP1 Type">
@@ -8037,7 +8037,7 @@
             <compositeSetting label="PA1 Type" value="0"/>
             <compositeSetting label="PA1 Timing" value="1"/>
             <compositeSetting label="PA2 Type" value="0"/>
-            <compositeSetting label="PA2 Timing" value="1"/> 
+            <compositeSetting label="PA2 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Dual Inverted">
             <compositeSetting label="PA1 Output-Input" value="0"/>
@@ -8051,7 +8051,7 @@
             <compositeSetting label="PA1 Type" value="0"/>
             <compositeSetting label="PA1 Timing" value="1"/>
             <compositeSetting label="PA2 Type" value="0"/>
-            <compositeSetting label="PA2 Timing" value="1"/> 
+            <compositeSetting label="PA2 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Signal">
             <compositeSetting label="PA1 Output-Input" value="0"/>
@@ -8146,7 +8146,7 @@
             <compositeSetting label="PA1 Type" value="0"/>
             <compositeSetting label="PA1 Timing" value="1"/>
             <compositeSetting label="PA2 Type" value="0"/>
-            <compositeSetting label="PA2 Timing" value="1"/> 
+            <compositeSetting label="PA2 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Dual Inverted">
             <compositeSetting label="PA1 Output-Input" value="0"/>
@@ -8160,7 +8160,7 @@
             <compositeSetting label="PA1 Type" value="0"/>
             <compositeSetting label="PA1 Timing" value="1"/>
             <compositeSetting label="PA2 Type" value="0"/>
-            <compositeSetting label="PA2 Timing" value="1"/> 
+            <compositeSetting label="PA2 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Signal">
             <compositeSetting label="PA1 Output-Input" value="0"/>
@@ -8255,7 +8255,7 @@
             <compositeSetting label="PA3 Type" value="0"/>
             <compositeSetting label="PA3 Timing" value="1"/>
             <compositeSetting label="PA4 Type" value="0"/>
-            <compositeSetting label="PA4 Timing" value="1"/> 
+            <compositeSetting label="PA4 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Dual Inverted">
             <compositeSetting label="PA3 Output-Input" value="0"/>
@@ -8269,7 +8269,7 @@
             <compositeSetting label="PA3 Type" value="0"/>
             <compositeSetting label="PA3 Timing" value="1"/>
             <compositeSetting label="PA4 Type" value="0"/>
-            <compositeSetting label="PA4 Timing" value="1"/> 
+            <compositeSetting label="PA4 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Signal">
             <compositeSetting label="PA3 Output-Input" value="0"/>
@@ -8364,7 +8364,7 @@
             <compositeSetting label="PA3 Type" value="0"/>
             <compositeSetting label="PA3 Timing" value="1"/>
             <compositeSetting label="PA4 Type" value="0"/>
-            <compositeSetting label="PA4 Timing" value="1"/> 
+            <compositeSetting label="PA4 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Dual Inverted">
             <compositeSetting label="PA3 Output-Input" value="0"/>
@@ -8378,7 +8378,7 @@
             <compositeSetting label="PA3 Type" value="0"/>
             <compositeSetting label="PA3 Timing" value="1"/>
             <compositeSetting label="PA4 Type" value="0"/>
-            <compositeSetting label="PA4 Timing" value="1"/> 
+            <compositeSetting label="PA4 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Signal">
             <compositeSetting label="PA3 Output-Input" value="0"/>
@@ -8473,7 +8473,7 @@
             <compositeSetting label="PA5 Type" value="0"/>
             <compositeSetting label="PA5 Timing" value="1"/>
             <compositeSetting label="PA6 Type" value="0"/>
-            <compositeSetting label="PA6 Timing" value="1"/> 
+            <compositeSetting label="PA6 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Dual Inverted">
             <compositeSetting label="PA5 Output-Input" value="0"/>
@@ -8487,7 +8487,7 @@
             <compositeSetting label="PA5 Type" value="0"/>
             <compositeSetting label="PA5 Timing" value="1"/>
             <compositeSetting label="PA6 Type" value="0"/>
-            <compositeSetting label="PA6 Timing" value="1"/> 
+            <compositeSetting label="PA6 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Signal">
             <compositeSetting label="PA5 Output-Input" value="0"/>
@@ -8582,7 +8582,7 @@
             <compositeSetting label="PA5 Type" value="0"/>
             <compositeSetting label="PA5 Timing" value="1"/>
             <compositeSetting label="PA6 Type" value="0"/>
-            <compositeSetting label="PA6 Timing" value="1"/> 
+            <compositeSetting label="PA6 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Dual Inverted">
             <compositeSetting label="PA5 Output-Input" value="0"/>
@@ -8596,7 +8596,7 @@
             <compositeSetting label="PA5 Type" value="0"/>
             <compositeSetting label="PA5 Timing" value="1"/>
             <compositeSetting label="PA6 Type" value="0"/>
-            <compositeSetting label="PA6 Timing" value="1"/> 
+            <compositeSetting label="PA6 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Signal">
             <compositeSetting label="PA5 Output-Input" value="0"/>
@@ -8691,7 +8691,7 @@
             <compositeSetting label="PA7 Type" value="0"/>
             <compositeSetting label="PA7 Timing" value="1"/>
             <compositeSetting label="PA8 Type" value="0"/>
-            <compositeSetting label="PA8 Timing" value="1"/> 
+            <compositeSetting label="PA8 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Dual Inverted">
             <compositeSetting label="PA7 Output-Input" value="0"/>
@@ -8705,7 +8705,7 @@
             <compositeSetting label="PA7 Type" value="0"/>
             <compositeSetting label="PA7 Timing" value="1"/>
             <compositeSetting label="PA8 Type" value="0"/>
-            <compositeSetting label="PA8 Timing" value="1"/> 
+            <compositeSetting label="PA8 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Signal">
             <compositeSetting label="PA7 Output-Input" value="0"/>
@@ -8800,7 +8800,7 @@
             <compositeSetting label="PA7 Type" value="0"/>
             <compositeSetting label="PA7 Timing" value="1"/>
             <compositeSetting label="PA8 Type" value="0"/>
-            <compositeSetting label="PA8 Timing" value="1"/> 
+            <compositeSetting label="PA8 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Dual Inverted">
             <compositeSetting label="PA7 Output-Input" value="0"/>
@@ -8814,7 +8814,7 @@
             <compositeSetting label="PA7 Type" value="0"/>
             <compositeSetting label="PA7 Timing" value="1"/>
             <compositeSetting label="PA8 Type" value="0"/>
-            <compositeSetting label="PA8 Timing" value="1"/> 
+            <compositeSetting label="PA8 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Signal">
             <compositeSetting label="PA7 Output-Input" value="0"/>
@@ -9440,7 +9440,7 @@
             <compositeSetting label="PA1 Type" value="0"/>
             <compositeSetting label="PA1 Timing" value="1"/>
             <compositeSetting label="PA2 Type" value="0"/>
-            <compositeSetting label="PA2 Timing" value="1"/> 
+            <compositeSetting label="PA2 Timing" value="1"/>
             <compositeSetting label="PA3 Output-Input" value="0"/>
             <compositeSetting label="PA4 Output-Input" value="0"/>
             <compositeSetting label="PA3 Paired" value="2"/>
@@ -9452,7 +9452,7 @@
             <compositeSetting label="PA3 Type" value="0"/>
             <compositeSetting label="PA3 Timing" value="1"/>
             <compositeSetting label="PA4 Type" value="0"/>
-            <compositeSetting label="PA4 Timing" value="1"/> 
+            <compositeSetting label="PA4 Timing" value="1"/>
             <compositeSetting label="PA5 Output-Input" value="0"/>
             <compositeSetting label="PA6 Output-Input" value="0"/>
             <compositeSetting label="PA5 Paired" value="2"/>
@@ -9464,7 +9464,7 @@
             <compositeSetting label="PA5 Type" value="0"/>
             <compositeSetting label="PA5 Timing" value="1"/>
             <compositeSetting label="PA6 Type" value="0"/>
-            <compositeSetting label="PA6 Timing" value="1"/> 
+            <compositeSetting label="PA6 Timing" value="1"/>
             <compositeSetting label="PA7 Output-Input" value="0"/>
             <compositeSetting label="PA8 Output-Input" value="0"/>
             <compositeSetting label="PA7 Paired" value="2"/>
@@ -9476,7 +9476,7 @@
             <compositeSetting label="PA7 Type" value="0"/>
             <compositeSetting label="PA7 Timing" value="1"/>
             <compositeSetting label="PA8 Type" value="0"/>
-            <compositeSetting label="PA8 Timing" value="1"/> 
+            <compositeSetting label="PA8 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Dual Inverted">
             <compositeSetting label="PA1 Output-Input" value="0"/>
@@ -9490,7 +9490,7 @@
             <compositeSetting label="PA1 Type" value="0"/>
             <compositeSetting label="PA1 Timing" value="1"/>
             <compositeSetting label="PA2 Type" value="0"/>
-            <compositeSetting label="PA2 Timing" value="1"/> 
+            <compositeSetting label="PA2 Timing" value="1"/>
             <compositeSetting label="PA3 Output-Input" value="0"/>
             <compositeSetting label="PA4 Output-Input" value="0"/>
             <compositeSetting label="PA3 Paired" value="2"/>
@@ -9502,7 +9502,7 @@
             <compositeSetting label="PA3 Type" value="0"/>
             <compositeSetting label="PA3 Timing" value="1"/>
             <compositeSetting label="PA4 Type" value="0"/>
-            <compositeSetting label="PA4 Timing" value="1"/> 
+            <compositeSetting label="PA4 Timing" value="1"/>
             <compositeSetting label="PA5 Output-Input" value="0"/>
             <compositeSetting label="PA6 Output-Input" value="0"/>
             <compositeSetting label="PA5 Paired" value="2"/>
@@ -9514,7 +9514,7 @@
             <compositeSetting label="PA5 Type" value="0"/>
             <compositeSetting label="PA5 Timing" value="1"/>
             <compositeSetting label="PA6 Type" value="0"/>
-            <compositeSetting label="PA6 Timing" value="1"/> 
+            <compositeSetting label="PA6 Timing" value="1"/>
             <compositeSetting label="PA7 Output-Input" value="0"/>
             <compositeSetting label="PA8 Output-Input" value="0"/>
             <compositeSetting label="PA7 Paired" value="2"/>
@@ -9526,7 +9526,7 @@
             <compositeSetting label="PA7 Type" value="0"/>
             <compositeSetting label="PA7 Timing" value="1"/>
             <compositeSetting label="PA8 Type" value="0"/>
-            <compositeSetting label="PA8 Timing" value="1"/> 
+            <compositeSetting label="PA8 Timing" value="1"/>
           </compositeChoice>
           <compositeChoice choice="Signal">
             <compositeSetting label="PA1 Output-Input" value="0"/>
@@ -9581,7 +9581,7 @@
           <compositeChoice choice="(Custom)" comment="If no other choice matches"/>
         </compositeVal>
       </variable>
- 
+
       <variable label="IOP2 Port Type">
         <compositeVal>
 
@@ -9749,7 +9749,7 @@
       <row>
         <column>
       	<label label=" "/>
-         <group>      	
+         <group>
            <qualifier>
              <variableref>Hardware ID</variableref>
              <relation>ne</relation>
@@ -9877,7 +9877,7 @@
             </label>
             <label label="&lt;html&gt;&lt;span style=&quot;color: red;&quot;&gt;&lt;strong&gt;Due to internal changes, check for proper message and logic operation following this upgrade.&lt;/span&gt;&lt;/strong&gt;&lt;/html&gt;">
             </label>
-          </group>          
+          </group>
           <group>
             <qualifier>
               <variableref>Hardware ID</variableref>
@@ -9890,7 +9890,7 @@
               <display label="Total Output Current Limit" item="Total Output Current" tooltip="Sets Total Output Current Limit."/>
               <label label="    (Automatic 5A limit during Dual Coil pulses)"/>
             </column>
-          </group>          
+          </group>
           <group>
             <qualifier>
               <variableref>Hardware ID</variableref>
@@ -9908,7 +9908,7 @@
               </label>
               <label label="&lt;html&gt;&lt;span style=&quot;color: red;&quot;&gt;&lt;strong&gt;Note: This unit has a firmware upgrade available that includes important bug fixes and feature upgrades. &lt;/span&gt;&lt;/strong&gt;&lt;/html&gt;">
               </label>
-          </group>          
+          </group>
         </column>
       </row>
       <row>

--- a/xml/decoders/RR-CirKits-SignalMan-basic.xml
+++ b/xml/decoders/RR-CirKits-SignalMan-basic.xml
@@ -8492,7 +8492,7 @@
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceLMode.xml"/><label>LT27 Var2 Type</label></variable>
       <variable item="LT27 Var2 Event" CV="472" mask="XXXVXXXX" default="0">
         <qualifier>
-          <variableref>LT27 Var22 Mode</variableref>
+          <variableref>LT27 Var2 Mode</variableref>
           <relation>eq</relation>
           <value>0</value>
         </qualifier>

--- a/xml/decoders/RR-CirKits-TowerMan-basic.xml
+++ b/xml/decoders/RR-CirKits-TowerMan-basic.xml
@@ -1159,7 +1159,7 @@
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceMode.xml"/>
         <label>PB1 Mode</label>
       </variable>
- 
+
       <variable item="PB1 Output-Input" CV="195" mask="XVXXXXXX">
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceOutputInput.xml"/>
         <label>PB1 Output-Input</label>
@@ -1195,7 +1195,7 @@
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/Choice1Transition.xml"/>
         <label>PB1 Transition</label>
       </variable>
- 
+
       <variable item="PB1 Paired" CV="194" mask="VVXXXXXX">
         <qualifier>
           <variableref>PB1 Output-Input</variableref>
@@ -2230,7 +2230,7 @@
         <label>PB8 Secondary 2 Type</label>
       </variable>
       <!-- End Outputs -->
-  
+
       <!-- Logic Table entry #1 -->
       <variable item="LT1 Block End" CV="257" mask="XVXXXXXX" default="1">
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceEnd.xml"/>
@@ -7108,7 +7108,7 @@
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceLMode.xml"/><label>LT27 Var2 Type</label></variable>
       <variable item="LT27 Var2 Event" CV="472" mask="XXXVXXXX" default="0">
         <qualifier>
-          <variableref>LT27 Var22 Mode</variableref>
+          <variableref>LT27 Var2 Mode</variableref>
           <relation>eq</relation>
           <value>0</value>
         </qualifier>
@@ -8025,7 +8025,7 @@
           <value>1</value>
         </qualifier>
         <xi:include href="http://jmri.org/xml/decoders/rr-cirkits/ChoiceAspect.xml"/><label>LT32 Var2 Aspect</label></variable>
- 
+
       <!-- End of Logic Table Variables -->
 
       <!-- Presets for Composite Variables -->


### PR DESCRIPTION
When setting a multiple segment route, the track and extra colors were not restored for the common block.