### PR TITLE
Fix html in Javadoc

### DIFF
--- a/help/en/html/doc/Technical/CI-status.shtml
+++ b/help/en/html/doc/Technical/CI-status.shtml
@@ -28,11 +28,14 @@
 		<a href='http://jmri.tagadab.com/jenkins/job/Development/job/SpotBugs/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/SpotBugs'></a>
 		</td></tr><tr><td align="right">
 		Version Checks:</td><td>
-		<a href='http://jmri.tagadab.com/jenkins/job/Development/job/VersionChecks/job/JDK%2010.0.1/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/VersionChecks/JDK%2010.0.1'></a>
 		<a href='http://jmri.tagadab.com/jenkins/job/Development/job/VersionChecks/job/JDK%209.0.4/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/VersionChecks/JDK%209.0.4'></a>
-		<a href='http://jmri.tagadab.com/jenkins/job/Development/job/VersionChecks/job/JRE%2010.0.1/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/VersionChecks/JRE%2010.0.1'></a>
+		<a href='http://jmri.tagadab.com/jenkins/job/Development/job/VersionChecks/job/JDK%2010.0.1/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/VersionChecks/JDK%2010.0.1'></a>
+		<a href='http://jmri.tagadab.com/jenkins/job/Development/job/VersionChecks/job/JDK%2011/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/VersionChecks/JDK%2011'></a>
+        &nbsp;&nbsp;&nbsp;
 		<a href='http://jmri.tagadab.com/jenkins/job/Development/VersionChecks/JRE%208u181'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/VersionChecks/JRE%208u181'></a>
 		<a href='http://jmri.tagadab.com/jenkins/job/Development/job/VersionChecks/job/JRE%209.0.4/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/VersionChecks/JRE%209.0.4'></a>
+		<a href='http://jmri.tagadab.com/jenkins/job/Development/job/VersionChecks/job/JRE%2010.0.1/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/VersionChecks/JRE%2010.0.1'></a>
+		<a href='http://jmri.tagadab.com/jenkins/job/Development/job/VersionChecks/job/JRE%2011/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/VersionChecks/JRE%2011'></a>
 		</td></tr><tr><td align="right">
 		Web Site:</td><td>
 		<a href='http://jmri.tagadab.com/jenkins/job/WebSite/job/generate-website/'><img src='http://jmri.tagadab.com/jenkins/buildStatus/icon?job=WebSite/generate-website'></a>

--- a/help/en/html/doc/Technical/Javadoc.shtml
+++ b/help/en/html/doc/Technical/Javadoc.shtml
@@ -81,11 +81,13 @@
     <a name="html" id="html"></a>
     <h3>HTML in Javadoc</h3>
     
-      <p>The Javadoc content is interpreted as HTML 4.01, so it
+      <p>The Java 8 Javadoc content is interpreted as HTML 4.01, so it
       should be valid HTML 4.01. If it's not, it probably won't
       display properly when somebody wants to understand your code,
       so it's in your interest to get the Javadoc comments
-      right.</p>
+      right.  In addition, Java 11 will eventually require us to 
+      write HTML 5 Javadoc content; keeping it orderly now will
+      help with that migration later.</p>
       
       <p>We run the <code>ant scanhelp</code> job
       during 
@@ -117,9 +119,24 @@
         <dt>"bad use of '&gt;'"</dt>
 
         <dd>Probably using '&gt;' as a character, e.g. A -&gt; B.
-        If so, replace with "&amp;gt;" or wrap the line with
-        @literal</dd>
+        If so, replace with "&amp;gt;" or wrap it with
+        @literal as in
+
+<pre style="font-family: monospace;">
+        {@literal 0.0 -&gt; 1.0.}
+</pre>
+        and
+<pre style="font-family: monospace;">
+        opcodes {@code &lt;opc, string description&gt;} via                
+</pre>
+        </dd>
       </dl>
+
+       <p>
+        Definitely use @code{...} in Javadoc comments
+        instead of trying to provide HTML-style 
+        elements like &lt;tt&gt; and &lt;code&gt;, as they 
+        won't format correctly.
 
       <p>You also have to (sometimes) end your paragraph tags to
       start another type of element, e.g. lists:</p>

--- a/java/src/jmri/NmraPacket.java
+++ b/java/src/jmri/NmraPacket.java
@@ -394,7 +394,7 @@ public class NmraPacket {
      * complex accessory decoders. Each signal head can display one aspect at a
      * time.
      * <p>
-     * {@code{preamble} 0 10AAAAAA 0 0AAA0AA1 0 000XXXXX 0 EEEEEEEE 1}
+     * {@code {preamble} 0 10AAAAAA 0 0AAA0AA1 0 000XXXXX 0 EEEEEEEE 1}
      * <p>
      * XXXXX is for a single head. A value of 00000 for XXXXX indicates the
      * absolute stop aspect. All other aspects represented by the values for

--- a/java/src/jmri/util/com/dictiography/collections/AbstractMap.java
+++ b/java/src/jmri/util/com/dictiography/collections/AbstractMap.java
@@ -17,24 +17,24 @@ package jmri.util.com.dictiography.collections;
 import java.util.*;
 
 /**
- * This class provides a skeletal implementation of the <tt>Map</tt>
+ * This class provides a skeletal implementation of the {@code Map}
  * interface, to minimize the effort required to implement this interface.
  * 
  * <p>To implement an unmodifiable map, the programmer needs only to extend this
- * class and provide an implementation for the <tt>entrySet</tt> method, which
+ * class and provide an implementation for the {@code entrySet} method, which
  * returns a set-view of the map's mappings.  Typically, the returned set
- * will, in turn, be implemented atop <tt>AbstractSet</tt>.  This set should
- * not support the <tt>add</tt> or <tt>remove</tt> methods, and its iterator
- * should not support the <tt>remove</tt> method.
+ * will, in turn, be implemented atop {@code AbstractSet}.  This set should
+ * not support the {@code add} or {@code remove} methods, and its iterator
+ * should not support the {@code remove} method.
  * 
  * <p>To implement a modifiable map, the programmer must additionally override
- * this class's <tt>put</tt> method (which otherwise throws an
- * <tt>UnsupportedOperationException</tt>), and the iterator returned by
- * <tt>entrySet().iterator()</tt> must additionally implement its
- * <tt>remove</tt> method.
+ * this class's {@code put} method (which otherwise throws an
+ * {@code UnsupportedOperationException}), and the iterator returned by
+ * {@code entrySet().iterator()} must additionally implement its
+ * {@code remove} method.
  * 
  * <p>The programmer should generally provide a void (no argument) and map
- * constructor, as per the recommendation in the <tt>Map</tt> interface
+ * constructor, as per the recommendation in the {@code Map} interface
  * specification.
  * 
  * <p>The documentation for each non-abstract method in this class describes its
@@ -68,7 +68,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
     /**
      * {@inheritDoc}
      * 
-     * <p>This implementation returns <tt>entrySet().size()</tt>.
+     * <p>This implementation returns {@code entrySet().size()}.
      */
     public int size() {
         return entrySet().size();
@@ -77,7 +77,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
     /**
      * {@inheritDoc}
      * 
-     * <p>This implementation returns <tt>size() == 0</tt>.
+     * <p>This implementation returns {@code size() == 0}.
      */
     public boolean isEmpty() {
         return size() == 0;
@@ -86,10 +86,10 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
     /**
      * {@inheritDoc}
      * 
-     * <p>This implementation iterates over <tt>entrySet()</tt> searching
+     * <p>This implementation iterates over {@code entrySet()} searching
      * for an entry with the specified value.  If such an entry is found,
-     * <tt>true</tt> is returned.  If the iteration terminates without
-     * finding such an entry, <tt>false</tt> is returned.  Note that this
+     * {@code true} is returned.  If the iteration terminates without
+     * finding such an entry, {@code false} is returned.  Note that this
      * implementation requires linear time in the size of the map.
      *
      * @throws ClassCastException   {@inheritDoc}
@@ -116,10 +116,10 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
     /**
      * {@inheritDoc}
      * 
-     * <p>This implementation iterates over <tt>entrySet()</tt> searching
+     * <p>This implementation iterates over {@code entrySet()} searching
      * for an entry with the specified key.  If such an entry is found,
-     * <tt>true</tt> is returned.  If the iteration terminates without
-     * finding such an entry, <tt>false</tt> is returned.  Note that this
+     * {@code true} is returned.  If the iteration terminates without
+     * finding such an entry, {@code false} is returned.  Note that this
      * implementation requires linear time in the size of the map; many
      * implementations will override this method.
      *
@@ -147,10 +147,10 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
     /**
      * {@inheritDoc}
      * 
-     * <p>This implementation iterates over <tt>entrySet()</tt> searching
+     * <p>This implementation iterates over {@code entrySet()} searching
      * for an entry with the specified key.  If such an entry is found,
      * the entry's value is returned.  If the iteration terminates without
-     * finding such an entry, <tt>null</tt> is returned.  Note that this
+     * finding such an entry, {@code null} is returned.  Note that this
      * implementation requires linear time in the size of the map; many
      * implementations will override this method.
      *
@@ -182,7 +182,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * {@inheritDoc}
      * 
      * <p>This implementation always throws an
-     * <tt>UnsupportedOperationException</tt>.
+     * {@code UnsupportedOperationException}.
      *
      * @throws UnsupportedOperationException {@inheritDoc}
      * @throws ClassCastException            {@inheritDoc}
@@ -196,18 +196,18 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
     /**
      * {@inheritDoc}
      * 
-     * <p>This implementation iterates over <tt>entrySet()</tt> searching for an
+     * <p>This implementation iterates over {@code entrySet()} searching for an
      * entry with the specified key.  If such an entry is found, its value is
-     * obtained with its <tt>getValue</tt> operation, the entry is removed
+     * obtained with its {@code getValue} operation, the entry is removed
      * from the collection (and the backing map) with the iterator's
-     * <tt>remove</tt> operation, and the saved value is returned.  If the
-     * iteration terminates without finding such an entry, <tt>null</tt> is
+     * {@code remove} operation, and the saved value is returned.  If the
+     * iteration terminates without finding such an entry, {@code null} is
      * returned.  Note that this implementation requires linear time in the
      * size of the map; many implementations will override this method.
      * 
      * <p>Note that this implementation throws an
-     * <tt>UnsupportedOperationException</tt> if the <tt>entrySet</tt>
-     * iterator does not support the <tt>remove</tt> method and this map
+     * {@code UnsupportedOperationException} if the {@code entrySet}
+     * iterator does not support the {@code remove} method and this map
      * contains a mapping for the specified key.
      *
      * @throws UnsupportedOperationException {@inheritDoc}
@@ -246,12 +246,12 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * {@inheritDoc}
      * 
      * <p>This implementation iterates over the specified map's
-     * <tt>entrySet()</tt> collection, and calls this map's <tt>put</tt>
+     * {@code entrySet()} collection, and calls this map's {@code put}
      * operation once for each entry returned by the iteration.
      * 
      * <p>Note that this implementation throws an
-     * <tt>UnsupportedOperationException</tt> if this map does not support
-     * the <tt>put</tt> operation and the specified map is nonempty.
+     * {@code UnsupportedOperationException} if this map does not support
+     * the {@code put} operation and the specified map is nonempty.
      *
      * @throws UnsupportedOperationException {@inheritDoc}
      * @throws ClassCastException            {@inheritDoc}
@@ -266,11 +266,11 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
     /**
      * {@inheritDoc}
      * 
-     * <p>This implementation calls <tt>entrySet().clear()</tt>.
+     * <p>This implementation calls {@code entrySet().clear()}.
      * 
      * <p>Note that this implementation throws an
-     * <tt>UnsupportedOperationException</tt> if the <tt>entrySet</tt>
-     * does not support the <tt>clear</tt> operation.
+     * {@code UnsupportedOperationException} if the {@code entrySet}
+     * does not support the {@code clear} operation.
      *
      * @throws UnsupportedOperationException {@inheritDoc}
      */
@@ -294,10 +294,10 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * 
      * <p>This implementation returns a set that subclasses {@link java.util.AbstractSet}.
      * The subclass's iterator method returns a "wrapper object" over this
-     * map's <tt>entrySet()</tt> iterator.  The <tt>size</tt> method
-     * delegates to this map's <tt>size</tt> method and the
-     * <tt>contains</tt> method delegates to this map's
-     * <tt>containsKey</tt> method.
+     * map's {@code entrySet()} iterator.  The {@code size} method
+     * delegates to this map's {@code size} method and the
+     * {@code contains} method delegates to this map's
+     * {@code containsKey} method.
      * 
      * <p>The set is created the first time this method is called,
      * and returned in response to all subsequent calls.  No synchronization
@@ -342,10 +342,10 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * 
      * <p>This implementation returns a collection that subclasses {@link
      * AbstractCollection}.  The subclass's iterator method returns a
-     * "wrapper object" over this map's <tt>entrySet()</tt> iterator.
-     * The <tt>size</tt> method delegates to this map's <tt>size</tt>
-     * method and the <tt>contains</tt> method delegates to this map's
-     * <tt>containsValue</tt> method.
+     * "wrapper object" over this map's {@code entrySet()} iterator.
+     * The {@code size} method delegates to this map's {@code size}
+     * method and the {@code contains} method delegates to this map's
+     * {@code containsValue} method.
      * 
      * <p>The collection is created the first time this method is called, and
      * returned in response to all subsequent calls.  No synchronization is
@@ -392,24 +392,24 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
 
     /**
      * Compares the specified object with this map for equality.  Returns
-     * <tt>true</tt> if the given object is also a map and the two maps
-     * represent the same mappings.  More formally, two maps <tt>m1</tt> and
-     * <tt>m2</tt> represent the same mappings if
-     * <tt>m1.entrySet().equals(m2.entrySet())</tt>.  This ensures that the
-     * <tt>equals</tt> method works properly across different implementations
-     * of the <tt>Map</tt> interface.
+     * {@code true} if the given object is also a map and the two maps
+     * represent the same mappings.  More formally, two maps {@code m1} and
+     * {@code m2} represent the same mappings if
+     * {@code m1.entrySet().equals(m2.entrySet())}.  This ensures that the
+     * {@code equals} method works properly across different implementations
+     * of the {@code Map} interface.
      * 
      * <p>This implementation first checks if the specified object is this map;
-     * if so it returns <tt>true</tt>.  Then, it checks if the specified
+     * if so it returns {@code true}.  Then, it checks if the specified
      * object is a map whose size is identical to the size of this map; if
-     * not, it returns <tt>false</tt>.  If so, it iterates over this map's
-     * <tt>entrySet</tt> collection, and checks that the specified map
+     * not, it returns {@code false}.  If so, it iterates over this map's
+     * {@code entrySet} collection, and checks that the specified map
      * contains each mapping that this map contains.  If the specified map
-     * fails to contain such a mapping, <tt>false</tt> is returned.  If the
-     * iteration completes, <tt>true</tt> is returned.
+     * fails to contain such a mapping, {@code false} is returned.  If the
+     * iteration completes, {@code true} is returned.
      *
      * @param o object to be compared for equality with this map
-     * @return <tt>true</tt> if the specified object is equal to this map
+     * @return {@code true} if the specified object is equal to this map
      */
     @SuppressWarnings("unchecked") // package needs update to Java 1.8 generics
     public boolean equals(Object o) {
@@ -448,12 +448,12 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
     /**
      * Returns the hash code value for this map.  The hash code of a map is
      * defined to be the sum of the hash codes of each entry in the map's
-     * <tt>entrySet()</tt> view.  This ensures that <tt>m1.equals(m2)</tt>
-     * implies that <tt>m1.hashCode()==m2.hashCode()</tt> for any two maps
-     * <tt>m1</tt> and <tt>m2</tt>, as required by the general contract of
+     * {@code entrySet()} view.  This ensures that {@code m1.equals(m2)}
+     * implies that {@code m1.hashCode()==m2.hashCode()} for any two maps
+     * {@code m1} and {@code m2}, as required by the general contract of
      * {@link Object#hashCode}.
      * 
-     * <p>This implementation iterates over <tt>entrySet()</tt>, calling
+     * <p>This implementation iterates over {@code entrySet()}, calling
      * {@link Map.Entry#hashCode hashCode()} on each element (entry) in the
      * set, and adding up the results.
      *
@@ -473,10 +473,10 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
     /**
      * Returns a string representation of this map.  The string representation
      * consists of a list of key-value mappings in the order returned by the
-     * map's <tt>entrySet</tt> view's iterator, enclosed in braces
-     * (<tt>"{}"</tt>).  Adjacent mappings are separated by the characters
-     * <tt>", "</tt> (comma and space).  Each key-value mapping is rendered as
-     * the key followed by an equals sign (<tt>"="</tt>) followed by the
+     * map's {@code entrySet} view's iterator, enclosed in braces
+     * ({@code "{}"}).  Adjacent mappings are separated by the characters
+     * {@code ", "} (comma and space).  Each key-value mapping is rendered as
+     * the key followed by an equals sign ({@code "="}) followed by the
      * associated value.  Keys and values are converted to strings as by
      * {@link String#valueOf(Object)}.
      *
@@ -503,7 +503,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
     }
 
     /**
-     * Returns a shallow copy of this <tt>AbstractMap</tt> instance: the keys
+     * Returns a shallow copy of this {@code AbstractMap} instance: the keys
      * and values themselves are not cloned.
      *
      * @return a shallow copy of this map
@@ -534,11 +534,11 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
 
     /**
      * An Entry maintaining a key and a value.  The value may be
-     * changed using the <tt>setValue</tt> method.  This class
+     * changed using the {@code setValue} method.  This class
      * facilitates the process of building custom map
      * implementations. For example, it may be convenient to return
-     * arrays of <tt>SimpleEntry</tt> instances in method
-     * <tt>Map.entrySet().toArray</tt>.
+     * arrays of {@code SimpleEntry} instances in method
+     * {@code Map.entrySet().toArray}.
      *
      * @since 1.6
      */
@@ -652,7 +652,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
         /**
          * Returns a String representation of this map entry.  This
          * implementation returns the string representation of this
-         * entry's key followed by the equals character ("<tt>=</tt>")
+         * entry's key followed by the equals character ("{@code =}")
          * followed by the string representation of this entry's value.
          *
          * @return a String representation of this map entry
@@ -665,7 +665,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
 
     /**
      * An Entry maintaining an immutable key and value.  This class
-     * does not support method <tt>setValue</tt>.  This class may be
+     * does not support method {@code setValue}.  This class may be
      * convenient in methods that return thread-safe snapshots of
      * key-value mappings.
      *
@@ -722,7 +722,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
         /**
          * Replaces the value corresponding to this entry with the specified
          * value (optional operation).  This implementation simply throws
-         * <tt>UnsupportedOperationException</tt>, as this class implements
+         * {@code UnsupportedOperationException}, as this class implements
          * an <i>immutable</i> map entry.
          *
          * @param value new value to be stored in this entry
@@ -782,7 +782,7 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
         /**
          * Returns a String representation of this map entry.  This
          * implementation returns the string representation of this
-         * entry's key followed by the equals character ("<tt>=</tt>")
+         * entry's key followed by the equals character ("{@code =}")
          * followed by the string representation of this entry's value.
          *
          * @return a String representation of this map entry

--- a/java/src/jmri/util/com/dictiography/collections/AbstractSet.java
+++ b/java/src/jmri/util/com/dictiography/collections/AbstractSet.java
@@ -20,20 +20,20 @@ import java.util.Set;
 
 
 /**
- * This class provides a skeletal implementation of the <tt>Set</tt>
+ * This class provides a skeletal implementation of the {@code Set}
  * interface to minimize the effort required to implement this
  * interface. <p>
  * 
  * The process of implementing a set by extending this class is identical
  * to that of implementing a Collection by extending AbstractCollection,
  * except that all of the methods and constructors in subclasses of this
- * class must obey the additional constraints imposed by the <tt>Set</tt>
+ * class must obey the additional constraints imposed by the {@code Set}
  * interface (for instance, the add method must not permit addition of
  * multiple instances of an object to a set).<p>
  * 
  * Note that this class does not override any of the implementations from
- * the <tt>AbstractCollection</tt> class.  It merely adds implementations
- * for <tt>equals</tt> and <tt>hashCode</tt>.<p>
+ * the {@code AbstractCollection} class.  It merely adds implementations
+ * for {@code equals} and {@code hashCode}.<p>
  * 
  * This class is a member of the
  * <a href="{@docRoot}/../technotes/guides/collections/index.html">
@@ -61,20 +61,20 @@ public abstract class AbstractSet<E> extends AbstractCollection<E> implements Se
 
     /**
      * Compares the specified object with this set for equality.  Returns
-     * <tt>true</tt> if the given object is also a set, the two sets have
+     * {@code true} if the given object is also a set, the two sets have
      * the same size, and every member of the given set is contained in
-     * this set.  This ensures that the <tt>equals</tt> method works
-     * properly across different implementations of the <tt>Set</tt>
+     * this set.  This ensures that the {@code equals} method works
+     * properly across different implementations of the {@code Set}
      * interface.<p>
      * 
      * This implementation first checks if the specified object is this
-     * set; if so it returns <tt>true</tt>.  Then, it checks if the
+     * set; if so it returns {@code true}.  Then, it checks if the
      * specified object is a set whose size is identical to the size of
      * this set; if not, it returns false.  If so, it returns
-     * <tt>containsAll((Collection) o)</tt>.
+     * {@code containsAll((Collection) o)}.
      *
      * @param o object to be compared for equality with this set
-     * @return <tt>true</tt> if the specified object is equal to this set
+     * @return {@code true} if the specified object is equal to this set
      */
     public boolean equals(Object o) {
         if (o == this)
@@ -97,14 +97,14 @@ public abstract class AbstractSet<E> extends AbstractCollection<E> implements Se
     /**
      * Returns the hash code value for this set.  The hash code of a set is
      * defined to be the sum of the hash codes of the elements in the set,
-     * where the hash code of a <tt>null</tt> element is defined to be zero.
-     * This ensures that <tt>s1.equals(s2)</tt> implies that
-     * <tt>s1.hashCode()==s2.hashCode()</tt> for any two sets <tt>s1</tt>
-     * and <tt>s2</tt>, as required by the general contract of
+     * where the hash code of a {@code null} element is defined to be zero.
+     * This ensures that {@code s1.equals(s2)} implies that
+     * {@code s1.hashCode()==s2.hashCode()} for any two sets {@code s1}
+     * and {@code s2}, as required by the general contract of
      * {@link Object#hashCode}.
      * 
      * <p>This implementation iterates over the set, calling the
-     * <tt>hashCode</tt> method on each element in the set, and adding up
+     * {@code hashCode} method on each element in the set, and adding up
      * the results.
      *
      * @return the hash code value for this set
@@ -130,24 +130,24 @@ public abstract class AbstractSet<E> extends AbstractCollection<E> implements Se
      * the two sets.
      * 
      * <p>This implementation determines which is the smaller of this set
-     * and the specified collection, by invoking the <tt>size</tt>
+     * and the specified collection, by invoking the {@code size}
      * method on each.  If this set has fewer elements, then the
      * implementation iterates over this set, checking each element
      * returned by the iterator in turn to see if it is contained in
      * the specified collection.  If it is so contained, it is removed
-     * from this set with the iterator's <tt>remove</tt> method.  If
+     * from this set with the iterator's {@code remove} method.  If
      * the specified collection has fewer elements, then the
      * implementation iterates over the specified collection, removing
      * from this set each element returned by the iterator, using this
-     * set's <tt>remove</tt> method.
+     * set's {@code remove} method.
      * 
      * <p>Note that this implementation will throw an
-     * <tt>UnsupportedOperationException</tt> if the iterator returned by the
-     * <tt>iterator</tt> method does not implement the <tt>remove</tt> method.
+     * {@code UnsupportedOperationException} if the iterator returned by the
+     * {@code iterator} method does not implement the {@code remove} method.
      *
      * @param c collection containing elements to be removed from this set
-     * @return <tt>true</tt> if this set changed as a result of the call
-     * @throws UnsupportedOperationException if the <tt>removeAll</tt> operation
+     * @return {@code true} if this set changed as a result of the call
+     * @throws UnsupportedOperationException if the {@code removeAll} operation
      *                                       is not supported by this set
      * @throws ClassCastException            if the class of an element of this set
      *                                       is incompatible with the specified collection (optional)

--- a/java/src/jmri/util/com/dictiography/collections/IndexedTreeMap.java
+++ b/java/src/jmri/util/com/dictiography/collections/IndexedTreeMap.java
@@ -23,21 +23,21 @@ import java.util.*;
  * creation time, depending on which constructor is used.
  * 
  * <p>This implementation provides guaranteed log(n) time cost for the
- * <tt>containsKey</tt>, <tt>get</tt>, <tt>put</tt> and <tt>remove</tt>
+ * {@code containsKey}, {@code get}, {@code put} and {@code remove}
  * operations.  Algorithms are adaptations of those in Cormen, Leiserson, and
  * Rivest's <I>Introduction to Algorithms</I>.
  * 
  * <p>Note that the ordering maintained by a sorted map (whether or not an
  * explicit comparator is provided) must be <i>consistent with equals</i> if
- * this sorted map is to correctly implement the <tt>Map</tt> interface.  (See
- * <tt>Comparable</tt> or <tt>Comparator</tt> for a precise definition of
- * <i>consistent with equals</i>.)  This is so because the <tt>Map</tt>
+ * this sorted map is to correctly implement the {@code Map} interface.  (See
+ * {@code Comparable} or {@code Comparator} for a precise definition of
+ * <i>consistent with equals</i>.)  This is so because the {@code Map}
  * interface is defined in terms of the equals operation, but a map performs
- * all key comparisons using its <tt>compareTo</tt> (or <tt>compare</tt>)
+ * all key comparisons using its {@code compareTo} (or {@code compare})
  * method, so two keys that are deemed equal by this method are, from the
  * standpoint of the sorted map, equal.  The behavior of a sorted map
  * <i>is</i> well-defined even if its ordering is inconsistent with equals; it
- * just fails to obey the general contract of the <tt>Map</tt> interface.
+ * just fails to obey the general contract of the {@code Map} interface.
  * 
  * <p><strong>Note that this implementation is not synchronized.</strong>
  * If multiple threads access a map concurrently, and at least one of the
@@ -53,11 +53,11 @@ import java.util.*;
  * unsynchronized access to the map: <pre>
  *   SortedMap m = Collections.synchronizedSortedMap(new IndexedTreeMap(...));</pre>
  * 
- * <p>The iterators returned by the <tt>iterator</tt> method of the collections
+ * <p>The iterators returned by the {@code iterator} method of the collections
  * returned by all of this class's "collection view methods" are
  * <i>fail-fast</i>: if the map is structurally modified at any time after the
  * iterator is created, in any way except through the iterator's own
- * <tt>remove</tt> method, the iterator will throw a {@link
+ * {@code remove} method, the iterator will throw a {@link
  * java.util.ConcurrentModificationException}.  Thus, in the face of concurrent
  * modification, the iterator fails quickly and cleanly, rather than risking
  * arbitrary, non-deterministic behavior at an undetermined time in the future.
@@ -65,16 +65,16 @@ import java.util.*;
  * <p>Note that the fail-fast behavior of an iterator cannot be guaranteed
  * as it is, generally speaking, impossible to make any hard guarantees in the
  * presence of unsynchronized concurrent modification.  Fail-fast iterators
- * throw <tt>ConcurrentModificationException</tt> on a best-effort basis.
+ * throw {@code ConcurrentModificationException} on a best-effort basis.
  * Therefore, it would be wrong to write a program that depended on this
  * exception for its correctness:   <i>the fail-fast behavior of iterators
  * should be used only to detect bugs.</i>
  * 
- * <p>All <tt>Map.Entry</tt> pairs returned by methods in this class
+ * <p>All {@code Map.Entry} pairs returned by methods in this class
  * and its views represent snapshots of mappings at the time they were
- * produced. They do <em>not</em> support the <tt>Entry.setValue</tt>
+ * produced. They do <em>not</em> support the {@code Entry.setValue}
  * method. (Note however that it is possible to change mappings in the
- * associated map using <tt>put</tt>.)
+ * associated map using {@code put}.)
  * 
  * <p>This class is a member of the
  * <a href="{@docRoot}/../technotes/guides/collections/index.html">
@@ -120,13 +120,13 @@ public class IndexedTreeMap<K, V>
      * Constructs a new, empty tree map, using the natural ordering of its
      * keys.  All keys inserted into the map must implement the {@link
      * Comparable} interface.  Furthermore, all such keys must be
-     * <i>mutually comparable</i>: <tt>k1.compareTo(k2)</tt> must not throw
-     * a <tt>ClassCastException</tt> for any keys <tt>k1</tt> and
-     * <tt>k2</tt> in the map.  If the user attempts to put a key into the
+     * <i>mutually comparable</i>: {@code k1.compareTo(k2)} must not throw
+     * a {@code ClassCastException} for any keys {@code k1} and
+     * {@code k2} in the map.  If the user attempts to put a key into the
      * map that violates this constraint (for example, the user attempts to
      * put a string key into a map whose keys are integers), the
-     * <tt>put(Object key, Object value)</tt> call will throw a
-     * <tt>ClassCastException</tt>.
+     * {@code put(Object key, Object value)} call will throw a
+     * {@code ClassCastException}.
      */
     public IndexedTreeMap() {
         comparator = null;
@@ -135,15 +135,15 @@ public class IndexedTreeMap<K, V>
     /**
      * Constructs a new, empty tree map, ordered according to the given
      * comparator.  All keys inserted into the map must be <i>mutually
-     * comparable</i> by the given comparator: <tt>comparator.compare(k1,
-     * k2)</tt> must not throw a <tt>ClassCastException</tt> for any keys
-     * <tt>k1</tt> and <tt>k2</tt> in the map.  If the user attempts to put
-     * a key into the map that violates this constraint, the <tt>put(Object
-     * key, Object value)</tt> call will throw a
-     * <tt>ClassCastException</tt>.
+     * comparable</i> by the given comparator: {@code comparator.compare(k1,
+     * k2)} must not throw a {@code ClassCastException} for any keys
+     * {@code k1} and {@code k2} in the map.  If the user attempts to put
+     * a key into the map that violates this constraint, the {@code put(Object
+     * key, Object value)} call will throw a
+     * {@code ClassCastException}.
      *
      * @param comparator the comparator that will be used to order this map.
-     *                   If <tt>null</tt>, the {@linkplain Comparable natural
+     *                   If {@code null}, the {@linkplain Comparable natural
      *                   ordering} of the keys will be used.
      */
     public IndexedTreeMap(Comparator<? super K> comparator) {
@@ -155,9 +155,9 @@ public class IndexedTreeMap<K, V>
      * map, ordered according to the <i>natural ordering</i> of its keys.
      * All keys inserted into the new map must implement the {@link
      * Comparable} interface.  Furthermore, all such keys must be
-     * <i>mutually comparable</i>: <tt>k1.compareTo(k2)</tt> must not throw
-     * a <tt>ClassCastException</tt> for any keys <tt>k1</tt> and
-     * <tt>k2</tt> in the map.  This method runs in n*log(n) time.
+     * <i>mutually comparable</i>: {@code k1.compareTo(k2)} must not throw
+     * a {@code ClassCastException} for any keys {@code k1} and
+     * {@code k2} in the map.  This method runs in n*log(n) time.
      *
      * @param m the map whose mappings are to be placed in this map
      * @throws ClassCastException   if the keys in m are not {@link Comparable},
@@ -202,11 +202,11 @@ public class IndexedTreeMap<K, V>
     }
 
     /**
-     * Returns <tt>true</tt> if this map contains a mapping for the specified
+     * Returns {@code true} if this map contains a mapping for the specified
      * key.
      *
      * @param key key whose presence in this map is to be tested
-     * @return <tt>true</tt> if this map contains a mapping for the
+     * @return {@code true} if this map contains a mapping for the
      *         specified key
      * @throws ClassCastException   if the specified key cannot be compared
      *                              with the keys currently in the map
@@ -219,16 +219,16 @@ public class IndexedTreeMap<K, V>
     }
 
     /**
-     * Returns <tt>true</tt> if this map maps one or more keys to the
-     * specified value.  More formally, returns <tt>true</tt> if and only if
-     * this map contains at least one mapping to a value <tt>v</tt> such
-     * that <tt>(value==null ? v==null : value.equals(v))</tt>.  This
+     * Returns {@code true} if this map maps one or more keys to the
+     * specified value.  More formally, returns {@code true} if and only if
+     * this map contains at least one mapping to a value {@code v} such
+     * that {@code (value==null ? v==null : value.equals(v))}.  This
      * operation will probably require time linear in the map size for
      * most implementations.
      *
      * @param value value whose presence in this map is to be tested
-     * @return <tt>true</tt> if a mapping to <tt>value</tt> exists;
-     *         <tt>false</tt> otherwise
+     * @return {@code true} if a mapping to {@code value} exists;
+     *         {@code false} otherwise
      * @since 1.2
      */
     public boolean containsValue(Object value) {
@@ -318,10 +318,10 @@ public class IndexedTreeMap<K, V>
     }
 
     /**
-     * Returns this map's entry for the given key, or <tt>null</tt> if the map
+     * Returns this map's entry for the given key, or {@code null} if the map
      * does not contain an entry for the key.
      *
-     * @return this map's entry for the given key, or <tt>null</tt> if the map
+     * @return this map's entry for the given key, or {@code null} if the map
      *         does not contain an entry for the key
      * @throws ClassCastException   if the specified key cannot be compared
      *                              with the keys currently in the map
@@ -379,7 +379,7 @@ public class IndexedTreeMap<K, V>
      * Gets the entry corresponding to the specified key; if no such entry
      * exists, returns the entry for the least key greater than the specified
      * key; if no such entry exists (i.e., the greatest key in the Tree is less
-     * than the specified key), returns <tt>null</tt>.
+     * than the specified key), returns {@code null}.
      */
     final Entry<K, V> getCeilingEntry(K key) {
         Entry<K, V> p = root;
@@ -411,7 +411,7 @@ public class IndexedTreeMap<K, V>
     /**
      * Gets the entry corresponding to the specified key; if no such entry
      * exists, returns the entry for the greatest key less than the specified
-     * key; if no such entry exists, returns <tt>null</tt>.
+     * key; if no such entry exists, returns {@code null}.
      */
     final Entry<K, V> getFloorEntry(K key) {
         Entry<K, V> p = root;
@@ -469,7 +469,7 @@ public class IndexedTreeMap<K, V>
      * Gets the entry for the least key greater than the specified
      * key; if no such entry exists, returns the entry for the least
      * key greater than the specified key; if no such entry exists
-     * returns <tt>null</tt>.
+     * returns {@code null}.
      */
     final Entry<K, V> getHigherEntry(K key) {
         Entry<K, V> p = root;
@@ -500,7 +500,7 @@ public class IndexedTreeMap<K, V>
     /**
      * Returns the entry for the greatest key less than the specified key; if
      * no such entry exists (i.e., the least key in the Tree is greater than
-     * the specified key), returns <tt>null</tt>.
+     * the specified key), returns {@code null}.
      */
     final Entry<K, V> getLowerEntry(K key) {
         Entry<K, V> p = root;
@@ -535,10 +535,10 @@ public class IndexedTreeMap<K, V>
      *
      * @param key   key with which the specified value is to be associated
      * @param value value to be associated with the specified key
-     * @return the previous value associated with <tt>key</tt>, or
-     *         <tt>null</tt> if there was no mapping for <tt>key</tt>.
-     *         (A <tt>null</tt> return can also indicate that the map
-     *         previously associated <tt>null</tt> with <tt>key</tt>.)
+     * @return the previous value associated with {@code key}, or
+     *         {@code null} if there was no mapping for {@code key}.
+     *         (A {@code null} return can also indicate that the map
+     *         previously associated {@code null} with {@code key}.)
      * @throws ClassCastException   if the specified key cannot be compared
      *                              with the keys currently in the map
      * @throws NullPointerException if the specified key is null
@@ -608,10 +608,10 @@ public class IndexedTreeMap<K, V>
      * Removes the mapping for this key from this IndexedTreeMap if present.
      *
      * @param key key for which mapping should be removed
-     * @return the previous value associated with <tt>key</tt>, or
-     *         <tt>null</tt> if there was no mapping for <tt>key</tt>.
-     *         (A <tt>null</tt> return can also indicate that the map
-     *         previously associated <tt>null</tt> with <tt>key</tt>.)
+     * @return the previous value associated with {@code key}, or
+     *         {@code null} if there was no mapping for {@code key}.
+     *         (A {@code null} return can also indicate that the map
+     *         previously associated {@code null} with {@code key}.)
      * @throws ClassCastException   if the specified key cannot be compared
      *                              with the keys currently in the map
      * @throws NullPointerException if the specified key is null
@@ -639,7 +639,7 @@ public class IndexedTreeMap<K, V>
     }
 
     /**
-     * Returns a shallow copy of this <tt>IndexedTreeMap</tt> instance. (The keys and
+     * Returns a shallow copy of this {@code IndexedTreeMap} instance. (The keys and
      * values themselves are not cloned.)
      *
      * @return a shallow copy of this map
@@ -899,12 +899,12 @@ public class IndexedTreeMap<K, V>
      * The set is backed by the map, so changes to the map are
      * reflected in the set, and vice-versa.  If the map is modified
      * while an iteration over the set is in progress (except through
-     * the iterator's own <tt>remove</tt> operation), the results of
+     * the iterator's own {@code remove} operation), the results of
      * the iteration are undefined.  The set supports element removal,
      * which removes the corresponding mapping from the map, via the
-     * <tt>Iterator.remove</tt>, <tt>Set.remove</tt>,
-     * <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt>
-     * operations.  It does not support the <tt>add</tt> or <tt>addAll</tt>
+     * {@code Iterator.remove}, {@code Set.remove},
+     * {@code removeAll}, {@code retainAll}, and {@code clear}
+     * operations.  It does not support the {@code add} or {@code addAll}
      * operations.
      */
     public Set<K> keySet() {
@@ -934,13 +934,13 @@ public class IndexedTreeMap<K, V>
      * The collection is backed by the map, so changes to the map are
      * reflected in the collection, and vice-versa.  If the map is
      * modified while an iteration over the collection is in progress
-     * (except through the iterator's own <tt>remove</tt> operation),
+     * (except through the iterator's own {@code remove} operation),
      * the results of the iteration are undefined.  The collection
      * supports element removal, which removes the corresponding
-     * mapping from the map, via the <tt>Iterator.remove</tt>,
-     * <tt>Collection.remove</tt>, <tt>removeAll</tt>,
-     * <tt>retainAll</tt> and <tt>clear</tt> operations.  It does not
-     * support the <tt>add</tt> or <tt>addAll</tt> operations.
+     * mapping from the map, via the {@code Iterator.remove},
+     * {@code Collection.remove}, {@code removeAll},
+     * {@code retainAll} and {@code clear} operations.  It does not
+     * support the {@code add} or {@code addAll} operations.
      */
     public Collection<V> values() {
         Collection<V> vs = values;
@@ -953,14 +953,14 @@ public class IndexedTreeMap<K, V>
      * The set is backed by the map, so changes to the map are
      * reflected in the set, and vice-versa.  If the map is modified
      * while an iteration over the set is in progress (except through
-     * the iterator's own <tt>remove</tt> operation, or through the
-     * <tt>setValue</tt> operation on a map entry returned by the
+     * the iterator's own {@code remove} operation, or through the
+     * {@code setValue} operation on a map entry returned by the
      * iterator) the results of the iteration are undefined.  The set
      * supports element removal, which removes the corresponding
-     * mapping from the map, via the <tt>Iterator.remove</tt>,
-     * <tt>Set.remove</tt>, <tt>removeAll</tt>, <tt>retainAll</tt> and
-     * <tt>clear</tt> operations.  It does not support the
-     * <tt>add</tt> or <tt>addAll</tt> operations.
+     * mapping from the map, via the {@code Iterator.remove},
+     * {@code Set.remove}, {@code removeAll}, {@code retainAll} and
+     * {@code clear} operations.  It does not support the
+     * {@code add} or {@code addAll} operations.
      */
     public Set<Map.Entry<K, V>> entrySet() {
         EntrySet es = entrySet;
@@ -981,7 +981,7 @@ public class IndexedTreeMap<K, V>
 
     /**
      * @throws ClassCastException       {@inheritDoc}
-     * @throws NullPointerException     if <tt>fromKey</tt> or <tt>toKey</tt> is
+     * @throws NullPointerException     if {@code fromKey} or {@code toKey} is
      *                                  null and this map uses natural ordering, or its comparator
      *                                  does not permit null keys
      * @throws IllegalArgumentException {@inheritDoc}
@@ -997,7 +997,7 @@ public class IndexedTreeMap<K, V>
 
     /**
      * @throws ClassCastException       {@inheritDoc}
-     * @throws NullPointerException     if <tt>toKey</tt> is null
+     * @throws NullPointerException     if {@code toKey} is null
      *                                  and this map uses natural ordering, or its comparator
      *                                  does not permit null keys
      * @throws IllegalArgumentException {@inheritDoc}
@@ -1012,7 +1012,7 @@ public class IndexedTreeMap<K, V>
 
     /**
      * @throws ClassCastException       {@inheritDoc}
-     * @throws NullPointerException     if <tt>fromKey</tt> is null
+     * @throws NullPointerException     if {@code fromKey} is null
      *                                  and this map uses natural ordering, or its comparator
      *                                  does not permit null keys
      * @throws IllegalArgumentException {@inheritDoc}
@@ -1027,7 +1027,7 @@ public class IndexedTreeMap<K, V>
 
     /**
      * @throws ClassCastException       {@inheritDoc}
-     * @throws NullPointerException     if <tt>fromKey</tt> or <tt>toKey</tt> is
+     * @throws NullPointerException     if {@code fromKey} or {@code toKey} is
      *                                  null and this map uses natural ordering, or its comparator
      *                                  does not permit null keys
      * @throws IllegalArgumentException {@inheritDoc}
@@ -1038,7 +1038,7 @@ public class IndexedTreeMap<K, V>
 
     /**
      * @throws ClassCastException       {@inheritDoc}
-     * @throws NullPointerException     if <tt>toKey</tt> is null
+     * @throws NullPointerException     if {@code toKey} is null
      *                                  and this map uses natural ordering, or its comparator
      *                                  does not permit null keys
      * @throws IllegalArgumentException {@inheritDoc}
@@ -1049,7 +1049,7 @@ public class IndexedTreeMap<K, V>
 
     /**
      * @throws ClassCastException       {@inheritDoc}
-     * @throws NullPointerException     if <tt>fromKey</tt> is null
+     * @throws NullPointerException     if {@code fromKey} is null
      *                                  and this map uses natural ordering, or its comparator
      *                                  does not permit null keys
      * @throws IllegalArgumentException {@inheritDoc}
@@ -1366,7 +1366,7 @@ public class IndexedTreeMap<K, V>
 
     /**
      * Test two values for equality.  Differs from o1.equals(o2) only in
-     * that it copes with <tt>null</tt> o1 properly.
+     * that it copes with {@code null} o1 properly.
      */
     final static boolean valEquals(Object o1, Object o2) {
         return (o1 == null ? o2 == null : o1.equals(o2));
@@ -2176,7 +2176,7 @@ public class IndexedTreeMap<K, V>
 
         /**
          * Make a new cell with given key, value, and parent, and with
-         * <tt>null</tt> child links, and BLACK color.
+         * {@code null} child links, and BLACK color.
          */
         Entry(K key, V value, Entry<K, V> parent) {
             this.key = key;
@@ -2589,7 +2589,7 @@ public class IndexedTreeMap<K, V>
     private static final long serialVersionUID = 919286545866124006L;
 
     /**
-     * Save the state of the <tt>IndexedTreeMap</tt> instance to a stream (i.e.,
+     * Save the state of the {@code IndexedTreeMap} instance to a stream (i.e.,
      * serialize it).
      *
      * @serialData The <i>size</i> of the IndexedTreeMap (the number of key-value
@@ -2617,7 +2617,7 @@ public class IndexedTreeMap<K, V>
     }
 
     /**
-     * Reconstitute the <tt>IndexedTreeMap</tt> instance from a stream (i.e.,
+     * Reconstitute the {@code IndexedTreeMap} instance from a stream (i.e.,
      * deserialize it).
      */
     private void readObject(final java.io.ObjectInputStream s)

--- a/java/src/jmri/util/com/dictiography/collections/IndexedTreeSet.java
+++ b/java/src/jmri/util/com/dictiography/collections/IndexedTreeSet.java
@@ -214,7 +214,7 @@ public class IndexedTreeSet<E> extends java.util.AbstractSet<E>
      * Returns {@code true} if this set contains the specified element.
      * More formally, returns {@code true} if and only if this set
      * contains an element {@code e} such that
-     * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>.
+     * {@code (o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))}.
      *
      * @param o object to be checked for containment in this set
      * @return {@code true} if this set contains the specified element
@@ -232,7 +232,7 @@ public class IndexedTreeSet<E> extends java.util.AbstractSet<E>
      * Adds the specified element to this set if it is not already present.
      * More formally, adds the specified element {@code e} to this set if
      * the set contains no element {@code e2} such that
-     * <tt>(e==null&nbsp;?&nbsp;e2==null&nbsp;:&nbsp;e.equals(e2))</tt>.
+     * {@code (e==null&nbsp;?&nbsp;e2==null&nbsp;:&nbsp;e.equals(e2))}.
      * If this set already contains the element, the call leaves the set
      * unchanged and returns {@code false}.
      *
@@ -252,7 +252,7 @@ public class IndexedTreeSet<E> extends java.util.AbstractSet<E>
     /**
      * Removes the specified element from this set if it is present.
      * More formally, removes an element {@code e} such that
-     * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>,
+     * {@code (o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))},
      * if this set contains such an element.  Returns {@code true} if
      * this set contained the element (or equivalently, if this set
      * changed as a result of the call).  (This set will not contain the

--- a/java/src/jmri/util/iharder/dnd/DnDList.java
+++ b/java/src/jmri/util/iharder/dnd/DnDList.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
  * An extension of {@link javax.swing.JList} that supports drag and drop to
  * rearrange its contents and to move objects in and out of the list. The
  * objects in the list will be passed either as a String by calling the object's
- * <tt>toString()</tt> object, or if your drag and drop target accepts the
+ * {@code toString()} object, or if your drag and drop target accepts the
  * {@link TransferableObject#DATA_FLAVOR} data flavor then the actual object
  * will be passed.
  * <p>

--- a/java/src/jmri/util/iharder/dnd/TransferableObject.java
+++ b/java/src/jmri/util/iharder/dnd/TransferableObject.java
@@ -30,8 +30,8 @@ import java.awt.datatransfer.DataFlavor;
  *
  * The {@link java.awt.datatransfer.DataFlavor} associated with
  * {@link TransferableObject} has the representation class
- * <tt>net.iharder.dnd.TransferableObject.class</tt> and MIME type
- * <tt>application/x-net.iharder.dnd.TransferableObject</tt>. This data flavor
+ * {@code net.iharder.dnd.TransferableObject.class} and MIME type
+ * {@code application/x-net.iharder.dnd.TransferableObject}. This data flavor
  * is accessible via the static {@link #DATA_FLAVOR} property.
  *
  *
@@ -57,7 +57,7 @@ public class TransferableObject implements java.awt.datatransfer.Transferable {
 
     /**
      * The MIME type for {@link #DATA_FLAVOR} is
-     * <tt>application/x-net.iharder.dnd.TransferableObject</tt>.
+     * {@code application/x-net.iharder.dnd.TransferableObject}.
      *
      * @since 1.1
      */
@@ -66,9 +66,9 @@ public class TransferableObject implements java.awt.datatransfer.Transferable {
     /**
      * The default {@link java.awt.datatransfer.DataFlavor} for
      * {@link TransferableObject} has the representation class
-     * <tt>net.iharder.dnd.TransferableObject.class</tt>
+     * {@code net.iharder.dnd.TransferableObject.class}
      * and the MIME type
-     * <tt>application/x-net.iharder.dnd.TransferableObject</tt>.
+     * {@code application/x-net.iharder.dnd.TransferableObject}.
      *
      * @since 1.1
      */
@@ -85,7 +85,7 @@ public class TransferableObject implements java.awt.datatransfer.Transferable {
      * Along with the {@link #DATA_FLAVOR} associated with this class, this
      * creates a custom data flavor with a representation class determined from
      * <code>data.getClass()</code> and the MIME type
-     * <tt>application/x-net.iharder.dnd.TransferableObject</tt>.
+     * {@code application/x-net.iharder.dnd.TransferableObject}.
      *
      * @param data The data to transfer
      * @since 1.1
@@ -114,7 +114,7 @@ public class TransferableObject implements java.awt.datatransfer.Transferable {
      * associated with this class, this creates a custom data flavor with a
      * representation class <var>dataClass</var>
      * and the MIME type
-     * <tt>application/x-net.iharder.dnd.TransferableObject</tt>.
+     * {@code application/x-net.iharder.dnd.TransferableObject}.
      *
      * @see Fetcher
      * @param dataClass The {@link java.lang.Class} to use in the custom data
@@ -129,7 +129,7 @@ public class TransferableObject implements java.awt.datatransfer.Transferable {
 
     /**
      * Returns the custom {@link java.awt.datatransfer.DataFlavor} associated
-     * with the encapsulated object or <tt>null</tt> if the {@link Fetcher}
+     * with the encapsulated object or {@code null} if the {@link Fetcher}
      * constructor was used without passing a {@link java.lang.Class}.
      *
      * @return The custom data flavor for the encapsulated object
@@ -192,7 +192,7 @@ public class TransferableObject implements java.awt.datatransfer.Transferable {
     }   // end getTransferData
 
     /**
-     * Returns <tt>true</tt> if <var>flavor</var> is one of the supported
+     * Returns {@code true} if <var>flavor</var> is one of the supported
      * flavors. Flavors are supported using the <code>equals(...)</code> method.
      *
      * @param flavor The data flavor to check


### PR DESCRIPTION
- Replace `<tt>..</tt>` in Javadoc (mostly external code) with `{@code .. }` to generate correct HTML
- Add that to documentation
- Add the Java 11 test builds to the CI summary page

Each version of Java has had more powerful, yet more fussy, Javadoc generating tools.  Now that JDK 11 is out, cleaning up the Javadoc is (AFAIK now) the last step toward basic JDK 11 compatibility of our current code base.