### PR TITLE
Update of LAISDCC decoder definition

### DIFF
--- a/xml/decoders/LaisDcc.xml
+++ b/xml/decoders/LaisDcc.xml
@@ -16,6 +16,7 @@
   <version author="Alain Le Marchand" version="2" lastUpdated="20170408"/>
   <version author="Stanley@laisdcc.com" version="3" lastUpdated="20180103"/>
   <version author="Alain Le Marchand" version="4" lastUpdated="20180106"/>
+  <version author="Alain Carasso" version="5" lastUpdated="20181008"/>
   <!-- Version 1: original version from LaisDCC website                                  -->
   <!-- Version 2: updated low and high values for decoder version, based on real models -->
   <!--            Updated manufacturer name to "LaisDCC" - with capital lettter for DCC -->
@@ -35,9 +36,13 @@
   <!--            - Removed CV15 CV lock: used for dynamic programming                  -->
   <!--              not as permanent value. Not in JMRI to avoid errors.                -->
   <!--            Added 860010/LaisDcc-Z2                                               -->
+  <!-- Version 5: highversionID modified up to 6 to take care of newer decoder family:           -->
+  <!--            - replaced old decoder model based on form factor by new model,based on available outputs    -->
+  <!--            - unavailable fonctions output  will not show on, the Function map pane              -->
   <decoder>
-    <family name="Locomotive Decoders" mfg="LaisDCC" comment="LaisDCC decoder range" lowVersionID="02" highVersionID="04">
-      <model model="860010/LaisDcc-Z2" numOuts="2" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860010" formFactor="Z" connector="Wires" comment="Z/N scale, wires NEM651">
+    <family name="Locomotive Decoders" mfg="LaisDCC" comment="LaisDCC decoder range" lowVersionID="02" highVersionID="06">
+  <!--           old models not showing anymore  -->
+      <model show="no" model="860010/LaisDcc-Z2" numOuts="2" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860010" formFactor="Z" connector="Wires" comment="Z/N scale, wires NEM651">
         <output name="1" label="White|Pin 5" connection="wire" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Pin 6" connection="wire" maxcurrent="100 mA"/>
         <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
@@ -46,7 +51,7 @@
         <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
         <size length="13.3" width="7.3" height="3.8" units="mm"/>
       </model>
-      <model model="860012" numOuts="2" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860012" formFactor="N" connector="Wires" comment="N scale, wires NEM651">
+      <model show="no" model="860012" numOuts="2" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860012" formFactor="N" connector="Wires" comment="N scale, wires NEM651">
         <output name="1" label="White|Pin 5" connection="wire" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Pin 6" connection="wire" maxcurrent="100 mA"/>
         <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
@@ -55,7 +60,7 @@
         <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
         <size length="14.5" width="8.2" height="3" units="mm"/>
       </model>
-      <model model="860013" numOuts="2" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860013" formFactor="N" connector="NEM651" comment="N scale, 6-pin direct NEM651 plug">
+      <model show="no" model="860013" numOuts="2" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860013" formFactor="N" connector="NEM651" comment="N scale, 6-pin direct NEM651 plug">
         <output name="1" label="White|Pin 5" connection="plug" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Pin 6" connection="plug" maxcurrent="100 mA"/>
         <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
@@ -64,7 +69,7 @@
         <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
         <size length="14.5" width="8.2" height="3" units="mm"/>
       </model>
-      <model model="860014" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860014" formFactor="HO" connector="Wires" comment="HO-scale, 9 Wires">
+      <model show="no" model="860014" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860014" formFactor="HO" connector="Wires" comment="HO-scale, 9 Wires">
         <output name="1" label="White|Wire" connection="wire" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Wire" connection="wire" maxcurrent="100 mA"/>
         <output name="3" label="Green|Wire" connection="wire" maxcurrent="100 mA"/>
@@ -75,7 +80,7 @@
         <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
         <size length="15" width="7" height="2.7" units="mm"/>
       </model>
-			<model model="860015" numOuts="6" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860015" formFactor="HO" connector="Next18" comment="HO-scale, with Next18 harness">
+			<model show="no" model="860015" numOuts="6" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860015" formFactor="HO" connector="Next18" comment="HO-scale, with Next18 harness">
         <output name="1" label="White|Pin 8" connection="plug" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Pin 17" connection="plug" maxcurrent="100 mA"/>
         <output name="3" label="Green|Pin 3" connection="plug" maxcurrent="100 mA"/>
@@ -88,7 +93,7 @@
         <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
         <size length="15" width="9.5" height="2.9" units="mm"/>
       </model>
-			<model model="860016" numOuts="6" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860016" formFactor="HO" connector="PluX22" comment="HO-scale, with Plux22 harness">
+			<model show="no" model="860016" numOuts="6" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860016" formFactor="HO" connector="PluX22" comment="HO-scale, with Plux22 harness">
         <output name="1" label="White|Pin 7" connection="plug" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Pin 13" connection="plug" maxcurrent="100 mA"/>
         <output name="3" label="Green|Pin 16" connection="plug" maxcurrent="100 mA"/>
@@ -102,7 +107,7 @@
         <size length="16" width="17.5" height="3" units="mm"/>
       </model>
       <!-- Model 860018 replaced by 860020 -->
-      <model show="maybe" model="860018" replacementModel="860020" replacementFamily="Locomotive Decoders" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860018" formFactor="HO" connector="NEM652" comment="HO-scale, direct NEM652 + wire for F2">
+      <model show="no" model="860018" replacementModel="860020" replacementFamily="Locomotive Decoders" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860018" formFactor="HO" connector="NEM652" comment="HO-scale, direct NEM652 + wire for F2">
         <output name="1" label="White|Pin 6" connection="plug" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Pin 2" connection="plug" maxcurrent="100 mA"/>
         <output name="3" label="Green|Pin 3" connection="plug" maxcurrent="100 mA"/>
@@ -113,7 +118,7 @@
         <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
         <size length="14.2" width="12.5" height="3.5" units="mm"/>
       </model>
-      <model model="860019" numOuts="6" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860019" formFactor="HO" connector="21MTC" comment="HO-scale, with 21MTC harness">
+      <model show="no" model="860019" numOuts="6" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860019" formFactor="HO" connector="21MTC" comment="HO-scale, with 21MTC harness">
         <output name="1" label="White|Pin 8" connection="plug" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Pin 7" connection="plug" maxcurrent="100 mA"/>
         <output name="3" label="Green|Pin 15" connection="plug" maxcurrent="100 mA"/>
@@ -126,7 +131,7 @@
         <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
         <size length="17" width="16" height="3.5" units="mm"/>
       </model>
-      <model model="860020" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860020" formFactor="HO" connector="NEM652" comment="HO-scale, direct NEM652 + wire for F2">
+      <model show="no" model="860020" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860020" formFactor="HO" connector="NEM652" comment="HO-scale, direct NEM652 + wire for F2">
         <output name="1" label="White|Pin 6" connection="plug" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Pin 2" connection="plug" maxcurrent="100 mA"/>
         <output name="3" label="Green|Pin 3" connection="plug" maxcurrent="100 mA"/>
@@ -137,7 +142,7 @@
         <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
         <size length="15" width="15" height="3.5" units="mm"/>
       </model>
-      <model model="860021" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860021" formFactor="HO" connector="Wires/NEM652" comment="HO-scale, Wires and NEM652">
+      <model show="no" model="860021" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860021" formFactor="HO" connector="Wires/NEM652" comment="HO-scale, Wires and NEM652">
         <output name="1" label="White|Pin 6" connection="plug" maxcurrent="100 mA"/>
         <output name="2" label="Yellow|Pin 2" connection="plug" maxcurrent="100 mA"/>
         <output name="3" label="Green|Pin 3" connection="plug" maxcurrent="100 mA"/>
@@ -148,6 +153,44 @@
         <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
         <size length="15" width="7" height="2.7" units="mm"/>
       </model>
+  <!--      new models based on available outputs defined, without form factor   -->
+      <model model="8x00nn - 2 outputs" numOuts="2" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860012" formFactor="N" connector="Wires" comment="N scale, wires NEM651">
+        <output name="1" label="White|Pin 5" connection="wire" maxcurrent="100 mA"/>
+        <output name="2" label="Yellow|Pin 6" connection="wire" maxcurrent="100 mA"/>
+        <output name="3" label="|"/>
+        <output name="4" label="|"/>
+        <output name="5" label="|"/>
+        <output name="6" label="|"/>
+        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
+        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
+        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
+        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
+     </model>
+    <model model="8x00nn - 4 outputs" numOuts="4" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860021" formFactor="HO" connector="Wires/NEM652" comment="HO-scale, Wires and NEM652">
+        <output name="1" label="White|Pin 6" connection="plug" maxcurrent="100 mA"/>
+        <output name="2" label="Yellow|Pin 2" connection="plug" maxcurrent="100 mA"/>
+        <output name="3" label="Green|Pin 3" connection="plug" maxcurrent="100 mA"/>
+        <output name="4" label="Purple|Wire" connection="wire" maxcurrent="100 mA"/>
+        <output name="5" label="|"/>
+        <output name="6" label="|"/>
+        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
+        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
+        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
+        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
+       </model>
+      <model model="8x00nn - 6 outputs" numOuts="6" numFns="14" maxMotorCurrent="1A (peak=2A)" productID="860019" formFactor="HO" connector="21MTC" comment="HO-scale, with 21MTC harness">
+        <output name="1" label="White|Pin 8" connection="plug" maxcurrent="100 mA"/>
+        <output name="2" label="Yellow|Pin 7" connection="plug" maxcurrent="100 mA"/>
+        <output name="3" label="Green|Pin 15" connection="plug" maxcurrent="100 mA"/>
+        <output name="4" label="Purple|Pin 14" connection="plug" maxcurrent="100 mA"/>
+        <output name="5" label="Pink|Pin 13" connection="plug" maxcurrent="100 mA"/>
+        <output name="6" label="Brown|Pin 4"  connection="plug" maxcurrent="100 mA"/>
+        <output name="7" label="Rule 17|Dimming"/>	<!-- virtual "output" -->
+        <output name="8" label="Ditch|Blink"/>		<!-- virtual "output" -->
+        <output name="9" label="Motor|Control"/>	<!-- virtual "output" -->
+        <output name="10" label="BEMF|Control"/>	<!-- virtual "output" -->
+      </model>
+ 
     </family>
     <programming direct="yes" paged="yes" register="yes" ops="yes"/>
     <variables>
@@ -156,7 +199,7 @@
           <decVal max="255"/>
           <label>Start voltage</label>
           <label xml:lang="it">Volt Partenza</label>
-          <label xml:lang="fr">V démarr.</label>
+          <label xml:lang="fr">V dÃ©marr.</label>
           <label xml:lang="de">Anfahrspannung</label>
           <comment>Range 0-255, 0 in CV 2, 6, 5 produces straight line acceleration</comment>
         </variable>
@@ -164,15 +207,15 @@
           <decVal max="255"/>
           <label>Acceleration Rate</label>
           <label xml:lang="it">Accellerazione (0-255)</label>
-          <label xml:lang="fr">Accelération (0-255)</label>
-          <label xml:lang="de">Anfahrverzögerung (0-255)</label>
+          <label xml:lang="fr">AccelÃ©ration (0-255)</label>
+          <label xml:lang="de">AnfahrverzÃ¶gerung (0-255)</label>
           <comment>Range 0-255</comment>
         </variable>
         <variable CV="4" item="Decel" default="3" tooltip="Sets the deceleration rate (delay or momentum), range 0-255">
           <decVal max="255"/>
                                   <label>Deceleration Rate</label>
           <label xml:lang="it">Decellerazione (0-255)</label>
-          <label xml:lang="fr">Décélération (0-255)</label>
+          <label xml:lang="fr">DÃ©cÃ©lÃ©ration (0-255)</label>
           <label xml:lang="de">Bremszeit (0-255)</label>
           <comment>Range 0-255</comment>
         </variable>
@@ -181,7 +224,7 @@
           <label>Maximum Voltage</label>
           <label xml:lang="it">Volt Massimi</label>
           <label xml:lang="fr">Vmax</label>
-          <label xml:lang="de">Höchstgeschwindigkeit</label>
+          <label xml:lang="de">HÃ¶chstgeschwindigkeit</label>
           <comment>Range 0-255, A value of 255 corresponds to 100%. 0 in CV 2, 6, 5 produces straight line acceleration</comment>
         </variable>
         <variable CV="6" item="Vmid" tooltip="sets the motor voltage at midrange throttle Speed Setting, range 0(default)-255">
@@ -196,7 +239,7 @@
           <decVal/>
           <label>Manufacturer Version No: </label>
           <label xml:lang="it">Versione Decoder: </label>
-          <label xml:lang="fr">Version décodeur: </label>
+          <label xml:lang="fr">Version dÃ©codeur: </label>
           <label xml:lang="de">Decoder Version: </label>
         </variable>
         <variable CV="8" readOnly="yes" item="Manufacturer" default="134" tooltip="Decoder Maker, Read Only">
@@ -213,98 +256,98 @@
         <variable item="Analog Mode Function Status - F1" CV="13" mask="XXXXXXXV" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F1</label>
-            <label xml:lang="fr">État de la fonction en analogique - F1</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F1</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F1</label>
             <label>Analog Mode Function Status - F1</label>
         </variable>
         <variable item="Analog Mode Function Status - F2" CV="13" mask="XXXXXXVX" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F2</label>
-            <label xml:lang="fr">État de la fonction en analogique - F2</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F2</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F2</label>
             <label>Analog Mode Function Status - F2</label>
         </variable>
         <variable item="Analog Mode Function Status - F3" CV="13" mask="XXXXXVXX" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F3</label>
-            <label xml:lang="fr">État de la fonction en analogique - F3</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F3</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F3</label>
             <label>Analog Mode Function Status - F3</label>
         </variable>
         <variable item="Analog Mode Function Status - F4" CV="13" mask="XXXXVXXX" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F4</label>
-            <label xml:lang="fr">État de la fonction en analogique - F4</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F4</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F4</label>
             <label>Analog Mode Function Status - F4</label>
         </variable>
         <variable item="Analog Mode Function Status - F5" CV="13" mask="XXXVXXXX" default="1">
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
                 <label xml:lang="it">Stato Funzioni in analogico - F5</label>
-                <label xml:lang="fr">État de la fonction en analogique - F5</label>
+                <label xml:lang="fr">Ã‰tat de la fonction en analogique - F5</label>
                 <label xml:lang="de">Funktionsstatus im Analogbetrieb - F5</label>
                 <label>Analog Mode Function Status - F5</label>
         </variable>
         <variable item="Analog Mode Function Status - F6" CV="13" mask="XXVXXXXX" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F6</label>
-            <label xml:lang="fr">État de la fonction en analogique - F6</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F6</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F6</label>
             <label>Analog Mode Function Status - F6</label>
         </variable>
         <variable item="Analog Mode Function Status - F7" CV="13" mask="XVXXXXXX" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F7</label>
-            <label xml:lang="fr">État de la fonction en analogique - F7</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F7</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F7</label>
             <label>Analog Mode Function Status - F7</label>
         </variable>
         <variable item="Analog Mode Function Status - F8" CV="13" mask="VXXXXXXX" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F8</label>
-            <label xml:lang="fr">État de la fonction en analogique - F8</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F8</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F8</label>
             <label>Analog Mode Function Status - F8</label>
         </variable>
         <variable item="Analog Mode Function Status - F0(f)" CV="14" mask="XXXXXXXV" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F0(f)</label>
-            <label xml:lang="fr">État de la fonction en analogique - F0(f)</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F0(f)</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F0(f)</label>
             <label>Analog Mode Function Status - F0(f)</label>
         </variable>
         <variable item="Analog Mode Function Status - F0(r)" CV="14" mask="XXXXXXVX" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F0(r)</label>
-            <label xml:lang="fr">État de la fonction en analogique - F0(r)</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F0(r)</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F0(r)</label>
             <label>Analog Mode Function Status - F0(r)</label>
         </variable>
         <variable item="Analog Mode Function Status - F9" CV="14" mask="XXXXXVXX" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F9</label>
-            <label xml:lang="fr">État de la fonction en analogique - F9</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F9</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F9</label>
             <label>Analog Mode Function Status - F9</label>
         </variable>
         <variable item="Analog Mode Function Status - F10" CV="14" mask="XXXXVXXX" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F10</label>
-            <label xml:lang="fr">État de la fonction en analogique - F10</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F10</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F10</label>
             <label>Analog Mode Function Status - F10</label>
         </variable>
         <variable item="Analog Mode Function Status - F11" CV="14" mask="XXXVXXXX" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F11</label>
-            <label xml:lang="fr">État de la fonction en analogique - F11</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F11</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F11</label>
             <label>Analog Mode Function Status - F11</label>
         </variable>
         <variable item="Analog Mode Function Status - F12" CV="14" mask="XXVXXXXX" default="1">
             <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>
             <label xml:lang="it">Stato Funzioni in analogico - F12</label>
-            <label xml:lang="fr">État de la fonction en analogique - F12</label>
+            <label xml:lang="fr">Ã‰tat de la fonction en analogique - F12</label>
             <label xml:lang="de">Funktionsstatus im Analogbetrieb - F12</label>
             <label>Analog Mode Function Status - F12</label>
         </variable>


### PR DESCRIPTION
This update will take care of the higher version available in CV7 (6 instead of current limitation 4), thus highVersionID field is now 6.

I also made unavailable previous decoders models based on form factor and DCC plugs and replaced them by definitions based on function outputs (2, 4 or 6 depending on the DCC plug of the decoder).

All changes based on excellent suggestions made by Dave Heap in previous PR#5948 and #5964 closed.