### PR TITLE
MERG CBUS Command Station Monitor Update

### DIFF
--- a/help/en/html/hardware/can/cbus/Names.shtml
+++ b/help/en/html/hardware/can/cbus/Names.shtml
@@ -607,7 +607,9 @@
         >Event Table</a> - Mainly event OPCs</li>
        <li><a href="../../../../package/jmri/jmrix/can/cbus/swing/nodeconfig/NodeConfigToolPane.shtml#opc"
         >Node Config</a> - Node Management OPCs</li>
-       <li><a href="../../../../package/jmri/jmrix/can/cbus/swing/console/CbusConsoleFrame.shtml#opc"
+       <li><a href="../../../../package/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorPane.shtml#opc"
+        >Command Station Monitor</a> - Command Station Monitor OPCs</li>
+        <li><a href="../../../../package/jmri/jmrix/can/cbus/swing/console/CbusConsoleFrame.shtml#opc"
         >Console</a> - All OPCs</li>
        </ul>        
         
@@ -635,7 +637,7 @@
         <p>The flexibility in the hex form of creating Sensors, Turnouts and Lights 
         allows any OPC to be sent, or received as an input.</p>
         
-        <p>When used as a short form address, eg "N123E456" : </p>
+        <p>When used as a short form address, eg "+N123E456" : </p>
       
         <ul>
         <li>ASON / ASOF Sent when status changed, node number = 0</li>
@@ -735,18 +737,18 @@
         <a href="https://github.com/JMRI/JMRI/blob/master/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java"
         >CbusThrottleManager.java</a>
         </p>
-        
+        <p>Messages sent by JMRI</p>
         <ul>
         <li>RLOC - Sent by JMRI</li>
         </ul>
         
-        <p>Messages sent by JMRI</p>
+        <p>Listeners for messages sent by JMRI</p>
         <ul>
         <li>ESTOP - Constant Listener</li>
         <li>RESTP - Constant Listener</li>
         <li>KLOC - Constant Listener</li>
         </ul>
-        
+        <p>Listeners for messages received by JMRI</p>
         <ul>
         <li>PLOC - Constant Listener</li>
         <li>ERR - Constant Listener + Errors translated from error codes</li>

--- a/help/en/package/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorPane.shtml
+++ b/help/en/package/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorPane.shtml
@@ -26,20 +26,90 @@
   <div class="nomenu" id="mBody">
     <div id="mainContent">
      <h1>JMRI : MERG CBUS Command Station Monitor</h1>
-     
-        <p>More info to follow.</p>
-        <p>Slot monitor for CBUS Command Stations</p>
+        <p>Main Table - Train session monitor.</p>
 
+        
+    <h2>Train List</h2>
+        <p> Every train heard on the network will be added to the table, 
+        there is one row per loco.</p>
+        <p>Train speed and direction are updated in real time 
+        according to the latest instruction by 
+        a JMRI throttle, MERG CANCAB throttle controller, 
+        or MERG CBUS connected Command Station.</p>
+        <p>Train columns : </p>
+        <ul>
+        <li>Session</li>
+        <li>Loco ID</li>
+        <li>Long Address Format?</li>
+        <li>Speed (Commanded)</li>
+        <li>Direction</li>
+        <li>Speed Steps</li>
+        <li>TD Alt - Alternative Block Value to track</li>
+        <li>Block - Current Block Username</li>
+        <li>Direction of current block</li>
+        <li>Next Block Username</li>
+        <li>Next Signal Mast Username</li>
+        <li>Next Aspect </li>
+        </ul>
+        
+        <p>The table will follow the block route of the train until 
+        it finds the next signal.</p>
+        <p>This system uses Signal Mast Logic, the legacy 
+        Simple Signal Logic within JMRI is not supported.</p>
+        
+    <h3>Block Tracking</h3>
+        <p>The table will attempt to identify which 
+        block the train is in via the 
+        block value ( train describer ).</p>
+        <p>By default, the table will update when the 
+        train number is the block value,
+        this can be changed to track a different block value 
+        by adding an alternative in the table.</p>
+        <p>A block initially has no direction set, 
+        forward values can only be calculated 
+        when JMRI knows what direction the block is set.</p>
+        <p>The direction is normally calculated by 
+        JMRI when a new block is occupied, 
+        then comparing neighbouring blocks.</p>
+        <p>Layout Editor blocks can be checked by 
+        taking the panel into edit mode, 
+        then clicking on Tools > Check.</p>
+        <p>You can view block routing by right clicking 
+        on an individual Layout Editor 
+        track segment and selecting View Block Routing.</p>
+        <p>As the tracking takes data from the block table, 
+        you will currently need to 
+        load the Command Station monitor after opening any panels.</p>
+        
     <h3><a name="opc" id="opc">Supported Operation Codes</a></h3>
+
+<p>Sent by the Command Station Monitor</p>
+
+QLOC
+RSTAT
+
+
+
+<p>Listeners for message sent by JMRI instance or external to JMRI</p>
+    
+    
+    PLOC
+RLOC
+DSPD
+KLOC
+DKEEP ( if session not on table sends a QLOC )
+STAT ( Used to determine if command station is capable of CBUS protocol 8a )
+GLOC
+ERR
+STMOD
     
 
     <h3>JMRI Help</h3>
       
-      <p>You can view this help page within JMRI by selecting Help > Window Help in the top bar of the MERG CBUS Command Station Monitor.</p>
+        <p>You can view this help page within JMRI by selecting Help > Window Help in the top bar of the 
+        MERG CBUS Command Station Monitor.</p>
       
-      <p><a href="../../../../../../../html/hardware/can/cbus/index.shtml">Main JMRI MERG CBUS Help page</a>.</p>
-        
-        
+        <p><a href="../../../../../../../html/hardware/can/cbus/index.shtml">Main JMRI MERG CBUS Help page</a>.</p>
         
       <!--#include virtual="/Footer" -->
     </div><!-- closes #mainContent-->

--- a/java/src/jmri/jmrix/can/cbus/CbusBundle.properties
+++ b/java/src/jmri/jmrix/can/cbus/CbusBundle.properties
@@ -320,6 +320,19 @@ LabelEventLightOff  = "Off" sends:
 ButtonCaptureNext   = Capture Next
 CaptureNextTooltip  = <html>Click to wait for the desired message to appear on the CBUS connection<br>and use it as a value for this item/state.</html>
 
+# Command Station Monitor Stuff
+
+QuerySession8a = CBUS Spec 8a + Firmware detected with loco moving, requesting details session {0} via QLOC.
+
+
+CNFO_PLOC     = PLOC Session {0} is allocated to loco 
+CNFO_KLOC     = KLOC Throttle releasing itself from session {0}, loco continues if speed set.
+CNFO_RLOC     = RLOC Throttle requesting session for loco 
+
+CNFO_GLOC     = GLOC Throttle requesting session for loco 
+CNFO_GLOC_ST  = GLOC Throttle requesting STEAL session for loco 
+CNFO_GLOC_SH  = GLOC Throttle requesting SHARED session for loco 
+CNFO_STMOD    = STMOD Set CAB Session {0} Speed Mode:{1} Service Mode:{2} Sound Control Mode:{3}
 
 # Cbus configure pane items
 ToolTipNodeNumber = Enter Node number from 256 to 65535 (decimal)
@@ -340,13 +353,13 @@ AddReporterEntryToolTip = 18<br>\
 Max. value for RFID Reporter is ?
 
 #networkinfo
-CBUS_IN       = JMRI  < <  CBUS
-CBUS_OUT      = JMRI  > >  CBUS
-CBUS_IN_CMD   = JMRI  < <  CMND
-CBUS_OUT_CMD  = JMRI  > >  CMND
-CBUS_IN_CAB   = JMRI  < <  CMND  < < CCAB
-CBUS_OUT_CAB  = JMRI  > >  CMND  > > CCAB
-CBUS_CMND_BR  = JMRI  < <  CMND  > > CCAB
+CBUS_IN       = JMRI  < <  CBUS | 
+CBUS_OUT      = JMRI  > >  CBUS | 
+CBUS_IN_CMD   = JMRI  < <  CMND | 
+CBUS_OUT_CMD  = JMRI  > >  CMND | 
+CBUS_IN_CAB   = JMRI  < <  CAB | 
+CBUS_OUT_CAB  = JMRI  > >  CAB | 
+CBUS_CMND_BR  = JMRI  < <  CMND  > >  CAB | 
 
 # general
 OPC_RESERVED  = Reserved opcode

--- a/java/src/jmri/jmrix/can/cbus/CbusOpCodes.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusOpCodes.java
@@ -55,20 +55,16 @@ public class CbusOpCodes {
         
         // extra info for ERR opc
         if (opc==CbusConstants.CBUS_ERR) {
-            // log.warn(" full err message for err no. {}",msg.getElement(3));
             // elements 1 & 2 depend on element 3
+            int rcvdIntAddr = (msg.getElement(1) & 0x3f) * 256 + msg.getElement(2);
             switch (msg.getElement(3)) {
                 case 1:
                     buf.append(Bundle.getMessage("ERR_LOCO_STACK_FULL"));
-                    buf.append(msg.getElement(1));
-                    buf.append(" ");
-                    buf.append(msg.getElement(2));
+                    buf.append(rcvdIntAddr);
                     break;
                 case 2:
                     buf.append(Bundle.getMessage("ERR_LOCO_ADDRESS_TAKEN"));
-                    buf.append(msg.getElement(1));
-                    buf.append(" ");
-                    buf.append(msg.getElement(2));
+                    buf.append(rcvdIntAddr);
                     break;
                 case 3:
                     buf.append(Bundle.getMessage("ERR_SESSION_NOT_PRESENT"));
@@ -87,9 +83,7 @@ public class CbusOpCodes {
                     break;
                 case 7:
                     buf.append(Bundle.getMessage("ERR_INVALID_REQUEST"));
-                    buf.append(msg.getElement(1));
-                    buf.append(" ");
-                    buf.append(msg.getElement(2));
+                    buf.append(rcvdIntAddr);
                     break;
                 case 8:
                     buf.append(Bundle.getMessage("ERR_SESSION_CANCELLED"));

--- a/java/src/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/cbusslotmonitor/CbusSlotMonitorDataModel.java
@@ -17,8 +17,6 @@ import java.util.Objects;
 import jmri.Block;
 import jmri.BlockManager;
 import jmri.InstanceManager;
-import jmri.jmrit.display.layoutEditor.LayoutBlock;
-// import jmri.jmrit.display.layoutEditor.LayoutBlockConnectivityTools;
 import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
 import jmri.jmrit.roster.RosterEntry;
 
@@ -30,6 +28,7 @@ import jmri.jmrix.can.cbus.CbusConstants;
 import jmri.jmrix.can.cbus.CbusMessage;
 import jmri.jmrix.can.cbus.CbusOpCodes;
 import jmri.jmrix.can.TrafficController;
+import jmri.Path;
 import jmri.SignalMast;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,51 +45,80 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
     protected int _contype=0; //  pane console message type
     protected String _context=null; // pane console text
 
+    private PropertyChangeListener _cconSignalMastListener = null;
+    private int pFromDir[] = new int[50];
+    
+    private int cmndstat_fw =0;
+    
+    
     private ArrayList<Integer> cmndstatarr;
     private ArrayList<Integer> sessionidarr;
- //   private ArrayList<Integer> shortarr;
+    private ArrayList<Integer> throttlecountarr;
+    private ArrayList<String> functionarr;
     private ArrayList<Integer> locoidarr;
     private ArrayList<Boolean> locolongarr;
     private ArrayList<String> namearr;
     private ArrayList<Integer> directionarr;
     private ArrayList<Integer> speedarr;
-    private ArrayList<Integer> speedsteparr;
+    private ArrayList<String> speedsteparr;
     private ArrayList<String> alttdarr;
     private ArrayList<String> currblockarr;
-    
-    private static List<PropertyChangeListener> mBlockListeners = new ArrayList<>();
-    private static List<Block> mBlockList = new ArrayList<>();
+    private ArrayList<String> blockdirarr;
+    private ArrayList<Block> blockarr;
+    private ArrayList<String> nextblockarr;
+    private ArrayList<String> nextsignalarr;
+    private ArrayList<String> nextaspectarr;
+    private ArrayList<PropertyChangeListener> mBlockListeners;
+    private ArrayList<SignalMast> sigListeners;
+    private ArrayList<Block> mBlockList;
     
     CanSystemConnectionMemo memo;
     TrafficController tc;
     
     // column order needs to match list in column tooltips
-    static public final int CMND_STATION_ID_COLUMN = 99; 
+
     static public final int SESSION_ID_COLUMN = 0; 
-    static public final int LOCO_ID_LONG_COLUMN = 2; 
+
     static public final int LOCO_ID_COLUMN = 1;
-    static public final int LOCO_NAME_COLUMN = 98;
+    static public final int LOCO_ID_LONG_COLUMN = 2; 
+    static public final int LOCO_COMMANDED_SPEED_COLUMN = 3;    
     static public final int LOCO_DIRECTION_COLUMN = 4;
-    static public final int LOCO_COMMANDED_SPEED_COLUMN = 3;
-    static public final int SPEED_STEP_COLUMN = 97;
-    static public final int ALT_TD = 5;
-    static public final int CURRENT_BLOCK = 6;
-    static public final int MAX_COLUMN = 7;
+    static public final int SPEED_STEP_COLUMN = 5;
+    static public final int NUM_THROTTLES = 97;
+    static public final int FUNCTION_LIST = 96;
+    static public final int ALT_TD = 6;
+    static public final int CURRENT_BLOCK = 7;
+    static public final int BLOCK_DIR = 8;
+    static public final int NEXT_BLOCK = 9;
+    static public final int NEXT_SIGNAL = 10;
+    static public final int NEXT_ASPECT = 11;
+
+    static public final int LOCO_NAME_COLUMN = 98;
+    static public final int CMND_STATION_ID_COLUMN = 99;
+    
+    static public final int MAX_COLUMN = 12;
     
     CbusSlotMonitorDataModel(CanSystemConnectionMemo memo, int row, int column) {
         
         cmndstatarr = new ArrayList<Integer>();
         sessionidarr = new ArrayList<Integer>();
+        throttlecountarr = new ArrayList<Integer>();
+        functionarr = new ArrayList<String>();
         locoidarr = new ArrayList<Integer>();
         locolongarr = new ArrayList<Boolean>();
         namearr = new ArrayList<String>();
         directionarr = new ArrayList<Integer>();
         speedarr = new ArrayList<Integer>();
-        speedsteparr = new ArrayList<Integer>();
+        speedsteparr = new ArrayList<String>();
         alttdarr = new ArrayList<String>();
         currblockarr = new ArrayList<String>();
-        
-        
+        blockdirarr = new ArrayList<String>();
+        blockarr = new ArrayList<Block>();
+        nextblockarr = new ArrayList<String>();
+        nextsignalarr = new ArrayList<String>();
+        nextaspectarr = new ArrayList<String>();
+        sigListeners = new ArrayList<SignalMast>();
+        mBlockListeners = new ArrayList<PropertyChangeListener>();
         
         // connect to the CanInterface
         tc = memo.getTrafficController();
@@ -98,11 +126,26 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
         
         initblocks();
         
+        getcmdstatversion();
     }
 
     // order needs to match column list top of dtabledatamodel
     static protected final String[] columnToolTips = {
-        ("tt c1"),("tt c2"),("tt c3"),("tt c4"),("tt c5"),("tt c6"),("tt c7"),("tt c8"),("tt c9"),("tt c10")
+        ("tt c1"),
+        ("tt c2"),
+        ("tt c3"),
+        ("tt c4"),
+        ("tt c5"),
+        ("tt c6"),
+        ("tt c7"),
+        ("tt c8"),
+        ("tt c9"),
+        ("tt c10"),
+        ("tt c11"),
+        ("tt c12"),
+        ("tt c13"),
+        ("tt c14"),
+        ("tt c15")
 
     }; // Length = number of items in array should (at least) match number of columns
     
@@ -136,19 +179,31 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
             case LOCO_ID_COLUMN:
                 return ("Loco ID");
             case LOCO_ID_LONG_COLUMN:
-                return ("Long Add");
+                return ("Long");
             case LOCO_NAME_COLUMN:
                 return ("Name");
             case LOCO_DIRECTION_COLUMN:
                 return ("Direction");
             case LOCO_COMMANDED_SPEED_COLUMN:
-                return ("Commanded Speed");   
+                return ("Speed (Commanded)");   
             case SPEED_STEP_COLUMN:
                 return ("Steps");
+            case NUM_THROTTLES:
+                return ("Num. Throttles");
+            case FUNCTION_LIST:
+                return("Functions");
             case ALT_TD:
                 return("TD Alt");
             case CURRENT_BLOCK:
                 return("Block");
+            case BLOCK_DIR:
+                return("Direction of Block");
+            case NEXT_BLOCK:
+                return("Next Block");
+            case NEXT_SIGNAL:
+                return("Next Signal");
+            case NEXT_ASPECT:
+                return("Next Aspect");
             default:
                 return "unknown"; // NOI18N
         }
@@ -168,18 +223,30 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
             case LOCO_ID_LONG_COLUMN:
                 return new JTextField(3).getPreferredSize().width;
             case LOCO_ID_COLUMN:
-                return new JTextField(6).getPreferredSize().width;
+                return new JTextField(4).getPreferredSize().width;
             case LOCO_NAME_COLUMN:
                 return new JTextField(10).getPreferredSize().width;
             case LOCO_DIRECTION_COLUMN:
                 return new JTextField(5).getPreferredSize().width;
             case LOCO_COMMANDED_SPEED_COLUMN:
-                return new JTextField(4).getPreferredSize().width;
+                return new JTextField(3).getPreferredSize().width;
             case SPEED_STEP_COLUMN:
-                return new JTextField(4).getPreferredSize().width;
+                return new JTextField(3).getPreferredSize().width;
+            case NUM_THROTTLES:
+                return new JTextField(3).getPreferredSize().width;
+            case FUNCTION_LIST:
+                return new JTextField(6).getPreferredSize().width;
             case ALT_TD:
                 return new JTextField(4).getPreferredSize().width;
             case CURRENT_BLOCK:
+                return new JTextField(6).getPreferredSize().width;
+            case BLOCK_DIR:
+                return new JTextField(6).getPreferredSize().width;
+            case NEXT_BLOCK:
+                return new JTextField(6).getPreferredSize().width;
+            case NEXT_SIGNAL:
+                return new JTextField(6).getPreferredSize().width;
+            case NEXT_ASPECT:
                 return new JTextField(6).getPreferredSize().width;
             default:
                 return new JLabel(" <unknown> ").getPreferredSize().width; // NOI18N
@@ -207,11 +274,23 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
                 return String.class;
             case LOCO_COMMANDED_SPEED_COLUMN:
                 return Integer.class;
-            case SPEED_STEP_COLUMN:
+            case NUM_THROTTLES:
                 return Integer.class;
+            case FUNCTION_LIST:
+                return String.class;
+            case SPEED_STEP_COLUMN:
+                return String.class;
             case ALT_TD:
                 return String.class;
             case CURRENT_BLOCK:
+                return String.class;
+            case BLOCK_DIR:
+                return String.class;
+            case NEXT_BLOCK:
+                return String.class;
+            case NEXT_SIGNAL:
+                return String.class;
+            case NEXT_ASPECT:
                 return String.class;
             default:
                 log.error("no column class located");
@@ -233,6 +312,27 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
         }
     }
 
+    /**
+     * Configure a table to have our standard rows and columns.
+     * <p>
+     * This is optional, in that other table formats can use this table model.
+     * But we put it here to help keep it consistent.
+     * </p>
+     */
+    public void configureTable(JTable cmdStatTable) {
+        // allow reordering of the columns
+        cmdStatTable.getTableHeader().setReorderingAllowed(true);
+
+        // shut off autoResizeMode to get horizontal scroll to work (JavaSwing p 541)
+        cmdStatTable.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
+
+        // resize columns as requested
+        for (int i = 0; i < cmdStatTable.getColumnCount(); i++) {
+            int width = getPreferredWidth(i);
+            cmdStatTable.getColumnModel().getColumn(i).setPreferredWidth(width);
+        }
+        cmdStatTable.sizeColumnsToFit(-1);
+    }
 
     /**
      * Return table values
@@ -257,61 +357,55 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
             case LOCO_ID_COLUMN:
                 return locoidarr.get(row);
             case LOCO_ID_LONG_COLUMN:
-            //    if (locolongarr.get(row)) {
-            //        return("L");
-            //    } else {
-            //        return("S");
-            //    }
                 return locolongarr.get(row);
             case LOCO_NAME_COLUMN:
                 return namearr.get(row);
             case LOCO_DIRECTION_COLUMN:  // on or off event  1 is on, 0 is off, null unknown
-                if ( speedarr.get(row) > -1 ) {
-                    
-                   // String  teststring = Integer.toBinaryString(speedarr.get(row));
-                    
-                    String speedflags = String.format("%8s", 
-                    Integer.toBinaryString(speedarr.get(row) & 0xFF)).replace(' ', '0');
-                    
-                   // log.warn("value at 0 is {} {} ",speedflags, String.valueOf(speedflags.charAt(0)));
-                    
-                    if (Objects.equals("1",String.valueOf(speedflags.charAt(0)))) {
+                if ( directionarr.get(row) > -1 ) {
+                    if ( directionarr.get(row) == 1 ) {
                         return("Forward");
                     } else {
                         return("Reverse");
                     }
-                    
                 } else {
                     return "";
                 }
             case LOCO_COMMANDED_SPEED_COLUMN:
                 int speed=speedarr.get(row);
                 if ( speed > -1 ) {
-                    String speedflags = String.format("%8s", 
-                    Integer.toBinaryString(speedarr.get(row) & 0xFF)).replace(' ', '0');                    
-                    
-                    int decimal = Integer.parseInt((speedflags.substring(1)), 2); 
-                    return decimal;
-                    
+                    return speed;
                 } else {
                     return null;
                 }
+                
+            case NUM_THROTTLES:
+                return throttlecountarr.get(row);
+            case FUNCTION_LIST:
+                return functionarr.get(row);
             case SPEED_STEP_COLUMN:
-                if ( speedsteparr.get(row) > -1 ) {
-                    return speedsteparr.get(row);
-                } else {
-                    return 128;
+                if ( (speedsteparr.get(row)).isEmpty() ) {
+                    return "128";
                 }
+                else {
+                    return speedsteparr.get(row);
+                } 
             case ALT_TD:
                 return alttdarr.get(row);
             case CURRENT_BLOCK:
                 return currblockarr.get(row);
+            case BLOCK_DIR:
+                return blockdirarr.get(row);
+            case NEXT_BLOCK:
+                return nextblockarr.get(row);
+            case NEXT_SIGNAL:
+                return nextsignalarr.get(row);
+            case NEXT_ASPECT:
+                return nextaspectarr.get(row);
             default:
                 log.error("internal state inconsistent with table request for row {} col {}", row, col);
                 return null;
         }
     }
-    
     
     /**
      * @param value object value
@@ -345,12 +439,40 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
             javax.swing.SwingUtilities.invokeLater(r);
             }
         else if (col == LOCO_COMMANDED_SPEED_COLUMN) {
-            speedarr.set(row, (Integer) value);
+            String speedflags = String.format("%8s", 
+            Integer.toBinaryString((Integer) value & 0xFF)).replace(' ', '0');
+            int decimal = Integer.parseInt((speedflags.substring(1)), 2);
+            speedarr.set(row, decimal);
+            Runnable r = new Notify(row, this); 
+            javax.swing.SwingUtilities.invokeLater(r);
+        }
+        else if (col == LOCO_DIRECTION_COLUMN) {
+            String speedflags = String.format("%8s", 
+            Integer.toBinaryString((Integer) value & 0xFF)).replace(' ', '0');
+            
+            int olddir = directionarr.get(row);
+            int newdir = Integer.parseInt(String.valueOf(speedflags.charAt(0)));
+            
+            directionarr.set(row, newdir);
+            if (olddir != newdir) {
+                log.debug("direction changed");
+                // potentially use in editing current block direction ?
+            }
+            Runnable r = new Notify(row, this); 
+            javax.swing.SwingUtilities.invokeLater(r);
+        }
+        else if (col == NUM_THROTTLES) {
+            throttlecountarr.set(row, (Integer) value);
+            Runnable r = new Notify(row, this); 
+            javax.swing.SwingUtilities.invokeLater(r);
+            }
+        else if (col == FUNCTION_LIST) {
+            functionarr.set(row, (String) value);
             Runnable r = new Notify(row, this); 
             javax.swing.SwingUtilities.invokeLater(r);
         }
         else if (col == SPEED_STEP_COLUMN) {
-            speedsteparr.set(row, (Integer) value);
+            speedsteparr.set(row, (String) value);
             Runnable r = new Notify(row, this); 
             javax.swing.SwingUtilities.invokeLater(r);
         }
@@ -364,6 +486,26 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
             Runnable r = new Notify(row, this); 
             javax.swing.SwingUtilities.invokeLater(r);            
         }
+        else if (col == BLOCK_DIR) {
+            blockdirarr.set(row, (String) value);
+            Runnable r = new Notify(row, this); 
+            javax.swing.SwingUtilities.invokeLater(r);            
+        }
+        else if (col == NEXT_BLOCK) {
+            nextblockarr.set(row, (String) value);
+            Runnable r = new Notify(row, this); 
+            javax.swing.SwingUtilities.invokeLater(r);            
+        }
+        else if (col == NEXT_SIGNAL) {
+            nextsignalarr.set(row, (String) value);
+            Runnable r = new Notify(row, this); 
+            javax.swing.SwingUtilities.invokeLater(r);            
+        }
+        else if (col == NEXT_ASPECT) {
+            nextaspectarr.set(row, (String) value);
+            Runnable r = new Notify(row, this); 
+            javax.swing.SwingUtilities.invokeLater(r);            
+        }
     }
 
 
@@ -372,7 +514,6 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
      * @param row int row number
      */    
     void removeRow(int row) {
-        // log.warn("322 delete row {} with max rows rowcount as {} ", row, _rowCount);
 
         _context = Bundle.getMessage("TableConfirmDelete");
         
@@ -386,125 +527,64 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
         speedsteparr.remove(row);
         alttdarr.remove(row);
         currblockarr.remove(row);
+        blockdirarr.remove(row);
+        nextblockarr.remove(row);
+        nextsignalarr.remove(row);
+        nextaspectarr.remove(row);
+        sigListeners.remove(row);
+        throttlecountarr.remove(row);
+        functionarr.remove(row);
+        
         Runnable r = new Notify(row, this);
         javax.swing.SwingUtilities.invokeLater(r);
         addToLog(3,_context);
     }
     
-    
-    /**
-     * Configure a table to have our standard rows and columns.
-     * <p>
-     * This is optional, in that other table formats can use this table model.
-     * But we put it here to help keep it consistent.
-     * </p>
-     */
-    public void configureTable(JTable cmdStatTable) {
-        // allow reordering of the columns
-        cmdStatTable.getTableHeader().setReorderingAllowed(true);
-
-        // shut off autoResizeMode to get horizontal scroll to work (JavaSwing p 541)
-        cmdStatTable.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
-
-        // resize columns as requested
-        for (int i = 0; i < cmdStatTable.getColumnCount(); i++) {
-            int width = getPreferredWidth(i);
-            cmdStatTable.getColumnModel().getColumn(i).setPreferredWidth(width);
-        }
-        cmdStatTable.sizeColumnsToFit(-1);
+    public int createnewrow(int locoid, Boolean islong){
+        // log.warn("createnewrow {}",locoid);
+        locoidarr.add(locoid);
+        locolongarr.add(islong);
+        cmndstatarr.add(-1);
+        sessionidarr.add(-1);        
+        namearr.add("");
+        directionarr.add(-1);
+        speedarr.add(-1);
+        speedsteparr.add("");
+        alttdarr.add("");
+        currblockarr.add("");
+        blockdirarr.add("");
+        nextblockarr.add("");
+        blockarr.add(null);
+        nextsignalarr.add(null);
+        nextaspectarr.add(null);
+        sigListeners.add(null);
+        throttlecountarr.add(0);
+        functionarr.add("");
+        
+        Runnable r = new Notify(getRowCount(), this);   // -1 in first arg means all
+        javax.swing.SwingUtilities.invokeLater(r);
+        
+        return getRowCount();
     }
-
-
-    /**
-     * @param m canmessage
-     */
-    @Override
-    public void message(CanMessage m) { // outgoing cbus message
-        // log.debug("296 Received new message: {} getevent: {} ", m, CbusMessage.getEvent(m) );
-        
-        // see CbusThrottleManager
-        int opc = CbusMessage.getOpcode(m);
-        
-        if (opc==CbusConstants.CBUS_PLOC) {
-            int rcvdIntAddr = (m.getElement(2) & 0x3f) * 256 + m.getElement(3);
-            boolean rcvdIsLong = (m.getElement(2) & 0xc0) != 0;
-            processploc(true,m.getElement(1),rcvdIntAddr,rcvdIsLong,m.getElement(4),
-            m.getElement(5),m.getElement(6),m.getElement(7));
-        }
-        else if (opc==CbusConstants.CBUS_RLOC) {
-            int rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
-            boolean rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
-            processrloc(true,rcvdIntAddr,rcvdIsLong);
-        }
-        else if (opc==CbusConstants.CBUS_DSPD) {
-            processdspd(true,m.getElement(1),m.getElement(2));
-        }
-        else if (opc==CbusConstants.CBUS_DKEEP) {
-            // log.warn(" kick dkeep ");
-            processdkeep(true,m.getElement(1));
-        }
-        else if (opc==CbusConstants.CBUS_KLOC) {
-            processkloc(true,m.getElement(1));
-        }
-    }
-
-    /**
-     * @param m canmessage
-     */
-    @Override
-    public void reply(CanReply m) { // incoming cbus message
-        
-        int opc = CbusMessage.getOpcode(m);
-
-       // log.warn(" opc {}",opc);
-        
-        if (opc==CbusConstants.CBUS_PLOC) {
-            int rcvdIntAddr = (m.getElement(2) & 0x3f) * 256 + m.getElement(3);
-            boolean rcvdIsLong = (m.getElement(2) & 0xc0) != 0;
-            processploc(true,m.getElement(1),rcvdIntAddr,rcvdIsLong,m.getElement(4),
-            m.getElement(5),m.getElement(6),m.getElement(7));
-        }
-        else if (opc==CbusConstants.CBUS_RLOC) {
-            int rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
-            boolean rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
-            processrloc(true,rcvdIntAddr,rcvdIsLong);
-        }
-        else if (opc==CbusConstants.CBUS_DSPD) {
-            processdspd(true,m.getElement(1),m.getElement(2));
-        }
-        else if (opc==CbusConstants.CBUS_DKEEP) {
-            processdkeep(true,m.getElement(1));
-        }
-        else if (opc==CbusConstants.CBUS_KLOC) {
-            processkloc(true,m.getElement(1));
-        }
-    }
-
     
     // return row number for a loco address, creates new row if no existing
-    public int gettablerow(int locoid){
-        for (int i = 0; i < getRowCount(); i++) {          
+    public int gettablerow(int locoid, Boolean islong){
+        for (int i = 0; i < getRowCount(); i++) {
+            // log.warn("check {} for locoid {}",i,locoid);
             if (locoid==locoidarr.get(i))  {
                 return i;
             }
         }
-        return createnewrow(locoid);
+        return createnewrow(locoid,islong);
     }
     
-    public int gettablerowfromblock(String blockval){
+    public int getrowfromblock(String blockval){
         for (int i = 0; i < getRowCount(); i++) {
-            
             String altd = alttdarr.get(i);
             String locoidstr = locoidarr.get(i).toString();
-            
-            log.debug("blockval {} i {} {} {} ",blockval,i,altd,locoidstr);
-            
-            
-            
             if (Objects.equals(blockval,altd)) {
                 return i;
             }
-            
             if (Objects.equals(blockval,locoidstr)) {
                 return i;
             }
@@ -512,9 +592,8 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
         return -1;
     }    
     
-    
     public int getrowfromsession(int sessionid){
-        for (int i = 0; i < getRowCount(); i++) {          
+        for (int i = 0; i < getRowCount(); i++) {
             if (sessionid==sessionidarr.get(i))  {
                 return i;
             }
@@ -530,64 +609,224 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
         return -1;
     }
     
-    public int createnewrow(int locoid){
+    /**
+     * @param m canmessage
+     */
+    @Override
+    public void message(CanMessage m) { // outgoing cbus message
+        // see CbusThrottleManager
+        int opc = CbusMessage.getOpcode(m);
+        // process is false as outgoing message
         
-        locoidarr.add(locoid);
-        locolongarr.add(null);
-        cmndstatarr.add(-1);
-        sessionidarr.add(-1);        
-        namearr.add("");
-        speedarr.add(-1);
-        speedsteparr.add(-1);
-        alttdarr.add("");
-        currblockarr.add("");
-        
-        Runnable r = new Notify(getRowCount(), this);   // -1 in first arg means all
-        javax.swing.SwingUtilities.invokeLater(r);
-        
-        return getRowCount();
+        if (opc==CbusConstants.CBUS_PLOC) {
+            int rcvdIntAddr = (m.getElement(2) & 0x3f) * 256 + m.getElement(3);
+            boolean rcvdIsLong = (m.getElement(2) & 0xc0) != 0;
+            processploc(false,m.getElement(1),rcvdIntAddr,rcvdIsLong,m.getElement(4),
+            m.getElement(5),m.getElement(6),m.getElement(7));
+        }
+        else if (opc==CbusConstants.CBUS_RLOC) {
+            int rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
+            boolean rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
+            processrloc(false,rcvdIntAddr,rcvdIsLong);
+        }
+        else if (opc==CbusConstants.CBUS_DSPD) {
+            processdspd(false,m.getElement(1),m.getElement(2));
+        }
+        else if (opc==CbusConstants.CBUS_DKEEP) {
+            // log.warn(" kick dkeep ");
+            processdkeep(false,m.getElement(1));
+        }
+        else if (opc==CbusConstants.CBUS_KLOC) {
+            processkloc(false,m.getElement(1));
+        }
+        else if (opc==CbusConstants.CBUS_GLOC) {
+            int rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
+            boolean rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
+            processgloc(false,rcvdIntAddr,rcvdIsLong,m.getElement(3));
+        }
+        else if (opc==CbusConstants.CBUS_ERR) {
+            processerr(false,m.getElement(1),m.getElement(2),m.getElement(3));
+        }
+        else if (opc==CbusConstants.CBUS_STMOD) {
+            processstmod(false,m.getElement(1),m.getElement(2));
+        }  
     }
-    
+
+    /**
+     * @param m canmessage
+     */
+    @Override
+    public void reply(CanReply m) { // incoming cbus message
+        int opc = CbusMessage.getOpcode(m);
+        // log.warn(" opc {}",opc);
+        // process is true as incoming message
+        
+        if (opc==CbusConstants.CBUS_STAT) {
+            // todo more on this when finished tested v3 firmware with all opcs
+            // for now, if a stat opc is received then it's v4
+            // no stat received when < v4 Firmware
+            cmndstat_fw = 4;
+        }
+        
+        if (opc==CbusConstants.CBUS_PLOC) {
+            int rcvdIntAddr = (m.getElement(2) & 0x3f) * 256 + m.getElement(3);
+            boolean rcvdIsLong = (m.getElement(2) & 0xc0) != 0;
+            processploc(true,m.getElement(1),rcvdIntAddr,rcvdIsLong,m.getElement(4),
+            m.getElement(5),m.getElement(6),m.getElement(7));
+        }
+        else if (opc==CbusConstants.CBUS_RLOC) {
+            int rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
+            boolean rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
+            processrloc(true,rcvdIntAddr,rcvdIsLong);
+        }
+        else if (opc==CbusConstants.CBUS_DSPD) {
+            processdspd(true,m.getElement(1),m.getElement(2));
+        }
+        else if (opc==CbusConstants.CBUS_DKEEP) {
+            processdkeep(true,m.getElement(1));
+        }
+        else if (opc==CbusConstants.CBUS_KLOC) {
+            processkloc(true,m.getElement(1));
+        }
+        else if (opc==CbusConstants.CBUS_GLOC) {
+            int rcvdIntAddr = (m.getElement(1) & 0x3f) * 256 + m.getElement(2);
+            boolean rcvdIsLong = (m.getElement(1) & 0xc0) != 0;
+            processgloc(true,rcvdIntAddr,rcvdIsLong,m.getElement(3));
+        }
+        else if (opc==CbusConstants.CBUS_ERR) {
+            processerr(true,m.getElement(1),m.getElement(2),m.getElement(3));
+        }
+        else if (opc==CbusConstants.CBUS_STMOD) {
+            processstmod(true,m.getElement(1),m.getElement(2));
+        }        
+    }
+
     // ploc sent from a command station to a throttle
     public void processploc(boolean messagein, int session, int locoid, Boolean islong, int speeddir, int fa, int fb, int fc) {
-        _context = ("PLOC Session allocated for locoid  "+ session + " " + locoid);
+        _context = ( Bundle.getMessage("CBUS_CMND_BR") + Bundle.getMessage("CNFO_PLOC",session) + locoid);
         addToLog(1,_context); 
-        int row=gettablerow(locoid);
+        int row=gettablerow(locoid,islong);
         if (row < 0 ) {
             log.error("Invalid Row");
+        } else {
+            setValueAt(session, row, SESSION_ID_COLUMN);
+            setValueAt(speeddir, row, LOCO_COMMANDED_SPEED_COLUMN);
+            setValueAt(speeddir, row, LOCO_DIRECTION_COLUMN);
+            // int currthrottles = throttlecountarr.get(gettablerow(locoid))+1;
+            // setValueAt(currthrottles, gettablerow(locoid), NUM_THROTTLES);
         }
-        setValueAt(islong, gettablerow(locoid), LOCO_ID_LONG_COLUMN);
-        setValueAt(session, gettablerow(locoid), SESSION_ID_COLUMN);
-        setValueAt(speeddir, gettablerow(locoid), LOCO_COMMANDED_SPEED_COLUMN);
     }
     
     // kloc sent from throttle to command station to release loco, which will continue at current speed
     public void processkloc(boolean messagein, int session) {
-        log.warn("processing kloc");
-        _context = ("KLOC Throttle releasing session " + session );
+        String messagedir;
+        if (messagein){ // external throttle
+            messagedir = Bundle.getMessage("CBUS_IN_CAB");
+        } else { // jmri throttle
+            messagedir = Bundle.getMessage("CBUS_OUT_CMD");
+        }
+        _context = (messagedir + Bundle.getMessage("CNFO_KLOC",session));
         addToLog(1,_context);
         int row=getrowfromsession(session);
         if ( row > -1 ) {
-            setValueAt(0, row, SESSION_ID_COLUMN);
+            setValueAt(0, row, SESSION_ID_COLUMN); // Session restored by sending QLOC if v4 firmware
+           // int currthrottles = throttlecountarr.get(row)-1;
+           // setValueAt(currthrottles, row, NUM_THROTTLES);
+            
+            // version 4 fw maintains version number, so to check this request session details from command station
+            // if this is sent with the v3 firmware then a popup error comes up from cbus throttlemanager when 
+            // errStr is populated in the switch error clauses in canreply.
+            // check if version 4
+            if ( ( cmndstat_fw > 3 ) && ( speedarr.get(row) > 0 )) {
+                _context = (Bundle.getMessage("CBUS_OUT_CMD") + Bundle.getMessage("QuerySession8a",session));
+                addToLog(1,_context);
+                CanMessage m = new CanMessage(tc.getCanid());
+                m.setNumDataElements(2);
+                CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
+                m.setElement(0, CbusConstants.CBUS_QLOC);
+                m.setElement(1, session);
+                tc.sendCanMessage(m, null);
+            }
         }        
     }    
 
-    // rloc sent from throttle to command station to get loco, deprecated? use gloc
+    // rloc sent from throttle to command station to get loco
     public void processrloc(boolean messagein, int address, boolean islong) {
-        int row = gettablerow(address);
-        _context = ("RLOC Throttle requesting session for islong address  " + row + " " + islong + " " + address );
+        int row = gettablerow(address,islong); // add to table if not already
+        if (log.isDebugEnabled()) {
+            log.debug ("processrloc row {}",row);
+        }
+        String messagedir;
+        if (messagein){ // external throttle
+            messagedir = Bundle.getMessage("CBUS_IN_CAB");
+        } else { // jmri throttle
+            messagedir = Bundle.getMessage("CBUS_OUT_CMD");
+        }
+        _context = (messagedir + Bundle.getMessage("CNFO_RLOC") + address);
         addToLog(1,_context);
-        locolongarr.set(gettablerow(address),islong);
     }
     
     // gloc sent from throttle to command station to get loco
-    public void processgloc(boolean messagein, int high, int low, int flags) {
-        log.warn("processing gloc");   
+    public void processgloc(boolean messagein, int address, Boolean islong, int flags) {
+        int row = gettablerow(address,islong); // add to table if not already
+        if (log.isDebugEnabled()) {
+            log.debug ("processgloc row {}",row);
+        }
+        String messagedir;
+        if (messagein){ // external throttle
+            messagedir = Bundle.getMessage("CBUS_IN_CAB");
+        } else { // jmri throttle
+            messagedir = Bundle.getMessage("CBUS_OUT_CMD");
+        }
+
+        boolean stealmode = ((flags >> 0 ) & 1) != 0;
+        boolean sharemode = ((flags >> 1 ) & 1) != 0;
+        // log.debug("stealmode {} sharemode {} ",stealmode,sharemode);
+        if (stealmode){
+            _context = (messagedir + Bundle.getMessage("CNFO_GLOC_ST") + address );
+        }
+        else if (sharemode){
+            _context = (messagedir + Bundle.getMessage("CNFO_GLOC_SH") + address );
+        }
+        else {
+            _context = (messagedir + Bundle.getMessage("CNFO_GLOC") + address );
+        }
+        addToLog(1,_context);
     }
     
     // stmod sent from throttle to cmmnd station if speed steps not 128 / set service mode / sound mode
-    public void processstmod(boolean messagein, int high, int low, int flags) {
-        log.warn("processing stmod");   
+    public void processstmod(boolean messagein, int session, int flags) {
+        int row=getrowfromsession(session);
+        if ( row > -1 ) {
+            String messagedir;
+            if (messagein){ // external throttle
+                messagedir=( Bundle.getMessage("CBUS_IN_CAB"));
+            } else { // jmri throttle
+                messagedir=( Bundle.getMessage("CBUS_OUT_CMD"));
+            }            
+            
+            boolean sm0 = ((flags >> 0 ) & 1) != 0;
+            boolean sm1 = ((flags >> 1 ) & 1) != 0;
+            boolean servicemode = ((flags >> 2 ) & 1) != 0;
+            boolean soundmode = ((flags >> 3 ) & 1) != 0;
+            
+            String speedstep="";
+            if ((!sm0) && (!sm1)){
+                speedstep="128";
+            }
+            else if ((!sm0) && (sm1)){
+                speedstep="14";
+            }        
+            else if ((sm0) && (!sm1)){
+                speedstep="28 Interleave";
+            }        
+            else if ((sm0) && (sm1)){
+                speedstep="28";
+            }        
+            _context = (messagedir + Bundle.getMessage("CNFO_STMOD",session,speedstep,servicemode,soundmode));
+            addToLog(1,_context);
+            setValueAt(speedstep, row, SPEED_STEP_COLUMN);
+        }
     }
 
     // DKEEP sent as keepalive from throttle to command station 
@@ -602,18 +841,14 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
     
     // DSPD sent from throttle to command station , speed / direction
     public void processdspd(boolean messagein, int session, int speeddir) {
-        log.warn("processing dspd");
+        // log.warn("processing dspd");
         int row=getrowfromsession(session);
         if ( row > -1 ) {
             setValueAt(speeddir, row, LOCO_COMMANDED_SPEED_COLUMN);
+            setValueAt(speeddir, row, LOCO_DIRECTION_COLUMN);
         }
     }
 
-    // STAT sent from command station in response to RSTAT
-    public void processstat(boolean messagein, int high, int low, int flags) {
-        log.warn("processing rstat");
-    }
-    
     // DFLG sent from throttle to command station to notify engine change in flags
     public void processdflg(boolean messagein, int high, int low, int flags) {
         log.warn("processing dflg");   
@@ -624,54 +859,100 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
         log.warn("processing dfnon");   
     }    
     
-    // DFNON Sent by a cab to turn on a specific loco function, alternative method to DFUN
+    // DFNOF Sent by a cab to turn on a specific loco function, alternative method to DFUN
     public void processdfnof(boolean messagein, int high, int low, int flags) {
-        log.warn("processing dfnon");   
+        log.warn("processing dfnof");   
     }
 
     // DFUN Sent by a cab to trigger loco function
     public void processdfun(boolean messagein, int high, int low, int flags) {
-        log.warn("processing dfnon");   
+        log.warn("processing dfun");   
     }
     
     // ERR sent by command station
-    public void processerr(boolean messagein, int high, int low, int flags) {
-        log.warn("processing dfnon");   
+    public void processerr(boolean messagein, int one, int two, int errnum) {
+        // log.warn("processing err");
+        int rcvdIntAddr = (one & 0x3f) * 256 + two;
+        boolean rcvdIsLong = (one & 0xc0) != 0;        
+        StringBuilder buf = new StringBuilder();
+        if (messagein){ // external throttle
+            buf.append( Bundle.getMessage("CBUS_CMND_BR"));
+        } else { // jmri throttle
+            buf.append( Bundle.getMessage("CBUS_OUT_CMD"));
+        }        
+        
+        switch (errnum) {
+            case 1:
+                buf.append(Bundle.getMessage("ERR_LOCO_STACK_FULL"));
+                buf.append(rcvdIntAddr);
+                break;
+            case 2:
+                buf.append(Bundle.getMessage("ERR_LOCO_ADDRESS_TAKEN"));
+                buf.append(rcvdIntAddr);
+                break;
+            case 3:
+                buf.append(Bundle.getMessage("ERR_SESSION_NOT_PRESENT"));
+                buf.append(one);
+                break;
+            case 4:
+                buf.append(Bundle.getMessage("ERR_CONSIST_EMPTY"));
+                buf.append(one);
+                break;
+            case 5:
+                buf.append(Bundle.getMessage("ERR_LOCO_NOT_FOUND"));
+                buf.append(one);
+                break;
+            case 6:
+                buf.append(Bundle.getMessage("ERR_CAN_BUS_ERROR"));
+                break;
+            case 7:
+                buf.append(Bundle.getMessage("ERR_INVALID_REQUEST"));
+                buf.append(rcvdIntAddr);
+                break;
+            case 8:
+                buf.append(Bundle.getMessage("ERR_SESSION_CANCELLED"));
+                buf.append(one);
+                // cancel session number in table
+                int row = gettablerow(rcvdIntAddr,rcvdIsLong);
+                if ( row > -1 ) {
+                    setValueAt(0, row, SESSION_ID_COLUMN);
+                }
+                break;
+            default:
+                break;
+        }
+        _context = buf.toString();
+        addToLog(1,_context);
     }
     
     // RDCC3 RDCC4 RDCC5 RDCC6
     
+    public void getcmdstatversion(){
+        CanMessage m = new CanMessage(tc.getCanid());
+        m.setNumDataElements(1);
+        CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
+        m.setElement(0, CbusConstants.CBUS_RSTAT);
+        tc.sendCanMessage(m, null);
+    }
     
-    
+    // Adds changelistener to blocks
     public void initblocks(){
-        
-      //  log.warn("initblocks");
-
-        // List<String> blocks = blockManager.getSystemNameList();
-        
-        // Handle Blocks
+        mBlockList=null;
+        mBlockList = new ArrayList<>();
         BlockManager bmgr = jmri.InstanceManager.getDefault(jmri.BlockManager.class);
         Set<Block> blockSet = bmgr.getNamedBeanSet();
-       // Object[][] blockTable = new Object[blockSet.size()][6];
-      //  blockMap = new HashMap<>();
         int i = 0;
         for (Block b : blockSet) {
-         //   log.warn("block found {}",i);
             mBlockList.add(b);
             final int index = i; 
             PropertyChangeListener listener = (PropertyChangeEvent e) -> {
-         //       log.warn("pcl handle index {} {}",index,e);
                 handleBlockChange(index,e);
             };
             b.addPropertyChangeListener(listener);
             mBlockListeners.add(listener);
             i++;
         }
-        
-      //  log.warn("finished initblocks");
-        
     }
-    
     
     /**
      * Handle tasks when block changes
@@ -679,45 +960,127 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
      * @param e propChgEvent
      */
     private void handleBlockChange(int index, PropertyChangeEvent e) {
-            
-        log.debug("block changed at index {} {}",index, e);
+        Block b = mBlockList.get(index);
         
-        if (e.getPropertyName().equals("value")) {
-            Block b = mBlockList.get(index);
+        if ((e.getPropertyName().equals("state")) || (e.getPropertyName().equals("direction"))) {
             Object val = b.getValue();
-            
             if (val == null) {
                 return; 
             }
-            
-            String blockname = b.getUserName();
             String strval = val.toString();
-            
-         //   log.warn("block {} value changed to {}",blockname,strval);
-            
-            int row = gettablerowfromblock(strval);
+            int row = getrowfromblock(strval);
             if (row > -1 ) {
-                setValueAt(blockname, row, CURRENT_BLOCK);
-             //   getpathfromblock(b);
+                blockarr.set(row,b);
+                String blockname = b.getUserName();
+                String directionstr = Path.decodeDirection(b.getDirection());
+                setValueAt(( directionstr ), row, BLOCK_DIR);
+                setValueAt(( blockname ), row, CURRENT_BLOCK);
+                updateblocksforrow(row);
             }
         }
     }
     
-    
-  //  private void getpathfromblock(Block b){
-      //  List<Block> currentPath = new ArrayList<>();
-     //   log.warn("getting path for block {}",b);
+    void updateblocksforrow(int row){
+        List<Block> routelist = new ArrayList<>();
+        if (sigListeners.get(row) != null) {
+            sigListeners.get(row).removePropertyChangeListener(_cconSignalMastListener);
+        }
+        sigListeners.set(row,null);
         
-      //  LayoutBlockManager lbm = InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class);
-      //  LayoutBlock lb = lbm.getLayoutBlock(b);
-      //  SignalMast getFacingSignalMast = lbm.getFacingSignalMast(b,null,null);
+        Block b = blockarr.get(row);
+        Block nB;
+        SignalMast sm = null;
+        LayoutBlockManager lbm = InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class);
         
-     //   log.warn("path list {}",getFacingSignalMast);
-   // }
+        int dir = b.getDirection();
+        int blockstep = 0;
+        
+        routelist.add(b);
+        pFromDir[0] = dir;
+        
+        if ( dir > 0 ) {
+            nB = getnextblock(blockstep,(routelist.get(blockstep)),pFromDir[blockstep]);
+            routelist.add(nB);
+            while (sm == null && nB != null) {
+                sm = lbm.getFacingSignalMast(b, nB);
+                if (sm == null) {
+                    blockstep++;                                
+                    b = nB;
+                    nB = getnextblock(blockstep,(routelist.get(blockstep)),pFromDir[blockstep]);
+                    routelist.add(nB);
+                }
+            }
+            if ( sm == null) {
+                sm = lbm.getSignalMastAtEndBumper(routelist.get(blockstep),null);
+            }
+            if ( sm == null) {
+                setValueAt(( "" ), row, NEXT_SIGNAL);
+                setValueAt(( "" ), row, NEXT_ASPECT);
+            } else {
+                setValueAt(( sm.getDisplayName() ), row, NEXT_SIGNAL);
+                setValueAt(( sm.getAspect() ), row, NEXT_ASPECT);
+                // add signal changelistener
+                sm.addPropertyChangeListener(_cconSignalMastListener = (PropertyChangeEvent e) -> {
+                    updateblocksforrow(row);
+                });
+                sigListeners.set(row,sm);
+            }
+        } else {
+            // no direction
+            setValueAt(( "" ), row, NEXT_SIGNAL);
+            setValueAt(( "" ), row, NEXT_ASPECT);
+            setValueAt("", row, NEXT_BLOCK);
+        }
+        if ( routelist.size()==1 ) {
+            setValueAt("", row, NEXT_BLOCK);
+        } else {
+            if ( routelist.get(1)==null) {
+                setValueAt("", row, NEXT_BLOCK);
+            } else {
+                setValueAt(routelist.get(1).getUserName(), row, NEXT_BLOCK);
+            }
+        }
+    }    
     
-    
-    
-    
+    private Block getnextblock(int step, Block b, int fromdirection){
+        List<Path> thispaths =b.getPaths();
+        for (final Path testpath : thispaths) {
+            if (testpath.checkPathSet()) {
+                Block blockTest = testpath.getBlock();
+                int dirftTest = testpath.getFromBlockDirection();
+                int dirtoTest = testpath.getToBlockDirection();
+                if ((((fromdirection & Path.NORTH) != 0) && ((dirtoTest & Path.NORTH) != 0)) ||
+                    (((fromdirection & Path.SOUTH) != 0) && ((dirtoTest & Path.SOUTH) != 0)) ||
+                    (((fromdirection & Path.EAST) != 0) && ((dirtoTest & Path.EAST) != 0)) ||
+                    (((fromdirection & Path.WEST) != 0) && ((dirtoTest & Path.WEST) != 0)) ||
+                    (((fromdirection & Path.CW) != 0) && ((dirtoTest & Path.CW) != 0)) ||
+                    (((fromdirection & Path.CCW) != 0) && ((dirtoTest & Path.CCW) != 0)) ||
+                    (((fromdirection & Path.LEFT) != 0) && ((dirtoTest & Path.LEFT) != 0)) ||
+                    (((fromdirection & Path.RIGHT) != 0) && ((dirtoTest & Path.RIGHT) != 0)) ||
+                    (((fromdirection & Path.UP) != 0) && ((dirtoTest & Path.UP) != 0)) ||
+                    (((fromdirection & Path.DOWN) != 0) && ((dirtoTest & Path.DOWN) != 0)))
+                { // most reliable
+                    pFromDir[(step+1)] = dirtoTest;
+                    _context = ("method 1 exiting with direction " + Path.decodeDirection(dirtoTest));
+                    addToLog(1,_context);
+                    return blockTest;
+                }
+                if (((fromdirection & dirftTest)) == 0) { // less reliable
+                    pFromDir[(step+1)] = dirtoTest;
+                    _context = ("method 2 exiting with direction " + Path.decodeDirection(dirtoTest));
+                    addToLog(1,_context);
+                    return blockTest;
+                }
+                if ((fromdirection != dirftTest)){ // least reliable but copes with 180 degrees 
+                    pFromDir[(step+1)] = dirtoTest;
+                    _context = ("method 3 exiting with direction " + Path.decodeDirection(dirtoTest));
+                    addToLog(1,_context);
+                    return blockTest;
+                }
+            }
+        }
+      return null;
+    }
     
     /**
      * Add to Slot Monitor Console Log
@@ -754,7 +1117,6 @@ public class CbusSlotMonitorDataModel extends javax.swing.table.AbstractTableMod
         if (tc != null) {
             tc.removeCanListener(this);
         }
-        
     }
 
     private final static Logger log = LoggerFactory.getLogger(CbusSlotMonitorDataModel.class);

--- a/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/PackageTest.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 })
 
 /**
- * Tests for the jmri.jmrix.can.cbus.swing.eventtable package
+ * Tests for the jmri.jmrix.can.cbus.swing.cbusslotmonitor package
  *
  * @author Bob Jacobsen Copyright 2008
  * @author  Paul Bender	Copyright (C) 2016

--- a/xml/signals/BR-2003/index.shtml
+++ b/xml/signals/BR-2003/index.shtml
@@ -91,8 +91,15 @@
     <ul>
     <li><a href="appearance-feather.xml">Feather with up to 6 positions</a></li>
     </ul>
+    <p>1 North West<br>
+    2 West<br>
+    3 South West<br>
+    4 North East<br>
+    5 East<br>
+    6 South East<br>
+    </p>
     
-    <p>Position Light Signals definitions:</p>
+    <p>Position Light Signals definitions ( aka Shunt or Shunting Signals ):</p>
     <ul>
     <li><a href="appearance-plr.xml">Position Light Signal Red White Apperance</a>
     <li><a href="appearance-ply.xml">Position Light Signal Yellow White Apperance</a>


### PR DESCRIPTION
Adds monitors for STMOD, ERR & GLOC OPC's.
Adds next block / signalmast / aspect support.
Start move to Bundle.
Update support page.

Convert byte pair to loco ID in Cmnd station errors - main MERG CBUS Console
Add feather position numerics to BR2003 support page