### PR TITLE
Fix ConcurrentModificationError in LayoutBlockManager

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -277,43 +277,25 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
     public void initializeLayoutBlockPaths() {
         log.debug("start initializeLayoutBlockPaths");
 
-        //cycle through all LayoutBlocks, completing initialization of associated jmri.Blocks
-        java.util.Iterator<String> iter = getSystemNameList().iterator();
-
-        while (iter.hasNext()) {
-            String sName = iter.next();
-
-            if (sName == null) {
-                log.error("System name null during 1st initialization of LayoutBlocks");
-            } else {
-                LayoutBlock b = getBySystemName(sName);
-                log.debug("Calling block '" + sName + "(" + b.getDisplayName() + ")'.initializeLayoutBlock()");
+        // cycle through all LayoutBlocks, completing initialization of associated jmri.Blocks
+        for (LayoutBlock b : getNamedBeanSet()) {
+                log.debug("Calling block '{}({})'.initializeLayoutBlock()", b.getSystemName(), b.getDisplayName());
                 b.initializeLayoutBlock();
-            }
         }
 
         //cycle through all LayoutBlocks, updating Paths of associated jmri.Blocks
-        badBeanErrors = 0;
-        iter = getSystemNameList().iterator();
-
-        while (iter.hasNext()) {
-            String sName = iter.next();
-
-            if (sName == null) {
-                log.error("System name null during 2nd initialization of LayoutBlocks");
-            } else {
-                LayoutBlock b = getBySystemName(sName);
-                log.debug("Calling block '" + sName + "(" + b.getDisplayName() + ")'.updatePaths()");
+        badBeanErrors = 0; // perhaps incremented via addBadBeanError(), but that's never called?
+        for (LayoutBlock b : getNamedBeanSet()) {
+                log.debug("Calling block '{}({})'.updatePaths()", b.getSystemName(), b.getDisplayName());
 
                 b.updatePaths();
 
                 if (b.getBlock().getValue() != null) {
                     b.getBlock().setValue(null);
                 }
-            }
         }
 
-        if (badBeanErrors > 0) {
+        if (badBeanErrors > 0) { // perhaps incremented via addBadBeanError(), but that's never called?
             JOptionPane.showMessageDialog(null, "" + badBeanErrors + " " + Bundle.getMessage("Warn2"),
                     Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
         }
@@ -326,9 +308,10 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
         }
 
         //special tests for getFacingSignalHead method - comment out next three lines unless using LayoutEditorTests
-//LayoutEditorTests layoutEditorTests = new LayoutEditorTests();
-//layoutEditorTests.runClinicTests();
-//layoutEditorTests.runTestPanel3Tests();
+        //LayoutEditorTests layoutEditorTests = new LayoutEditorTests();
+        //layoutEditorTests.runClinicTests();
+        //layoutEditorTests.runTestPanel3Tests();
+
         initialized = true;
         log.debug("start initializeLayoutBlockRouting");
         initializeLayoutBlockRouting();
@@ -336,11 +319,12 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
     }	//initializeLayoutBlockPaths
 
     private boolean initialized = false;
-    private int badBeanErrors = 0;
 
+    // Is this ever called?
     public void addBadBeanError() {
         badBeanErrors++;
     }
+    private int badBeanErrors = 0;
 
     /**
      * Method to return the Signal Head facing into a specified Block from a

--- a/java/src/jmri/util/ThreadingUtil.java
+++ b/java/src/jmri/util/ThreadingUtil.java
@@ -126,6 +126,7 @@ public class ThreadingUtil {
                 Thread.currentThread().interrupt();
             } catch (InvocationTargetException e) {
                 log.error("Error while on GUI thread", e.getCause());
+                log.error("   Came from call to runOnGUI:", e);
                 // should have been handled inside the ThreadAction
             }
         }
@@ -163,6 +164,7 @@ public class ThreadingUtil {
                 Thread.currentThread().interrupt();
             } catch (InvocationTargetException e) {
                 log.error("Error while on GUI thread", e.getCause());
+                log.error("   Came from call to runOnGUIwithReturn:", e);
                 // should have been handled inside the ThreadAction
             }
             return result.get();


### PR DESCRIPTION
Fix a _very__ intermittent ConcurrentModificationError due to modifying the list of LayoutBlocks while accessing it.