### PR TITLE
F2 is not always the horn.

### DIFF
--- a/java/src/jmri/jmrit/throttle/FunctionPanel.java
+++ b/java/src/jmri/jmrit/throttle/FunctionPanel.java
@@ -460,8 +460,6 @@ public class FunctionPanel extends JInternalFrame implements FunctionListener, j
         functionButton[26].setKeyCode(0xF00D);
         functionButton[27].setKeyCode(0xF00E);
         functionButton[28].setKeyCode(0xF00F);
-        // Make F2 (Horn) momentary
-        functionButton[2].setIsLockable(false);
 
         alt1Button.setVisible(true);
         alt2Button.setVisible(true);

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -60,6 +60,35 @@ abstract public class AbstractThrottle implements DccThrottle {
     public AbstractThrottle(SystemConnectionMemo memo) {
         active = true;
         adapterMemo = memo;
+	// set defaults for Momentary status.
+	f0Momentary = false;
+        f1Momentary = false;
+        f2Momentary = false;
+        f3Momentary = false;
+        f4Momentary = false;
+        f5Momentary = false;
+        f6Momentary = false;
+        f7Momentary = false;
+        f9Momentary = false;
+        f10Momentary = false;
+        f11Momentary = false;
+        f12Momentary = false;
+        f13Momentary = false;
+        f14Momentary = false;
+        f15Momentary = false;
+        f16Momentary = false;
+        f17Momentary = false;
+        f18Momentary = false;
+        f19Momentary = false;
+        f20Momentary = false;
+        f21Momentary = false;
+        f22Momentary = false;
+        f23Momentary = false;
+        f24Momentary = false;
+        f25Momentary = false;
+        f26Momentary = false;
+        f27Momentary = false;
+        f28Momentary = false;
     }
 
     protected SystemConnectionMemo adapterMemo;

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
@@ -53,10 +53,6 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
         this.speedIncrement = SPEED_STEP_128_INCREMENT;
         this.speedStepMode = DccThrottle.SpeedStepMode128;
 
-        f0Momentary = f1Momentary = f2Momentary = f3Momentary = f4Momentary
-                = f5Momentary = f6Momentary = f7Momentary = f8Momentary = f9Momentary
-                = f10Momentary = f11Momentary = f12Momentary = false;
-
         requestList = new LinkedBlockingQueue<RequestMessage>();
         if (log.isDebugEnabled()) {
             log.debug("DCCppThrottle constructor called for address " + address);

--- a/java/src/jmri/jmrix/lenz/XNetThrottle.java
+++ b/java/src/jmri/jmrix/lenz/XNetThrottle.java
@@ -66,10 +66,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
         //       this.isForward=true;
         setIsAvailable(false);
 
-        f0Momentary = f1Momentary = f2Momentary = f3Momentary = f4Momentary
-                = f5Momentary = f6Momentary = f7Momentary = f8Momentary = f9Momentary
-                = f10Momentary = f11Momentary = f12Momentary = false;
-
         requestList = new LinkedBlockingQueue<RequestMessage>();
         sendStatusInformationRequest();
         if (log.isDebugEnabled()) {

--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -95,6 +95,10 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         this.f27 = slot.isF27();
         this.f28 = slot.isF28();
 
+	// for LocoNet throttles, the default is f2 momentary (for the horn)
+	// all other functions are continuos (as set in AbstractThrottle).
+        this.f2Momentary = true;
+
         this.address = slot.locoAddr();
         this.isForward = slot.isForward();
         this.slotStatus = slot.slotStatus();

--- a/java/test/jmri/jmrix/loconet/Ib1ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib1ThrottleTest.java
@@ -402,6 +402,16 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testSendFunctionGroup5() {
     }
 
+    /**
+     * Test of getF2Momentary method, of class AbstractThrottle.
+     */
+    @Test
+    public void testGetF2Momentary() {
+        boolean expResult = true;
+        boolean result = instance.getF2Momentary();
+        Assert.assertEquals(expResult, result);
+    }
+
     @Before
     @Override
     public void setUp() {

--- a/java/test/jmri/jmrix/loconet/Ib2ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib2ThrottleTest.java
@@ -402,6 +402,15 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testSendFunctionGroup5() {
     }
 
+    /**
+     * Test of getF2Momentary method, of class AbstractThrottle.
+     */
+    @Test
+    public void testGetF2Momentary() {
+        boolean expResult = true;
+        boolean result = instance.getF2Momentary();
+        Assert.assertEquals(expResult, result);
+    }
 
     // The minimal setup for log4J
     @Before

--- a/java/test/jmri/jmrix/loconet/LocoNetThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetThrottleTest.java
@@ -478,6 +478,15 @@ public class LocoNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     public void testSendFunctionGroup5() {
     }
 
+    /**
+     * Test of getF2Momentary method, of class AbstractThrottle.
+     */
+    @Test
+    public void testGetF2Momentary() {
+        boolean expResult = true;
+        boolean result = instance.getF2Momentary();
+        Assert.assertEquals(expResult, result);
+    }
 
     private LocoNetInterfaceScaffold lnis;
     private SlotManager slotmanager;


### PR DESCRIPTION
This PR restores the ability for a command station to decide if F2 should be momentary or continuous (lockable).

While some system manufacturers have decided that certain functions (F2 on Digitrax in particular) will always be momentary, this is not universally true.

Other command stations (Lenz in particular) allow the user to configure ANY function to be momentary or continuous.  The setting of the horn to be momentary inside the JMRI throttle's Function panel prevented the XPressNet code from updating the function status to match the command station's idea of whether or not the function is momentary.

