### PR TITLE
[DCC++] Implement background refresh of function values

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.dccpp;
 
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -16,6 +18,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2002
  * @author Paul Bender Copyright (C) 2003-2010
  * @author Mark Underwood Copyright (C) 2015
+ * @author Costin Grigoras Copyright (C) 2018
  *
  * Based on XNetMessage by Bob Jacobsen and Paul Bender
  */
@@ -36,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * the higher level code from needing to know what order/format the actual message is
  * in.
  */
-public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
+public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delayed {
 
     static private int _nRetries = 5;
 
@@ -2456,6 +2459,91 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage {
                    DCCppConstants.LIST_REGISTER_CONTENTS_REGEX));
     }
 
+    /**
+     * This implementation of equals is targeted to the background function refreshing in {@link SerialDCCppPacketizer#sendDCCppMessage(DCCppMessage, DCCppListener)}.
+     * To keep only one function group in the refresh queue the logic is as follows. Two messages are equal if they are:
+     * <ul>
+     * <li>actually identical, or</li>
+     * <li>a function call to the same address and same function group</li>
+     * </ul>
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        final DCCppMessage other = (DCCppMessage) obj;
+
+        final String myCmd = this.toString();
+        final String otherCmd = other.toString();
+
+        if (myCmd.equals(otherCmd))
+            return true;
+
+        if (!isFunctionMessage() || !other.isFunctionMessage())
+            return false;
+
+        return getFuncBaseByte1(this.getFuncByte1Int()) == getFuncBaseByte1(other.getFuncByte1Int());
+    }
+
+    /**
+     * Get the function group from the first byte of the function setting call.
+     * 
+     * @param byte1 first byte (mixed in with function bits for groups 1 to 3, or standalone value for groups 4 and 5)
+     * @return the base group
+     */
+    private static final int getFuncBaseByte1(final int byte1) {
+        if (byte1 == DCCppConstants.FUNCTION_GROUP4_BYTE1 || byte1 == DCCppConstants.FUNCTION_GROUP5_BYTE1)
+            return byte1;
+
+        if (byte1 < 160)
+            return 128;
+
+        if (byte1 < 176)
+            return 160;
+
+        return 176;
+    }
+
+    /**
+     * When is this message supposed to be resent.
+     * 
+     * @see SerialDCCppPacketizer
+     */
+    private long expireTime;
+
+    /**
+     * Before adding the message to the delay queue call this method to set when the message should be repeated.
+     * The only time guarantee is that it will be repeated after <u>at least</u> this much time, but it can be
+     * significantly longer until it is repeated, function of the message queue length.
+     * 
+     * @param millis milliseconds in the future
+     */
+    public void delayFor(final long millis) {
+        expireTime = System.currentTimeMillis() + millis;
+    }
+
+    /**
+     * Comparing two queued message for refreshing the function calls, based on their expected execution time.
+     */
+    @Override
+    public int compareTo(final Delayed o) {
+        final long diff = this.expireTime - ((DCCppMessage) o).expireTime;
+
+        if (diff < 0)
+            return -1;
+
+        if (diff > 0)
+            return 1;
+
+        return 0;
+    }
+
+    /**
+     * From the {@link Delayed} interface, how long this message still has until it should be executed.
+     */
+    @Override
+    public long getDelay(final TimeUnit unit) {
+        return unit.convert(expireTime - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+    }
+    
     // initialize logging    
     private final static Logger log = LoggerFactory.getLogger(DCCppMessage.class);
 

--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -2460,7 +2460,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     }
 
     /**
-     * This implementation of equals is targeted to the background function refreshing in {@link SerialDCCppPacketizer#sendDCCppMessage(DCCppMessage, DCCppListener)}.
+     * This implementation of equals is targeted to the background function refreshing in SerialDCCppPacketizer.
      * To keep only one function group in the refresh queue the logic is as follows. Two messages are equal if they are:
      * <ul>
      * <li>actually identical, or</li>

--- a/java/src/jmri/jmrix/dccpp/serial/SerialDCCppPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/serial/SerialDCCppPacketizer.java
@@ -3,12 +3,18 @@
  */
 package jmri.jmrix.dccpp.serial;
 
-import jmri.jmrix.dccpp.DCCppPacketizer;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jmri.jmrix.dccpp.DCCppListener;
+import jmri.jmrix.dccpp.DCCppMessage;
+import jmri.jmrix.dccpp.DCCppPacketizer;
+
 /**
- * This is an extention of the DCCppPacketizer to handle the device specific
+ * This is an extension of the DCCppPacketizer to handle the device specific
  * requirements of the DCC++.
  * <P>
  * In particular, SerialDCCppPacketizer adds functions to add and remove the
@@ -18,16 +24,56 @@ import org.slf4j.LoggerFactory;
  * a protocol thing, not an interface implementation thing. We'll come back to
  * that later.
  *
+ * What is however interface specific is the background refresh of functions.
+ * DCC++ sends the DCC commands exactly once. A background thread will
+ * repeat the last seen function commands to compensate for any momentary
+ * power loss or to recover from power off / power on events. It only makes
+ * sense to do this on the actual serial interface as it will be transparent for
+ * the
+ * network clients.
+ *
  * @author Paul Bender Copyright (C) 2005
  * @author Mark Underwood Copyright (C) 2015
+ * @author Costin Grigoras Copyright (C) 2018
  *
- * Based on LIUSBXNetPacketizer by Paul Bender
+ *         Based on LIUSBXNetPacketizer by Paul Bender
  */
 public class SerialDCCppPacketizer extends DCCppPacketizer {
 
-    public SerialDCCppPacketizer(jmri.jmrix.dccpp.DCCppCommandStation pCommandStation) {
+    final DelayQueue<DCCppMessage> resendFunctions = new DelayQueue<>();
+
+    public SerialDCCppPacketizer(final jmri.jmrix.dccpp.DCCppCommandStation pCommandStation) {
         super(pCommandStation);
         log.debug("Loading Serial Extention to DCCppPacketizer");
+
+        // this is the background thread that periodically refreshes the last
+        // known function settings
+        final Thread backgroundRefresh = new Thread() {
+            @Override
+            public void run() {
+                while (true) {
+                    try {
+                        final DCCppMessage message = resendFunctions.poll(1, TimeUnit.MINUTES);
+
+                        if (message != null) {
+                            message.setRetries(1);
+                            sendDCCppMessage(message, null);
+
+                            // At 115200 baud only ~1k messages/s can be sent.
+                            // Be nice and don't overload the wire.
+                            sleep(1);
+                        }
+
+                        setName("SerialDCCppPacketizer.bkg_refresh (" + resendFunctions.size() + " msg)");
+                    } catch (@SuppressWarnings("unused") final InterruptedException e) {
+                        // should exit if interrupted
+                    }
+                }
+            }
+        };
+
+        backgroundRefresh.setDaemon(true);
+        backgroundRefresh.start();
     }
 
     /**
@@ -38,13 +84,34 @@ public class SerialDCCppPacketizer extends DCCppPacketizer {
      * @return Number of bytes
      */
     @Override
-    protected int lengthOfByteStream(jmri.jmrix.AbstractMRMessage m) {
-        int len = m.getNumDataElements() + 2;
+    protected int lengthOfByteStream(final jmri.jmrix.AbstractMRMessage m) {
+        final int len = m.getNumDataElements() + 2;
         return len;
     }
 
+    @Override
+    public void sendDCCppMessage(final DCCppMessage m, final DCCppListener reply) {
+        final boolean isFunction = m.isFunctionMessage();
+
+        /**
+         * Remove a previous value for the same function (DCC address + function
+         * group) based on
+         * {@link jmri.jmrix.dccpp.DCCppMessage#equals(DCCppMessage)}
+         */
+        if (isFunction)
+            resendFunctions.remove(m);
+
+        super.sendDCCppMessage(m, reply);
+
+        if (isFunction) {
+            /**
+             * Set again the same group function value 250ms later (or more,
+             * depending on the queue depth; limited to 1kHz of calls)
+             */
+            m.delayFor(250);
+            resendFunctions.offer(m);
+        }
+    }
 
     private final static Logger log = LoggerFactory.getLogger(SerialDCCppPacketizer.class);
 }
-
-

--- a/java/src/jmri/jmrix/dccpp/serial/SerialDCCppPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/serial/SerialDCCppPacketizer.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jmri.jmrix.dccpp.DCCppListener;
 import jmri.jmrix.dccpp.DCCppMessage;
 import jmri.jmrix.dccpp.DCCppPacketizer;
@@ -38,7 +39,9 @@ import jmri.jmrix.dccpp.DCCppPacketizer;
  *
  *         Based on LIUSBXNetPacketizer by Paul Bender
  */
-public class SerialDCCppPacketizer extends DCCppPacketizer {
+public final class SerialDCCppPacketizer extends DCCppPacketizer {
+    
+    @SuppressFBWarnings(value = "SC_START_IN_CTOR", justification = "with existing code structure, we do not expect this to ever be subclassed.")
 
     final DelayQueue<DCCppMessage> resendFunctions = new DelayQueue<>();
 


### PR DESCRIPTION
This is to periodically refresh the function values by re-sending the last seen DCC++ string, with the DCC address + the function group as key.
It would close this issue: https://github.com/JMRI/JMRI/issues/3817

Cheers,

.costin