### PR TITLE
Add Bachmann Mikado 2-8-2 definition and CV corrections

### DIFF
--- a/xml/decoders/2_CV35-54_Fn.xml
+++ b/xml/decoders/2_CV35-54_Fn.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<variables xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+      <variable label="FL(f) controls output 1" CV="35" mask="XXXXXXXV" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 1</label>
+        <label xml:lang="it">Luci (in avanti) controlla uscita 1</label>
+      </variable>
+      <variable label="FL(r) controls output 1" CV="35" mask="XXXXXXVX" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 1</label>
+        <label xml:lang="it">Luci (in retro) controlla uscita 1</label>
+      </variable>
+      <variable label="F1 controls output 1" CV="35" mask="XXXXXVXX" minOut="1" default="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 1</label>
+        <label xml:lang="it">F1 controlla uscita 1</label>
+      </variable>
+      <variable label="F2 controls output 1" CV="35" mask="XXXXVXXX" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 1</label>
+        <label xml:lang="it">F2 controlla uscita 1</label>
+      </variable>
+      <variable label="F3 controls output 1" CV="35" mask="XXXVXXXX" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 1</label>
+        <label xml:lang="it">F3 controlla uscita 1</label>
+      </variable>
+      <variable label="F4 controls output 1" CV="35" mask="XXVXXXXX" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 1</label>
+        <label xml:lang="it">F4 controlla uscita 1</label>
+      </variable>
+      <variable label="F5 controls output 1" CV="35" mask="XVXXXXXX" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 1</label>
+        <label xml:lang="it">F5 controlla uscita 1</label>
+      </variable>
+      <variable label="F6 controls output 1" CV="35" mask="VXXXXXXX" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 1</label>
+        <label xml:lang="it">F6 controlla uscita 1</label>
+      </variable>
+      <variable label="FL(f) controls output 2" CV="36" mask="XXXXXXXV" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 2</label>
+        <label xml:lang="it">Luci (in avanti) controlla uscita 1</label>
+      </variable>
+      <variable label="FL(r) controls output 2" CV="36" mask="XXXXXXVX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 2</label>
+        <label xml:lang="it">Luci (in retro) controlla uscita 2</label>
+      </variable>
+      <variable label="F1 controls output 2" CV="36" mask="XXXXXVXX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 2</label>
+        <label xml:lang="it">F1 controlla uscita 2</label>
+      </variable>
+      <variable label="F2 controls output 2" CV="36" mask="XXXXVXXX" minOut="2" default="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 2</label>
+        <label xml:lang="it">F2 controlla uscita 2</label>
+      </variable>
+      <variable label="F3 controls output 2" CV="36" mask="XXXVXXXX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 2</label>
+        <label xml:lang="it">F3 controlla uscita 2</label>
+      </variable>
+      <variable label="F4 controls output 2" CV="36" mask="XXVXXXXX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 2</label>
+        <label xml:lang="it">F4 controlla uscita 2</label>
+      </variable>
+      <variable label="F5 controls output 2" CV="36" mask="XVXXXXXX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 2</label>
+        <label xml:lang="it">F5 controlla uscita 2</label>
+      </variable>
+      <variable label="F6 controls output 2" CV="36" mask="VXXXXXXX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 2</label>
+        <label xml:lang="it">F6 controlla uscita 2</label>
+      </variable>
+      <variable label="F7 controls output 1" CV="37" mask="XXXXXVXX" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F7 controls output 1</label>
+        <label xml:lang="it">F7 controlla uscita 1</label>
+      </variable>
+      <variable label="F8 controls output 1" CV="37" mask="XXXXVXXX" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F8 controls output 1</label>
+        <label xml:lang="it">F8 controlla uscita 1</label>
+      </variable>
+      <variable label="F9 controls output 1" CV="37" mask="XXXVXXXX" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F9 controls output 1</label>
+        <label xml:lang="it">F9 controlla uscita 1</label>
+      </variable>
+      <variable label="F10 controls output 1" CV="37" mask="XXVXXXXX" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F10 controls output 1</label>
+        <label xml:lang="it">F10 controlla uscita 1</label>
+      </variable>
+      <variable label="F11 controls output 1" CV="37" mask="XVXXXXXX" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F11 controls output 1</label>
+        <label xml:lang="it">F11 controlla uscita 1</label>
+      </variable>
+      <variable label="F12 controls output 1" CV="37" mask="VXXXXXXX" minOut="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F12 controls output 1</label>
+        <label xml:lang="it">F12 controlla uscita 1</label>
+      </variable>
+      <variable label="F7 controls output 2" CV="38" mask="XXXXXVXX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F7 controls output 2</label>
+        <label xml:lang="it">F7 controlla uscita 2</label>
+      </variable>
+      <variable label="F8 controls output 2" CV="38" mask="XXXXVXXX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F8 controls output 2</label>
+        <label xml:lang="it">F8 controlla uscita 2</label>
+      </variable>
+      <variable label="F9 controls output 2" CV="38" mask="XXXVXXXX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F9 controls output 2</label>
+        <label xml:lang="it">F9 controlla uscita 2</label>
+      </variable>
+      <variable label="F10 controls output 2" CV="38" mask="XXVXXXXX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F10 controls output 2</label>
+        <label xml:lang="it">F10 controlla uscita 2</label>
+      </variable>
+      <variable label="F11 controls output 2" CV="38" mask="XVXXXXXX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F11 controls output 2</label>
+        <label xml:lang="it">F11 controlla uscita 2</label>
+      </variable>
+      <variable label="F12 controls output 2" CV="38" mask="VXXXXXXX" minOut="2">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F12 controls output 2</label>
+        <label xml:lang="it">F12 controlla uscita 2</label>
+      </variable>
+      <variable label="FL(f) controls output 3" CV="39" mask="XXXXXXXV" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 3</label>
+        <label xml:lang="it">Luci (in avanti) controlla uscita 3</label>
+      </variable>
+      <variable label="FL(r) controls output 3" CV="39" mask="XXXXXXVX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 3</label>
+        <label xml:lang="it">Luci (in retro) controlla uscita 3</label>
+      </variable>
+      <variable label="F1 controls output 3" CV="39" mask="XXXXXVXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 3</label>
+        <label xml:lang="it">F1 controlla uscita 3</label>
+      </variable>
+      <variable label="F2 controls output 3" CV="39" mask="XXXXVXXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 3</label>
+        <label xml:lang="it">F2 controlla uscita 3</label>
+      </variable>
+      <variable label="F3 controls output 3" CV="39" mask="XXXVXXXX" minOut="3" default="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 3</label>
+        <label xml:lang="it">F3 controlla uscita 3</label>
+      </variable>
+      <variable label="F4 controls output 3" CV="39" mask="XXVXXXXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 3</label>
+        <label xml:lang="it">F4 controlla uscita 3</label>
+      </variable>
+      <variable label="F5 controls output 3" CV="39" mask="XVXXXXXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 3</label>
+        <label xml:lang="it">F5 controlla uscita 3</label>
+      </variable>
+      <variable label="F6 controls output 3" CV="39" mask="VXXXXXXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 3</label>
+        <label xml:lang="it">F6 controlla uscita 3</label>
+      </variable>
+      <variable label="FL(f) controls output 4" CV="40" mask="XXXXXXXV" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(f) controls output 4</label>
+        <label xml:lang="it">Luci (in avanti) controlla uscita 4</label>
+      </variable>
+      <variable label="FL(r) controls output 4" CV="40" mask="XXXXXXVX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>FL(r) controls output 4</label>
+        <label xml:lang="it">Luci (in retro) controlla uscita 4</label>
+      </variable>
+      <variable label="F1 controls output 4" CV="40" mask="XXXXXVXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F1 controls output 4</label>
+        <label xml:lang="it">F1 controlla uscita 4</label>
+      </variable>
+      <variable label="F2 controls output 4" CV="40" mask="XXXXVXXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F2 controls output 4</label>
+        <label xml:lang="it">F2 controlla uscita 4</label>
+      </variable>
+      <variable label="F3 controls output 4" CV="40" mask="XXXVXXXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F3 controls output 4</label>
+        <label xml:lang="it">F3 controlla uscita 4</label>
+      </variable>
+      <variable label="F4 controls output 4" CV="40" mask="XXVXXXXX" minOut="4" default="1">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F4 controls output 4</label>
+        <label xml:lang="it">F4 controlla uscita 4</label>
+      </variable>
+      <variable label="F5 controls output 4" CV="40" mask="XVXXXXXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F5 controls output 4</label>
+        <label xml:lang="it">F5 controlla uscita 4</label>
+      </variable>
+      <variable label="F6 controls output 4" CV="40" mask="VXXXXXXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F6 controls output 4</label>
+        <label xml:lang="it">F6 controlla uscita 4</label>
+      </variable>
+      <variable label="F7 controls output 3" CV="41" mask="XXXXXVXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F7 controls output 3</label>
+        <label xml:lang="it">F7 controlla uscita 3</label>
+      </variable>
+      <variable label="F8 controls output 3" CV="41" mask="XXXXVXXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F8 controls output 3</label>
+        <label xml:lang="it">F8 controlla uscita 3</label>
+      </variable>
+      <variable label="F9 controls output 3" CV="41" mask="XXXVXXXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F9 controls output 3</label>
+        <label xml:lang="it">F9 controlla uscita 3</label>
+      </variable>
+      <variable label="F10 controls output 3" CV="41" mask="XXVXXXXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F10 controls output 3</label>
+        <label xml:lang="it">F10 controlla uscita 3</label>
+      </variable>
+      <variable label="F11 controls output 3" CV="41" mask="XVXXXXXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F11 controls output 3</label>
+        <label xml:lang="it">F11 controlla uscita 3</label>
+      </variable>
+      <variable label="F12 controls output 3" CV="41" mask="VXXXXXXX" minOut="3">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F12 controls output 3</label>
+        <label xml:lang="it">F12 controlla uscita 3</label>
+      </variable>
+      <variable label="F7 controls output 4" CV="42" mask="XXXXXVXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F7 controls output 4</label>
+        <label xml:lang="it">F7 controlla uscita 4</label>
+      </variable>
+      <variable label="F8 controls output 4" CV="42" mask="XXXXVXXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F8 controls output 4</label>
+        <label xml:lang="it">F8 controlla uscita 4</label>
+      </variable>
+      <variable label="F9 controls output 4" CV="42" mask="XXXVXXXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F9 controls output 4</label>
+        <label xml:lang="it">F9 controlla uscita 4</label>
+      </variable>
+      <variable label="F10 controls output 4" CV="42" mask="XXVXXXXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F10 controls output 4</label>
+        <label xml:lang="it">F10 controlla uscita 4</label>
+      </variable>
+      <variable label="F11 controls output 4" CV="42" mask="XVXXXXXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F11 controls output 4</label>
+        <label xml:lang="it">F11 controlla uscita 4</label>
+      </variable>
+      <variable label="F12 controls output 4" CV="42" mask="VXXXXXXX" minOut="4">
+        <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
+        <label>F12 controls output 4</label>
+        <label xml:lang="it">F12 controlla uscita 4</label>
+      </variable>
+      <variable label="Green Wire Effect" CV="51" mask="XXXVVVVV" minOut="1" item="Output 3 effect generated">
+      <enumVal>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+			</enumVal>
+		<label>Green Wire Effect</label>
+		<label xml:lang="it">Effetti filo Verde</label>
+	</variable>
+	<variable label="Green Wire Timing" CV="51" mask="XXVVXXXX" minOut="1" item="Output 3 behavior" default="2">
+		    <xi:include href="http://jmri.org/xml/decoders/tcs/enum-frw_rev_both_reserv.xml"/>
+        <label>Green Wire Timing</label>
+        <label xml:lang="it">Temporizzazioni filo Verde</label>
+      </variable>
+      <variable label="Purple Wire Effect" CV="52" mask="XXXXVVVV" minOut="2" item="Output 4 effect generated">
+      <enumVal>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMars.xml"/>
+			</enumVal>
+		<label>Purple Wire Effect</label>
+		<label xml:lang="it">Effetti filo Porpora</label>
+	</variable>
+	<variable label="Purple Wire Timing" CV="52" mask="XXVVXXXX" minOut="2" item="Output 4 behavior" default="2">
+        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-frw_rev_both_reserv.xml"/>
+        <label>Purple Wire Timing</label>
+        <label xml:lang="it">Temporizzazioni filo Porpora</label>
+      </variable>
+      <variable label="Brown Wire Effect" CV="53" mask="XXXXVVVV" minOut="3" item="Output 5 effect generated">
+      <enumVal>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMars.xml"/>
+			</enumVal>
+        <label>Brown Wire Effect</label>
+        <label xml:lang="it">Effetti filo Marrone</label>
+      </variable>
+      <variable label="Brown Wire Timing" CV="53" mask="XXVVXXXX" minOut="3" item="Output 5 behavior" default="2">
+        <xi:include href="http://jmri.org/xml/decoders/tcs/enum-frw_rev_both_reserv.xml"/>
+        <label>Brown Wire Timing</label>
+        <label xml:lang="it">Temporizzazioni filo Marrone</label>
+      </variable>
+      <variable label="Pink Wire Effect" CV="54" mask="XXXXVVVV" minOut="4" item="Output 6 effect generated">
+      <enumVal>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constantbright.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_group2.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_BlinkingditchAB.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_Constdim.xml"/>
+			<xi:include href="http://jmri.org/xml/decoders/tcs/Choice_AutoMars.xml"/>
+			</enumVal>
+		<label>Pink Wire Effect</label>
+		<label xml:lang="it">Effetti filo Rosa</label>
+	</variable>
+	<variable label="Pink Wire Timing" CV="54" mask="XXVVXXXX" minOut="4" item="Output 6 behavior" default="2">
+     <xi:include href="http://jmri.org/xml/decoders/tcs/enum-frw_rev_both_reserv.xml"/>
+     <label>Pink Wire Timing</label>
+     <label xml:lang="it">Temporizzazioni filo Rosa</label>
+  </variable>
+  </variables>

--- a/xml/decoders/Choice_BlinkingditchAB.xml
+++ b/xml/decoders/Choice_BlinkingditchAB.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2-009, 2010 All rights reserved -->
+<enumChoiceGroup xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+          
+		  <enumChoice choice="Reserved">
+            <choice>Reserved</choice>
+            <choice xml:lang="it">Reserved</choice>
+          </enumChoice>
+		  
+		  <enumChoice choice="Blinking ditch light A">
+            <choice>Blinking ditch light A</choice>
+            <choice xml:lang="it">Lampeggiante Ditch tipo A</choice>
+          </enumChoice>
+          <enumChoice choice="Blinking ditch light B">
+            <choice>Blinking ditch light B</choice>
+            <choice xml:lang="it">Lampeggiante Ditch tipo B</choice>
+          </enumChoice>
+ </enumChoiceGroup>

--- a/xml/decoders/SoundTraxx_Tsu_Steam_Bachmann_SndVal.xml
+++ b/xml/decoders/SoundTraxx_Tsu_Steam_Bachmann_SndVal.xml
@@ -19,6 +19,7 @@
   <version author="Alain Le Marchand" version="4" lastUpdated="20150524"/>
   <version author="Alain Le Marchand" version="5" lastUpdated="20160522"/>
   <version author="Alain Le Marchand" version="6" lastUpdated="20180103"/>
+  <version author="Marc N Fournier" version="7" lastUpdated="20181018"/>
   <!-- This file contains the definitions for the Bachmann spec'd Sound Value series of decoders	-->
   <!-- version 1	Based on the "Soundtraxx_Tsu files.                                             -->
   <!--			Includes the Alco 2-6-0                                                         -->
@@ -38,6 +39,7 @@
   <!--                  Renamed "Alco 2-6-0" in "2-6-0 Mogul - Alco [HO]"                                   -->
   <!-- version 6        Specific UserID with tooltip indicating version number,
                         from SoundTraxx Product Identification guide Rev.B                                  -->
+  <!-- version 7		Add 2-8-2 Mikado (as per single Soundtraxx doc)										--> 						
   <!-- Note:    Output number for "named" outputs (i.e. when name is not an integer) starts at numOuts+1.
                 Numbering is then incremental in the order of declaration of the named outputs.
                 For these decoders, convention is taken that FX5=output 3, FX6=output 4, Whistle=output 5, etc.
@@ -167,6 +169,40 @@
           <functionlabel num="6" lockable="true">FX6 function</functionlabel>
         </functionlabels>
       </model>
+	  
+	  <model model="2-8-2 Mikado - [HO]" numOuts="2" numFns="14" connector="other" productID="Bald282" formFactor="HO" comment="&lt;html&gt;Baldwin Mikado 2-8-2 &lt;br&gt;Exhaust Chuff: Medium Steam&lt;br&gt;Air Compressor: Cross Compound&lt;br&gt;&lt;/html&gt;">
+        <versionCV lowVersionID="82"/>
+        <output name="3" label="FX5| Rule 17">
+            <label xml:lang="it">FX5|Regola 17</label>
+        </output>
+        <output name="4" label="FX6|Mode">
+            <label xml:lang="it">FX6|Modo</label>
+        </output>
+        <output name="5" label="Whistle| ">
+            <label xml:lang="it">Fischio| </label>
+        </output>
+        <output name="6" label="Bell| ">
+            <label xml:lang="it">Campana| </label>
+        </output>
+        <output name="7" label="|"/>	<!-- Not used for for this decoder -->
+        <output name="8" label="Short|Whistle">
+            <label xml:lang="it">Breve|Fischio</label>
+        </output>
+        <output name="9" label="Steam|Release">
+            <label xml:lang="it">Rilascio|Vapore</label>
+        </output>
+        <output name="10" label="|"/>	<!-- Not used for for this decoder -->
+        <output name="11" label="Dimming| ">
+            <label xml:lang="it">Smorzam| </label>
+        </output>
+        <output name="12" label="Mute| ">
+            <label xml:lang="it">Silenzio| </label>
+        </output>
+        <functionlabels>
+          <functionlabel num="6" lockable="true">FX6 function</functionlabel>
+        </functionlabels>
+      </model>
+	  
       <!-- keep the initial model entry for compatibility purpose as it has already been released -->
       <model show="no" model="2-8-4 Berkshire" replacementModel="2-8-4 Berkshire - Pere Marquette [HO]" replacementFamily="Tsunami Steam Bachmann Sound Value" numOuts="2" numFns="14" connector="other" productID="Lima284_PM" formFactor="HO" comment="&lt;html&gt;Lima Locomotive Works 2-8-4 (HO scale)&lt;br&gt;Exhaust Chuff: Medium Steam&lt;br&gt;Air Compressor: Cross Compound&lt;br&gt;&lt;/html&gt;">
         <versionCV lowVersionID="82"/>
@@ -1666,6 +1702,23 @@
         <label>Whistle Select</label>
         <comment>Show these whistles for the models (productID) listed in the "include" statement</comment>
       </variable>
+	  
+	  <variable CV="115" mask="XXXXVVVV" item="Sound Option 9" default="0" include="Bald282" tooltip="Selects which whistle to use">
+        <enumVal>
+          <enumChoice choice="Southern 3-Chime">
+            <choice>Southern 3-Chime</choice>
+          </enumChoice>
+          <enumChoice choice="B&amp;O 3-Chime">
+            <choice>B&amp;O 3-Chime</choice>
+          </enumChoice>
+          <enumChoice choice="Crosby 3-Chime">
+            <choice>Crosby 3-Chime</choice>
+          </enumChoice>
+        </enumVal>
+        <label>Whistle Select</label>
+        <comment>Show these whistles for the models (productID) listed in the "include" statement</comment>
+      </variable>
+	  
       <variable CV="115" mask="XXXXVVVV" item="Sound Option 9" default="0" include="Lima284_PM,Lima284_PM_N" tooltip="Selects which whistle to use">
         <enumVal>
           <enumChoice choice="D&amp;RGW K-36 No.489 3-Chime">
@@ -1737,11 +1790,11 @@
         <decVal/>
         <label>Whistle Volume</label>
       </variable>
-      <variable CV="129" mask="VVVVVVVV" item="Sound Setting 5" default="195" include="Baldwin460" tooltip="Sets the volume of the whistle">
+      <variable CV="129" mask="VVVVVVVV" item="Sound Setting 5" default="195" include="Baldwin460,Bald282" tooltip="Sets the volume of the whistle">
         <decVal/>
         <label>Whistle Volume</label>
       </variable>
-      <variable CV="129" mask="VVVVVVVV" item="Sound Setting 5" default="225" exclude="440,Baldwin460" tooltip="Sets the volume of the whistle">
+      <variable CV="129" mask="VVVVVVVV" item="Sound Setting 5" default="225" exclude="440,Baldwin460,Bald282" tooltip="Sets the volume of the whistle">
         <decVal/>
         <label>Whistle Volume</label>
       </variable>
@@ -1840,7 +1893,7 @@
         <decVal/>
         <label>Motor Kp Coefficient (0-255)</label>
       </variable>
-      <variable CV="209" mask="VVVVVVVV" item="Advanced Group 2 Option 1" default="60" include="Baldwin460,Lima284_PM,Lima284_NKP,Lima284_CO" tooltip="Specifies a gain factor for the proportional part of the PID motor control equation">
+      <variable CV="209" mask="VVVVVVVV" item="Advanced Group 2 Option 1" default="60" include="Baldwin460,Lima284_PM,Lima284_NKP,Lima284_CO,Bald282" tooltip="Specifies a gain factor for the proportional part of the PID motor control equation">
         <decVal/>
         <label>Motor Kp Coefficient (0-255)</label>
       </variable>
@@ -1856,7 +1909,7 @@
         <decVal/>
         <label>Motor Ki Coefficient (0-255)</label>
       </variable>
-      <variable CV="210" mask="VVVVVVVV" item="Advanced Group 2 Option 2" default="30" include="Baldwin460,Lima284_PM,Lima284_NKP,Lima284_CO" tooltip="Specifies a gain factor for the integral part of the PID motor control equation">
+      <variable CV="210" mask="VVVVVVVV" item="Advanced Group 2 Option 2" default="30" include="Baldwin460,Lima284_PM,Lima284_NKP,Lima284_CO,Bald282" tooltip="Specifies a gain factor for the integral part of the PID motor control equation">
         <decVal/>
         <label>Motor Ki Coefficient (0-255)</label>
       </variable>
@@ -1872,7 +1925,7 @@
         <decVal max="31"/>
         <label>Motor Control Sample Period (0-31)</label>
       </variable>
-      <variable CV="214" mask="VVVVVVVV" item="Advanced Group 2 Option 5" default="8" include="440,Alco260,Baldwin460,Lima284_PM,Lima284_NKP,Lima284_CO" tooltip="Specifies a gain factor for the derivative part of the PID motor control equation">
+      <variable CV="214" mask="VVVVVVVV" item="Advanced Group 2 Option 5" default="8" include="440,Alco260,Baldwin460,Lima284_PM,Lima284_NKP,Lima284_CO,Bald282" tooltip="Specifies a gain factor for the derivative part of the PID motor control equation">
         <decVal/>
         <label>Motor Control Sample Aperture Time (0-255)</label>
       </variable>
@@ -1884,7 +1937,7 @@
         <decVal max="255"/>
         <label>BEMF Reference Voltage</label>
       </variable>
-      <variable CV="216" item="EMF Option 1" default="70" include="Baldwin460,PRRK4_N,Lima284_PM,Lima284_NKP,Lima284_CO" tooltip="Specifies the reference voltage for BEMF">
+      <variable CV="216" item="EMF Option 1" default="70" include="Baldwin460,PRRK4_N,Lima284_PM,Lima284_NKP,Lima284_CO,Bald282" tooltip="Specifies the reference voltage for BEMF">
         <decVal max="255"/>
         <label>BEMF Reference Voltage</label>
       </variable>

--- a/xml/decoders/TCS_Fn2.xml
+++ b/xml/decoders/TCS_Fn2.xml
@@ -15,10 +15,12 @@
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
   <version author="Michael Mosher" version="1" lastUpdated="20061010"/>
   <version author="John Crellin" version="1.2" lastUpdated="20140601"/>
+  <version author="Marc N Fournier" version="1.3" lastUpdated="20181018"/>  
   <!-- Version 1 - made from TCS_X.xml -->
   <!-- Version 1.1- 20110214 Added Rest to Factory defaults CV8>2(wsthompson@earthlink.net) -->
   <!-- Version 1.2- 20140602 Added CV 15 and missing lighting effects(jcrellin0661@gmail.com) -->
   <!-- 20140627 Added Translation and XI:include (fortuna.enzo@gmail.com) -->
+  <!-- Version 1.3- 20181019  Correction to CV51, CV52. Bit value of 9 is not used -->
   <decoder>
     <family name="TCS FL2 and FL4 Decoders" mfg="Train Control Systems">
       <model model="FL2" numOuts="2" numFns="14">

--- a/xml/decoders/TCS_Fn_FW86.xml
+++ b/xml/decoders/TCS_Fn_FW86.xml
@@ -13,6 +13,9 @@
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
   <version author="Simon Ginsburg" version="1" lastUpdated="20130317"/>
+  <version author="Marc N Fournier" version="2" lastUpdated="20181018"/>
+<!-- Version 2 Correction for CV51 and CV52, bit value of 9 not used in decoders -->
+
   <decoder>
     <family name="Jan 2012" mfg="Train Control Systems" comment="TCS FW Starting Jan 2012">
       <model model="FL2" numOuts="2" numFns="14" lowVersionID="86" highVersionID="88" formFactor="HO" productID="6">


### PR DESCRIPTION
Add Bachmann Mikado 2-8-2 to definition SndVal
Correction to CV51, CV52 in TCS FL2 and FL4. Bit value of 9 is not used on CV51 and CV52