### PR TITLE
WIP: Fix potential bugs in ConditionalVariable

### DIFF
--- a/java/src/jmri/ConditionalVariable.java
+++ b/java/src/jmri/ConditionalVariable.java
@@ -72,10 +72,16 @@ public class ConditionalVariable {
 
     /**
      * Create a ConditionalVariable with a set of given properties.
+     * @param not true if the ConditionalVariable should be negated
+     * @param opern the boolean operator for this ConditionalVariable
+     * @param type the type this ConditionalVariable operates on (Turnout, Sensor, ...)
+     * @param name the device name
+     * @param trigger
      */
     public ConditionalVariable(boolean not, int opern, int type, String name, boolean trigger) {
         _not = not;
-        _opern = opern;
+        // setOpern does some checks of opern
+        setOpern(opern);
         _type = type;
         _name = name;
         _triggersActions = trigger;
@@ -188,7 +194,7 @@ public class ConditionalVariable {
         return _opern;
     }
 
-    public void setOpern(int opern) {
+    public final void setOpern(int opern) {
         switch (opern) {
             case Conditional.OPERATOR_AND_NOT:
                 _opern = Conditional.OPERATOR_AND;

--- a/java/src/jmri/ConditionalVariable.java
+++ b/java/src/jmri/ConditionalVariable.java
@@ -277,6 +277,8 @@ public class ConditionalVariable {
             //Once all refactored, we should probably register an error if the bean is returned null.
             if (bean != null) {
                 _namedBean = nbhm.getNamedBeanHandle(_name, bean);
+            } else {
+                log.warn("Did not have or create \"{}\" in setName. namedBean is unchanged", _name);
             }
 
         } catch (IllegalArgumentException ex) {

--- a/java/src/jmri/ConditionalVariable.java
+++ b/java/src/jmri/ConditionalVariable.java
@@ -76,7 +76,7 @@ public class ConditionalVariable {
      * @param opern the boolean operator for this ConditionalVariable
      * @param type the type this ConditionalVariable operates on (Turnout, Sensor, ...)
      * @param name the device name
-     * @param trigger
+     * @param trigger true if actions should be performed if triggered
      */
     public ConditionalVariable(boolean not, int opern, int type, String name, boolean trigger) {
         _not = not;

--- a/java/test/jmri/ConditionalVariableTest.java
+++ b/java/test/jmri/ConditionalVariableTest.java
@@ -100,6 +100,8 @@ public class ConditionalVariableTest {
         // Test a bad device name
         cv.setName("A bad device name");
         jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"A bad device name\" in setName. namedBean is unchanged");
+        // setName should not change the bean if called with wrong name. For example, it should not set the bean to null.
+        Assert.assertTrue("getName() still has correct bean", otherBean.equals(((NamedBeanHandle)cv.getNamedBean()).getBean()));
     }
     
     @Test

--- a/java/test/jmri/ConditionalVariableTest.java
+++ b/java/test/jmri/ConditionalVariableTest.java
@@ -97,6 +97,9 @@ public class ConditionalVariableTest {
         Assert.assertTrue("getNamedBean() returns correct bean", bean.equals(((NamedBeanHandle)cv.getNamedBean()).getBean()));
         cv.setName("OB4");
         Assert.assertTrue("setName() sets correct bean", otherBean.equals(((NamedBeanHandle)cv.getNamedBean()).getBean()));
+        // Test a bad device name
+        cv.setName("A bad device name");
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"A bad device name\" in setName. namedBean is unchanged");
     }
     
     @Test

--- a/java/test/jmri/implementation/DefaultConditionalTest.java
+++ b/java/test/jmri/implementation/DefaultConditionalTest.java
@@ -346,10 +346,14 @@ public class DefaultConditionalTest {
         ConditionalVariable[] conditionalVariables_TrueWithTrigger
                 = { new ConditionalVariableStatic(Conditional.TRUE, "MyName", true) };
         List<ConditionalVariable> conditionalVariablesList_TrueWithTrigger = Arrays.asList(conditionalVariables_TrueWithTrigger);
+        // ConditionalVariable.setName() gives a warning, but this test doesn't care.
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"MyName\" in setName. namedBean is unchanged");
         
         ConditionalVariable[] conditionalVariables_TrueWithNotTrigger
                 = { new ConditionalVariableStatic(Conditional.TRUE, "MyName", false) };
         List<ConditionalVariable> conditionalVariablesList_TrueWithNotTrigger = Arrays.asList(conditionalVariables_TrueWithNotTrigger);
+        // ConditionalVariable.setName() gives a warning, but this test doesn't care.
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"MyName\" in setName. namedBean is unchanged");
         
         TestConditionalAction testConditionalAction = new TestConditionalAction();
         List<ConditionalAction> conditionalActionList = new ArrayList<>();
@@ -397,6 +401,8 @@ public class DefaultConditionalTest {
         testConditionalAction._deviceName = null;
         ix1.calculate(true, new PropertyChangeEvent(namedBeanTestSystemName, "MyName", "OldValue", "NewValue"));
         Assert.assertTrue("action has not been executed", "InitialValue".equals(myMemory.getValue()));
+        // ConditionalVariable.setName() gives a warning, but this test doesn't care.
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"MyName\" in setName. namedBean is unchanged");
         jmri.util.JUnitAppender.assertErrorMessageStartsWith("IXIC 1 - invalid memory name in action - ");
         
         // Test trigger event with system name.
@@ -412,6 +418,8 @@ public class DefaultConditionalTest {
         testConditionalAction._actionString = "NewValue";
         ix1.calculate(true, new PropertyChangeEvent(namedBeanTestSystemName, "MyName", "OldValue1", "NewValue2"));
         Assert.assertTrue("action has been executed", "NewValue".equals(myMemory.getValue()));
+        // ConditionalVariable.setName() gives a warning, but this test doesn't care.
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"MyName\" in setName. namedBean is unchanged");
         
         // Test trigger event with user name.
         // This action wants to trigger the event.
@@ -426,6 +434,9 @@ public class DefaultConditionalTest {
         testConditionalAction._actionString = "NewValue";
         ix1.calculate(true, new PropertyChangeEvent(namedBeanTestUserName, "MyName", "OldValue1", "NewValue2"));
         Assert.assertTrue("action has been executed", "NewValue".equals(myMemory.getValue()));
+        // ConditionalVariable.setName() is called twice and gives a warning each time, but this test doesn't care.
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"MyName\" in setName. namedBean is unchanged");
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"MyName\" in setName. namedBean is unchanged");
         
         // Test trigger event with bad system and user name.
         // This action wants to trigger the event.
@@ -440,6 +451,8 @@ public class DefaultConditionalTest {
         testConditionalAction._actionString = "NewValue";
         ix1.calculate(true, new PropertyChangeEvent(namedBeanTestSystemName, "MyOtherName", "OldValue1", "NewValue2"));
         Assert.assertTrue("action has been executed", "NewValue".equals(myMemory.getValue()));
+        // ConditionalVariable.setName() gives a warning, but this test doesn't care.
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"MyName\" in setName. namedBean is unchanged");
         
         // Test not trigger event.
         // This action does not want to trigger the event.
@@ -454,6 +467,8 @@ public class DefaultConditionalTest {
         testConditionalAction._actionString = "NewValue";
         ix1.calculate(true, new PropertyChangeEvent(namedBeanTestSystemName, "MyName", "OldValue1", "NewValue2"));
         Assert.assertTrue("action has not been executed", "InitialValue".equals(myMemory.getValue()));
+        // ConditionalVariable.setName() gives a warning, but this test doesn't care.
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"MyName\" in setName. namedBean is unchanged");
         
         // Test trigger event on change.
         // _triggerActionsOnChange == true
@@ -471,6 +486,8 @@ public class DefaultConditionalTest {
         // Calculate changes state from NamedBean.UNKNOWN to Conditional.TRUE
         ix1.calculate(true, new PropertyChangeEvent(namedBeanTestSystemName, "MyName", "OldValue1", "NewValue2"));
         Assert.assertTrue("action has been executed", "NewValue".equals(myMemory.getValue()));
+        // ConditionalVariable.setName() gives a warning, but this test doesn't care.
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"MyName\" in setName. namedBean is unchanged");
         
         // Test trigger event on change.
         // _triggerActionsOnChange == true
@@ -490,6 +507,8 @@ public class DefaultConditionalTest {
         // Calculate doesn't change state since the state already is Conditional.TRUE
         ix1.calculate(true, new PropertyChangeEvent(namedBeanTestSystemName, "MyName", "OldValue1", "NewValue2"));
         Assert.assertTrue("action has not been executed", "InitialValue".equals(myMemory.getValue()));
+        // ConditionalVariable.setName() gives a warning, but this test doesn't care.
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"MyName\" in setName. namedBean is unchanged");
         
         // Test trigger event on change.
         // _triggerActionsOnChange == false
@@ -507,6 +526,8 @@ public class DefaultConditionalTest {
         // Calculate changes state from NamedBean.UNKNOWN to Conditional.TRUE
         ix1.calculate(true, new PropertyChangeEvent(namedBeanTestSystemName, "MyName", "OldValue1", "NewValue2"));
         Assert.assertTrue("action has been executed", "NewValue".equals(myMemory.getValue()));
+        // ConditionalVariable.setName() gives a warning, but this test doesn't care.
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"MyName\" in setName. namedBean is unchanged");
         
         // Test trigger event on change.
         // _triggerActionsOnChange == false
@@ -526,6 +547,8 @@ public class DefaultConditionalTest {
         // Calculate doesn't change state since the state already is Conditional.TRUE
         ix1.calculate(true, new PropertyChangeEvent(namedBeanTestSystemName, "MyName", "OldValue1", "NewValue2"));
         Assert.assertTrue("action has been executed", "NewValue".equals(myMemory.getValue()));
+        // ConditionalVariable.setName() gives a warning, but this test doesn't care.
+        jmri.util.JUnitAppender.assertWarnMessage("Did not have or create \"MyName\" in setName. namedBean is unchanged");
     }
     
     


### PR DESCRIPTION
@bobjacobsen or @pabender : Could you take a look at this?

This PR tries to fix the potential bugs found in PR #5828. See my comments to Bob Jacobsen.

ConditionalVariable.setOpern() has some validation tests of parameter opern which the constructor of ConditionalVariable doesn't have. So I use setOpern() in the constructor. And to not cause any problem in case ConditionalVariable is inherited, I made setOpern() final. This also fixes the problem if the parameter opern is OPERATOR_NOT.

How about the operator OPERATOR_OR_NOT? It is not handled by ConditionalVariable.setOpern() and if opern == OPERATOR_OR_NOT, ConditionalEditBase.makeAntecedent() seems to fail handling it. Should ConditionalVariable.setOpern() check for OPERATOR_OR_NOT and in that case, change it to OPERATOR_OR and set "not" to true?

One thing I'm thinking about is:
c = ConditionalVariable(true, OPERATOR_AND_NOT, ...)

What is the intention of that (if it's ever used)? For now, setOpern() always sets "_not" to true, and therefore the above statement is the equivalent of the statements below:
c = ConditionalVariable(false, OPERATOR_AND_NOT, ...)
c = ConditionalVariable(true, OPERATOR_AND, ...)

However, the caller might expected this instead:
c = ConditionalVariable(false, OPERATOR_AND, ...)

since when the parameter "not" is true and the operator is "AND_NOT", the "not" would take out each other.

My question is if setOpern(OPERATOR_AND_NOT) should invert "_not" instead of setting "_not" to true? But that could in turn break current layout setups.

Could the changes in this PR break existing layout configurations? That people have layouts using Logix there OPERATOR_AND_NOT is sent to the ConditionalVariable constructor and therefore breaks with this PR?