### PR TITLE
Refactor com.dictiography.collections tests

### DIFF
--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -672,15 +672,16 @@
     <p>
         You then reference "folder" in your test code:
 <pre style="font-family: monospace;">
-        // create a file in "temp"
-        File rosterDir = folder.newFolder();
-        File backupDir = folder.newFolder();
+        // create a temporary file
+        File randomNameFile = folder.newFile();
+        // create a temporary directory
+        File randomNameDir = folder.newFolder();
 </pre>
 
     
       JUnit4 will make sure the file or folder is removed afterwards regardless of whether the 
       test succeeds or fails. For more information on this, see the 
-      <a href="http://junit.org/junit4/javadoc/latest/org/junit/rules/TemporaryFolder.html">Javadoc for TemporaryFolderTest</a>.
+      <a href="http://junit.org/junit4/javadoc/latest/org/junit/rules/TemporaryFolder.html">Javadoc for TemporaryFolder</a>.
      
      <p>
      If you're not using JUnit4, consider converting the 
@@ -1172,6 +1173,16 @@ import org.junit.Test;
 </pre>
         </li>
 
+        <li>If you have bare <code>assert</code> calls, like
+<pre style="font-family: monospace;">
+    assertEquals(k, ind);
+</pre>
+    change them to the JUnit4 form:
+<pre style="font-family: monospace;">
+    Assert.assertEquals(k, ind);
+</pre>
+        </li>
+        
         <li>More of our Test classes have a "from here down is
         testing infrastructure" comment, followed by setup code.
         Some of that can be removed. First, remove the class

--- a/java/test/jmri/util/com/dictiography/collections/IndexedTreeMapTest.java
+++ b/java/test/jmri/util/com/dictiography/collections/IndexedTreeMapTest.java
@@ -1,6 +1,6 @@
 package jmri.util.com.dictiography.collections;
 
-import junit.framework.TestCase;
+import org.junit.*;
 
 import java.util.*;
 
@@ -10,8 +10,9 @@ import java.util.*;
  * Time: 15:01
  * Email: Vitaly.Sazanovich@gmail.com
  */
-public class IndexedTreeMapTest extends TestCase {
+public class IndexedTreeMapTest {
 
+    @Test
     public void testIndexedTreeMap() throws Exception {
         long t1 = System.currentTimeMillis();
         for (int i = 0; i < 5; i++) {
@@ -34,27 +35,25 @@ public class IndexedTreeMapTest extends TestCase {
                 int ev = m.exactEntry(k).getValue().intValue();
                 int ind = m.keyIndex(ek);
 
-                assertEquals(ints[k].intValue(), ek);
-                assertEquals(ints[k].intValue(), ev);
-                assertEquals(k, ind);
+                Assert.assertEquals(ints[k].intValue(), ek);
+                Assert.assertEquals(ints[k].intValue(), ev);
+                Assert.assertEquals(k, ind);
 
             }
             Iterator<Integer> it = set.iterator();
             while (it.hasNext()) {
                 Integer next = it.next();
                 m.remove(next);
-                assertEquals(false, m.containsKey(next));
+                Assert.assertEquals(false, m.containsKey(next));
                 ((IndexedTreeMap) m).debug();
             }
-            assertEquals(0, m.size());
+            Assert.assertEquals(0, m.size());
         }
 
-        System.out.println("DONE IN:" + (System.currentTimeMillis() - t1));
+        log.debug("DONE IN:" + (System.currentTimeMillis() - t1));
     }
 
-
-
-
+    @Test
     public void testComparePutMap() throws Exception {
 
         Random random = new Random(System.currentTimeMillis());
@@ -86,9 +85,10 @@ public class IndexedTreeMapTest extends TestCase {
         }
         long t4 = System.currentTimeMillis();
 
-        System.out.println("For " + set.size() + " elements TreeMap wins IndexedTreeMap in put by:" + ((t2 - t1) - (t4 - t3)) + " milliseconds");
+        log.debug("For " + set.size() + " elements TreeMap wins IndexedTreeMap in put by:" + ((t2 - t1) - (t4 - t3)) + " milliseconds");
     }
 
+    @Test
     public void testCompareDeleteMap() throws Exception {
 
         Random random = new Random(System.currentTimeMillis());
@@ -122,7 +122,19 @@ public class IndexedTreeMapTest extends TestCase {
         }
         long t4 = System.currentTimeMillis();
 
-        System.out.println("For " + set.size() + " elements TreeMap wins IndexedTreeMap in remove by:" + ((t2 - t1) - (t4 - t3)) + " milliseconds");
+        log.debug("For " + set.size() + " elements TreeMap wins IndexedTreeMap in remove by:" + ((t2 - t1) - (t4 - t3)) + " milliseconds");
     }
+    
+    @BeforeClass
+    static public void setUpClass() {
+          jmri.util.JUnitUtil.setUp();
+    }
+
+    @AfterClass
+    static public void tearDownClass() {
+          jmri.util.JUnitUtil.tearDown();
+    }
+    
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(IndexedTreeSetTest.class);
 
 }

--- a/java/test/jmri/util/com/dictiography/collections/IndexedTreeSetTest.java
+++ b/java/test/jmri/util/com/dictiography/collections/IndexedTreeSetTest.java
@@ -1,6 +1,7 @@
 package jmri.util.com.dictiography.collections;
 
-import junit.framework.TestCase;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.*;
 import java.util.*;
@@ -10,18 +11,23 @@ import java.util.*;
  * Date: 2/10/13
  * Time: 12:14 PM
  */
-public class IndexedTreeSetTest  extends TestCase {
+public class IndexedTreeSetTest {
 
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+    
+    @Test
     public void testQuickCheck() {
         IndexedNavigableSet<String> s = new IndexedTreeSet<String>();
         s.add("Z");
         s.add("A");
         s.add("B");
-        assertEquals("A", s.exact(0));
-        assertEquals("B", s.exact(1));
-        assertEquals("Z", s.exact(2));    
+        Assert.assertEquals("A", s.exact(0));
+        Assert.assertEquals("B", s.exact(1));
+        Assert.assertEquals("Z", s.exact(2));    
     }
     
+    @Test
     public void testQuickComparator() {
         IndexedNavigableSet<String> s = new IndexedTreeSet<String>(new java.util.Comparator<String>(){
             public int compare(String e1, String e2) { return - e1.toString().compareTo(e2.toString()); } // note minus sign
@@ -29,11 +35,12 @@ public class IndexedTreeSetTest  extends TestCase {
         s.add("Z");
         s.add("A");
         s.add("B");
-        assertEquals("Z", s.exact(0));    
-        assertEquals("B", s.exact(1));
-        assertEquals("A", s.exact(2));
+        Assert.assertEquals("Z", s.exact(0));    
+        Assert.assertEquals("B", s.exact(1));
+        Assert.assertEquals("A", s.exact(2));
     }
     
+    @Test
     public void testIndexedTreeSet() throws Exception {
         long t1 = System.currentTimeMillis();
         for (int i = 0; i < 5; i++) {
@@ -55,8 +62,8 @@ public class IndexedTreeSetTest  extends TestCase {
                 int ev = s.exact(k).intValue();
                 int ind = s.entryIndex(ints[k]);
 
-                assertEquals(ints[k].intValue(), ev);
-                assertEquals(k, ind);
+                Assert.assertEquals(ints[k].intValue(), ev);
+                Assert.assertEquals(k, ind);
 
             }
             Iterator<Integer> it = set.iterator();
@@ -66,9 +73,12 @@ public class IndexedTreeSetTest  extends TestCase {
                 ((IndexedTreeSet) s).debug();
             }
         }
-        System.out.println("DONE IN:" + (System.currentTimeMillis() - t1));
+        log.debug("DONE IN:" + (System.currentTimeMillis() - t1));
     }
 
+    // Although JMRI doesn't use this kind of serialization,
+    // we're leaving the test in place for any downstream uses.
+    @Test
     @SuppressWarnings("unchecked") // this is 3rd party code
     public void testPersistence() throws Exception {
         long t1 = System.currentTimeMillis();
@@ -86,20 +96,18 @@ public class IndexedTreeSetTest  extends TestCase {
                 }
             }
 
-            System.out.println("adding:" + (System.currentTimeMillis() - t1));
+            log.debug("adding:" + (System.currentTimeMillis() - t1));
             t1 = System.currentTimeMillis();
 
             int hash = System.identityHashCode(m);
-            File f = new File("tmp.ser");
-            if (f.exists()){
-                f.delete();
-            }
+            
+            File f = folder.newFile();  // temporary
+            
             store(f, m);
             m = (IndexedTreeSet<String>) load(f);  // unchecked conversion here
-            assertNotSame(hash,System.identityHashCode(m));
+            Assert.assertNotSame(hash,System.identityHashCode(m));
 
-            System.out.println("saving - restoring:" + (System.currentTimeMillis() - t1));
-
+            log.debug("saving - restoring:" + (System.currentTimeMillis() - t1));
 
             String[] ints = set.toArray(new String[set.size()]);
             Arrays.sort(ints);
@@ -110,21 +118,21 @@ public class IndexedTreeSetTest  extends TestCase {
                 String ek = m.exact(k);
                 int ind = m.entryIndex(ek);
 
-                assertEquals(ints[k], ek);
-                assertEquals(k, ind);
+                Assert.assertEquals(ints[k], ek);
+                Assert.assertEquals(k, ind);
 
             }
             Iterator<String> it = set.iterator();
             while (it.hasNext()) {
                 String next = it.next();
                 m.remove(next);
-                assertEquals(false, m.contains(next));
+                Assert.assertEquals(false, m.contains(next));
 //                ((IndexedTreeSet) m).debug();
             }
-            assertEquals(0, m.size());
+            Assert.assertEquals(0, m.size());
         }
 
-        System.out.println("checking - removing:" + (System.currentTimeMillis() - t1));
+        log.debug("checking - removing:" + (System.currentTimeMillis() - t1));
     }
 
 
@@ -154,4 +162,16 @@ public class IndexedTreeSetTest  extends TestCase {
             return null;
         }
     }
+    
+    @BeforeClass
+    static public void setUpClass() {
+          jmri.util.JUnitUtil.setUp();
+    }
+
+    @AfterClass
+    static public void tearDownClass() {
+          jmri.util.JUnitUtil.tearDown();
+    }
+    
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(IndexedTreeSetTest.class);
 }


### PR DESCRIPTION
The com.dictiography.collections indexed collections came with some tests. This PR makes them work better in our CI context:
 - Convert to JUnit4
 - use logging instead of System.err
 - standard setup and teardown
 - use temporary file rule to avoid leaving test artifacts around

Also includes a small update to temp file and migration sections of our JUnit page.
