### PR TITLE
Test SoundUtil with proper parameters for sample file

### DIFF
--- a/java/test/jmri/jmrit/sound/SoundUtilTest.java
+++ b/java/test/jmri/jmrit/sound/SoundUtilTest.java
@@ -32,9 +32,11 @@ public class SoundUtilTest {
     public void testLargeBuffer() throws java.io.IOException, javax.sound.sampled.UnsupportedAudioFileException {
         String name = FileUtil.getAbsoluteFilename("program:resources/sounds/Button.wav");
         byte[] results = SoundUtil.bufferFromFile(name,
-                11025.0f, 8, 1, false, false);
-        Assert.assertEquals("length", 11235, results.length);
-        Assert.assertEquals("byte 0", 0x7F, 0xFF & results[0]);
-        Assert.assertEquals("byte 1", 0x7F, 0xFF & results[1]);
+                44100.0f, 16, 1, true, false);
+        Assert.assertEquals("length", 89872, results.length);
+        Assert.assertEquals("byte 0", 0x09, 0xFF & results[0]);
+        Assert.assertEquals("byte 1", 0x00, 0xFF & results[1]);
+        Assert.assertEquals("byte 2", 0x0B, 0xFF & results[2]);
+        Assert.assertEquals("byte 3", 0x00, 0xFF & results[3]);
     }
 }


### PR DESCRIPTION
The previous SoundUtilTest was trying to load a file with parameters inconsistent with the content (looks like the file was reformatted at some point).  This caused the test to fail with certain codecs were installed.