### PR TITLE
New utility: shorten stack trace

### DIFF
--- a/java/src/jmri/util/Log4JUtil.java
+++ b/java/src/jmri/util/Log4JUtil.java
@@ -1,12 +1,17 @@
 package jmri.util;
 
 import apps.SystemConsole;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
+
+import javax.annotation.Nonnull
+
 import jmri.util.exceptionhandler.UncaughtExceptionHandler;
+
 import org.apache.log4j.Appender;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.FileAppender;
@@ -48,7 +53,7 @@ public class Log4JUtil {
      */
     // Goal is to be lightweight and fast; this will only be used in a few places,
     // and only those should appear in data structure.
-    static public boolean warnOnce(Logger log, String msg, Object... args) {
+    static public boolean warnOnce(@Nonnull Logger log, @Nonnull String msg, Object... args) {
         // the  Map<String, Boolean> is just being checked for existence; it's never False
         Map<String, Boolean> loggerMap = warnedOnce.get(log);
         if (loggerMap == null) {
@@ -86,7 +91,7 @@ public class Log4JUtil {
      *
      * @param controlfile the logging control file
      */
-    static public void initLogging(String controlfile) {
+    static public void initLogging(@Nonnull String controlfile) {
         initLog4J(controlfile);
     }
 
@@ -102,7 +107,7 @@ public class Log4JUtil {
      * @see jmri.util.FileUtil#getPreferencesPath()
      * @see jmri.util.FileUtil#getProgramPath()
      */
-    static void initLog4J(String logFile) {
+    static void initLog4J(@Nonnull String logFile) {
         if (log4JSetUp) {
             log.debug("initLog4J already initialized!");
             return;
@@ -148,7 +153,7 @@ public class Log4JUtil {
     }
 
     @SuppressWarnings("unchecked")
-    static public String startupInfo(String program) {
+    static public @Nonnull String startupInfo(@Nonnull String program) {
         log.info(jmriLog);
         Enumeration<org.apache.log4j.Logger> e = org.apache.log4j.Logger.getRootLogger().getAllAppenders();
         while (e.hasMoreElements()) {
@@ -175,9 +180,9 @@ public class Log4JUtil {
      *
      * @see jmri.util.FileUtil#getPreferencesPath()
      */
-    static private void configureLogging(String config) throws IOException {
+    static private void configureLogging(@Nonnull String configFile) throws IOException {
         Properties p = new Properties();
-        try (FileInputStream f = new FileInputStream(config)) {
+        try (FileInputStream f = new FileInputStream(configFile)) {
             p.load(f);
         }
 
@@ -196,4 +201,18 @@ public class Log4JUtil {
         PropertyConfigurator.configure(p);
     }
 
+    /**
+     * Shorten this stack trace in a Throwable.  If you then pass it to 
+     * Log4J for logging, it'll take up less space.
+     * @param t The Throwable to truncate and return
+     * @param len The number of stack trace entries to keep.
+     * @return THe original object with truncated stack trace
+     */
+    public static <T extends Throwable> @Nonnull T shortenStacktrace(@Nonnull T t, int len) {
+        StackTraceElement[]	originalTrace = t.getStackTrace();
+        StackTraceElement[] newTrace = new StackTraceElement[len];
+        for (int i = 0; i < len; i++) newTrace[i] = originalTrace[i];
+        t.setStackTrace(newTrace);
+        return t;
+    }
 }

--- a/java/src/jmri/util/Log4JUtil.java
+++ b/java/src/jmri/util/Log4JUtil.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
 
-import javax.annotation.Nonnull
+import javax.annotation.Nonnull;
 
 import jmri.util.exceptionhandler.UncaughtExceptionHandler;
 

--- a/java/src/jmri/util/Log4JUtil.java
+++ b/java/src/jmri/util/Log4JUtil.java
@@ -208,7 +208,7 @@ public class Log4JUtil {
      * @param len The number of stack trace entries to keep.
      * @return THe original object with truncated stack trace
      */
-    public static <T extends Throwable> @Nonnull T shortenStacktrace(@Nonnull T t, int len) {
+    public  @Nonnull static <T extends Throwable> T shortenStacktrace(@Nonnull T t, int len) {
         StackTraceElement[]	originalTrace = t.getStackTrace();
         StackTraceElement[] newTrace = new StackTraceElement[len];
         for (int i = 0; i < len; i++) newTrace[i] = originalTrace[i];

--- a/java/test/jmri/util/Log4JUtilTest.java
+++ b/java/test/jmri/util/Log4JUtilTest.java
@@ -57,6 +57,14 @@ public class Log4JUtilTest {
 
         Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
     }
+    
+    @Test
+    public void testShortenStacktrace() {
+        IllegalArgumentException ex = new IllegalArgumentException("for test");
+        Assert.assertTrue("Needs long enough trace for test", ex.getStackTrace().length > 3);
+        
+        Assert.assertEquals(3, Log4JUtil.shortenStacktrace(ex, 3).getStackTrace().length);
+    }
 
     // The minimal setup for log4J
     @Before

--- a/java/test/jmri/util/junit/TestClassMainMethod.java
+++ b/java/test/jmri/util/junit/TestClassMainMethod.java
@@ -17,6 +17,7 @@ public class TestClassMainMethod {
         className = className.replace("//","/");    
         if (className.endsWith(".java")) className = className.replace(".java","");
         if (className.startsWith("java/test/")) className = className.replace("java/test/","");
+        if (className.startsWith("java/src/")) className = className.replace("java/src/","");
         if (className.startsWith("/")) className = className.substring(1, className.length());
 
         // as a convenience, allow e.g. jmri/BundleTest in addition to jmri.BundleTest


### PR DESCRIPTION
- add shortenStacktrace() which, well, shortens a stack trace so it doesn't take so much space in a log. Useful if you want to print a bunch of trace-backs to find a problem.
- Annotate methods in Log4JUtil
