### PR TITLE
add toMonitorString (with default implementation) to jmri.jmrix.Message Interface

### DIFF
--- a/java/src/jmri/jmrix/Message.java
+++ b/java/src/jmri/jmrix/Message.java
@@ -16,4 +16,12 @@ public interface Message {
     @Override
     String toString();
 
+
+    /*
+     * @return a human readable representation of the message.
+     */
+    public default String toMonitorString(){
+          return toString();
+    };
+
 }

--- a/java/src/jmri/jmrix/ieee802154/IEEE802154Message.java
+++ b/java/src/jmri/jmrix/ieee802154/IEEE802154Message.java
@@ -105,9 +105,5 @@ public class IEEE802154Message extends jmri.jmrix.AbstractMRMessage {
         return responseLength;
     }
 
-    public String toMonitorString() {
-        return toString();
-    }
-
 }
 

--- a/java/src/jmri/jmrix/ieee802154/IEEE802154Reply.java
+++ b/java/src/jmri/jmrix/ieee802154/IEEE802154Reply.java
@@ -275,8 +275,4 @@ public class IEEE802154Reply extends jmri.jmrix.AbstractMRReply {
         return ((chksum & 0xFFFF) == ((getElement(len - 2) << 8) + getElement(len - 1)));
     }
 
-    public String toMonitorString() {
-        return toString();
-    }
-
 }

--- a/java/src/jmri/jmrix/powerline/SerialMessage.java
+++ b/java/src/jmri/jmrix/powerline/SerialMessage.java
@@ -79,8 +79,6 @@ abstract public class SerialMessage extends jmri.jmrix.AbstractMRMessage {
         return responseLength;
     }
 
-    abstract public String toMonitorString();
-
     // static methods to recognize a message
     public boolean isPoll() {
         return getElement(1) == 48;

--- a/java/src/jmri/jmrix/powerline/SerialReply.java
+++ b/java/src/jmri/jmrix/powerline/SerialReply.java
@@ -49,8 +49,6 @@ abstract public class SerialReply extends jmri.jmrix.AbstractMRReply {
         return index;
     }
 
-    abstract public String toMonitorString();
-
     private final static Logger log = LoggerFactory.getLogger(SerialReply.class);
 
 }

--- a/java/src/jmri/jmrix/rfid/RfidMessage.java
+++ b/java/src/jmri/jmrix/rfid/RfidMessage.java
@@ -89,11 +89,4 @@ abstract public class RfidMessage extends jmri.jmrix.AbstractMRMessage {
         return responseLength;
     }
 
-    /**
-     * Returns a string representation of this message to use in a monitor
-     *
-     * @return monitor string
-     */
-    abstract public String toMonitorString();
-
 }

--- a/java/src/jmri/jmrix/rfid/RfidReply.java
+++ b/java/src/jmri/jmrix/rfid/RfidReply.java
@@ -40,6 +40,4 @@ abstract public class RfidReply extends jmri.jmrix.AbstractMRReply {
         return index;
     }
 
-    abstract public String toMonitorString();
-
 }

--- a/java/test/jmri/jmrix/AbstractMessageTest.java
+++ b/java/test/jmri/jmrix/AbstractMessageTest.java
@@ -10,27 +10,23 @@ import org.junit.Test;
  *
  * @author Paul Bender Copyright (C) 2017	
  */
-public class AbstractMessageTest {
-
-    @Test
-    public void testCTor() {
-        AbstractMessage t = new AbstractMessage(5){
-            @Override
-            public String toString(){
-                 return "";
-            }
-        };
-        Assert.assertNotNull("exists",t);
-    }
+public class AbstractMessageTest extends AbstractMessageTestBase {
 
     // The minimal setup for log4J
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        m = new AbstractMessage(5){
+            @Override
+            public String toString(){
+                 return "";
+            }
+        };
     }
 
     @After
     public void tearDown() {
+	m = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/AbstractMessageTestBase.java
+++ b/java/test/jmri/jmrix/AbstractMessageTestBase.java
@@ -1,0 +1,35 @@
+package jmri.jmrix;
+
+import jmri.util.JUnitUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Base tests for messages implementing the jmri.jmrix.Message interface.
+ *
+ * @author Paul Bender Copyright (C) 2017	
+ */
+abstract public class AbstractMessageTestBase {
+
+    protected AbstractMessage m = null; // set in setUp
+
+    @Before
+    abstract public void setUp();
+
+    @Test
+    public void testCTor() {
+        Assert.assertNotNull("exists",m);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertNotNull("toString has result",m.toString());
+    }
+
+    @Test
+    public void testToMonitorString() {
+        Assert.assertNotNull("toMonitorString has result",m.toMonitorString());
+    }
+
+}


### PR DESCRIPTION
Also remove definition of toMonitorString from derived classes for which this is now redundant.