### PR TITLE
Fastclock test update

### DIFF
--- a/java/test/jmri/jmrit/simpleclock/SimpleTimebaseTest.java
+++ b/java/test/jmri/jmrit/simpleclock/SimpleTimebaseTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.simpleclock;
 
+import java.beans.*;
 import java.time.Instant;
 import java.util.Date;
 import junit.framework.Test;
@@ -107,6 +108,29 @@ public class SimpleTimebaseTest extends TestCase {
         Assert.assertEquals(2.0, p.getRate(), 0.01);        
         Assert.assertFalse(p.getRun());  // still
         
+    }
+    
+    double seenNewMinutes;
+    double seenOldMinutes;
+    
+    public void testSetSendsUpdate() {
+        SimpleTimebase p = new SimpleTimebase();
+        p.setRun(false); // prevent clock ticking during test
+
+        seenNewMinutes = -1;
+        seenOldMinutes = -1;
+        p.addMinuteChangeListener(new PropertyChangeListener() {
+            public void propertyChange(PropertyChangeEvent e) {
+                seenOldMinutes = (Double) e.getOldValue();
+                seenNewMinutes = (Double) e.getNewValue();
+            }
+        });
+
+        Date date = p.getTime();
+        Date tenMinLater = new Date(10*60*1000L+date.getTime());
+        
+        p.setTime(tenMinLater);
+        Assert.assertEquals(seenOldMinutes + 10.0, seenNewMinutes, 0.01);
     }
     
     /* 	public void testShortDelay() { */

--- a/java/test/jmri/jmrit/simpleclock/SimpleTimebaseTest.java
+++ b/java/test/jmri/jmrit/simpleclock/SimpleTimebaseTest.java
@@ -40,6 +40,11 @@ public class SimpleTimebaseTest extends TestCase {
         p.dispose();
     }
 
+    public void testGetBeanType() {
+        SimpleTimebase p = new SimpleTimebase();
+        Assert.assertEquals("Time", p.getBeanType());
+    }
+    
     public void testSetStartTime() {
         SimpleTimebase p = new SimpleTimebase();
         p.setRun(false); // prevent clock ticking during test
@@ -66,11 +71,17 @@ public class SimpleTimebaseTest extends TestCase {
     public void testSetTimeDate() {
         SimpleTimebase p = new SimpleTimebase();
         p.setRun(false); // prevent clock ticking during test
+        Assert.assertFalse(p.getRun());
 
         Date now = new Date();
 
         p.setTime(now);
+        Assert.assertFalse(p.getRun());  // still
         Assert.assertEquals("Time Set",now.toString(),p.getTime().toString());
+        
+        p.setRun(true);       
+        Assert.assertTrue(p.getRun());
+
         p.dispose();
     }
 
@@ -86,6 +97,18 @@ public class SimpleTimebaseTest extends TestCase {
         p.dispose();
     }
 
+    public void testSetGetRate() {
+        SimpleTimebase p = new SimpleTimebase();
+        p.setRun(false); // prevent clock ticking during test
+
+        Assert.assertEquals(1.0, p.getRate(), 0.01);
+        
+        p.setRate(2.0);
+        Assert.assertEquals(2.0, p.getRate(), 0.01);        
+        Assert.assertFalse(p.getRun());  // still
+        
+    }
+    
     /* 	public void testShortDelay() { */
     /* 		SimpleTimebase p = new SimpleTimebase(); */
     /* 		Date now = new Date(); */


### PR DESCRIPTION
Improve tests for jmri.jmrit.simpleclock.SimpleTimebase including checking that setTime(..) sends minute events.