### PR TITLE
More test improvements

### DIFF
--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -330,6 +330,18 @@
      these should be replaced by the corresponding calls
      to the <code>JUnitUtil</code> methods.
      
+     <p>In addition, the tearDown() method should set all member variable 
+            references to null.  This is because JUnit4 keeps the test class
+            objects around until <em>all</em> the tests are complete, so any
+            memory you allocate in one class can't be garbage collected until all 
+            the tests are done.  Setting the references to null allows the objects
+            to be collected. (If the allocated objects have a dispose() method
+            or similar, you should call that too). You should <u>not</u>
+            <a href="#ResetInstMgr">reset the InstanceManager</a>
+            or other managers in the tearDown
+            method; any necessary manager resets will be done automatically, 
+            and duplicating those wastes test time.
+
      <p>
      You may also choose to copy an existing test file and make
      modifications to suite the needs of your new class. Please
@@ -445,7 +457,7 @@
         <li>All the test classes should include common code in
         their setUp() and tearDown() code to ensure that log4j is
         properly initiated, and that the custom appender is told
-        when a test is beginning and ending.
+        when a test is beginning and ending. 
 
 <pre style="font-family: monospace;">
     // The minimal setup for log4J
@@ -459,13 +471,6 @@
     }
 </pre>
         </li>
-        <li>In addition, the tearDown() method should set all member variable 
-            references to null.  This is because JUnit4 keeps the test class
-            objects around until <em>all</em> the tests are complete, so any
-            memory you allocate in one class can't be garbage collected until all 
-            the tests are done.  Setting the references to null allows the objects
-            to be collected. (If the allocated objects have a dispose() method
-            or similar, you should call that too)
 
         <li>When a test is deliberately invoking a message, it
         should then use the check to see that the message was
@@ -499,8 +504,7 @@
       won't be able to merge your code into the common repository
       until those are handled.</p>
 
-      <h3><a name="ResetInstMgr" id="ResetInstMgr">Resetting the
-      InstanceManager</a></h3>
+      <h3><a name="ResetInstMgr" id="ResetInstMgr">Resetting the InstanceManager</a></h3>
       If you are testing code that is going
       to reference the InstanceManager, you should clear and reset
       it to ensure you get reproducible results.

--- a/java/test/jmri/ApplicationTest.java
+++ b/java/test/jmri/ApplicationTest.java
@@ -58,14 +58,14 @@ public class ApplicationTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetApplication();
     }
 
     @Override
     protected void tearDown() {
         jmri.util.JUnitUtil.resetApplication();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
     private static final Logger log = LoggerFactory.getLogger(ApplicationTest.class);

--- a/java/test/jmri/NamedBeanTest.java
+++ b/java/test/jmri/NamedBeanTest.java
@@ -42,12 +42,12 @@ public class NamedBeanTest extends TestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/RunCucumberTest.java
+++ b/java/test/jmri/RunCucumberTest.java
@@ -30,13 +30,13 @@ public class RunCucumberTest {
    
    @BeforeClass
    public static void beforeTests(){
-      apps.tests.Log4JFixture.setUp();
+     jmri.util.JUnitUtil.setUp();
    }
 
    @AfterClass
    public static void afterTests(){
       jmri.util.web.BrowserFactory.CloseAllDriver();
-      apps.tests.Log4JFixture.tearDown();
+      jmri.util.JUnitUtil.tearDown();
    }
 
 }

--- a/java/test/jmri/TurnoutOperationTest.java
+++ b/java/test/jmri/TurnoutOperationTest.java
@@ -71,7 +71,7 @@ public class TurnoutOperationTest extends TestCase {
 
     @Override
     protected void setUp() throws Exception { 
-        apps.tests.Log4JFixture.setUp(); 
+        jmri.util.JUnitUtil.setUp(); 
         super.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         JUnitUtil.initInternalTurnoutManager();
@@ -80,9 +80,7 @@ public class TurnoutOperationTest extends TestCase {
     @Override
     protected void tearDown() throws Exception { 
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown(); 
-        JUnitUtil.resetTurnoutOperationManager();
-        JUnitUtil.resetInstanceManager();
+        jmri.util.JUnitUtil.tearDown(); 
     }
 
 }

--- a/java/test/jmri/implementation/AbstractSensorTest.java
+++ b/java/test/jmri/implementation/AbstractSensorTest.java
@@ -35,7 +35,7 @@ public class AbstractSensorTest extends AbstractSensorTestBase {
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         t = new AbstractSensor("Foo", "Bar"){
             @Override
                 public void requestUpdateFromLayout(){}
@@ -45,8 +45,8 @@ public class AbstractSensorTest extends AbstractSensorTestBase {
     @Override
     @After
     public void tearDown() {
-	t.dispose();
-	t = null;
+	    t.dispose();
+	    t = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/implementation/AccessoryOpsModeProgrammerFacadeTest.java
+++ b/java/test/jmri/implementation/AccessoryOpsModeProgrammerFacadeTest.java
@@ -173,7 +173,7 @@ public class AccessoryOpsModeProgrammerFacadeTest {
     // The minimal setup for log4J
     @Before
     public void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         InstanceManager.setDefault(CommandStation.class, new MockCommandStation());
         lastPacket = null;

--- a/java/test/jmri/implementation/DefaultConditionalActionTest.java
+++ b/java/test/jmri/implementation/DefaultConditionalActionTest.java
@@ -49,7 +49,7 @@ public class DefaultConditionalActionTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();

--- a/java/test/jmri/implementation/DefaultConditionalTest.java
+++ b/java/test/jmri/implementation/DefaultConditionalTest.java
@@ -44,7 +44,7 @@ public class DefaultConditionalTest extends NamedBeanTest {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();

--- a/java/test/jmri/implementation/DefaultLogixTest.java
+++ b/java/test/jmri/implementation/DefaultLogixTest.java
@@ -48,7 +48,7 @@ public class DefaultLogixTest extends NamedBeanTest {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();

--- a/java/test/jmri/implementation/SignalHeadSignalMastTest.java
+++ b/java/test/jmri/implementation/SignalHeadSignalMastTest.java
@@ -239,7 +239,6 @@ public class SignalHeadSignalMastTest {
     @After
     public void tearDown() {
         JUnitUtil.tearDown();
-        JUnitUtil.resetInstanceManager();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(SignalHeadSignalMastTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/Pr1ImportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/Pr1ImportActionTest.java
@@ -34,7 +34,6 @@ public class Pr1ImportActionTest {
 
     @After
     public void tearDown() {
-        jmri.util.JUnitUtil.resetInstanceManager();
         apps.tests.Log4JFixture.tearDown();
     }
 

--- a/java/test/jmri/jmrix/loconet/spjfile/SpjFileTest.java
+++ b/java/test/jmri/jmrix/loconet/spjfile/SpjFileTest.java
@@ -79,4 +79,15 @@ public class SpjFileTest extends TestCase {
         return suite;
     }
 
+    // The minimal setup for log4J
+    @Override
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @Override
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/jmrix/maple/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/maple/SerialTurnoutTest.java
@@ -52,6 +52,7 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
     @Override
     @Before
     public void setUp() {
+        jmri.util.JUnitUtil.setUp();
         // prepare an interface
         tcis = new SerialTrafficControlScaffold();
         _memo = new MapleSystemConnectionMemo("K", "Maple");
@@ -67,7 +68,8 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
         _memo.dispose();
         n = null;
         t = null;
-        // JUnitUtil.tearDown() clean up is done through the AbstractTurnoutTestBase
+        // Some clean up is done through the AbstractTurnoutTestBase
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/nce/NceAIUTest.java
+++ b/java/test/jmri/jmrix/nce/NceAIUTest.java
@@ -44,4 +44,14 @@ public class NceAIUTest extends TestCase {
         return suite;
     }
 
+    // The minimal setup for log4J
+    @Override
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @Override
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
 }

--- a/java/test/jmri/jmrix/nce/NceMessageTest.java
+++ b/java/test/jmri/jmrix/nce/NceMessageTest.java
@@ -18,6 +18,7 @@ public class NceMessageTest extends TestCase {
 
     @Override
     public void setUp() {
+        jmri.util.JUnitUtil.setUp();
         saveCommandOptions = tc.getCommandOptions();
     }
 
@@ -27,6 +28,8 @@ public class NceMessageTest extends TestCase {
         tc.setCommandOptions(saveCommandOptions);
         Assert.assertTrue("Command has been set", tc.commandOptionSet);
         tc.commandOptionSet = false;	// kill warning message
+        tc = null;
+        jmri.util.JUnitUtil.tearDown();
     }
 
     public void testCreate() {

--- a/java/test/jmri/jmrix/nce/NcePowerManagerTest.java
+++ b/java/test/jmri/jmrix/nce/NcePowerManagerTest.java
@@ -60,6 +60,7 @@ public class NcePowerManagerTest extends AbstractPowerManagerTestBase {
     @Before
     @Override
     public void setUp() {
+        jmri.util.JUnitUtil.setUp();
         controller = new NceTrafficControlScaffold();
         p = new NcePowerManager(controller, "N");
     }

--- a/java/test/jmri/jmrix/nce/NceProgrammerTest.java
+++ b/java/test/jmri/jmrix/nce/NceProgrammerTest.java
@@ -26,6 +26,7 @@ public class NceProgrammerTest extends TestCase {
 
     @Override
     public void setUp() {
+        jmri.util.JUnitUtil.setUp();
         tc = new NceTrafficController();
         saveCommandOptions = tc.getCommandOptions();
     }
@@ -33,7 +34,10 @@ public class NceProgrammerTest extends TestCase {
     @Override
     public void tearDown() {
         tc.setCommandOptions(saveCommandOptions);
+        tc = null;
+        jmri.util.JUnitUtil.tearDown();
     }
+
     NceTrafficController tc;
     int saveCommandOptions;
 
@@ -529,10 +533,6 @@ public class NceProgrammerTest extends TestCase {
         return suite;
     }
 
-    // The minimal setup is for log4J
-    // apps.tests.Log4JFixture log4jfixtureInst = new apps.tests.Log4JFixture(this);
-    // protected void setUp() { log4jfixtureInst.setUp(); }
-    // protected void tearDown() { log4jfixtureInst.tearDown(); }
     private final static Logger log = LoggerFactory.getLogger(NceProgrammerTest.class);
 
 }

--- a/java/test/jmri/jmrix/nce/NceReplyTest.java
+++ b/java/test/jmri/jmrix/nce/NceReplyTest.java
@@ -197,4 +197,14 @@ public class NceReplyTest extends TestCase {
         return suite;
     }
 
+    @Override
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @Override
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/managers/ProxyTurnoutManagerTest.java
+++ b/java/test/jmri/managers/ProxyTurnoutManagerTest.java
@@ -197,7 +197,7 @@ public class ProxyTurnoutManagerTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // create and register the manager object
         l = new InternalTurnoutManager() {
             @Override
@@ -205,7 +205,7 @@ public class ProxyTurnoutManagerTest extends TestCase {
                 return "J";
             }
         };
-        jmri.InstanceManager.setTurnoutManager(l);
+        InstanceManager.setTurnoutManager(l);
     }
 
     @Override

--- a/java/test/jmri/util/AlphanumComparatorTest.java
+++ b/java/test/jmri/util/AlphanumComparatorTest.java
@@ -181,13 +181,13 @@ public class AlphanumComparatorTest {
     // from here down is testing infrastructure
     @Before
     public void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         ac = new AlphanumComparator();
     }
 
     @After
     public void tearDown() throws Exception {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/util/ColorUtilTest.java
+++ b/java/test/jmri/util/ColorUtilTest.java
@@ -165,14 +165,14 @@ public class ColorUtilTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-       apps.tests.Log4JFixture.setUp();
+       jmri.util.JUnitUtil.setUp();
        super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
        super.tearDown();
-       apps.tests.Log4JFixture.tearDown();
+       jmri.util.JUnitUtil.tearDown();
     }
 
     public ColorUtilTest(String s) {

--- a/java/test/jmri/util/DateUtilTest.java
+++ b/java/test/jmri/util/DateUtilTest.java
@@ -68,12 +68,12 @@ public class DateUtilTest extends TestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
         super.tearDown();
     }
 

--- a/java/test/jmri/util/FileLineEndingsTest.java
+++ b/java/test/jmri/util/FileLineEndingsTest.java
@@ -1,6 +1,5 @@
 package jmri.util;
 
-import apps.tests.Log4JFixture;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
@@ -88,7 +87,7 @@ public class FileLineEndingsTest {
      * @return a collection of files to validate
      */
     public static Collection<Object[]> getFiles(File directory, String[] patterns, String[] antiPatterns) {
-        Log4JFixture.setUp(); // setup logging early so this method can log
+        jmri.util.JUnitUtil.setUp(); // setup logging early so this method can log
         ArrayList<Object[]> files = new ArrayList<>();
         ArrayList<PathMatcher> antiMatchers = new ArrayList<>();
         for (String antiPattern : antiPatterns) {

--- a/java/test/jmri/util/FileUtilSupportTest.java
+++ b/java/test/jmri/util/FileUtilSupportTest.java
@@ -329,7 +329,7 @@ public class FileUtilSupportTest {
 
     @Before
     public void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
         this.instance = new FileUtilSupport();
         this.programTestFile = new File(UUID.randomUUID().toString());
@@ -356,6 +356,6 @@ public class FileUtilSupportTest {
         JUnitUtil.waitFor(() -> {
             return !this.preferencesTestFile.exists();
         }, "Remove program test file");
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/util/FileUtilTest.java
+++ b/java/test/jmri/util/FileUtilTest.java
@@ -331,7 +331,7 @@ public class FileUtilTest {
 
     @Before
     public void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
         this.programTestFile = new File(UUID.randomUUID().toString());
         this.programTestFile.createNewFile();
@@ -357,6 +357,6 @@ public class FileUtilTest {
         JUnitUtil.waitFor(() -> {
             return !this.preferencesTestFile.exists();
         }, "Remove program test file");
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/util/JLogoutputFrameTest.java
+++ b/java/test/jmri/util/JLogoutputFrameTest.java
@@ -62,6 +62,6 @@ public class JLogoutputFrameTest {
         }
 
         jmri.util.JUnitUtil.resetInstanceManager();
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/util/JTextPaneAppenderTest.java
+++ b/java/test/jmri/util/JTextPaneAppenderTest.java
@@ -1,6 +1,5 @@
 package jmri.util;
 
-import apps.tests.Log4JFixture;
 import java.util.*;
 import org.apache.log4j.*;
 import org.junit.After;
@@ -73,7 +72,7 @@ public class JTextPaneAppenderTest {
         }
         
         jmri.util.JUnitUtil.resetInstanceManager();
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/util/JUnitAppenderTest.java
+++ b/java/test/jmri/util/JUnitAppenderTest.java
@@ -279,7 +279,7 @@ public class JUnitAppenderTest extends TestCase {
     @Override
     protected void tearDown() {
 
-        apps.tests.Log4JFixture.tearDown();     
+        jmri.util.JUnitUtil.tearDown();     
 
         // continue the testUnexpectedCheck test
         if (testingUnexpected) {

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -739,10 +739,10 @@ public class JUnitUtil {
             if (frame.isDisplayable()) {
                 if (frame.getClass().getName().equals("javax.swing.SwingUtilities$SharedOwnerFrame")) {
                     String message = "Cleaning up nameless invisible frame created by creating a dialog with a null parent in {}.";
-                    if (!error) {
-                        log.warn(message, getTestClassName());
-                    } else if (warn) {
+                    if (error) {
                         log.error(message, getTestClassName());
+                    } else if (warn) {
+                        log.warn(message, getTestClassName());
                     }
                 } else {
                     String message = "Cleaning up frame \"{}\" (a {}) in {}.";
@@ -759,10 +759,10 @@ public class JUnitUtil {
             if (window.isDisplayable()) {
                 if (window.getClass().getName().equals("javax.swing.SwingUtilities$SharedOwnerFrame")) {
                     String message = "Cleaning up nameless invisible window created by creating a dialog with a null parent in {}.";
-                    if (!error) {
-                        log.warn(message, getTestClassName());
-                    } else if (warn) {
+                    if (error) {
                         log.error(message, getTestClassName());
+                    } else if (warn) {
+                        log.warn(message, getTestClassName());
                     }
                 } else {
                     String message = "Cleaning up window \"{}\" (a {}) in {}.";

--- a/java/test/jmri/util/Log4JUtilTest.java
+++ b/java/test/jmri/util/Log4JUtilTest.java
@@ -78,12 +78,12 @@ public class Log4JUtilTest extends TestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
         super.tearDown();
     }
 

--- a/java/test/jmri/util/MathUtilTest.java
+++ b/java/test/jmri/util/MathUtilTest.java
@@ -268,12 +268,12 @@ public class MathUtilTest extends TestCase {
     @Before
     protected void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
 
     @After
     protected void tearDown() throws Exception {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
         super.tearDown();
     }
 

--- a/java/test/jmri/util/PropertyChangeEventQueueTest.java
+++ b/java/test/jmri/util/PropertyChangeEventQueueTest.java
@@ -103,7 +103,7 @@ public class PropertyChangeEventQueueTest extends TestCase {
 
     @Override
     protected void tearDown() throws Exception {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
         super.tearDown();
     }
 

--- a/java/test/jmri/util/ThreadingDemoAndTest.java
+++ b/java/test/jmri/util/ThreadingDemoAndTest.java
@@ -366,12 +366,12 @@ public class ThreadingDemoAndTest extends TestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
         super.tearDown();
     }
 

--- a/java/test/jmri/util/ThreadingUtilTest.java
+++ b/java/test/jmri/util/ThreadingUtilTest.java
@@ -174,12 +174,12 @@ public class ThreadingUtilTest extends TestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
         super.tearDown();
     }
 

--- a/java/test/jmri/util/WaitHandlerTest.java
+++ b/java/test/jmri/util/WaitHandlerTest.java
@@ -199,12 +199,12 @@ public class WaitHandlerTest extends TestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
         super.tearDown();
     }
 


### PR DESCRIPTION
- add missing JUnitUtil.setup() calls in some tests, adding setUp() and tearDown methods as needed
- doc update on Log4JFixture vs JUnitJtil, use of resets in tearDown()
- some replacement of deprecated Log4JFixture with JUnitJtil
- remove some redundant resets
- yet another fix to frame-close logging logic
