### PR TITLE
Catch exceptions when adding items using the picklist panel

### DIFF
--- a/java/src/jmri/jmrit/Bundle.properties
+++ b/java/src/jmri/jmrit/Bundle.properties
@@ -133,6 +133,7 @@ ThrottleMenuPowerOff = Power Off
 # Pickers
 CantAddNew      = Cannot add new items to this pick panel.
 OpenToAdd       = Open the Table to add this type of item.
+PickAddFailed   = Unable to add a new item:\n  {0}
 
 # Common gui strings
 ButtonAdd       = Add...

--- a/java/src/jmri/jmrit/picker/PickPanel.java
+++ b/java/src/jmri/jmrit/picker/PickPanel.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTable;
@@ -99,7 +100,15 @@ public class PickPanel extends JPanel implements ListSelectionListener, ChangeLi
             if (uname != null && uname.trim().length() == 0) {
                 uname = null;
             }
-            jmri.NamedBean bean = model.addBean(sysname, uname);
+            jmri.NamedBean bean = null;
+            try {
+                bean = model.addBean(sysname, uname);
+            } catch (IllegalArgumentException ex) {
+                JOptionPane.showMessageDialog(null,
+                    Bundle.getMessage("PickAddFailed", ex.getMessage()),  // NOI18N
+                    Bundle.getMessage("WarningTitle"),  // NOI18N
+                    JOptionPane.WARNING_MESSAGE);
+            }
             if (bean != null) {
                 int setRow = model.getIndexOf(bean);
                 model.getTable().setRowSelectionInterval(setRow, setRow);

--- a/java/src/jmri/jmrit/picker/PickSinglePanel.java
+++ b/java/src/jmri/jmrit/picker/PickSinglePanel.java
@@ -80,10 +80,8 @@ public class PickSinglePanel<T extends NamedBean> extends JPanel {
         if (bean == null) {
             return null;
         }
-//         NamedBeanHandleManager nbhm = InstanceManager.getDefault(NamedBeanHandleManager.class);
-        return InstanceManager.getDefault(NamedBeanHandleManager.class)   // TODO SB
+        return InstanceManager.getDefault(NamedBeanHandleManager.class)
                         .getNamedBeanHandle(beanName, bean);
-//         return nbhm.getNamedBeanHandle(beanName, bean);
     }
 
     public JTable getTable() { return _table; }

--- a/java/src/jmri/jmrit/picker/PickSinglePanel.java
+++ b/java/src/jmri/jmrit/picker/PickSinglePanel.java
@@ -105,7 +105,7 @@ public class PickSinglePanel<T extends NamedBean> extends JPanel {
         };
         _addPanel = new jmri.jmrit.beantable.AddNewDevicePanel(
                 _sysNametext, _userNametext, "addToTable", okListener, cancelListener); // No I18N
-        // hide Cancel button as not handled bij Picker Panel
+        // hide Cancel button as not handled by Picker Panel
 
         _cantAddPanel = new JPanel();
         _cantAddPanel.setLayout(new BorderLayout(5, 5));

--- a/java/src/jmri/jmrit/picker/PickSinglePanel.java
+++ b/java/src/jmri/jmrit/picker/PickSinglePanel.java
@@ -45,7 +45,7 @@ public class PickSinglePanel<T extends NamedBean> extends JPanel {
                 _model.getTable().setColumnSelectionInterval(0,0);
             }
         });
-        
+
         JPanel p = new JPanel();
         p.setLayout(new BorderLayout(5, 5));
         p.add(new JLabel(_model.getName(), SwingConstants.CENTER), BorderLayout.NORTH);
@@ -55,26 +55,39 @@ public class PickSinglePanel<T extends NamedBean> extends JPanel {
         setLayout(new BorderLayout(5, 5));
         add(p, BorderLayout.CENTER);
         add(makeAddToTablePanel(), BorderLayout.SOUTH);
+
+        if (_model.canAddBean()) {
+            _cantAddPanel.setVisible(false);
+            _addPanel.setVisible(true);
+        } else {
+            _addPanel.setVisible(false);
+            _cantAddPanel.setVisible(true);
+        }
     }
 
     public NamedBeanHandle<T> getSelectedBeanHandle() {
         int row = getTable().getSelectedRow();
         int col = getTable().getSelectedColumn(); // might be -1 if just inserted
-        System.out.println(" r c "+row+" "+col);
-        
+        log.debug("PickSinglePanel: r = {}, c = {}", row, col);
+
         // are we sure this is always col 0 for sysname and col 1 for user name?
         String sysname = _model.getTable().getValueAt(row, 0).toString();
         String username = (String) _model.getTable().getValueAt(row, 1);
-        
+
         String beanName = sysname;
         if (col == 1 && username != null) beanName = username;
         T bean = _model.addBean(sysname, username);
-        return InstanceManager.getDefault(NamedBeanHandleManager.class)
+        if (bean == null) {
+            return null;
+        }
+//         NamedBeanHandleManager nbhm = InstanceManager.getDefault(NamedBeanHandleManager.class);
+        return InstanceManager.getDefault(NamedBeanHandleManager.class)   // TODO SB
                         .getNamedBeanHandle(beanName, bean);
+//         return nbhm.getNamedBeanHandle(beanName, bean);
     }
-    
+
     public JTable getTable() { return _table; }
-    
+
     private JPanel makeAddToTablePanel() {
         _sysNametext = new JTextField();
         _userNametext = new JTextField();
@@ -110,13 +123,20 @@ public class PickSinglePanel<T extends NamedBean> extends JPanel {
 
     void addToTable() {
         String sysname = _model.getManager().normalizeSystemName(_sysNametext.getText());
-        
-        if (sysname != null && sysname.length() > 1) {
+        if (sysname.length() > 1) {
             String uname = NamedBean.normalizeUserName(_userNametext.getText());
             if (uname != null && uname.trim().length() == 0) {
                 uname = null;
             }
-            T bean = _model.addBean(sysname, uname);
+            T bean = null;
+            try {
+                bean = _model.addBean(sysname, uname);
+            } catch (IllegalArgumentException ex) {
+                JOptionPane.showMessageDialog(null,
+                    Bundle.getMessage("PickAddFailed", ex.getMessage()),  // NOI18N
+                    Bundle.getMessage("WarningTitle"),  // NOI18N
+                    JOptionPane.WARNING_MESSAGE);
+            }
             if (bean != null) {
                 int setRow = _model.getIndexOf(bean);
                 _model.getTable().setRowSelectionInterval(setRow, setRow);
@@ -127,5 +147,5 @@ public class PickSinglePanel<T extends NamedBean> extends JPanel {
     }
 
     // initialize logging
-    // private final static Logger log = LoggerFactory.getLogger(PickSinglePanel.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PickSinglePanel.class);
 }

--- a/java/test/jmri/jmrit/picker/PickFrameTest.java
+++ b/java/test/jmri/jmrit/picker/PickFrameTest.java
@@ -49,6 +49,18 @@ public class PickFrameTest {
         JLabelOperator jlo = new JLabelOperator(jfo, 1);
         Assert.assertTrue(jlo.getText().startsWith("Cannot add new items"));
 
+        // Display other pages
+        jtab.selectPage("Turnout Table");
+        jtab.selectPage("Signal Head Table");
+        jtab.selectPage("Signal Mast Table");
+        jtab.selectPage("Memory Table");
+        jtab.selectPage("Reporter Table");
+        jtab.selectPage("Light Table");
+        jtab.selectPage("Warrant Table");
+        jtab.selectPage("Block Table");
+        jtab.selectPage("Entry Exit Table");
+        jtab.selectPage("Logix Table");
+
         JUnitUtil.dispose(f);
     }
 

--- a/java/test/jmri/jmrit/picker/PickFrameTest.java
+++ b/java/test/jmri/jmrit/picker/PickFrameTest.java
@@ -2,15 +2,13 @@ package jmri.jmrit.picker;
 
 import java.awt.GraphicsEnvironment;
 import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
+import org.netbeans.jemmy.operators.*;
 
 /**
  *
- * @author Paul Bender Copyright (C) 2017	
+ * @author Paul Bender Copyright (C) 2017
+ * @author Dave Sand Copyright (C) 2018
  */
 public class PickFrameTest {
 
@@ -20,6 +18,50 @@ public class PickFrameTest {
         PickFrame t = new PickFrame("Pick Frame Test");
         Assert.assertNotNull("exists",t);
         JUnitUtil.dispose(t);
+    }
+
+    @Test
+    public void testAddNames() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        PickFrame f = new PickFrame("Pick Frame Test Adds");
+        Assert.assertNotNull("exists",f);
+        JFrameOperator jfo = new JFrameOperator("Pick Frame Test Adds");
+        Assert.assertNotNull(jfo);
+
+        JTabbedPaneOperator jtab = new JTabbedPaneOperator(jfo);
+        jtab.selectPage("Sensor Table");
+
+        // Add an invalid name
+        JTextFieldOperator jto = new JTextFieldOperator(jfo, 0);
+        jto.enterText("AAA");
+        Thread add1 = createModalDialogOperatorThread(Bundle.getMessage("WarningTitle"), Bundle.getMessage("ButtonOK"), "add1");  // NOI18N
+        new JButtonOperator(jfo, "Add to Table").doClick();  // NOI18N
+        JUnitUtil.waitFor(()->{return !(add1.isAlive());}, "add1 finished");  // NOI18N
+
+        // Add a valid name
+        jto.enterText("IS123");
+        new JButtonOperator(jfo, "Add to Table").doClick();  // NOI18N
+
+        // Switch to the signal mast table
+        jtab.selectPage("Signal Mast Table");
+
+        //  Verify that the add fields are gone
+        JLabelOperator jlo = new JLabelOperator(jfo, 1);
+        Assert.assertTrue(jlo.getText().startsWith("Cannot add new items"));
+
+        JUnitUtil.dispose(f);
+    }
+
+    Thread createModalDialogOperatorThread(String dialogTitle, String buttonText, String threadName) {
+        Thread t = new Thread(() -> {
+            // constructor for jdo will wait until the dialog is visible
+            JDialogOperator jdo = new JDialogOperator(dialogTitle);
+            JButtonOperator jbo = new JButtonOperator(jdo, buttonText);
+            jbo.pushNoBlock();
+        });
+        t.setName(dialogTitle + " Close Dialog Thread: " + threadName);  // NOI18N
+        t.start();
+        return t;
     }
 
     // The minimal setup for log4J
@@ -33,7 +75,4 @@ public class PickFrameTest {
     public void tearDown() {
         JUnitUtil.tearDown();
     }
-
-    // private final static Logger log = LoggerFactory.getLogger(PickFrameTest.class);
-
 }

--- a/java/test/jmri/jmrit/picker/PickPanelTest.java
+++ b/java/test/jmri/jmrit/picker/PickPanelTest.java
@@ -13,7 +13,8 @@ public class PickPanelTest {
     @Test
     public void testCTor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        PickListModel[] models = {PickListModel.turnoutPickModelInstance(),
+        PickListModel[] models = {
+            PickListModel.turnoutPickModelInstance(),
             PickListModel.sensorPickModelInstance(),
             PickListModel.multiSensorPickModelInstance(),
             PickListModel.signalHeadPickModelInstance(),
@@ -25,7 +26,8 @@ public class PickPanelTest {
             PickListModel.oBlockPickModelInstance(),
             PickListModel.warrantPickModelInstance(),
             PickListModel.entryExitPickModelInstance(),
-            PickListModel.logixPickModelInstance()};
+            PickListModel.logixPickModelInstance()
+        };
         PickPanel t = new PickPanel(models);
         Assert.assertNotNull("exists",t);
     }

--- a/java/test/jmri/jmrit/picker/PickPanelTest.java
+++ b/java/test/jmri/jmrit/picker/PickPanelTest.java
@@ -3,7 +3,6 @@ package jmri.jmrit.picker;
 import java.awt.GraphicsEnvironment;
 import jmri.util.JUnitUtil;
 import org.junit.*;
-import org.netbeans.jemmy.EventTool;
 
 /**
  *
@@ -16,14 +15,17 @@ public class PickPanelTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         PickListModel[] models = {PickListModel.turnoutPickModelInstance(),
             PickListModel.sensorPickModelInstance(),
+            PickListModel.multiSensorPickModelInstance(),
             PickListModel.signalHeadPickModelInstance(),
             PickListModel.signalMastPickModelInstance(),
             PickListModel.memoryPickModelInstance(),
+            PickListModel.blockPickModelInstance(),
             PickListModel.reporterPickModelInstance(),
             PickListModel.lightPickModelInstance(),
-            PickListModel.warrantPickModelInstance(),
             PickListModel.oBlockPickModelInstance(),
-            PickListModel.entryExitPickModelInstance(),};
+            PickListModel.warrantPickModelInstance(),
+            PickListModel.entryExitPickModelInstance(),
+            PickListModel.logixPickModelInstance()};
         PickPanel t = new PickPanel(models);
         Assert.assertNotNull("exists",t);
     }

--- a/java/test/jmri/jmrit/picker/PickPanelTest.java
+++ b/java/test/jmri/jmrit/picker/PickPanelTest.java
@@ -2,15 +2,12 @@ package jmri.jmrit.picker;
 
 import java.awt.GraphicsEnvironment;
 import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
+import org.netbeans.jemmy.EventTool;
 
 /**
  *
- * @author Paul Bender Copyright (C) 2017	
+ * @author Paul Bender Copyright (C) 2017
  */
 public class PickPanelTest {
 
@@ -41,7 +38,4 @@ public class PickPanelTest {
     public void tearDown() {
         JUnitUtil.tearDown();
     }
-
-    // private final static Logger log = LoggerFactory.getLogger(PickPanelTest.class);
-
 }

--- a/java/test/jmri/jmrit/picker/PickSinglePanelTest.java
+++ b/java/test/jmri/jmrit/picker/PickSinglePanelTest.java
@@ -39,7 +39,14 @@ public class PickSinglePanelTest {
         // Add a valid name
         jto = new JTextFieldOperator(jfo, 0);
         jto.enterText("IS999");
+        jto = new JTextFieldOperator(jfo, 1);
+        jto.enterText("User Name");
         new JButtonOperator(jfo, "Add to Table").doClick();  // NOI18N
+
+        JTableOperator jtbo = new JTableOperator(jfo);
+        jtbo.clickOnCell(0, 1);
+        jmri.NamedBeanHandle nbh = sensorPanel.getSelectedBeanHandle();
+        Assert.assertNotNull(nbh);
 
         // Switch to the signal head table
         f.remove(sensorPanel);
@@ -77,4 +84,5 @@ public class PickSinglePanelTest {
     public void tearDown() {
         JUnitUtil.tearDown();
     }
+//     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PickSinglePanelTest.class);
 }

--- a/java/test/jmri/jmrit/picker/PickSinglePanelTest.java
+++ b/java/test/jmri/jmrit/picker/PickSinglePanelTest.java
@@ -2,25 +2,69 @@ package jmri.jmrit.picker;
 
 import java.awt.GraphicsEnvironment;
 import jmri.Sensor;
+import jmri.SignalHead;
 import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
+import org.netbeans.jemmy.operators.*;
 
 /**
  *
- * @author Paul Bender Copyright (C) 2017	
+ * @author Paul Bender Copyright (C) 2017
+ * @author Dave Sand Copyright (C) 2018
  */
 public class PickSinglePanelTest {
 
     @Test
-    public void testCTor() {
+    public void testSinglePanel() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        PickListModel<Sensor> tableModel = PickListModel.sensorPickModelInstance(); // N11N
-        PickSinglePanel<Sensor> panel = new PickSinglePanel<Sensor>(tableModel);
-        Assert.assertNotNull("exists",panel);
+        PickListModel<Sensor> sensorModel = PickListModel.sensorPickModelInstance(); // N11N
+        PickSinglePanel<Sensor> sensorPanel = new PickSinglePanel<Sensor>(sensorModel);
+        Assert.assertNotNull("exists", sensorPanel);
+
+        jmri.util.JmriJFrame f = new jmri.util.JmriJFrame("Single Pick List");  // NOI18N
+        f.setContentPane(sensorPanel);
+        f.pack();
+        f.setVisible(true);
+
+        JFrameOperator jfo = new JFrameOperator("Single Pick List");
+        Assert.assertNotNull(jfo);
+
+        // Add an invalid name
+        JTextFieldOperator jto = new JTextFieldOperator(jfo, 0);
+        jto.enterText("QRS");
+        Thread add1 = createModalDialogOperatorThread(Bundle.getMessage("WarningTitle"), Bundle.getMessage("ButtonOK"), "add1");  // NOI18N
+        new JButtonOperator(jfo, "Add to Table").doClick();  // NOI18N
+        JUnitUtil.waitFor(()->{return !(add1.isAlive());}, "add1 finished");  // NOI18N
+
+        // Add a valid name
+        jto = new JTextFieldOperator(jfo, 0);
+        jto.enterText("IS999");
+        new JButtonOperator(jfo, "Add to Table").doClick();  // NOI18N
+
+        // Switch to the signal head table
+        f.remove(sensorPanel);
+        PickListModel<SignalHead> signalHeadModel = PickListModel.signalHeadPickModelInstance(); // N11N
+        PickSinglePanel<SignalHead> signalHeadPanel = new PickSinglePanel<SignalHead>(signalHeadModel);
+        f.setContentPane(signalHeadPanel);
+        f.pack();
+
+        //  Verify that the add fields are gone
+        JLabelOperator jlo = new JLabelOperator(jfo, 1);
+        Assert.assertTrue(jlo.getText().startsWith("Cannot add new items"));
+
+        JUnitUtil.dispose(f);
+    }
+
+    Thread createModalDialogOperatorThread(String dialogTitle, String buttonText, String threadName) {
+        Thread t = new Thread(() -> {
+            // constructor for jdo will wait until the dialog is visible
+            JDialogOperator jdo = new JDialogOperator(dialogTitle);
+            JButtonOperator jbo = new JButtonOperator(jdo, buttonText);
+            jbo.pushNoBlock();
+        });
+        t.setName(dialogTitle + " Close Dialog Thread: " + threadName);  // NOI18N
+        t.start();
+        return t;
     }
 
     // The minimal setup for log4J
@@ -33,7 +77,4 @@ public class PickSinglePanelTest {
     public void tearDown() {
         JUnitUtil.tearDown();
     }
-
-    // private final static Logger log = LoggerFactory.getLogger(PickSinglePanelTest.class);
-
 }


### PR DESCRIPTION
Illegal argument exceptions can occur when adding new items from a pick list panel.

Rather than validating the inputs, the exceptions are caught and displayed in a dialog box.  The exception approach was chosen since it generally provides a useful response.