### PR TITLE
FIx HTML tidy errors,  CI status page

### DIFF
--- a/help/en/html/doc/Technical/CI-status.shtml
+++ b/help/en/html/doc/Technical/CI-status.shtml
@@ -73,7 +73,7 @@
 
         <tr><td><a href="http://jmri.tagadab.com/jenkins/job/Development/job/JaCoCo/">JaCoCo</a><br>
         <a href="http://jmri.tagadab.com/jenkins/job/Development/job/JaCoCo/lastBuild/">
-            <img src="http://jmri.tagadab.com/jenkins/job/Development/job/JaCoCo/jacoco/graph?width=640&height=240">
+            <img src="http://jmri.tagadab.com/jenkins/job/Development/job/JaCoCo/jacoco/graph">
         </a>
         </td><td align="center">
             <b><a href="jacoco_sort_report.php">JaCoCo Sortable Coverage Report</a></b>

--- a/help/en/html/doc/Technical/jacoco_sort_report.php
+++ b/help/en/html/doc/Technical/jacoco_sort_report.php
@@ -28,7 +28,7 @@ libxml_use_internal_errors(true);
 $url = 'http://jmri.tagadab.com/jenkins/job/Development/job/JaCoCo/lastStableBuild/jacoco/';
 
 // Is the script run from the command line?
-if ($argc > 0) {
+if (isset($argc) && ($argc > 0)) {
 
 	if ($argc == 2) {	// Package list
 		parse_page($argv[1], '', false);

--- a/scripts/tidy-check.sh
+++ b/scripts/tidy-check.sh
@@ -8,8 +8,8 @@ else
     WHERE=$@
 fi
 
-# first, scan for whether there's an issue
-find ${WHERE} -name \*html -exec echo Filename: {} \;  ! -exec tidy -eq -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | awk -f scripts/tidy.awk | grep Warning 1>&2
+# first, scan for whether there's an issue (omitting known fragment files)
+find ${WHERE} ! -name Sidebar.shtml -name \*html -exec echo Filename: {} \;  ! -exec tidy -eq -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | awk -f scripts/tidy.awk | grep Warning 1>&2
 
 # swap return code from grep
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
- The `ant scanhelp` CI process was failing because it was separately scanning (and not understanding) a Sidebar.shtml fragment file; fixed the test
- It was also rejecting an ampersand in an IMG URL.  It shouldn't have (the URL was in quotation marks), but this seems to be a `tidy` failure, so bypassed it by using a not-quite-as-awesome URL.
- synch the two JaCoCo scripts

Travis was failing due to this, so will also restart PR #5871 and #5872 CI after this