### PR TITLE
Suppress two json.server intermittent tests

### DIFF
--- a/java/test/jmri/server/json/util/JsonUtilHttpServiceTest.java
+++ b/java/test/jmri/server/json/util/JsonUtilHttpServiceTest.java
@@ -26,11 +26,9 @@ import jmri.util.JUnitUtil;
 import jmri.util.node.NodeIdentity;
 import jmri.util.zeroconf.ZeroConfService;
 import jmri.web.server.WebServerPreferences;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -426,6 +424,7 @@ public class JsonUtilHttpServiceTest {
      *
      * @throws jmri.server.json.JsonException if unable to read profiles
      */
+    @Ignore // See Issue #5642
     @Test
     public void testGetConfigProfiles() throws JsonException {
         Locale locale = Locale.ENGLISH;

--- a/java/test/jmri/server/json/util/JsonUtilSocketServiceTest.java
+++ b/java/test/jmri/server/json/util/JsonUtilSocketServiceTest.java
@@ -12,12 +12,9 @@ import jmri.server.json.JSON;
 import jmri.server.json.JsonMockConnection;
 import jmri.util.JUnitUtil;
 import jmri.web.server.WebServerPreferences;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
+import org.junit.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,6 +101,7 @@ public class JsonUtilSocketServiceTest {
      *                             these tests occurs
      */
     @Test
+    @Ignore // See Issue #5642
     public void testOnList() throws Exception {
         Locale locale = Locale.ENGLISH;
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
See Issue #5642 on history dependence of tests.

This has started hitting other test sequences when run by JUnit4, so I'm putting @Ignore on the tests.

