### PR TITLE
Team Digital 'decoder' LOCONETOPSBOARD updates

### DIFF
--- a/xml/decoders/TD_BlocD8.xml
+++ b/xml/decoders/TD_BlocD8.xml
@@ -13,11 +13,13 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd" showEmptyPanes="no">
+  <version author="B. Milhaupt" version="1.3" lastUpdated="20180823"/>
   <version author="td@teamdigital1.com" version="1.2" lastUpdated="20101101"/>
   <!-- Version 1 initial release -->
   <!-- Version 1.1 release correct input 4 secondary address -->
   <!-- Version 1.2 release correct input 5 primary address and default output state -->
   <!-- and added unoccupied delay time CVs -->
+  <!-- Version 1.3 release, added "LOCONETOPSBOARD" programming token to allow LocoNet-connected boards to read CV values -->
   <decoder>
     <family name="BlocD8" mfg="Team Digital" type="stationary">
       <model model="BlocD8" lowVersionID="1" comment="BlocD8 can be programmed in the usual way"/>

--- a/xml/decoders/TD_BlocD8.xml
+++ b/xml/decoders/TD_BlocD8.xml
@@ -22,7 +22,9 @@
     <family name="BlocD8" mfg="Team Digital" type="stationary">
       <model model="BlocD8" lowVersionID="1" comment="BlocD8 can be programmed in the usual way"/>
     </family>
-    <programming direct="yes" paged="yes" register="no" ops="yes"/>
+    <programming direct="yes" paged="yes" register="no" ops="yes">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable CV="1" mask="XVVVVVVV" item="Short Address" default="1" tooltip="Range 1-99">
         <shortAddressVal/>

--- a/xml/decoders/TD_CSC.xml
+++ b/xml/decoders/TD_CSC.xml
@@ -13,9 +13,11 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="B. Milhaupt" version="1.2" lastUpdated="20180823"/>
   <version author="td@teamdigital1.com" version="1.0" lastUpdated="20130520"/>
   <!-- Version 1 initial release 10/27/13-->
   <!-- Version 1.1 added delay for inputs 9-16 release 10/27/13-->  
+  <!-- Version 1.2 release, added "LOCONETOPSBOARD" programming token to allow LocoNet-connected boards to read CV values -->
   <decoder>
     <family name="CSC Family" mfg="Team Digital" type="stationary" comment="The CSC can be programmed in the usual way">
       <model model="CSC" lowVersionID="10" comment="Original HW"/>

--- a/xml/decoders/TD_CSC.xml
+++ b/xml/decoders/TD_CSC.xml
@@ -21,7 +21,9 @@
       <model model="CSC" lowVersionID="10" comment="Original HW"/>
       <model model="CSCe" lowVersionID="10" comment="Later HW"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes"/>
+    <programming direct="no" paged="yes" register="no" ops="yes">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable CV="1" mask="VVVVVVVV" item="Short Address" tooltip="Range 1-16000, max value of 127 when programming via DCC" default="10010">
         <splitVal highCV="2" upperMask="XXVVVVVV"/>

--- a/xml/decoders/TD_SC8.xml
+++ b/xml/decoders/TD_SC8.xml
@@ -13,10 +13,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="B. Milhaupt" version="1.3" lastUpdated="20180823"/>
   <version author="td@teamdigital1.com" version="1.2" lastUpdated="20120221"/>
   <!-- Version 1 initial release 2/18/11-->
   <!-- Version 1.1 release 3/14/11 corrected ops mode enable and speed to position-->
   <!-- Version 1.2 release 2/21/12 corrected CV28 options and added startup delay-->
+  <!-- Version 1.3 release, added "LOCONETOPSBOARD" programming token to allow LocoNet-connected boards to read CV values -->
   <decoder>
     <family name="Stationary Decoder" mfg="Team Digital" type="stationary">
       <model model="SC8" lowVersionID="1" comment="SC8 is a stationary decoder, but it can be programmed in the usual way"/>

--- a/xml/decoders/TD_SC8.xml
+++ b/xml/decoders/TD_SC8.xml
@@ -21,7 +21,9 @@
     <family name="Stationary Decoder" mfg="Team Digital" type="stationary">
       <model model="SC8" lowVersionID="1" comment="SC8 is a stationary decoder, but it can be programmed in the usual way"/>
     </family>
-    <programming direct="yes" paged="yes" register="no" ops="yes"/>
+    <programming direct="yes" paged="yes" register="no" ops="yes">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable item="Servo 1 Address" CV="1" mask="VVVVVVVV" default="1" tooltip="Range 1-2040">
         <splitVal highCV="9" upperMask="XXXXVVVV"/>

--- a/xml/decoders/TD_SC82.xml
+++ b/xml/decoders/TD_SC82.xml
@@ -19,7 +19,9 @@
     <family name="Stationary Decoder" mfg="Team Digital" type="stationary">
       <model model="SC82" lowVersionID="1" comment="SC82 is a stationary decoder, but it can be programmed in the usual way"/>
     </family>
-    <programming direct="yes" paged="yes" register="no" ops="yes"/>
+    <programming direct="yes" paged="yes" register="no" ops="yes">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable CV="1" mask="VVVVVVVV" item="Short Address" tooltip="Range 1-16000, max value of 127 when programming via DCC" default="1">
         <splitVal highCV="2" upperMask="XXVVVVVV"/>

--- a/xml/decoders/TD_SC82.xml
+++ b/xml/decoders/TD_SC82.xml
@@ -13,8 +13,10 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="B. Milhaupt" version="1.3" lastUpdated="20180823"/>
   <version author="td@teamdigital1.com" version="1.2" lastUpdated="20150720"/>
   <!-- Version 1 initial release 7/20/15-->
+  <!-- Version 1.3 release, added "LOCONETOPSBOARD" programming token to allow LocoNet-connected boards to read CV values -->
   <decoder>
     <family name="Stationary Decoder" mfg="Team Digital" type="stationary">
       <model model="SC82" lowVersionID="1" comment="SC82 is a stationary decoder, but it can be programmed in the usual way"/>

--- a/xml/decoders/TD_SIC24.xml
+++ b/xml/decoders/TD_SIC24.xml
@@ -13,10 +13,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="B. Milhaupt" version="1.3" lastUpdated="20180823"/>
   <version author="td@teamdigital1.com" version="1.2" lastUpdated="20070709"/>
   <!-- Version 1 initial release 12/13/05-->
   <!-- Version 1.1 release 2/23/06 - correct logic cell 3 -->
   <!-- Version 1.2 release 6/9/07 - added option 5 and input toggle, requires version 17 or later of SIC24-->
+  <!-- Version 1.3 release, added "LOCONETOPSBOARD" programming token to allow LocoNet-connected boards to read CV values -->
   <decoder>
     <family name="SIC24" mfg="Team Digital" type="stationary" comment="SIC24 is not stationary decoder, but it can be programmed in the usual way">
       <model model="SIC24" lowVersionID="12"/>

--- a/xml/decoders/TD_SIC24.xml
+++ b/xml/decoders/TD_SIC24.xml
@@ -21,7 +21,9 @@
     <family name="SIC24" mfg="Team Digital" type="stationary" comment="SIC24 is not stationary decoder, but it can be programmed in the usual way">
       <model model="SIC24" lowVersionID="12"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes"/>
+    <programming direct="no" paged="yes" register="no" ops="yes">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable item="Output Addresses" CV="1" mask="VVVVVVVV" default="101" tooltip="Range 1-2040">
         <splitVal highCV="9" upperMask="XXXXVVVV"/>

--- a/xml/decoders/TD_SIC24AD.xml
+++ b/xml/decoders/TD_SIC24AD.xml
@@ -13,6 +13,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="B. Milhaupt" version="1.7" lastUpdated="20180823"/>
   <version author="td@teamdigital1.com" version="1.5" lastUpdated="20130807"/>
   <!-- Version 1 initial release 10/14/08-->
   <!-- Version 1.1 added ops mode option 4/23/09-->
@@ -21,6 +22,7 @@
   <!-- Version 1.4 added cell address reference 11/14/10-->
   <!-- Version 1.5 update decoder-config xmlns 08/07/13-->
   <!-- Version 1.6 correct Input 5 toggle, was labeled same as input 1 toggle and did not fuction correctly 06/12/17-->
+  <!-- Version 1.7 release, added "LOCONETOPSBOARD" programming token to allow LocoNet-connected boards to read CV values -->
   <decoder>
     <family name="SIC24AD" mfg="Team Digital" type="stationary" comment="The SIC24AD can be programmed in the usual way">
       <model model="SIC24AD" lowVersionID="10"/>

--- a/xml/decoders/TD_SIC24AD.xml
+++ b/xml/decoders/TD_SIC24AD.xml
@@ -25,7 +25,9 @@
     <family name="SIC24AD" mfg="Team Digital" type="stationary" comment="The SIC24AD can be programmed in the usual way">
       <model model="SIC24AD" lowVersionID="10"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes"/>
+    <programming direct="no" paged="yes" register="no" ops="yes">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable CV="1" mask="XVVVVVVV" item="Short Address" default="1" tooltip="Range 1-99">
         <shortAddressVal/>

--- a/xml/decoders/TD_SIC24e.xml
+++ b/xml/decoders/TD_SIC24e.xml
@@ -13,8 +13,10 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="B. Milhaupt" version="1.1" lastUpdated="20180823"/>
   <version author="td@teamdigital1.com" version="1.0" lastUpdated="20150805"/>
   <!-- Version 1 initial release 8/5/15-->
+  <!-- Version 1.1 release, added "LOCONETOPSBOARD" programming token to allow LocoNet-connected boards to read CV values -->
   <decoder>
     <family name="SIC24e" mfg="Team Digital" type="stationary" comment="The SIC24e can be programmed in the usual way">
       <model model="SIC24e" lowVersionID="10"/>

--- a/xml/decoders/TD_SIC24e.xml
+++ b/xml/decoders/TD_SIC24e.xml
@@ -19,7 +19,9 @@
     <family name="SIC24e" mfg="Team Digital" type="stationary" comment="The SIC24e can be programmed in the usual way">
       <model model="SIC24e" lowVersionID="10"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes"/>
+    <programming direct="no" paged="yes" register="no" ops="yes">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable CV="1" mask="VVVVVVVV" item="Short Address" tooltip="Range 1-16000, max value of 127 when programming via DCC" default="1">
         <splitVal highCV="2" upperMask="XXVVVVVV"/>

--- a/xml/decoders/TD_SMD84.xml
+++ b/xml/decoders/TD_SMD84.xml
@@ -13,8 +13,10 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="B. Milhaupt" version="1.1" lastUpdated="20180823"/>
   <version author="td@teamdigital1.com" version="1.0" lastUpdated="20101103"/>
   <!-- Version 1 initial release -->
+  <!-- Version 1.1 release, added "LOCONETOPSBOARD" programming token to allow LocoNet-connected boards to read CV values -->
   <decoder>
     <family name="Stationary Decoder" mfg="Team Digital" type="stationary">
       <model model="SMD84" lowVersionID="1" comment="SMD84 is a stationary decoder, but it can be programmed in the usual way"/>

--- a/xml/decoders/TD_SMD84.xml
+++ b/xml/decoders/TD_SMD84.xml
@@ -19,7 +19,9 @@
     <family name="Stationary Decoder" mfg="Team Digital" type="stationary">
       <model model="SMD84" lowVersionID="1" comment="SMD84 is a stationary decoder, but it can be programmed in the usual way"/>
     </family>
-    <programming direct="yes" paged="yes" register="no" ops="yes"/>
+    <programming direct="yes" paged="yes" register="no" ops="yes">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable item="Output 1 Address" CV="1" mask="VVVVVVVV" default="1" tooltip="Range 1-2040">
         <splitVal highCV="9" upperMask="XXXXVVVV"/>

--- a/xml/decoders/TD_SRC16.xml
+++ b/xml/decoders/TD_SRC16.xml
@@ -13,6 +13,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="B. Milhaupt" version="1.9" lastUpdated="20180823"/>
   <version author="Michael Mosher" version="1.8" lastUpdated="20140513"/>
   <version author="Michael Mosher" version="1.7" lastUpdated="20111011"/>
   <version author="td@teamdigital1.com" version="1.6" lastUpdated="20100305"/>
@@ -27,6 +28,7 @@
   <!-- Version 1.6 added input lockout and CV10 option 5-->
   <!-- Version 1.7 corrected "Rte Num S8" CV (was 64 should be 63) -->
   <!-- Version 1.8 added power on state for 16 outputs -->
+  <!-- Version 1.9 release, added "LOCONETOPSBOARD" programming token to allow LocoNet-connected boards to read CV values -->
   <decoder>
     <family name="Stationary Decoder" mfg="Team Digital" type="stationary">
       <model model="SRC16" lowVersionID="1" comment="SRC16 is a stationary decoder with serial bus"/>

--- a/xml/decoders/TD_SRC16.xml
+++ b/xml/decoders/TD_SRC16.xml
@@ -31,7 +31,9 @@
     <family name="Stationary Decoder" mfg="Team Digital" type="stationary">
       <model model="SRC16" lowVersionID="1" comment="SRC16 is a stationary decoder with serial bus"/>
     </family>
-    <programming direct="yes" paged="yes" register="no" ops="yes"/>
+    <programming direct="yes" paged="yes" register="no" ops="yes">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
     <variables>
       <variable CV="1" mask="XVVVVVVV" item="Short Address" default="1" tooltip="Range 1-99">
         <shortAddressVal/>

--- a/xml/decoders/TD_SRC162.xml
+++ b/xml/decoders/TD_SRC162.xml
@@ -21,7 +21,10 @@
     <family name="Stationary Decoder" mfg="Team Digital" type="stationary">
       <model model="SRC162" lowVersionID="1" comment="SRC162 is a stationary decoder with serial bus"/>
     </family>
-    <programming direct="yes" paged="yes" register="no" ops="yes"/>
+    <programming direct="yes" paged="yes" register="no" ops="yes">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
+
     <variables>
       <!-- item="Short Address" tells the system that this is the DCC address -->
       <!-- "dccaddress" name required in panel to see correct address -->

--- a/xml/decoders/TD_SRC162.xml
+++ b/xml/decoders/TD_SRC162.xml
@@ -13,10 +13,12 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="B. Milhaupt" version="1.12" lastUpdated="20180823"/>
   <version author="td@teamdigital1.com" version="1.11" lastUpdated="20170130"/>
   <!-- Version 1 initial release -->
   <!-- Version 1.1 release, increase route max to to 15, add the t in Digitrax, improve tool tip for route send delay -->
   <!-- Version 1.11 release, added single output options in Power On Outputs sheet -->
+  <!-- Version 1.12 release, added "LOCONETOPSBOARD" programming token to allow LocoNet-connected boards to read CV values -->
   <decoder>
     <family name="Stationary Decoder" mfg="Team Digital" type="stationary">
       <model model="SRC162" lowVersionID="1" comment="SRC162 is a stationary decoder with serial bus"/>

--- a/xml/decoders/TD_SRC8.xml
+++ b/xml/decoders/TD_SRC8.xml
@@ -19,7 +19,10 @@
     <family name="SRC8" mfg="Team Digital" type="stationary" comment="SRC8 is not stationary decoder, but it can be programmed in the usual way">
       <model model="SRC8" lowVersionID="12"/>
     </family>
-    <programming direct="no" paged="yes" register="no" ops="yes"/>
+    <programming direct="no" paged="yes" register="no" ops="yes">
+        <mode>LOCONETOPSBOARD</mode>
+    </programming>
+
     <variables>
       <variable item="Base Address CV1" CV="1" mask="XVVVVVVV" default="1" tooltip="Range 1-127">
         <decVal/>

--- a/xml/decoders/TD_SRC8.xml
+++ b/xml/decoders/TD_SRC8.xml
@@ -13,8 +13,10 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="B. Milhaupt" version="1.1" lastUpdated="20180823"/>
   <version author="td@teamdigital1.com" version="1" lastUpdated="20051215"/>
   <!-- Version 1 initial release -->
+  <!-- Version 1.1 release, added "LOCONETOPSBOARD" programming token to allow LocoNet-connected boards to read CV values -->
   <decoder>
     <family name="SRC8" mfg="Team Digital" type="stationary" comment="SRC8 is not stationary decoder, but it can be programmed in the usual way">
       <model model="SRC8" lowVersionID="12"/>


### PR DESCRIPTION
Updates some Team Digital "Decoder" XML files for LOCONETOPSBOARD.  Only those Team Digital devices which seem to support reading CVs via LocoNet cable with Ops Mode programming are modified.

See issue #5660 .