### PR TITLE
turnout Direct Feedback test; make sure property change listener is triggered for DCC++

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppTurnout.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnout.java
@@ -154,7 +154,11 @@ public class DCCppTurnout extends AbstractTurnout implements DCCppListener {
             synchronized (this) {
                 newKnownState(INCONSISTENT);
             }
-        }
+        } else if( _activeFeedbackType == DIRECT ){
+            synchronized (this) {
+                newKnownState(s);
+            }
+	}
     }
 
     // Handle a request to change state by sending a DCC++ command
@@ -194,7 +198,7 @@ public class DCCppTurnout extends AbstractTurnout implements DCCppListener {
             // Convert the integer Turnout value to boolean for DCC++ internal code.
             // Assume if it's not THROWN (true), it must be CLOSED (false).
             msg = DCCppMessage.makeAccessoryDecoderMsg(mNumber, newstate);
-            internalState = IDLE; // change this!
+	    internalState = IDLE;
             break;
             
         }

--- a/java/test/jmri/implementation/AbstractTurnoutTestBase.java
+++ b/java/test/jmri/implementation/AbstractTurnoutTestBase.java
@@ -41,12 +41,16 @@ public abstract class AbstractTurnoutTestBase {
     protected Turnout t = null;	// holds objects under test; set by setUp()
 
     static protected boolean listenerResult = false;
+    static protected int listenStatus = Turnout.UNKNOWN;
 
-    protected class Listen implements PropertyChangeListener {
+    public class Listen implements PropertyChangeListener {
 
         @Override
         public void propertyChange(java.beans.PropertyChangeEvent e) {
             listenerResult = true;
+            if(e.getPropertyName().equals("KnownState")){
+		    listenStatus = ((Integer) e.getNewValue()).intValue();
+	    }
         }
     }
 
@@ -205,10 +209,14 @@ public abstract class AbstractTurnoutTestBase {
     public void testOneSensorFeedback() throws jmri.JmriException {
         Sensor s1 = InstanceManager.getDefault(jmri.SensorManager.class).provideSensor("IS1");
         t.setFeedbackMode(Turnout.ONESENSOR); 
-        t.provideFirstFeedbackSensor("IS1");
+        listenStatus = Turnout.UNKNOWN;
+	t.addPropertyChangeListener(new Listen());
+	t.provideFirstFeedbackSensor("IS1");
         s1.setKnownState(Sensor.INACTIVE);
         Assert.assertEquals("known state for ONESENSOR feedback Inactive",Turnout.CLOSED,t.getKnownState());
+        Assert.assertEquals("listener notified of change for ONESENSOR feedback",Turnout.CLOSED,listenStatus);
         s1.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("listener notified of change for ONESENSOR feedback",Turnout.THROWN,listenStatus);
         Assert.assertEquals("known state for ONESENSOR feedback active",Turnout.THROWN,t.getKnownState());
     }
 
@@ -221,6 +229,9 @@ public abstract class AbstractTurnoutTestBase {
         t.setFeedbackMode(Turnout.TWOSENSOR); 
         Assert.assertEquals("known state for TWOSENSOR feedback (UNKNOWN,UNKNOWN)",Turnout.UNKNOWN,t.getKnownState());
 
+	listenStatus = Turnout.UNKNOWN;
+	t.addPropertyChangeListener(new Listen());
+
         s1.setKnownState(Sensor.ACTIVE);
         s2.setKnownState(Sensor.INACTIVE);
 
@@ -230,6 +241,8 @@ public abstract class AbstractTurnoutTestBase {
 
         Assert.assertEquals("state changed by TWOSENSOR feedback (Active,Inactive)", Turnout.THROWN, t.getKnownState());
 
+	Assert.assertEquals("listener notified of change for TWOSENSOR feedback",Turnout.THROWN,listenStatus);
+
         s1.setKnownState(Sensor.INACTIVE);
         s2.setKnownState(Sensor.INACTIVE);
         Assert.assertEquals("known state for TWOSENSOR feedback (Inactive,Inactive)",Turnout.INCONSISTENT,t.getKnownState());
@@ -238,11 +251,33 @@ public abstract class AbstractTurnoutTestBase {
         s2.setKnownState(Sensor.ACTIVE);
         Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive,Active)", Turnout.CLOSED, t.getKnownState());
 
+	Assert.assertEquals("listener notified of change for TWOSENSOR feedback ",Turnout.CLOSED,listenStatus);
+
         s1.setKnownState(Sensor.ACTIVE);
         s2.setKnownState(Sensor.ACTIVE);
         Assert.assertEquals("state changed by TWOSENSOR feedback (Active,Active)", Turnout.INCONSISTENT, t.getKnownState());
     }
 
+    @Test 
+    public void testDirectFeedback() throws Exception {
+
+        // Default mode is DIRECT
+        Assert.assertEquals(Turnout.DIRECT, t.getFeedbackMode());
+
+	listenStatus = Turnout.UNKNOWN;
+	t.addPropertyChangeListener(new Listen());
+        
+        // Check that state changes appropriately
+        t.setCommandedState(Turnout.THROWN);
+        checkThrownMsgSent();
+        Assert.assertEquals(t.getState(), Turnout.THROWN);
+	Assert.assertEquals("listener notified of change for DIRECT feedback",Turnout.THROWN,listenStatus);
+
+	t.setCommandedState(Turnout.CLOSED);
+        checkClosedMsgSent();
+        Assert.assertEquals(t.getState(), Turnout.CLOSED);
+	Assert.assertEquals("listener notified of change for DIRECT feedback",Turnout.CLOSED,listenStatus);
+    }
 
     @Test
     public void testGetBeanType(){

--- a/java/test/jmri/jmrix/dccpp/DCCppTurnoutTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppTurnoutTest.java
@@ -6,8 +6,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * DCCppThrottleTest.java
@@ -18,8 +16,6 @@ import org.slf4j.LoggerFactory;
  * @author	Mark Underwood
  */
 public class DCCppTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
-
-    private final static Logger log = LoggerFactory.getLogger(DCCppTurnoutTest.class);
 
     @Override
     public int numListeners() {

--- a/java/test/jmri/jmrix/dccpp/DCCppTurnoutTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppTurnoutTest.java
@@ -67,41 +67,6 @@ public class DCCppTurnoutTest extends jmri.implementation.AbstractTurnoutTestBas
         
     }
    
-    @Test 
-    public void testDirectMode() throws Exception {
-
-        // Default mode is DIRECT
-        Assert.assertEquals(Turnout.DIRECT, t.getFeedbackMode());
-        
-        // Check that state changes appropriately
-        t.setCommandedState(Turnout.THROWN);
-        //Assert.assertEquals(t.getState(), Turnout.THROWN);
-        DCCppMessage m = dnis.outbound.elementAt(0);
-        Assert.assertTrue(m.isAccessoryMessage());
-        Assert.assertEquals(1, m.getAccessoryStateInt());
-        t.setCommandedState(Turnout.CLOSED);
-        //Assert.assertEquals(t.getState(), Turnout.CLOSED);
-        m = dnis.outbound.elementAt(1);
-        Assert.assertTrue(m.isAccessoryMessage());
-        Assert.assertEquals(0, m.getAccessoryStateInt());
-        
-        // Test Inverted state
-        // Check that state changes appropriately
-        t.setInverted(true);
-        t.setCommandedState(Turnout.THROWN);
-        //Assert.assertEquals(t.getState(), Turnout.THROWN);
-        m = dnis.outbound.elementAt(2);
-        log.debug("Inverted Direct: {}", m.toString());
-        Assert.assertTrue(m.isAccessoryMessage());
-        Assert.assertEquals(0, m.getAccessoryStateInt());
-        t.setCommandedState(Turnout.CLOSED);
-        //Assert.assertEquals(t.getState(), Turnout.CLOSED);
-        m = dnis.outbound.elementAt(3);
-        Assert.assertTrue(m.isAccessoryMessage());
-        Assert.assertEquals(1, m.getAccessoryStateInt());        
-    }
-
-    @Test    
     public void testMonitoringMode() throws Exception {
         // Set mode to Monitoring
         t.setFeedbackMode(Turnout.MONITORING);

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientTurnoutTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientTurnoutTest.java
@@ -1,9 +1,6 @@
 package jmri.jmrix.jmriclient;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 /**
  * JMRIClientTurnoutTest.java
@@ -44,10 +41,10 @@ public class JMRIClientTurnoutTest extends jmri.implementation.AbstractTurnoutTe
         Assert.assertEquals("controller listeners remaining", 1, numListeners());
     }
 
-
     @Test
-    public void testCtor() {
-        Assert.assertNotNull(t);
+    @Override
+    @Ignore("requires work for jmriclient turnouts")
+    public void testDirectFeedback() throws jmri.JmriException {
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/lenz/XNetTurnoutTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetTurnoutTest.java
@@ -1,6 +1,9 @@
 package jmri.jmrix.lenz;
 
 import jmri.util.JUnitUtil;
+import jmri.Turnout;
+import jmri.Sensor;
+import jmri.InstanceManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -167,6 +170,66 @@ public class XNetTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
     @Override
     @Ignore("requires work for XpressNet turnouts")
     public void testTwoSensorFeedback() throws jmri.JmriException {
+        Sensor s1 = InstanceManager.getDefault(jmri.SensorManager.class).provideSensor("IS1");
+        Sensor s2 = InstanceManager.getDefault(jmri.SensorManager.class).provideSensor("IS2");
+        t.provideFirstFeedbackSensor("IS1");
+        t.provideSecondFeedbackSensor("IS2");
+        t.setFeedbackMode(Turnout.TWOSENSOR); 
+        Assert.assertEquals("known state for TWOSENSOR feedback (UNKNOWN,UNKNOWN)",Turnout.UNKNOWN,t.getKnownState());
+
+	listenStatus = Turnout.UNKNOWN;
+	t.addPropertyChangeListener(new Listen());
+
+        s1.setKnownState(Sensor.ACTIVE);
+        s2.setKnownState(Sensor.INACTIVE);
+
+        JUnitUtil.waitFor( () -> {
+            return t.getKnownState() != Turnout.UNKNOWN;
+        });
+
+        Assert.assertEquals("state changed by TWOSENSOR feedback (Active,Inactive)", Turnout.THROWN, t.getKnownState());
+
+	Assert.assertEquals("listener notified of change for TWOSENSOR feedback",Turnout.THROWN,listenStatus);
+
+        s1.setKnownState(Sensor.INACTIVE);
+        s2.setKnownState(Sensor.INACTIVE);
+        Assert.assertEquals("known state for TWOSENSOR feedback (Inactive,Inactive)",Turnout.INCONSISTENT,t.getKnownState());
+
+        s1.setKnownState(Sensor.INACTIVE);
+        s2.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (Inactive,Active)", Turnout.CLOSED, t.getKnownState());
+
+	Assert.assertEquals("listener notified of change for TWOSENSOR feedback ",Turnout.CLOSED,listenStatus);
+
+        s1.setKnownState(Sensor.ACTIVE);
+        s2.setKnownState(Sensor.ACTIVE);
+        Assert.assertEquals("state changed by TWOSENSOR feedback (Active,Active)", Turnout.INCONSISTENT, t.getKnownState());
+    }
+
+    @Test
+    @Override
+    @Ignore("requires work for XpressNet turnouts")
+    public void testDirectFeedback() throws jmri.JmriException {
+        // Default mode is DIRECT
+        Assert.assertEquals(Turnout.DIRECT, t.getFeedbackMode());
+
+	listenStatus = Turnout.UNKNOWN;
+	t.addPropertyChangeListener(new Listen());
+        
+        // Check that state changes appropriately
+        t.setCommandedState(Turnout.THROWN);
+        checkThrownMsgSent();
+	((XNetTurnout)t).message(new XNetReply("01 04 05"));
+	((XNetTurnout)t).message(new XNetReply("01 04 05"));
+        Assert.assertEquals(t.getState(), Turnout.THROWN);
+	Assert.assertEquals("listener notified of change for DIRECT feedback",Turnout.THROWN,listenStatus);
+
+	t.setCommandedState(Turnout.CLOSED);
+        checkClosedMsgSent();
+	((XNetTurnout)t).message(new XNetReply("01 04 05"));
+	((XNetTurnout)t).message(new XNetReply("01 04 05"));
+        Assert.assertEquals(t.getState(), Turnout.CLOSED);
+	Assert.assertEquals("listener notified of change for DIRECT feedback",Turnout.CLOSED,listenStatus);
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/loconet/LnTurnoutTest.java
+++ b/java/test/jmri/jmrix/loconet/LnTurnoutTest.java
@@ -1,10 +1,7 @@
 package jmri.jmrix.loconet;
 
 import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,6 +101,12 @@ public class LnTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
         m.setElement(3, 0x00);
         lnis.sendTestMessage(m);
         Assert.assertTrue(t.getCommandedState() == jmri.Turnout.THROWN);
+    }
+
+    @Test
+    @Override
+    @Ignore("requires work for LocoNet turnouts")
+    public void testDirectFeedback() throws jmri.JmriException {
     }
 
     // LnTurnout test for incoming status message

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutInheritedTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutInheritedTest.java
@@ -2,8 +2,7 @@ package jmri.jmrix.openlcb;
 
 import jmri.util.JUnitUtil;
 import jmri.implementation.AbstractTurnoutTestBase;
-import org.junit.Before;
-import org.junit.After;
+import org.junit.*;
 
 /**
  * Tests inherited from the abstract turnout test base, specialized for the OlcbTurnout. This is
@@ -49,5 +48,11 @@ public class OlcbTurnoutInheritedTest extends AbstractTurnoutTestBase {
     public void checkClosedMsgSent() throws InterruptedException {
         tif.flush();
         tif.assertSentMessage(":X195B4C4CN0102030405060709;");
+    }
+
+    @Test
+    @Override
+    @Ignore("requires work for olcb turnouts")
+    public void testDirectFeedback() throws jmri.JmriException {
     }
 }

--- a/java/test/jmri/jmrix/tams/TamsTurnoutTest.java
+++ b/java/test/jmri/jmrix/tams/TamsTurnoutTest.java
@@ -1,10 +1,7 @@
 package jmri.jmrix.tams;
 
 import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 /**
  *
@@ -31,10 +28,10 @@ public class TamsTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
                 tnis.outbound.elementAt(tnis.outbound.size() - 1).toString());
     }
 
-
     @Test
-    public void testCTor() {
-        Assert.assertNotNull("exists",t);
+    @Override
+    @Ignore("requires work for tams turnouts")
+    public void testDirectFeedback() throws jmri.JmriException {
     }
 
     // The minimal setup for log4J


### PR DESCRIPTION
new ignored tests for this mode appear to be systems that expect to see a message from the command station before setting feedback.  This is definitely required for some systems (like XPressNet).