### PR TITLE
Consistent import/export roster terminology

### DIFF
--- a/help/en/html/apps/DecoderPro/RosterFile.shtml
+++ b/help/en/html/apps/DecoderPro/RosterFile.shtml
@@ -32,24 +32,23 @@
 
       <p>The Roster information presented in the selection box, and
       used for automatic selection of a Locomotive, is stored in
-      the roster.xml file in the JMRI Preferences directory. You
-      can find your Preferences directory location by choosing
+      a number of individual files. You
+      can find their location by choosing
       "Locations" from the main JMRI Help menu. Click the "Open
       Roster Location" button to open the directory in
       Finder/Explorer. More information is available on the
       <a href="Files.shtml#location">"Configuration Files" Help
-      page</a>. You may open your Roster file and look at it to see
-      the format. You should only use the Roster menu to manipulate
+      page</a>. You should only use the Roster menu to manipulate
       the Roster file, to ensure that it stays self-consistent.</p>
 
       <p>To move the entire Roster to another computer, choose
-      "Export Roster" from the Roster menu, select a location to
-      save the file and then move that set of files to the other
-      computer before you choose "Import Roster" from the menu to
+      "Export Complete Roster" from the File menu, select a location to
+      save the file, move that file to the other
+      computer, then choose "Import Complete Roster" from the menu to
       import it there.</p>
 
-      <p>To do this manually at the file level, in the Preferences
-      directory there will be a file called "roster.xml", and a
+      <p>To do this manually at the file level, 
+      there will be a file called "roster.xml", and a
       directory called "roster". You need to move the "roster.xml"
       file, the "roster" directory, and all it's contents. Read
       more about the <a href="../../setup/Files.shtml">JMRI

--- a/help/en/manual/DecoderPro3/dp3_menubar.shtml
+++ b/help/en/manual/DecoderPro3/dp3_menubar.shtml
@@ -54,7 +54,7 @@
             Opens another instance of Main DecoderPro
             <strong>Roster</strong> window.</li>
 
-            <li><strong>Import Roster</strong><br>
+            <li><strong>Import Complete Roster</strong><br>
             Imports Roster into DecoderPro</li>
 
             <li><strong>Import Roster Entry</strong><br>

--- a/help/en/package/apps/gui3/dp3/DecoderPro3.shtml
+++ b/help/en/package/apps/gui3/dp3/DecoderPro3.shtml
@@ -160,8 +160,8 @@
         <li>Export Roster Entry...</li>
         <li>Import Roster Entry...</li>
         <li>------------------</li>
-        <li>Export Roster...</li>
-        <li>Import Roster...</li>
+        <li>Export Complete Roster...</li>
+        <li>Import Complete Roster...</li>
         <li>------------------</li>
         <li>Rebuild Roster</li>
         <li>Validate XML File</li>

--- a/xml/config/parts/jmri/jmrit/roster/swing/RosterFrameMenu.xml
+++ b/xml/config/parts/jmri/jmrit/roster/swing/RosterFrameMenu.xml
@@ -68,7 +68,7 @@
         <adapter>jmri.jmrit.roster.ImportRosterItemAction</adapter>
     </node>
     <node>separator</node><!-- separator -->
-    <node name="Export Roster...">
+    <node name="Export Complete Roster...">
         <name xml:lang="fr">Exporter l'Inventaire complet...</name>
         <name xml:lang="it">Esporta Roster Completo...</name>
         <name xml:lang="de">Exportiere gesamten Lokpark...</name>
@@ -77,7 +77,7 @@
         <name xml:lang="nl">Exporteer hele Loclijst...</name>
         <adapter>jmri.jmrit.roster.FullBackupExportAction</adapter>
     </node>
-    <node name="Import Roster...">
+    <node name="Import Complete Roster...">
         <name xml:lang="fr">Importer l'Inventaire...</name>
         <name xml:lang="it">Importa Roster...</name>
         <name xml:lang="de">Importiere gesamten Lokpark...</name>


### PR DESCRIPTION
"Import complete roster" and "export complete roster" were just "import roster" and "export roster" in a couple places.