### PR TITLE
It did not work having several MFX locomotives controlled by an ECOS.

### DIFF
--- a/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
@@ -85,8 +85,15 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
 
         ecosretry = 0;
 
+        log.debug("EcosDccThrottle constructor " + address);
+
         //We go on a hunt to find an object with the dccaddress sent by our controller.
-        objEcosLoco = objEcosLocoManager.provideByDccAddress(address.getNumber());
+        if (address.getNumber() < EcosLocoAddress.MFX_DCCAddressOffset) {
+            objEcosLoco = objEcosLocoManager.provideByDccAddress(address.getNumber());
+        } else {
+            int ecosID = address.getNumber()-EcosLocoAddress.MFX_DCCAddressOffset;
+            objEcosLoco = objEcosLocoManager.provideByEcosObject(String.valueOf(ecosID));
+        }
 
         this.objectNumber = objEcosLoco.getEcosObject();
         if (this.objectNumber == null) {

--- a/java/src/jmri/jmrix/ecos/EcosDccThrottleManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottleManager.java
@@ -86,6 +86,7 @@ public class EcosDccThrottleManager extends AbstractThrottleManager implements E
     public String[] getAddressTypes() {
         return new String[]{
             LocoAddress.Protocol.DCC.getPeopleName(),
+            LocoAddress.Protocol.MFX.getPeopleName(),
             LocoAddress.Protocol.MOTOROLA.getPeopleName(),
             LocoAddress.Protocol.SELECTRIX.getPeopleName(),
             LocoAddress.Protocol.LGB.getPeopleName()};
@@ -94,6 +95,7 @@ public class EcosDccThrottleManager extends AbstractThrottleManager implements E
     @Override
     public LocoAddress.Protocol[] getAddressProtocolTypes() {
         return new LocoAddress.Protocol[]{LocoAddress.Protocol.DCC,
+            LocoAddress.Protocol.MFX,
             LocoAddress.Protocol.MOTOROLA,
             LocoAddress.Protocol.SELECTRIX,
             LocoAddress.Protocol.LGB};
@@ -104,7 +106,7 @@ public class EcosDccThrottleManager extends AbstractThrottleManager implements E
      * Decide whether given a long address or not.
      */
     static boolean isLongAddress(int num) {
-        return (num >= 100);
+        return (num >= 127);
     }
 
     @Override

--- a/java/src/jmri/jmrix/ecos/EcosLocoAddress.java
+++ b/java/src/jmri/jmrix/ecos/EcosLocoAddress.java
@@ -24,6 +24,7 @@ public class EcosLocoAddress implements jmri.LocoAddress {
     boolean direction;
     int currentSpeed;
     private boolean doNotAddToRoster = false;
+    public static int MFX_DCCAddressOffset = 20000;
 
     public EcosLocoAddress(int dCCAddress) {
         _dccAddress = dCCAddress;

--- a/java/src/jmri/jmrix/ecos/utilities/EcosLocoToRoster.java
+++ b/java/src/jmri/jmrix/ecos/utilities/EcosLocoToRoster.java
@@ -542,7 +542,11 @@ public class EcosLocoToRoster implements EcosListener {
         re.setDecoderModel(pDecoderFile.getModel());
         re.setDecoderFamily(pDecoderFile.getFamily());
 
-        re.setDccAddress(Integer.toString(ecosLoco.getNumber()));
+        if (ecosLoco.getNumber() == 0) {
+            re.setDccAddress(Integer.toString(ecosLoco.MFX_DCCAddressOffset+ecosLoco.getEcosObjectAsInt()));
+        } else {
+            re.setDccAddress(Integer.toString(ecosLoco.getNumber()));
+        }
         //re.setLongAddress(true);
 
         re.setRoadName("");


### PR DESCRIPTION
Since they all got DCC address 0, selecting one of them in a JMRI throttle just took the oldest registrered MFX locomotive.