### PR TITLE
Small updates so JMRI can compile and run under Java 10

### DIFF
--- a/java/src/jmri/jmrit/catalog/CatalogPanel.java
+++ b/java/src/jmri/jmrit/catalog/CatalogPanel.java
@@ -258,9 +258,9 @@ public class CatalogPanel extends JPanel {
                     node.toString(), node.getChildCount());
         }
         CatalogTreeNode root = (CatalogTreeNode) _model.getRoot();
-        Enumeration<CatalogTreeNode> e = node.children();
+        Enumeration<TreeNode> e = node.children();
         while (e.hasMoreElements()) {
-            CatalogTreeNode n = e.nextElement();
+            CatalogTreeNode n = (CatalogTreeNode)e.nextElement();
             addNode(root, n);
         }
     }
@@ -272,9 +272,9 @@ public class CatalogPanel extends JPanel {
         CatalogTreeNode node = new CatalogTreeNode((String) n.getUserObject());
         node.setLeaves(n.getLeaves());
         parent.add(node);
-        Enumeration<CatalogTreeNode> e = n.children();
+        Enumeration<TreeNode> e = n.children();
         while (e.hasMoreElements()) {
-            CatalogTreeNode nChild = e.nextElement();
+            CatalogTreeNode nChild = (CatalogTreeNode)e.nextElement();
             addNode(node, nChild);
         }
     }
@@ -305,10 +305,10 @@ public class CatalogPanel extends JPanel {
         if (idx == nodes.length) {
             return cRoot;
         }
-        Enumeration<CatalogTreeNode> e = cRoot.children();
+        Enumeration<TreeNode> e = cRoot.children();
         CatalogTreeNode result = null;
         while (e.hasMoreElements()) {
-            CatalogTreeNode cNode = e.nextElement();
+            CatalogTreeNode cNode = (CatalogTreeNode)e.nextElement();
             if (nodes[idx].toString().equals(cNode.toString())) {
                 result = match(cNode, nodes, idx + 1);
                 break;
@@ -345,9 +345,9 @@ public class CatalogPanel extends JPanel {
             return false;
         }
         int index = 0;
-        Enumeration<CatalogTreeNode> e = parent.children();
+        Enumeration<TreeNode> e = parent.children();
         while (e.hasMoreElements()) {
-            CatalogTreeNode n = e.nextElement();
+            CatalogTreeNode n = (CatalogTreeNode)e.nextElement();
             if (name.compareTo(n.toString()) < 0) {
                 break;
             }

--- a/java/src/jmri/jmrit/catalog/CatalogTreeNode.java
+++ b/java/src/jmri/jmrit/catalog/CatalogTreeNode.java
@@ -2,7 +2,7 @@ package jmri.jmrit.catalog;
 
 import java.util.ArrayList;
 import java.util.Enumeration;
-import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,7 +109,7 @@ public class CatalogTreeNode extends DefaultMutableTreeNode {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Enumeration<CatalogTreeNode> children() {
+    public Enumeration<TreeNode> children() {  // for JDK 9 typing
         return super.children();
     }
 

--- a/java/src/jmri/jmrit/catalog/ImageIndexEditor.java
+++ b/java/src/jmri/jmrit/catalog/ImageIndexEditor.java
@@ -18,7 +18,8 @@ import javax.swing.JPopupMenu;
 import javax.swing.JSplitPane;
 import javax.swing.JTree;
 import javax.swing.SwingConstants;
-import javax.swing.tree.TreePath;
+import javax.swing.tree.*;
+
 import jmri.CatalogTreeManager;
 import jmri.InstanceInitializer;
 import jmri.InstanceManager;
@@ -312,9 +313,9 @@ public final class ImageIndexEditor extends JmriJFrame {
 
     int countSubNodes(CatalogTreeNode node) {
         int cnt = 0;
-        Enumeration<CatalogTreeNode> e = node.children();
+        Enumeration<TreeNode> e = node.children();
         while (e.hasMoreElements()) {
-            CatalogTreeNode n = e.nextElement();
+            CatalogTreeNode n = (CatalogTreeNode)e.nextElement();
             cnt += countSubNodes(n) + 1;
         }
         return cnt;
@@ -322,9 +323,9 @@ public final class ImageIndexEditor extends JmriJFrame {
 
     private int countIcons(CatalogTreeNode node) {
         int cnt = 0;
-        Enumeration<CatalogTreeNode> e = node.children();
+        Enumeration<TreeNode> e = node.children();
         while (e.hasMoreElements()) {
-            CatalogTreeNode n = e.nextElement();
+            CatalogTreeNode n =(CatalogTreeNode)e.nextElement();
             cnt += countIcons(n);
         }
         cnt += node.getNumLeaves();

--- a/java/src/jmri/jmrit/catalog/configurexml/DefaultCatalogTreeManagerXml.java
+++ b/java/src/jmri/jmrit/catalog/configurexml/DefaultCatalogTreeManagerXml.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
-import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.*;
 import jmri.CatalogTree;
 import jmri.CatalogTreeManager;
 import jmri.InstanceManager;
@@ -56,9 +56,9 @@ public class DefaultCatalogTreeManagerXml extends XmlFile {
                 log.debug("enumerateTree called for root= {}, has {} children", root, root.getChildCount());
 
                 @SuppressWarnings("unchecked") // root.depthFirstEnumeration isn't fully typed in JDOM2
-                Enumeration<CatalogTreeNode> e = root.depthFirstEnumeration();
+                Enumeration<TreeNode> e = root.depthFirstEnumeration();
                 while (e.hasMoreElements()) {
-                    CatalogTreeNode n = e.nextElement();
+                    CatalogTreeNode n = (CatalogTreeNode)e.nextElement();
                     log.debug("nodeName= {} has {} leaves and {} subnodes.", n.getUserObject(), n.getLeaves().size(), n.getChildCount());
                 }
             }
@@ -155,9 +155,9 @@ public class DefaultCatalogTreeManagerXml extends XmlFile {
             element.addContent(el);
         }
         parent.addContent(element);
-        Enumeration<CatalogTreeNode> e = node.children();
+        Enumeration<TreeNode> e = node.children();
         while (e.hasMoreElements()) {
-            CatalogTreeNode n = e.nextElement();
+            CatalogTreeNode n = (CatalogTreeNode) e.nextElement();
             storeNode(element, n);
         }
     }

--- a/java/src/jmri/jmrit/display/IconAdder.java
+++ b/java/src/jmri/jmrit/display/IconAdder.java
@@ -41,6 +41,8 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
+import javax.swing.tree.TreeNode;
+
 import jmri.CatalogTree;
 import jmri.CatalogTreeManager;
 import jmri.InstanceManager;
@@ -129,10 +131,10 @@ public class IconAdder extends JPanel implements ListSelectionListener {
         if (tree != null) {
             CatalogTreeNode node = tree.getRoot();
 
-            Enumeration<CatalogTreeNode> e = node.children();
+            Enumeration<TreeNode> e = node.children();
 
             while (e.hasMoreElements()) {
-                CatalogTreeNode nChild = e.nextElement();
+                CatalogTreeNode nChild = (CatalogTreeNode)e.nextElement();
                 if (_type.equals(nChild.toString())) {
                     _defaultIcons = nChild;
                     _userDefaults = true;
@@ -692,11 +694,11 @@ public class IconAdder extends JPanel implements ListSelectionListener {
         }
         CatalogTreeNode root = tree.getRoot();
 
-        Enumeration<CatalogTreeNode> e = root.children();
+        Enumeration<TreeNode> e = root.children();
 
         String name = _defaultIcons.toString();
         while (e.hasMoreElements()) {
-            CatalogTreeNode nChild = e.nextElement();
+            CatalogTreeNode nChild = (CatalogTreeNode)e.nextElement();
             if (name.equals(nChild.toString())) {
                 log.debug("Remove node {}", nChild);
                 root.remove(nChild);

--- a/java/src/jmri/jmrit/display/palette/ItemPalette.java
+++ b/java/src/jmri/jmrit/display/palette/ItemPalette.java
@@ -22,6 +22,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import javax.swing.tree.TreeNode;
+
 import jmri.*;
 import jmri.jmrit.catalog.CatalogTreeLeaf;
 import jmri.jmrit.catalog.CatalogTreeNode;
@@ -236,9 +238,9 @@ public class ItemPalette extends DisplayFrame implements ChangeListener {
         CatalogTree tree = manager.getBySystemName("NXPI");
         if (tree != null) {
             CatalogTreeNode root = tree.getRoot();
-            Enumeration<CatalogTreeNode> e = root.children();
+            Enumeration<TreeNode> e = root.children();
             while (e.hasMoreElements()) {
-                CatalogTreeNode node = e.nextElement();
+                CatalogTreeNode node = (CatalogTreeNode)e.nextElement();
                 String typeName = (String) node.getUserObject();
                 // detect this is a 4 level map collection.
                 // not very elegant (i.e. extensible), but maybe all that's needed.
@@ -269,9 +271,9 @@ public class ItemPalette extends DisplayFrame implements ChangeListener {
             loadIndicatorFamilyMap(CatalogTreeNode node, Editor ed) {
         HashMap<String, HashMap<String, HashMap<String, NamedIcon>>> familyMap
                 = new HashMap<>();
-        Enumeration<CatalogTreeNode> ee = node.children();
+        Enumeration<TreeNode> ee = node.children();
         while (ee.hasMoreElements()) {
-            CatalogTreeNode famNode = ee.nextElement();
+            CatalogTreeNode famNode = (CatalogTreeNode)ee.nextElement();
             String name = (String) famNode.getUserObject();
             familyMap.put(name, loadFamilyMap(famNode, ed));
             Thread.yield();
@@ -282,9 +284,9 @@ public class ItemPalette extends DisplayFrame implements ChangeListener {
     static HashMap<String, HashMap<String, NamedIcon>> loadFamilyMap(CatalogTreeNode node, Editor ed) {
         HashMap<String, HashMap<String, NamedIcon>> familyMap
                 = new HashMap<>();
-        Enumeration<CatalogTreeNode> ee = node.children();
+        Enumeration<TreeNode> ee = node.children();
         while (ee.hasMoreElements()) {
-            CatalogTreeNode famNode = ee.nextElement();
+            CatalogTreeNode famNode = (CatalogTreeNode)ee.nextElement();
             String familyName = (String) famNode.getUserObject();
             HashMap<String, NamedIcon> iconMap = new HashMap<>();
             List<CatalogTreeLeaf> list = famNode.getLeaves();

--- a/java/src/jmri/jmrit/symbolicprog/CombinedLocoSelTreePane.java
+++ b/java/src/jmri/jmrit/symbolicprog/CombinedLocoSelTreePane.java
@@ -341,9 +341,9 @@ public class CombinedLocoSelTreePane extends CombinedLocoSelPane {
      * All".
      */
     public void resetSelections() {
-        Enumeration<DecoderTreeNode> e = dRoot.breadthFirstEnumeration();
+        Enumeration<TreeNode> e = dRoot.breadthFirstEnumeration();
         while (e.hasMoreElements()) {
-            e.nextElement().setIdentified(false);
+            ((DecoderTreeNode)e.nextElement()).setIdentified(false);
         }
         setShowMatchedOnly(false);
         selectedPath = new ArrayList<>();
@@ -387,9 +387,9 @@ public class CombinedLocoSelTreePane extends CombinedLocoSelPane {
         }
 
         // set everybody not identified
-        Enumeration<DecoderTreeNode> e = dRoot.breadthFirstEnumeration();
+        Enumeration<TreeNode> e = dRoot.breadthFirstEnumeration();
         while (e.hasMoreElements()) { // loop over the tree
-            DecoderTreeNode node = e.nextElement();
+            DecoderTreeNode node = ((DecoderTreeNode)e.nextElement());
             node.setIdentified(false);
         }
 
@@ -405,7 +405,7 @@ public class CombinedLocoSelTreePane extends CombinedLocoSelPane {
             String findModel = f.getModel();
 
             while (e.hasMoreElements()) { // loop over the tree & find node
-                DecoderTreeNode node = e.nextElement();
+                DecoderTreeNode node = ((DecoderTreeNode)e.nextElement());
                 // never match show=NO nodes
                 if (node.getShowable() == DecoderFile.Showable.NO) {
                     continue;
@@ -468,12 +468,12 @@ public class CombinedLocoSelTreePane extends CombinedLocoSelPane {
         // find this mfg to select it
         dTree.clearSelection();
 
-        Enumeration<DecoderTreeNode> e = dRoot.breadthFirstEnumeration();
+        Enumeration<TreeNode> e = dRoot.breadthFirstEnumeration();
 
         ArrayList<DecoderTreeNode> selected = new ArrayList<>();
         selectedPath = new ArrayList<>();
         while (e.hasMoreElements()) {
-            DecoderTreeNode node = e.nextElement();
+            DecoderTreeNode node = (DecoderTreeNode)e.nextElement();
             if (node.getParent() != null && node.getParent().toString().equals("Root")) {
                 if (node.toString().equals(pMfg)) {
                     TreePath path = new TreePath(node.getPath());
@@ -491,10 +491,10 @@ public class CombinedLocoSelTreePane extends CombinedLocoSelPane {
         for (DecoderTreeNode node : selected) {
             node.setIdentified(true);
 
-            Enumeration<DecoderTreeNode> es = dRoot.breadthFirstEnumeration();
+            Enumeration<TreeNode> es = dRoot.breadthFirstEnumeration();
 
             while (es.hasMoreElements()) {
-                es.nextElement().setIdentified(true);
+                ((DecoderTreeNode)es.nextElement()).setIdentified(true);
             }
         }
         if (showMatched.isSelected()) {
@@ -541,10 +541,10 @@ public class CombinedLocoSelTreePane extends CombinedLocoSelPane {
         // close the entire GUI (not currently done, users want left open)
         //collapseAll();
         // find this one to select it
-        Enumeration<DecoderTreeNode> e = dRoot.breadthFirstEnumeration();
+        Enumeration<TreeNode> e = dRoot.breadthFirstEnumeration();
 
         while (e.hasMoreElements()) {
-            DecoderTreeNode node = e.nextElement();
+            DecoderTreeNode node = (DecoderTreeNode)e.nextElement();
             DecoderTreeNode parentNode = (DecoderTreeNode) node.getParent();
             if (node.toString().equals(modelString)
                     && parentNode.toString().equals(familyString)) {
@@ -651,7 +651,7 @@ public class CombinedLocoSelTreePane extends CombinedLocoSelPane {
 
         @Override
         @SuppressWarnings("unchecked") // required because super.breadthFirstEnumeration not fully typed
-        public Enumeration<DecoderTreeNode> breadthFirstEnumeration() {
+        public Enumeration<TreeNode> breadthFirstEnumeration() { // JDK 9 typing
             return super.breadthFirstEnumeration();
         }
 

--- a/java/src/jmri/jmrix/ecos/utilities/EcosLocoToRoster.java
+++ b/java/src/jmri/jmrix/ecos/utilities/EcosLocoToRoster.java
@@ -819,9 +819,9 @@ public class EcosLocoToRoster implements EcosListener {
         String msg = "Found mfg " + pMfgID + " (" + pMfg + ") version " + pModelID + "; no such decoder defined";
         log.warn(msg);
         dTree.clearSelection();
-        Enumeration<DefaultMutableTreeNode> e = dRoot.breadthFirstEnumeration();
+        Enumeration<TreeNode> e = dRoot.breadthFirstEnumeration();
         while (e.hasMoreElements()) {
-            DefaultMutableTreeNode node = e.nextElement();
+            DefaultMutableTreeNode node = (DefaultMutableTreeNode)e.nextElement();
             if (node.toString().equals(pMfg)) {
                 TreePath path = new TreePath(node.getPath());
                 dTree.expandPath(path);
@@ -869,9 +869,9 @@ public class EcosLocoToRoster implements EcosListener {
             String findFamily = f.getFamily();
             String findModel = f.getModel();
 
-            Enumeration<DefaultMutableTreeNode> e = dRoot.breadthFirstEnumeration();
+            Enumeration<TreeNode> e = dRoot.breadthFirstEnumeration();
             while (e.hasMoreElements()) {
-                DefaultMutableTreeNode node = e.nextElement();
+                DefaultMutableTreeNode node = (DefaultMutableTreeNode)e.nextElement();
 
                 // convert path to comparison string
                 TreeNode[] list = node.getPath();

--- a/jython/AAR105.py
+++ b/jython/AAR105.py
@@ -39,6 +39,7 @@
 # and everything will slow right down....
 
 import java
+import java.beans
 import jmri
 
 #

--- a/jython/AlarmClock.py
+++ b/jython/AlarmClock.py
@@ -5,6 +5,7 @@
 # Part of the JMRI distribution
 
 import java
+import java.beans
 import jmri
 
 # Change the next line to the name of the turnout you want to

--- a/jython/AutoDispatcher2.py
+++ b/jython/AutoDispatcher2.py
@@ -68,6 +68,12 @@
 # JAVA imports
 
 import java
+import java.awt
+import java.awt.event
+import java.beans
+import java.io
+import java.util
+
 import jmri
 
 from java.beans import PropertyChangeListener

--- a/jython/BlockLister.py
+++ b/jython/BlockLister.py
@@ -6,6 +6,8 @@
 import jmri
 
 import java
+import java.awt
+import java.awt.event
 import javax.swing
 
 HighDebug = 3

--- a/jython/BlockOccupancyAnnouncer.py
+++ b/jython/BlockOccupancyAnnouncer.py
@@ -8,6 +8,7 @@
 # Part of the JMRI distribution
 
 import java
+import java.beans
 import jmri
 
 # Define routine to map status numbers to text

--- a/jython/CmriNodeTool.py
+++ b/jython/CmriNodeTool.py
@@ -7,6 +7,7 @@
 # Part of the JMRI distribution
 
 import java
+import java.awt
 import jmri
 import javax.swing
 

--- a/jython/CombineSensors.py
+++ b/jython/CombineSensors.py
@@ -16,6 +16,7 @@
 
 import jmri
 import java
+import java.beans
 
 # Define the listener. 
 class CombineSensors(java.beans.PropertyChangeListener):

--- a/jython/CombineTurnouts.py
+++ b/jython/CombineTurnouts.py
@@ -16,6 +16,7 @@
 
 import jmri
 import java
+import java.beans
 
 # Define the listener. 
 class CombineTurnouts(java.beans.PropertyChangeListener):

--- a/jython/ControlPanel.py
+++ b/jython/ControlPanel.py
@@ -13,6 +13,7 @@
 import jmri
 
 import java
+import java.awt
 import javax.swing
 
 # create a frame to hold the button(s), put button in it, and display

--- a/jython/CsvToTurnouts.py
+++ b/jython/CsvToTurnouts.py
@@ -15,6 +15,7 @@
 import jmri
 
 import java
+import java.io
 import com.csvreader
 
 b = java.io.FileReader(java.io.File("demo.csv"))

--- a/jython/DebounceSensor.py
+++ b/jython/DebounceSensor.py
@@ -13,6 +13,9 @@
 import jmri
 
 import java
+import java.awt
+import java.awt.event
+import java.beans
 import javax.swing
 
 # declare things

--- a/jython/FileLogging.py
+++ b/jython/FileLogging.py
@@ -9,6 +9,7 @@ import jmri
 
 import java
 import java.beans
+import java.util
 import jarray
 import java.util.Calendar
 

--- a/jython/FileLogging.py
+++ b/jython/FileLogging.py
@@ -8,6 +8,7 @@
 import jmri
 
 import java
+import java.beans
 import jarray
 import java.util.Calendar
 

--- a/jython/FollowSE8c.py
+++ b/jython/FollowSE8c.py
@@ -18,6 +18,7 @@
 
 import jmri
 import java
+import java.beans
 
 class FollowSE8c(java.beans.PropertyChangeListener):
   def set(self, signalHeadName, lowTurnoutName, highTurnoutName) :

--- a/jython/GradeCrossing.py
+++ b/jython/GradeCrossing.py
@@ -18,6 +18,10 @@
 # Part of the JMRI distribution
 #
 import java
+import java.awt
+import java.awt.event
+import java.beans
+import java.util
 import java.util.ArrayList as ArrayList
 import jmri
 import javax.swing.Timer as Timer

--- a/jython/HeljanCrane.py
+++ b/jython/HeljanCrane.py
@@ -9,6 +9,7 @@
 import jmri
 
 import java
+import java.awt
 import javax.swing
 
 class HeljanCrane(jmri.jmrit.automat.AbstractAutomaton) :

--- a/jython/HoldSignalForSensor.py
+++ b/jython/HoldSignalForSensor.py
@@ -10,6 +10,8 @@
 # Part of the JMRI distribution
 
 import jmri
+import java
+import java.beans
 
 from org.apache.log4j import Logger
 

--- a/jython/IoT/JMRI_TcpPeripheral.py
+++ b/jython/IoT/JMRI_TcpPeripheral.py
@@ -53,6 +53,7 @@
 # imports, module variables and imediate running code
 
 import java
+import java.beans
 import socket
 import threading
 import time

--- a/jython/JButtonActionExample.py
+++ b/jython/JButtonActionExample.py
@@ -34,4 +34,3 @@ f.contentPane.add(b)
 
 f.pack()
 f.show()
-

--- a/jython/JButtonActionExample.py
+++ b/jython/JButtonActionExample.py
@@ -7,6 +7,8 @@
 import jmri
 
 import java
+import java.awt
+import java.awt.event
 import javax.swing
 
 # define a class that has some state

--- a/jython/Jynstruments/Test.jyn/Test.py
+++ b/jython/Jynstruments/Test.jyn/Test.py
@@ -2,6 +2,7 @@
 # Will go anywhere
 
 import java
+import java.awt
 import jmri
 import jmri.jmrit.jython.Jynstrument as Jynstrument
 import java.awt.CardLayout as CardLayout

--- a/jython/Jynstruments/ThrottleFrame/Bell.jyn/Bell.py
+++ b/jython/Jynstruments/ThrottleFrame/Bell.jyn/Bell.py
@@ -1,4 +1,7 @@
 import java
+import java.awt
+import java.awt.event
+import java.beans
 import jmri
 import jmri.jmrit.jython.Jynstrument as Jynstrument
 import java.awt.CardLayout as CardLayout

--- a/jython/Jynstruments/ThrottleFrame/Direction.jyn/Direction.py
+++ b/jython/Jynstruments/ThrottleFrame/Direction.jyn/Direction.py
@@ -1,4 +1,7 @@
 import java
+import java.awt
+import java.awt.event
+import java.beans
 import jmri
 import jmri.jmrit.jython.Jynstrument as Jynstrument
 import java.awt.CardLayout as CardLayout

--- a/jython/Jynstruments/ThrottleFrame/EStop.jyn/EStop.py
+++ b/jython/Jynstruments/ThrottleFrame/EStop.jyn/EStop.py
@@ -1,4 +1,7 @@
 import java
+import java.awt
+import java.awt.event
+import java.beans
 import jmri
 import jmri.jmrit.jython.Jynstrument as Jynstrument
 import java.awt.CardLayout as CardLayout

--- a/jython/Jynstruments/ThrottleFrame/Horn.jyn/Horn.py
+++ b/jython/Jynstruments/ThrottleFrame/Horn.jyn/Horn.py
@@ -1,4 +1,7 @@
 import java
+import java.awt
+import java.awt.event
+import java.beans
 import jmri
 import jmri.jmrit.jython.Jynstrument as Jynstrument
 import java.awt.CardLayout as CardLayout

--- a/jython/Jynstruments/ThrottleFrame/Light.jyn/Light.py
+++ b/jython/Jynstruments/ThrottleFrame/Light.jyn/Light.py
@@ -1,4 +1,7 @@
 import java
+import java.awt
+import java.awt.event
+import java.beans
 import jmri
 import jmri.jmrit.jython.Jynstrument as Jynstrument
 import java.awt.CardLayout as CardLayout

--- a/jython/Jynstruments/ThrottleFrame/RosterImage.jyn/RosterImage.py
+++ b/jython/Jynstruments/ThrottleFrame/RosterImage.jyn/RosterImage.py
@@ -3,6 +3,7 @@
 #
 
 import java
+import java.awt
 import jmri
 import jmri.jmrit.jython.Jynstrument as Jynstrument
 import java.awt.BorderLayout as BorderLayout

--- a/jython/Jynstruments/ThrottleFrame/SoundOn2xF0.jyn/SoundOn2xF0.py
+++ b/jython/Jynstruments/ThrottleFrame/SoundOn2xF0.jyn/SoundOn2xF0.py
@@ -1,4 +1,6 @@
 import java
+import java.awt
+import java.awt.event
 import jmri
 import jmri.jmrit.jython.Jynstrument as Jynstrument
 import java.awt.CardLayout as CardLayout

--- a/jython/Jynstruments/ThrottleFrame/SoundOnF8.jyn/SoundOnF8.py
+++ b/jython/Jynstruments/ThrottleFrame/SoundOnF8.jyn/SoundOnF8.py
@@ -1,4 +1,7 @@
 import java
+import java.awt
+import java.awt.event
+import java.beans
 import jmri
 import jmri.jmrit.jython.Jynstrument as Jynstrument
 import java.awt.CardLayout as CardLayout

--- a/jython/Jynstruments/ThrottleFrame/VideoView.jyn/VideoView.py
+++ b/jython/Jynstruments/ThrottleFrame/VideoView.jyn/VideoView.py
@@ -17,6 +17,9 @@
 #    the StartJMRI shell script in the JMRI application bundle you use (by the end of the file where other lines like that appear)
 
 import java
+import java.awt
+import java.awt.event
+import java.beans
 import jmri
 import jmri.jmrit.jython.Jynstrument as Jynstrument
 import java.awt.CardLayout as CardLayout

--- a/jython/Jynstruments/ThrottleWindowToolBar/USBThrottle.jyn/USBThrottle.py
+++ b/jython/Jynstruments/ThrottleWindowToolBar/USBThrottle.jyn/USBThrottle.py
@@ -19,6 +19,10 @@ import sys
 import thread
 
 import java
+import java.awt
+import java.awt.event
+import java.beans
+import java.util
 import jmri
 import java.beans.PropertyChangeListener as PropertyChangeListener
 import java.util.Calendar as Calendar

--- a/jython/Jynstruments/ThrottleWindowToolBar/WiimoteThrottle.jyn/WiimoteThrottle.py
+++ b/jython/Jynstruments/ThrottleWindowToolBar/WiimoteThrottle.jyn/WiimoteThrottle.py
@@ -38,6 +38,10 @@ valueSpeedIncrement = 0.01
 delay4double = 500 # delay for double tap on button (ms)
 
 import java
+import java.awt
+import java.awt.event
+import java.beans
+import java.util
 import jmri
 import jmri.jmrit.jython.Jynstrument as Jynstrument
 import java.beans.PropertyChangeListener as PropertyChangeListener

--- a/jython/Jynstruments/ThrottleWindowToolBar/WiimoteThrottle2.jyn/WiimoteThrottle2.py
+++ b/jython/Jynstruments/ThrottleWindowToolBar/WiimoteThrottle2.jyn/WiimoteThrottle2.py
@@ -29,6 +29,10 @@ valueSpeedTimerRepeat = 25 # repeat time in ms for speed set task
 valueSpeedIncrement = 0.01
 
 import java
+import java.awt
+import java.awt.event
+import java.beans
+import java.util
 import java.beans.PropertyChangeListener as PropertyChangeListener
 import java.awt.event.ActionListener as ActionListener
 import java.util.Calendar as Calendar

--- a/jython/ListenerExample.py
+++ b/jython/ListenerExample.py
@@ -5,6 +5,7 @@
 # Part of the JMRI distribution
 
 import java
+import java.beans
 import jmri
 
 # First, define the listener.  This one just prints some

--- a/jython/LnSendTool.py
+++ b/jython/LnSendTool.py
@@ -17,6 +17,8 @@
 import jmri
 
 import java
+import java.awt
+import java.awt.event
 import javax.swing
 
 typePacket = 0

--- a/jython/MakeOriginalDecoderPro.py
+++ b/jython/MakeOriginalDecoderPro.py
@@ -6,7 +6,9 @@
 
 import jmri
 import javax.swing.JButton
+import java.util
 import java.util.ResourceBundle
+
 import jmri.Application
 import apps
 

--- a/jython/ManageBlocks.py
+++ b/jython/ManageBlocks.py
@@ -27,6 +27,8 @@
 from java.awt import Color
 import jmri
 import java
+import java.awt
+import java.beans
 
 debug = False
 

--- a/jython/NumberInput.py
+++ b/jython/NumberInput.py
@@ -8,6 +8,7 @@
 
 import jmri
 import java
+import java.beans
 
 # Define a listener which appends a single character (from its
 # local 'digit' variable) to a memory (in its local 'memory' variable)

--- a/jython/ParallelPortTurnouts.py
+++ b/jython/ParallelPortTurnouts.py
@@ -10,6 +10,7 @@
 
 import jmri
 import java
+import java.beans
 
 name = "LPT1" 
 #name = "/dev/cu.usbmodem3d11" # debug

--- a/jython/PowerSensor.py
+++ b/jython/PowerSensor.py
@@ -6,6 +6,7 @@
 
 import jmri
 import java
+import java.beans
 
 # The sensor number used to indicate the power status is hardcoded
 # below as "100". Change this if you want to use some other sensor.

--- a/jython/RailDriver.py
+++ b/jython/RailDriver.py
@@ -40,6 +40,7 @@
 
 import jmri
 import java
+import java.beans
 
 #
 # Set the name of the controller you're using

--- a/jython/ReporterFontControl.py
+++ b/jython/ReporterFontControl.py
@@ -15,6 +15,7 @@
 
 import jmri
 import java
+import java.awt
 
 # set the desired colour and size in the two lines below.
 # Many normal colour names can be used instead of WHITE 

--- a/jython/ReporterFormatter.py
+++ b/jython/ReporterFormatter.py
@@ -10,6 +10,7 @@
 
 import jmri
 import java
+import java.beans
 
 # First, define the listener class.  This gets messages
 # from the reporter, uses them to keep track of the decoders

--- a/jython/ReporterOperations.py
+++ b/jython/ReporterOperations.py
@@ -14,6 +14,7 @@
 
 import jmri
 import java
+import java.beans
 
 # First, define the listener class.  This gets messages
 # from the reporter, uses the reports to look up equipment

--- a/jython/RobotThrottle.py
+++ b/jython/RobotThrottle.py
@@ -91,6 +91,9 @@
 
 import jmri
 import java
+import java.awt
+import java.awt.event
+import java.beans
 import javax.swing
 
 # set up a throttle with the loco address

--- a/jython/RobotThrottle2.py
+++ b/jython/RobotThrottle2.py
@@ -96,6 +96,9 @@
 
 import jmri
 import java
+import java.awt
+import java.awt.event
+import java.beans
 import javax.swing
 
 HighDebug = 3

--- a/jython/RobotThrottle3.py
+++ b/jython/RobotThrottle3.py
@@ -100,6 +100,10 @@
 
 import jmri
 import java
+import java.awt
+import java.awt.event
+import java.beans
+import java.util
 import javax.swing
 import java.util.Calendar
 

--- a/jython/RocoCrane46800.py
+++ b/jython/RocoCrane46800.py
@@ -22,6 +22,7 @@
 
 import jmri
 import java
+import java.awt
 import javax.swing
 
 class RocoCrane(jmri.jmrit.automat.AbstractAutomaton) :

--- a/jython/RocoCrane46902.py
+++ b/jython/RocoCrane46902.py
@@ -22,6 +22,7 @@
 
 import jmri
 import java
+import java.awt
 import javax.swing
 
 class RocoCrane(jmri.jmrit.automat.AbstractAutomaton) :

--- a/jython/RosterCsvExport.py
+++ b/jython/RosterCsvExport.py
@@ -17,6 +17,8 @@ import com.csvreader
 from javax.swing import JFileChooser, JOptionPane
 from jmri.jmrit.symbolicprog import CvTableModel
 import java
+import java.awt
+import java.io
 
 # Define some default values
 

--- a/jython/SampleLnStats.py
+++ b/jython/SampleLnStats.py
@@ -8,6 +8,7 @@
 # make the jmri libraries easily availble
 import jmri
 import java
+import java.util
 
 class SampleLnStats(jmri.jmrit.automat.AbstractAutomaton) :
 

--- a/jython/Sensor-sound.py
+++ b/jython/Sensor-sound.py
@@ -5,6 +5,7 @@
 
 import jmri
 import java
+import java.beans
 
 # Define the listener to play a sound when a sensor goes active
 class SoundListener(java.beans.PropertyChangeListener):

--- a/jython/SensorGroupAutoItem.py
+++ b/jython/SensorGroupAutoItem.py
@@ -12,6 +12,7 @@
 
 import jmri
 import java
+import java.beans
 
 # Define the listener. 
 class SensorGroupAutoItem(java.beans.PropertyChangeListener):

--- a/jython/SensorLog.py
+++ b/jython/SensorLog.py
@@ -13,6 +13,7 @@
 
 import jmri
 import java
+import java.beans
 
 # Define routine to map status numbers to text
 def stateName(state) :

--- a/jython/SensorToTurnout.py
+++ b/jython/SensorToTurnout.py
@@ -7,6 +7,7 @@
 
 import jmri
 import java
+import java.beans
 
 # Define routine to map status numbers to text
 def stateMap(state) :

--- a/jython/SignalFollower.py
+++ b/jython/SignalFollower.py
@@ -8,6 +8,7 @@
 
 import jmri
 import java
+import java.beans
 
 # Define the listener. 
 class SignalFollowerListener(java.beans.PropertyChangeListener):

--- a/jython/SignalHeadFromSensors.py
+++ b/jython/SignalHeadFromSensors.py
@@ -15,6 +15,7 @@
 
 import jmri
 import java
+import java.beans
 
 # Define the listener. 
 class SignalSensorListener(java.beans.PropertyChangeListener):

--- a/jython/SignalMastFollower.py
+++ b/jython/SignalMastFollower.py
@@ -8,6 +8,7 @@
 
 import jmri
 import java
+import java.beans
 
 # Define the listener. 
 class SignalMastFollowerListener(java.beans.PropertyChangeListener):

--- a/jython/ThrottleBridge.py
+++ b/jython/ThrottleBridge.py
@@ -27,6 +27,7 @@
 
 import jmri
 import java
+import java.beans
 
 from time import sleep
 

--- a/jython/ThrottleFunctionForLight.py
+++ b/jython/ThrottleFunctionForLight.py
@@ -7,6 +7,7 @@
 
 import jmri
 import java
+import java.beans
 
 import jmri.Light.ON         as ON
 import jmri.Light.OFF        as OFF

--- a/jython/ThrottleFunctionForSensor.py
+++ b/jython/ThrottleFunctionForSensor.py
@@ -8,6 +8,7 @@
 
 import jmri
 import java
+import java.beans
 
 from org.apache.log4j import Logger
 

--- a/jython/ThrottleFunctionForTurnout.py
+++ b/jython/ThrottleFunctionForTurnout.py
@@ -7,6 +7,7 @@
 
 import jmri
 import java
+import java.beans
 
 from org.apache.log4j import Logger
 

--- a/jython/ThrottleSound.py
+++ b/jython/ThrottleSound.py
@@ -7,6 +7,7 @@
 
 import jmri
 import java
+import java.beans
 
 # Define the listener class to play a sound when a  throttle function changes
 class ThrottleListener(java.beans.PropertyChangeListener):

--- a/jython/ThrottleSoundMultiAddress.py
+++ b/jython/ThrottleSoundMultiAddress.py
@@ -52,6 +52,7 @@
 
 import jmri
 import java
+import java.beans
 
 # Define the listener class to play a sound when a  throttle function changes
 class ThrottleListener(java.beans.PropertyChangeListener):

--- a/jython/TurnoutReset.py
+++ b/jython/TurnoutReset.py
@@ -13,6 +13,7 @@
 
 import jmri
 import java
+import java.beans
 
 # First, define the listener.  
 class MyListener(java.beans.PropertyChangeListener):

--- a/jython/TurnoutStatePersistence.py
+++ b/jython/TurnoutStatePersistence.py
@@ -16,6 +16,8 @@
 import jmri
 
 import java
+import java.io
+import java.util
 import com.csvreader
 from org.apache.log4j import Logger
 

--- a/jython/TurntableDCC.py
+++ b/jython/TurntableDCC.py
@@ -8,6 +8,7 @@
 #
 
 import java
+import java.awt
 import javax.swing
 import jmri
 

--- a/jython/TwoOutputTurnouts.py
+++ b/jython/TwoOutputTurnouts.py
@@ -20,6 +20,7 @@
 
 import jmri
 import java
+import java.beans
 
 # First, define the listener that does everything
 class MainTurnoutListener(java.beans.PropertyChangeListener):

--- a/jython/USBThrottle.py
+++ b/jython/USBThrottle.py
@@ -6,6 +6,7 @@
 
 import jmri
 import java
+import java.beans
 
 #
 # Set the name of the controller you're using

--- a/jython/XlateCurve.py
+++ b/jython/XlateCurve.py
@@ -9,6 +9,7 @@
 #
 
 import java
+import java.beans
 import jmri
 
 class XlateCurve (java.beans.PropertyChangeListener) :

--- a/jython/javaone/doublestoprule.py
+++ b/jython/javaone/doublestoprule.py
@@ -3,6 +3,7 @@
 # of the main & sidings go OCCUPIED
 
 import java
+import java.beans
 
 class ReleaseFromSidings(java.beans.PropertyChangeListener):
   # to1, to2 are turnout objects; block1, block2 are corresponding

--- a/jython/javaone/setup.py
+++ b/jython/javaone/setup.py
@@ -1,6 +1,8 @@
 # basic setup for JavaOne demo
 
 import java
+import java.beans
+import java.io
 
 # define constants
 

--- a/jython/jmri_defaults.py
+++ b/jython/jmri_defaults.py
@@ -11,6 +11,7 @@
 # Part of the JMRI distribution
 
 import jmri
+import java.beans
 
 # define a helper function
 def decodeJmriFilename(name) :

--- a/jython/operations/OperationsListenersAllTrains.py
+++ b/jython/operations/OperationsListenersAllTrains.py
@@ -5,6 +5,8 @@
 # Author: Daniel Boudreau, copyright 2010, 2012
 # Part of the JMRI distribution
 
+import java
+import java.beans
 import java.beans.PropertyChangeListener as PropertyChangeListener
 import jmri
 

--- a/jython/operations/OperationsResetTrainColor.py
+++ b/jython/operations/OperationsResetTrainColor.py
@@ -8,6 +8,8 @@
 # Part of the JMRI distribution
 #
 
+import java
+import java.beans
 import java.beans.PropertyChangeListener as PropertyChangeListener
 import jmri
     

--- a/jython/test/CmriNodeMonitorTest.py
+++ b/jython/test/CmriNodeMonitorTest.py
@@ -2,6 +2,7 @@
 
 import jmri
 import java
+import java.awt
 
 # create and self-register
 c = jmri.jmrix.cmri.CMRISystemConnectionMemo()

--- a/jython/test/CmriNodeToolTest.py
+++ b/jython/test/CmriNodeToolTest.py
@@ -2,6 +2,7 @@
 
 import jmri
 import java
+import java.awt
 
 # create and self-register
 c = jmri.jmrix.cmri.CMRISystemConnectionMemo()

--- a/jython/test/ControlPanelTest.py
+++ b/jython/test/ControlPanelTest.py
@@ -1,5 +1,7 @@
 # Test the ControlPanel.py script - make sure it runs, then close its window
 import java
+import java.awt
+
 if ( not java.awt.GraphicsEnvironment.isHeadless()) :
     # just confirm that this runs OK in headed mode
     execfile("jython/ControlPanel.py")

--- a/jython/test/JButtonActionExampleTest.py
+++ b/jython/test/JButtonActionExampleTest.py
@@ -2,6 +2,8 @@
 #  Just starts one up to make sure of syntax, etc.
 
 import java
+import java.awt
+
 if (not java.awt.GraphicsEnvironment.isHeadless()) : 
     
     execfile("jython/JButtonActionExample.py")

--- a/jython/test/ReporterFormatterTest.py
+++ b/jython/test/ReporterFormatterTest.py
@@ -1,4 +1,6 @@
 # Test the ReporterFormatter.py script
+import java
+import java.beans
 
 # First, check syntax
 execfile("jython/ReporterFormatter.py")

--- a/jython/test/RosterCsvExportTest.py
+++ b/jython/test/RosterCsvExportTest.py
@@ -1,5 +1,7 @@
 # Test the RosterCsvExport.py script
 
+import java
+import java.awt
 import java.awt.GraphicsEnvironment
 
 if (java.awt.GraphicsEnvironment.isHeadless()) :

--- a/jython/xAPadapter.py
+++ b/jython/xAPadapter.py
@@ -25,6 +25,7 @@ import jarray
 import jmri
 import xAPlib
 import java
+import java.beans
 
 # create the network
 print "opening "

--- a/jython/xboxThrottle.py
+++ b/jython/xboxThrottle.py
@@ -46,6 +46,7 @@
 
 import jmri
 import java
+import java.beans
 
 #
 # Set the name of the controller you're using

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -516,9 +516,6 @@ OPTIONS="${OPTIONS} -Djava.security.policy=${LIBDIR}/security.policy"
 OPTIONS="${OPTIONS} -Djava.rmi.server.codebase=file:target/classes/"
 OPTIONS="${OPTIONS} -Djava.library.path=.:$SYSLIBPATH:${LIBDIR}"
 
-# Java 9/10 run options
-OPTIONS="${OPTIONS} --add-modules java.desktop"
-
 # memory start and max limits
 OPTIONS="${OPTIONS} ${OS_OPTIONS-} ${jmri_xms} ${jmri_xmx}"
 [ -n "${DEBUG}" ] && echo "OPTIONS: '${OPTIONS}'" | tee -a ${launcher_log}

--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -516,6 +516,9 @@ OPTIONS="${OPTIONS} -Djava.security.policy=${LIBDIR}/security.policy"
 OPTIONS="${OPTIONS} -Djava.rmi.server.codebase=file:target/classes/"
 OPTIONS="${OPTIONS} -Djava.library.path=.:$SYSLIBPATH:${LIBDIR}"
 
+# Java 9/10 run options
+OPTIONS="${OPTIONS} --add-modules java.desktop"
+
 # memory start and max limits
 OPTIONS="${OPTIONS} ${OS_OPTIONS-} ${jmri_xms} ${jmri_xmx}"
 [ -n "${DEBUG}" ] && echo "OPTIONS: '${OPTIONS}'" | tee -a ${launcher_log}


### PR DESCRIPTION
- Add Python imports needed to run scripts on Java 10: Until we can migrate to Jython 2.7.2, scripts need to import at package level (i.e. not just `import java`, but also `import java.beans`) so updated the scripts we run in tests. Imports for `java.awt`, `java.awt.event`,`java.beans`, `java.io` and `java.util` have been added. _Migration of all other imports is not complete_, as it might be easier/faster to pick up Jython 2.7.2 to get an upstream fix that to figure out how to find and test all those.
- Fix some type-safety issues required by new generic forms of Swing Tree classes in Java 10; still compiles and runs OK on Java 8 (`Enumeration<A extends B>` can't be assigned from an `Enumeration<B>`)


