### PR TITLE
Make DefaultSignalMastLogicManager inherit from AbstractManager

### DIFF
--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -516,11 +516,13 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
     }
 
     /** {@inheritDoc} */
+    @Override
     public void addDataListener(ManagerDataListener<E> e) {
         if (e != null) listeners.add(e);
     }
 
     /** {@inheritDoc} */
+    @Override
     public void removeDataListener(ManagerDataListener<E> e) {
         if (e != null) listeners.remove(e);
     }
@@ -530,6 +532,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
     private boolean muted = false;
     
     /** {@inheritDoc} */
+    @Override
     public void setDataListenerMute(boolean m) {
         if (muted && !m) {
             // send a total update, as we haven't kept track of specifics

--- a/java/src/jmri/managers/DefaultSignalMastLogicManager.java
+++ b/java/src/jmri/managers/DefaultSignalMastLogicManager.java
@@ -4,9 +4,6 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.*;
 
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import jmri.ConfigureManager;
 import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.Manager;
@@ -29,7 +26,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Kevin Dickerson Copyright (C) 2011
  */
-public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManager, java.beans.VetoableChangeListener {
+public class DefaultSignalMastLogicManager
+        extends AbstractManager<SignalMastLogic>
+        implements jmri.SignalMastLogicManager, java.beans.VetoableChangeListener {
 
     public DefaultSignalMastLogicManager() {
         registerSelf();
@@ -54,9 +53,9 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
     /** {@inheritDoc} */
     @Override
     public SignalMastLogic getSignalMastLogic(SignalMast source) {
-        for (int i = 0; i < signalMastLogic.size(); i++) {
-            if (signalMastLogic.get(i).getSourceMast() == source) {
-                return signalMastLogic.get(i);
+        for (SignalMastLogic signalMastLogic : _beans) {
+            if (signalMastLogic.getSourceMast() == source) {
+                return signalMastLogic;
             }
         }
         return null;
@@ -65,19 +64,16 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
     /** {@inheritDoc} */
     @Override
     public SignalMastLogic newSignalMastLogic(SignalMast source) {
-        for (int i = 0; i < signalMastLogic.size(); i++) {
-            if (signalMastLogic.get(i).getSourceMast() == source) {
-                return signalMastLogic.get(i);
+        for (SignalMastLogic signalMastLogic : _beans) {
+            if (signalMastLogic.getSourceMast() == source) {
+                return signalMastLogic;
             }
         }
         SignalMastLogic logic = new DefaultSignalMastLogic(source);
-        signalMastLogic.add(logic);
-        firePropertyChange("length", null, Integer.valueOf(signalMastLogic.size()));
+        _beans.add(logic);
+        firePropertyChange("length", null, _beans.size());
         return logic;
     }
-
-    List<SignalMastLogic> signalMastLogic = new ArrayList<SignalMastLogic>();
-    //Hashtable<SignalMast, List<SignalMastLogic>> destLocationList = new Hashtable<SignalMast, List<SignalMastLogic>>();
 
     /** {@inheritDoc} */
     @Override
@@ -85,7 +81,7 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
         if (oldMast == null || newMast == null) {
             return;
         }
-        for (SignalMastLogic source : signalMastLogic) {
+        for (SignalMastLogic source : _beans) {
             if (source.getSourceMast() == oldMast) {
                 source.replaceSourceMast(oldMast, newMast);
             } else {
@@ -126,7 +122,7 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
     @Override
     public List<SignalMastLogic> getLogicsByDestination(SignalMast destination) {
         List<SignalMastLogic> list = new ArrayList<>();
-        for (SignalMastLogic source : signalMastLogic) {
+        for (SignalMastLogic source : _beans) {
             if (source.isDestinationValid(destination)) {
                 list.add(source);
             }
@@ -137,7 +133,7 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
     /** {@inheritDoc} */
     @Override
     public List<SignalMastLogic> getSignalMastLogicList() {
-        return signalMastLogic;
+        return new ArrayList<>(_beans);
     }
 
     /** {@inheritDoc} */
@@ -173,8 +169,8 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
         //Need to provide a method to delete and dispose.
         sml.dispose();
 
-        signalMastLogic.remove(sml);
-        firePropertyChange("length", null, Integer.valueOf(signalMastLogic.size()));
+        _beans.remove(sml);
+        firePropertyChange("length", null, Integer.valueOf(_beans.size()));
     }
 
     /** {@inheritDoc} */
@@ -183,7 +179,7 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
         if (mast == null) {
             return;
         }
-        for (SignalMastLogic source : signalMastLogic) {
+        for (SignalMastLogic source : _beans) {
             if (source.isDestinationValid(mast)) {
                 source.removeDestination(mast);
             }
@@ -212,28 +208,7 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
         }
     }
 
-    /**
-     * By default, register this manager to store as configuration information.
-     * Override to change that.
-     */
-    protected void registerSelf() {
-        ConfigureManager cm = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
-        if (cm != null) {
-            cm.registerConfig(this, jmri.Manager.SIGNALMASTLOGICS);
-        }
-    }
-
     // Abstract methods to be extended by subclasses:
-
-    /** {@inheritDoc} */
-    @Override
-    public void dispose() {
-        ConfigureManager cm = InstanceManager.getNullableDefault(jmri.ConfigureManager.class);
-        if (cm != null) {
-            cm.deregister(this);
-        }
-        signalMastLogic.clear();
-    }
 
     /**
      * Initialise all the Signal Mast Logics. Primarily used after
@@ -241,27 +216,9 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
      */
     @Override
     public void initialise() {
-        for (int i = 0; i < signalMastLogic.size(); i++) {
-            signalMastLogic.get(i).initialise();
+        for (SignalMastLogic signalMastLogic : _beans) {
+            signalMastLogic.initialise();
         }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public SignalMastLogic getBeanBySystemName(String systemName) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public SignalMastLogic getBeanByUserName(String userName) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public SignalMastLogic getNamedBean(String name) {
-        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     /** {@inheritDoc} */
@@ -276,119 +233,7 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public String makeSystemName(String s) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @return always 'VALID'
-     */
-    @Override
-    public NameValidity validSystemNameFormat(String systemName) {
-        return NameValidity.VALID;
-    }
-
-    /**
-     * Enforces, and as a user convenience converts to, the standard form for a system name
-     * for the NamedBeans handled by this manager.
-     *
-     * @param inputName System name to be normalized
-     * @throws NamedBean.BadSystemNameException If the inputName can't be converted to normalized form
-     * @return A system name in standard normalized form 
-     */
-    @Override
-    @CheckReturnValue
-    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
-        return inputName;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    @CheckReturnValue
-    public int getObjectCount() { 
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    @Deprecated  // will be removed when Manager method is removed due to @Override
-    public String[] getSystemNameArray() {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    @Deprecated  // will be removed when Manager method is removed due to @Override
-    public List<String> getSystemNameList() {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public SortedSet<SignalMastLogic> getNamedBeanSet(){
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    @Deprecated  // will be removed when Manager method is removed due to @Override
-    public List<SignalMastLogic> getNamedBeanList() {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    java.beans.PropertyChangeSupport pcs = new java.beans.PropertyChangeSupport(this);
-
-    /** {@inheritDoc} */
-    @Override
-    public synchronized void addPropertyChangeListener(java.beans.PropertyChangeListener l) {
-        pcs.addPropertyChangeListener(l);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public synchronized void removePropertyChangeListener(java.beans.PropertyChangeListener l) {
-        pcs.removePropertyChangeListener(l);
-    }
-
-    protected void firePropertyChange(String p, Object old, Object n) {
-        pcs.firePropertyChange(p, old, n);
-    }
-
     java.beans.VetoableChangeSupport vcs = new java.beans.VetoableChangeSupport(this);
-
-    /** {@inheritDoc} */
-    @Override
-    public synchronized void addVetoableChangeListener(java.beans.VetoableChangeListener l) {
-        vcs.addVetoableChangeListener(l);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public synchronized void removeVetoableChangeListener(java.beans.VetoableChangeListener l) {
-        vcs.removeVetoableChangeListener(l);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void deleteBean(SignalMastLogic bean, String property) throws java.beans.PropertyVetoException {
-
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void register(SignalMastLogic n) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void deregister(SignalMastLogic n) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
 
     int signalLogicDelay = 500;
 
@@ -411,8 +256,8 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
                 //boolean newValue = new Boolean.parseBoolean(String.valueOf(e.getNewValue()));
                 boolean newValue = (Boolean) e.getNewValue();
                 if (newValue) {
-                    for (int i = 0; i < signalMastLogic.size(); i++) {
-                        signalMastLogic.get(i).setupLayoutEditorDetails();
+                    for (SignalMastLogic signalMastLogic : _beans) {
+                        signalMastLogic.setupLayoutEditorDetails();
                     }
                     if (runWhenStablised) {
                         try {
@@ -439,7 +284,7 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
     public void discoverSignallingDest(SignalMast source, LayoutEditor layout) throws JmriException {
         firePropertyChange("autoSignalMastGenerateStart", null, source.getDisplayName());
 
-        Hashtable<NamedBean, List<NamedBean>> validPaths = new Hashtable<NamedBean, List<NamedBean>>();
+        Hashtable<NamedBean, List<NamedBean>> validPaths = new Hashtable<>();
         jmri.jmrit.display.layoutEditor.LayoutBlockManager lbm = InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class);
         if (!lbm.isAdvancedRoutingEnabled()) {
             //log.debug("advanced routing not enabled");
@@ -599,58 +444,9 @@ public class DefaultSignalMastLogicManager implements jmri.SignalMastLogicManage
 
     /** {@inheritDoc} */
     @Override
-    public void vetoableChange(java.beans.PropertyChangeEvent evt) throws java.beans.PropertyVetoException {
-        if ("CanDelete".equals(evt.getPropertyName())) { //NOI18N
-            StringBuilder message = new StringBuilder();
-            boolean found = false;
-            message.append(Bundle.getMessage("VetoFoundInSignalMastLogic"));
-            message.append("<ul>");
-            for (int i = 0; i < signalMastLogic.size(); i++) {
-                try {
-                    signalMastLogic.get(i).vetoableChange(evt);
-                } catch (java.beans.PropertyVetoException e) {
-                    if (e.getPropertyChangeEvent().getPropertyName().equals("DoNotDelete")) { //NOI18N
-                        throw e;
-                    }
-                    found = true;
-
-                    message.append(e.getMessage());
-                    message.append("<br>");
-
-                }
-            }
-            message.append("</ul>");
-            if (found) {
-                throw new java.beans.PropertyVetoException(message.toString(), evt);
-            }
-        } else {
-            for (SignalMastLogic sml : signalMastLogic) {
-                try {
-                    sml.vetoableChange(evt);
-                } catch (java.beans.PropertyVetoException e) {
-                    throw e;
-                }
-            }
-        }
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public String getBeanTypeHandled() {
         return Bundle.getMessage("BeanNameSignalMastLogic");
     }
-
-    /** {@inheritDoc} */
-    public void addDataListener(ManagerDataListener e) {
-        if (e != null) listeners.add(e);
-    }
-
-    /** {@inheritDoc} */
-    public void removeDataListener(ManagerDataListener e) {
-        if (e != null) listeners.remove(e);
-    }
-
-    final List<ManagerDataListener> listeners = new ArrayList<>();
 
     private final static Logger log = LoggerFactory.getLogger(DefaultSignalMastLogicManager.class);
 }

--- a/java/src/jmri/util/HelpUtil.java
+++ b/java/src/jmri/util/HelpUtil.java
@@ -160,7 +160,7 @@ public class HelpUtil {
                 if (hsURL != null) {
                     log.debug("JavaHelp using {}", helpsetName);
                 } else {
-                    log.warn("JavaHelp: File {} not found, dropping to default", helpsetName);
+                    log.info("JavaHelp: File {} not found, dropping to default", helpsetName);
                     language = "en";
                     helpsetName = "help/" + language + "/JmriHelp_" + language + ".hs";
                     hsURL = FileUtil.findURL(helpsetName);

--- a/java/test/jmri/jmrit/display/SignalSystemTest.java
+++ b/java/test/jmri/jmrit/display/SignalSystemTest.java
@@ -151,7 +151,7 @@ public class SignalSystemTest {
         checkAspect("IF$vsm:UP-2008:SL-3A($0248)", "Stop");
         checkAspect("IF$vsm:UP-2008:SL-3L2($0249)", "Approach Restricting");
         checkAspect("IF$vsm:UP-2008:SL-3L2($0250)", "Approach");
-
+ 
         // clean up messages from file
         jmri.util.JUnitAppender.assertErrorMessage("No facing block found for source mast IF$vsm:BNSF-1996:SL-2A($0010)");
         jmri.util.JUnitAppender.clearBacklog();

--- a/java/test/jmri/jmrit/display/SignalSystemTest.java
+++ b/java/test/jmri/jmrit/display/SignalSystemTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.display;
 
+import java.util.Locale;
 import java.awt.GraphicsEnvironment;
 import jmri.ConfigureManager;
 import jmri.InstanceManager;
@@ -174,6 +175,14 @@ public class SignalSystemTest {
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        
+        // set the locale to US English
+        // This is required since the test else gives this error message in the
+        // when running the test on a computer with a locale that JMRI is not
+        // translated to:
+        // "JavaHelp: File help/sv/JmriHelp_sv.hs not found, dropping to default"
+        Locale.setDefault(Locale.ENGLISH);
+        
         jmri.util.JUnitUtil.resetProfileManager();
         JUnitUtil.initConfigureManager();
         InstanceManager.store(new NamedBeanHandleManager(), NamedBeanHandleManager.class);

--- a/java/test/jmri/jmrit/display/SignalSystemTest.java
+++ b/java/test/jmri/jmrit/display/SignalSystemTest.java
@@ -8,6 +8,7 @@ import jmri.NamedBeanHandleManager;
 import jmri.Sensor;
 import jmri.SignalMast;
 import jmri.Turnout;
+import jmri.util.HelpUtil;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -151,12 +152,12 @@ public class SignalSystemTest {
         checkAspect("IF$vsm:UP-2008:SL-3A($0248)", "Stop");
         checkAspect("IF$vsm:UP-2008:SL-3L2($0249)", "Approach Restricting");
         checkAspect("IF$vsm:UP-2008:SL-3L2($0250)", "Approach");
- 
+
+        final int numErrorMessages = 19;
         // clean up messages from file
-        jmri.util.JUnitAppender.assertErrorMessage("No facing block found for source mast IF$vsm:BNSF-1996:SL-2A($0010)");
-        jmri.util.JUnitAppender.clearBacklog();
-        jmri.util.JUnitAppender.verifyNoBacklog();
-        log.info("suppressing multiple \"No facing block found ...\" messages from AA1UPtest.xml file");
+        for (int i=0; i < numErrorMessages; i++) {
+            jmri.util.JUnitAppender.assertErrorMessageStartsWith("No facing block found for source mast IF$vsm:BNSF-1996:SL-");
+        }
     }
 
     void checkAspect(String mastName, String aspect) {

--- a/java/test/jmri/jmrit/display/SignalSystemTest.java
+++ b/java/test/jmri/jmrit/display/SignalSystemTest.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.display;
 
-import java.util.Locale;
 import java.awt.GraphicsEnvironment;
 import jmri.ConfigureManager;
 import jmri.InstanceManager;
@@ -8,15 +7,12 @@ import jmri.NamedBeanHandleManager;
 import jmri.Sensor;
 import jmri.SignalMast;
 import jmri.Turnout;
-import jmri.util.HelpUtil;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test signal system via a specific layout file
@@ -176,14 +172,6 @@ public class SignalSystemTest {
     @Before
     public void setUp() {
         JUnitUtil.setUp();
-        
-        // set the locale to US English
-        // This is required since the test else gives this error message in the
-        // when running the test on a computer with a locale that JMRI is not
-        // translated to:
-        // "JavaHelp: File help/sv/JmriHelp_sv.hs not found, dropping to default"
-        Locale.setDefault(Locale.ENGLISH);
-        
         jmri.util.JUnitUtil.resetProfileManager();
         JUnitUtil.initConfigureManager();
         InstanceManager.store(new NamedBeanHandleManager(), NamedBeanHandleManager.class);
@@ -197,5 +185,5 @@ public class SignalSystemTest {
     public void tearDown() {
         JUnitUtil.tearDown();
     }
-    private final static Logger log = LoggerFactory.getLogger(SignalSystemTest.class);
+    
 }

--- a/java/test/jmri/jmrit/display/SignalSystemTest.java
+++ b/java/test/jmri/jmrit/display/SignalSystemTest.java
@@ -153,7 +153,7 @@ public class SignalSystemTest {
         checkAspect("IF$vsm:UP-2008:SL-3L2($0250)", "Approach");
 
         // clean up messages from file
-        jmri.util.JUnitAppender.assertErrorMessage("No facing block found for source mast IF$vsm:BNSF-1996:SL-2A($0100)");
+        jmri.util.JUnitAppender.assertErrorMessage("No facing block found for source mast IF$vsm:BNSF-1996:SL-2A($0010)");
         jmri.util.JUnitAppender.clearBacklog();
         jmri.util.JUnitAppender.verifyNoBacklog();
         log.info("suppressing multiple \"No facing block found ...\" messages from AA1UPtest.xml file");


### PR DESCRIPTION
This PR tries to fix the problem with DefaultSignalMastLogicManager.getNamedBeanSet() that @bobjacobsen addresses in PR #5881 .

Have I got this correct?