### PR TITLE
Update HornbyTTS.xml

### DIFF
--- a/xml/decoders/HornbyTTS.xml
+++ b/xml/decoders/HornbyTTS.xml
@@ -88,45 +88,44 @@
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>	
             </model>
-			<model model="Hornby TTS Class 20" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="159">
+	    <model model="Hornby TTS Class 20" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="159">
                 <versionCV lowVersionID="2" highVersionID="132"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>	
             </model>
-			<model model="Hornby TTS Class 31" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="161">
+	    <model model="Hornby TTS Class 31" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="161">
                 <versionCV lowVersionID="2" highVersionID="132"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
-			</model>
+	    </model>
             <model model="Hornby TTS Class 37" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="cl37,147">
                 <versionCV lowVersionID="2" highVersionID="132"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
-			</model>
+	    </model>
             <model model="Hornby TTS Class 40" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="151">
                 <versionCV lowVersionID="120" highVersionID="120"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>	
             </model>
-			<model model="Hornby TTS Class 43 HST (Valenta)" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="181">    
-			    <versionCV lowVersionID="2" highVersionID="132"/>
+	    <model model="Hornby TTS Class 43 HST (Valenta)" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="181">    
+		<versionCV lowVersionID="2" highVersionID="132"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
             </model>
-			<model model="Hornby TTS Class 43 HST (MTU)" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="157">    
-			    <versionCV lowVersionID="2" highVersionID="132"/>
+	    <model model="Hornby TTS Class 43 HST (MTU)" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="157">    
+	        <versionCV lowVersionID="2" highVersionID="132"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
             </model>
             <model model="Hornby TTS Class 47" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="149">    
-			
-                <versionCV lowVersionID="2" highVersionID="132"/>
+	        <versionCV lowVersionID="2" highVersionID="132"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
@@ -149,12 +148,12 @@
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
             </model>
-			<model model="Hornby TTS Duke of Gloucester" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="DoG, 131">
+	    <model model="Hornby TTS Duke of Gloucester" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="DoG, 131">
                 <versionCV lowVersionID="90" highVersionID="99"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
-			</model>
+	    </model>
             <model model="Hornby TTS Flying Scotsman" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="137">
                 <versionCV lowVersionID="2" highVersionID="120"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
@@ -167,12 +166,12 @@
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
             </model>
-			 <model model="Hornby TTS P2 2-8-2" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="133">
+	    <model model="Hornby TTS P2 2-8-2" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="133">
                 <versionCV lowVersionID="2" highVersionID="132"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
-			</model>	
+	    </model>	
             <model model="Hornby TTS 9F 2-10-0" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="655">
                 <versionCV lowVersionID="2" highVersionID="120"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>

--- a/xml/decoders/HornbyTTS.xml
+++ b/xml/decoders/HornbyTTS.xml
@@ -13,7 +13,11 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-    <version author="Brian Jackson" version="1.7" lastUpdated="20180901"/>
+    	<version author="Brian Jackson brian-jackson1@blueyonder.co.uk" version="1.9" lastUpdated="20181009"/>
+	<version author="Brian Jackson" version="1.10" lastUpdated="20181001"/>
+	<version author="Brian Jackson" version="1.9" lastUpdated="20180916"/>
+	<version author="Brian Jackson" version="1.8" lastUpdated="20180912"/>
+	<version author="Brian Jackson" version="1.7" lastUpdated="20180901"/>
 	<version author="Brian Jackson" version="1.6" lastUpdated="20180826"/>
 	<version author="Brian Jackson" version="1.5" lastUpdated="20180825"/>
 	<version author="Dave Heap" version="1.4" lastUpdated="23170520"/>
@@ -54,7 +58,28 @@
 				Class 43 (valenta) _= 181
 				Class 43 (MTU) _	= 157
 				Added option of factory reset of sound volumes only using value of 5 in CV8
-	-->	
+	-->
+	<!--  Version 1.8 added Class 5MT 4-6-0 Black 5 ID 171  -->
+	<!--  Version 1.9 added and explanation of how composite product ID value is achieved:
+				Hall Class 4-6-0					ID 2699  CV 158 = 10,  CV159 = 139 
+				Castle Class 4-6-0 					ID 	139 hidden awaiting manual to associate the correct sound level cv's
+				S15 Class 4-6-0   					ID	179 hidden awaiting manual to associate the correct sound level cv's
+				Coronation Class 4-6-2 				ID	177 hidden awaiting manual to associate the correct sound level cv's
+				Peppercorn Class A1 4-6=2 (Tornado)	ID 	129 hidden awaiting manual to associate the correct sound level cv's
+				Merchant Navy Class 4-6-2			ID 	169	hidden awaiting manual to associate the correct sound level cv's
+				6000 King Class 4-6-0				ID 	141 hidden awaiting manual to associate the correct sound level cv's
+				Lord Nelson Class 4-6-2				ID 	183 hidden awaiting manual to associate the correct sound level cv's
+				
+	-->
+	<!--  Version 1.10 king  class and merchant navy class now showing in list after finding sound manual -->
+	<!--  Version 1.11 the following alterations and additions have been made
+				Peppercorm A1 Tornado now showing in list live after receiving copy of sound manual 
+				Class 08 missing sound level CV's added and corrected error in V1.7 regarding CV166 having two horn definitions
+	-->
+	<!-- NOTE - FOR DECODERS WITH IDENTICAL CV159 VALUES, CV158 IS USED AS THE LOW BYTE AND CV159 THE HIGH BYTE
+			EXAMPLE   CV 158 = 10 BINARY IS 00001010  CV159 = 139 BINARY IS 10001011
+			COMPOSITE PRODUCT ID VALUE BECOMES 0000101010001011 WHICH IN DECIMAL IS 2699
+	-->		
     <decoder>
         <family name="Hornby TTS Sound Decoder" mfg="Hornby" comment="">
             <model model="Hornby TTS Class 08" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="175">
@@ -106,12 +131,18 @@
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
             </model>
-			 <model model="Hornby TTS Class 60" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="163">
+	    <model model="Hornby TTS Class 60" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="163">
                 <versionCV lowVersionID="2" highVersionID="132"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
             </model>
+	    <model model="Hornby TTS Class 66" show="no" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="153">
+                <versionCV lowVersionID="2" highVersionID="132"/>
+                <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
+                <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
+                <output name="Aux" label="Gr" maxcurrent="0.1A"/>
+            </model>	
             <model model="Hornby TTS Class 67" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="153">
                 <versionCV lowVersionID="2" highVersionID="132"/>
                 <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
@@ -166,6 +197,60 @@
                 <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
                 <output name="Aux" label="Gr" maxcurrent="0.1A"/>
             </model>
+		<model model="Hornby TTS 5MT Black 5 4-6-0" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="171">
+                <versionCV lowVersionID="2" highVersionID="132"/>
+                <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
+                <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
+                <output name="Aux" label="Gr" maxcurrent="0.1A"/>
+            </model>
+	    <model model="Hornby TTS Hall Class 4-6-0" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="2699">
+                <versionCV lowVersionID="2" highVersionID="120"/>
+                <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
+                <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
+                <output name="Aux" label="Gr" maxcurrent="0.1A"/>
+	    </model>
+	    <model model="Hornby TTS Castle Class 4-6-0" show="no" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="139">
+                <versionCV lowVersionID="2" highVersionID="120"/>
+                <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
+                <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
+                <output name="Aux" label="Gr" maxcurrent="0.1A"/>
+	    </model>
+	    <model model="Hornby TTS S15 Class 4-6-0" show="no" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="179">
+                <versionCV lowVersionID="2" highVersionID="120"/>
+                <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
+                <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
+                <output name="Aux" label="Gr" maxcurrent="0.1A"/>
+	    </model>
+	    <model model="Hornby TTS Coronation Class 4-6-2" show="no" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="177">
+                <versionCV lowVersionID="2" highVersionID="120"/>
+                <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
+                <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
+                <output name="Aux" label="Gr" maxcurrent="0.1A"/>
+	    </model>
+	    <model model="Hornby TTS Peppercorn Class A1 4-6-2 (Tornado)" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="129">
+                <versionCV lowVersionID="1" highVersionID="1"/>
+                <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
+                <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
+                <output name="Aux" label="Gr" maxcurrent="0.1A"/>
+	    </model>
+	    <model model="Hornby TTS Merchant Navy Class 4-6-2" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="169">
+                <versionCV lowVersionID="2" highVersionID="120"/>
+                <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
+                <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
+                <output name="Aux" label="Gr" maxcurrent="0.1A"/>
+	    </model>
+	    <model model="Hornby TTS 6000 King Class 4-6-0" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="141">
+                <versionCV lowVersionID="2" highVersionID="120"/>
+                <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
+                <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
+                <output name="Aux" label="Gr" maxcurrent="0.1A"/>
+	    </model>
+	    <model model="Hornby TTS Lord Nelson Class 4-6-2" show="no" numOuts="3" numFns="30" maxMotorCurrent="1.0A" formFactor="HO" maxTotalCurrent="1.0A" productID="181">
+                <versionCV lowVersionID="2" highVersionID="120"/>
+                <output name="Headlight" label="Wh" maxcurrent="0.1A"/>
+                <output name="Rear Light" label="Ye" maxcurrent="0.1A"/>
+                <output name="Aux" label="Gr" maxcurrent="0.1A"/>
+	    </model>
         </family>
         <programming direct="yes" paged="yes" register="yes" ops="yes"/>
         <variables>
@@ -222,11 +307,11 @@
                 <decVal/>
                 <label>Decoder sound ID: </label>
             </variable>
-            <variable CV="160" default="4" item="Sound Setting 1" tooltip="Range 0-8" comment="Range 0-8" include="DoG,131,133,135,137,2703,655,145">
+            <variable CV="160" default="4" item="Sound Setting 1" tooltip="Range 0-8" comment="Range 0-8" include="DoG,129,131,133,135,137,139,141,169,2699,2703,655,145,171,179">
                 <decVal max="8"/>
                 <label>Background Steam, Cylinder Cocks</label>
             </variable>
-            <variable CV="161" default="4" item="Sound Setting 22" tooltip="F1 Volume" comment="Range 0-8" include="DoG,131,133,135,137,2703,655,145">
+            <variable CV="161" default="4" item="Sound Setting 22" tooltip="F1 Volume" comment="Range 0-8" include="DoG,129,131,133,135,137,139,141,169,2699,2703,655,145,171,179">
                 <decVal max="8"/>
                 <label>Locomotive Running - accelerating</label>
             </variable>
@@ -234,23 +319,43 @@
                 <decVal max="8"/>
                 <label>Engine Startup/Shutdown</label>
             </variable>
-            <variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="DoG,131,135,2703,655,145,175">
+            <variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="DoG,131,135,169,2703,655,145,175,179">
                 <decVal max="8"/>
                 <label>Long Whistle</label>
+            </variable>
+	    <variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="139,2699">
+                <decVal max="8"/>
+                <label>Low Whistle</label>
+            </variable>
+	    <variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="171">
+                <decVal max="8"/>
+                <label>Long Whistle + 2 short bursts</label>
+            </variable>
+	    <variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="141">
+                <decVal max="8"/>
+                <label>Medium Whistle</label>
+            </variable>
+	    <variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="139">
+                <decVal max="8"/>
+                <label>Long Passing Whistle</label>
             </variable>
             <variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="137">
                 <decVal max="8"/>
                 <label>Four Burst Whistle</label>
             </variable>
-			<variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="133">
+	    <variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="133">
                 <decVal max="8"/>
                 <label>Chime Whistle Long</label>
+            </variable>
+	    <variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="129">
+                <decVal max="8"/>
+                <label>Chime Whistle</label>
             </variable>
             <variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="Cl37,147,149,151,153,159,161">
                 <decVal max="8"/>
                 <label>Horn High-Low</label>
             </variable>
-			<variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="163">
+	    <variable CV="162" default="4" item="Sound Setting 2"  tooltip="F2 Volume" comment="Range 0-8" include="163">
                 <decVal max="8"/>
                 <label>Horn Low-High</label>
             </variable>
@@ -258,41 +363,61 @@
                 <decVal max="8"/>
                 <label>Coupler Clank</label>
             </variable>
-            <variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="137,175">
+            <variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="137,139,175,2699">
                 <decVal max="8"/>
                 <label>Two Burst Whistle</label>
             </variable>
-            <variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="2703,655,145">
+            <variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="2703,655,145,169,171,179">
                 <decVal max="8"/>
                 <label>Medium Whistle</label>
             </variable>
-            <variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="135">
+            <variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="135,139">
                 <decVal max="8"/>
                 <label>Short Whistle 1</label>
             </variable>
-			<variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="133">
+	    <variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="141">
+                <decVal max="8"/>
+                <label>Long Whistle</label>
+            </variable>
+	    <variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="129">
                 <decVal max="8"/>
                 <label>Chime Whistle Short</label>
+            </variable>
+	    <variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="133">
+                <decVal max="8"/>
+                <label>Screech Whistle</label>
             </variable>
             <variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="Cl37,147,149,151,153,159,161">
                 <decVal max="8"/>
                 <label>Horn Low-High</label>
             </variable>
-			<variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="163">
+	    <variable CV="163" default="4" item="Sound Setting 3"  tooltip="F3 Volume"  comment="Range 0-8" include="163">
                 <decVal max="8"/>
                 <label>Horn High-Low</label>
             </variable>
-            <variable CV="164" default="4" item="Sound Setting 4"  tooltip="F4 Volume"  comment="Range 0-8" include="DoG,131,137,2703,655,145">
+            <variable CV="164" default="4" item="Sound Setting 4"  tooltip="F4 Volume"  comment="Range 0-8" include="DoG,131,137,141,2703,655,145,169,179">
                 <decVal max="8"/>
                 <label>Short Whistle</label>
             </variable>
-            <variable CV="164" default="4" item="Sound Setting 4"  tooltip="F4 Volume"  comment="Range 0-8" include="135">
+	    <variable CV="164" default="4" item="Sound Setting 4"  tooltip="F4 Volume"  comment="Range 0-8" include="139,2699">
+                <decVal max="8"/>
+                <label>Whistle High</label>
+            </variable>
+	    <variable CV="164" default="4" item="Sound Setting 4"  tooltip="F4 Volume"  comment="Range 0-8" include="129">
+                <decVal max="8"/>
+                <label>Long Chime Whistle</label>
+            </variable>
+            <variable CV="164" default="4" item="Sound Setting 4"  tooltip="F4 Volume"  comment="Range 0-8" include="135,139">
                 <decVal max="8"/>
                 <label>Short Whistle 2</label>
             </variable>
-			<variable CV="164" default="4" item="Sound Setting 4"  tooltip="F4 Volume"  comment="Range 0-8" include="133">
+	    <variable CV="164" default="4" item="Sound Setting 4"  tooltip="F4 Volume"  comment="Range 0-8" include="133">
                 <decVal max="8"/>
                 <label>Chime Whistle Two bursts</label>
+            </variable>
+	    <variable CV="164" default="4" item="Sound Setting 4"  tooltip="F4 Volume"  comment="Range 0-8" include="171">
+                <decVal max="8"/>
+                <label>Whistle Medium + Short Burst</label>
             </variable>
             <variable CV="164" default="4" item="Sound Setting 4"  tooltip="F4 Volume"  comment="Range 0-8" include="Cl37,147,149,151,153,159,161,163,175">
                 <decVal max="8"/>
@@ -306,15 +431,31 @@
                 <decVal max="8"/>
                 <label>Door Slamming</label>
             </variable>
-            <variable CV="165" default="4" item="Sound Setting 5"  tooltip="F5 Volume"  comment="Range 0-8" include="2703,655,145">
+            <variable CV="165" default="4" item="Sound Setting 5"  tooltip="F5 Volume"  comment="Range 0-8" include="2703,655,139,141,145,179">
                 <decVal max="8"/>
                 <label>Two Burst Whistle</label>
             </variable>
-			<variable CV="165" default="4" item="Sound Setting 5"  tooltip="F5 Volume"  comment="Range 0-8" include="133">
+	    <variable CV="165" default="4" item="Sound Setting 5"  tooltip="F5 Volume"  comment="Range 0-8" include="171">
+                <decVal max="8"/>
+                <label>Very Short Two Burst Whistle</label>
+            </variable>
+	    <variable CV="165" default="4" item="Sound Setting 5"  tooltip="F5 Volume"  comment="Range 0-8" include="139,2699">
+                <decVal max="8"/>
+                <label>Whistle Short</label>
+            </variable>
+	    <variable CV="165" default="4" item="Sound Setting 5"  tooltip="F5 Volume"  comment="Range 0-8" include="129">
+                <decVal max="8"/>
+                <label>Short Screech Whistle</label>
+            </variable>
+	    <variable CV="165" default="4" item="Sound Setting 5"  tooltip="F5 Volume"  comment="Range 0-8" include="169">
+                <decVal max="8"/>
+                <label>Whistle Very Short</label>
+            </variable>
+	    <variable CV="165" default="4" item="Sound Setting 5"  tooltip="F5 Volume"  comment="Range 0-8" include="133">
                 <decVal max="8"/>
                 <label>Chime Whistle Passing</label>
             </variable>
-            <variable CV="166" default="4" item="Sound Setting 6"  tooltip="F6 Volume"  comment="Range 0-8" include="DoG,131,133,135,137,2703,655,145">
+            <variable CV="166" default="4" item="Sound Setting 6"  tooltip="F6 Volume"  comment="Range 0-8" include="DoG,131,133,135,137,139,141,169,2699,2703,655,145,171,179">
                 <decVal max="8"/>
                 <label>Wheel Slip</label>
             </variable>
@@ -325,16 +466,20 @@
             <variable CV="166" default="4" item="Sound Setting 6"  tooltip="F10 Volume"  comment="Range 0-8" include="153">
                 <decVal max="8"/>
                 <label>Horn Special</label>
-			</variable>	
-			<variable CV="166" default="4" item="Sound Setting 6"  tooltip="F10 Volume"  comment="Range 0-8" include="159">
+	    </variable>
+	    <variable CV="166" default="4" item="Sound Setting 6"  tooltip="F10 Volume"  comment="Range 0-8" include="129">
                 <decVal max="8"/>
-                <label>Horn High Two Bursts</label>	
-            </variable>
-			<variable CV="166" default="4" item="Sound Setting 6"  tooltip="F10 Volume"  comment="Range 0-8" include="175">
+                <label>Short Chime Whistle</label>
+	    </variable>
+	    <variable CV="166" default="4" item="Sound Setting 6"  tooltip="F10 Volume"  comment="Range 0-8" include="175">
                 <decVal max="8"/>
                 <label>Horn High Three Bursts</label>	
             </variable>
-            <variable CV="167" default="4" item="Sound Setting 7"  tooltip="F7 Volume"  comment="Range 0-8" include="DoG,131,133,135,137,2703,655,145">
+	    <variable CV="167" default="4" item="Sound Setting 6"  tooltip="F11 Volume"  comment="Range 0-8" include="159,175">
+                <decVal max="8"/>
+                <label>Horn High Two Bursts</label>	
+            </variable>
+            <variable CV="167" default="4" item="Sound Setting 7"  tooltip="F7 Volume"  comment="Range 0-8" include="DoG,129,131,133,135,137,139,141,169,2699,2703,655,145,171,179">
                 <decVal max="8"/>
                 <label>Coal Shovelling</label>
             </variable>
@@ -342,7 +487,7 @@
                 <decVal max="8"/>
                 <label>Door Slam</label>
             </variable>
-            <variable CV="168" default="4" item="Sound Setting 8"  tooltip="F8 Volume"  comment="Range 0-8" include="DoG,131,133,135,137,2703,655,145">
+            <variable CV="168" default="4" item="Sound Setting 8"  tooltip="F8 Volume"  comment="Range 0-8" include="DoG,129,131,133,135,137,139,141,169,2699,2703,655,145,171,179">
                 <decVal max="8"/>
                 <label>Blow Down</label>
             </variable>
@@ -350,19 +495,23 @@
                 <decVal max="8"/>
                 <label>Fan</label>
             </variable>
-			<variable CV="168" default="4" item="Sound Setting 8"  tooltip="F12 Volume"  comment="Range 0-8" include="175">
+	    <variable CV="168" default="4" item="Sound Setting 8"  tooltip="F12 Volume"  comment="Range 0-8" include="175">
                 <decVal max="8"/>
                 <label>Reverser</label>
             </variable>
-            <variable CV="169" default="4" item="Sound Setting 9"   tooltip="F9 Volume" comment="Range 0-8" include="DoG,131,133,135,137,2703,655,145">
+            <variable CV="169" default="4" item="Sound Setting 9"   tooltip="F9 Volume" comment="Range 0-8" include="DoG,129,131,133,135,137,139,141,169,2699,2703,655,145,171,179">
                 <decVal max="8"/>
                 <label>Safety Valve</label>
+            </variable>
+	    <variable CV="169" default="4" item="Sound Setting 9"   tooltip="F13 Volume" comment="Range 0-8" include="175">
+                <decVal max="8"/>
+                <label>Air Release</label>
             </variable>
             <variable CV="169" default="4" item="Sound Setting 9"   tooltip="F13 Volume" comment="Range 0-8" include="Cl37,147,149,151,153,159,161">
                 <decVal max="8"/>
                 <label>Horn Long High</label>
             </variable>
-			<variable CV="169" default="4" item="Sound Setting 9"   tooltip="F13 Volume" comment="Range 0-8" include="163">
+	    <variable CV="169" default="4" item="Sound Setting 9"   tooltip="F13 Volume" comment="Range 0-8" include="163">
                 <decVal max="8"/>
                 <label>Horn High Low High</label>
             </variable>
@@ -370,23 +519,27 @@
                 <decVal max="8"/>
                 <label>Coal Pusher</label>
             </variable>
-            <variable CV="170" default="4" item="Sound Setting 10"  tooltip="F10 Volume"  comment="Range 0-8" include="133,135,137,2703,655,145">
+            <variable CV="170" default="4" item="Sound Setting 10"  tooltip="F10 Volume"  comment="Range 0-8" include="129,133,135,137,139,141,169,2699,2703,655,171,179">
                 <decVal max="8"/>
                 <label>Injector</label>
+            </variable>
+	    <variable CV="170" default="4" item="Sound Setting 10"  tooltip="F14 Volume"  comment="Range 0-8" include="175">
+                <decVal max="8"/>
+                <label>Air Dump</label>
             </variable>
             <variable CV="170" default="4" item="Sound Setting 10"  tooltip="F14 Volume"  comment="Range 0-8" include="Cl37,147,149,151,153,161">
                 <decVal max="8"/>
                 <label>Horn Long Low</label>
-			</variable>	
-			<variable CV="170" default="4" item="Sound Setting 10"  tooltip="F14 Volume"  comment="Range 0-8" include="163">
+	    </variable>	
+	    <variable CV="170" default="4" item="Sound Setting 10"  tooltip="F14 Volume"  comment="Range 0-8" include="163">
                 <decVal max="8"/>
                 <label>Horn Low High Low</label>
-			</variable>
-			<variable CV="170" default="4" item="Sound Setting 10"  tooltip="F14 Volume"  comment="Range 0-8" include="159">
+	    </variable>
+	    <variable CV="170" default="4" item="Sound Setting 10"  tooltip="F14 Volume"  comment="Range 0-8" include="159">
                 <decVal max="8"/>
                 <label>Horn Short Two bursts</label>	
             </variable>
-            <variable CV="171" default="4" item="Sound Setting 11"  tooltip="F11 Volume"  comment="Range 0-8" include="DoG,131,133,135,137,2703,655,145">
+            <variable CV="171" default="4" item="Sound Setting 11"  tooltip="F11 Volume"  comment="Range 0-8" include="DoG,129,131,133,135,137,139,141,169,2699,2703,655,145,171,179">
                 <decVal max="8"/>
                 <label>Cylinder Cock</label>
             </variable>
@@ -394,15 +547,23 @@
                 <decVal max="8"/>
                 <label>Primer</label>
             </variable>
-            <variable CV="172" default="4" item="Sound Setting 12"  tooltip="F12 Volume"  comment="Range 0-8" include="DoG,131,133,135,137,2703,655,145">
+	    <variable CV="171" default="4" item="Sound Setting 11"  tooltip="F15 Volume"  comment="Range 0-8" include="175">
+                <decVal max="8"/>
+                <label>Detonator</label>
+            </variable>
+            <variable CV="172" default="4" item="Sound Setting 12"  tooltip="F12 Volume"  comment="Range 0-8" include="DoG,129,131,133,135,137,139,141,169,2699,2703,655,145,171,179">
                 <decVal max="8"/>
                 <label>Brake</label>
+            </variable>
+	    <variable CV="172" default="4" item="Sound Setting 12"  tooltip="F12 Volume"  comment="Range 0-8" include="175">
+                <decVal max="8"/>
+                <label>Couple</label>
             </variable>
             <variable CV="172" default="4" item="Sound Setting 12"  tooltip="F16 Volume"  comment="Range 0-8" include="Cl37,147,149,151,153,159,161,163">
                 <decVal max="8"/>
                 <label>Slow flange squeal</label>
             </variable>
-            <variable CV="173" default="4" item="Sound Setting 13"   tooltip="F13 Volume" comment="Range 0-8" include="DoG,131,133,135,137,2703,655,145">
+            <variable CV="173" default="4" item="Sound Setting 13"   tooltip="F13 Volume" comment="Range 0-8" include="DoG,129,131,133,135,137,139,141,169,2699,2703,655,145,171,179">
                 <decVal max="8"/>
                 <label>Blower</label>
             </variable>
@@ -410,7 +571,11 @@
                 <decVal max="8"/>
                 <label>Spirax Valve</label>
             </variable>
-            <variable CV="174" default="4" item="Sound Setting 14"  tooltip="F14 Volume"  comment="Range 0-8" include="DoG,131,133,135,137,2703,655,145">
+	    <variable CV="173" default="4" item="Sound Setting 13"   tooltip="F17 Volume" comment="Range 0-8" include="175">
+                <decVal max="8"/>
+                <label>Un-Couple</label>
+            </variable>
+            <variable CV="174" default="4" item="Sound Setting 14"  tooltip="F14 Volume"  comment="Range 0-8" include="DoG,131,133,135,137,139,141,169,2699,2703,655,145,171,179">
                 <decVal max="8"/>
                 <label>Guard’s Whistle</label>
             </variable>
@@ -418,15 +583,23 @@
                 <decVal max="8"/>
                 <label>Horn Short Low</label>
             </variable>
-			<variable CV="174" default="4" item="Sound Setting 14"  tooltip="F18 Volume"  comment="Range 0-8" include="163">
+	    <variable CV="174" default="4" item="Sound Setting 14"  tooltip="F18 Volume"  comment="Range 0-8" include="175">
+                <decVal max="8"/>
+                <label>Primer</label>
+            </variable>
+	    <variable CV="174" default="4" item="Sound Setting 14"  tooltip="F18 Volume"  comment="Range 0-8" include="163">
                 <decVal max="8"/>
                 <label>Horn Low</label>
             </variable>
-            <variable CV="175" default="4" item="Sound Setting 15"  tooltip="F15 Volume"  comment="Range 0-8" include="DoG,131">
+	    <variable CV="174" default="4" item="Sound Setting 14"  tooltip="F18 Volume"  comment="Range 0-8" include="129">
+                <decVal max="8"/>
+                <label>Wheel Slip</label>
+            </variable>
+            <variable CV="175" default="4" item="Sound Setting 15"  tooltip="F15 Volume"  comment="Range 0-8" include="129">
                 <decVal max="8"/>
                 <label>Doors Slam</label>
             </variable>
-            <variable CV="175" default="4" item="Sound Setting 15"  tooltip="F15 Volume"  comment="Range 0-8" include="133,135,137,2703,655,145,153,161,163">
+            <variable CV="175" default="4" item="Sound Setting 15"  tooltip="F15 Volume"  comment="Range 0-8" include="129,133,135,137,139,141,169,2699,703,655,145,153,161,163,171,179">
                 <decVal max="8"/>
                 <label>Coupler Clank</label>
             </variable>
@@ -434,11 +607,15 @@
                 <decVal max="8"/>
                 <label>Horn Short High</label>
             </variable>
-			<variable CV="175" default="4" item="Sound Setting 15"  tooltip="F19 Volume"  comment="Range 0-8" include="163">
+	    <variable CV="175" default="4" item="Sound Setting 15"  tooltip="F19 Volume"  comment="Range 0-8" include="175">
+                <decVal max="8"/>
+                <label>Exhauster</label>
+            </variable>
+	    <variable CV="175" default="4" item="Sound Setting 15"  tooltip="F19 Volume"  comment="Range 0-8" include="163">
                 <decVal max="8"/>
                 <label>Horn High</label>
             </variable>
-            <variable CV="176" default="4" item="Sound Setting 16"   tooltip="F16 Volume" comment="Range 0-8" include="DoG,131,133,135,137,2703,655,145">
+            <variable CV="176" default="4" item="Sound Setting 16"   tooltip="F16 Volume" comment="Range 0-8" include="DoG,129,131,133,135,137,139,141,169,2699,2703,655,145,171,179">
                 <decVal max="8"/>
                 <label>Fireman Breakfast</label>
             </variable>
@@ -446,15 +623,27 @@
                 <decVal max="8"/>
                 <label>Wagons Buffering</label>
             </variable>
-            <variable CV="177" default="4" item="Sound Setting 23" tooltip="F1 Volume" comment="Range 0-8" include="DoG,131,133,135,137,2703,655,145">
+	    <variable CV="176" default="4" item="Sound Setting 16"   tooltip="F20 Volume" comment="Range 0-8" include="175">
+                <decVal max="8"/>
+                <label>Compressor</label>
+            </variable>
+            <variable CV="177" default="4" item="Sound Setting 23" tooltip="F1 Volume" comment="Range 0-8" include="DoG,129,131,133,135,137,139,141,145,169,171,655,2699,2703">
                 <decVal max="8"/>
                 <label>Locomotive Running - Decelerating</label>
+            </variable>
+	    <variable CV="177" default="4" item="Sound Setting 23" tooltip="F1 Volume" comment="Range 0-8" include="179,139">
+                <decVal max="8"/>
+                <label>Chuffing - Coasting</label>
             </variable>
             <variable CV="177" default="4" item="Sound Setting 17" tooltip="F21 Volume" comment="Range 0-8" include="Cl37,147,149,151,153,159,161,163">
                 <decVal max="8"/>
                 <label>Wagons Clanging</label>
             </variable>
-            <variable CV="178" default="4" item="Sound Setting 21" tooltip="Overall vol (write only)" comment="Range 0-8" include="DoG,131,135,137,2703,655,145">
+	    <variable CV="177" default="4" item="Sound Setting 17" tooltip="F21 Volume" comment="Range 0-8" include="175">
+                <decVal max="8"/>
+                <label>Hand Brake</label>
+            </variable>
+            <variable CV="178" default="4" item="Sound Setting 21" tooltip="Overall vol (write only)" comment="Range 0-8" include="DoG,129,131,135,137,139,141,145,655,2699,2703">
                 <decVal max="8"/>
                 <label>Quick Set Volume level</label>
             </variable>
@@ -462,27 +651,87 @@
                 <decVal max="8"/>
                 <label>Alternative Door Slam</label>
             </variable>
+	    <variable CV="178" default="4" item="Sound Setting 18" tooltip="F22 Volume" comment="Range 0-8" include="175">
+                <decVal max="8"/>
+                <label>Spirax Valve</label>
+            </variable>
             <variable CV="178" default="4" item="Sound Setting 18" tooltip="F22 Volume" comment="Range 0-8" include="149,153,161,163">
                 <decVal max="8"/>
                 <label>Coupling</label>
-			</variable>	
-			<variable CV="178" default="4" item="Sound Setting 18" tooltip="F22 Volume" comment="Range 0-8" include="159">
+	    </variable>	
+	    <variable CV="178" default="4" item="Sound Setting 18" tooltip="F22 Volume" comment="Range 0-8" include="159">
                 <decVal max="8"/>
                 <label>Coupling 1</label>	
+            </variable>
+	    <variable CV="178" default="4" item="Sound Setting 18" tooltip="F19 Volume" comment="Range 0-8" include="171">
+                <decVal max="8"/>
+                <label>Long Whistle</label>	
+            </variable>
+	    <variable CV="178" default="4" item="Sound Setting 18" tooltip="F19 Volume" comment="Range 0-8" include="169">
+                <decVal max="8"/>
+                <label>Long Whistle alt</label>	
+            </variable>
+	    <variable CV="178" default="4" item="Sound Setting 18" tooltip="F19 Volume" comment="Range 0-8" include="179">
+                <decVal max="8"/>
+                <label>Whistle Medium Alt</label>	
             </variable>
             <variable CV="179" default="4" item="Sound Setting 19" tooltip="F23 Volume" comment="Range 0-8" include="Cl37,147,149,151,153,159,161,163">
                 <decVal max="8"/>
                 <label>Guards Whistle</label>
             </variable>
+	    <variable CV="179" default="4" item="Sound Setting 19" tooltip="F23 Volume" comment="Range 0-8" include="175">
+                <decVal max="8"/>
+                <label>Flange Squeal</label>
+            </variable>
+	    <variable CV="179" default="4" item="Sound Setting 19" tooltip="F20 Volume" comment="Range 0-8" include="171">
+                <decVal max="8"/>
+                <label>Long Whistle 2 Short Bursts Alternative</label>
+            </variable>
+	    <variable CV="179" default="4" item="Sound Setting 19" tooltip="F20 Volume" comment="Range 0-8" include="169">
+                <decVal max="8"/>
+                <label>whistle Passing</label>
+            </variable>
+	    <variable CV="179" default="4" item="Sound Setting 19" tooltip="F20 Volume" comment="Range 0-8" include="179">
+                <decVal max="8"/>
+                <label>Whistle Short Alternative</label>
+            </variable>
             <variable CV="180" default="4" item="Sound Setting 24" tooltip="F24 Volume" comment="Range 0-8" include="Cl37,147,149,151,153,161,163">
                 <decVal max="8"/>
                 <label>Locomotive Buffering</label>
-			</variable>	
-			<variable CV="180" default="4" item="Sound Setting 24" tooltip="F24 Volume" comment="Range 0-8" include="159">
+	    </variable>
+	    <variable CV="180" default="4" item="Sound Setting 24" tooltip="F24 Volume" comment="Range 0-8" include="175">
+                <decVal max="8"/>
+                <label>Metal Door</label>
+	    </variable>
+	    <variable CV="180" default="4" item="Sound Setting 24" tooltip="F21 Volume" comment="Range 0-8" include="171">
+                <decVal max="8"/>
+                <label>Whistle Medium Fancy</label>
+	    </variable>
+	    <variable CV="180" default="4" item="Sound Setting 24" tooltip="F21 Volume" comment="Range 0-8" include="169">
+                <decVal max="8"/>
+                <label>Whistle Medium alt</label>
+	    </variable>
+	    <variable CV="180" default="4" item="Sound Setting 24" tooltip="F21 Volume" comment="Range 0-8" include="179">
+                <decVal max="8"/>
+                <label>Whistle Short Hi</label>
+	    </variable>
+	    <variable CV="180" default="4" item="Sound Setting 24" tooltip="F24 Volume" comment="Range 0-8" include="159">
                 <decVal max="8"/>
                 <label>Coupling 2</label>	
             </variable>
-            <variable CV="182" default="4" item="Sound Setting 21" tooltip="Overall vol (write only)" comment="Range 0-8" include="Cl37,147,149,151,153,159,161,163">
+	    <variable CV="181" default="4" item="Sound Setting 22" tooltip="F22 Volume" comment="Range 0-8" include="171">
+                <decVal max="8"/>
+                <label>Very Short Whistle Alternative</label>	
+            </variable>
+	    <variable CV="181" default="4" item="Sound Setting 22" tooltip="F22 Volume" comment="Range 0-8" include="169">
+                <decVal max="8"/>
+                <label>Very Short Whistle</label>	
+            </variable>
+            <variable CV="181" default="4" item="Sound Setting 22" tooltip="F22 Volume" comment="Range 0-8" include="179">
+                <decVal max="8"/>
+                <label>Whistle Short Lo</label>	
+            </variable>
+            <variable CV="182" default="4" item="Sound Setting 21" tooltip="Overall vol (write only)" comment="Range 0-8" include="Cl37,147,149,151,153,159,161,163,169,171,179">
                 <decVal max="8"/>
                 <label>Quick Set Volume level</label>
             </variable>


### PR DESCRIPTION
I have now added additional decoders to the file:
Hall Class 4-6-0					ID 2699  CV 158 = 10,  CV159 = 139
Castle Class 4-6-0 					ID 	139 hidden awaiting manual to associate the correct sound level cv's
S15 Class 4-6-0   					ID	179 hidden awaiting manual to associate the correct sound level cv's
Coronation Class 4-6-2 				ID	177 hidden awaiting manual to associate the correct sound level cv's
Peppercorn Class A1 4-6=2 (Tornado)	ID 	129 
Merchant Navy Class 4-6-2			ID 	169	
6000 King Class 4-6-0				ID 	141 
Lord Nelson Class 4-6-2		                ID 	183 hidden awaiting manual to associate the correct sound level cv's
Class 5MT 4-6-0 Black 5                          ID 171

I have also amended the Class 08  to rectify an issue with two horn sounds associated to the same cv166. One should have been CV167.  I also noticed not all the class 08 sounds had been attached to CV No's so that has also been rectified.

You will notice that I have included 4 Steam Locos but Left them hidden.  Two are forthcoming and two I have not been able to get hold of the manuals so at the moment I have left them hidden.

I also realised that the class 66 entry and the class 37/class 40 entry should have been left and hidden rather than removed or altered allowing anyone who had already chosen these definitions to keep using them.

Hope this is useful

Brian