### PR TITLE
Reduce test runtime warnings due to logging; testing logging structure update

### DIFF
--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -319,6 +319,18 @@
 </pre>
 
      <p>
+     Note that you should be invoking
+     <code>jmri.util.JUnitUtil.setUp()</code>
+     and
+     <code>jmri.util.JUnitUtil.tearDown()</code>
+     as above. Some older tests use calls to
+     <code>apps.tests.Log4JFixture.setUp()</code>
+     and
+     <code>apps.tests.Log4JFixture.tearDown()</code>;
+     these should be replaced by the corresponding calls
+     to the <code>JUnitUtil</code> methods.
+     
+     <p>
      You may also choose to copy an existing test file and make
      modifications to suite the needs of your new class. Please
      make sure you're copying a file in the new JUnit4 format,

--- a/help/en/html/doc/Technical/JVMCapabilities.shtml
+++ b/help/en/html/doc/Technical/JVMCapabilities.shtml
@@ -112,6 +112,15 @@
         </tr>
 
         <tr>
+          <td>The Deprecated annotation can take "since" and "forRemoval" specifications, 
+                which simplifies our API migration management a lot.</td>
+
+          <td>9</td>
+
+          <td>8</td>
+        </tr>
+
+        <tr>
           <td>JMRI uses several com.sun classes that will, at some point,
           no longer be accessible.  This was originally scheduled as part of JPMS for
           1.9, but was later removed.  At some point, we will

--- a/java/test/apps/JmriFacelessTest.java
+++ b/java/test/apps/JmriFacelessTest.java
@@ -58,6 +58,7 @@ public class JmriFacelessTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
+        JUnitUtil.setUp();
         JUnitUtil.resetApplication();
         JUnitUtil.resetProfileManager();
     }
@@ -66,6 +67,7 @@ public class JmriFacelessTest {
     public void tearDown() {
         JUnitUtil.resetApplication();
         apps.tests.Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/apps/gui3/FirstTimeStartUpWizardTest.java
+++ b/java/test/apps/gui3/FirstTimeStartUpWizardTest.java
@@ -67,6 +67,7 @@ public class FirstTimeStartUpWizardTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
+        JUnitUtil.setUp();
         JUnitUtil.resetApplication();
         JUnitUtil.resetProfileManager();
     }
@@ -75,6 +76,7 @@ public class FirstTimeStartUpWizardTest {
     public void tearDown() {
         JUnitUtil.resetApplication();
         apps.tests.Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(FirstTimeStartUpWizardTest.class);

--- a/java/test/apps/gui3/dp3/DecoderPro3Test.java
+++ b/java/test/apps/gui3/dp3/DecoderPro3Test.java
@@ -64,6 +64,7 @@ public class DecoderPro3Test {
     // The minimal setup for log4J
     @Before
     public void setUp() {
+        JUnitUtil.setUp();
         JUnitUtil.resetApplication();
         JUnitUtil.resetProfileManager();
     }
@@ -72,6 +73,7 @@ public class DecoderPro3Test {
     public void tearDown() {
         JUnitUtil.resetApplication();
         apps.tests.Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/apps/gui3/mdi/MDITest.java
+++ b/java/test/apps/gui3/mdi/MDITest.java
@@ -62,6 +62,7 @@ public class MDITest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
+        JUnitUtil.setUp();
         JUnitUtil.resetApplication();
         JUnitUtil.resetProfileManager();
     }
@@ -69,7 +70,7 @@ public class MDITest {
     @After
     public void tearDown() {
         JUnitUtil.resetApplication();
-        apps.tests.Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/apps/tests/Log4JFixture.java
+++ b/java/test/apps/tests/Log4JFixture.java
@@ -7,12 +7,14 @@ import jmri.util.Log4JUtil;
 import org.apache.log4j.Level;
 import org.junit.Assert;
 
+@Deprecated // (since="4.11.4", forRemoval=true) Java9 syntax // use jmri.util.Log4JUtil
 public class Log4JFixture {
 
     private Log4JFixture() {
         // prevent instanciation
     }
-
+    
+    @Deprecated // (since="4.11.4", forRemoval=true) Java9 syntax // use jmri.util.JUnitUtil
     public static void setUp() {
         // always init logging if needed
         initLogging();
@@ -29,6 +31,8 @@ public class Log4JFixture {
     }
 
     static int count = 0;
+    
+    @Deprecated // (since="4.11.4", forRemoval=true) Java9 syntax // use jmri.util.JUnitUtil
     public static void tearDown() {
         JUnitAppender.end();
         Level severity = Level.ERROR; // level at or above which we'll complain

--- a/java/test/jmri/PathLengthTest.java
+++ b/java/test/jmri/PathLengthTest.java
@@ -88,15 +88,15 @@ public class PathLengthTest extends TestCase {
         return suite;
     }
 
-    @Before
-    protected void setUp() {
+    @Override
+    public void setUp() {
         jmri.util.JUnitUtil.setUp();
         
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
     }
 
-    @After
+    @Override
     public void tearDown() {
         jmri.util.JUnitUtil.tearDown();
     }

--- a/java/test/jmri/PathLengthTest.java
+++ b/java/test/jmri/PathLengthTest.java
@@ -3,7 +3,7 @@ package jmri;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-import org.junit.Assert;
+import org.junit.*;
 
 /**
  * Tests for setting and changing path lengths of the Path class
@@ -88,9 +88,17 @@ public class PathLengthTest extends TestCase {
         return suite;
     }
 
-    @Override
+    @Before
     protected void setUp() {
+        jmri.util.JUnitUtil.setUp();
+        
+        jmri.util.JUnitUtil.resetInstanceManager();
         jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
+    }
+
+    @After
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/PathTest.java
+++ b/java/test/jmri/PathTest.java
@@ -145,7 +145,15 @@ public class PathTest extends TestCase {
 
     @Override
     protected void setUp() {
+        jmri.util.JUnitUtil.setUp();
+        
+        jmri.util.JUnitUtil.resetInstanceManager();
         jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
+    }
+
+    @Override
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/SignalGroupTest.java
+++ b/java/test/jmri/SignalGroupTest.java
@@ -15,7 +15,6 @@ public class SignalGroupTest {
 
     @Test
     public void testSetup() {
-        //apps.tests.Log4JFixture.initLogging();
         // provide 2 turnouts:
         Turnout it1 = InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
         Turnout it2 = InstanceManager.turnoutManagerInstance().provideTurnout("IT2");

--- a/java/test/jmri/configurexml/LoadXmlUserActionTest.java
+++ b/java/test/jmri/configurexml/LoadXmlUserActionTest.java
@@ -21,8 +21,8 @@ public class LoadXmlUserActionTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        JUnitUtil.resetProfileManager();
         JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager();
     }
 
     @After

--- a/java/test/jmri/configurexml/SchemaTestBase.java
+++ b/java/test/jmri/configurexml/SchemaTestBase.java
@@ -118,7 +118,7 @@ public class SchemaTestBase {
 
     @BeforeClass
     public static void preClassInit() throws Exception {
-        Log4JFixture.setUp(); // setup logging early so static methods can log
+        JUnitUtil.tearDown();
     }
 
     @After

--- a/java/test/jmri/configurexml/SchemaTestBase.java
+++ b/java/test/jmri/configurexml/SchemaTestBase.java
@@ -118,7 +118,7 @@ public class SchemaTestBase {
 
     @BeforeClass
     public static void preClassInit() throws Exception {
-        JUnitUtil.tearDown();
+        JUnitUtil.setUp();  // so static ctors can log
     }
 
     @After

--- a/java/test/jmri/implementation/DccConsistTest.java
+++ b/java/test/jmri/implementation/DccConsistTest.java
@@ -39,7 +39,7 @@ public class DccConsistTest extends AbstractConsistTestBase {
     @After
     @Override
     public void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
         c = null;
     }
 

--- a/java/test/jmri/implementation/DefaultSignalAppearanceMapTest.java
+++ b/java/test/jmri/implementation/DefaultSignalAppearanceMapTest.java
@@ -128,7 +128,8 @@ public class DefaultSignalAppearanceMapTest {
 
     @Before
     public void setUp() {
-        JUnitUtil.setUp();        h1 = new DefaultSignalHead("IH1", "head1") {
+        JUnitUtil.setUp();        
+        h1 = new DefaultSignalHead("IH1", "head1") {
             @Override
             protected void updateOutput() {
             }
@@ -151,8 +152,12 @@ public class DefaultSignalAppearanceMapTest {
     public void tearDown() {
         InstanceManager.getDefault(jmri.SignalHeadManager.class).deregister(h1);
         h1.dispose();
+        h1 = null;
         InstanceManager.getDefault(jmri.SignalHeadManager.class).deregister(h2);
         h2.dispose();
-        apps.tests.Log4JFixture.tearDown();
+        h2 = null;
+        l1 = null;
+        l2 = null;
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/implementation/MatrixSignalMastTest.java
+++ b/java/test/jmri/implementation/MatrixSignalMastTest.java
@@ -157,12 +157,12 @@ public class MatrixSignalMastTest {
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
-        JUnitUtil.resetInstanceManager();
+        JUnitUtil.tearDown();
     }
 
     private final static Logger log = LoggerFactory.getLogger(MatrixSignalMastTest.class);

--- a/java/test/jmri/implementation/SignalHeadSignalMastTest.java
+++ b/java/test/jmri/implementation/SignalHeadSignalMastTest.java
@@ -238,7 +238,7 @@ public class SignalHeadSignalMastTest {
 
     @After
     public void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
         JUnitUtil.resetInstanceManager();
     }
 

--- a/java/test/jmri/implementation/SignalSpeedMapTest.java
+++ b/java/test/jmri/implementation/SignalSpeedMapTest.java
@@ -91,8 +91,8 @@ public class SignalSpeedMapTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
         super.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();
         jmri.util.JUnitUtil.initInternalLightManager();

--- a/java/test/jmri/jmris/srcp/JmriSRCPProgrammerServerTest.java
+++ b/java/test/jmri/jmris/srcp/JmriSRCPProgrammerServerTest.java
@@ -26,7 +26,7 @@ public class JmriSRCPProgrammerServerTest{
     }
 
     @Before
-    protected void setUp() {
+    public void setUp() {
         jmri.util.JUnitUtil.setUp();
         
         jmri.util.JUnitUtil.resetInstanceManager();

--- a/java/test/jmri/jmris/srcp/JmriSRCPProgrammerServerTest.java
+++ b/java/test/jmri/jmris/srcp/JmriSRCPProgrammerServerTest.java
@@ -1,6 +1,6 @@
 package jmri.jmris.srcp;
 
-import org.junit.Assert;
+import org.junit.*;
 import org.junit.Test;
 
 
@@ -25,5 +25,17 @@ public class JmriSRCPProgrammerServerTest{
         Assert.assertNotNull(a);
     }
 
+    @Before
+    protected void setUp() {
+        jmri.util.JUnitUtil.setUp();
+        
+        jmri.util.JUnitUtil.resetInstanceManager();
+        jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
+    }
+
+    @After
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
 
 }

--- a/java/test/jmri/jmris/srcp/JmriSRCPTimeServerTest.java
+++ b/java/test/jmri/jmris/srcp/JmriSRCPTimeServerTest.java
@@ -13,6 +13,7 @@ public class JmriSRCPTimeServerTest extends jmri.jmris.AbstractTimeServerTestBas
     @Before
     @Override
     public void setUp(){
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         java.io.DataOutputStream output = new java.io.DataOutputStream(
                 new java.io.OutputStream() {
@@ -28,8 +29,9 @@ public class JmriSRCPTimeServerTest extends jmri.jmris.AbstractTimeServerTestBas
     @After
     @Override
     public void tearDown(){
-       a = null;
-       jmri.util.JUnitUtil.resetInstanceManager();
+        a = null;
+        jmri.util.JUnitUtil.resetInstanceManager();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrit/DccLocoAddressSelectorTest.java
+++ b/java/test/jmri/jmrit/DccLocoAddressSelectorTest.java
@@ -151,4 +151,14 @@ public class DccLocoAddressSelectorTest extends TestCase {
         return suite;
     }
 
+    @Override
+    protected void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @Override
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrit/dispatcher/DispatcherTrainInfoTest.java
+++ b/java/test/jmri/jmrit/dispatcher/DispatcherTrainInfoTest.java
@@ -102,7 +102,7 @@ public class DispatcherTrainInfoTest extends TestCase {
 
     @Override
     protected void tearDown() throws Exception {
-        apps.tests.Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
         super.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/log/LogOutputWindowActionTest.java
+++ b/java/test/jmri/jmrit/log/LogOutputWindowActionTest.java
@@ -59,8 +59,8 @@ public class LogOutputWindowActionTest {
             }                        
         }
         
-        jmri.util.JUnitUtil.resetInstanceManager();
-        Log4JFixture.tearDown();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrit/powerpanel/PowerPaneTest.java
+++ b/java/test/jmri/jmrit/powerpanel/PowerPaneTest.java
@@ -1,9 +1,7 @@
 package jmri.jmrit.powerpanel;
 
 import jmri.util.JUnitUtil;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 /**
  * Tests for the Jmrit PowerPanel
@@ -16,10 +14,15 @@ public class PowerPaneTest extends jmri.util.swing.JmriPanelTest {
     @Before
     @Override
     public void setUp() {
+        JUnitUtil.setUp();
         JUnitUtil.initDebugPowerManager();
         panel = new PowerPane();
         helpTarget="package.jmri.jmrit.powerpanel.PowerPanelFrame";
         title=Bundle.getMessage("TitlePowerPanel");
+    }
+    @After
+    public void tearDown() {
+        JUnitUtil.tearDown();
     }
 
     // test on button routine

--- a/java/test/jmri/jmrit/roster/RosterEntryPaneTest.java
+++ b/java/test/jmri/jmrit/roster/RosterEntryPaneTest.java
@@ -21,6 +21,7 @@ public class RosterEntryPaneTest extends TestCase {
 
     @Override
     public void setUp() {
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
         // create Element
         eOld = new org.jdom2.Element("locomotive")
@@ -62,6 +63,11 @@ public class RosterEntryPaneTest extends TestCase {
             protected void warnShortLong(String s) {
             }
         };
+    }
+
+    @Override
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
     }
 
     public void testCreate() {

--- a/java/test/jmri/jmrit/withrottle/ThrottleControllerTest.java
+++ b/java/test/jmri/jmrit/withrottle/ThrottleControllerTest.java
@@ -44,6 +44,6 @@ public class ThrottleControllerTest extends TestCase {
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/can/cbus/CbusLightTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusLightTest.java
@@ -117,7 +117,6 @@ public class CbusLightTest {
     @Before
     public void setUp() {
         JUnitUtil.setUp();
-    //    apps.tests.Log4JFixture.setUp();
     }
 
     @After

--- a/java/test/jmri/jmrix/dccpp/DCCppSensorManagerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppSensorManagerTest.java
@@ -115,7 +115,6 @@ public class DCCppSensorManagerTest extends jmri.managers.AbstractSensorMgrTestB
         xnis = null;
         jmri.util.JUnitUtil.clearShutDownManager();
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/lenz/XNetMessageTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetMessageTest.java
@@ -1529,7 +1529,7 @@ public class XNetMessageTest{
 
     @After
     public void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
         // make sure the message timeouts and retries are set to
         // the defaults.
         XNetMessage.setXNetMessageTimeout(5000); 

--- a/java/test/jmri/jmrix/loconet/locomon/LlnmonTest.java
+++ b/java/test/jmri/jmrix/loconet/locomon/LlnmonTest.java
@@ -6281,7 +6281,7 @@ public class LlnmonTest extends TestCase {
     // The minimal setup for log4J
     protected void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.initReporterManager();
+        JUnitUtil.initReporterManager();
 
         jmri.jmrix.loconet.LocoNetInterfaceScaffold lnis = new jmri.jmrix.loconet.LocoNetInterfaceScaffold();
         lntm = new LnTurnoutManager(lnis, lnis, "L", false);
@@ -6297,7 +6297,7 @@ public class LlnmonTest extends TestCase {
     @Override
     protected void tearDown() {
         lnsm.dispose();
-        apps.tests.Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/loconet/locomon/LocoMonPaneTest.java
+++ b/java/test/jmri/jmrix/loconet/locomon/LocoMonPaneTest.java
@@ -109,10 +109,10 @@ public class LocoMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
     @Before
     public void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager();
-        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
-        jmri.util.JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initDefaultUserMessagePreferences();
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
 
         // prepare an interface, register
         jmri.jmrix.loconet.LocoNetInterfaceScaffold lnis = new jmri.jmrix.loconet.LocoNetInterfaceScaffold();
@@ -140,6 +140,6 @@ public class LocoMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
     public void tearDown() {
         pane.dispose();
         
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/nce/NceClockControlTest.java
+++ b/java/test/jmri/jmrix/nce/NceClockControlTest.java
@@ -24,14 +24,14 @@ public class NceClockControlTest {
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
         tcis = new NceTrafficControlScaffold();
     }
 
     @After
     public void tearDown() {
-        jmri.util.JUnitUtil.resetInstanceManager();
-        tcis = new NceTrafficControlScaffold();
-        apps.tests.Log4JFixture.tearDown();
+        tcis = null;
+        JUnitUtil.tearDown();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(NceClockControlTest.class);

--- a/java/test/jmri/jmrix/pi/RaspberryPiConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiConnectionConfigTest.java
@@ -22,7 +22,7 @@ public class RaspberryPiConnectionConfigTest {
 
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         GpioProvider myprovider = new PiGpioProviderScaffold();
         GpioFactory.setDefaultProvider(myprovider);
 

--- a/java/test/jmri/jmrix/pi/RaspberryPiSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiSystemConnectionMemoTest.java
@@ -138,8 +138,8 @@ public class RaspberryPiSystemConnectionMemoTest extends jmri.jmrix.SystemConnec
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
-        jmri.util.JUnitUtil.resetInstanceManager();
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
         
         GpioProvider myprovider = new PiGpioProviderScaffold();
         GpioFactory.setDefaultProvider(myprovider);

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetInitializationManagerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetInitializationManagerTest.java
@@ -53,7 +53,7 @@ public class Z21XNetInitializationManagerTest {
 
     @After
     public void tearDown() throws Exception {
-        Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/managers/JmriUserPreferencesManagerTest.java
+++ b/java/test/jmri/managers/JmriUserPreferencesManagerTest.java
@@ -999,6 +999,7 @@ public class JmriUserPreferencesManagerTest {
     @Before
     public void setUp() throws Exception {
         JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
         JUnitUtil.resetPreferencesProviders();
         // ensure no existing UserPreferencesManager interferes with this test
         InstanceManager.reset(UserPreferencesManager.class);
@@ -1006,8 +1007,7 @@ public class JmriUserPreferencesManagerTest {
 
     @After
     public void tearDown() throws Exception {
-        apps.tests.Log4JFixture.tearDown();
-        JUnitUtil.resetInstanceManager();
+        JUnitUtil.tearDown();
     }
 
     private static class TestJmriUserPreferencesManager extends JmriUserPreferencesManager {

--- a/scripts/run_tests_separately
+++ b/scripts/run_tests_separately
@@ -5,20 +5,17 @@
 # Argument, if present, is a starting _directory_ under java/test, e.g. "jmri/managers"
 #  
 # The list of test files that fail goes into /failed_files.txt
-# Log output from all files is concatenated into /test_results.txt
 #
 
 rm -f ./failed_files.txt
 touch ./failed_files.txt
 
-rm -f ./test_results.txt
-
 for jmri_test in $( find java/test/$1 -name \*Test.java ! -name AllTest.java ! -name HeadLessTest.java ! -name PackageTest.java ! -name FailTest.java | sort -r) 
     do jmri_test=${jmri_test#java/test/} 
         jmri_test=${jmri_test%\.java}
-        echo ${jmri_test} >> ./test_results.txt
-        ./runtest.csh ${jmri_test} >> ./test_results.txt 2>&1 || echo ${jmri_test} >> ./failed_files.txt
+        echo ${jmri_test}
+        ./runtest.csh ${jmri_test} || echo ${jmri_test} >> ./failed_files.txt
 done
 
 # error exit if any failed
-if [ -s ./failed_files.txt ]; then echo "The following files failed, details in test_results.txt"; cat ./failed_files.txt; exit 1; fi
+if [ -s ./failed_files.txt ]; then echo "The following files failed"; cat ./failed_files.txt; exit 1; fi


### PR DESCRIPTION
- Fix some warnings due to non-initialized Log4J due to missing calls or missing setUp() in tests
- Formally deprecate `apps.tests.Log4JFixture` and update many of the uses
