### PR TITLE
MERG CBUS Response Event Support for Sens / Turn / Light

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusLight.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusLight.java
@@ -4,6 +4,7 @@ import jmri.implementation.AbstractLight;
 import jmri.jmrix.can.CanListener;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
+import jmri.jmrix.can.cbus.CbusMessage;
 import jmri.jmrix.can.TrafficController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,6 +97,8 @@ public class CbusLight extends AbstractLight
 
     @Override
     public void reply(CanReply f) {
+        // convert response events to normal
+        f = CbusMessage.opcRangeToStl(f);
         if (addrOn.match(f)) {
             setState(ON);
         } else if (addrOff.match(f)) {

--- a/java/src/jmri/jmrix/can/cbus/CbusMessage.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusMessage.java
@@ -26,12 +26,12 @@ public class CbusMessage {
      * @return CBUS message converted from response to normal.
      */
     public static CanReply opcRangeToStl(CanReply msg){
-        int opc = CbusMessage.getOpcode(msg);
+        int opc = getOpcode(msg);
         // log.debug(" about to check opc {} ",opc);
-        if (opc==CbusConstants.CBUS_ARON) { msg.setElement(0, CbusConstants.CBUS_ACON);}
-        if (opc==CbusConstants.CBUS_AROF) { msg.setElement(0, CbusConstants.CBUS_ACOF);}
-        if (opc==CbusConstants.CBUS_ARSON) { msg.setElement(0, CbusConstants.CBUS_ASON);}
-        if (opc==CbusConstants.CBUS_ARSOF) { msg.setElement(0, CbusConstants.CBUS_ASOF);}
+        if (opc==CbusConstants.CBUS_ARON) { msg.setElement(0, CbusConstants.CBUS_ACON); }
+        else if (opc==CbusConstants.CBUS_AROF) { msg.setElement(0, CbusConstants.CBUS_ACOF); }
+        else if (opc==CbusConstants.CBUS_ARSON) { msg.setElement(0, CbusConstants.CBUS_ASON); }
+        else if (opc==CbusConstants.CBUS_ARSOF) { msg.setElement(0, CbusConstants.CBUS_ASOF); }
         return msg;
     }
     

--- a/java/src/jmri/jmrix/can/cbus/CbusMessage.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusMessage.java
@@ -16,6 +16,25 @@ import org.slf4j.LoggerFactory;
 public class CbusMessage {
     /* Methods that take a CanMessage as argument */
 
+    
+    /**
+     * Return a CBUS Message for use in sensors, turnouts + light
+     * If a response event, set to normal event
+     * In future, this may also translate extended messages down to normal messages.
+     *
+     * @param msg CbusMessage to be coverted to normal opc
+     * @return CBUS message converted from response to normal.
+     */
+    public static CanReply opcRangeToStl(CanReply msg){
+        int opc = CbusMessage.getOpcode(msg);
+        // log.debug(" about to check opc {} ",opc);
+        if (opc==CbusConstants.CBUS_ARON) { msg.setElement(0, CbusConstants.CBUS_ACON);}
+        if (opc==CbusConstants.CBUS_AROF) { msg.setElement(0, CbusConstants.CBUS_ACOF);}
+        if (opc==CbusConstants.CBUS_ARSON) { msg.setElement(0, CbusConstants.CBUS_ASON);}
+        if (opc==CbusConstants.CBUS_ARSOF) { msg.setElement(0, CbusConstants.CBUS_ASOF);}
+        return msg;
+    }
+    
     public static int getId(CanMessage m) {
         if (m.isExtended()) {
             return m.getHeader() & 0x1FFFFFF;

--- a/java/src/jmri/jmrix/can/cbus/CbusSensor.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensor.java
@@ -6,6 +6,7 @@ import jmri.jmrix.can.CanListener;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.TrafficController;
+import jmri.jmrix.can.cbus.CbusMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,11 +110,13 @@ public class CbusSensor extends AbstractSensor implements CanListener {
     }
 
     /**
-     * Track layout status from messages being received from CAN
+     * Event status from messages being received from CAN
      *
      */
     @Override
     public void reply(CanReply f) {
+        // convert response events to normal
+        f = CbusMessage.opcRangeToStl(f);
         if (addrActive.match(f)) {
             setOwnState(Sensor.ACTIVE);
         } else if (addrInactive.match(f)) {

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
@@ -4,6 +4,7 @@ import jmri.Turnout;
 import jmri.jmrix.can.CanListener;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
+import jmri.jmrix.can.cbus.CbusMessage;
 import jmri.jmrix.can.TrafficController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,6 +96,8 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
 
     @Override
     public void reply(CanReply f) {
+        // convert response events to normal
+        f = CbusMessage.opcRangeToStl(f);
         if (addrThrown.match(f)) {
             newCommandedState(THROWN);
         } else if (addrClosed.match(f)) {


### PR DESCRIPTION
Sensor / Turnout / Light status will now change in response to incoming ARON / AROF / ARSON / ARSOF.
Response event support enables cleaner SOD processes without having to throw turnouts etc.
Format of STL unchanged.