### PR TITLE
MERG CBUS Query Turnout / Sensor

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusConstants.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusConstants.java
@@ -226,11 +226,6 @@ public final class CbusConstants {
     public static final int DEFAULT_MINOR_PRIORITY = 3;
 
     /**
-     * Event Table
-     */
-    public static final int MAX_TABLE_EVENTS = 5000;
-
-    /**
      * Function bits for group1
      */
     public static final int CBUS_F0 = 16;

--- a/java/src/jmri/jmrix/can/cbus/CbusOpCodes.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusOpCodes.java
@@ -480,10 +480,12 @@ public class CbusOpCodes {
         Bundle.getMessage("OPC_VL") + ":,%1"); // NOI18N
         
         result.put(CbusConstants.CBUS_ACDAT, Bundle.getMessage("CBUS_ACDAT") + " " + 
-        Bundle.getMessage("OPC_DA") + ":,%1, ,%1, ,%1, ,%1, ,%1, ,%1, ,%1"); // NOI18N
+        Bundle.getMessage("OPC_NN") + ":,%2, " +
+        Bundle.getMessage("OPC_DA") + ":,%1, ,%1, ,%1, ,%1, ,%1"); // NOI18N
         
         result.put(CbusConstants.CBUS_ARDAT, Bundle.getMessage("CBUS_ARDAT") + " " + 
-        Bundle.getMessage("OPC_DA") + ":,%1, ,%1, ,%1, ,%1, ,%1, ,%1, ,%1"); // NOI18N
+        Bundle.getMessage("OPC_NN") + ":,%2, " +
+        Bundle.getMessage("OPC_DA") + ":,%1, ,%1, ,%1, ,%1, ,%1"); // NOI18N
         
         result.put(CbusConstants.CBUS_ASON3, Bundle.getMessage("CBUS_ASON3") + " " + 
         Bundle.getMessage("OPC_NN") + ":,%2, " + Bundle.getMessage("OPC_DN") + ":,%2, " + 

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
@@ -96,36 +96,63 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
     protected void forwardCommandChangeToLayout(int s) {
         CanMessage m;
         if (s == Turnout.THROWN) {
-            m = addrThrown.makeMessage(tc.getCanid());
+            if (getInverted()){
+                m = addrClosed.makeMessage(tc.getCanid());
+            } else {
+                m = addrThrown.makeMessage(tc.getCanid());
+            }
             tc.sendCanMessage(m, this);
         } else if (s == Turnout.CLOSED) {
-            m = addrClosed.makeMessage(tc.getCanid());
+            if (getInverted()){
+                m = addrThrown.makeMessage(tc.getCanid());
+            }
+            else {
+                m = addrClosed.makeMessage(tc.getCanid());
+            }
             tc.sendCanMessage(m, this);
         }
     }
 
+    
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void message(CanMessage f) {
         if (addrThrown.match(f)) {
-            newCommandedState(THROWN);
+            newCommandedState(!getInverted() ? THROWN : CLOSED);
         } else if (addrClosed.match(f)) {
-            newCommandedState(CLOSED);
+            newCommandedState(!getInverted() ? CLOSED : THROWN);
         }
     }
-
+    
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void reply(CanReply f) {
         // convert response events to normal
         f = CbusMessage.opcRangeToStl(f);
         if (addrThrown.match(f)) {
-            newCommandedState(THROWN);
+            newCommandedState(!getInverted() ? THROWN : CLOSED);
         } else if (addrClosed.match(f)) {
-            newCommandedState(CLOSED);
+            newCommandedState(!getInverted() ? CLOSED : THROWN);
         }
     }
-
+    
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected void turnoutPushbuttonLockout(boolean locked) {
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean canInvert() {
+        return true;
     }
 
     private final static Logger log = LoggerFactory.getLogger(CbusTurnout.class);

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
@@ -4,7 +4,9 @@ import jmri.Turnout;
 import jmri.jmrix.can.CanListener;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
+import jmri.jmrix.can.cbus.CbusConstants;
 import jmri.jmrix.can.cbus.CbusMessage;
+import jmri.jmrix.can.cbus.CbusOpCodes;
 import jmri.jmrix.can.TrafficController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,6 +70,23 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
         tc.addCanListener(this);
     }
 
+    /**
+     * Request an update on status by sending CBUS request message to thrown address.
+     */
+    @Override
+    public void requestUpdateFromLayout() {
+        CanMessage m;
+        m = addrThrown.makeMessage(tc.getCanid());
+        int opc = CbusMessage.getOpcode(m);
+        if (CbusOpCodes.isShortEvent(opc)) {
+            m.setOpCode(CbusConstants.CBUS_ASRQ);
+        }
+        else {
+            m.setOpCode(CbusConstants.CBUS_AREQ);
+        }
+        tc.sendCanMessage(m, this);
+    }
+    
     /**
      * Handle a request to change state by sending CBUS events.
      *


### PR DESCRIPTION
Adds support to
Turnout table query button ( queries thrown address )
Sensor table query button ( queries active address )
Sensor table forget status button ( does not send anything to layout ).