### PR TITLE
some test refactoring.

### DIFF
--- a/java/test/jmri/jmrit/logix/NXFrameTest.java
+++ b/java/test/jmri/jmrit/logix/NXFrameTest.java
@@ -9,6 +9,7 @@ import jmri.Sensor;
 import jmri.SensorManager;
 import jmri.jmrit.display.controlPanelEditor.ControlPanelEditor;
 import jmri.util.JUnitUtil;
+import jmri.util.swing.JemmyUtil;
 
 import org.junit.*;
 
@@ -16,7 +17,6 @@ import org.netbeans.jemmy.operators.JButtonOperator;
 import org.netbeans.jemmy.operators.JDialogOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JRadioButtonOperator;
-import org.netbeans.jemmy.operators.WindowOperator;
 
 /**
  * Tests for the NXFrame class, and it's interactions with Warrants.
@@ -49,24 +49,23 @@ public class NXFrameTest {
         JFrameOperator jfo = new JFrameOperator(nxFrame);
 
         nxFrame.setVisible(true);
-        pressButton(jfo, Bundle.getMessage("Calculate"));
+        JemmyUtil.pressButton(jfo, Bundle.getMessage("Calculate"));
 
-        confirmJOptionPane(jfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("SetEndPoint", Bundle.getMessage("OriginBlock")), "OK");
+        JemmyUtil.confirmJOptionPane(jfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("SetEndPoint", Bundle.getMessage("OriginBlock")), "OK");
 
         nxFrame._origin.blockBox.setText("NowhereBlock");
 
-        pressButton(jfo, Bundle.getMessage("Calculate"));
+        JemmyUtil.pressButton(jfo, Bundle.getMessage("Calculate"));
 
-        confirmJOptionPane(jfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("BlockNotFound", "NowhereBlock"), "OK");
+        JemmyUtil.confirmJOptionPane(jfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("BlockNotFound", "NowhereBlock"), "OK");
 
-        confirmJOptionPane(jfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("SetEndPoint", Bundle.getMessage("OriginBlock")), "OK");
+        JemmyUtil.confirmJOptionPane(jfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("SetEndPoint", Bundle.getMessage("OriginBlock")), "OK");
 
         jfo.requestClose();
     }
 
     @Test
-    @Ignore("Causes timeouts due to threading issues; probably real problems, but we can't have a 30% PK of CI")
-    public void testNXWarrant() throws Exception {
+    public void testNXWarrantSetup() throws Exception {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // load and display
         File f = new File("java/test/jmri/jmrit/logix/valid/NXWarrantTest.xml");
@@ -86,50 +85,108 @@ public class NXFrameTest {
         nxFrame._origin.blockBox.setText("OB0");
         nxFrame._destination.blockBox.setText("OB10");
 
-        pressButton(nfo, Bundle.getMessage("Calculate"));
+        JemmyUtil.pressButton(nfo, Bundle.getMessage("Calculate"));
 
         JDialogOperator jdo = new JDialogOperator(nfo,Bundle.getMessage("DialogTitle"));
 
-        pressButton(jdo, Bundle.getMessage("ButtonReview"));
+        JemmyUtil.pressButton(jdo, Bundle.getMessage("ButtonReview"));
 
-        confirmJOptionPane(nfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("SelectRoute"), "OK");
-
+        JemmyUtil.confirmJOptionPane(nfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("SelectRoute"), "OK");
 
         // click the third radio button in the dialog
         JRadioButtonOperator jrbo = new JRadioButtonOperator(jdo,3);
         jrbo.clickMouse();
         // then the Review Button
-        pressButton(jdo, Bundle.getMessage("ButtonReview"));
+        JemmyUtil.pressButton(jdo, Bundle.getMessage("ButtonReview"));
 
         // click the 1st radio button in the dialog
         jrbo = new JRadioButtonOperator(jdo,1);
         jrbo.clickMouse();
         // then the Review Button
-        pressButton(jdo, Bundle.getMessage("ButtonReview"));
+        JemmyUtil.pressButton(jdo, Bundle.getMessage("ButtonReview"));
 
         nxFrame.setThrottleIncrement(0.05f);
 
-        pressButton(jdo, Bundle.getMessage("ButtonSelect"));
+        JemmyUtil.pressButton(jdo, Bundle.getMessage("ButtonSelect"));
         nxFrame.setMaxSpeed(2);
-        pressButton(nfo, Bundle.getMessage("ButtonRunNX"));
-        confirmJOptionPane(nfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("badSpeed", "2"), "OK");
+        JemmyUtil.pressButton(nfo, Bundle.getMessage("ButtonRunNX"));
+        JemmyUtil.confirmJOptionPane(nfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("badSpeed", "2"), "OK");
         
         nxFrame.setMaxSpeed(0.6f);
-        pressButton(nfo, Bundle.getMessage("ButtonRunNX"));
-        confirmJOptionPane(nfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("BadDccAddress", ""), "OK");
+        JemmyUtil.pressButton(nfo, Bundle.getMessage("ButtonRunNX"));
+        JemmyUtil.confirmJOptionPane(nfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("BadDccAddress", ""), "OK");
 
         nxFrame.setTrainInfo("666");
         nxFrame.setTrainName("Nick");
-        pressButton(nfo, Bundle.getMessage("ButtonRunNX"));
+        JemmyUtil.pressButton(nfo, Bundle.getMessage("ButtonRunNX"));
+
+        // we may want to use jemmy to close the panel as well.
+        ControlPanelEditor panel = (ControlPanelEditor) jmri.util.JmriJFrame.getFrame("NXWarrantTest");
+        panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
+    }
+
+    @Test
+    @Ignore("Causes timeouts due to threading issues; probably real problems, but we can't have a 30% PK of CI")
+    public void testNXWarrant() throws Exception {
+        // The first part of this test duplicates testNXWarrantSetup().  It
+        // then goes on to test a Warrant through the WarrantTableFrame.
+        // it is the WarrantTableframe portion of this test that hangs.
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        // load and display
+        File f = new File("java/test/jmri/jmrit/logix/valid/NXWarrantTest.xml");
+        InstanceManager.getDefault(ConfigureManager.class).load(f);
+        _OBlockMgr = InstanceManager.getDefault(OBlockManager.class);
+        _sensorMgr = InstanceManager.getDefault(SensorManager.class);
+        OBlock block = _OBlockMgr.getBySystemName("OB0");
+
+        NXFrame nxFrame = new NXFrame();
+        WarrantTableAction.setNXFrame(nxFrame);
+        nxFrame.setVisible(true);
+
+        JFrameOperator nfo = new JFrameOperator(nxFrame);
+
+        // if _origin.blockBox and _destination.blockBox were labeled,
+        // we could use jemmy to find these and fill in the text.
+        nxFrame._origin.blockBox.setText("OB0");
+        nxFrame._destination.blockBox.setText("OB10");
+
+        JemmyUtil.pressButton(nfo, Bundle.getMessage("Calculate"));
+
+        JDialogOperator jdo = new JDialogOperator(nfo,Bundle.getMessage("DialogTitle"));
+
+        JemmyUtil.pressButton(jdo, Bundle.getMessage("ButtonReview"));
+
+        JemmyUtil.confirmJOptionPane(nfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("SelectRoute"), "OK");
+
+        // click the third radio button in the dialog
+        JRadioButtonOperator jrbo = new JRadioButtonOperator(jdo,3);
+        jrbo.clickMouse();
+        // then the Review Button
+        JemmyUtil.pressButton(jdo, Bundle.getMessage("ButtonReview"));
+
+        // click the 1st radio button in the dialog
+        jrbo = new JRadioButtonOperator(jdo,1);
+        jrbo.clickMouse();
+        // then the Review Button
+        JemmyUtil.pressButton(jdo, Bundle.getMessage("ButtonReview"));
+
+        nxFrame.setThrottleIncrement(0.05f);
+
+        JemmyUtil.pressButton(jdo, Bundle.getMessage("ButtonSelect"));
+        nxFrame.setMaxSpeed(2);
+        JemmyUtil.pressButton(nfo, Bundle.getMessage("ButtonRunNX"));
+        JemmyUtil.confirmJOptionPane(nfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("badSpeed", "2"), "OK");
+        
+        nxFrame.setMaxSpeed(0.6f);
+        JemmyUtil.pressButton(nfo, Bundle.getMessage("ButtonRunNX"));
+        JemmyUtil.confirmJOptionPane(nfo, Bundle.getMessage("WarningTitle"), Bundle.getMessage("BadDccAddress", ""), "OK");
 
         // from this point to the end of the test, there are no more references
         // to nxFrame.  Do we need to split this into multiple tests?  
         // The next part deals with a WarrantTableFrame, should it still be
         // in this test file?
 
-
-
-       WarrantTableFrame tableFrame = WarrantTableFrame.getDefault();
+        WarrantTableFrame tableFrame = WarrantTableFrame.getDefault();
         Assert.assertNotNull("tableFrame", tableFrame);
         WarrantTableModel model = tableFrame.getModel();
         Assert.assertNotNull("tableFrame model", model);
@@ -211,19 +268,6 @@ public class NXFrameTest {
         panel.dispose();    // disposing this way allows test to be rerun (i.e. reload panel file) multiple times
     }
 
-    private void pressButton(WindowOperator frame, String text) {
-        JButtonOperator jbo = new JButtonOperator(frame,text);
-        jbo.push();
-    }
-
-    private void confirmJOptionPane(WindowOperator wo, String title, String message, String buttonLabel) {
-        // the previous version of this message verified the text string
-        // in the dialog matched the passed message value.  We need to 
-        // determine how to do that using Jemmy.
-        JDialogOperator jdo = new JDialogOperator(wo,title);
-        JButtonOperator jbo = new JButtonOperator(jdo,buttonLabel);
-        jbo.push();
-    }
 
     /**
      * Simulates the movement of a warranted train over its route.

--- a/java/test/jmri/jmrit/logix/NXFrameTest.java
+++ b/java/test/jmri/jmrit/logix/NXFrameTest.java
@@ -72,7 +72,6 @@ public class NXFrameTest {
         InstanceManager.getDefault(ConfigureManager.class).load(f);
         _OBlockMgr = InstanceManager.getDefault(OBlockManager.class);
         _sensorMgr = InstanceManager.getDefault(SensorManager.class);
-        OBlock block = _OBlockMgr.getBySystemName("OB0");
 
         NXFrame nxFrame = new NXFrame();
         WarrantTableAction.setNXFrame(nxFrame);

--- a/java/test/jmri/util/swing/JemmyUtil.java
+++ b/java/test/jmri/util/swing/JemmyUtil.java
@@ -11,6 +11,7 @@ import org.netbeans.jemmy.operators.JDialogOperator;
 import org.netbeans.jemmy.operators.JFrameOperator;
 import org.netbeans.jemmy.operators.JRadioButtonOperator;
 import org.netbeans.jemmy.operators.JToggleButtonOperator;
+import org.netbeans.jemmy.operators.WindowOperator;
 import org.netbeans.jemmy.util.NameComponentChooser;
 
 /**
@@ -62,5 +63,19 @@ public class JemmyUtil {
     static public void enterClickAndLeave(JToggleButton comp) {
         JToggleButtonOperator jtbo = new JToggleButtonOperator(comp);
         jtbo.doClick();
+    }
+
+    static public void pressButton(WindowOperator frame, String text) {
+        JButtonOperator jbo = new JButtonOperator(frame,text);
+        jbo.push();
+    }
+
+    static public void confirmJOptionPane(WindowOperator wo, String title, String message, String buttonLabel) {
+        // the previous version of this message verified the text string
+        // in the dialog matched the passed message value.  We need to 
+        // determine how to do that using Jemmy.
+        JDialogOperator jdo = new JDialogOperator(wo,title);
+        JButtonOperator jbo = new JButtonOperator(jdo,buttonLabel);
+        jbo.push();
     }
 }


### PR DESCRIPTION
This is a followup to #5917.  It pulls the part of the ignored test out that interacts with the NXFrame GUI as a separate test.  

This leaves in place the Ignore on the full test which includes the interaction with the WarrantTableFrame that were causing #5911.  I believe that the WarrantTableFrame interaction is probably in the wrong test file, because it is not really testing the NXFrame.