### PR TITLE
No  I18N for test infrastructure

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1281,14 +1281,21 @@
         <java classname="apps.tests.AllTest"
           dir="."
           fork="yes" >
-            <classpath refid="test.class.path"/>
+
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
             <sysproperty key="jinput.plugins" path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
+
             <sysproperty key="java.awt.headless" value="true"/>
+
+            <sysproperty key="user.language" value="en"/>
+            <sysproperty key="user.country" value="US"/>
+
+            <classpath refid="test.class.path"/>
+
             <jvmarg line="${jvm.args}"/>
             <arg value="${antargline}"/>
         </java>
@@ -1297,6 +1304,7 @@
     <target name="headlesstest" depends="tests, runtime-library-selection" description="run headless test suite">
         <jacoco:coverage destfile="${jacocoexec}">
         <junit haltonerror="false" haltonfailure="false" printsummary="yes" fork="yes" dir="." >
+
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
@@ -1305,6 +1313,9 @@
             <sysproperty key="jinput.plugins" path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
 
             <sysproperty key="java.awt.headless" value="true"/>
+
+            <sysproperty key="user.language" value="en"/>
+            <sysproperty key="user.country" value="US"/>
 
             <classpath refid="test.class.path"/>
 
@@ -1367,11 +1378,16 @@
 
     <target name="ci-test" depends="tests, runtime-library-selection" description="run AllTest CI tests">
         <junit haltonerror="false" haltonfailure="false" printsummary="yes" fork="yes" dir="." errorProperty="test.failed" failureProperty="test.failed">
+
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
+            <sysproperty key="jinput.plugins" path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
+
+            <sysproperty key="user.language" value="en"/>
+            <sysproperty key="user.country" value="US"/>
 
             <classpath refid="test.class.path"/>
 
@@ -1389,11 +1405,16 @@
     <target name="ci-test-travis" depends="tests, runtime-library-selection" description="run ci-test using Travis-CI">
         <jacoco:coverage destfile="${jacocoexec}" excludes="org.slf4j.*">
         <junit haltonerror="false" haltonfailure="false" printsummary="yes" fork="yes" dir="." errorProperty="test.failed" failureProperty="test.failed">
+
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
+            <sysproperty key="jinput.plugins" path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
+
+            <sysproperty key="user.language" value="en"/>
+            <sysproperty key="user.country" value="US"/>
 
             <classpath refid="test.class.path"/>
 
@@ -1416,15 +1437,21 @@
         <!-- identical to ci-test target except test output is different -->
         <jacoco:coverage destfile="${jacocoexec}" excludes="org.slf4j.*">
         <junit haltonerror="false" haltonfailure="false" printsummary="yes" showoutput="yes" fork="yes" maxmemory="2048m" dir="." errorProperty="test.failed" failureProperty="test.failed">
+
+            <sysproperty key="cucumber.options" value="--tags 'not @Ignore'"/>
+            <sysproperty key="wdm.forceCache" value="true"/>
+            <!-- wdm.targetPath specifies the locaion of the web drivers on appveyor. -->
+            <sysproperty key="wdm.targetPath" value="C:\Tools\WebDriver"/> 
+
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
-            <sysproperty key="cucumber.options" value="--tags 'not @Ignore'"/>
-            <sysproperty key="wdm.forceCache" value="true"/>
-            <!-- wdm.targetPath specifies the locaion of the web drivers on appveyor. -->
-            <sysproperty key="wdm.targetPath" value="C:\Tools\WebDriver"/> 
+            <sysproperty key="jinput.plugins" path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
+
+            <sysproperty key="user.language" value="en"/>
+            <sysproperty key="user.country" value="US"/>
 
             <classpath refid="test.class.path"/>
 
@@ -1447,13 +1474,19 @@
         <java classname="apps.tests.AllTest"
           dir="."
           fork="yes" >
-            <classpath refid="test.class.path"/>
+
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
             <sysproperty key="jinput.plugins" path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
+
+            <sysproperty key="user.language" value="en"/>
+            <sysproperty key="user.country" value="US"/>
+
+            <classpath refid="test.class.path"/>
+
             <jvmarg line="${jvm.args}"/>
             <arg value="${antargline}"/>
         </java>
@@ -1464,12 +1497,16 @@
         <jacoco:coverage destfile="${jacocoexec}" excludes="org.slf4j.*">
 
         <junit haltonerror="false" haltonfailure="false" showoutput="yes" printsummary="withOutAndErr" fork="yes" dir="." timeout="3600000">
+
             <sysproperty key="java.security.policy" value="${libdir}/security.policy"/>
             <sysproperty key="apple.laf.useScreenMenuBar" value="true"/>
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
             <sysproperty key="jinput.plugins" path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
+
+            <sysproperty key="user.language" value="en"/>
+            <sysproperty key="user.country" value="US"/>
 
             <classpath refid="test.class.path"/>
 

--- a/help/en/html/doc/Technical/ContinuousIntegration.shtml
+++ b/help/en/html/doc/Technical/ContinuousIntegration.shtml
@@ -44,7 +44,7 @@
       <a href="CI-status.shtml">CI status page</a>
       that shows the combined status of that.</p>
 
-      <p>We also use two additioanl CI engines to test every change
+      <p>We also use two additional CI engines to test every change
       entered into our GitHub code repository.</p>
 
       <a name="travis" id="travis"></a>

--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -169,6 +169,34 @@
     runs a specific test or test suite.<br>
     (Hint: How to set this up <a href="IntelliJ.shtml#test">using IntelliJ</a>)
 
+      <h3><a name="I18N" id="I18N">A Note on Internationalization (I18N)</h3>
+      
+      Tests check the correctness of text in GUI elements, warning messages, and 
+      other places. Many of these are 
+      <a href="I8N.shtml">internationalized</a>,
+      varying depending on the computer's Locale.
+      
+      <p>To avoid false failures, the 
+      <a href="Ant.shtml">Ant</a> and
+      <a href="Ant.shtml#maven">Maven</a>
+      build control files set the locale to en_US 
+      before running tests.  This covers 
+      <a href="ContinuousIntegration.shtml">continuous integration</a> running,
+      and running locally using e.g. "ant headlesstest" or "ant alltest".
+      <p>
+      The ./runtest.csh mechanism does <u>not</u>
+      automatically set the locale.  To do that, the easiest approach
+      is to set the JMRI_OPTIONS environment variable via one of:
+
+<pre style="font-family: monospace;">
+   setenv JMRI_OPTIONS "-Duser.language=en -Duser.region=US"
+   export JMRI_OPTIONS="-Duser.language=en -Duser.region=US"
+</pre>   
+
+      depending on what kind of OS and shell you're using.  
+      For more on how this works, see the page on
+      <a href="StartUpScripts.shtml">startup scripts</a>. 
+      
       <h2><a name="Continuous" id="Continuous">Continuous
       Integration Test Execution</a></h2>The <a href=
       "ContinuousIntegration.shtml">continuous integration
@@ -917,10 +945,22 @@
       <p>Here are a few tips for locating items with Jemmy:</p>
 
       <ul>
-      <li>Some of the Jemmy Operator Constructors allow leaving off an identifier.  If there is only one object of a given type on the screen at any time, it is acceptable to use this version of the constructor, but the test may be fragile.</li>
-      <li>It is easiest to find objects if they have a unique identifier.  In the case where no unique identifier exists, Jemmy provides a version of most searches that allows you to specify an ordinal index.  Using these may result in tests that break when GUI elements are added or removed from the frame.</li>
-      <li>If an item contains its own text (Buttons, for example), it is recommended you use the text to search for a component.</li>
-      <li>If an item does not contain its own description, but the GUI contains a JLabel describing that component, be certain the JLabel's LabelFor property is set.  A Jemmy JLabelOperator can then be used to find the label, and retrieve the object.</li>
+      <li>Some of the Jemmy Operator Constructors allow leaving off an identifier.  
+            If there is only one object of a given type on the screen at any time, 
+            it is acceptable to use this version of the constructor, 
+            but the test may be fragile.</li>
+      <li>It is easiest to find objects if they have a unique identifier.  
+            In the case where no unique identifier exists, 
+            Jemmy provides a version of most searches that allows you to specify an ordinal index.  
+            Using these may result in tests that break when GUI elements are 
+            added or removed from the frame.</li>
+      <li>If an item contains its own text (Buttons, for example), 
+            it is recommended you use the text to search for a component.</li>
+      <li>If an item does not contain its own description,
+            but the GUI contains a JLabel describing that component, 
+            be certain the JLabel's LabelFor property is set.  
+            A Jemmy JLabelOperator can then be used to find the label,
+            and retrieve the object.</li>
       </ul>
 
       <h4>Example of Closing a Dialog Box</h4>

--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -169,7 +169,7 @@
     runs a specific test or test suite.<br>
     (Hint: How to set this up <a href="IntelliJ.shtml#test">using IntelliJ</a>)
 
-      <h3><a name="I18N" id="I18N">A Note on Internationalization (I18N)</h3>
+      <h3><a name="I18N" id="I18N">A Note on Internationalization (I18N)</a></h3>
       
       Tests check the correctness of text in GUI elements, warning messages, and 
       other places. Many of these are 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <jinput.plugins>net.bobis.jinput.hidraw.HidRawEnvironmentPlugin</jinput.plugins>
         <ant.version>1.10.1</ant.version>
         <ant.jvm.args></ant.jvm.args>
-        <argLine>-Xmx1536m</argLine>
+        <argLine>-Xmx1536m -Duser.language=en -Duser.region=US</argLine>
         <surefire.version>2.20</surefire.version>
     </properties>
     <scm>


### PR DESCRIPTION
Updates build.xml (Ant) and pom.xml (Maven) control files to always use the en_US locale when running tests.  This will carry into the CI runs.

Note that this doesn't change targets for running applications (DecoderPro et al), nor when running with e.g. ./runtest.sh and/or native IDEs.

For background, see PR #5916