### PR TITLE
'Inconsistent' Turnout line drawings for Layout Editor

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
@@ -1115,6 +1115,24 @@ public class LayoutSlip extends LayoutTurnout {
         }
     }
 
+    /**
+     * Check if either turnout is inconsistent.
+     * This is used to create an alternate slip image.
+     *
+     * @return true if either turnout is inconsistent.
+     */
+    private boolean isTurnoutInconsistent() {
+        Turnout tA = getTurnout();
+        if (tA != null && tA.getKnownState() == INCONSISTENT) {
+            return true;
+        }
+        Turnout tB = getTurnoutB();
+        if (tB != null && tB.getKnownState() == INCONSISTENT) {
+            return true;
+        }
+        return false;
+    }
+
     @Override
     protected void draw1(Graphics2D g2, boolean drawMain, boolean isBlock) {
         if (isBlock && getLayoutBlock() == null) {
@@ -1167,6 +1185,29 @@ public class LayoutSlip extends LayoutTurnout {
 
         Point2D midPointAD = MathUtil.midPoint(oneThirdPointAC, twoThirdsPointBD);
         Point2D midPointBC = MathUtil.midPoint(oneThirdPointBD, twoThirdsPointAC);
+
+        if (isTurnoutInconsistent()) {
+            // If either turnout is inconsistent, draw an alternate slip image
+            // draw A<= =>C
+            if (drawMain == mainlineA) {
+                g2.setColor(colorA);
+                g2.draw(new Line2D.Double(pA, oneForthPointAC));
+            }
+            if (drawMain == mainlineC) {
+                g2.setColor(colorC);
+                g2.draw(new Line2D.Double(threeFourthsPointAC, pC));
+            }
+            // draw B<= =>D
+            if (drawMain == mainlineB) {
+                g2.setColor(colorB);
+                g2.draw(new Line2D.Double(pB, oneForthPointBD));
+            }
+            if (drawMain == mainlineD) {
+                g2.setColor(colorD);
+                g2.draw(new Line2D.Double(threeFourthsPointBD, pD));
+            }
+            return;
+        }
 
         int slipState = getSlipState();
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
@@ -157,6 +157,7 @@ public class LayoutTurnout extends LayoutTrack {
 
     // operational instance variables (not saved between sessions)
     public static final int UNKNOWN = Turnout.UNKNOWN;
+    public static final int INCONSISTENT = Turnout.INCONSISTENT;
     public static final int STATE_AC = 0x02;
     public static final int STATE_BD = 0x04;
     public static final int STATE_AD = 0x06;
@@ -3199,7 +3200,7 @@ public class LayoutTurnout extends LayoutTrack {
 
         int type = getTurnoutType();
         if (type == DOUBLE_XOVER) {
-            if (state != Turnout.THROWN) { // unknown or continuing path - not crossed over
+            if (state != Turnout.THROWN && state != INCONSISTENT) { // unknown or continuing path - not crossed over
                 if (isMain == mainlineA) {
                     g2.setColor(colorA);
                     g2.draw(new Line2D.Double(pA, pABM));
@@ -3229,7 +3230,7 @@ public class LayoutTurnout extends LayoutTrack {
                     }
                 }
             }
-            if (state != Turnout.CLOSED) { // unknown or diverting path - crossed over
+            if (state != Turnout.CLOSED && state != INCONSISTENT) { // unknown or diverting path - crossed over
                 if (isMain == mainlineA) {
                     g2.setColor(colorA);
                     g2.draw(new Line2D.Double(pA, pAM));
@@ -3263,13 +3264,49 @@ public class LayoutTurnout extends LayoutTrack {
                     }
                 }
             }
+            if (state == INCONSISTENT) {
+                if (isMain == mainlineA) {
+                    g2.setColor(colorA);
+                    g2.draw(new Line2D.Double(pA, pAM));
+                }
+                if (isMain == mainlineB) {
+                    g2.setColor(colorB);
+                    g2.draw(new Line2D.Double(pB, pBM));
+                }
+                if (isMain == mainlineC) {
+                    g2.setColor(colorC);
+                    g2.draw(new Line2D.Double(pC, pCM));
+                }
+                if (isMain == mainlineD) {
+                    g2.setColor(colorD);
+                    g2.draw(new Line2D.Double(pD, pDM));
+                }
+                if (!isBlock || drawUnselectedLeg) {
+                    if (isMain == mainlineA) {
+                        g2.setColor(colorA);
+                        g2.draw(new Line2D.Double(pAF, pM));
+                    }
+                    if (isMain == mainlineC) {
+                        g2.setColor(colorC);
+                        g2.draw(new Line2D.Double(pCF, pM));
+                    }
+                    if (isMain == mainlineB) {
+                        g2.setColor(colorB);
+                        g2.draw(new Line2D.Double(pBF, pM));
+                    }
+                    if (isMain == mainlineD) {
+                        g2.setColor(colorD);
+                        g2.draw(new Line2D.Double(pDF, pM));
+                    }
+                }
+            }
         } else if ((type == RH_XOVER)
                 || (type == LH_XOVER)) {    // draw (rh & lh) cross overs
             pAF = MathUtil.midPoint(pABM, pM);
             pBF = MathUtil.midPoint(pABM, pM);
             pCF = MathUtil.midPoint(pCDM, pM);
             pDF = MathUtil.midPoint(pCDM, pM);
-            if (state != Turnout.THROWN) { // unknown or continuing path - not crossed over
+            if (state != Turnout.THROWN && state != INCONSISTENT) { // unknown or continuing path - not crossed over
                 if (isMain == mainlineA) {
                     g2.setColor(colorA);
                     g2.draw(new Line2D.Double(pA, pABM));
@@ -3308,7 +3345,7 @@ public class LayoutTurnout extends LayoutTrack {
                     }
                 }
             }
-            if (state != Turnout.CLOSED) { // unknown or diverting path - crossed over
+            if (state != Turnout.CLOSED && state != INCONSISTENT) { // unknown or diverting path - crossed over
                 if (getTurnoutType() == RH_XOVER) {
                     if (isMain == mainlineA) {
                         g2.setColor(colorA);
@@ -3357,6 +3394,45 @@ public class LayoutTurnout extends LayoutTrack {
                     }
                 }
             }
+            if (state == INCONSISTENT) {
+                if (isMain == mainlineA) {
+                    g2.setColor(colorA);
+                    g2.draw(new Line2D.Double(pA, pAM));
+                }
+                if (isMain == mainlineB) {
+                    g2.setColor(colorB);
+                    g2.draw(new Line2D.Double(pB, pBM));
+                }
+                if (isMain == mainlineC) {
+                    g2.setColor(colorC);
+                    g2.draw(new Line2D.Double(pC, pCM));
+                }
+                if (isMain == mainlineD) {
+                    g2.setColor(colorD);
+                    g2.draw(new Line2D.Double(pD, pDM));
+                }
+                if (!isBlock || drawUnselectedLeg) {
+                    if (getTurnoutType() == RH_XOVER) {
+                        if (isMain == mainlineA) {
+                            g2.setColor(colorA);
+                            g2.draw(new Line2D.Double(pAF, pM));
+                        }
+                        if (isMain == mainlineC) {
+                            g2.setColor(colorC);
+                            g2.draw(new Line2D.Double(pCF, pM));
+                        }
+                    } else if (getTurnoutType() == LH_XOVER) {
+                        if (isMain == mainlineB) {
+                            g2.setColor(colorB);
+                            g2.draw(new Line2D.Double(pBF, pM));
+                        }
+                        if (isMain == mainlineD) {
+                            g2.setColor(colorD);
+                            g2.draw(new Line2D.Double(pDF, pM));
+                        }
+                    }
+                }
+            }
         } else if ((type == SINGLE_SLIP) || (type == DOUBLE_SLIP)) {
             log.error("slips should be being drawn by LayoutSlip sub-class");
         } else {    // LH, RH, or WYE Turnouts
@@ -3365,7 +3441,8 @@ public class LayoutTurnout extends LayoutTrack {
                 g2.setColor(colorA);
                 g2.draw(new Line2D.Double(pA, pM));
             }
-            if (state == UNKNOWN || continuingSense == state) { // unknown or continuing path
+
+            if (state == UNKNOWN || (continuingSense == state && state != INCONSISTENT)) { // unknown or continuing path
                 // draw center<===>B
                 if (isMain == mainlineB) {
                     g2.setColor(colorB);
@@ -3378,7 +3455,8 @@ public class LayoutTurnout extends LayoutTrack {
                     g2.draw(new Line2D.Double(MathUtil.twoThirdsPoint(pM, pB), pB));
                 }
             }
-            if (continuingSense != state) { // unknown or diverting path
+
+            if (state == UNKNOWN || (continuingSense != state && state != INCONSISTENT)) { // unknown or diverting path
                 // draw center<===>C
                 if (isMain == mainlineC) {
                     g2.setColor(colorC);


### PR DESCRIPTION
When using TWOSENSOR turnout feedback, a turnout normally has an INCONSISTENT state between CLOSED and THROWN.  As of 4.12, the THROWN line drawing is being shown for INCONSISTENT.  This shows an incorrect state for the turnout.