### PR TITLE
SCWarrant improvements

### DIFF
--- a/java/src/jmri/jmrit/logix/OBlock.java
+++ b/java/src/jmri/jmrit/logix/OBlock.java
@@ -568,6 +568,14 @@ public class OBlock extends jmri.Block implements java.beans.PropertyChangeListe
 //        setState(getState() | ALLOCATED);  DO NOT ALLOCATE
         return null;
     }
+    
+    public String getAllocatingWarrantName() {
+        if (_warrant == null) {
+            return ("no warrant");
+        } else {
+            return _warrant.getDisplayName();
+        }
+    }
 
     /**
      * Remove allocation state Remove listener regardless of ownership

--- a/java/src/jmri/jmrit/logix/SCWarrant.java
+++ b/java/src/jmri/jmrit/logix/SCWarrant.java
@@ -245,11 +245,11 @@ public class SCWarrant extends Warrant {
                 wait(2500);
             } catch (InterruptedException ie) {
                 log.debug(_trainName+" waitForStartblockToGetOccupied InterruptedException "+ie);
-                LogStackTrace(ie);
+                logStackTrace(ie);
             }
             catch(Exception e){
                 log.debug(_trainName+" waitForStartblockToGetOccupied unexpected exception "+e);
-                LogStackTrace(e);
+                logStackTrace(e);
             }
         }
     }
@@ -579,7 +579,7 @@ public class SCWarrant extends Warrant {
                     } catch (InterruptedException e) {
                     } catch(Exception e){
                         log.debug(_trainName+" wait unexpected exception "+e);
-                        LogStackTrace(e);
+                        logStackTrace(e);
                     }
                     // And then let our main loop continue
                     notify();
@@ -631,12 +631,12 @@ public class SCWarrant extends Warrant {
             manager.setPower(PowerManager.OFF);
         } catch (Exception e) {
             log.debug(_trainName+" EMERGENCY STOP FAILED WITH EXCEPTION: "+e);
-            LogStackTrace(e);
+            logStackTrace(e);
         }
         log.debug(_trainName+" EMERGENCY STOP");
     }
     
-    void LogStackTrace(Exception e) {
+    private void logStackTrace(Exception e) {
         StringWriter outError = new StringWriter();
         e.printStackTrace(new PrintWriter(outError));
         log.debug(outError.toString());
@@ -679,7 +679,7 @@ public class SCWarrant extends Warrant {
                     }
                 } catch (Exception ex) {
                     log.debug(_trainName+" isItOurTurn exception ignored: "+ex);
-                    LogStackTrace(ex);
+                    logStackTrace(ex);
                 }
             }
             // we should not reach this point, but if we do, we should try to run
@@ -699,7 +699,7 @@ public class SCWarrant extends Warrant {
                         waitToRunQ.put(_warrant);
                     } catch (InterruptedException ie) {
                         log.debug(_trainName+" waitToRunQ.put InterruptedException "+ie);
-                        LogStackTrace(ie);
+                        logStackTrace(ie);
                     }
 
                     while (!AllocationDone) {
@@ -711,11 +711,11 @@ public class SCWarrant extends Warrant {
                                 _warrant.wait(2500 + Math.round(1000*Math.random()));
                             } catch (InterruptedException ie) {
                                 log.debug(_trainName+" _warrant.wait InterruptedException "+ie);
-                                LogStackTrace(ie);
+                                logStackTrace(ie);
                             }
                             catch(Exception e){
                                 log.debug(_trainName+" _warrant.wait unexpected exception "+e);
-                                LogStackTrace(e);
+                                logStackTrace(e);
                             }
                         }
                         allocateStartBlock();
@@ -727,11 +727,11 @@ public class SCWarrant extends Warrant {
                                 _warrant.wait(10000 + Math.round(1000*Math.random()));
                             } catch (InterruptedException ie) {
                                 log.debug(_trainName+" _warrant.wait !AllocationDone InterruptedException "+ie);
-                                LogStackTrace(ie);
+                                logStackTrace(ie);
                             }
                             catch(Exception e){
                                 log.debug(_trainName+" _warrant.wait !AllocationDone unexpected exception "+e);
-                                LogStackTrace(e);
+                                logStackTrace(e);
                             }
                         }
                     }
@@ -745,11 +745,11 @@ public class SCWarrant extends Warrant {
                             _warrant.wait(2500);
                         } catch (InterruptedException ie) {
                             log.debug(_trainName+" _warrant.wait InterruptedException "+ie);
-                            LogStackTrace(ie);
+                            logStackTrace(ie);
                         }
                         catch(Exception e){
                             log.debug(_trainName+" _warrant.wait unexpected exception "+e);
-                            LogStackTrace(e);
+                            logStackTrace(e);
                         }
                     }
                     // And then wait another 3 seconds to make the last turnout settle - just in case the command station is not giving correct feedback
@@ -757,11 +757,11 @@ public class SCWarrant extends Warrant {
                         _warrant.wait(3000);
                     } catch (InterruptedException ie) {
                         log.debug(_trainName+" InterruptedException "+ie);
-                        LogStackTrace(ie);
+                        logStackTrace(ie);
                     }
                     catch(Exception e){
                         log.debug(_trainName+" wait unexpected exception "+e);
-                        LogStackTrace(e);
+                        logStackTrace(e);
                     }
                 }
 
@@ -787,7 +787,7 @@ public class SCWarrant extends Warrant {
                         } catch (Exception e) {
                             emergencyStop();
                             log.debug(_warrant._trainName+" exception trying to stop train due to block not free: "+e);
-                            LogStackTrace(e);
+                            logStackTrace(e);
                         }
                     }
                     log.debug(_warrant._trainName+" "+_warrant.getDisplayName()+" before wait "+_warrant.getRunningMessage()+" _idxCurrentOrder: "+_warrant._idxCurrentOrder+" orders.size(): "+orders.size());
@@ -796,11 +796,11 @@ public class SCWarrant extends Warrant {
                         _warrant.wait(2000);
                     } catch (InterruptedException ie) {
                         log.debug(_warrant._trainName+" InterruptedException "+ie);
-                        LogStackTrace(ie);
+                        logStackTrace(ie);
                     }
                     catch(Exception e){
                         log.debug(_trainName+" wait unexpected exception "+e);
-                        LogStackTrace(e);
+                        logStackTrace(e);
                     }
                     log.debug(_warrant._trainName+" "+_warrant.getDisplayName()+" after wait "+_warrant.getRunningMessage()+" _idxCurrentOrder: "+_warrant._idxCurrentOrder+" orders.size(): "+orders.size());
                 }
@@ -825,11 +825,11 @@ public class SCWarrant extends Warrant {
                         _warrant.wait(500);
                     } catch (InterruptedException ie) {
                         log.debug(_warrant._trainName+" InterruptedException "+ie);
-                        LogStackTrace(ie);
+                        logStackTrace(ie);
                     }
                     catch(Exception e){
                         log.debug(_trainName+" wait unexpected exception "+e);
-                        LogStackTrace(e);
+                        logStackTrace(e);
                     }
                     log.debug(_warrant._trainName+" runSignalControlledTrain woken after last wait.... _orders.size()="+orders.size());
                 }
@@ -843,7 +843,7 @@ public class SCWarrant extends Warrant {
                             _warrant.wait(remaining);
                         } catch (InterruptedException e) {
                             log.debug(_warrant._trainName+" InterruptedException "+e);
-                            LogStackTrace(e);
+                            logStackTrace(e);
                         }
                     }
                 }

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -68,14 +68,14 @@ public class Warrant extends jmri.implementation.AbstractNamedBean implements Th
     // transient members
     private LearnThrottleFrame _student; // need to callback learning throttle in learn mode
     private boolean _tempRunBlind; // run mode flag to allow running on ET only
-    private boolean _delayStart; // allows start block unoccupied and wait for train
+    protected boolean _delayStart; // allows start block unoccupied and wait for train
     protected int _idxCurrentOrder; // Index of block at head of train (if running)
     protected int _idxLastOrder; // Index of block at tail of train just left
     private String _curSpeedType; // name of last moving speed, i.e. never "Stop".  Used to restore previous speed
     protected ArrayList<BlockSpeedInfo> _speedInfo; // map max speeds and occupation times of each block in route
 
     protected int _runMode;
-    protected Engineer _engineer; // thread that runs the train
+    private Engineer _engineer; // thread that runs the train
     private CommandDelay _delayCommand; // thread for delayed ramp down
     private boolean _allocated; // initial Blocks of _orders have been allocated
     private boolean _totalAllocated; // All Blocks of _orders have been allocated


### PR DESCRIPTION
a. SCWarrant no longer uses the Engineer and SpeedUtil classes. This gives fewer bindings to the base Warrant class and also means that SCWarrants code become more transparent and thereby hopefully less error-prone.

b. An emergency stop is made by switching the layout power off, if a train cannot be stopped due to a lost throttle.

c. A mechanism has been introduced for handling a situation where several SCWarrants are competing for the same blocks.

d. Error correction: SCWarrants have never been able to handle a train arriving at the start block after the warrant has been initiated.