### PR TITLE
Better handle legacy rosters with local dates

### DIFF
--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -8,15 +8,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.Math;
-import java.text.DateFormat;
-import java.text.ParseException;
+import java.text.*;
 import java.util.ArrayList;
-import java.util.Date;
+import java.util.*;
 import java.util.List;
 import java.util.ResourceBundle;
-import java.util.StringTokenizer;
-import java.util.TreeMap;
-import java.util.Vector;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.swing.ImageIcon;
@@ -535,12 +531,18 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
     public void setDateModified(@Nonnull String date) throws ParseException {
         try {
             // parse using ISO 8601 date format(s)
-            this.setDateModified(new ISO8601DateFormat().parse(date));
+            setDateModified(new ISO8601DateFormat().parse(date));
         } catch (ParseException ex) {
-            log.debug("ParseException in setDateModified");
-            // parse using defaults since thats how it was saved if saved
+            log.debug("ParseException in setDateModified ISO attempt: \"{}\"", date);
+            // next, try parse using defaults since thats how it was saved if saved
             // by earlier versions of JMRI
-            this.setDateModified(DateFormat.getDateTimeInstance().parse(date));
+            try {
+                setDateModified(DateFormat.getDateTimeInstance().parse(date));
+            } catch (ParseException ex2) {
+                // then try with a specific format to handle e.g. "Apr 1, 2016 9:13:36 AM"
+                DateFormat customFmt = new SimpleDateFormat ("MMM dd, yyyy hh:mm:ss a");
+                setDateModified(customFmt.parse(date));
+            }
         } catch (IllegalArgumentException ex2) {
             // warn that there's perhaps something wrong with the classpath
             log.error("IllegalArgumentException in RosterEntry.setDateModified - this may indicate a problem with the classpath, specifically multiple copies of the 'jackson` library. See release notes" );

--- a/java/test/jmri/jmrit/roster/RosterEntryPaneTest.java
+++ b/java/test/jmri/jmrit/roster/RosterEntryPaneTest.java
@@ -1,17 +1,14 @@
 package jmri.jmrit.roster;
 
 import jmri.InstanceManager;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.junit.Assert;
+import org.junit.*;
 
 /**
  * Tests for the jmrit.roster.RosterEntryPane class.
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2002
   */
-public class RosterEntryPaneTest extends TestCase {
+public class RosterEntryPaneTest {
 
     // statics for test objects
     org.jdom2.Element eOld = null;
@@ -19,7 +16,7 @@ public class RosterEntryPaneTest extends TestCase {
     RosterEntry rOld = null;
     RosterEntry rNew = null;
 
-    @Override
+    @Before
     public void setUp() {
         jmri.util.JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
@@ -65,11 +62,12 @@ public class RosterEntryPaneTest extends TestCase {
         };
     }
 
-    @Override
+    @After
     public void tearDown() {
         jmri.util.JUnitUtil.tearDown();
     }
 
+    @Test
     public void testCreate() {
         RosterEntryPane p = new RosterEntryPane(rOld);
 
@@ -92,6 +90,7 @@ public class RosterEntryPaneTest extends TestCase {
 
     }
 
+    @Test
     public void testGuiChanged1() {
         RosterEntryPane p = new RosterEntryPane(rOld);
 
@@ -105,6 +104,7 @@ public class RosterEntryPaneTest extends TestCase {
 
     }
 
+    @Test
     public void testGuiChanged2() {
         RosterEntryPane p = new RosterEntryPane(rOld);
 
@@ -118,6 +118,7 @@ public class RosterEntryPaneTest extends TestCase {
 
     }
 
+    @Test
     public void testGuiChanged3() {
 
         RosterEntryPane p = new RosterEntryPane(rNew);
@@ -132,6 +133,7 @@ public class RosterEntryPaneTest extends TestCase {
 
     }
 
+    @Test
     public void testGuiChanged4() {
         RosterEntryPane p = new RosterEntryPane(rNew);
         // copy to a new entry
@@ -145,6 +147,7 @@ public class RosterEntryPaneTest extends TestCase {
 
     }
 
+    @Test
     public void testGuiChanged5() {
         RosterEntryPane p = new RosterEntryPane(rNew);
         // copy to a new entry
@@ -159,6 +162,7 @@ public class RosterEntryPaneTest extends TestCase {
 
     }
 
+    @Test
     public void testNotDuplicate() {
         RosterEntryPane p = new RosterEntryPane(rNew);
         // reset Roster
@@ -167,6 +171,7 @@ public class RosterEntryPaneTest extends TestCase {
         Assert.assertTrue(!p.checkDuplicate());
     }
 
+    @Test
     public void testIsDuplicate() {
         RosterEntryPane p = new RosterEntryPane(rNew);
         // reset Roster
@@ -177,6 +182,7 @@ public class RosterEntryPaneTest extends TestCase {
         Assert.assertTrue(!p.checkDuplicate());
     }
 
+    @Test
     public void testRenamedDuplicate() {
         RosterEntryPane p = new RosterEntryPane(rOld);
         // reset Roster
@@ -190,22 +196,4 @@ public class RosterEntryPaneTest extends TestCase {
 
         Assert.assertTrue(p.checkDuplicate());
     }
-
-    // from here down is testing infrastructure
-    public RosterEntryPaneTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {RosterEntryPaneTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(RosterEntryPaneTest.class);
-        return suite;
-    }
-
 }

--- a/java/test/jmri/jmrit/roster/RosterEntryTest.java
+++ b/java/test/jmri/jmrit/roster/RosterEntryTest.java
@@ -6,19 +6,18 @@ import java.io.IOException;
 import jmri.InstanceManager;
 import jmri.util.FileUtil;
 import jmri.util.JUnitUtil;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
 import org.jdom2.JDOMException;
-import org.junit.Assert;
+import org.junit.*;
 
 /**
  * Tests for the jmrit.roster.RosterEntry class.
  *
- * @author	Bob Jacobsen Copyright (C) 2001, 2002
+ * @author	Bob Jacobsen Copyright (C) 2001, 2002, 2018
   */
-public class RosterEntryTest extends TestCase {
+public class RosterEntryTest {
 
+    @Test
     public void testCreate() {
         RosterEntry r = new RosterEntry("file here");
         Assert.assertEquals("file name ", "file here", r.getFileName());
@@ -30,6 +29,7 @@ public class RosterEntryTest extends TestCase {
         Assert.assertEquals("family ", "", r.getDecoderFamily());
     }
 
+    @Test
     public void testPartialLoad() {
         // create Element
         org.jdom2.Element e = new org.jdom2.Element("locomotive")
@@ -58,6 +58,7 @@ public class RosterEntryTest extends TestCase {
         Assert.assertEquals("family ", "", r.getDecoderFamily());
     }
 
+    @Test
     public void testEmptyLoad() {
         // create Element
         org.jdom2.Element e = new org.jdom2.Element("locomotive")
@@ -79,6 +80,7 @@ public class RosterEntryTest extends TestCase {
         Assert.assertEquals("family ", "", r.getDecoderFamily());
     }
 
+    @Test
     public void testFullLoad() {
         // create Element
         org.jdom2.Element e = new org.jdom2.Element("locomotive")
@@ -109,6 +111,7 @@ public class RosterEntryTest extends TestCase {
         Assert.assertEquals("family ", "91", r.getDecoderFamily());
     }
 
+    @Test
     public void testFromFile() throws JDOMException, IOException {
         
         //create a RosterEntry from a test xml file
@@ -123,6 +126,7 @@ public class RosterEntryTest extends TestCase {
         Assert.assertEquals("family ", "Brilliance Sound Decoders", r.getDecoderFamily());
     }
 
+    @Test
     public void testStoreFunctionLabel() {
         RosterEntry r = new RosterEntry("file here");
 
@@ -132,6 +136,7 @@ public class RosterEntryTest extends TestCase {
 
     }
 
+    @Test
     public void testModifyDate() {
         RosterEntry r = new RosterEntry("file here");
 
@@ -141,6 +146,7 @@ public class RosterEntryTest extends TestCase {
         jmri.util.JUnitAppender.assertWarnMessage("Unable to parse \"unparseable date\" as a date in roster entry \"test Id\"."); 
     }
 
+    @Test
     public void testStoreFunctionLockable() {
         RosterEntry r = new RosterEntry("file here");
 
@@ -158,6 +164,7 @@ public class RosterEntryTest extends TestCase {
 
     }
 
+    @Test
     public void testXmlLoadStore() {
         // create Element
         org.jdom2.Element e = new org.jdom2.Element("locomotive")
@@ -185,6 +192,7 @@ public class RosterEntryTest extends TestCase {
         Assert.assertEquals("model ", "33", o.getChild("decoder").getAttribute("model").getValue());
     }
 
+    @Test
     public void testXmlFunctionLabelsLoadStore() {
         // create Element
         org.jdom2.Element e = new org.jdom2.Element("locomotive")
@@ -233,6 +241,7 @@ public class RosterEntryTest extends TestCase {
         Assert.assertEquals("label 2", "label 2", o.getChild("functionlabels").getChild("functionlabel").getText());
     }
 
+    @Test
     public void testEnsureFilenameExistsNew() {
         RosterEntry r = new RosterEntry();
         Assert.assertEquals("initial filename ", null, r.getFileName());
@@ -249,6 +258,7 @@ public class RosterEntryTest extends TestCase {
         }
     }
 
+    @Test
     public void testEnsureFilenameExistsOld() throws IOException {
         FileUtil.createDirectory(LocoFile.getFileLocation());
         RosterEntry r = new RosterEntry();
@@ -279,17 +289,20 @@ public class RosterEntryTest extends TestCase {
         }
     }
 
+    @Test
     public void testNoAttribute() {
         RosterEntry r = new RosterEntry();
         Assert.assertNull(r.getAttribute("foo"));
     }
 
+    @Test
     public void testOneAttribute() {
         RosterEntry r = new RosterEntry();
         r.putAttribute("foo", "bar");
         Assert.assertEquals("bar", r.getAttribute("foo"));
     }
 
+    @Test
     public void testReplaceAttribute() {
         RosterEntry r = new RosterEntry();
         r.putAttribute("foo", "bar");
@@ -297,6 +310,7 @@ public class RosterEntryTest extends TestCase {
         Assert.assertEquals("a nicer bar", r.getAttribute("foo"));
     }
 
+    @Test
     public void testNullAttributeValue() {
         RosterEntry r = new RosterEntry();
         r.putAttribute("foo", "bar");
@@ -304,6 +318,7 @@ public class RosterEntryTest extends TestCase {
         Assert.assertNull(r.getAttribute("foo"));
     }
 
+    @Test
     public void testAttributeList() {
         RosterEntry r = new RosterEntry();
         r.putAttribute("key 2", "value 2");
@@ -318,6 +333,7 @@ public class RosterEntryTest extends TestCase {
         Assert.assertTrue(!i.hasNext());
     }
 
+    @Test
     public void testXmlAttributesLoadStore() {
         // create Element
         org.jdom2.Element e = new org.jdom2.Element("locomotive")
@@ -361,6 +377,7 @@ public class RosterEntryTest extends TestCase {
         Assert.assertEquals(null, r.getAttribute("key 4"));
     }
 
+    @Test
     public void testStoreAttribute() {
         RosterEntry r = new RosterEntry("dummy filename");
         r.putAttribute("foo", "bar");
@@ -384,33 +401,15 @@ public class RosterEntryTest extends TestCase {
                 .getChild("value").getText());
     }
 
-    // from here down is testing infrastructure
-    public RosterEntryTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {"-noloading", RosterEntryTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(RosterEntryTest.class);
-        return suite;
-    }
-
-    // The minimal setup for log4J
-    @Override
-    protected void setUp() {
+    @Before
+    public void setUp() {
         JUnitUtil.setUp();
         jmri.util.JUnitUtil.resetProfileManager();
         InstanceManager.setDefault(RosterConfigManager.class, new RosterConfigManager());
     }
 
-    @Override
-    protected void tearDown() {
+    @After
+    public void tearDown() {
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
Add code and test to better handle old date formats in rosters that haven't been opened for a while.