### PR TITLE
Repair StopRun call so SCWarrant does not change functions on abort

### DIFF
--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -701,7 +701,6 @@ public class Warrant extends jmri.implementation.AbstractNamedBean implements Th
             _protectSignal = null;
             _idxProtectSignal = -1;
         }
-        clearStoppingBlock();
         if (_shareTOBlock != null) {
             _shareTOBlock.removePropertyChangeListener(this);
             _shareTOBlock = null;


### PR DESCRIPTION
Use turnOffFunctions flag in stopRun call so SCWarrants won't change function settings.
Remove clearStoppingBlock on abort