### PR TITLE
Use proper method to set main window location and position

### DIFF
--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -1129,12 +1129,13 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         Dimension screen = frame.getToolkit().getScreenSize();
         Dimension size = frame.getSize();
 
-        Point p = InstanceManager.getDefault(UserPreferencesManager.class).getWindowLocation(containedPane.getClass().getName());
-        if (p != null) {
-            frame.setLocation(p);
-        } else {
-            frame.setLocation((screen.width - size.width) / 2, (screen.height - size.height) / 2);
-        }
+        // first set a default position and size
+        frame.setLocation((screen.width - size.width) / 2, (screen.height - size.height) / 2);
+        
+        // then attempt set from stored preference
+        frame.setFrameLocation();
+        
+        // and finally show
         frame.setVisible(true);
     }
 

--- a/java/src/apps/AppsLaunchFrame.java
+++ b/java/src/apps/AppsLaunchFrame.java
@@ -71,11 +71,16 @@ public class AppsLaunchFrame extends jmri.util.JmriJFrame {
         // handle window close
         setDefaultCloseOperation(WindowConstants.HIDE_ON_CLOSE);
 
-        // pack and center this frame
+        // pack
         pack();
+        
+        // center as default
         Dimension screen = getToolkit().getScreenSize();
         Dimension size = getSize();
         setLocation((screen.width - size.width) / 2, (screen.height - size.height) / 2);
+        
+        // then try to load location and size from preferences
+        setFrameLocation();
     }
 
     /**

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -165,7 +165,10 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         }
     }
 
-    void setFrameLocation() {
+    /**
+      * Reset frame location and size to stored preference value
+      */
+    public void setFrameLocation() {
         InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(prefsMgr -> {
             if (prefsMgr.hasProperties(windowFrameRef)) {
                 Dimension screen = getToolkit().getScreenSize();
@@ -217,6 +220,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
                 initref = initref + ":" + this.getTitle();
             }
         }
+
         int refNo = 1;
         String ref = initref;
         JmriJFrameManager m = getJmriJFrameManager();
@@ -230,9 +234,9 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         }
         log.debug("Created windowFrameRef: {}", ref);
         windowFrameRef = ref;
-
     }
 
+    /** @inheritDoc */
     @Override
     public void pack() {
         // work around for Linux, sometimes the stored window size is too small
@@ -384,6 +388,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         // modelled after code in JavaDev mailing list item by Bill Tschumy <bill@otherwise.com> 08 Dec 2004
         AbstractAction act = new AbstractAction() {
 
+            /** @inheritDoc */
             @Override
             public void actionPerformed(ActionEvent e) {
                 // log.debug("keystroke requested close window ", JmriJFrame.this.getTitle());
@@ -466,6 +471,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         if (closesWindow) {
             setEscapeKeyAction(new AbstractAction() {
 
+                /** @inheritDoc */
                 @Override
                 public void actionPerformed(ActionEvent ae) {
                     JmriJFrame.this.processWindowEvent(new java.awt.event.WindowEvent(JmriJFrame.this,
@@ -491,6 +497,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
     }
 
     /**
+     * @inheritDoc
      * Provide a maximum frame size that is limited to what can fit on the
      * screen after toolbars, etc are deducted.
      * <p>
@@ -566,6 +573,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
     }
 
     /**
+     * @inheritDoc
      * The preferred size must fit on the physical screen, so calculate the
      * lesser of either the preferred size from the layout or the screen size.
      *
@@ -644,6 +652,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
     // handle resizing when first shown
     private boolean mShown = false;
 
+    /** @inheritDoc */
     @Override
     public void addNotify() {
         super.addNotify();
@@ -705,6 +714,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
     }
 
     /**
+     * @inheritDoc
      * A frame is considered "modified" if it has changes that have not been
      * stored.
      */
@@ -715,11 +725,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         markWindowModified(this.modifiedFlag);
     }
 
-    /**
-     * Get the balue of the modified flag.
-     * <p>
-     * Not a bound parameter
-     */
+    /** @inheritDoc */
     @Override
     public boolean getModifiedFlag() {
         return modifiedFlag;
@@ -760,39 +766,48 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
     }
 
     // Window methods
+    /** Does nothing in this class */
     @Override
     public void windowOpened(java.awt.event.WindowEvent e) {
     }
 
+    /** Does nothing in this class */
     @Override
     public void windowClosed(java.awt.event.WindowEvent e) {
     }
 
+    /** Does nothing in this class */
     @Override
     public void windowActivated(java.awt.event.WindowEvent e) {
     }
 
+    /** Does nothing in this class */
     @Override
     public void windowDeactivated(java.awt.event.WindowEvent e) {
     }
 
+    /** Does nothing in this class */
     @Override
     public void windowIconified(java.awt.event.WindowEvent e) {
     }
 
+    /** Does nothing in this class */
     @Override
     public void windowDeiconified(java.awt.event.WindowEvent e) {
     }
 
+    /** Does nothing in this class */
     @Override
     public void windowClosing(java.awt.event.WindowEvent e) {
         handleModified();
     }
 
+    /** Does nothing in this class */
     @Override
     public void componentHidden(java.awt.event.ComponentEvent e) {
     }
 
+    /** @inheritDoc */
     @Override
     public void componentMoved(java.awt.event.ComponentEvent e) {
         InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(p -> {
@@ -802,6 +817,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         });
     }
 
+    /** @inheritDoc */
     @Override
     public void componentResized(java.awt.event.ComponentEvent e) {
         InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent(p -> {
@@ -811,6 +827,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         });
     }
 
+    /** Does nothing in this class */
     @Override
     public void componentShown(java.awt.event.ComponentEvent e) {
     }
@@ -834,6 +851,8 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
     protected boolean reuseFrameSavedSized = true;
 
     /**
+     * @inheritDoc
+     * 
      * When window is finally destroyed, remove it from the list of windows.
      * <p>
      * Subclasses that over-ride this method must invoke this implementation
@@ -904,6 +923,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      */
     protected HashMap<String, Object> properties = new HashMap<>();
 
+    /** @inheritDoc */
     @Override
     public void setIndexedProperty(String key, int index, Object value) {
         if (Beans.hasIntrospectedProperty(this, key)) {
@@ -916,6 +936,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         }
     }
 
+    /** @inheritDoc */
     @Override
     public Object getIndexedProperty(String key, int index) {
         if (properties.containsKey(key) && properties.get(key).getClass().isArray()) {
@@ -924,7 +945,9 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         return Beans.getIntrospectedIndexedProperty(this, key, index);
     }
 
-    // subclasses should override this method with something more direct and faster
+    /** @inheritDoc 
+     * Subclasses should override this method with something more direct and faster
+     */
     @Override
     public void setProperty(String key, Object value) {
         if (Beans.hasIntrospectedProperty(this, key)) {
@@ -934,7 +957,9 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         }
     }
 
-    // subclasses should override this method with something more direct and faster
+    /** @inheritDoc 
+     * Subclasses should override this method with something more direct and faster
+     */
     @Override
     public Object getProperty(String key) {
         if (properties.containsKey(key)) {
@@ -943,11 +968,13 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         return Beans.getIntrospectedProperty(this, key);
     }
 
+    /** @inheritDoc */
     @Override
     public boolean hasProperty(String key) {
         return (properties.containsKey(key) || Beans.hasIntrospectedProperty(this, key));
     }
 
+    /** @inheritDoc */
     @Override
     public boolean hasIndexedProperty(String key) {
         return ((this.properties.containsKey(key) && this.properties.get(key).getClass().isArray())
@@ -956,6 +983,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
 
     protected transient WindowInterface windowInterface = null;
 
+    /** @inheritDoc */
     @Override
     public void show(JmriPanel child, JmriAbstractAction action) {
         if (null != windowInterface) {
@@ -963,6 +991,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         }
     }
 
+    /** @inheritDoc */
     @Override
     public void show(JmriPanel child, JmriAbstractAction action, Hint hint) {
         if (null != windowInterface) {
@@ -970,6 +999,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         }
     }
 
+    /** @inheritDoc */
     @Override
     public boolean multipleInstances() {
         if (null != windowInterface) {
@@ -986,6 +1016,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         return windowInterface;
     }
 
+    /** @inheritDoc */
     @Override
     public Set<String> getPropertyNames() {
         Set<String> names = new HashSet<>();
@@ -1002,6 +1033,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
         return allowInFrameServlet;
     }
 
+    /** @inheritDoc */
     @Override
     public Frame getFrame() {
         return this;


### PR DESCRIPTION
The apps.Apps and apps.AppsLaunchFrame windows were using an older method to set their initial location and position.  This PR converts that to the modern, normal method, which means they'll now remember their location and position from run to run.