### PR TITLE
Fix NPE when LnReporter is automatically created

### DIFF
--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -114,7 +114,11 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
         sysNameList = getManager().getSystemNameList();
         // and add them back in
         for (int i = 0; i < sysNameList.size(); i++) {
-            getBySystemName(sysNameList.get(i)).addPropertyChangeListener(this, null, "Table View");
+            // if object has been deleted, it's not here; ignore it
+            T b = getBySystemName(sysNameList.get(i));
+            if (b != null) {
+                b.addPropertyChangeListener(this, null, "Table View");
+            }
         }
     }
 

--- a/java/src/jmri/jmrix/loconet/LnReporterManager.java
+++ b/java/src/jmri/jmrix/loconet/LnReporterManager.java
@@ -118,7 +118,7 @@ public class LnReporterManager extends jmri.managers.AbstractReporterManager imp
         // message type OK, check address
         int addr = (l.getElement(1) & 0x1F) * 128 + l.getElement(2) + 1;
 
-        LnReporter r = (LnReporter) provideReporter("LR" + addr); // NOI18N
+        LnReporter r = (LnReporter) provideReporter(this.prefix+ "R" + addr); // NOI18N
         r.message(l); // make sure it got the message
     }
 


### PR DESCRIPTION
Fix an NPE when an LnReporter is automatically created. The creation process does a create/recreate, where the last parts wasn't handled right. They're handled right with this patch. The question of a more efficient process is left for later.