### PR TITLE
Fix calculateSpeed() in DefaultSignalMastLogic. Show speed in SML table.

### DIFF
--- a/java/src/jmri/implementation/DefaultSignalMastLogic.java
+++ b/java/src/jmri/implementation/DefaultSignalMastLogic.java
@@ -2478,14 +2478,14 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
 
             for (NamedBeanSetting nbh : userSetTurnouts) {
                 Turnout key = (Turnout) nbh.getBean();
-                if (key.getState() == Turnout.CLOSED) {
+                if (nbh.getSetting() == Turnout.CLOSED) {
                     if (((key.getStraightLimit() < minimumBlockSpeed) || (minimumBlockSpeed == 0)) && (key.getStraightLimit() != -1)) {
                         minimumBlockSpeed = key.getStraightLimit();
                         if (log.isDebugEnabled()) {
                             log.debug(destination.getDisplayName() + " turnout " + key.getDisplayName() + " set speed to " + minimumBlockSpeed);
                         }
                     }
-                } else if (key.getState() == Turnout.THROWN) {
+                } else if (nbh.getSetting() == Turnout.THROWN) {
                     if (((key.getDivergingLimit() < minimumBlockSpeed) || (minimumBlockSpeed == 0)) && (key.getDivergingLimit() != -1)) {
                         minimumBlockSpeed = key.getDivergingLimit();
                         if (log.isDebugEnabled()) {

--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -168,6 +168,7 @@ LabelDarkTurnoutNumber = Dark output
 LabelSignalheadNumber = Signal Head ID 
 LabelAspectType = Aspect
 LabelAspects = Aspects
+LabelMaxSpeed = Max Speed
 LabelTurnoutClosedAppearance = Appearance when Closed 
 LabelTurnoutThrownAppearance = Appearance when Thrown 
 LabelNumberToAdd = Number of items:

--- a/java/src/jmri/jmrit/beantable/SignalMastLogicTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalMastLogicTableAction.java
@@ -122,6 +122,8 @@ public class SignalMastLogicTableAction extends AbstractTableAction<SignalMastLo
             static public final int DELCOL = 5;
             static public final int ENABLECOL = 6;
             static public final int EDITLOGICCOL = 7;
+            static public final int MAXSPEEDCOL = 8;
+            static public final int COLUMNCOUNT = 9;
 
             //We have to set a manager first off, but this gets replaced.
             @Override
@@ -231,7 +233,7 @@ public class SignalMastLogicTableAction extends AbstractTableAction<SignalMastLo
 
             @Override
             public int getColumnCount() {
-                return EDITLOGICCOL + 1;
+                return COLUMNCOUNT;
             }
 
             @Override
@@ -287,6 +289,8 @@ public class SignalMastLogicTableAction extends AbstractTableAction<SignalMastLo
                         return ""; // override default, no title for Edit column
                     case ENABLECOL:
                         return Bundle.getMessage("ColumnHeadEnabled");
+                    case MAXSPEEDCOL:
+                        return Bundle.getMessage("LabelMaxSpeed");
                     default:
                         return "unknown";
                 }
@@ -300,6 +304,7 @@ public class SignalMastLogicTableAction extends AbstractTableAction<SignalMastLo
                     case SOURCEAPPCOL:
                     case COMCOL:
                     case DESTAPPCOL:
+                    case MAXSPEEDCOL:
                         return String.class;
                     case ENABLECOL:
                         return Boolean.class;
@@ -360,6 +365,7 @@ public class SignalMastLogicTableAction extends AbstractTableAction<SignalMastLo
                     case DESTCOL:
                     case DESTAPPCOL:
                     case SOURCEAPPCOL:
+                    case MAXSPEEDCOL:
                         return new JTextField(10).getPreferredSize().width;
                     case COMCOL:
                         return 75;
@@ -448,6 +454,8 @@ public class SignalMastLogicTableAction extends AbstractTableAction<SignalMastLo
                         return Bundle.getMessage("ButtonEdit");
                     case ENABLECOL:
                         return (b != null) ? b.isEnabled(getDestMastFromRow(row)) : null;
+                    case MAXSPEEDCOL:
+                        return  b.getMaximumSpeed(getDestMastFromRow(row));
                     default:
                         //log.error("internal state inconsistent with table requst for "+row+" "+col);
                         return null;


### PR DESCRIPTION
The calculate max speed only runs at panel load or SM edit apply, therefore test for switch thrown or closed should be looking at the setting bean not at the current switch condition.

Add a column to show max speed for SM Rte table, so everyone knows what the value is.