### PR TITLE
WIP Fix InstanceManager

### DIFF
--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -804,9 +804,6 @@ public final class InstanceManager {
         log.debug("Clearing InstanceManager");
         if (traceFileActive) traceFileWriter.println("clearAll");
         
-        // replace the instance manager, so future calls will invoke the new one
-        LazyInstanceManager.instanceManager = new InstanceManager();
-        
         // continue to clean up this one
         new HashSet<>(managerLists.keySet()).forEach((type) -> {
             clear(type);
@@ -825,6 +822,9 @@ public final class InstanceManager {
             traceFileWriter.println(""); // marks new InstanceManager
             traceFileWriter.flush();
         }
+        
+        // replace the instance manager, so future calls will invoke the new one
+        LazyInstanceManager.instanceManager = new InstanceManager();
     }
 
     /**

--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -252,7 +252,7 @@ public final class InstanceManager {
      */
     @CheckForNull
     public <T> T getInstance(@Nonnull Class<T> type) {
-        log.trace("getOptionalDefault of type {}", type.getName());
+        log.trace("getInstance of type {}", type.getName());
         List<T> l = getInstances(type);
         if (l.isEmpty()) {
             synchronized (type) {
@@ -344,6 +344,34 @@ public final class InstanceManager {
 
     /**
      * Retrieve the last object of type T that was registered with
+     * {@link #store(java.lang.Object, java.lang.Class) } if and only if that
+     * object exists. Else returns null.
+     * <p>
+     * Unless specifically set, the default is the last object stored, see the
+     * {@link #setDefault(java.lang.Class, java.lang.Object) } method.
+     * <p>
+     * In most cases, system configuration assures the existence of a default
+     * object, but this method also handles the case where one doesn't exist.
+     * Use {@link #getDefault(java.lang.Class)} when the object is guaranteed to
+     * exist.
+     *
+     * @param <T>  The type of the class
+     * @param type The class Object for the item's type.
+     * @return The default object for type.
+     * @see #getOptionalDefault(java.lang.Class)
+     */
+    @CheckForNull
+    public <T> T getDefaultIfExists(@Nonnull Class<T> type) {
+        log.trace("getDefaultIfExists of type {}", type.getName());
+        List<T> l = getInstances(type);
+        if (l.isEmpty()) {
+            return null;
+        }
+        return l.get(l.size() - 1);
+    }
+
+    /**
+     * Retrieve the last object of type T that was registered with
      * {@link #store(java.lang.Object, java.lang.Class)} wrapped in an
      * {@link java.util.Optional}.
      * <p>
@@ -366,7 +394,7 @@ public final class InstanceManager {
      */
     @Nonnull
     static public <T> Optional<T> getOptionalDefault(@Nonnull Class< T> type) {
-        return Optional.ofNullable(InstanceManager.getNullableDefault(type));
+        return Optional.ofNullable(getDefault().getDefaultIfExists(type));
     }
 
     /**

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrameTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgFrameTest.java
@@ -176,7 +176,9 @@ public class PaneProgFrameTest extends TestCase {
     @Override
     protected void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initDebugProgrammerManager();
     }
 
     @Override

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPaneTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/PaneProgPaneTest.java
@@ -425,7 +425,9 @@ public class PaneProgPaneTest {
     @Before
     public void setUp() {
         JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetProfileManager();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetProfileManager();
+        JUnitUtil.initDebugProgrammerManager();
     }
 
     @After

--- a/java/test/jmri/jmrit/symbolicprog/tabbedframe/QualifiedVarTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/tabbedframe/QualifiedVarTest.java
@@ -199,7 +199,9 @@ public class QualifiedVarTest extends TestCase {
     @Override
     protected void setUp() {
         JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager();
+        JUnitUtil.initDebugProgrammerManager();
     }
 
     @Override


### PR DESCRIPTION
@bobjacobsen 

I apologize for disturbing you again with the InstanceManager, but I think I fixed the problem with
InstanceManager.clearAll() [discussed](https://github.com/JMRI/JMRI/pull/5881#issuecomment-437471559) in PR #5881.

The problem seems to be that InstanceManager.getOptionalDefault calls getNullableDefault which in turn
calls getInstance() which in some cases creates a new object. I therefore changed getOptionalDefault to
use the new method getDefaultIfExists() to ensure that a new object is not created.

This seems to solve the problem.