### PR TITLE
Update and add new sections to Scripting web page

### DIFF
--- a/help/en/html/tools/scripting/index.shtml
+++ b/help/en/html/tools/scripting/index.shtml
@@ -29,30 +29,37 @@
 
       <h2>JMRI: Scripting</h2>
       
-      <p>Any <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/prog_guide/api.html">
+      <p>Any <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/prog_guide/api.html" target="_blank">
         Java Scripting API </a> (commonly refered to JSR-223) compliant scripting language can be added to JMRI,
-        however, beyond JavaScript and Python are not directly supported in the default installation.
+        however, only JavaScript and Python (Jython) are directly supported in the default installation.
         If you want to add another scripting language, find a JSR-223 compliant interpreter and add it to
-        the JMRI classpath as <a href="../../doc/Technical/StartUpScripts.shtml">documented for your operating system</a>
+        the JMRI classpath as <a href="../../doc/Technical/StartUpScripts.shtml" target="_blank">documented for your operating system</a>
         (different operating systems have different launchers that are configured differently).</p>
 
       <p>The following pages discuss scripting JMRI using the Jython version of Python:</p>
 
-      <ol>
+      <ul>
         <li><a href="Start.shtml">Getting started with simple scripts</a></li>
 
-        <li><a href="Python.shtml">The language itself</a></li>
+        <li><a href="Python_Jython.shtml">The Python/Jython language</a></li>
 
-        <li><a href="Examples.shtml">Example Scripts (List)</a></li>
-        
-        <li><a href="ex_set_turnouts.shtml">Example Script: Setting the Default State of Turnouts</a></li>
+        <li><a href="ex_set_turnouts.shtml">Example script: Setting the default state of turnouts</a></li>
 
-        <li><a href="FAQ.shtml">Frequently asked questions</a></li>
-
+		<li><a href="Examples.shtml">Many other example scripts (Links)</a></li>
+		
+		<li><a href="JMRI_scripts_How_To.shtml">Lots of "How To..." for JMRI scripting</a></li>
+            
+		<li><a href="JMRI_scripts_What_Where.shtml">"What...Where" interesting tidbits about creating Jython scripts for use with JMRI</a></li>
+		
         <li><a href="Jynstruments.shtml">Modifying the GUI with Jynstruments</a></li>
-      </ol>
+        
+        <li><a href="AppleScript.shtml">Open Scripting Arcitecture(available for Mac)</a></li>
+		    
+      </ul>
       
-      <p>See also the help section on <a href="Python.shtml">Python and JMRI.</a></p> 
+      <p>See also the help section on <a href="Python.shtml">Python and JMRI.</a> and 
+	  the <a href="FAQ_Jython_lang.shtml">FAQ about the Jython language used in JMRI scripts</a></p>
+</p> 
       
       <!--#include virtual="/Footer" -->
     </div><!-- closes #mainContent-->


### PR DESCRIPTION
I've been working on JMRI Scripting and hope that this overall update will be found useful.
Structure of files changed somewhat to allow for futher expansion of this material:

FAQ.shtml replaced by two files:  JMRI_scripts_How_To.shtml and JMRI_scripts_What_Where.shtml.
Python.shtml replaced by Python_Jython.shtml.  Some sections moved to Start.shtml.  
index.shtml and sidebar modified accordingly.  [Please delete FAQ.shtml and Python.shtml if this
update is accepted.]

Added several sections to each of these files based on information found in JMRIusers@group.io.

Many other small clean-ups made for clarity and ease of use, including putting an index at the 
beginning of multi-section pages and adding target="_blank" to all href's pointing to sites outside
 of JMRI.org (and some within) so these links will open in a new browser tab.

AppleScript.shtml in this directory is indexed ihn the Help system but not in exuisting Sidebar
 or index.shtml so I added them.

N.B. I did NOT change index files in the Help system as I assume these are all automatically generated
from the files in help/en/html/tools/scripting.  If this is not true, please contact me and I will make
changes to files as instructed.

I intend to post something to the JMRIusers to ask for review of this material and will add/change/delete
based on feedback.

Jerry Grochow