### PR TITLE
LayoutEditor test threading

### DIFF
--- a/help/en/html/doc/Technical/StartUpScripts.shtml
+++ b/help/en/html/doc/Technical/StartUpScripts.shtml
@@ -150,6 +150,18 @@
             <dd>When set true, run some extra tests; usually used during code migration,
                 where not everything is right yet but you want to be able to include
                 tests for individual running.  </dd>
+        <dt>jmri.util.JUnitUtil.printSetUpTearDownNames</dt>
+            <dd>If true, JUnit tests will print out each JUnitUtil.setUp() and JUnitUtil.teardown() call.
+                This can be useful if i.e. the CI tests are hanging, and you can't figure out which
+                test class is the problem.</dd>
+        <dt>jmri.util.JUnitUtil.checkSetUpTearDownSequence</dt>
+            <dd>If true, check for whether JUnitUtil.setUp() and JUnitUtil.teardown() follow each other
+                int the proper sequence. Print a message if not.  (This slows execution a 
+                bit due to the time needed to keep history for the message)</dd>
+        <dt>jmri.util.JUnitUtil.checkSequenceDumpsStack</dt>
+            <dd>If true, makes jmri.util.JUnitUtil.checkSetUpTearDownSequence more verbose by also
+                including the current stack trace along with the traces of the most recent setUp and 
+                tearDown calls.</dd>
       </dl>
 
       <h2 id="Linux">Linux</h2>

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -9135,6 +9135,9 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         setOptionMenuTurnoutCircleSize();
     }
 
+    /**
+     * Should only be invoked on the GUI (Swing) thread
+     */
     public void setTurnoutDrawUnselectedLeg(boolean state) {
         if (turnoutDrawUnselectedLeg != state) {
             turnoutDrawUnselectedLeg = state;
@@ -9187,6 +9190,9 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         layoutName = name;
     }
 
+    /**
+     * Should only be invoked on the GUI (Swing) thread
+     */
     public void setShowHelpBar(boolean state) {
         if (showHelpBar != state) {
             showHelpBar = state;
@@ -9213,6 +9219,9 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         }
     }
 
+    /**
+     * Should only be invoked on the GUI (Swing) thread
+     */
     public void setDrawGrid(boolean state) {
         if (drawGrid != state) {
             drawGrid = state;
@@ -9220,6 +9229,9 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         }
     }
 
+    /**
+     * Should only be invoked on the GUI (Swing) thread
+     */
     public void setSnapOnAdd(boolean state) {
         if (snapToGridOnAdd != state) {
             snapToGridOnAdd = state;
@@ -9227,6 +9239,9 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         }
     }
 
+    /**
+     * Should only be invoked on the GUI (Swing) thread
+     */
     public void setSnapOnMove(boolean state) {
         if (snapToGridOnMove != state) {
             snapToGridOnMove = state;
@@ -9234,6 +9249,9 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         }
     }
 
+    /**
+     * Should only be invoked on the GUI (Swing) thread
+     */
     public void setAntialiasingOn(boolean state) {
         if (antialiasingOn != state) {
             antialiasingOn = state;

--- a/java/test/apps/JmriFacelessTest.java
+++ b/java/test/apps/JmriFacelessTest.java
@@ -66,7 +66,6 @@ public class JmriFacelessTest {
     @After
     public void tearDown() {
         JUnitUtil.resetApplication();
-        apps.tests.Log4JFixture.tearDown();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/apps/gui3/FirstTimeStartUpWizardTest.java
+++ b/java/test/apps/gui3/FirstTimeStartUpWizardTest.java
@@ -75,7 +75,6 @@ public class FirstTimeStartUpWizardTest {
     @After
     public void tearDown() {
         JUnitUtil.resetApplication();
-        apps.tests.Log4JFixture.tearDown();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/apps/gui3/dp3/DecoderPro3Test.java
+++ b/java/test/apps/gui3/dp3/DecoderPro3Test.java
@@ -72,7 +72,6 @@ public class DecoderPro3Test {
     @After
     public void tearDown() {
         JUnitUtil.resetApplication();
-        apps.tests.Log4JFixture.tearDown();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/apps/gui3/paned/PanedTest.java
+++ b/java/test/apps/gui3/paned/PanedTest.java
@@ -1,7 +1,6 @@
 package apps.gui3.paned;
 
 import apps.AppsBase;
-import apps.tests.Log4JFixture;
 import java.awt.GraphicsEnvironment;
 import jmri.InstanceManager;
 import jmri.util.JUnitUtil;
@@ -66,7 +65,8 @@ public class PanedTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         JUnitUtil.resetApplication();
         JUnitUtil.resetProfileManager();
     }
@@ -74,7 +74,7 @@ public class PanedTest {
     @After
     public void tearDown() {
         JUnitUtil.resetApplication();
-        Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(PanedTest.class);

--- a/java/test/apps/startup/AbstractActionModelTest.java
+++ b/java/test/apps/startup/AbstractActionModelTest.java
@@ -1,6 +1,5 @@
 package apps.startup;
 
-import apps.tests.Log4JFixture;
 import javax.swing.Action;
 import jmri.JmriException;
 import org.junit.After;
@@ -29,12 +28,12 @@ public class AbstractActionModelTest {
     
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
     
     @After
     public void tearDown() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
     /**

--- a/java/test/apps/startup/AbstractStartupModelTest.java
+++ b/java/test/apps/startup/AbstractStartupModelTest.java
@@ -1,6 +1,5 @@
 package apps.startup;
 
-import apps.tests.Log4JFixture;
 import jmri.JmriException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -28,12 +27,12 @@ public class AbstractStartupModelTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
 
     @After
     public void tearDown() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
     /**

--- a/java/test/apps/startup/StartupPauseModelTest.java
+++ b/java/test/apps/startup/StartupPauseModelTest.java
@@ -1,6 +1,5 @@
 package apps.startup;
 
-import apps.tests.Log4JFixture;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -27,12 +26,12 @@ public class StartupPauseModelTest {
     
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
     
     @After
     public void tearDown() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
     /**

--- a/java/test/apps/tests/AllTest.java
+++ b/java/test/apps/tests/AllTest.java
@@ -1,9 +1,7 @@
 package apps.tests;
 
-import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 /**
  * Invoke all the JMRI project JUnit tests via a GUI interface.
@@ -21,46 +19,24 @@ import junit.framework.TestSuite;
  *
  * @author	Bob Jacobsen
  */
-public class AllTest extends TestCase {
-
-    public AllTest(String s) {
-        super(s);
-    }
-
-    // note that initLogging has to be invoked _twice_ to get logging to
-    // work in both the test routines themselves, and also in the TestSuite
-    // code.  And even though it should be protected by a static, it runs
-    // twice!  There are probably two sets of classes being created here...
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", AllTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite
-    public static Test suite() {
-        // all tests from here down in heirarchy
-        TestSuite suite = new TestSuite("AllTest");  // no tests in this class itself
-        // all tests from other classes
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.PackageTest.class));
-        suite.addTest(new junit.framework.JUnit4TestAdapter(apps.PackageTest.class));
+ 
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        jmri.PackageTest.class,
+        apps.PackageTest.class,
         // at the end, we check for logging messages again
-        suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.Log4JErrorIsErrorTest.class));
-        return suite;
-    }
+        jmri.util.Log4JErrorIsErrorTest.class
+})
+
+public class AllTest {
 
     @Deprecated // 4.13.3  No longer needed so long as there's a call to jmri.util.JUnitUtil.setup() in the usual way
     public static void initLogging() {
     }
 
-    @Override
-    protected void setUp() {
-        JUnitUtil.setUp();
-    }
-
-    @Override
-    protected void tearDown() {
-        JUnitUtil.tearDown();
-    }
+   static public void main(String[] args) {
+        // launch this class via JUnit4
+       org.junit.runner.JUnitCore.main("apps.tests.AllTest");
+   }
 
 }

--- a/java/test/apps/tests/AllTest.java
+++ b/java/test/apps/tests/AllTest.java
@@ -44,16 +44,15 @@ public class AllTest extends TestCase {
         // all tests from other classes
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.PackageTest.class));
         suite.addTest(new junit.framework.JUnit4TestAdapter(apps.PackageTest.class));
-        // at the end, we check for Log4J messages again
+        // at the end, we check for logging messages again
         suite.addTest(new junit.framework.JUnit4TestAdapter(jmri.util.Log4JErrorIsErrorTest.class));
         return suite;
     }
 
+    @Deprecated // 4.13.3  No longer needed so long as there's a call to jmri.util.JUnitUtil.setup() in the usual way
     public static void initLogging() {
-        apps.tests.Log4JFixture.initLogging();
     }
 
-    // The minimal setup for log4J
     @Override
     protected void setUp() {
         JUnitUtil.setUp();

--- a/java/test/apps/tests/Log4JFixture.java
+++ b/java/test/apps/tests/Log4JFixture.java
@@ -14,7 +14,7 @@ public class Log4JFixture {
         // prevent instanciation
     }
     
-    @Deprecated // (since="4.11.4", forRemoval=true) Java9 syntax // use jmri.util.JUnitUtil
+    @Deprecated // (since="4.11.4", forRemoval=true) Java9 syntax // needs to be migrated into a jmri.util class
     public static void setUp() {
         // always init logging if needed
         initLogging();
@@ -32,7 +32,7 @@ public class Log4JFixture {
 
     static int count = 0;
     
-    @Deprecated // (since="4.11.4", forRemoval=true) Java9 syntax // use jmri.util.JUnitUtil
+    @Deprecated // (since="4.11.4", forRemoval=true) Java9 syntax // needs to be migrated into a jmri.util class
     public static void tearDown() {
         JUnitAppender.end();
         Level severity = Level.ERROR; // level at or above which we'll complain

--- a/java/test/jmri/AudioTest.java
+++ b/java/test/jmri/AudioTest.java
@@ -200,4 +200,14 @@ public class AudioTest extends TestCase {
         return suite;
     }
 
+    @Override
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @Override
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/IdTagTest.java
+++ b/java/test/jmri/IdTagTest.java
@@ -42,4 +42,14 @@ public class IdTagTest extends TestCase {
         return suite;
     }
 
+    @Override
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @Override
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
+
 }

--- a/java/test/jmri/SchemaTest.java
+++ b/java/test/jmri/SchemaTest.java
@@ -29,13 +29,4 @@ public class SchemaTest extends SchemaTestBase {
         super(file, pass);
     }
 
-    @Before
-    public void setUp() {
-        jmri.util.JUnitUtil.setUp();
-    }
-
-    @After
-    public void tearDown() {
-        jmri.util.JUnitUtil.tearDown();
-    }
 }

--- a/java/test/jmri/SchemaTest.java
+++ b/java/test/jmri/SchemaTest.java
@@ -2,6 +2,8 @@ package jmri;
 
 import java.io.File;
 import jmri.configurexml.SchemaTestBase;
+
+import org.junit.*;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -25,5 +27,15 @@ public class SchemaTest extends SchemaTestBase {
 
     public SchemaTest(File file, boolean pass) {
         super(file, pass);
+    }
+
+    @Before
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/VersionTest.java
+++ b/java/test/jmri/VersionTest.java
@@ -3,7 +3,7 @@ package jmri;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
+import org.junit.*;
 
 /**
  *
@@ -38,6 +38,16 @@ public class VersionTest {
         assertTrue(Version.compareCanonicalVersions("1.2.3-P", "1.2.3") == 0);
         assertTrue(Version.compareCanonicalVersions("213.1.1", "213.1.1") == 0);
         assertTrue(Version.compareCanonicalVersions("213.1.1", "213.1.10") < 0);
+    }
+
+    @Before
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/configurexml/SchemaTestBase.java
+++ b/java/test/jmri/configurexml/SchemaTestBase.java
@@ -109,6 +109,7 @@ public class SchemaTestBase {
     }
 
     @Before
+    @javax.annotation.OverridingMethodsMustInvokeSuper
     public void setUp() throws Exception {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
@@ -116,6 +117,7 @@ public class SchemaTestBase {
     }
 
     @After
+    @javax.annotation.OverridingMethodsMustInvokeSuper
     public void tearDown() throws Exception {
         XmlFile.setDefaultValidate(this.validate);
         JUnitUtil.tearDown();

--- a/java/test/jmri/configurexml/SchemaTestBase.java
+++ b/java/test/jmri/configurexml/SchemaTestBase.java
@@ -1,6 +1,5 @@
 package jmri.configurexml;
 
-import apps.tests.Log4JFixture;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/java/test/jmri/configurexml/SchemaTestBase.java
+++ b/java/test/jmri/configurexml/SchemaTestBase.java
@@ -115,11 +115,6 @@ public class SchemaTestBase {
         this.validate = XmlFile.getDefaultValidate();
     }
 
-    @BeforeClass
-    public static void preClassInit() throws Exception {
-        JUnitUtil.setUp();  // so static ctors can log
-    }
-
     @After
     public void tearDown() throws Exception {
         XmlFile.setDefaultValidate(this.validate);

--- a/java/test/jmri/implementation/testAspects.xml
+++ b/java/test/jmri/implementation/testAspects.xml
@@ -14,6 +14,22 @@
       <holder>JMRI</holder>
     </copyright>
 
+    <authorgroup xmlns="http://docbook.org/ns/docbook" >
+        <author>
+            <personname><firstname>Bob</firstname><surname>Jacobsen</surname></personname>
+            <email>jake@physics.berkeley.edu</email>
+        </author>    
+    </authorgroup>
+
+    <revhistory xmlns="http://docbook.org/ns/docbook">
+        <revision>
+            <revnumber>1</revnumber>
+            <date>2009-12-21</date>
+            <authorinitials>RGJ</authorinitials>
+            <revremark>Initial version</revremark>
+        </revision>    
+    </revhistory>
+
     <aspects>
 
     </aspects>

--- a/java/test/jmri/jmris/JmriConnectionTest.java
+++ b/java/test/jmri/jmris/JmriConnectionTest.java
@@ -46,14 +46,15 @@ public class JmriConnectionTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
 }

--- a/java/test/jmri/jmris/JmriServerActionTest.java
+++ b/java/test/jmri/jmris/JmriServerActionTest.java
@@ -1,6 +1,5 @@
 package jmri.jmris;
 
-import apps.tests.Log4JFixture;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -22,12 +21,13 @@ public class JmriServerActionTest {
     // The minimal setup for log4J
     @Before
     public void setUp() throws Exception {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
 
     @After
     public void tearDown() throws Exception {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
 }

--- a/java/test/jmri/jmris/JmriServerTest.java
+++ b/java/test/jmri/jmris/JmriServerTest.java
@@ -50,14 +50,15 @@ public class JmriServerTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
 }

--- a/java/test/jmri/jmris/ServiceHandlerTest.java
+++ b/java/test/jmri/jmris/ServiceHandlerTest.java
@@ -146,14 +146,15 @@ public class ServiceHandlerTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
 }

--- a/java/test/jmri/jmris/simpleserver/SimpleServerManagerTest.java
+++ b/java/test/jmri/jmris/simpleserver/SimpleServerManagerTest.java
@@ -38,7 +38,7 @@ public class SimpleServerManagerTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
     }
@@ -46,7 +46,8 @@ public class SimpleServerManagerTest extends TestCase {
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
 }

--- a/java/test/jmri/jmrit/MemoryContentsTest.java
+++ b/java/test/jmri/jmrit/MemoryContentsTest.java
@@ -838,14 +838,15 @@ public class MemoryContentsTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
     private final static Logger log = LoggerFactory.getLogger(MemoryContentsTest.class);
 

--- a/java/test/jmri/jmrit/SoundTest.java
+++ b/java/test/jmri/jmrit/SoundTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit;
 
-import apps.tests.Log4JFixture;
 import java.awt.GraphicsEnvironment;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.LineUnavailableException;
@@ -21,12 +20,14 @@ public class SoundTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
 
     @After
     public void tearDown() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
     
     /**

--- a/java/test/jmri/jmrit/beantable/AddNewDevicePanelTest.java
+++ b/java/test/jmri/jmrit/beantable/AddNewDevicePanelTest.java
@@ -31,14 +31,16 @@ public class AddNewDevicePanelTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         jmri.util.JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(AddNewDevicePanelTest.class);

--- a/java/test/jmri/jmrit/beantable/AddNewHardwareDevicePanelTest.java
+++ b/java/test/jmri/jmrit/beantable/AddNewHardwareDevicePanelTest.java
@@ -43,7 +43,8 @@ public class AddNewHardwareDevicePanelTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         jmri.util.JUnitUtil.resetInstanceManager();
     }
 
@@ -51,7 +52,8 @@ public class AddNewHardwareDevicePanelTest {
     public void tearDown() {
 
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(AddNewHardwareDevicePanelTest.class);

--- a/java/test/jmri/jmrit/beantable/LRouteTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LRouteTableActionTest.java
@@ -121,7 +121,8 @@ public class LRouteTableActionTest extends jmri.util.SwingTestCase //TestCase //
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         super.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
 

--- a/java/test/jmri/jmrit/beantable/LightTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LightTableActionTest.java
@@ -108,7 +108,8 @@ public class LightTableActionTest extends AbstractTableActionBase {
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.initInternalLightManager();
         jmri.util.JUnitUtil.resetInstanceManager();
@@ -123,7 +124,8 @@ public class LightTableActionTest extends AbstractTableActionBase {
         a = null;
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(LightTableActionTest.class);

--- a/java/test/jmri/jmrit/beantable/LogixTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixTableActionTest.java
@@ -171,7 +171,7 @@ public class LogixTableActionTest extends AbstractTableActionBase {
     }
 
     @Test
-    public void testDeleteLogix() {
+    public void testDeleteLogix() throws InterruptedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         LogixTableAction lgxTable = (LogixTableAction) a;
 
@@ -180,21 +180,23 @@ public class LogixTableActionTest extends AbstractTableActionBase {
         Assert.assertNotNull("Found Logix Frame", lgxFrame);  // NOI18N
 
         // Delete IX102, respond No
-        createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonNo"));  // NOI18N
+        Thread t1 = createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonNo"));  // NOI18N
         lgxTable.deletePressed("IX102");  // NOI18N
+        t1.join();
         Logix chk102 = jmri.InstanceManager.getDefault(jmri.LogixManager.class).getBySystemName("IX102");  // NOI18N
         Assert.assertNotNull("Verify IX102 Not Deleted", chk102);  // NOI18N
 
         // Delete IX103, respond Yes
-        createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonYes"));  // NOI18N
+        Thread t2 = createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonYes"));  // NOI18N
         lgxTable.deletePressed("IX103");  // NOI18N
+        t2.join();
         Logix chk103 = jmri.InstanceManager.getDefault(jmri.LogixManager.class).getBySystemName("IX103");  // NOI18N
         Assert.assertNull("Verify IX103 Is Deleted", chk103);  // NOI18N
 
         JUnitUtil.dispose(lgxFrame);
     }
 
-    void createModalDialogOperatorThread(String dialogTitle, String buttonText) {
+    Thread createModalDialogOperatorThread(String dialogTitle, String buttonText) {
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
             JDialogOperator jdo = new JDialogOperator(dialogTitle);
@@ -203,6 +205,7 @@ public class LogixTableActionTest extends AbstractTableActionBase {
         });
         t.setName(dialogTitle + " Close Dialog Thread");
         t.start();
+        return t;
     }
 
     @Before

--- a/java/test/jmri/jmrit/beantable/LogixTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LogixTableActionTest.java
@@ -4,12 +4,13 @@ import java.awt.GraphicsEnvironment;
 import javax.swing.JFrame;
 import jmri.InstanceManager;
 import jmri.Logix;
-import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+
+import jmri.util.*;
+import jmri.util.junit.rules.*;
+
+import org.junit.*;
+import org.junit.rules.*;
+
 import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JCheckBoxOperator;
 import org.netbeans.jemmy.operators.JDialogOperator;
@@ -23,6 +24,12 @@ import org.netbeans.jemmy.operators.JTextFieldOperator;
 * @author Dave Sand Copyright (C) 2017
  */
 public class LogixTableActionTest extends AbstractTableActionBase {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10); // 10 second timeout for methods in this test class.
+
+    @Rule
+    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
 
     @Test
     public void testCtor() {

--- a/java/test/jmri/jmrit/decoderdefn/DuplicateTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/DuplicateTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.decoderdefn;
 
-import apps.tests.Log4JFixture;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -78,12 +77,14 @@ public class DuplicateTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
 
     @After
     public void tearDown() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     private final static Logger log = LoggerFactory.getLogger(DuplicateTest.class);

--- a/java/test/jmri/jmrit/display/PositionableTestBase.java
+++ b/java/test/jmri/jmrit/display/PositionableTestBase.java
@@ -21,9 +21,11 @@ abstract public class PositionableTestBase {
     protected Editor editor = null;   // derived classes should set editor in setup;
     protected Positionable p = null;  //derived classes should set p in setUp
 
+    // Should do JUnitUtil.setUp() in subclass to make sure it's before anything
     @Before
-    abstract public void setUp();
+    abstract public void setUp(); 
 
+    // Should do JUnitUtil.tearDown() in subclass to make sure it's after everything
     @After
     @javax.annotation.OverridingMethodsMustInvokeSuper 
     public void tearDown() {
@@ -39,7 +41,6 @@ abstract public class PositionableTestBase {
         JUnitUtil.resetWindows(false, false);  // don't log here.  should be from this class.
         editor = null;
         p = null;
-        JUnitUtil.tearDown();
     }
 
     @Test

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -2,17 +2,15 @@ package jmri.jmrit.display.layoutEditor;
 
 import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
+
 import jmri.InstanceManager;
 import jmri.UserPreferencesManager;
 import jmri.jmrit.display.EditorFrameOperator;
-import jmri.util.ColorUtil;
-import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import jmri.util.*;
+import jmri.util.junit.rules.*;
+
+import org.junit.*;
+import org.junit.rules.*;
 import org.netbeans.jemmy.operators.JMenuOperator;
 
 /**
@@ -21,6 +19,12 @@ import org.netbeans.jemmy.operators.JMenuOperator;
  * @author Paul Bender Copyright (C) 2016
  */
 public class LayoutEditorTest extends jmri.jmrit.display.AbstractEditorTestBase {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(10); // 10 second timeout for methods in this test class.
+
+    @Rule
+    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
 
     private LayoutEditor le = null;
 
@@ -183,14 +187,16 @@ public class LayoutEditorTest extends jmri.jmrit.display.AbstractEditorTestBase 
     @Test
     public void testSetLayoutDimensions() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        // set the panel dimensions to known values
-        le.setLayoutDimensions(100, 100, 100, 100, 100, 100);
-        Assert.assertEquals("layout width after set", 100, le.getLayoutWidth());
-        Assert.assertEquals("layout height after set", 100, le.getLayoutHeight());
-        Assert.assertEquals("window width after set", 100, le.getWindowWidth());
-        Assert.assertEquals("window height after set", 100, le.getWindowHeight());
-        Assert.assertEquals("upper left X after set", 100, le.getUpperLeftX());
-        Assert.assertEquals("upper left Y after set", 100, le.getUpperLeftX());
+        ThreadingUtil.runOnGUI(() -> {
+            // set the panel dimensions to known values
+            le.setLayoutDimensions(100, 100, 100, 100, 100, 100);
+            Assert.assertEquals("layout width after set", 100, le.getLayoutWidth());
+            Assert.assertEquals("layout height after set", 100, le.getLayoutHeight());
+            Assert.assertEquals("window width after set", 100, le.getWindowWidth());
+            Assert.assertEquals("window height after set", 100, le.getWindowHeight());
+            Assert.assertEquals("upper left X after set", 100, le.getUpperLeftX());
+            Assert.assertEquals("upper left Y after set", 100, le.getUpperLeftX());
+        });
     }
 
     @Test
@@ -381,24 +387,29 @@ public class LayoutEditorTest extends jmri.jmrit.display.AbstractEditorTestBase 
     @Test
     public void testGetShowHelpBar() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        le.setShowHelpBar(true);
-        Assert.assertTrue("getShowHelpBar", le.getShowHelpBar());
-        le.setShowHelpBar(false);
-        Assert.assertFalse("getShowHelpBar", le.getShowHelpBar());
+        
+        ThreadingUtil.runOnGUI(() -> {
+            le.setShowHelpBar(true);
+            Assert.assertTrue("getShowHelpBar", le.getShowHelpBar());
+            le.setShowHelpBar(false);
+            Assert.assertFalse("getShowHelpBar", le.getShowHelpBar());
+        });
     }
 
     @Test
     public void testSetShowHelpBar() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        // toggle a couple of times
-        le.setShowHelpBar(false);
-        Assert.assertFalse("getShowHelpBar after set", le.getShowHelpBar());
-        le.setShowHelpBar(true);
-        Assert.assertTrue("getShowHelpBar", le.getShowHelpBar());
-        le.setShowHelpBar(false);
-        Assert.assertFalse("getShowHelpBar", le.getShowHelpBar());
-        le.setShowHelpBar(true);
-        Assert.assertTrue("getShowHelpBar", le.getShowHelpBar());
+        ThreadingUtil.runOnGUI(() -> {
+            // toggle a couple of times
+            le.setShowHelpBar(false);
+            Assert.assertFalse("getShowHelpBar after set", le.getShowHelpBar());
+            le.setShowHelpBar(true);
+            Assert.assertTrue("getShowHelpBar", le.getShowHelpBar());
+            le.setShowHelpBar(false);
+            Assert.assertFalse("getShowHelpBar", le.getShowHelpBar());
+            le.setShowHelpBar(true);
+            Assert.assertTrue("getShowHelpBar", le.getShowHelpBar());
+        });
     }
 
     @Test

--- a/java/test/jmri/jmrit/display/palette/IndicatorTOIconDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/IndicatorTOIconDialogTest.java
@@ -33,7 +33,8 @@ public class IndicatorTOIconDialogTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.resetInstanceManager();
     }
@@ -41,7 +42,8 @@ public class IndicatorTOIconDialogTest {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(IndicatorTOIconDialogTest.class);

--- a/java/test/jmri/jmrit/log/LogOutputWindowActionTest.java
+++ b/java/test/jmri/jmrit/log/LogOutputWindowActionTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.log;
 
-import apps.tests.Log4JFixture;
 import java.util.*;
 import jmri.util.JTextPaneAppender;
 import jmri.util.JUnitUtil;

--- a/java/test/jmri/jmrit/logix/SpeedUtilTest.java
+++ b/java/test/jmri/jmrit/logix/SpeedUtilTest.java
@@ -24,14 +24,16 @@ public class SpeedUtilTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         jmri.util.JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(SpeedUtilTest.class);

--- a/java/test/jmri/jmrit/logix/WarrantTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantTest.java
@@ -250,7 +250,8 @@ public class WarrantTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
         JUnitUtil.initDebugThrottleManager();

--- a/java/test/jmri/jmrit/operations/OperationsSwingTestCase.java
+++ b/java/test/jmri/jmrit/operations/OperationsSwingTestCase.java
@@ -145,7 +145,8 @@ public class OperationsSwingTestCase {
 
     @Before
     public void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
 
         // Set things up outside of operations
         JUnitUtil.resetInstanceManager();

--- a/java/test/jmri/jmrit/operations/OperationsTestCase.java
+++ b/java/test/jmri/jmrit/operations/OperationsTestCase.java
@@ -20,7 +20,8 @@ public class OperationsTestCase extends TestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
 
         // Set things up outside of operations
         JUnitUtil.resetInstanceManager();

--- a/java/test/jmri/jmrit/operations/automation/AutomationTableFrameTest.java
+++ b/java/test/jmri/jmrit/operations/automation/AutomationTableFrameTest.java
@@ -225,7 +225,8 @@ public class AutomationTableFrameTest extends OperationsSwingTestCase {
     @Override
     @After
     public void tearDown() throws Exception {
-        // apps.tests.Log4JFixture.tearDown();
+        // jmri.util.JUnitUtil.tearDown();
+
         super.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/operations/automation/AutomationsTableFrameTest.java
+++ b/java/test/jmri/jmrit/operations/automation/AutomationsTableFrameTest.java
@@ -48,7 +48,8 @@ public class AutomationsTableFrameTest extends OperationsSwingTestCase {
     @Override
     @After
     public void tearDown() throws Exception {
-        // apps.tests.Log4JFixture.tearDown();
+        // jmri.util.JUnitUtil.tearDown();
+
         super.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/operations/rollingstock/OperationsRollingStockTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/OperationsRollingStockTest.java
@@ -241,7 +241,8 @@ public class OperationsRollingStockTest extends OperationsTestCase {
     // Ensure minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         super.setUp();
     }
 
@@ -265,6 +266,7 @@ public class OperationsRollingStockTest extends OperationsTestCase {
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/operations/setup/BackupSetTest.java
+++ b/java/test/jmri/jmrit/operations/setup/BackupSetTest.java
@@ -25,14 +25,16 @@ public class BackupSetTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         jmri.util.JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(BackupSetTest.class.getName());

--- a/java/test/jmri/jmrit/operations/setup/OperationsBackupTest.java
+++ b/java/test/jmri/jmrit/operations/setup/OperationsBackupTest.java
@@ -130,7 +130,8 @@ public class OperationsBackupTest extends TestCase {
      */
     @Override
     protected void setUp() throws IOException {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
 
         // set the file location to temp (in the root of the build directory).
         OperationsSetupXml.setFileLocation("temp" + File.separator);
@@ -178,7 +179,8 @@ public class OperationsBackupTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
         deleteTestFiles();
     }
 

--- a/java/test/jmri/jmrit/operations/trains/timetable/TrainScheduleTest.java
+++ b/java/test/jmri/jmrit/operations/trains/timetable/TrainScheduleTest.java
@@ -20,14 +20,16 @@ public class TrainScheduleTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         jmri.util.JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(TrainScheduleTest.class);

--- a/java/test/jmri/jmrit/roster/FunctionLabelPaneTest.java
+++ b/java/test/jmri/jmrit/roster/FunctionLabelPaneTest.java
@@ -69,7 +69,8 @@ public class FunctionLabelPaneTest {
     @Before
     public void setUp() {
         // log4J
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         jmri.util.JUnitUtil.resetProfileManager();
 
         // create Element

--- a/java/test/jmri/jmrit/roster/RosterEntryTest.java
+++ b/java/test/jmri/jmrit/roster/RosterEntryTest.java
@@ -404,7 +404,7 @@ public class RosterEntryTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
         InstanceManager.setDefault(RosterConfigManager.class, new RosterConfigManager());
     }

--- a/java/test/jmri/jmrit/roster/swing/RosterTableModelTest.java
+++ b/java/test/jmri/jmrit/roster/swing/RosterTableModelTest.java
@@ -58,7 +58,8 @@ public class RosterTableModelTest extends TestCase {
 
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         jmri.util.JUnitUtil.resetProfileManager();
 
         // Create empty test instance

--- a/java/test/jmri/jmrit/roster/swing/attributetable/AttributeTableModelTest.java
+++ b/java/test/jmri/jmrit/roster/swing/attributetable/AttributeTableModelTest.java
@@ -58,7 +58,8 @@ public class AttributeTableModelTest extends TestCase {
 
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         jmri.util.JUnitUtil.resetProfileManager();
 
         // Create empty test instance

--- a/java/test/jmri/jmrit/sound/SoundUtilTest.java
+++ b/java/test/jmri/jmrit/sound/SoundUtilTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.sound;
 
-import apps.tests.Log4JFixture;
 import jmri.util.FileUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -19,12 +18,14 @@ public class SoundUtilTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
 
     @After
     public void tearDown() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     @Test

--- a/java/test/jmri/jmrit/symbolicprog/CVNameComparatorTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CVNameComparatorTest.java
@@ -40,14 +40,15 @@ public class CVNameComparatorTest extends jmri.util.AlphanumComparatorTest {
     @Before
     @Override
     public void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         ac = new CVNameComparator();
     }
 
     @After
     @Override
     public void tearDown() throws Exception {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
 }

--- a/java/test/jmri/jmrit/symbolicprog/CombinedLocoSelPaneTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CombinedLocoSelPaneTest.java
@@ -24,7 +24,7 @@ public class CombinedLocoSelPaneTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.InstanceManager.setDefault(ProgrammerConfigManager.class,new ProgrammerConfigManager());
@@ -33,7 +33,8 @@ public class CombinedLocoSelPaneTest {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(CombinedLocoSelPaneTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/CombinedLocoSelTreePaneTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CombinedLocoSelTreePaneTest.java
@@ -24,7 +24,7 @@ public class CombinedLocoSelTreePaneTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.InstanceManager.setDefault(ProgrammerConfigManager.class,new ProgrammerConfigManager());
@@ -33,7 +33,8 @@ public class CombinedLocoSelTreePaneTest {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(CombinedLocoSelTreePaneTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/ComboOffRadioButtonTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/ComboOffRadioButtonTest.java
@@ -58,14 +58,15 @@ public class ComboOffRadioButtonTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(ComboOffRadioButtonTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/ComboOnRadioButtonTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/ComboOnRadioButtonTest.java
@@ -58,14 +58,15 @@ public class ComboOnRadioButtonTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(ComboOnRadioButtonTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/CsvExportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CsvExportActionTest.java
@@ -27,14 +27,15 @@ public class CsvExportActionTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
     }
 
     @After
     public void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(CsvExportActionTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/CsvImportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/CsvImportActionTest.java
@@ -25,14 +25,15 @@ public class CsvImportActionTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(CsvImportActionTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/DccAddressVarHandlerTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/DccAddressVarHandlerTest.java
@@ -54,14 +54,15 @@ public class DccAddressVarHandlerTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(DccAddressVarHandlerTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/FactoryResetActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/FactoryResetActionTest.java
@@ -28,7 +28,7 @@ public class FactoryResetActionTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.initDebugProgrammerManager();
@@ -37,7 +37,8 @@ public class FactoryResetActionTest {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(FactoryResetActionTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/GenericImportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/GenericImportActionTest.java
@@ -27,7 +27,7 @@ public class GenericImportActionTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
     }
@@ -35,7 +35,8 @@ public class GenericImportActionTest {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(GenericImportActionTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/KnownLocoSelPaneTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/KnownLocoSelPaneTest.java
@@ -32,7 +32,7 @@ public class KnownLocoSelPaneTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.InstanceManager.setDefault(ProgrammerConfigManager.class,new ProgrammerConfigManager());
@@ -41,7 +41,8 @@ public class KnownLocoSelPaneTest {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(KnownLocoSelPaneTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/LocoSelTreePaneTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/LocoSelTreePaneTest.java
@@ -24,7 +24,7 @@ public class LocoSelTreePaneTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.InstanceManager.setDefault(ProgrammerConfigManager.class,new ProgrammerConfigManager());
@@ -33,7 +33,8 @@ public class LocoSelTreePaneTest {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(LocoSelTreePaneTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/LokProgImportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/LokProgImportActionTest.java
@@ -27,7 +27,7 @@ public class LokProgImportActionTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.resetInstanceManager();
     }
@@ -35,7 +35,8 @@ public class LokProgImportActionTest {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(LokProgImportActionTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/Pr1ExportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/Pr1ExportActionTest.java
@@ -27,7 +27,7 @@ public class Pr1ExportActionTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.resetInstanceManager();
     }
@@ -35,7 +35,8 @@ public class Pr1ExportActionTest {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(Pr1ExportActionTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/Pr1ImportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/Pr1ImportActionTest.java
@@ -27,14 +27,15 @@ public class Pr1ImportActionTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.setUp();
     }
 
     // private final static Logger log = LoggerFactory.getLogger(Pr1ImportActionTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/Pr1WinExportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/Pr1WinExportActionTest.java
@@ -27,7 +27,7 @@ public class Pr1WinExportActionTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.resetInstanceManager();
     }
@@ -35,7 +35,8 @@ public class Pr1WinExportActionTest {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(Pr1WinExportActionTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/QualifierAdderTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/QualifierAdderTest.java
@@ -272,7 +272,7 @@ public class QualifierAdderTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
 
         p = new ProgDebugger();
         cvtable = new CvTableModel(new JLabel(""), p);

--- a/java/test/jmri/jmrit/symbolicprog/QualifierCombinerTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/QualifierCombinerTest.java
@@ -57,7 +57,7 @@ public class QualifierCombinerTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
 
         p = new ProgDebugger();
         cvtable = new CvTableModel(new JLabel(""), p);

--- a/java/test/jmri/jmrit/symbolicprog/QuantumCvMgrImportActionTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/QuantumCvMgrImportActionTest.java
@@ -27,7 +27,7 @@ public class QuantumCvMgrImportActionTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.resetInstanceManager();
     }
@@ -35,7 +35,8 @@ public class QuantumCvMgrImportActionTest {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(QuantumCvMgrImportActionTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/ResetTableModelTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/ResetTableModelTest.java
@@ -22,7 +22,7 @@ public class ResetTableModelTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initDebugProgrammerManager();
     }
@@ -30,7 +30,8 @@ public class ResetTableModelTest {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     // private final static Logger log = LoggerFactory.getLogger(ResetTableModelTest.class);

--- a/java/test/jmri/jmrit/symbolicprog/ValueQualifierTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/ValueQualifierTest.java
@@ -111,7 +111,7 @@ public class ValueQualifierTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         v = createCvMap();
         cv1 = new CvValue("81", p);
         cv1.setValue(3);

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/CheckProgrammerNamesTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/CheckProgrammerNamesTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.symbolicprog.tabbedframe;
 
-import apps.tests.Log4JFixture;
 import java.io.File;
 import org.junit.After;
 import org.junit.Assert;
@@ -95,11 +94,12 @@ public class CheckProgrammerNamesTest {
 
     @Before
     public void setUp() throws Exception {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
 
     @After
     public void tearDown() throws Exception {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/AddressPanelTest.java
+++ b/java/test/jmri/jmrit/throttle/AddressPanelTest.java
@@ -38,13 +38,15 @@ public class AddressPanelTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         JUnitUtil.resetProfileManager();
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/FunctionButtonTest.java
+++ b/java/test/jmri/jmrit/throttle/FunctionButtonTest.java
@@ -37,12 +37,14 @@ public class FunctionButtonTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/LargePowerManagerButtonTest.java
+++ b/java/test/jmri/jmrit/throttle/LargePowerManagerButtonTest.java
@@ -37,12 +37,14 @@ public class LargePowerManagerButtonTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/LoadDefaultXmlThrottlesLayoutActionTest.java
+++ b/java/test/jmri/jmrit/throttle/LoadDefaultXmlThrottlesLayoutActionTest.java
@@ -37,12 +37,14 @@ public class LoadDefaultXmlThrottlesLayoutActionTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/LoadXmlThrottlesLayoutActionTest.java
+++ b/java/test/jmri/jmrit/throttle/LoadXmlThrottlesLayoutActionTest.java
@@ -37,12 +37,14 @@ public class LoadXmlThrottlesLayoutActionTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/SmallPowerManagerButtonTest.java
+++ b/java/test/jmri/jmrit/throttle/SmallPowerManagerButtonTest.java
@@ -37,12 +37,14 @@ public class SmallPowerManagerButtonTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/StopAllButtonTest.java
+++ b/java/test/jmri/jmrit/throttle/StopAllButtonTest.java
@@ -37,12 +37,14 @@ public class StopAllButtonTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/StoreDefaultXmlThrottlesLayoutActionTest.java
+++ b/java/test/jmri/jmrit/throttle/StoreDefaultXmlThrottlesLayoutActionTest.java
@@ -37,12 +37,14 @@ public class StoreDefaultXmlThrottlesLayoutActionTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/StoreXmlThrottlesLayoutActionTest.java
+++ b/java/test/jmri/jmrit/throttle/StoreXmlThrottlesLayoutActionTest.java
@@ -37,12 +37,14 @@ public class StoreXmlThrottlesLayoutActionTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/ThrottleCreationActionTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottleCreationActionTest.java
@@ -37,12 +37,14 @@ public class ThrottleCreationActionTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/ThrottlesListPanelTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottlesListPanelTest.java
@@ -37,12 +37,14 @@ public class ThrottlesListPanelTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/ThrottlesPreferencesActionTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottlesPreferencesActionTest.java
@@ -37,12 +37,14 @@ public class ThrottlesPreferencesActionTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/ThrottlesPreferencesPaneTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottlesPreferencesPaneTest.java
@@ -37,12 +37,14 @@ public class ThrottlesPreferencesPaneTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/ThrottlesPreferencesTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottlesPreferencesTest.java
@@ -37,12 +37,14 @@ public class ThrottlesPreferencesTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/throttle/ThrottlesTableCellRendererTest.java
+++ b/java/test/jmri/jmrit/throttle/ThrottlesTableCellRendererTest.java
@@ -37,12 +37,14 @@ public class ThrottlesTableCellRendererTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/ussctc/OsIndicatorTest.java
+++ b/java/test/jmri/jmrit/ussctc/OsIndicatorTest.java
@@ -144,7 +144,8 @@ public class OsIndicatorTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         super.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();

--- a/java/test/jmri/jmrit/vsdecoder/VSDSoundTest.java
+++ b/java/test/jmri/jmrit/vsdecoder/VSDSoundTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.vsdecoder;
 
-import apps.tests.Log4JFixture;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -68,13 +67,15 @@ public class VSDSoundTest extends TestCase {
     @Before
     @Override
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
 
     @After
     @Override
     public void tearDown() {
         jmri.util.JUnitAppender.suppressWarnMessage("Initialised Null audio system - no sounds will be available.");
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/withrottle/ConsistControllerTest.java
+++ b/java/test/jmri/jmrit/withrottle/ConsistControllerTest.java
@@ -42,7 +42,8 @@ public class ConsistControllerTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         jmri.util.JUnitUtil.resetProfileManager();
 
         jmri.util.JUnitUtil.initDebugCommandStation();

--- a/java/test/jmri/jmrit/withrottle/ConsistFunctionControllerTest.java
+++ b/java/test/jmri/jmrit/withrottle/ConsistFunctionControllerTest.java
@@ -40,13 +40,14 @@ public class ConsistFunctionControllerTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         InstanceManager.setDefault(NamedBeanHandleManager.class, new NamedBeanHandleManager());
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/withrottle/TrackPowerControllerTest.java
+++ b/java/test/jmri/jmrit/withrottle/TrackPowerControllerTest.java
@@ -37,12 +37,14 @@ public class TrackPowerControllerTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrit/withrottle/TurnoutControllerTest.java
+++ b/java/test/jmri/jmrit/withrottle/TurnoutControllerTest.java
@@ -38,7 +38,7 @@ public class TurnoutControllerTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
     
     @Override

--- a/java/test/jmri/jmrit/withrottle/WiThrottlesListModelTest.java
+++ b/java/test/jmri/jmrit/withrottle/WiThrottlesListModelTest.java
@@ -38,12 +38,13 @@ public class WiThrottlesListModelTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
     
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/jmrix/AbstractMRNodeTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/AbstractMRNodeTrafficControllerTest.java
@@ -26,7 +26,7 @@ public class AbstractMRNodeTrafficControllerTest extends AbstractMRTrafficContro
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp(); 
+        JUnitUtil.setUp(); 
         JUnitUtil.resetInstanceManager();
         tc = new AbstractMRNodeTrafficController(){
            @Override

--- a/java/test/jmri/jmrix/AbstractMRTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/AbstractMRTrafficControllerTest.java
@@ -56,7 +56,7 @@ public class AbstractMRTrafficControllerTest {
 
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp(); 
+        JUnitUtil.setUp(); 
         JUnitUtil.resetInstanceManager();
         tc = new AbstractMRTrafficController(){
            @Override

--- a/java/test/jmri/jmrix/ConnectionConfigManagerTest.java
+++ b/java/test/jmri/jmrix/ConnectionConfigManagerTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrix;
 
-import apps.tests.Log4JFixture;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -50,14 +49,14 @@ public class ConnectionConfigManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         this.workspace = Files.createTempDirectory(this.getClass().getSimpleName());
         JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() throws Exception {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager();
         JUnitUtil.resetFileUtilSupport();

--- a/java/test/jmri/jmrix/acela/AcelaNodeTest.java
+++ b/java/test/jmri/jmrix/acela/AcelaNodeTest.java
@@ -179,7 +179,7 @@ public class AcelaNodeTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
 
         tcis = new AcelaTrafficControlScaffold();
 

--- a/java/test/jmri/jmrix/acela/AcelaTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/acela/AcelaTrafficControllerTest.java
@@ -146,7 +146,7 @@ public class AcelaTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffic
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         tc = new AcelaTrafficController();
     }
 

--- a/java/test/jmri/jmrix/acela/AcelaTurnoutTest.java
+++ b/java/test/jmri/jmrix/acela/AcelaTurnoutTest.java
@@ -92,7 +92,7 @@ public class AcelaTurnoutTest extends jmri.implementation.AbstractTurnoutTestBas
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
 
         tcis = new AcelaTrafficControlScaffold();
         memo = new AcelaSystemConnectionMemo(tcis);

--- a/java/test/jmri/jmrix/acela/configurexml/AcelaSignalHeadXmlTest.java
+++ b/java/test/jmri/jmrix/acela/configurexml/AcelaSignalHeadXmlTest.java
@@ -25,7 +25,7 @@ public class AcelaSignalHeadXmlTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         InstanceManager.setDefault(AcelaSystemConnectionMemo.class, new AcelaSystemConnectionMemo());
     }
 

--- a/java/test/jmri/jmrix/can/AbstractCanTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/AbstractCanTrafficControllerTest.java
@@ -16,7 +16,7 @@ public class AbstractCanTrafficControllerTest extends jmri.jmrix.AbstractMRTraff
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp(); 
+        jmri.util.JUnitUtil.setUp(); 
         JUnitUtil.resetInstanceManager();
         tc = new AbstractCanTrafficController(){
            @Override

--- a/java/test/jmri/jmrix/can/CanMessageTest.java
+++ b/java/test/jmri/jmrix/can/CanMessageTest.java
@@ -147,8 +147,8 @@ public class CanMessageTest extends CanMRCommonTestBase {
     // The minimal setup for log4J
     @Override
     protected void setUp() {
+        jmri.util.JUnitUtil.setUp();
         new TrafficControllerScaffold();
-        apps.tests.Log4JFixture.setUp();
     }
 
     @Override

--- a/java/test/jmri/jmrix/can/TrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/TrafficControllerTest.java
@@ -29,7 +29,7 @@ public class TrafficControllerTest extends AbstractCanTrafficControllerTest {
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp(); 
+        jmri.util.JUnitUtil.setUp(); 
         JUnitUtil.resetInstanceManager();
         tc = new TrafficController(){
            @Override

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/GcTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/GcTrafficControllerTest.java
@@ -13,7 +13,7 @@ public class GcTrafficControllerTest extends jmri.jmrix.can.TrafficControllerTes
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp(); 
+        jmri.util.JUnitUtil.setUp(); 
         JUnitUtil.resetInstanceManager();
         tc = new GcTrafficController();
     }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/MergMessageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/MergMessageTest.java
@@ -80,8 +80,8 @@ public class MergMessageTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() {
+        jmri.util.JUnitUtil.setUp();
         new TrafficControllerScaffold();
-        apps.tests.Log4JFixture.setUp();
     }
 
     @Override

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/MergTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/MergTrafficControllerTest.java
@@ -22,7 +22,7 @@ public class MergTrafficControllerTest extends jmri.jmrix.can.adapters.gridconne
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp(); 
+        jmri.util.JUnitUtil.setUp(); 
         JUnitUtil.resetInstanceManager();
         tc = new MergTrafficController();
     }

--- a/java/test/jmri/jmrix/can/adapters/lawicell/LawicellTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/adapters/lawicell/LawicellTrafficControllerTest.java
@@ -13,7 +13,7 @@ public class LawicellTrafficControllerTest extends jmri.jmrix.can.TrafficControl
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp(); 
+        jmri.util.JUnitUtil.setUp(); 
         JUnitUtil.resetInstanceManager();
         tc = new LawicellTrafficController();
     }
@@ -21,7 +21,7 @@ public class LawicellTrafficControllerTest extends jmri.jmrix.can.TrafficControl
     @Override
     @After
     public void tearDown(){
-       tc = null;
+        tc = null;
         JUnitUtil.tearDown(); 
     }
 

--- a/java/test/jmri/jmrix/can/adapters/loopback/LoopbackTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/can/adapters/loopback/LoopbackTrafficControllerTest.java
@@ -13,7 +13,7 @@ public class LoopbackTrafficControllerTest extends jmri.jmrix.can.TrafficControl
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp(); 
+        jmri.util.JUnitUtil.setUp(); 
         JUnitUtil.resetInstanceManager();
         tc = new LoopbackTrafficController();
     }

--- a/java/test/jmri/jmrix/cmri/CMRISystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/cmri/CMRISystemConnectionMemoTest.java
@@ -69,15 +69,15 @@ public class CMRISystemConnectionMemoTest extends jmri.jmrix.SystemConnectionMem
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         scm = new CMRISystemConnectionMemo();
     }
    
     @After
     public void tearDown() {
-        jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        scm = null;
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/cmri/serial/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/PackageTest.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-   jmri.jmrix.cmri.serial.SerialTurnoutTest.class,
    jmri.jmrix.cmri.serial.SerialTurnoutManagerTest.class,
    jmri.jmrix.cmri.serial.SerialSensorManagerTest.class,
    jmri.jmrix.cmri.serial.SerialNodeTest.class,

--- a/java/test/jmri/jmrix/cmri/serial/SerialTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTrafficControllerTest.java
@@ -156,13 +156,14 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         tc = new SerialTrafficController();
     }
 
     @Override
     @After
     public void tearDown() {
+        tc = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
@@ -3,9 +3,7 @@ package jmri.jmrix.cmri.serial;
 import jmri.implementation.AbstractTurnoutTestBase;
 import jmri.*;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 /**
  * Tests for the jmri.jmrix.cmri.serial.SerialTurnout class
@@ -26,7 +24,7 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         
         // prepare an interface
@@ -39,6 +37,11 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
         
         t = memo.getTurnoutManager().provideTurnout("4");
         Assert.assertNotNull("turnout exists", t);
+    }
+
+    @After
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
     }
 
     int startingNumListeners; // number at creation, before tests start allocating them.

--- a/java/test/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetMetricsActionTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetMetricsActionTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.cmri.serial.cmrinetmanager;
 
-import apps.tests.Log4JFixture;
 import jmri.util.JUnitUtil;
 import jmri.jmrix.cmri.CMRISystemConnectionMemo;
 import org.junit.After;
@@ -33,13 +32,13 @@ public class CMRInetMetricsActionTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
         JUnitUtil.resetInstanceManager();
-        Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetMetricsFrameTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/cmrinetmanager/CMRInetMetricsFrameTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.cmri.serial.cmrinetmanager;
 
-import apps.tests.Log4JFixture;
 import jmri.util.JUnitUtil;
 import jmri.jmrix.cmri.CMRISystemConnectionMemo;
 import org.junit.After;
@@ -26,13 +25,12 @@ public class CMRInetMetricsFrameTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
-        JUnitUtil.resetInstanceManager();
-        Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/cmri/serial/cmrinetmetrics/CMRInetMetricsCollectorTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/cmrinetmetrics/CMRInetMetricsCollectorTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.cmri.serial.cmrinetmetrics;
 
-import apps.tests.Log4JFixture;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -32,13 +31,12 @@ public class CMRInetMetricsCollectorTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
-        JUnitUtil.resetInstanceManager();
-        Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/cmri/serial/cmrinetmetrics/CMRInetMetricsDataTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/cmrinetmetrics/CMRInetMetricsDataTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.cmri.serial.cmrinetmetrics;
 
-import apps.tests.Log4JFixture;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -25,13 +24,12 @@ public class CMRInetMetricsDataTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
-        JUnitUtil.resetInstanceManager();
-        Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/dcc/DccTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/dcc/DccTurnoutManagerTest.java
@@ -24,7 +24,7 @@ public class DccTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestB
     @Override
     @Before
     public void setUp(){
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         // create and register the manager object
         l = new DccTurnoutManager();
         jmri.InstanceManager.setTurnoutManager(l);

--- a/java/test/jmri/jmrix/dcc/DccTurnoutTest.java
+++ b/java/test/jmri/jmrix/dcc/DccTurnoutTest.java
@@ -20,7 +20,7 @@ public class DccTurnoutTest extends AbstractTurnoutTestBase {
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tcis = new CommandStationScaffold();
         InstanceManager.setDefault(CommandStation.class, tcis);
         t = new DccTurnout(4);
@@ -71,6 +71,8 @@ public class DccTurnoutTest extends AbstractTurnoutTestBase {
     // The minimal setup for log4J
     @After
     public void tearDown() {
+        tcis = null;
+        t = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/dcc4pc/Dcc4PcTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/Dcc4PcTrafficControllerTest.java
@@ -153,7 +153,7 @@ public class Dcc4PcTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCon
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         tc = new Dcc4PcTrafficController();
     }
 

--- a/java/test/jmri/jmrix/dccpp/DCCppInitializationManagerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppInitializationManagerTest.java
@@ -56,14 +56,14 @@ public class DCCppInitializationManagerTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/dccpp/DCCppLightManagerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppLightManagerTest.java
@@ -54,7 +54,7 @@ public class DCCppLightManagerTest extends jmri.managers.AbstractLightMgrTestBas
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // prepare an interface, register
         xnis = new DCCppInterfaceScaffold(new DCCppCommandStation());
         // create and register the manager object
@@ -70,7 +70,6 @@ public class DCCppLightManagerTest extends jmri.managers.AbstractLightMgrTestBas
         xnis = null;
         jmri.util.JUnitUtil.clearShutDownManager();
         jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/dccpp/DCCppLightTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppLightTest.java
@@ -38,7 +38,7 @@ public class DCCppLightTest extends jmri.implementation.AbstractLightTestBase {
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // prepare an interface
         xnis = new DCCppInterfaceScaffold(new DCCppCommandStation());
         DCCppLightManager xlm = new DCCppLightManager(xnis, "DCCpp");

--- a/java/test/jmri/jmrix/dccpp/DCCppTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppTrafficControllerTest.java
@@ -22,7 +22,7 @@ public class DCCppTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCont
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         tc = new DCCppTrafficController(new DCCppCommandStation()){
             @Override
             public void sendDCCppMessage(DCCppMessage m, DCCppListener reply){

--- a/java/test/jmri/jmrix/dccpp/DCCppTurnoutTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppTurnoutTest.java
@@ -210,7 +210,7 @@ public class DCCppTurnoutTest extends jmri.implementation.AbstractTurnoutTestBas
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // infrastructure objects
         dnis = new DCCppInterfaceScaffold(new DCCppCommandStation());
         t = new DCCppTurnout("DCCPP", 42, dnis);

--- a/java/test/jmri/jmrix/dccpp/network/DCCppEthernetPacketizerTest.java
+++ b/java/test/jmri/jmrix/dccpp/network/DCCppEthernetPacketizerTest.java
@@ -17,7 +17,7 @@ public class DCCppEthernetPacketizerTest extends jmri.jmrix.dccpp.DCCppPacketize
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         tc = new DCCppEthernetPacketizer(new jmri.jmrix.dccpp.DCCppCommandStation()) {
             @Override
             protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {

--- a/java/test/jmri/jmrix/dccpp/serial/SerialDCCppPacketizerTest.java
+++ b/java/test/jmri/jmrix/dccpp/serial/SerialDCCppPacketizerTest.java
@@ -17,7 +17,7 @@ public class SerialDCCppPacketizerTest extends jmri.jmrix.dccpp.DCCppPacketizerT
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         tc = new SerialDCCppPacketizer(new jmri.jmrix.dccpp.DCCppCommandStation()) {
             @Override
             protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {

--- a/java/test/jmri/jmrix/easydcc/EasyDccPowerManagerTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccPowerManagerTest.java
@@ -62,7 +62,7 @@ public class EasyDccPowerManagerTest extends AbstractPowerManagerTestBase {
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         EasyDccSystemConnectionMemo memo = new EasyDccSystemConnectionMemo("E", "EasyDCC via Serial");
         controller = new EasyDccTrafficControlScaffold(memo);
         memo.setEasyDccTrafficController(controller); // important for successful getTrafficController()

--- a/java/test/jmri/jmrix/easydcc/EasyDccTurnoutTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccTurnoutTest.java
@@ -19,7 +19,7 @@ public class EasyDccTurnoutTest extends AbstractTurnoutTestBase {
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // prepare an interface
         memo = new EasyDccSystemConnectionMemo("E", "EasyDCC Test");
         tcis = new EasyDccTrafficControlScaffold(memo);

--- a/java/test/jmri/jmrix/grapevine/SerialLightManagerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialLightManagerTest.java
@@ -22,7 +22,7 @@ public class SerialLightManagerTest extends jmri.managers.AbstractLightMgrTestBa
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
 
         // replace the SerialTrafficController
         memo = new GrapevineSystemConnectionMemo();

--- a/java/test/jmri/jmrix/grapevine/SerialTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialTrafficControllerTest.java
@@ -418,7 +418,7 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new SerialTrafficController(new GrapevineSystemConnectionMemo()) {
             @Override
             void loadBuffer(AbstractMRReply msg) {

--- a/java/test/jmri/jmrix/ieee802154/IEEE802154NodeTest.java
+++ b/java/test/jmri/jmrix/ieee802154/IEEE802154NodeTest.java
@@ -71,7 +71,7 @@ public class IEEE802154NodeTest{
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         m = new IEEE802154Node() {
             @Override
             public AbstractMRMessage createInitPacket() {

--- a/java/test/jmri/jmrix/ieee802154/IEEE802154TrafficControllerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/IEEE802154TrafficControllerTest.java
@@ -155,7 +155,7 @@ public class IEEE802154TrafficControllerTest extends jmri.jmrix.AbstractMRNodeTr
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new IEEE802154TrafficController() {
             @Override
             public void setInstance() {

--- a/java/test/jmri/jmrix/ieee802154/serialdriver/SerialTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/serialdriver/SerialTrafficControllerTest.java
@@ -23,8 +23,6 @@ public class SerialTrafficControllerTest extends jmri.jmrix.ieee802154.IEEE80215
         Assert.assertNotNull("IEEE802154Message", ((SerialTrafficController)tc).getIEEE802154Message(5));
     }
 
-
-
     @Test
     public void testCreateNode() {
         // test the code to get a new IEEE802154 node
@@ -156,7 +154,7 @@ public class SerialTrafficControllerTest extends jmri.jmrix.ieee802154.IEEE80215
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new SerialTrafficController();
     }
 

--- a/java/test/jmri/jmrix/ieee802154/xbee/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/swing/PackageTest.java
@@ -23,7 +23,7 @@ public class PackageTest{
 
     // Main entry point
     static public void main(String[] args) {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         org.junit.runner.Result result = org.junit.runner.JUnitCore
                  .runClasses(PackageTest.class);
         for(org.junit.runner.notification.Failure fail: result.getFailures()) {

--- a/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
@@ -69,7 +69,7 @@ public class InternalLightManagerTest extends jmri.managers.AbstractLightMgrTest
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         // create and register the manager object
         l = new InternalLightManager();
         jmri.InstanceManager.setLightManager(l);

--- a/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
@@ -83,7 +83,7 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         // create and register the manager object
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalSensorManager();

--- a/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
@@ -23,7 +23,7 @@ public class InternalTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgr
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         // create and register the manager object
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientPowerManagerTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientPowerManagerTest.java
@@ -61,7 +61,7 @@ public class JMRIClientPowerManagerTest extends jmri.jmrix.AbstractPowerManagerT
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         stc = new JMRIClientTrafficControlScaffold();
         p = new JMRIClientPowerManager(new JMRIClientSystemConnectionMemo(stc));
     }

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientTrafficControllerTest.java
@@ -18,7 +18,6 @@ public class JMRIClientTrafficControllerTest extends jmri.jmrix.AbstractMRTraffi
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
         tc = new JMRIClientTrafficController();
     }
 

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientTurnoutTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientTurnoutTest.java
@@ -54,14 +54,15 @@ public class JMRIClientTurnoutTest extends jmri.implementation.AbstractTurnoutTe
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jcins = new JMRIClientTrafficControlScaffold();
         t = new JMRIClientTurnout(3, new JMRIClientSystemConnectionMemo(jcins));
     }
 
     @After
     public void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
         jcins = null;
     }
 

--- a/java/test/jmri/jmrix/jmriclient/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/jmriclient/swing/PackageTest.java
@@ -22,7 +22,7 @@ public class PackageTest{
 
     // Main entry point
     static public void main(String[] args) {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         org.junit.runner.Result result = org.junit.runner.JUnitCore
                  .runClasses(PackageTest.class);
         for(org.junit.runner.notification.Failure fail: result.getFailures()) {

--- a/java/test/jmri/jmrix/lenz/XNetConsistTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetConsistTest.java
@@ -95,7 +95,7 @@ public class XNetConsistTest extends jmri.implementation.AbstractConsistTestBase
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new XNetInterfaceScaffold(new LenzCommandStation());
         memo = new XNetSystemConnectionMemo(tc);
         c = new XNetConsist(5, tc, memo);
@@ -104,7 +104,7 @@ public class XNetConsistTest extends jmri.implementation.AbstractConsistTestBase
     @After
     @Override
     public void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
         tc=null;
         memo=null;
     }

--- a/java/test/jmri/jmrix/lenz/XNetLightTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetLightTest.java
@@ -37,7 +37,7 @@ public class XNetLightTest extends jmri.implementation.AbstractLightTestBase {
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // prepare an interface
         xnis = new XNetInterfaceScaffold(new LenzCommandStation());
         XNetLightManager xlm = new XNetLightManager(xnis, "X");

--- a/java/test/jmri/jmrix/lenz/XNetTimeSlotListenerTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetTimeSlotListenerTest.java
@@ -60,7 +60,7 @@ public class XNetTimeSlotListenerTest {
     @Before
     public void setUp(){
 
-       apps.tests.Log4JFixture.setUp();
+       jmri.util.JUnitUtil.setUp();
 
        p = new XNetSimulatorPortController(){
            @Override
@@ -85,7 +85,7 @@ public class XNetTimeSlotListenerTest {
     public void tearDown(){
        p=null;
        tsl=null;
-       apps.tests.Log4JFixture.tearDown();
+       jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/XNetTurnoutTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetTurnoutTest.java
@@ -173,7 +173,7 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         // prepare an interface
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalSensorManager();

--- a/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetInitializationManagerTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetInitializationManagerTest.java
@@ -58,14 +58,14 @@ public class EliteXNetInitializationManagerTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetTurnoutTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetTurnoutTest.java
@@ -98,7 +98,7 @@ public class EliteXNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest{
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // prepare an interface
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalSensorManager();

--- a/java/test/jmri/jmrix/lenz/li100/LI100XNetInitializationManagerTest.java
+++ b/java/test/jmri/jmrix/lenz/li100/LI100XNetInitializationManagerTest.java
@@ -60,14 +60,14 @@ public class LI100XNetInitializationManagerTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/lenz/li100/LI100XNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/lenz/li100/LI100XNetPacketizerTest.java
@@ -17,7 +17,7 @@ public class LI100XNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketizerTest 
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new LI100XNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
             @Override
             protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {

--- a/java/test/jmri/jmrix/lenz/liusb/LIUSBXNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/lenz/liusb/LIUSBXNetPacketizerTest.java
@@ -44,7 +44,7 @@ public class LIUSBXNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketizerTest 
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new LIUSBXNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
             @Override
             protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {

--- a/java/test/jmri/jmrix/lenz/liusbethernet/LIUSBEthernetXNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/lenz/liusbethernet/LIUSBEthernetXNetPacketizerTest.java
@@ -42,7 +42,7 @@ public class LIUSBEthernetXNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketi
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new LIUSBEthernetXNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
             @Override
             protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {

--- a/java/test/jmri/jmrix/lenz/liusbserver/LIUSBServerXNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/lenz/liusbserver/LIUSBServerXNetPacketizerTest.java
@@ -49,7 +49,7 @@ public class LIUSBServerXNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketize
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new LIUSBServerXNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
             @Override
             protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {

--- a/java/test/jmri/jmrix/lenz/xntcp/XnTcpXNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/lenz/xntcp/XnTcpXNetPacketizerTest.java
@@ -151,7 +151,7 @@ public class XnTcpXNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketizerTest 
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new XnTcpXNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
             @Override
             protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {

--- a/java/test/jmri/jmrix/lenz/ztc640/ZTC640XNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/lenz/ztc640/ZTC640XNetPacketizerTest.java
@@ -18,7 +18,7 @@ public class ZTC640XNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketizerTest
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new ZTC640XNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
             @Override
             protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {

--- a/java/test/jmri/jmrix/loconet/CsOpSwAccessTest.java
+++ b/java/test/jmri/jmrix/loconet/CsOpSwAccessTest.java
@@ -25,7 +25,7 @@ public class CsOpSwAccessTest {
     @Before
     public void setUp() {
         // The minimal setup for log4J
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         lnis = new LocoNetInterfaceScaffold();
         sm = new SlotManager(lnis);
         memo = new LocoNetSystemConnectionMemo(lnis, sm);

--- a/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnOpsModeProgrammerTest.java
@@ -469,7 +469,7 @@ public class LnOpsModeProgrammerTest extends jmri.AddressedProgrammerTestBase{
 
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
 
         lnis = new LocoNetInterfaceScaffold();
         sm = new SlotManager(lnis);

--- a/java/test/jmri/jmrix/loconet/LnReporterTest.java
+++ b/java/test/jmri/jmrix/loconet/LnReporterTest.java
@@ -87,7 +87,7 @@ public class LnReporterTest {
 
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         tc = new jmri.jmrix.loconet.LocoNetInterfaceScaffold();
     }
 

--- a/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnTurnoutManagerTest.java
@@ -127,7 +127,7 @@ public class LnTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBa
     @Override
     @Before
     public void setUp(){
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         // prepare an interface, register
         lnis = new LocoNetInterfaceScaffold();

--- a/java/test/jmri/jmrix/loconet/locomon/LocoMonPaneTest.java
+++ b/java/test/jmri/jmrix/loconet/locomon/LocoMonPaneTest.java
@@ -109,10 +109,9 @@ public class LocoMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager();
         JUnitUtil.initDefaultUserMessagePreferences();
-        JUnitUtil.setUp();
-        JUnitUtil.resetInstanceManager();
 
         // prepare an interface, register
         jmri.jmrix.loconet.LocoNetInterfaceScaffold lnis = new jmri.jmrix.loconet.LocoNetInterfaceScaffold();

--- a/java/test/jmri/jmrix/maple/OutputBitsTest.java
+++ b/java/test/jmri/jmrix/maple/OutputBitsTest.java
@@ -71,8 +71,7 @@ public class OutputBitsTest extends TestCase {
 
     @Override
     protected void setUp() {
-        // The minimal setup for log4J
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         SerialTrafficControlScaffold tc = new SerialTrafficControlScaffold();
         obit = new OutputBits(tc);
     }

--- a/java/test/jmri/jmrix/maple/SerialTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/maple/SerialTrafficControllerTest.java
@@ -138,11 +138,10 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     static DataOutputStream tistream; // tests write to this
     static DataInputStream istream;  // so the traffic controller can read from this
 
-    // The minimal setup for log4J
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new SerialTrafficController();
     }
 

--- a/java/test/jmri/jmrix/maple/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/maple/SerialTurnoutManagerTest.java
@@ -56,7 +56,7 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
     @Override
     @Before
     public void setUp(){
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         // replace the SerialTrafficController
         SerialTrafficController t = new SerialTrafficController() {
             SerialTrafficController test() {

--- a/java/test/jmri/jmrix/marklin/MarklinTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/marklin/MarklinTrafficControllerTest.java
@@ -17,7 +17,7 @@ public class MarklinTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCo
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new MarklinTrafficController();
     }
     

--- a/java/test/jmri/jmrix/nce/NcePowerManagerTest.java
+++ b/java/test/jmri/jmrix/nce/NcePowerManagerTest.java
@@ -66,7 +66,6 @@ public class NcePowerManagerTest extends AbstractPowerManagerTestBase {
     NceTrafficControlScaffold controller;  // holds dummy NceTrafficController for testing
 
     @After
-    @Override
     public void tearDown() {
         controller = null;
         p = null;

--- a/java/test/jmri/jmrix/nce/NcePowerManagerTest.java
+++ b/java/test/jmri/jmrix/nce/NcePowerManagerTest.java
@@ -2,9 +2,7 @@ package jmri.jmrix.nce;
 
 import jmri.JmriException;
 import jmri.jmrix.AbstractPowerManagerTestBase;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
 
 /**
  * JUnit tests for the NcePowerManager class.
@@ -66,6 +64,14 @@ public class NcePowerManagerTest extends AbstractPowerManagerTestBase {
     }
 
     NceTrafficControlScaffold controller;  // holds dummy NceTrafficController for testing
+
+    @After
+    @Override
+    public void tearDown() {
+        controller = null;
+        p = null;
+        jmri.util.JUnitUtil.tearDown();
+    }
 
     // replace some standard tests, as there's no unsolicted message from the
     // master saying power has changed.  Instead, these test the

--- a/java/test/jmri/jmrix/nce/NceProgrammerManagerTest.java
+++ b/java/test/jmri/jmrix/nce/NceProgrammerManagerTest.java
@@ -61,7 +61,7 @@ public class NceProgrammerManagerTest extends TestCase {
     // The minimal setup is for log4J
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp(); 
+        jmri.util.JUnitUtil.setUp(); 
         jmri.util.JUnitUtil.resetInstanceManager();
         
         memo = new NceSystemConnectionMemo();
@@ -69,8 +69,9 @@ public class NceProgrammerManagerTest extends TestCase {
     }
 
     @Override
-    public void tearDown() {        
-        apps.tests.Log4JFixture.tearDown();
+    public void tearDown() {
+        memo = null;     
+        jmri.util.JUnitUtil.tearDown();
     }
 
     //private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(NceProgrammerManagerTest.class);

--- a/java/test/jmri/jmrix/nce/NceTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/nce/NceTrafficControllerTest.java
@@ -287,13 +287,14 @@ public class NceTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficContro
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc  = new NceTrafficController();
     }
 
     @Override
     @After
     public void tearDown() {
+        tc = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/nce/NceTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/nce/NceTurnoutManagerTest.java
@@ -26,7 +26,7 @@ public class NceTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestB
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
 
         // prepare an interface, register
         nis = new NceInterfaceScaffold();

--- a/java/test/jmri/jmrix/pi/RaspberryPiAdapterTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiAdapterTest.java
@@ -25,7 +25,7 @@ public class RaspberryPiAdapterTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-       apps.tests.Log4JFixture.setUp();
+       JUnitUtil.setUp();
        GpioProvider myprovider = new PiGpioProviderScaffold();
        GpioFactory.setDefaultProvider(myprovider);
        jmri.util.JUnitUtil.resetInstanceManager();

--- a/java/test/jmri/jmrix/pi/RaspberryPiSensorManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiSensorManagerTest.java
@@ -3,6 +3,7 @@ package jmri.jmrix.pi;
 import com.pi4j.io.gpio.GpioFactory;
 import com.pi4j.io.gpio.GpioProvider;
 import jmri.Sensor;
+import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -116,18 +117,18 @@ public class RaspberryPiSensorManagerTest extends jmri.managers.AbstractSensorMg
     @Override
     @Before
     public void setUp() {
-       apps.tests.Log4JFixture.setUp();
+       JUnitUtil.setUp();
        GpioProvider myprovider = new PiGpioProviderScaffold();
        GpioFactory.setDefaultProvider(myprovider);
-       jmri.util.JUnitUtil.resetInstanceManager();
+       JUnitUtil.resetInstanceManager();
        l = new RaspberryPiSensorManager("Pi");
     }
 
     @After
     public void tearDown() {
-        jmri.util.JUnitUtil.clearShutDownManager();
-        jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        JUnitUtil.clearShutDownManager();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/pi/RaspberryPiSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiSystemConnectionMemoTest.java
@@ -143,7 +143,7 @@ public class RaspberryPiSystemConnectionMemoTest extends jmri.jmrix.SystemConnec
         
         GpioProvider myprovider = new PiGpioProviderScaffold();
         GpioFactory.setDefaultProvider(myprovider);
-        JUnitUtil.setUp();
+
         RaspberryPiSystemConnectionMemo memo = new RaspberryPiSystemConnectionMemo();
         memo.configureManagers();
         scm = memo;
@@ -151,6 +151,7 @@ public class RaspberryPiSystemConnectionMemoTest extends jmri.jmrix.SystemConnec
 
     @After
     public void tearDown() {
+        scm = null;
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
@@ -106,7 +106,7 @@ public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnout
     @Override
     @Before
     public void setUp() {
-       apps.tests.Log4JFixture.setUp();
+       JUnitUtil.setUp();
        GpioProvider myprovider = new PiGpioProviderScaffold();
        GpioFactory.setDefaultProvider(myprovider);
        jmri.util.JUnitUtil.resetInstanceManager();
@@ -115,9 +115,9 @@ public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnout
 
     @After
     public void tearDown() {
-        jmri.util.JUnitUtil.clearShutDownManager();
-        jmri.util.JUnitUtil.resetInstanceManager();
-        apps.tests.Log4JFixture.tearDown();
+        JUnitUtil.clearShutDownManager();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.tearDown();
     }
 
 

--- a/java/test/jmri/jmrix/pi/RaspberryPiTurnoutTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiTurnoutTest.java
@@ -26,7 +26,7 @@ public class RaspberryPiTurnoutTest extends jmri.implementation.AbstractTurnoutT
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         GpioProvider myprovider = new PiGpioProviderScaffold();
         GpioFactory.setDefaultProvider(myprovider);
         jmri.util.JUnitUtil.resetInstanceManager();

--- a/java/test/jmri/jmrix/pi/configurexml/RaspberryPiClassMigrationTest.java
+++ b/java/test/jmri/jmrix/pi/configurexml/RaspberryPiClassMigrationTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.pi.configurexml;
 
-import apps.tests.Log4JFixture;
 import java.util.HashMap;
 import java.util.Map;
 import jmri.util.JUnitUtil;
@@ -17,14 +16,14 @@ public class RaspberryPiClassMigrationTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
     }
 
     @After
     public void tearDown() {
         JUnitUtil.resetInstanceManager();
-        Log4JFixture.tearDown();
+        JUnitUtil.tearDown();
     }
 
     @Test

--- a/java/test/jmri/jmrix/powerline/SerialTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/powerline/SerialTrafficControllerTest.java
@@ -16,7 +16,7 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCon
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp(); 
+        JUnitUtil.setUp(); 
         JUnitUtil.resetInstanceManager();
         tc = new SerialTrafficController(){
            @Override

--- a/java/test/jmri/jmrix/powerline/cm11/SpecificTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/powerline/cm11/SpecificTrafficControllerTest.java
@@ -231,7 +231,7 @@ public class SpecificTrafficControllerTest extends jmri.jmrix.powerline.SerialTr
     @Override
     @Test
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         memo = new SpecificSystemConnectionMemo();
         tc = t = new SpecificTrafficController(memo);
     }

--- a/java/test/jmri/jmrix/powerline/insteon2412s/SpecificTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/powerline/insteon2412s/SpecificTrafficControllerTest.java
@@ -252,7 +252,7 @@ public class SpecificTrafficControllerTest extends jmri.jmrix.powerline.SerialTr
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         m = new SpecificSystemConnectionMemo();
         tc = t = new SpecificTrafficController(m);
     }

--- a/java/test/jmri/jmrix/powerline/simulator/SpecificTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/powerline/simulator/SpecificTrafficControllerTest.java
@@ -251,7 +251,7 @@ public class SpecificTrafficControllerTest extends jmri.jmrix.powerline.SerialTr
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         m = new SpecificSystemConnectionMemo();
         tc = t = new SpecificTrafficController(m);
     }

--- a/java/test/jmri/jmrix/rfid/RfidReporterTest.java
+++ b/java/test/jmri/jmrix/rfid/RfidReporterTest.java
@@ -43,14 +43,14 @@ public class RfidReporterTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/rfid/TimeoutRfidReporterTest.java
+++ b/java/test/jmri/jmrix/rfid/TimeoutRfidReporterTest.java
@@ -43,14 +43,14 @@ public class TimeoutRfidReporterTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/rfid/protocol/coreid/CoreIdRfidProtocolTest.java
+++ b/java/test/jmri/jmrix/rfid/protocol/coreid/CoreIdRfidProtocolTest.java
@@ -170,14 +170,14 @@ public class CoreIdRfidProtocolTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/rfid/protocol/em18/Em18RfidProtocolTest.java
+++ b/java/test/jmri/jmrix/rfid/protocol/em18/Em18RfidProtocolTest.java
@@ -135,14 +135,14 @@ public class Em18RfidProtocolTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/rfid/protocol/olimex/OlimexRfid1356mifareProtocolTest.java
+++ b/java/test/jmri/jmrix/rfid/protocol/olimex/OlimexRfid1356mifareProtocolTest.java
@@ -128,14 +128,14 @@ public class OlimexRfid1356mifareProtocolTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/rfid/protocol/olimex/OlimexRfidProtocolTest.java
+++ b/java/test/jmri/jmrix/rfid/protocol/olimex/OlimexRfidProtocolTest.java
@@ -126,14 +126,14 @@ public class OlimexRfidProtocolTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/rfid/protocol/parallax/ParallaxRfidProtocolTest.java
+++ b/java/test/jmri/jmrix/rfid/protocol/parallax/ParallaxRfidProtocolTest.java
@@ -126,14 +126,14 @@ public class ParallaxRfidProtocolTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/rfid/protocol/seeedstudio/SeeedStudioRfidProtocolTest.java
+++ b/java/test/jmri/jmrix/rfid/protocol/seeedstudio/SeeedStudioRfidProtocolTest.java
@@ -142,14 +142,14 @@ public class SeeedStudioRfidProtocolTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetInitializationManagerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetInitializationManagerTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.roco.z21;
 
-import apps.tests.Log4JFixture;
 import jmri.jmrix.lenz.LenzCommandStation;
 import jmri.jmrix.lenz.XNetInterfaceScaffold;
 import jmri.jmrix.lenz.XNetListenerScaffold;

--- a/java/test/jmri/jmrix/roco/z21/Z21XNetTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21XNetTurnoutManagerTest.java
@@ -105,7 +105,7 @@ public class Z21XNetTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrT
     @Override
     @Before
     public void setUp(){
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // prepare an interface, register
         lnis = new XNetInterfaceScaffold(new RocoZ21CommandStation());
         // create and register the manager object

--- a/java/test/jmri/jmrix/rps/Ash1_0AlgorithmTest.java
+++ b/java/test/jmri/jmrix/rps/Ash1_0AlgorithmTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.rps;
 
-import apps.tests.Log4JFixture;
 import javax.vecmath.Point3d;
 import org.junit.After;
 import org.junit.Assert;
@@ -118,11 +117,11 @@ public class Ash1_0AlgorithmTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
     
     @After
     public void tearDown() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/rps/Ash1_1AlgorithmTest.java
+++ b/java/test/jmri/jmrix/rps/Ash1_1AlgorithmTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrix.rps;
 
-import apps.tests.Log4JFixture;
 import javax.vecmath.Point3d;
 import org.junit.After;
 import org.junit.Assert;
@@ -125,11 +124,11 @@ public class Ash1_1AlgorithmTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
 
     @After
     public void tearDown() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/secsi/SerialTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/secsi/SerialTrafficControllerTest.java
@@ -177,7 +177,7 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRNodeTraffi
     @Override
     @Before
     public  void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         SecsiSystemConnectionMemo memo = new SecsiSystemConnectionMemo();
         tc = new SerialTrafficController(memo);
     }

--- a/java/test/jmri/jmrix/secsi/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/secsi/SerialTurnoutTest.java
@@ -2,7 +2,7 @@ package jmri.jmrix.secsi;
 
 import jmri.implementation.AbstractTurnoutTestBase;
 import jmri.util.JUnitUtil;
-import org.junit.Before;
+import org.junit.*;
 
 /**
  * Tests for the jmri.jmrix.secsi.SerialTurnout class
@@ -23,6 +23,13 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
         memo.setTrafficController(tcis);
 
         t = new SerialTurnout("VT4", "t4", memo);
+    }
+
+    @After
+    public void tearDown() {
+        tcis = null;
+        t = null;
+        JUnitUtil.tearDown();
     }
 
     @Override

--- a/java/test/jmri/jmrix/sprog/SprogCSThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogCSThrottleManagerTest.java
@@ -25,7 +25,7 @@ public class SprogCSThrottleManagerTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         // prepare an interface
         jmri.util.JUnitUtil.resetInstanceManager();
 
@@ -41,6 +41,9 @@ public class SprogCSThrottleManagerTest {
     public void tearDown() {
         m.getSlotThread().interrupt();
         stcs.dispose();
+        op = null;
+        stcs = null;
+        m = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/sprog/SprogCSThrottleTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogCSThrottleTest.java
@@ -365,7 +365,7 @@ public class SprogCSThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         // prepare an interface
         jmri.util.JUnitUtil.resetInstanceManager();
 

--- a/java/test/jmri/jmrix/sprog/SprogCSTurnoutTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogCSTurnoutTest.java
@@ -44,7 +44,7 @@ public class SprogCSTurnoutTest extends jmri.implementation.AbstractTurnoutTestB
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // prepare an interface
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalSensorManager();

--- a/java/test/jmri/jmrix/sprog/SprogOpsModeProgrammerTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogOpsModeProgrammerTest.java
@@ -19,7 +19,7 @@ public class SprogOpsModeProgrammerTest extends jmri.jmrix.AbstractOpsModeProgra
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // prepare an interface
         jmri.util.JUnitUtil.resetInstanceManager();
 

--- a/java/test/jmri/jmrix/sprog/SprogPowerManagerTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogPowerManagerTest.java
@@ -90,7 +90,7 @@ public class SprogPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTestBa
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         SprogSystemConnectionMemo m = new SprogSystemConnectionMemo();
         stc = new SprogTrafficControlScaffold(m);
         stc.setTestReplies(true);

--- a/java/test/jmri/jmrix/sprog/SprogProgrammerManagerTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogProgrammerManagerTest.java
@@ -30,7 +30,7 @@ public class SprogProgrammerManagerTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         // prepare an interface
         jmri.util.JUnitUtil.resetInstanceManager();
 
@@ -44,6 +44,9 @@ public class SprogProgrammerManagerTest {
     @After
     public void tearDown() {
         stcs.dispose();
+        op = null;
+        m = null;
+        stcs = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/sprog/SprogProgrammerTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogProgrammerTest.java
@@ -41,7 +41,7 @@ public class SprogProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         // prepare an interface
         jmri.util.JUnitUtil.resetInstanceManager();
 

--- a/java/test/jmri/jmrix/sprog/SprogThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogThrottleManagerTest.java
@@ -23,7 +23,7 @@ public class SprogThrottleManagerTest extends jmri.managers.AbstractThrottleMana
     // The minimal setup for log4J
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // prepare an interface
         jmri.util.JUnitUtil.resetInstanceManager();
 

--- a/java/test/jmri/jmrix/sprog/SprogTurnoutTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogTurnoutTest.java
@@ -35,7 +35,7 @@ public class SprogTurnoutTest extends jmri.implementation.AbstractTurnoutTestBas
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // prepare an interface
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalSensorManager();

--- a/java/test/jmri/jmrix/srcp/SRCPPowerManagerTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPPowerManagerTest.java
@@ -80,7 +80,7 @@ public class SRCPPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTestBas
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         stc = new SRCPTrafficControlScaffold();
         SRCPBusConnectionMemo memo = new SRCPBusConnectionMemo(stc, "TEST", 1);
         p = new SRCPPowerManager(memo, 1);

--- a/java/test/jmri/jmrix/srcp/SRCPThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPThrottleManagerTest.java
@@ -18,7 +18,7 @@ public class SRCPThrottleManagerTest extends jmri.managers.AbstractThrottleManag
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         SRCPBusConnectionMemo sm = new SRCPBusConnectionMemo(new SRCPTrafficController() {
             @Override
             public void sendSRCPMessage(SRCPMessage m, SRCPListener reply) {

--- a/java/test/jmri/jmrix/srcp/SRCPTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPTrafficControllerTest.java
@@ -17,7 +17,7 @@ public class SRCPTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficContr
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new SRCPTrafficController();
     }
 

--- a/java/test/jmri/jmrix/tams/TamsTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/tams/TamsTrafficControllerTest.java
@@ -18,7 +18,7 @@ public class TamsTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficContr
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         tc = new TamsTrafficController();
     }
 

--- a/java/test/jmri/jmrix/tmcc/SerialTrafficControllerTest.java
+++ b/java/test/jmri/jmrix/tmcc/SerialTrafficControllerTest.java
@@ -264,7 +264,7 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCon
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         scm = new TmccSystemConnectionMemo("T", "TMCC Test"); // use a common memo to prevent T2, T3 unconnected instances
         tc = new SerialTrafficController(scm); // TrafficController for tests in super (AbstractMRTrafficControllerTest)
         c = null;
@@ -277,7 +277,7 @@ public class SerialTrafficControllerTest extends jmri.jmrix.AbstractMRTrafficCon
     @Override
     public void tearDown() {
         if (c != null) c.terminateThreads();
-        apps.tests.Log4JFixture.tearDown();
+       jmri.util.JUnitUtil.tearDown();
     }
 
     private final static Logger log = LoggerFactory.getLogger(SerialTrafficControllerTest.class);

--- a/java/test/jmri/jmrix/tmcc/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/tmcc/SerialTurnoutManagerTest.java
@@ -22,7 +22,7 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
 
     @Override
     public void setUp(){
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
 
         // create and register the manager object
         TmccSystemConnectionMemo memo = new TmccSystemConnectionMemo("T", "TMCC Test");

--- a/java/test/jmri/jmrix/xpa/XpaPowerManagerTest.java
+++ b/java/test/jmri/jmrix/xpa/XpaPowerManagerTest.java
@@ -69,14 +69,14 @@ public class XpaPowerManagerTest extends jmri.jmrix.AbstractPowerManagerTestBase
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new XpaTrafficControlScaffold();
         p = new XpaPowerManager(tc);
     }
 
     @After
     public void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
         tc = null;
     }
 

--- a/java/test/jmri/jmrix/xpa/XpaTurnoutTest.java
+++ b/java/test/jmri/jmrix/xpa/XpaTurnoutTest.java
@@ -43,7 +43,7 @@ public class XpaTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase 
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         memo = new XpaSystemConnectionMemo();
         xnis = new XpaTrafficControlScaffold();
         memo.setXpaTrafficController(xnis);
@@ -52,7 +52,7 @@ public class XpaTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase 
 
     @After
     public void tearDown() {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
         memo = null;
         xnis = null;
     }

--- a/java/test/jmri/jmrix/ztc/ztc611/ZTC611XNetInitializationManagerTest.java
+++ b/java/test/jmri/jmrix/ztc/ztc611/ZTC611XNetInitializationManagerTest.java
@@ -59,14 +59,14 @@ public class ZTC611XNetInitializationManagerTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
     }
 
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/ztc/ztc611/ZTC611XNetPacketizerTest.java
+++ b/java/test/jmri/jmrix/ztc/ztc611/ZTC611XNetPacketizerTest.java
@@ -18,7 +18,7 @@ public class ZTC611XNetPacketizerTest extends jmri.jmrix.lenz.XNetPacketizerTest
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         tc = new ZTC611XNetPacketizer(new jmri.jmrix.lenz.LenzCommandStation()) {
             @Override
             protected void handleTimeout(jmri.jmrix.AbstractMRMessage msg, jmri.jmrix.AbstractMRListener l) {

--- a/java/test/jmri/jmrix/ztc/ztc611/ZTC611XNetTurnoutTest.java
+++ b/java/test/jmri/jmrix/ztc/ztc611/ZTC611XNetTurnoutTest.java
@@ -87,7 +87,7 @@ public class ZTC611XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest{
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         // prepare an interface
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalSensorManager();
@@ -100,6 +100,8 @@ public class ZTC611XNetTurnoutTest extends jmri.jmrix.lenz.XNetTurnoutTest{
     @Override
     @After
     public void tearDown() {
+        t = null;
+        lnis = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/managers/DefaultConditionalManagerTest.java
+++ b/java/test/jmri/managers/DefaultConditionalManagerTest.java
@@ -48,7 +48,7 @@ public class DefaultConditionalManagerTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();

--- a/java/test/jmri/managers/DefaultIdTagManagerTest.java
+++ b/java/test/jmri/managers/DefaultIdTagManagerTest.java
@@ -116,7 +116,7 @@ public class DefaultIdTagManagerTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();

--- a/java/test/jmri/managers/DefaultLogixManagerTest.java
+++ b/java/test/jmri/managers/DefaultLogixManagerTest.java
@@ -71,7 +71,7 @@ public class DefaultLogixManagerTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         super.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();

--- a/java/test/jmri/managers/InternalLightManagerTest.java
+++ b/java/test/jmri/managers/InternalLightManagerTest.java
@@ -57,7 +57,7 @@ public class InternalLightManagerTest extends jmri.managers.AbstractLightMgrTest
     @Before
     @Override
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
 
         jmri.util.JUnitUtil.resetInstanceManager();
         l = new InternalLightManager();

--- a/java/test/jmri/managers/InternalSensorManagerTest.java
+++ b/java/test/jmri/managers/InternalSensorManagerTest.java
@@ -308,7 +308,7 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
     @Override
     @Before
     public void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // create and register the manager object
         jmri.util.JUnitUtil.resetInstanceManager();
         

--- a/java/test/jmri/managers/LogixSystemTest.java
+++ b/java/test/jmri/managers/LogixSystemTest.java
@@ -58,7 +58,8 @@ public class LogixSystemTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         super.setUp();
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();

--- a/java/test/jmri/managers/ProxyLightManagerTest.java
+++ b/java/test/jmri/managers/ProxyLightManagerTest.java
@@ -197,7 +197,7 @@ public class ProxyLightManagerTest extends TestCase {
     // The minimal setup for log4J
     @Override
     protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // create and register the manager object
         l = new InternalLightManager() {
             @Override

--- a/java/test/jmri/managers/ProxySensorManagerTest.java
+++ b/java/test/jmri/managers/ProxySensorManagerTest.java
@@ -538,7 +538,7 @@ public class ProxySensorManagerTest extends TestCase implements Manager.ManagerD
     // The minimal setup for log4J
     @Override
     protected void setUp() {
-        apps.tests.Log4JFixture.setUp();
+        JUnitUtil.setUp();
         // create and register the manager object
         l = new ProxySensorManager();
         // initially has three systems: IS, JS, KS

--- a/java/test/jmri/profile/ProfileListCellRendererTest.java
+++ b/java/test/jmri/profile/ProfileListCellRendererTest.java
@@ -1,6 +1,5 @@
 package jmri.profile;
 
-import apps.tests.Log4JFixture;
 import javax.swing.JList;
 import jmri.util.JUnitUtil;
 import org.junit.After;
@@ -16,13 +15,13 @@ public class ProfileListCellRendererTest {
     
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
     }
     
     @After
     public void tearDown() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
         JUnitUtil.resetProfileManager();
     }
 

--- a/java/test/jmri/profile/ProfileTest.java
+++ b/java/test/jmri/profile/ProfileTest.java
@@ -1,6 +1,5 @@
 package jmri.profile;
 
-import apps.tests.Log4JFixture;
 import java.io.File;
 import java.io.IOException;
 import jmri.util.FileUtil;
@@ -27,12 +26,12 @@ public class ProfileTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
     }
 
     @AfterClass
     public static void tearDownClass() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
     @Before

--- a/java/test/jmri/profile/ProfileUtilsTest.java
+++ b/java/test/jmri/profile/ProfileUtilsTest.java
@@ -2,7 +2,6 @@ package jmri.profile;
 
 import static org.junit.Assert.fail;
 
-import apps.tests.Log4JFixture;
 import java.io.File;
 import java.io.IOException;
 import jmri.util.JUnitUtil;
@@ -28,14 +27,14 @@ public class ProfileUtilsTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
     }
 
     @After
     public void tearDown() {
         JUnitUtil.resetProfileManager();
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
     }
 
     @Test

--- a/java/test/jmri/server/json/util/JsonUtilSocketServiceTest.java
+++ b/java/test/jmri/server/json/util/JsonUtilSocketServiceTest.java
@@ -1,6 +1,5 @@
 package jmri.server.json.util;
 
-import apps.tests.Log4JFixture;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.DataOutputStream;
@@ -32,14 +31,16 @@ public class JsonUtilSocketServiceTest {
 
     @BeforeClass
     public static void setUpClass() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager();
     }
 
     @AfterClass
     public static void tearDownClass() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     @Before

--- a/java/test/jmri/server/web/app/JsonMenuItemTest.java
+++ b/java/test/jmri/server/web/app/JsonMenuItemTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import apps.tests.Log4JFixture;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Locale;
@@ -24,12 +23,14 @@ public class JsonMenuItemTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
 
     @After
     public void tearDown() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     @Test

--- a/java/test/jmri/server/web/app/WebAppConfigurationTest.java
+++ b/java/test/jmri/server/web/app/WebAppConfigurationTest.java
@@ -1,6 +1,5 @@
 package jmri.server.web.app;
 
-import apps.tests.Log4JFixture;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -14,12 +13,14 @@ public class WebAppConfigurationTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
 
     @After
     public void tearDown() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     @Test

--- a/java/test/jmri/server/web/spi/AngularRouteTest.java
+++ b/java/test/jmri/server/web/spi/AngularRouteTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
-import apps.tests.Log4JFixture;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,12 +16,14 @@ public class AngularRouteTest {
 
     @Before
     public void setUp() throws Exception {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
 
     @After
     public void tearDown() throws Exception {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     @Test

--- a/java/test/jmri/server/web/spi/WebServerConfigurationTest.java
+++ b/java/test/jmri/server/web/spi/WebServerConfigurationTest.java
@@ -1,6 +1,5 @@
 package jmri.server.web.spi;
 
-import apps.tests.Log4JFixture;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,12 +30,14 @@ public class WebServerConfigurationTest {
 
     @Before
     public void setUp() {
-        Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
     }
 
     @After
     public void tearDown() {
-        Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 
     /**

--- a/java/test/jmri/util/ColorUtilTest.java
+++ b/java/test/jmri/util/ColorUtilTest.java
@@ -162,7 +162,6 @@ public class ColorUtilTest extends TestCase {
 
     // from here down is infrastructure
 
-    // The minimal setup for log4J
     @Override
     protected void setUp() throws Exception {
        jmri.util.JUnitUtil.setUp();
@@ -181,7 +180,6 @@ public class ColorUtilTest extends TestCase {
 
     // Main entry point
     static public void main(String[] args) {
-        apps.tests.Log4JFixture.initLogging();
         String[] testCaseName = {"-noloading", ColorUtilTest.class.getName()};
         junit.textui.TestRunner.main(testCaseName);
     }

--- a/java/test/jmri/util/JLogoutputFrameTest.java
+++ b/java/test/jmri/util/JLogoutputFrameTest.java
@@ -1,6 +1,5 @@
 package jmri.util;
 
-import apps.tests.Log4JFixture;
 import java.awt.GraphicsEnvironment;
 import java.util.*;
 import org.apache.log4j.*;

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -92,7 +92,7 @@ public class JUnitUtil {
     static boolean checkSetUpTearDownSequence = Boolean.getBoolean("jmri.util.JUnitUtil.checkSetUpTearDownSequence"); // false unless set true
     static boolean checkSequenceDumpsStack =    Boolean.getBoolean("jmri.util.JUnitUtil.checkSequenceDumpsStack"); // false unless set true
 
-    static boolean printSetUpTearDownNames = true; // Boolean.getBoolean("jmri.util.JUnitUtil.printSetUpTearDownNames"); // false unless set true
+    static boolean printSetUpTearDownNames = Boolean.getBoolean("jmri.util.JUnitUtil.printSetUpTearDownNames"); // false unless set true
 
     /**
      * Setup for tests. This should be the first line in the {@code @Before}

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -83,7 +83,9 @@ public class JUnitUtil {
     static boolean didSetUp = false;
     static boolean didTearDown = true;
     static String lastSetUpClassName = "<unknown>";
+    static String lastSetUpThreadName = "<unknown>";
     static String lastTearDownClassName = "<unknown>";
+    static String lastTearDownThreadName = "<unknown>";
     
     static boolean checkSetUpTearDownSequence = true; // Boolean.getBoolean("jmri.util.JUnitUtil.checkSetUpTearDownSequence"); // false unless set
     static boolean printSetUpTearDownNames = true; // Boolean.getBoolean("jmri.util.JUnitUtil.printSetUpTearDownNames"); // false unless set
@@ -102,11 +104,15 @@ public class JUnitUtil {
 
         resetInstanceManager();
 
-        if (checkSetUpTearDownSequence || printSetUpTearDownNames) lastSetUpClassName = getTestClassName();
+        if (checkSetUpTearDownSequence || printSetUpTearDownNames) {
+            lastSetUpClassName = getTestClassName();
+            lastSetUpThreadName = Thread.currentThread().getName();
+        }
+        
         if (printSetUpTearDownNames) System.err.println(">> Starting test in "+lastSetUpClassName);
         
         if ( checkSetUpTearDownSequence)  {
-            if (didSetUp || ! didTearDown) System.err.println("   "+getTestClassName()+".setUp unexpectedly found setUp="+didSetUp+" tearDown="+didTearDown+" last tearDown in "+lastTearDownClassName);
+            if (didSetUp || ! didTearDown) System.err.println("   "+getTestClassName()+".setUp on thread "+lastSetUpThreadName+" unexpectedly found setUp="+didSetUp+" tearDown="+didTearDown+"; last tearDown was in "+lastTearDownClassName+" thread "+lastTearDownThreadName);
             didTearDown = false;
             didSetUp = true;
         }
@@ -117,10 +123,13 @@ public class JUnitUtil {
      * annotated method.
      */
     public static void tearDown() {
-        if (checkSetUpTearDownSequence || printSetUpTearDownNames) lastTearDownClassName = getTestClassName();
+        if (checkSetUpTearDownSequence || printSetUpTearDownNames) {
+            lastTearDownClassName = getTestClassName();
+            lastTearDownThreadName = Thread.currentThread().getName();
+        }
 
         if (checkSetUpTearDownSequence) {
-            if (! didSetUp || didTearDown) System.err.println("   "+getTestClassName()+".tearDown unexpectedly found setUp="+didSetUp+" tearDown="+didTearDown+" last setUp in "+lastSetUpClassName);
+            if (! didSetUp || didTearDown) System.err.println("   "+getTestClassName()+".tearDown on thread "+lastTearDownThreadName+" unexpectedly found setUp="+didSetUp+" tearDown="+didTearDown+"; last setUp was in "+lastSetUpClassName+" thread "+lastSetUpThreadName);
             didSetUp = false;
             didTearDown = true;
         }

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -80,26 +80,45 @@ public class JUnitUtil {
     static final int WAITFOR_MAX_DELAY = 30000; // really long, but only matters when failing, and LayoutEditor/SignalMastLogic is slow
 
     static int count = 0;
-
+    
+    static boolean didSetUp = false;
+    static boolean didTearDown = true;
+    
     /**
      * Setup for tests. This should be the first line in the {@code @Before}
      * annotated method.
      */
     public static void setUp() {
         Log4JFixture.setUp();
+
         // ideally this would be false, true to force an error if an earlier
         // test left a window open, but different platforms seem to have just
-        // enough differences that this is, for now, only emitting a warning
+        // enough differences that this is, for now, turned off
         resetWindows(false, false);
-        resetInstanceManager();
-    }
 
+        resetInstanceManager();
+
+        System.err.println(">> Starting test in "+getTestClassName());
+        if (didSetUp || ! didTearDown) System.err.println("   "+getTestClassName()+".setUp unexpectedly found "+didSetUp+" "+didTearDown);
+        didTearDown = false;
+        didSetUp = true;
+    }
+    
     /**
      * Teardown from tests. This should be the last line in the {@code @After}
      * annotated method.
      */
     public static void tearDown() {
+        if (! didSetUp || didTearDown) System.err.println("   "+getTestClassName()+".tearDown unexpectedly found "+didSetUp+" "+didTearDown);
+        didSetUp = false;
+        didTearDown = true;
+        System.err.println("<<   Ending test in "+getTestClassName());
+
+        // ideally this would be false, true to force an error if an earlier
+        // test left a window open, but different platforms seem to have just
+        // enough differences that this is, for now, turned off
         resetWindows(false, false);
+
         resetInstanceManager();
         Log4JFixture.tearDown();
     }

--- a/java/test/jmri/util/OrderedHashtableTest.java
+++ b/java/test/jmri/util/OrderedHashtableTest.java
@@ -167,6 +167,10 @@ public class OrderedHashtableTest extends TestCase {
     public void setUp() {
         jmri.util.JUnitUtil.setUp();
     }
+    @Override
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
 
     // test suite from all defined tests
     public static Test suite() {

--- a/java/test/jmri/util/exceptionhandler/UncaughtExceptionHandlerTest.java
+++ b/java/test/jmri/util/exceptionhandler/UncaughtExceptionHandlerTest.java
@@ -69,7 +69,8 @@ public class UncaughtExceptionHandlerTest extends SwingTestCase {
     @Before
     @Override
     public void setUp() throws Exception {
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         this.defaultExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler());
         super.setUp();
@@ -80,6 +81,7 @@ public class UncaughtExceptionHandlerTest extends SwingTestCase {
     public void tearDown() throws Exception {
         super.tearDown();
         Thread.setDefaultUncaughtExceptionHandler(this.defaultExceptionHandler);
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
     }
 }

--- a/java/test/jmri/util/swing/sdi/SdiJfcUnitTest.java
+++ b/java/test/jmri/util/swing/sdi/SdiJfcUnitTest.java
@@ -82,7 +82,8 @@ public class SdiJfcUnitTest extends jmri.util.SwingTestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        apps.tests.Log4JFixture.setUp();
+        jmri.util.JUnitUtil.setUp();
+
         jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
         
@@ -94,7 +95,8 @@ public class SdiJfcUnitTest extends jmri.util.SwingTestCase {
 
     @Override
     protected void tearDown() throws Exception {
-        apps.tests.Log4JFixture.tearDown();
+        jmri.util.JUnitUtil.tearDown();
+
         super.tearDown();
     }
 }


### PR DESCRIPTION
- add note on GUI-thread LayoutEditor methods
- set LayoutEditorTest to timeout tests at 10 seconds, allow 2 retries
- put some tests on GUI thread
- add diagnostic code to JUnitUtil to track down incomplete setUp or tearDown calls
- add some missing setUp and tearDown calls; fix some malformed ones (including replacing direct calls to Log4JFixture)
- add timeout, retry to LogixTableActionTest, which was occasionally hanging (doesn't fix it but lets us know that's why the CI failed)
- CMRI SerialTurnoutTest was being run twice
- null some class-scope references in tearDown so that they can be garbage collected during long test runs