### PR TITLE
Fix tabs in SignalMastLogic Add screen

### DIFF
--- a/java/src/jmri/jmrit/signalling/SignallingPanel.java
+++ b/java/src/jmri/jmrit/signalling/SignallingPanel.java
@@ -283,7 +283,7 @@ public class SignallingPanel extends jmri.util.swing.JmriPanel {
         containerPanel.add(header);
 
         JTabbedPane detailsTab = new JTabbedPane();
-        detailsTab.setLayout(new BoxLayout(detailsTab, BoxLayout.Y_AXIS));
+        //detailsTab.setLayout(new BoxLayout(detailsTab, BoxLayout.Y_AXIS));
         detailsTab.add(Bundle.getMessage("Blocks"), buildBlocksPanel());  // NOI18N
         detailsTab.add(Bundle.getMessage("Turnouts"), buildTurnoutPanel());  // NOI18N
         detailsTab.add(Bundle.getMessage("Sensors"), buildSensorPanel());  // NOI18N

--- a/java/src/jmri/jmrit/signalling/SignallingPanel.java
+++ b/java/src/jmri/jmrit/signalling/SignallingPanel.java
@@ -283,7 +283,6 @@ public class SignallingPanel extends jmri.util.swing.JmriPanel {
         containerPanel.add(header);
 
         JTabbedPane detailsTab = new JTabbedPane();
-        //detailsTab.setLayout(new BoxLayout(detailsTab, BoxLayout.Y_AXIS));
         detailsTab.add(Bundle.getMessage("Blocks"), buildBlocksPanel());  // NOI18N
         detailsTab.add(Bundle.getMessage("Turnouts"), buildTurnoutPanel());  // NOI18N
         detailsTab.add(Bundle.getMessage("Sensors"), buildSensorPanel());  // NOI18N
@@ -992,11 +991,6 @@ public class SignallingPanel extends jmri.util.swing.JmriPanel {
         jFrame = null;
     }
 
-    @Override
-    public void initComponents() {
-
-    }
-
     int blockModeFromBox(JComboBox<String> box) {
         String mode = (String) box.getSelectedItem();
         int result = jmri.util.StringUtil.getStateFromName(mode, blockInputModeValues, blockInputModes);
@@ -1085,13 +1079,6 @@ public class SignallingPanel extends jmri.util.swing.JmriPanel {
                 newAmast.setState(sml.getAutoSignalMastState(mast, destMast));
             }
         }
-    }
-
-    /**
-     * Free up resources when no longer used.
-     */
-    @Override
-    public void dispose() {
     }
 
     ButtonGroup selGroup = null;

--- a/java/test/jmri/jmrit/signalling/SignallingPanelTest.java
+++ b/java/test/jmri/jmrit/signalling/SignallingPanelTest.java
@@ -18,7 +18,8 @@ public class SignallingPanelTest {
     public void testNullCTor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         jmri.util.JmriJFrame jf = new jmri.util.JmriJFrame("Signalling Panel");
-        SignallingPanel t = new SignallingPanel(jf);
+        
+        new SignallingPanel(jf);
         // just checking for no exceptions in ctor
         
         JUnitUtil.dispose(jf);
@@ -42,8 +43,8 @@ public class SignallingPanelTest {
         
         jmri.NamedBeanHandleManager nbhm = jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class);
         Turnout it1 = InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
-        Sensor is1 = InstanceManager.sensorManagerInstance().provideSensor("IS1");
-        Sensor is2 = InstanceManager.sensorManagerInstance().provideSensor("IS2");
+        InstanceManager.sensorManagerInstance().provideSensor("IS1");
+        InstanceManager.sensorManagerInstance().provideSensor("IS2");
         SignalMast sm1 = new jmri.implementation.VirtualSignalMast("IF$vsm:AAR-1946:CPL($0001)");
         InstanceManager.getDefault(jmri.SignalMastManager.class).register(sm1);
         SignalMast sm2 = new jmri.implementation.VirtualSignalMast("IF$vsm:AAR-1946:CPL($0002)");

--- a/java/test/jmri/jmrit/signalling/SignallingPanelTest.java
+++ b/java/test/jmri/jmrit/signalling/SignallingPanelTest.java
@@ -1,12 +1,12 @@
 package jmri.jmrit.signalling;
 
 import java.awt.GraphicsEnvironment;
+import java.util.Hashtable;
+
+import jmri.*;
 import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.*;
 
 /**
  *
@@ -15,11 +15,55 @@ import org.junit.Test;
 public class SignallingPanelTest {
 
     @Test
-    public void testCTor() {
+    public void testNullCTor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         jmri.util.JmriJFrame jf = new jmri.util.JmriJFrame("Signalling Panel");
         SignallingPanel t = new SignallingPanel(jf);
-        Assert.assertNotNull("exists",t);
+        // just checking for no exceptions in ctor
+        
+        JUnitUtil.dispose(jf);
+    }
+
+    @Test
+    public void testCancel() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        jmri.util.JmriJFrame jf = new jmri.util.JmriJFrame("Signalling Panel");
+        SignallingPanel t = new SignallingPanel(jf);
+        
+        t.cancelPressed(null);
+        JUnitUtil.dispose(jf);
+    }
+
+
+    @Test
+    public void testDoubleCTor() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        jmri.util.JmriJFrame jf = new jmri.util.JmriJFrame("Signalling Panel");
+        
+        jmri.NamedBeanHandleManager nbhm = jmri.InstanceManager.getDefault(jmri.NamedBeanHandleManager.class);
+        Turnout it1 = InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
+        Sensor is1 = InstanceManager.sensorManagerInstance().provideSensor("IS1");
+        Sensor is2 = InstanceManager.sensorManagerInstance().provideSensor("IS2");
+        SignalMast sm1 = new jmri.implementation.VirtualSignalMast("IF$vsm:AAR-1946:CPL($0001)");
+        InstanceManager.getDefault(jmri.SignalMastManager.class).register(sm1);
+        SignalMast sm2 = new jmri.implementation.VirtualSignalMast("IF$vsm:AAR-1946:CPL($0002)");
+        InstanceManager.getDefault(jmri.SignalMastManager.class).register(sm2);
+        
+        SignalMastLogic sml = InstanceManager.getDefault(jmri.SignalMastLogicManager.class).newSignalMastLogic(sm1);
+        sml.setDestinationMast(sm2);
+        sml.allowAutoMaticSignalMastGeneration(false, sm2);
+        // add a control sensor
+        sml.addSensor("IS1", 1, sm2); // Active
+        // add 1 control turnout
+        Hashtable<NamedBeanHandle<Turnout>, Integer> hashTurnouts = new Hashtable<NamedBeanHandle<Turnout>, Integer>();
+        NamedBeanHandle<Turnout> namedTurnout1 = nbhm.getNamedBeanHandle("IT1", it1);
+        hashTurnouts.put(namedTurnout1, 1); // 1 = Closed
+        sml.setTurnouts(hashTurnouts, sm2);        
+        
+        SignallingPanel t = new SignallingPanel(sm1, sm2, jf);
+        
+        t.applyPressed(null);
+        
         JUnitUtil.dispose(jf);
     }
 
@@ -27,6 +71,7 @@ public class SignallingPanelTest {
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.initDefaultSignalMastManager();
     }


### PR DESCRIPTION
With some look&feels, the tabs on the SignalMastLogic Add screen don't show. (See screen shot in #5932). This restores them, at least the known cases.

The `.jmrit.signalling.SignallingPanel` class's logic still needs a bunch of Swing work so that the panel can properly resize, etc.