### PR TITLE
Fix NamedBean equals

### DIFF
--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -17,7 +17,7 @@ import javax.annotation.Nonnull;
  * The "system" name is provided by the system-specific implementations, and
  * provides a unique mapping to the layout control system (for example LocoNet
  * or NCE) and address within that system. It must be present and unique across
- * the JMRI instance.
+ * the JMRI instance. Two beans are identical if they have the same system name; if not, not.
  * <p>
  * The "user" name is optional. It's free form text except for two restrictions:
  * <ul>

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -312,9 +312,9 @@ public abstract class AbstractNamedBean implements NamedBean {
     /**
      * {@inheritDoc}
      * <p>
-     * This implementation tests that the results of
-     * {@link jmri.NamedBean#getSystemName()} and
-     * {@link jmri.NamedBean#getUserName()} are equal for this and obj.
+     * This implementation tests that 
+     * {@link jmri.NamedBean#getSystemName()}
+     * is equal for this and obj.
      *
      * @param obj the reference object with which to compare.
      * @return {@code true} if this object is the same as the obj argument;
@@ -322,39 +322,24 @@ public abstract class AbstractNamedBean implements NamedBean {
      */
     @Override
     public boolean equals(Object obj) {
-        // test the obj == this
-        boolean result = super.equals(obj);
+        if (obj == this) return true;  // for efficiency
+        if (obj == null) return false; // by contract
 
-        if (!result && (obj != null) && obj instanceof AbstractNamedBean) {
+        if (obj instanceof AbstractNamedBean) {  // NamedBeans are not equal to things of other types
             AbstractNamedBean b = (AbstractNamedBean) obj;
-            if (this.getSystemName().equals(b.getSystemName())) {
-                String bUserName = b.getUserName();
-                if ((mUserName != null) && (bUserName != null)
-                        && mUserName.equals(bUserName)) {
-                    result = true;
-                }
-            }
+            return this.getSystemName().equals(b.getSystemName());
         }
-        return result;
+        return false;
     }
 
     /**
-     * Calculate our hash code.
-     *
-     * @return our hash code
+     * {@inheritDoc}
+     * 
+     * @return hash code value is based on sthe ystem name.
      */
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        if (mSystemName != null) {
-            result = mSystemName.hashCode();
-            if (mUserName != null) {
-                result = (result * 37) + mUserName.hashCode();
-            }
-        } else if (mUserName != null) {
-            result = mUserName.hashCode();
-        }
-        return result;
+        return getSystemName().hashCode(); // as the 
     }
     
     /**

--- a/java/src/jmri/jmrix/loconet/LnTrafficController.java
+++ b/java/src/jmri/jmrix/loconet/LnTrafficController.java
@@ -86,11 +86,13 @@ public abstract class LnTrafficController implements LocoNetInterface {
         synchronized (this) {
             v = (Vector<LocoNetListener>) listeners.clone();
         }
-        log.debug("notify of incoming LocoNet packet: {}", m.toString());
+
         // forward to all listeners
+        log.debug("notify of incoming LocoNet packet: {}", m);
         int cnt = v.size();
         for (int i = 0; i < cnt; i++) {
             LocoNetListener client = listeners.elementAt(i);
+            log.trace("  notify {} of incoming LocoNet packet: {}", client, m);
             client.message(m);
         }
     }

--- a/java/src/jmri/jmrix/loconet/LnTurnout.java
+++ b/java/src/jmri/jmrix/loconet/LnTurnout.java
@@ -240,9 +240,8 @@ public class LnTurnout extends AbstractTurnout implements LocoNetListener {
                 int sw1 = l.getElement(1);
                 int sw2 = l.getElement(2);
                 if (myAddress(sw1, sw2)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("SW_REQ received with valid address");
-                    }
+                
+                    log.debug("SW_REQ received with valid address");
                     //sort out states
                     int state;
                     if ((sw2 & LnConstants.OPC_SW_REQ_DIR) != 0) {
@@ -267,9 +266,8 @@ public class LnTurnout extends AbstractTurnout implements LocoNetListener {
                 int sw1 = l.getElement(1);
                 int sw2 = l.getElement(2);
                 if (myAddress(sw1, sw2)) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("SW_REP received with valid address");
-                    }
+
+                    log.debug("SW_REP received with valid address");
                     // see if its a turnout state report
                     if ((sw2 & LnConstants.OPC_SW_REP_INPUTS) == 0) {
                         // LnConstants.OPC_SW_REP_INPUTS not set, these report outputs

--- a/java/test/jmri/SignalMastLogicTest.java
+++ b/java/test/jmri/SignalMastLogicTest.java
@@ -81,6 +81,85 @@ public class SignalMastLogicTest {
         sml.dispose();
     }
 
+    /**
+     * Check that you can rename the SignalMast user names
+     */
+    @Test
+    public void testRename() {
+        jmri.NamedBeanHandleManager nbhm = jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class);
+        // provide 2 turnouts:
+        Turnout it1 = InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
+        Turnout it2 = InstanceManager.turnoutManagerInstance().provideTurnout("IT2");
+        // provide 2 sensors:
+        Sensor is1 = InstanceManager.sensorManagerInstance().provideSensor("IS1");
+        Sensor is2 = InstanceManager.sensorManagerInstance().provideSensor("IS2");
+        // provide 3 virtual signal masts:
+        SignalMast sm1 = new jmri.implementation.VirtualSignalMast("IF$vsm:AAR-1946:CPL($0002)");
+        Assert.assertNotNull("SignalMast is null!", sm1);
+        SignalMast sm2 = new jmri.implementation.VirtualSignalMast("IF$vsm:AAR-1946:CPL($0002)");
+        Assert.assertNotNull("SignalMast is null!", sm2);
+        SignalMast sm3 = new jmri.implementation.VirtualSignalMast("IF$vsm:AAR-1946:CPL($0002)");
+        Assert.assertNotNull("SignalMast is null!", sm3);
+        // provide a signal mast logic:
+        SignalMastLogic sml = InstanceManager.getDefault(jmri.SignalMastLogicManager.class).newSignalMastLogic(sm1);
+        sml.setDestinationMast(sm2);
+        Assert.assertNotNull("SignalMastLogic is null!", sml);
+        sml.allowAutoMaticSignalMastGeneration(false, sm2);
+        // add a control sensor
+        sml.addSensor("IS1", 1, sm2); // Active
+        // check config
+        Assert.assertEquals("IS1 included", true, sml.isSensorIncluded(is1, sm2));
+        Assert.assertEquals("IS2 not included", false, sml.isSensorIncluded(is2, sm2));
+        Assert.assertEquals("IS1 state", 1, sml.getSensorState(is1, sm2));
+        // add 1 control turnout
+        Hashtable<NamedBeanHandle<Turnout>, Integer> hashTurnouts = new Hashtable<NamedBeanHandle<Turnout>, Integer>();
+        NamedBeanHandle<Turnout> namedTurnout1 = nbhm.getNamedBeanHandle("IT1", it1);
+        hashTurnouts.put(namedTurnout1, 1); // 1 = Closed
+        sml.setTurnouts(hashTurnouts, sm2);
+        // check config
+        Assert.assertTrue("IT1 included", sml.isTurnoutIncluded(it1, sm2));
+        Assert.assertFalse("IT2 before", sml.isTurnoutIncluded(it2, sm2));
+        // add another control turnout
+        NamedBeanHandle<Turnout> namedTurnout2 = nbhm.getNamedBeanHandle("IT2", it2);
+        hashTurnouts.put(namedTurnout2, 2); // 2 = Thrown
+        sml.setTurnouts(hashTurnouts, sm2);
+        Assert.assertEquals("IT2 after", true, sml.isTurnoutIncluded(it2, sm2));
+        Assert.assertEquals("IT1 state", 1, sml.getTurnoutState(it1, sm2));
+        // add a control signal mast
+        Hashtable<SignalMast, String> hashSignalMast = new Hashtable<SignalMast, String>();
+        hashSignalMast.put(sm3, "Stop");
+        sml.setMasts(hashSignalMast, sm2);
+        
+        // check config
+        Assert.assertEquals("SM3 included", true, sml.isSignalMastIncluded(sm3, sm2));
+        Assert.assertEquals("SM3 aspect before", "Stop", sml.getSignalMastState(sm3, sm2));
+        
+        
+        // rename the masts
+        sm1.setUserName("new name 1");
+        sm2.setUserName("new name 1");
+        sm3.setUserName("new name 1");
+        
+        
+        // set aspect to Proceed
+        hashSignalMast.put(sm3, "Proceed");
+        sml.setMasts(hashSignalMast, sm2);
+        Assert.assertEquals("SM3 aspect after", "Proceed", sml.getSignalMastState(sm3, sm2));
+        // set comment
+        sml.setComment("SMLTest", sm2);
+        Assert.assertEquals("comment", "SMLTest", sml.getComment(sm2));
+        sml.initialise(sm2);
+        // set SML disabled
+        sml.setDisabled(sm2);
+        Assert.assertEquals("disabled", false, sml.isEnabled(sm2));
+        // change source mast and check
+        sml.replaceSourceMast(sm1, sm3);
+        Assert.assertFalse("sourcemast", sml.getSourceMast() == sm1);
+        Assert.assertTrue("sourcemast", sml.getSourceMast() == sm3);
+        // clean up
+        sml.dispose();
+    }
+
     // The minimal setup for log4J
     @Before
     public void setUp() {

--- a/java/test/jmri/jmrix/loconet/LnTurnoutTest.java
+++ b/java/test/jmri/jmrix/loconet/LnTurnoutTest.java
@@ -136,7 +136,6 @@ public class LnTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
     public void testLnTurnoutExactFeedback() {
         LocoNetMessage m;
         // prepare a specific test
-        t = new LnTurnout("L", 21, lnis); // note different address; we have traces for this address
         t.setBinaryOutput(true);
         t.setCommandedState(jmri.Turnout.CLOSED);
         t.setFeedbackMode(jmri.Turnout.EXACT);
@@ -145,6 +144,7 @@ public class LnTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
         Assert.assertEquals("KnownState after set CLOSED is UNKNOWN", jmri.Turnout.UNKNOWN, t.getKnownState());
 
         // notify the Ln of first feedback - AUX is thrown, so moved off 
+        log.debug("notify of 1st feedback");
         m = new LocoNetMessage(4);
         m.setOpCode(0xb1);
         m.setElement(1, 0x14);
@@ -155,6 +155,7 @@ public class LnTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
         Assert.assertEquals("KnownState after AUX report THROWN is INCONSISTENT", jmri.Turnout.INCONSISTENT, t.getKnownState());
 
         // notify the Ln of second feedback - SWITCH is closed, so moved on
+        log.debug("notify of 2nd feedback");
         m = new LocoNetMessage(4);
         m.setOpCode(0xb1);
         m.setElement(1, 0x14);
@@ -269,7 +270,6 @@ public class LnTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
     // test that only one message is sent when binaryOutput is set
     @Test
     public void testBasicSet() throws InterruptedException {
-        t = new LnTurnout("L", 121, lnis);
         t.setBinaryOutput(true);
         t.setCommandedState(jmri.Turnout.THROWN);
 
@@ -281,7 +281,7 @@ public class LnTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
         // check for messages
         Assert.assertTrue("just one messages", lnis.outbound.size() == 1);
         Assert.assertEquals(lnis.outbound.elementAt(lnis.outbound.size() - 1).toString(),
-                "B0 78 10 00");  // THROWN/ON loconet message
+                "B0 14 10 00");  // THROWN/ON loconet message
         Assert.assertTrue(t.getCommandedState() == jmri.Turnout.THROWN);
     }
 


### PR DESCRIPTION
The NamedBean equals(..) operator (from AbstractNamedBean) was comparing on userName, in addition to systemName. It shouldn't have.  Fixed. Also fixed one tests (LnTurnoutTest) that was erroneously depending on this.