### PR TITLE
Correct a few XBee bugs that have crept into the code over the last several months

### DIFF
--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeLightManager.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeLightManager.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.ieee802154.xbee;
 
+import javax.annotation.*;
 import jmri.Light;
 import jmri.managers.AbstractLightManager;
 import org.slf4j.Logger;
@@ -183,6 +184,17 @@ public class XBeeLightManager extends AbstractLightManager {
     public String getEntryToolTip() {
         String entryToolTip = Bundle.getMessage("AddOutputEntryToolTip");
         return entryToolTip;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @CheckReturnValue
+    @Override
+    public @Nonnull
+    String normalizeSystemName(@Nonnull String inputName) {
+        return inputName; // toUpperCase and trim don't behave well with 
+                          // the XBee Node Identifier based addresses.
     }
 
     private final static Logger log = LoggerFactory.getLogger(XBeeLightManager.class);

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeNode.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeNode.java
@@ -327,7 +327,7 @@ public class XBeeNode extends IEEE802154Node {
     public XBeeIOStream getIOStream() {
         if (mStream == null) {
             mStream = new XBeeIOStream(this, tc);
-	    mStream.configure(); // start the threads for the stream.
+	        mStream.configure(); // start the threads for the stream.
         }
         return mStream;
     }

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeNode.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeNode.java
@@ -327,6 +327,7 @@ public class XBeeNode extends IEEE802154Node {
     public XBeeIOStream getIOStream() {
         if (mStream == null) {
             mStream = new XBeeIOStream(this, tc);
+	    mStream.configure(); // start the threads for the stream.
         }
         return mStream;
     }

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeSensorManager.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeSensorManager.java
@@ -8,6 +8,7 @@ import com.digi.xbee.api.io.IOLine;
 import com.digi.xbee.api.io.IOMode;
 import com.digi.xbee.api.io.IOSample;
 import com.digi.xbee.api.listeners.IIOSampleReceiveListener;
+import javax.annotation.*;
 import jmri.JmriException;
 import jmri.Sensor;
 import org.slf4j.Logger;
@@ -278,6 +279,17 @@ public class XBeeSensorManager extends jmri.managers.AbstractSensorManager imple
     public String getEntryToolTip() {
         String entryToolTip = Bundle.getMessage("AddInputEntryToolTip");
         return entryToolTip;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @CheckReturnValue
+    @Override
+    public @Nonnull
+    String normalizeSystemName(@Nonnull String inputName) {
+        return inputName; // toUpperCase and trim don't behave well with 
+                          // the XBee Node Identifier based addresses.
     }
 
     private final static Logger log = LoggerFactory.getLogger(XBeeSensorManager.class);

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManager.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManager.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.ieee802154.xbee;
 
+import javax.annotation.*;
 import jmri.JmriException;
 import jmri.Turnout;
 import jmri.managers.AbstractTurnoutManager;
@@ -215,6 +216,17 @@ public class XBeeTurnoutManager extends AbstractTurnoutManager {
     public String getEntryToolTip() {
         String entryToolTip = Bundle.getMessage("AddOutputEntryToolTip");
         return entryToolTip;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @CheckReturnValue
+    @Override
+    public @Nonnull
+    String normalizeSystemName(@Nonnull String inputName) {
+        return inputName; // toUpperCase and trim don't behave well with 
+                          // the XBee Node Identifier based addresses.
     }
 
     private final static Logger log = LoggerFactory.getLogger(XBeeTurnoutManager.class);

--- a/java/test/jmri/jmrix/ieee802154/xbee/XBeeLightManagerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/XBeeLightManagerTest.java
@@ -22,7 +22,7 @@ public class XBeeLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
 
     @Override
     public String getSystemName(int i) {
-        return "ABCL2:" + i;
+        return "AL2:" + i;
     }
 
 
@@ -38,7 +38,34 @@ public class XBeeLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
         Light t = l.provide("" + getSystemName(getNumToTest1()));
         // check
         Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
+        Assert.assertEquals("system name correct ", t,l.getBySystemName(getSystemName(getNumToTest1())));
+    }
+
+    @Test
+    public void testProvideIdStringName() {
+        // create
+        Light t = l.provide("ALNode 1:2");
+        // check
+        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertEquals("correct object returned ", t ,l.getBySystemName("ALNODE 1:2"));
+    }
+
+    @Test
+    public void testProvide16BitAddress() {
+        // create
+        Light t = l.provide("AL00 02:2");
+        // check
+        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertEquals("system name correct ", t,l.getBySystemName("AL00 02:2"));
+    }
+
+    @Test
+    public void testProvide64BitAddress() {
+        // create
+        Light t = l.provide("AL00 13 A2 00 40 A0 4D 2D:2");
+        // check
+        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertEquals("system name correct ", t , l.getBySystemName("AL00 13 A2 00 40 A0 4D 2D:2"));
     }
 
     @Override
@@ -48,7 +75,7 @@ public class XBeeLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
         Light t = l.provideLight(getSystemName(getNumToTest1()));
         // check
         Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
+        Assert.assertEquals("system name correct ", t,l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
     @Override
@@ -67,9 +94,9 @@ public class XBeeLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
         jmri.util.JUnitUtil.setUp();
         tc = new XBeeInterfaceScaffold();
         XBeeConnectionMemo m = new XBeeConnectionMemo();
-        m.setSystemPrefix("ABC");
+        m.setSystemPrefix("A");
         tc.setAdapterMemo(m);
-        l = new XBeeLightManager(tc, "ABC");
+        l = new XBeeLightManager(tc, "A");
         m.setLightManager(l);
         byte pan[] = {(byte) 0x00, (byte) 0x42};
         byte uad[] = {(byte) 0x00, (byte) 0x02};

--- a/java/test/jmri/jmrix/ieee802154/xbee/XBeeSensorManagerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/XBeeSensorManagerTest.java
@@ -28,7 +28,7 @@ public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
 
     @Override
     public String getSystemName(int i) {
-        return "ABCS2:" + i;
+        return "AS2:" + i;
     }
 
     @Test
@@ -43,7 +43,34 @@ public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         Sensor t = l.provide(getSystemName(getNumToTest1()));
         // check
         Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
+        Assert.assertEquals("system name correct ", t ,l.getBySystemName(getSystemName(getNumToTest1())));
+    }
+
+    @Test
+    public void testProvideIdStringName() {
+        // create
+        Sensor t = l.provide("ASNode 1:2");
+        // check
+        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertEquals("correct object returned ", t ,l.getBySystemName("ASNODE 1:2"));
+    }
+
+    @Test
+    public void testProvide16BitAddress() {
+        // create
+        Sensor t = l.provide("AS00 02:2");
+        // check
+        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertEquals("system name correct ", t,l.getBySystemName("AS00 02:2"));
+    }
+
+    @Test
+    public void testProvide64BitAddress() {
+        // create
+        Sensor t = l.provide("AS00 13 A2 00 40 A0 4D 2D:2");
+        // check
+        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertEquals("system name correct ", t ,l.getBySystemName("AS00 13 A2 00 40 A0 4D 2D:2"));
     }
 
     @Override
@@ -53,7 +80,7 @@ public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         Sensor t = l.provideSensor(getSystemName(getNumToTest1()));
         // check
         Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
+        Assert.assertEquals("system name correct ", t, l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
     @Override
@@ -93,9 +120,9 @@ public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         tc = new XBeeInterfaceScaffold();
 
         XBeeConnectionMemo m = new XBeeConnectionMemo();
-        m.setSystemPrefix("ABC");
+        m.setSystemPrefix("A");
         tc.setAdapterMemo(m);
-        l = new XBeeSensorManager(tc, "ABC");
+        l = new XBeeSensorManager(tc, "A");
         m.setSensorManager(l);
         byte pan[] = {(byte) 0x00, (byte) 0x42};
         byte uad[] = {(byte) 0x00, (byte) 0x02};

--- a/java/test/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManagerTest.java
@@ -37,8 +37,36 @@ public class XBeeTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         Turnout t = l.provide("" + (getSystemName(getNumToTest1())));
         // check
         Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
+        Assert.assertEquals("system name correct ", t,l.getBySystemName(getSystemName(getNumToTest1())));
     }
+
+    @Test
+    public void testProvideIdStringName() {
+        // create
+        Turnout t = l.provide("ATNode 1:2");
+        // check
+        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertEquals("correct object returned ", t ,l.getBySystemName("ATNODE 1:2"));
+    }
+
+    @Test
+    public void testProvide16BitAddress() {
+        // create
+        Turnout t = l.provide("AT00 02:2");
+        // check
+        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertEquals("system name correct ", t,l.getBySystemName("AT00 02:2"));
+    }
+
+    @Test
+    public void testProvide64BitAddress() {
+        // create
+        Turnout t = l.provide("AT00 13 A2 00 40 A0 4D 2D:2");
+        // check
+        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertEquals("system name correct ", t , l.getBySystemName("AT00 13 A2 00 40 A0 4D 2D:2"));
+    }
+
 
     @Override
     @Test
@@ -47,7 +75,7 @@ public class XBeeTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         Turnout t = l.provideTurnout(getSystemName(getNumToTest1()));
         // check
         Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
+        Assert.assertEquals("system name correct ", t , l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
     @Override


### PR DESCRIPTION
This PR corrects broken IO streams (due to a change I have yet to track down) and broken Sensor/Turnout/Light creation based on Node Identifiers (which can have spaces).  The issue with Sensors/Turnouts/Lights is directly linked to normalizing system names in the Abstract managers.

This PR includes new tests for all possible Sensor/Turnout/Light name variations the respective managers may create.