### PR TITLE
try/catch added to avoid crashes

### DIFF
--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -318,7 +318,32 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         int old = _current;
         _current = v;
         // notify
-        firePropertyChange("state", old, _current);
+        // It is rather unpleasant that the following needs to be done in a try-catch, but exceptions have been observed: 
+        // java.lang.IllegalArgumentException: illegal component position
+	// at java.awt.Container.addImpl(Container.java:1087)
+	// at javax.swing.JLayeredPane.addImpl(JLayeredPane.java:231)
+	// at java.awt.Container.add(Container.java:973)
+	// at jmri.jmrit.display.Editor$TargetPane.add(Editor.java:608)
+	// at jmri.jmrit.display.Editor.addToTarget(Editor.java:1716)
+	// at jmri.jmrit.display.Editor.displayLevelChange(Editor.java:1673)
+	// at jmri.jmrit.display.PositionableJComponent.setDisplayLevel(PositionableJComponent.java:143)
+	// at jmri.jmrit.display.controlPanelEditor.shape.PositionableShape.<init>(PositionableShape.java:70)
+	// at jmri.jmrit.display.controlPanelEditor.shape.PositionableRectangle.<init>(PositionableRectangle.java:16)
+	// at jmri.jmrit.display.controlPanelEditor.shape.PositionableRoundRect.<init>(PositionableRoundRect.java:20)
+	// at jmri.jmrit.display.controlPanelEditor.shape.LocoLabel.<init>(LocoLabel.java:13)
+	// at jmri.jmrit.display.IndicatorTrackPaths.setLocoIcon(IndicatorTrackPaths.java:132)
+	// at jmri.jmrit.display.IndicatorTrackIcon.setStatus(IndicatorTrackIcon.java:282)
+	// at jmri.jmrit.display.IndicatorTrackIcon.propertyChange(IndicatorTrackIcon.java:263)
+	// at java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:335)
+	// at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:327)
+	// at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:263)
+	// at jmri.implementation.AbstractNamedBean.firePropertyChange(AbstractNamedBean.java:243)
+	// at jmri.Block.setState(Block.java:321)
+        try {
+            firePropertyChange("state", old, _current);
+        } catch (Exception e) {
+            log.debug(getDisplayName()+" got exception during fireProperTyChange("+old+","+_current+"): "+e);
+        }
     }
 
     /**

--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -12,6 +12,8 @@ import javax.annotation.Nonnull;
 import jmri.implementation.AbstractNamedBean;
 import jmri.implementation.SignalSpeedMap;
 import jmri.util.PhysicalLocation;
+import java.io.StringWriter;
+import java.io.PrintWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -342,7 +344,11 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         try {
             firePropertyChange("state", old, _current);
         } catch (Exception e) {
-            log.debug(getDisplayName()+" got exception during fireProperTyChange("+old+","+_current+"): "+e);
+            log.error(getDisplayName()+" got exception during fireProperTyChange("+old+","+_current+") in thread "+
+                    Thread.currentThread().getName()+" "+Thread.currentThread().getId()+": "+e);
+            StringWriter outError = new StringWriter();
+            e.printStackTrace(new PrintWriter(outError));
+            log.error(outError.toString());
         }
     }
 

--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -12,8 +12,6 @@ import javax.annotation.Nonnull;
 import jmri.implementation.AbstractNamedBean;
 import jmri.implementation.SignalSpeedMap;
 import jmri.util.PhysicalLocation;
-import java.io.StringWriter;
-import java.io.PrintWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -320,35 +318,13 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
         int old = _current;
         _current = v;
         // notify
-        // It is rather unpleasant that the following needs to be done in a try-catch, but exceptions have been observed: 
-        // java.lang.IllegalArgumentException: illegal component position
-	// at java.awt.Container.addImpl(Container.java:1087)
-	// at javax.swing.JLayeredPane.addImpl(JLayeredPane.java:231)
-	// at java.awt.Container.add(Container.java:973)
-	// at jmri.jmrit.display.Editor$TargetPane.add(Editor.java:608)
-	// at jmri.jmrit.display.Editor.addToTarget(Editor.java:1716)
-	// at jmri.jmrit.display.Editor.displayLevelChange(Editor.java:1673)
-	// at jmri.jmrit.display.PositionableJComponent.setDisplayLevel(PositionableJComponent.java:143)
-	// at jmri.jmrit.display.controlPanelEditor.shape.PositionableShape.<init>(PositionableShape.java:70)
-	// at jmri.jmrit.display.controlPanelEditor.shape.PositionableRectangle.<init>(PositionableRectangle.java:16)
-	// at jmri.jmrit.display.controlPanelEditor.shape.PositionableRoundRect.<init>(PositionableRoundRect.java:20)
-	// at jmri.jmrit.display.controlPanelEditor.shape.LocoLabel.<init>(LocoLabel.java:13)
-	// at jmri.jmrit.display.IndicatorTrackPaths.setLocoIcon(IndicatorTrackPaths.java:132)
-	// at jmri.jmrit.display.IndicatorTrackIcon.setStatus(IndicatorTrackIcon.java:282)
-	// at jmri.jmrit.display.IndicatorTrackIcon.propertyChange(IndicatorTrackIcon.java:263)
-	// at java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:335)
-	// at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:327)
-	// at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:263)
-	// at jmri.implementation.AbstractNamedBean.firePropertyChange(AbstractNamedBean.java:243)
-	// at jmri.Block.setState(Block.java:321)
+
+        // It is rather unpleasant that the following needs to be done in a try-catch, but exceptions have been observed
         try {
             firePropertyChange("state", old, _current);
         } catch (Exception e) {
             log.error(getDisplayName()+" got exception during fireProperTyChange("+old+","+_current+") in thread "+
-                    Thread.currentThread().getName()+" "+Thread.currentThread().getId()+": "+e);
-            StringWriter outError = new StringWriter();
-            e.printStackTrace(new PrintWriter(outError));
-            log.error(outError.toString());
+                    Thread.currentThread().getName()+" "+Thread.currentThread().getId()+": ", e);
         }
     }
 

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -650,9 +650,13 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
                 g2d.scale(_paintScale, _paintScale);
             }
 
-            super.paint(g);
-            paintTargetPanel(g);
-
+            try {
+               super.paint(g);
+               paintTargetPanel(g);
+            } catch (Exception e) {
+                log.error("paint failed: "+e);
+            }
+            
             Stroke stroke = new BasicStroke();
             if (g2d != null) {
                 stroke = g2d.getStroke();

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -28,8 +28,6 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -652,15 +650,13 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
                 g2d.scale(_paintScale, _paintScale);
             }
 
+            // It is rather unpleasant that the following needs to be done in a try-catch, but exceptions have been observed
             try {
                super.paint(g);
                paintTargetPanel(g);
             } catch (Exception e) {
                 log.error("paint failed in thread "+
-                    Thread.currentThread().getName()+" "+Thread.currentThread().getId()+": "+e);
-                StringWriter outError = new StringWriter();
-                e.printStackTrace(new PrintWriter(outError));
-                log.error(outError.toString());
+                    Thread.currentThread().getName()+" "+Thread.currentThread().getId()+": ", e);
             }
             
             Stroke stroke = new BasicStroke();

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -28,6 +28,8 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -654,7 +656,11 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
                super.paint(g);
                paintTargetPanel(g);
             } catch (Exception e) {
-                log.error("paint failed: "+e);
+                log.error("paint failed in thread "+
+                    Thread.currentThread().getName()+" "+Thread.currentThread().getId()+": "+e);
+                StringWriter outError = new StringWriter();
+                e.printStackTrace(new PrintWriter(outError));
+                log.error(outError.toString());
             }
             
             Stroke stroke = new BasicStroke();

--- a/java/src/jmri/jmrit/display/IndicatorTrackIcon.java
+++ b/java/src/jmri/jmrit/display/IndicatorTrackIcon.java
@@ -279,7 +279,11 @@ public class IndicatorTrackIcon extends PositionableIcon
     private void setStatus(OBlock block, int state) {
         _status = _pathUtil.getStatus(block, state);
         if ((state & (OBlock.OCCUPIED | OBlock.RUNNING)) != 0) {
-            _pathUtil.setLocoIcon(block, getLocation(), getSize(), _editor);
+            try {
+                _pathUtil.setLocoIcon(block, getLocation(), getSize(), _editor);
+            } catch (Exception e) {
+                log.error("setStatus on indicator track icon failed: "+e);
+            }
         }
         repaint();
         if ((block.getState() & OBlock.OUT_OF_SERVICE) != 0) {

--- a/java/src/jmri/jmrit/display/IndicatorTrackIcon.java
+++ b/java/src/jmri/jmrit/display/IndicatorTrackIcon.java
@@ -2,8 +2,6 @@ package jmri.jmrit.display;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -281,14 +279,12 @@ public class IndicatorTrackIcon extends PositionableIcon
     private void setStatus(OBlock block, int state) {
         _status = _pathUtil.getStatus(block, state);
         if ((state & (OBlock.OCCUPIED | OBlock.RUNNING)) != 0) {
+            // It is rather unpleasant that the following needs to be done in a try-catch, but exceptions have been observed
             try {
                 _pathUtil.setLocoIcon(block, getLocation(), getSize(), _editor);
             } catch (Exception e) {
                 log.error("setStatus on indicator track icon failed in thread "+
-                    Thread.currentThread().getName()+" "+Thread.currentThread().getId()+": "+e);
-                StringWriter outError = new StringWriter();
-                e.printStackTrace(new PrintWriter(outError));
-                log.error(outError.toString());
+                    Thread.currentThread().getName()+" "+Thread.currentThread().getId()+": ", e);
             }
         }
         repaint();

--- a/java/src/jmri/jmrit/display/IndicatorTrackIcon.java
+++ b/java/src/jmri/jmrit/display/IndicatorTrackIcon.java
@@ -2,6 +2,8 @@ package jmri.jmrit.display;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -282,7 +284,11 @@ public class IndicatorTrackIcon extends PositionableIcon
             try {
                 _pathUtil.setLocoIcon(block, getLocation(), getSize(), _editor);
             } catch (Exception e) {
-                log.error("setStatus on indicator track icon failed: "+e);
+                log.error("setStatus on indicator track icon failed in thread "+
+                    Thread.currentThread().getName()+" "+Thread.currentThread().getId()+": "+e);
+                StringWriter outError = new StringWriter();
+                e.printStackTrace(new PrintWriter(outError));
+                log.error(outError.toString());
             }
         }
         repaint();


### PR DESCRIPTION
A few select try/catch loops added in order to ensure that threads running warrants do not crash with runaway trains as effect.

There are underlying errors that are not fixed by these try-catch loops, but they seem to be limited to display status updates.