### PR TITLE
Fix more test runtime warnings, deprecations

### DIFF
--- a/java/src/jmri/AudioManager.java
+++ b/java/src/jmri/AudioManager.java
@@ -140,15 +140,6 @@ public interface AudioManager extends Manager<Audio> {
     public AudioFactory getActiveAudioFactory();
 
     /**
-     * Get a list of all Audio objects' system names.
-     *
-     * @return List of all Audio objects' system names
-     */
-    @Override
-    @Nonnull
-    public List<String> getSystemNameList();
-
-    /**
      * Get a list of specified Audio sub-type objects' system names.
      *
      * @param subType sub-type to retrieve

--- a/java/src/jmri/CatalogTreeManager.java
+++ b/java/src/jmri/CatalogTreeManager.java
@@ -89,13 +89,6 @@ public interface CatalogTreeManager extends Manager<CatalogTree> {
     public boolean isIndexChanged();
     
     public void indexChanged(boolean changed);
-    /**
-     * Get a list of all CatalogTree objects' system names.
-     *
-     * @return list of all CatalogTree system names
-     */
-    @Override
-    public List<String> getSystemNameList();
 
     @SuppressFBWarnings(value = "MS_MUTABLE_ARRAY",
             justification = "with existing code structure, just have to accept these exposed arrays. Someday...")

--- a/java/src/jmri/IdTagManager.java
+++ b/java/src/jmri/IdTagManager.java
@@ -136,16 +136,6 @@ public interface IdTagManager extends Manager<IdTag> {
     public IdTag newIdTag(@Nonnull String systemName, @CheckForNull String userName);
 
     /**
-     * Get a list of all IdTag's system names.
-     *
-     * @return a list of system names or an empty list
-     */
-    @Override
-    @CheckReturnValue
-    @Nonnull
-    public List<String> getSystemNameList();
-
-    /**
      * Get a list of all IdTags seen by a specified Reporter within a specific
      * time threshold from the most recently seen.
      *

--- a/java/src/jmri/LightManager.java
+++ b/java/src/jmri/LightManager.java
@@ -162,16 +162,6 @@ public interface LightManager extends ProvidingManager<Light> {
     public String convertSystemNameToAlternate(@Nonnull String systemName);
 
     /**
-     * Get a list of all Light system names.
-     *
-     * @return a list of all system names
-     */
-    @CheckReturnValue
-    @Nonnull
-    @Override
-    public List<String> getSystemNameList();
-
-    /**
      * Activate the control mechanism for each Light controlled by this
      * LightManager. Note that some Lights don't require any activation. The
      * activateLight method in AbstractLight.java determines what needs to be

--- a/java/src/jmri/LogixManager.java
+++ b/java/src/jmri/LogixManager.java
@@ -60,14 +60,6 @@ public interface LogixManager extends Manager<Logix> {
     public void activateAllLogixs();
 
     /**
-     * Get a list of all Logix system names.
-     *
-     * {@inheritDoc}
-     */
-    @Override
-    public List<String> getSystemNameList();
-
-    /**
      * Delete Logix by removing it from the manager. The Logix must first be
      * deactivated so it stops processing.
      *

--- a/java/src/jmri/MemoryManager.java
+++ b/java/src/jmri/MemoryManager.java
@@ -145,13 +145,4 @@ public interface MemoryManager extends Manager<Memory> {
     @Nonnull
     public Memory newMemory(@Nonnull String userName);
 
-    /**
-     * Get a list of system names of all Memory objects.
-     *
-     * {@inheritDoc}
-     */
-    @Nonnull
-    @Override
-    public List<String> getSystemNameList();
-
 }

--- a/java/src/jmri/RailComManager.java
+++ b/java/src/jmri/RailComManager.java
@@ -106,16 +106,6 @@ public interface RailComManager extends Manager<RailCom> {
     public RailCom newIdTag(@Nonnull String systemName, @CheckForNull String userName);
 
     /**
-     * Get a list of all IdTag's system names.
-     *
-     * @return a list of system names or an empty list
-     */
-    @Override
-    @CheckReturnValue
-    @Nonnull
-    public List<String> getSystemNameList();
-
-    /**
      * Get a list of all IdTags seen by a specified Reporter within a specific
      * time threshold from the most recently seen.
      *

--- a/java/src/jmri/RouteManager.java
+++ b/java/src/jmri/RouteManager.java
@@ -70,15 +70,6 @@ public interface RouteManager extends Manager<Route> {
     public Route getBySystemName(@Nonnull String s);
 
     /**
-     * Get a list of all Route system names.
-     *
-     * @return the list of route system names or an empty list
-     */
-    @Nonnull
-    @Override
-    public List<String> getSystemNameList();
-
-    /**
      * Delete Route by removing it from the manager. The Route must first be
      * deactivated so it stops processing.
      *

--- a/java/src/jmri/SensorManager.java
+++ b/java/src/jmri/SensorManager.java
@@ -99,11 +99,6 @@ public interface SensorManager extends ProvidingManager<Sensor> {
     @CheckForNull
     public Sensor getBySystemName(@Nonnull String s);
 
-    @CheckReturnValue
-    @Nonnull
-    @Override
-    public List<String> getSystemNameList();
-
     /**
      * Requests status of all layout sensors under this Sensor Manager. This
      * method may be invoked whenever the status of sensors needs to be updated

--- a/java/src/jmri/SignalGroupManager.java
+++ b/java/src/jmri/SignalGroupManager.java
@@ -29,7 +29,5 @@ public interface SignalGroupManager extends Manager<SignalGroup> {
 
     @Nonnull public SignalGroup provideSignalGroup(@Nonnull String systemName, String userName);
 
-    @Nonnull@Override public List<String> getSystemNameList();
-
     void deleteSignalGroup(@Nonnull SignalGroup s);
 }

--- a/java/src/jmri/SignalHeadManager.java
+++ b/java/src/jmri/SignalHeadManager.java
@@ -47,10 +47,4 @@ public interface SignalHeadManager extends Manager<SignalHead> {
     @CheckReturnValue
     @CheckForNull public SignalHead getBySystemName(@Nonnull String s);
 
-    /**
-     * Get a list of all SignalHead system names.
-     */
-    @Nonnull@Override
- public List<String> getSystemNameList();
-
 }

--- a/java/src/jmri/SignalMastManager.java
+++ b/java/src/jmri/SignalMastManager.java
@@ -62,10 +62,4 @@ public interface SignalMastManager extends Manager<SignalMast> {
 
     @CheckForNull public SignalMast getBySystemName(@Nonnull String s);
 
-    /**
-     * Get a list of all SignalMast system names.
-     */
-    @Nonnull@Override
-    public List<String> getSystemNameList();
-
 }

--- a/java/src/jmri/TurnoutManager.java
+++ b/java/src/jmri/TurnoutManager.java
@@ -128,16 +128,6 @@ public interface TurnoutManager extends ProvidingManager<Turnout> {
     public Turnout newTurnout(@Nonnull String systemName, @Nullable String userName) throws IllegalArgumentException;
 
     /**
-     * Get a list of all Turnout system names.
-     *
-     * @return the list of names or an empty list if no turnouts have been
-     *         defined
-     */
-    @Nonnull
-    @Override
-    public List<String> getSystemNameList();
-
-    /**
      * Get text to be used for the Turnout.CLOSED state in user communication.
      * Allows text other than "CLOSED" to be used with certain hardware system
      * to represent the Turnout.CLOSED state.

--- a/java/test/jmri/jmrit/audio/JoalAudioSourceTest.java
+++ b/java/test/jmri/jmrit/audio/JoalAudioSourceTest.java
@@ -44,5 +44,8 @@ public class JoalAudioSourceTest {
     }
 
     @After
-    public void tearDown() {        JUnitUtil.tearDown();    }
+    public void tearDown() {
+        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
+        JUnitUtil.tearDown(); 
+    }
 }

--- a/java/test/jmri/jmrit/audio/NullAudioSourceTest.java
+++ b/java/test/jmri/jmrit/audio/NullAudioSourceTest.java
@@ -34,5 +34,8 @@ public class NullAudioSourceTest {
     }
 
     @After
-    public void tearDown() {        JUnitUtil.tearDown();    }
+    public void tearDown() {
+        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
+        JUnitUtil.tearDown();
+    }
 }

--- a/java/test/jmri/jmrit/beantable/AudioTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/AudioTableActionTest.java
@@ -62,12 +62,13 @@ public class AudioTableActionTest extends AbstractTableActionBase {
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
         helpTarget = "package.jmri.jmrit.beantable.AudioTable";
-	a = new AudioTableAction();
+	    a = new AudioTableAction();
     }
 
     @After
     @Override
     public void tearDown() {
+        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
         a = null;
     }

--- a/java/test/jmri/jmrit/beantable/AudioTableFrameTest.java
+++ b/java/test/jmri/jmrit/beantable/AudioTableFrameTest.java
@@ -34,6 +34,7 @@ public class AudioTableFrameTest {
 
     @After
     public void tearDown() {
+        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/beantable/AudioTablePanelTest.java
+++ b/java/test/jmri/jmrit/beantable/AudioTablePanelTest.java
@@ -28,11 +28,13 @@ public class AudioTablePanelTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        JUnitUtil.setUp();        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
+        JUnitUtil.setUp();        
+        JUnitUtil.initDefaultUserMessagePreferences();
     }
 
     @After
     public void tearDown() {
+        jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/nce/NceTurnoutTest.java
+++ b/java/test/jmri/jmrix/nce/NceTurnoutTest.java
@@ -18,6 +18,7 @@ public class NceTurnoutTest extends AbstractTurnoutTestBase {
     @Before
     @Override
     public void setUp() {
+        jmri.util.JUnitUtil.setUp();
         // prepare an interface
         tcis = new NceTrafficControlScaffold();
 

--- a/java/test/jmri/jmrix/qsi/QsiTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/qsi/QsiTrafficControllerTest.java
@@ -231,6 +231,11 @@ public class QsiTrafficControllerTest extends TestCase {
         }
     }
 
+    @Override
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
     public QsiTrafficControllerTest(String s) {
         super(s);
     }

--- a/java/test/jmri/jmrix/qsi/packetgen/PacketGenFrameTest.java
+++ b/java/test/jmri/jmrix/qsi/packetgen/PacketGenFrameTest.java
@@ -1,17 +1,13 @@
-/**
- * PacketGenFrameTest.java
- *
- * Description:	tests for the jmri.jmrix.qsi.packetgen.PacketGenFrame class
- *
- * @author	Bob Jacobsen
- */
 package jmri.jmrix.qsi.packetgen;
 
 import java.awt.GraphicsEnvironment;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.*;
 
+/**
+ * Tests for the jmri.jmrix.qsi.packetgen.PacketGenFrame class
+ *
+ * @author	Bob Jacobsen
+ */
 public class PacketGenFrameTest {
 
     @Test
@@ -19,6 +15,11 @@ public class PacketGenFrameTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         PacketGenFrame packetGenFrame = new PacketGenFrame(new jmri.jmrix.qsi.QsiSystemConnectionMemo());
         Assert.assertNotNull(packetGenFrame);
+    }
+
+    @Before
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
     }
 
 }

--- a/java/test/jmri/jmrix/qsi/qsimon/QsiMonFrameTest.java
+++ b/java/test/jmri/jmrix/qsi/qsimon/QsiMonFrameTest.java
@@ -1,10 +1,3 @@
-/**
- * QsiMonFrameTest.java
- *
- * Description:	JUnit tests for the QsiProgrammer class
- *
- * @author	Bob Jacobsen
- */
 package jmri.jmrix.qsi.qsimon;
 
 import java.awt.GraphicsEnvironment;
@@ -13,12 +6,16 @@ import jmri.jmrix.qsi.QsiListener;
 import jmri.jmrix.qsi.QsiMessage;
 import jmri.jmrix.qsi.QsiReply;
 import jmri.jmrix.qsi.QsiTrafficController;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+
+import org.junit.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * JUnit tests for the QsiProgrammer class
+ *
+ * @author	Bob Jacobsen
+ */
 public class QsiMonFrameTest {
 
     @Test
@@ -28,7 +25,8 @@ public class QsiMonFrameTest {
         Assert.assertNotNull("exists", f);
     }
 
-    /* Following are not reliable, apparently time-sensitive, so commented out
+    // Following is not reliable, apparently time-sensitive, so commented out
+    @Ignore
     @Test
     public void testMsg() {
         QsiMessage m = new QsiMessage(3);
@@ -36,7 +34,7 @@ public class QsiMonFrameTest {
         m.setElement(1, '0');
         m.setElement(2, 'A');
 
-        QsiMonFrame f = new QsiMonFrame();
+        QsiMonFrame f = new QsiMonFrame(new jmri.jmrix.qsi.QsiSystemConnectionMemo());
 
         f.message(m);
 
@@ -44,6 +42,8 @@ public class QsiMonFrameTest {
         Assert.assertEquals("display", "cmd: \"L0A\"\n", f.getFrameText());
     }
 
+    // Following is not reliable, apparently time-sensitive, so commented out
+    @Ignore
     @Test
     public void testReply() {
         QsiReply m = new QsiReply();
@@ -51,17 +51,16 @@ public class QsiMonFrameTest {
         m.setElement(1, 'o');
         m.setElement(2, ':');
 
-        QsiMonFrame f = new QsiMonFrame();
+        QsiMonFrame f = new QsiMonFrame(new jmri.jmrix.qsi.QsiSystemConnectionMemo());
 
         f.reply(m);
 
         Assert.assertEquals("display", "rep: \"Co:\"\n", f.getFrameText());
         Assert.assertEquals("length ", "rep: \"Co:\"\n".length(), f.getFrameText().length());
     }
-     */
+
     @Test
     public void testWrite() {
-
         new QsiInterfaceScaffold();
     }
 
@@ -118,6 +117,11 @@ public class QsiMonFrameTest {
             return cmdListeners.size();
         }
 
+    }
+
+    @Before
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
     }
 
     private final static Logger log = LoggerFactory.getLogger(QsiMonFrameTest.class);

--- a/java/test/jmri/jmrix/rps/PositionFileTest.java
+++ b/java/test/jmri/jmrix/rps/PositionFileTest.java
@@ -96,6 +96,11 @@ public class PositionFileTest extends TestCase {
         super(s);
     }
 
+    @Override
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
     // Main entry point
     static public void main(String[] args) {
         String[] testCaseName = {PositionFileTest.class.getName()};

--- a/java/test/jmri/util/JUnitAppender.java
+++ b/java/test/jmri/util/JUnitAppender.java
@@ -246,19 +246,23 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
     }
 
     /**
-     * If there's a next matching message of Error severity, just ignore it. Not
-     * an error if not present; mismatch is an error.
+     * If there's a next matching message of specific severity, just ignore it. Not
+     * an error if not present; mismatch is an error. Skips messages of lower severity while looking for the specific one.
      *
      * @param msg the message to suppress
      */
-    public static void suppressErrorMessage(String msg) {
+    public static void suppressMessage(Level level, String msg) {
         if (list.isEmpty()) {
             return;
         }
 
         LoggingEvent evt = list.remove(0);
 
-        while ((evt.getLevel() == Level.INFO) || (evt.getLevel() == Level.DEBUG) || (evt.getLevel() == Level.TRACE)) { // better in Log4J 2
+        while ( 
+                 ( (level.equals(Level.WARN)) && (evt.getLevel() == Level.TRACE || evt.getLevel() == Level.DEBUG || evt.getLevel() == Level.INFO || evt.getLevel() == Level.WARN) )
+                 || 
+                 ( (level.equals(Level.ERROR)) && (evt.getLevel() == Level.TRACE || evt.getLevel() == Level.DEBUG || evt.getLevel() == Level.INFO || evt.getLevel() == Level.WARN || evt.getLevel() == Level.ERROR) )
+                ) { // this is much better with Log4J 2's compareTo method
             if (list.isEmpty()) {
                 return;
             }
@@ -266,13 +270,33 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
         }
 
         // check the remaining message, if any
-        if (evt.getLevel() != Level.ERROR) {
-            Assert.fail("Level mismatch when looking for ERROR message: \"" + msg + "\" found \"" + (String) evt.getMessage() + "\"");
+        if (evt.getLevel() != level) {
+            Assert.fail("Level mismatch when looking for "+level+" message: \"" + msg + "\" found \"" + (String) evt.getMessage() + "\"");
         }
 
         if (!compare(evt, msg)) {
-            Assert.fail("Looking for ERROR message \"" + msg + "\" got \"" + evt.getMessage() + "\"");
+            Assert.fail("Looking for "+level+" message \"" + msg + "\" got \"" + evt.getMessage() + "\"");
         }
+    }
+
+    /**
+     * If there's a next matching message of Error severity, just ignore it. Not
+     * an error if not present; mismatch is an error.
+     *
+     * @param msg the message to suppress
+     */
+    public static void suppressErrorMessage(String msg) {
+        suppressMessage(Level.ERROR, msg);
+    }
+
+    /**
+     * If there's a next matching message of Warn severity, just ignore it. Not
+     * an error if not present; mismatch is an error.
+     *
+     * @param msg the message to suppress
+     */
+    public static void suppressWarnMessage(String msg) {
+        suppressMessage(Level.WARN, msg);
     }
 
     /**

--- a/java/test/jmri/util/JUnitAppenderTest.java
+++ b/java/test/jmri/util/JUnitAppenderTest.java
@@ -228,6 +228,31 @@ public class JUnitAppenderTest extends TestCase {
         Assert.assertEquals(0,JUnitAppender.clearBacklog(org.apache.log4j.Level.INFO));
     }
 
+    public void suppressErrorMessage() {
+        String msg = "Message for testing to find";
+
+        log.warn("Dummy");        
+        log.warn(msg);        
+        Assert.assertFalse(JUnitAppender.verifyNoBacklog());
+        JUnitAppender.suppressErrorMessage(msg);
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
+        
+        log.warn("Dummy");        
+        log.warn(msg);        
+        log.warn("Dummy");        
+        Assert.assertFalse(JUnitAppender.verifyNoBacklog());
+        JUnitAppender.suppressErrorMessage(msg);
+        Assert.assertFalse(JUnitAppender.verifyNoBacklog());
+        
+        log.error("Dummy");        
+        log.warn(msg);        
+        log.warn("Dummy");        
+        Assert.assertFalse(JUnitAppender.verifyNoBacklog());
+        JUnitAppender.suppressErrorMessage(msg);
+        Assert.assertFalse(JUnitAppender.verifyNoBacklog());
+    }
+
+
     // from here down is testing infrastructure
     public JUnitAppenderTest(String s) {
         super(s);

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -741,7 +741,7 @@ public class JUnitUtil {
                     String message = "Cleaning up nameless invisible frame created by creating a dialog with a null parent in {}.";
                     if (!error) {
                         log.warn(message, getTestClassName());
-                    } else {
+                    } else if (warn) {
                         log.error(message, getTestClassName());
                     }
                 } else {
@@ -761,7 +761,7 @@ public class JUnitUtil {
                     String message = "Cleaning up nameless invisible window created by creating a dialog with a null parent in {}.";
                     if (!error) {
                         log.warn(message, getTestClassName());
-                    } else {
+                    } else if (warn) {
                         log.error(message, getTestClassName());
                     }
                 } else {

--- a/java/test/jmri/util/OrderedHashtableTest.java
+++ b/java/test/jmri/util/OrderedHashtableTest.java
@@ -163,6 +163,11 @@ public class OrderedHashtableTest extends TestCase {
         junit.textui.TestRunner.main(testCaseName);
     }
 
+    @Override
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
     // test suite from all defined tests
     public static Test suite() {
         TestSuite suite = new TestSuite(OrderedHashtableTest.class);


### PR DESCRIPTION
 - Add methods to JUnitAppender to allow skipping WARN messages; add tests of those
 - Skip some null audio warnings that can occur sometimes in tests
 - Remove some deprecated *Manager passthrough definitions
 - fix a few more missing or incomplete setUp methods
