### PR TITLE
Use Bundle.getMessage("ButtonYes") instead of "Yes"

### DIFF
--- a/java/test/jmri/jmrit/operations/setup/OperationsSetupFrameTest.java
+++ b/java/test/jmri/jmrit/operations/setup/OperationsSetupFrameTest.java
@@ -110,7 +110,7 @@ public class OperationsSetupFrameTest extends OperationsSwingTestCase {
                     Bundle.getMessage("MaxTrainLengthIncreased"), new Object[]{1234,"feet"}), "OK");
         // dialog window should appear regarding railroad name
         /*pressDialogButton(f,java.text.MessageFormat.format(Bundle
-                    .getMessage("ChangeRailroadName"), new Object[]{"My Jmri Railroad", "Test Railroad Name"}) ,"No");
+                    .getMessage("ChangeRailroadName"), new Object[]{"My Jmri Railroad", "Test Railroad Name"}) ,Bundle.getMessage("ButtonNo"));
         // done*/
         JUnitUtil.dispose(f);
         jfo.dispose();

--- a/java/test/jmri/jmrit/operations/trains/TrainBuilderGuiTest.java
+++ b/java/test/jmri/jmrit/operations/trains/TrainBuilderGuiTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 /**
  * Tests for the Operations Trains GUI class
- * 
+ *
  * @author Dan Boudreau Copyright (C) 2009
  */
 public class TrainBuilderGuiTest extends OperationsSwingTestCase {

--- a/java/test/jmri/jmrit/operations/trains/TrainBuilderGuiTest.java
+++ b/java/test/jmri/jmrit/operations/trains/TrainBuilderGuiTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 /**
  * Tests for the Operations Trains GUI class
- *
+ * 
  * @author Dan Boudreau Copyright (C) 2009
  */
 public class TrainBuilderGuiTest extends OperationsSwingTestCase {

--- a/java/test/jmri/jmrit/operations/trains/TrainBuilderGuiTest.java
+++ b/java/test/jmri/jmrit/operations/trains/TrainBuilderGuiTest.java
@@ -268,7 +268,7 @@ public class TrainBuilderGuiTest extends OperationsSwingTestCase {
         }, "wait for prompt");
         
         // next prompt asks if cars are to be released from train by reset
-        JemmyUtil.pressDialogButton(Bundle.getMessage("buildResetTrain"), "No");
+        JemmyUtil.pressDialogButton(Bundle.getMessage("buildResetTrain"), Bundle.getMessage("ButtonNo"));
         
         jmri.util.JUnitUtil.waitFor(() -> {
             return build.getState().equals(Thread.State.TERMINATED);
@@ -365,7 +365,7 @@ public class TrainBuilderGuiTest extends OperationsSwingTestCase {
         },"wait for prompt");
         
         // next prompt asks if cars are to be released from train by reset
-        JemmyUtil.pressDialogButton(Bundle.getMessage("buildResetTrain"), "Yes");
+        JemmyUtil.pressDialogButton(Bundle.getMessage("buildResetTrain"), Bundle.getMessage("ButtonYes"));
         
         jmri.util.JUnitUtil.waitFor(() -> {
             return build.getState().equals(Thread.State.TERMINATED);
@@ -455,7 +455,7 @@ public class TrainBuilderGuiTest extends OperationsSwingTestCase {
         },"wait for prompt");
         
         // next prompt asks if cars are to be released from train by reset
-        JemmyUtil.pressDialogButton(Bundle.getMessage("buildResetTrain"), "Yes");
+        JemmyUtil.pressDialogButton(Bundle.getMessage("buildResetTrain"), Bundle.getMessage("ButtonYes"));
         
         jmri.util.JUnitUtil.waitFor(() -> {
             return build.getState().equals(Thread.State.TERMINATED);
@@ -552,7 +552,7 @@ public class TrainBuilderGuiTest extends OperationsSwingTestCase {
         },"wait for prompt");
         
         // next prompt asks if cars are to be released from train by reset
-        JemmyUtil.pressDialogButton(Bundle.getMessage("buildResetTrain"), "Yes");
+        JemmyUtil.pressDialogButton(Bundle.getMessage("buildResetTrain"), Bundle.getMessage("ButtonYes"));
         
         jmri.util.JUnitUtil.waitFor(() -> {
             return build.getState().equals(Thread.State.TERMINATED);
@@ -644,7 +644,7 @@ public class TrainBuilderGuiTest extends OperationsSwingTestCase {
         },"wait for prompt");
         
         // next prompt asks if cars are to be released from train by reset
-        JemmyUtil.pressDialogButton(Bundle.getMessage("buildResetTrain"), "No");
+        JemmyUtil.pressDialogButton(Bundle.getMessage("buildResetTrain"), Bundle.getMessage("ButtonNo"));
         
         jmri.util.JUnitUtil.waitFor(() -> {
             return build.getState().equals(Thread.State.TERMINATED);


### PR DESCRIPTION
I don't know if it is possible, but it would be nice if there was a test that tested if the tests works on a non English computer. In Swedish for example, "Yes" is "Ja" and "No" is "Nej", which makes tests not work as desired unless Bundle.getMessage("ButtonYes") and Bundle.getMessage("ButtonNo") is used.

One possible way to do this could be to let Travis run the graphical tests with English locale and let AppVeyor run the tests with a different locale, for example French. That way, all tests would need to pass both locales. Or to add another Travis test that tests a different locale.