### PR TITLE
LocoNet, Roster clean up

### DIFF
--- a/help/en/Acknowledgements.shtml
+++ b/help/en/Acknowledgements.shtml
@@ -87,11 +87,12 @@
         <li>Rick Beaber contributed definitions for MRC
         decoders</li>
 
-        <li>Robin Becker, who has had a major role in the
+        <li>Robin Becker, <!-- n3ix -->
+        who has had a major role in the
         Soundtraxx decoder definitions, created our Windows icons,
         has debugged several difficult problems, created several
         Tam Valley decoder definitions, and is a primary author of
-        EngineDriver.</li><!-- n3ix on GitHub -->
+        EngineDriver.</li>
 
         <li>John Bell, who improved the NCE instructions</li>
 
@@ -195,7 +196,7 @@
         <a href="http://jmri.org/k/UDRP/index.shtml">despicable
         behavior</a>, and wrote a scripting example page</li>
 
-        <li><a href="https://github.com/JMRI/JMRI/pulls?utf8=✓&q=author%3Asilverailscolo+">Egbert Broerse</a>, 
+        <li><a href="https://github.com/JMRI/JMRI/pulls?utf8=✓&q=author%3Asilverailscolo+">Egbert Broerse</a>, <!-- silverailscolo -->
         who worked on translations, added
         Switchboards, graphic state display in the tables,
         the Output Matrix signal mast and the Rio Grande 1965
@@ -425,8 +426,9 @@
 
         <li>William C Gage provided an MRC decoder definition</li>
 
-        <li>Steve Gigiel, who fixed the XML definition of the block contents icon,
-        and helped fix the Transit implementation of comments.</li><!-- Pugwash1 -->
+        <li>Steve Gigiel, <!-- Pugwash1 -->
+        who fixed the XML definition of the block contents icon,
+        and helped fix the Transit implementation of comments.</li>
 
         <li>Brian Gilhuly, who helped debug a programmer problem in
         JMRI 3.11.1</li>
@@ -568,13 +570,16 @@
         several Quantum decoders</li>
 
         <li>The Jython project, who provided a very powerful
-        scripting engine for us <a name="K" id="K"></a></li>
+        scripting engine for us 
+        
+        <a name="K" id="K"></a></li>
 
         <li>Georg Kautzsch, who provided a decoder definition for
         the Uhlenbrock 67800 servo decoder.</li>
 
         <li>
-        Klaus Killinger, who improved the sound support <!-- klk32003 -->
+        Klaus Killinger, <!-- klk32003 -->
+            who improved the sound support
             and has provided multiple sound projects</li>
 
         <li>Scott Kitts, who helped debug the new communications
@@ -612,7 +617,9 @@
         <li>Tighe Kuykendall improved documentation.</li>
 
         <li>Bjorn Kvisli, who provided Doehler &amp; Haass decoder
-        definitions. <a name="L" id="L"></a></li>
+        definitions. 
+        
+        <a name="L" id="L"></a></li>
 
         <li>John Lang, who provided several signal definitions</li>
 
@@ -628,8 +635,9 @@
         He's also put a lot of work into test and development
         of the C/MRI support.</li>
 
-        <li>Alain Le Marchand, who provided a number of decoder
-        definitions and updates</li><!-- GitHub: AlanUS -->
+        <li>Alain Le Marchand, <!-- GitHub: AlanUS -->
+        who provided a number of decoder
+        definitions and updates</li>
 
         <li>Karl Johan Lisby, <!-- kjlisby  -->
         who made large improvements to the
@@ -683,9 +691,9 @@
         <li>John McAleely, who contributed Hornby and Bachmann
         decoder definitions</li>
 
-        <li>Greg McCartney, who provided a <a href=
-        "http://jmri.org/xml/signals/NW-1981/index.shtml">Norfolk
-        and Western signal definition</a>, the <a href=
+        <li>Greg McCartney, who provided a 
+        <a href="http://jmri.org/xml/signals/NW-1981/index.shtml">Norfolk and Western signal definition</a>, 
+        the <a href=
         "http://jmri.org/xml/signals/B&amp;O-1980/index.shtml">B&amp;O
         1980 signal definition</a>, and the
         <a href="http://jmri.org/xml/signals/SOU-1981/index.shtml">Southern 1981 system</a>.
@@ -872,9 +880,9 @@
         <li>Joe Salemi, who contributed the Atlas 345 decoder
         definition and updated the TCS Tx definition.</li>
 
-        <li><a href="https://github.com/JMRI/JMRI/pulls?utf8=✓&q=author%3Adsand47+">Dave Sand</a>, 
+        <li><a href="https://github.com/JMRI/JMRI/pulls?utf8=✓&q=author%3Adsand47+">Dave Sand</a>, <!-- dsand47 -->
         who's worked on Layout Editor, Logix, 
-        Entry/Exit signaling and other things.</li><!-- dsand47 -->
+        Entry/Exit signaling and other things.</li>
         
         <li>Richard Sauerbrun provided a definition for the
         DN163K4B decoder.</li>
@@ -1103,7 +1111,8 @@
         <li>Mike Yawn, who provided the instructions for building
         under Eclipse <a name="Z" id="Z"></a></li>
 
-        <li>Steve Young, who helped with CBUS documentation and the Groups.io migration</li><!-- icklesteve -->
+        <li>Steve Young, <!-- icklesteve -->
+            who helped with CBUS documentation and the Groups.io migration</li>
 
         <li>Luis Zamora, who done a lot of work on the 
         Catalan translation</li><!-- eldelinux --> 

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -89,7 +89,6 @@ import jmri.jmrix.ConnectionConfigManager;
 import jmri.jmrix.ConnectionStatus;
 import jmri.profile.Profile;
 import jmri.profile.ProfileManager;
-import jmri.progdebugger.ProgDebugger;
 import jmri.swing.JTablePersistenceManager;
 import jmri.swing.RowSorterUtil;
 import jmri.util.FileUtil;
@@ -174,7 +173,6 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
     JButton prog1Button = new JButton(Bundle.getMessage("Program"));
     JButton prog2Button = new JButton(Bundle.getMessage("BasicProgrammer"));
     ActionListener programModeListener;
-    transient ProgDebugger progDebugger = new ProgDebugger();
 
     // These are the names of the programmer _files_, not what should be displayed to the user
     String programmer1 = "Comprehensive"; // NOI18N
@@ -293,20 +291,7 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
             log.debug("Open programmer pressed");
             startProgrammer(null, re, programmer1);
         });
-        /*
-         * prog2Button.setEnabled(false); prog2Button.addActionListener( new
-         * ActionListener() { public void
-         * actionPerformed(java.awt.event.ActionEvent e) { if
-         * (log.isDebugEnabled()) log.debug("Open progDebugger pressed");
-         * startProgrammer(null, re, programmer2); } });
-         */
- /*
-         * throttleLabels.setEnabled(false); throttleLabels.addActionListener(
-         * new ActionListener() { public void
-         * actionPerformed(java.awt.event.ActionEvent e) { if
-         * (log.isDebugEnabled()) log.debug("Open progDebugger pressed");
-         * editMediaButton(); } });
-         */
+
         rosterMedia.setEnabled(false);
         rosterMedia.addActionListener((ActionEvent e) -> {
             log.debug("Open programmer pressed");
@@ -1196,7 +1181,7 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
     }
 
     /**
-     * Simple method to change over the progDebugger buttons.
+     * Simple method to change over the programmer buttons.
      * <p>
      * TODO This should be implemented with the buttons in their own class etc.
      * but this will work for now.
@@ -1498,7 +1483,7 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
     }
 
     /**
-     * Handle setting up and updating the GUI for the types of progDebugger
+     * Handle setting up and updating the GUI for the types of programmer
      * available.
      *
      * @param evt the triggering event; if not null and if a removal of a

--- a/java/src/jmri/jmrix/loconet/LnPacketizerStrict.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizerStrict.java
@@ -297,12 +297,8 @@ public class LnPacketizerStrict extends LnPacketizer {
                                 }
                                 // Oh my lost the echo...
                                 if (waitCount > 19) {
-                                    try {
-                                        log.warn("Retry Send for Lost Packet [{}] Count[{}]", waitForMsg.toString(),
+                                    log.warn("Retry Send for Lost Packet [{}] Count[{}]", waitForMsg,
                                                 reTryCount); // NOI18N
-                                    } catch (NullPointerException npe) {
-                                        log.warn("Retry Send for waitingOnMsg null?  Count[{}]", reTryCount); // NOI18N
-                                    }
                                     if (reTryCount < 5) {
                                         reTryRequired = true;
                                         reTryCount++;

--- a/java/src/jmri/jmrix/loconet/LnPowerManager.java
+++ b/java/src/jmri/jmrix/loconet/LnPowerManager.java
@@ -205,21 +205,8 @@ public class LnPowerManager
             msg.setOpCode(LnConstants.OPC_RQ_SL_DATA);
             msg.setElement(1, 0);
             msg.setElement(2, 0);
-            while (true) {
-                try {
-                    tc.sendLocoNetMessage(msg);
-                    break;
-                } catch (NullPointerException npe) {
-                    // sleep(500) or (750) mSec infrequently causes NPE upon sending first msg via tc, so repeat
-                    log.debug("init of LnPowerManager delayed");
-                    try {
-                        Thread.sleep(10); // wait 1 cycle for tc to init
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt(); // retain if needed later
-                        return; // and stop work
-                    }
-                }
-            }
+
+            tc.sendLocoNetMessage(msg);
             log.debug("LnTrackStatusUpdate sent");
         }
     }

--- a/java/src/jmri/jmrix/loconet/LnSensorManager.java
+++ b/java/src/jmri/jmrix/loconet/LnSensorManager.java
@@ -286,22 +286,8 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
                 }
                 msg.setElement(1, sw1[k]);
                 msg.setElement(2, sw2[k]);
-                while (true) {
-                    try {
-                        tc.sendLocoNetMessage(msg);
-                        break;
-                    } catch (NullPointerException npe) {
-                        // sleep(500) or (750) mSec infrequently causes NPE upon sending first msg via tc, so retry
-                        log.debug("init of LnSensorManager delayed");
-                        try {
-                            Thread.sleep(10); // wait 1 cycle for tc to init
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt(); // retain if needed later
-                            sm.setUpdateNotBusy();
-                            return; // and stop work
-                        }
-                    }
-                }
+                        
+                tc.sendLocoNetMessage(msg);
                 log.debug("LnSensorUpdate sent");
             }
             sm.setUpdateNotBusy();

--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -364,7 +364,7 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         }
 
         // reset timeout
-        if (mRefreshTimer != null) { // got NullPointerException sometimes
+        if (mRefreshTimer != null) {
             mRefreshTimer.stop();
             mRefreshTimer.setRepeats(true);     // refresh until stopped by dispose
             mRefreshTimer.start();

--- a/java/src/jmri/jmrix/loconet/locostats/LocoStatsFunc.java
+++ b/java/src/jmri/jmrix/loconet/locostats/LocoStatsFunc.java
@@ -1,9 +1,13 @@
 package jmri.jmrix.loconet.locostats;
+
 import java.util.Vector;
+import javax.annotation.Nonnull;
+
 import jmri.jmrix.loconet.LnConstants;
 import jmri.jmrix.loconet.LocoNetListener;
 import jmri.jmrix.loconet.LocoNetMessage;
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -175,11 +179,9 @@ public class LocoStatsFunc implements LocoNetListener {
      * 
      * @param l - LocoNetInterfaceStatsListener to be added
      */
-    public synchronized void addLocoNetInterfaceStatsListener(LocoNetInterfaceStatsListener l) {
+    public synchronized void addLocoNetInterfaceStatsListener(@Nonnull LocoNetInterfaceStatsListener l) {
+        java.util.Objects.requireNonNull(l);
         // add only if not already registered
-        if (l == null) {
-            throw new java.lang.NullPointerException();
-        }
         if (!listeners.contains(l)) {
             listeners.addElement(l);
         }
@@ -191,7 +193,8 @@ public class LocoStatsFunc implements LocoNetListener {
      * 
      * @param l - LocoNetInterfaceStatsListener to be removed
      */
-    public synchronized void removeLocoNetInterfaceStatsListener(LocoNetInterfaceStatsListener l) {
+    public synchronized void removeLocoNetInterfaceStatsListener(@Nonnull LocoNetInterfaceStatsListener l) {
+        java.util.Objects.requireNonNull(l);
         if (listeners.contains(l)) {
             listeners.removeElement(l);
         }


### PR DESCRIPTION
- remove some dead and commented code from Roster handling
- remove deliberate throws of NPE from LocoNet code.  Now, if a send request comes in too early to handle, it's held and processed first when the connection comes up, which also simplifies the code.