### PR TITLE
WIP Add ReadonlyThrottle

### DIFF
--- a/java/src/jmri/ReadonlyThrottle.java
+++ b/java/src/jmri/ReadonlyThrottle.java
@@ -1,0 +1,255 @@
+package jmri;
+
+import java.util.Vector;
+
+/**
+ * A ReadonlyThrottle object listens on changes to the speed, direction and
+ * functions of a single locomotive.
+ * <P>
+ * A ReadonlyThrottle implementation provides the actual control mechanism.
+ * These are obtained via a {@link ThrottleManager}.
+ * <P>
+ * With some control systems, there are only a limited number of Throttle's
+ * available.
+ * <p>
+ * On DCC systems, Throttles are often actually {@link DccThrottle} objects,
+ * which have some additional DCC-specific capabilities.
+ * <hr>
+ * This file is part of JMRI.
+ * <P>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * <P>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * <P>
+ *
+ * @author Bob Jacobsen Copyright (C) 2001, 2008
+ */
+public interface ReadonlyThrottle {
+
+    /**
+     * Constants to represent the functions F0 through F28.
+     */
+    public static final String F0 = "F0"; // NOI18N
+    public static final String F1 = "F1"; // NOI18N
+    public static final String F2 = "F2"; // NOI18N
+    public static final String F3 = "F3"; // NOI18N
+    public static final String F4 = "F4"; // NOI18N
+    public static final String F5 = "F5"; // NOI18N
+    public static final String F6 = "F6"; // NOI18N
+    public static final String F7 = "F7"; // NOI18N
+    public static final String F8 = "F8"; // NOI18N
+    public static final String F9 = "F9"; // NOI18N
+    public static final String F10 = "F10"; // NOI18N
+    public static final String F11 = "F11"; // NOI18N
+    public static final String F12 = "F12"; // NOI18N
+    public static final String F13 = "F13"; // NOI18N
+    public static final String F14 = "F14"; // NOI18N
+    public static final String F15 = "F15"; // NOI18N
+    public static final String F16 = "F16"; // NOI18N
+    public static final String F17 = "F17"; // NOI18N
+    public static final String F18 = "F18"; // NOI18N
+    public static final String F19 = "F19"; // NOI18N
+    public static final String F20 = "F20"; // NOI18N
+    public static final String F21 = "F21"; // NOI18N
+    public static final String F22 = "F22"; // NOI18N
+    public static final String F23 = "F23"; // NOI18N
+    public static final String F24 = "F24"; // NOI18N
+    public static final String F25 = "F25"; // NOI18N
+    public static final String F26 = "F26"; // NOI18N
+    public static final String F27 = "F27"; // NOI18N
+    public static final String F28 = "F28"; // NOI18N
+    /**
+     * Constants to represent the functions F0 through F28.
+     */
+    public static final String F0Momentary = "F0Momentary"; // NOI18N
+    public static final String F1Momentary = "F1Momentary"; // NOI18N
+    public static final String F2Momentary = "F2Momentary"; // NOI18N
+    public static final String F3Momentary = "F3Momentary"; // NOI18N
+    public static final String F4Momentary = "F4Momentary"; // NOI18N
+    public static final String F5Momentary = "F5Momentary"; // NOI18N
+    public static final String F6Momentary = "F6Momentary"; // NOI18N
+    public static final String F7Momentary = "F7Momentary"; // NOI18N
+    public static final String F8Momentary = "F8Momentary"; // NOI18N
+    public static final String F9Momentary = "F9Momentary"; // NOI18N
+    public static final String F10Momentary = "F10Momentary"; // NOI18N
+    public static final String F11Momentary = "F11Momentary"; // NOI18N
+    public static final String F12Momentary = "F12Momentary"; // NOI18N
+    public static final String F13Momentary = "F13Momentary"; // NOI18N
+    public static final String F14Momentary = "F14Momentary"; // NOI18N
+    public static final String F15Momentary = "F15Momentary"; // NOI18N
+    public static final String F16Momentary = "F16Momentary"; // NOI18N
+    public static final String F17Momentary = "F17Momentary"; // NOI18N
+    public static final String F18Momentary = "F18Momentary"; // NOI18N
+    public static final String F19Momentary = "F19Momentary"; // NOI18N
+    public static final String F20Momentary = "F20Momentary"; // NOI18N
+    public static final String F21Momentary = "F21Momentary"; // NOI18N
+    public static final String F22Momentary = "F22Momentary"; // NOI18N
+    public static final String F23Momentary = "F23Momentary"; // NOI18N
+    public static final String F24Momentary = "F24Momentary"; // NOI18N
+    public static final String F25Momentary = "F25Momentary"; // NOI18N
+    public static final String F26Momentary = "F26Momentary"; // NOI18N
+    public static final String F27Momentary = "F27Momentary"; // NOI18N
+    public static final String F28Momentary = "F28Momentary"; // NOI18N
+
+    /**
+     * Speed - expressed as a value {@literal 0.0 -> 1.0.} Negative means
+     * emergency stop. This is an bound property.
+     *
+     * @return the speed as a percentage of maximum possible speed
+     */
+    public float getSpeedSetting();
+
+    /**
+     * direction This is an bound property.
+     *
+     * @return true if forward, false if reverse or undefined
+     */
+    public boolean getIsForward();
+
+    // functions - note that we use the naming for DCC, though that's not the implication;
+    // see also DccThrottle interface
+    public boolean getF0();
+
+    public boolean getF1();
+
+    public boolean getF2();
+
+    public boolean getF3();
+
+    public boolean getF4();
+
+    public boolean getF5();
+
+    public boolean getF6();
+
+    public boolean getF7();
+
+    public boolean getF8();
+
+    public boolean getF9();
+
+    public boolean getF10();
+
+    public boolean getF11();
+
+    public boolean getF12();
+
+    public boolean getF13();
+
+    public boolean getF14();
+
+    public boolean getF15();
+
+    public boolean getF16();
+
+    public boolean getF17();
+
+    public boolean getF18();
+
+    public boolean getF19();
+
+    public boolean getF20();
+
+    public boolean getF21();
+
+    public boolean getF22();
+
+    public boolean getF23();
+
+    public boolean getF24();
+
+    public boolean getF25();
+
+    public boolean getF26();
+
+    public boolean getF27();
+
+    public boolean getF28();
+
+    // functions momentary status - note that we use the naming for DCC,
+    // though that's not the implication;
+    // see also DccThrottle interface
+    public boolean getF0Momentary();
+
+    public boolean getF1Momentary();
+
+    public boolean getF2Momentary();
+
+    public boolean getF3Momentary();
+
+    public boolean getF4Momentary();
+
+    public boolean getF5Momentary();
+
+    public boolean getF6Momentary();
+
+    public boolean getF7Momentary();
+
+    public boolean getF8Momentary();
+
+    public boolean getF9Momentary();
+
+    public boolean getF10Momentary();
+
+    public boolean getF11Momentary();
+
+    public boolean getF12Momentary();
+
+    public boolean getF13Momentary();
+
+    public boolean getF14Momentary();
+
+    public boolean getF15Momentary();
+
+    public boolean getF16Momentary();
+
+    public boolean getF17Momentary();
+
+    public boolean getF18Momentary();
+
+    public boolean getF19Momentary();
+
+    public boolean getF20Momentary();
+
+    public boolean getF21Momentary();
+
+    public boolean getF22Momentary();
+
+    public boolean getF23Momentary();
+
+    public boolean getF24Momentary();
+
+    public boolean getF25Momentary();
+
+    public boolean getF26Momentary();
+
+    public boolean getF27Momentary();
+
+    public boolean getF28Momentary();
+
+    /**
+     * Locomotive address. The exact format is defined by the specific
+     * implementation, as subclasses of LocoAddress will contain different
+     * information.
+     *
+     * This is an unbound property.
+     *
+     * @return The locomotive address
+     */
+    public LocoAddress getLocoAddress();
+
+    // register for notification if any of the properties change
+    public void removePropertyChangeListener(java.beans.PropertyChangeListener p);
+
+    public void addPropertyChangeListener(java.beans.PropertyChangeListener p);
+
+    public Vector<java.beans.PropertyChangeListener> getListeners();
+
+    public void setRosterEntry(BasicRosterEntry re);
+
+    public BasicRosterEntry getRosterEntry();
+}

--- a/java/src/jmri/ReadonlyThrottleListener.java
+++ b/java/src/jmri/ReadonlyThrottleListener.java
@@ -1,0 +1,104 @@
+package jmri;
+
+import java.util.EventListener;
+
+/**
+ * A listener interface for a class requesting a DccThrottle from the
+ * ThrottleManager.
+ * <P>
+ * Implementing classes used the methods here as part of the throttle request and initilization process as described shown in
+ * <img src="doc-files/ThrottleListener-Sequence.png" alt="Throttle initialization sequence UML diagram">
+ *
+ * <hr>
+ * This file is part of JMRI.
+ * <P>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * <P>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * <P>
+ * @author Bob Jacobsen Copyright (C) 2007
+ */
+public interface ReadonlyThrottleListener extends EventListener {
+
+    /**
+     * Get notification that a throttle has been found as you requested.
+     *
+     * @param t An instantiation of the DccThrottle with the address requested.
+     */
+    public void notifyThrottleFound(ReadonlyThrottle t);
+
+    /**
+     * Get notification that an attempt to request a throttle has failed
+     *
+     * @param address LocoAddress of the failed loco request.
+     * @param reason  The reason why the throttle request failed.
+     */
+    public void notifyFailedThrottleRequest(LocoAddress address, String reason);
+
+    /**
+     * Get notification that a throttle request requires is in use by another
+     * device, and a "steal" may be required.
+     *
+     * @param address LocoAddress of the throttle that needs to be stolen.
+     */
+    public void notifyStealThrottleRequired(LocoAddress address);
+
+}
+
+/*
+ * @startuml jmri/doc-files/ThrottleListener-Sequence.png
+ * participant ThrottleListener
+ * participant ThrottleManager
+ * participant Throttle
+ *
+ * == Quick Failure Scenario ==
+ *
+ * ThrottleListener-> ThrottleManager : requestThrottle(address,ThrottleListener)
+ * group If Throttle Request Cannot Continue
+ *    ThrottleListener <-- ThrottleManager : return false 
+ *    deactivate ThrottleManager
+ *    note over ThrottleListener : Request ends here
+ * end
+ * deactivate ThrottleListener
+ *
+ * == Normal Request Scenario ==
+ * 
+ * ThrottleListener-> ThrottleManager : requestThrottle(address,ThrottleListener)
+ *
+ * group If Throttle Request Can Continue
+ *    ThrottleListener <-- ThrottleManager : return true
+ *    note over ThrottleListener : Waits for callback to proceed.
+ *    group If Throttle Object Does not exist
+ *       note over ThrottleManager : Throttle Manager start system specific actions requred to create a throttle.
+ *    == Optional Steal ==
+ *       ThrottleListener <-- ThrottleManager : notifyStealThrottleRequired(address)
+ *       note over ThrottleListener : To steal or not is determined by the throttle Listener. 
+ *       group If the Throttle does not wish to steal
+ *           ThrottleListener --> ThrottleManager : stealThrottleRequest(address info, false )
+ *           note over ThrottleListener : Request ends here
+ *       end
+ *       group If the Throttle wishes to steal
+ *           ThrottleListener --> ThrottleManager : stealThrottleRequest(address info, true)
+ *               
+ *               note over ThrottleManager : Throttle creation continues normally.
+ *           end
+ *
+ *    == Creating the throttle  ==
+ *       ThrottleManager --> Throttle : new Throttle(address)
+ *       group If the Throttle creation fails
+            ThrottleListener <-- ThrottleManager: notifyFailedThrottleReqest(address)
+ *          note over ThrottleListener : Request ends here
+ *       end                    
+ *       group If the Throttle creation request succeeds
+            ThrottleManager <-- Throttle: return new Throttle
+ *       end
+ *    end
+ * ThrottleListener <-- ThrottleManager: notifyThrottleFound(Throttle)
+ * note over ThrottleListener : Throttle can now be controlled by ThrottleListener or a delegate.
+ * 
+ * @enduml
+ */ 

--- a/java/src/jmri/Throttle.java
+++ b/java/src/jmri/Throttle.java
@@ -1,7 +1,5 @@
 package jmri;
 
-import java.util.Vector;
-
 /**
  * A Throttle object can be manipulated to change the speed, direction and
  * functions of a single locomotive.
@@ -28,80 +26,7 @@ import java.util.Vector;
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2008
  */
-public interface Throttle {
-
-    /**
-     * Constants to represent the functions F0 through F28.
-     */
-    public static final String F0 = "F0"; // NOI18N
-    public static final String F1 = "F1"; // NOI18N
-    public static final String F2 = "F2"; // NOI18N
-    public static final String F3 = "F3"; // NOI18N
-    public static final String F4 = "F4"; // NOI18N
-    public static final String F5 = "F5"; // NOI18N
-    public static final String F6 = "F6"; // NOI18N
-    public static final String F7 = "F7"; // NOI18N
-    public static final String F8 = "F8"; // NOI18N
-    public static final String F9 = "F9"; // NOI18N
-    public static final String F10 = "F10"; // NOI18N
-    public static final String F11 = "F11"; // NOI18N
-    public static final String F12 = "F12"; // NOI18N
-    public static final String F13 = "F13"; // NOI18N
-    public static final String F14 = "F14"; // NOI18N
-    public static final String F15 = "F15"; // NOI18N
-    public static final String F16 = "F16"; // NOI18N
-    public static final String F17 = "F17"; // NOI18N
-    public static final String F18 = "F18"; // NOI18N
-    public static final String F19 = "F19"; // NOI18N
-    public static final String F20 = "F20"; // NOI18N
-    public static final String F21 = "F21"; // NOI18N
-    public static final String F22 = "F22"; // NOI18N
-    public static final String F23 = "F23"; // NOI18N
-    public static final String F24 = "F24"; // NOI18N
-    public static final String F25 = "F25"; // NOI18N
-    public static final String F26 = "F26"; // NOI18N
-    public static final String F27 = "F27"; // NOI18N
-    public static final String F28 = "F28"; // NOI18N
-    /**
-     * Constants to represent the functions F0 through F28.
-     */
-    public static final String F0Momentary = "F0Momentary"; // NOI18N
-    public static final String F1Momentary = "F1Momentary"; // NOI18N
-    public static final String F2Momentary = "F2Momentary"; // NOI18N
-    public static final String F3Momentary = "F3Momentary"; // NOI18N
-    public static final String F4Momentary = "F4Momentary"; // NOI18N
-    public static final String F5Momentary = "F5Momentary"; // NOI18N
-    public static final String F6Momentary = "F6Momentary"; // NOI18N
-    public static final String F7Momentary = "F7Momentary"; // NOI18N
-    public static final String F8Momentary = "F8Momentary"; // NOI18N
-    public static final String F9Momentary = "F9Momentary"; // NOI18N
-    public static final String F10Momentary = "F10Momentary"; // NOI18N
-    public static final String F11Momentary = "F11Momentary"; // NOI18N
-    public static final String F12Momentary = "F12Momentary"; // NOI18N
-    public static final String F13Momentary = "F13Momentary"; // NOI18N
-    public static final String F14Momentary = "F14Momentary"; // NOI18N
-    public static final String F15Momentary = "F15Momentary"; // NOI18N
-    public static final String F16Momentary = "F16Momentary"; // NOI18N
-    public static final String F17Momentary = "F17Momentary"; // NOI18N
-    public static final String F18Momentary = "F18Momentary"; // NOI18N
-    public static final String F19Momentary = "F19Momentary"; // NOI18N
-    public static final String F20Momentary = "F20Momentary"; // NOI18N
-    public static final String F21Momentary = "F21Momentary"; // NOI18N
-    public static final String F22Momentary = "F22Momentary"; // NOI18N
-    public static final String F23Momentary = "F23Momentary"; // NOI18N
-    public static final String F24Momentary = "F24Momentary"; // NOI18N
-    public static final String F25Momentary = "F25Momentary"; // NOI18N
-    public static final String F26Momentary = "F26Momentary"; // NOI18N
-    public static final String F27Momentary = "F27Momentary"; // NOI18N
-    public static final String F28Momentary = "F28Momentary"; // NOI18N
-
-    /**
-     * Speed - expressed as a value {@literal 0.0 -> 1.0.} Negative means
-     * emergency stop. This is an bound property.
-     *
-     * @return the speed as a percentage of maximum possible speed
-     */
-    public float getSpeedSetting();
+public interface Throttle extends ReadonlyThrottle {
 
     /**
      * Set the speed.
@@ -130,269 +55,128 @@ public interface Throttle {
      */
     public void setSpeedSettingAgain(float speed);
 
-    /**
-     * direction This is an bound property.
-     *
-     * @return true if forward, false if reverse or undefined
-     */
-    public boolean getIsForward();
-
     public void setIsForward(boolean forward);
 
     // functions - note that we use the naming for DCC, though that's not the implication;
     // see also DccThrottle interface
-    public boolean getF0();
-
     public void setF0(boolean f0);
-
-    public boolean getF1();
 
     public void setF1(boolean f1);
 
-    public boolean getF2();
-
     public void setF2(boolean f2);
-
-    public boolean getF3();
 
     public void setF3(boolean f3);
 
-    public boolean getF4();
-
     public void setF4(boolean f4);
-
-    public boolean getF5();
 
     public void setF5(boolean f5);
 
-    public boolean getF6();
-
     public void setF6(boolean f6);
-
-    public boolean getF7();
 
     public void setF7(boolean f7);
 
-    public boolean getF8();
-
     public void setF8(boolean f8);
-
-    public boolean getF9();
 
     public void setF9(boolean f9);
 
-    public boolean getF10();
-
     public void setF10(boolean f10);
-
-    public boolean getF11();
 
     public void setF11(boolean f11);
 
-    public boolean getF12();
-
     public void setF12(boolean f12);
-
-    public boolean getF13();
 
     public void setF13(boolean f13);
 
-    public boolean getF14();
-
     public void setF14(boolean f14);
-
-    public boolean getF15();
 
     public void setF15(boolean f15);
 
-    public boolean getF16();
-
     public void setF16(boolean f16);
-
-    public boolean getF17();
 
     public void setF17(boolean f17);
 
-    public boolean getF18();
-
     public void setF18(boolean f18);
-
-    public boolean getF19();
 
     public void setF19(boolean f19);
 
-    public boolean getF20();
-
     public void setF20(boolean f20);
-
-    public boolean getF21();
 
     public void setF21(boolean f21);
 
-    public boolean getF22();
-
     public void setF22(boolean f22);
-
-    public boolean getF23();
 
     public void setF23(boolean f23);
 
-    public boolean getF24();
-
     public void setF24(boolean f24);
-
-    public boolean getF25();
 
     public void setF25(boolean f25);
 
-    public boolean getF26();
-
     public void setF26(boolean f26);
 
-    public boolean getF27();
-
     public void setF27(boolean f27);
-
-    public boolean getF28();
 
     public void setF28(boolean f28);
 
     // functions momentary status - note that we use the naming for DCC,
     // though that's not the implication;
     // see also DccThrottle interface
-    public boolean getF0Momentary();
-
     public void setF0Momentary(boolean f0Momentary);
-
-    public boolean getF1Momentary();
 
     public void setF1Momentary(boolean f1Momentary);
 
-    public boolean getF2Momentary();
-
     public void setF2Momentary(boolean f2Momentary);
-
-    public boolean getF3Momentary();
 
     public void setF3Momentary(boolean f3Momentary);
 
-    public boolean getF4Momentary();
-
     public void setF4Momentary(boolean f4Momentary);
-
-    public boolean getF5Momentary();
 
     public void setF5Momentary(boolean f5Momentary);
 
-    public boolean getF6Momentary();
-
     public void setF6Momentary(boolean f6Momentary);
-
-    public boolean getF7Momentary();
 
     public void setF7Momentary(boolean f7Momentary);
 
-    public boolean getF8Momentary();
-
     public void setF8Momentary(boolean f8Momentary);
-
-    public boolean getF9Momentary();
 
     public void setF9Momentary(boolean f9Momentary);
 
-    public boolean getF10Momentary();
-
     public void setF10Momentary(boolean f10Momentary);
-
-    public boolean getF11Momentary();
 
     public void setF11Momentary(boolean f11Momentary);
 
-    public boolean getF12Momentary();
-
     public void setF12Momentary(boolean f12Momentary);
-
-    public boolean getF13Momentary();
 
     public void setF13Momentary(boolean f13Momentary);
 
-    public boolean getF14Momentary();
-
     public void setF14Momentary(boolean f14Momentary);
-
-    public boolean getF15Momentary();
 
     public void setF15Momentary(boolean f15Momentary);
 
-    public boolean getF16Momentary();
-
     public void setF16Momentary(boolean f16Momentary);
-
-    public boolean getF17Momentary();
 
     public void setF17Momentary(boolean f17Momentary);
 
-    public boolean getF18Momentary();
-
     public void setF18Momentary(boolean f18Momentary);
-
-    public boolean getF19Momentary();
 
     public void setF19Momentary(boolean f19Momentary);
 
-    public boolean getF20Momentary();
-
     public void setF20Momentary(boolean f20Momentary);
-
-    public boolean getF21Momentary();
 
     public void setF21Momentary(boolean f21Momentary);
 
-    public boolean getF22Momentary();
-
     public void setF22Momentary(boolean f22Momentary);
-
-    public boolean getF23Momentary();
 
     public void setF23Momentary(boolean f23Momentary);
 
-    public boolean getF24Momentary();
-
     public void setF24Momentary(boolean f24Momentary);
-
-    public boolean getF25Momentary();
 
     public void setF25Momentary(boolean f25Momentary);
 
-    public boolean getF26Momentary();
-
     public void setF26Momentary(boolean f26Momentary);
-
-    public boolean getF27Momentary();
 
     public void setF27Momentary(boolean f27Momentary);
 
-    public boolean getF28Momentary();
-
     public void setF28Momentary(boolean f28Momentary);
-
-    /**
-     * Locomotive address. The exact format is defined by the specific
-     * implementation, as subclasses of LocoAddress will contain different
-     * information.
-     *
-     * This is an unbound property.
-     *
-     * @return The locomotive address
-     */
-    public LocoAddress getLocoAddress();
-
-    // register for notification if any of the properties change
-    public void removePropertyChangeListener(java.beans.PropertyChangeListener p);
-
-    public void addPropertyChangeListener(java.beans.PropertyChangeListener p);
-
-    public Vector<java.beans.PropertyChangeListener> getListeners();
 
     /**
      * Not for general use, see {@link #release()} and {@link #dispatch()}.
@@ -489,7 +273,4 @@ public interface Throttle {
      */
     public void dispatch(ThrottleListener l);
 
-    public void setRosterEntry(BasicRosterEntry re);
-
-    public BasicRosterEntry getRosterEntry();
 }

--- a/java/src/jmri/ThrottleManager.java
+++ b/java/src/jmri/ThrottleManager.java
@@ -42,6 +42,21 @@ public interface ThrottleManager {
     public boolean requestThrottle(BasicRosterEntry re, ThrottleListener l);
 
     /**
+     * Request a readonly throttle from a given RosterEntry. When the decoder
+     * address is located, the ThrottleListener gets a callback via the
+     * ThrottleListener.notifyThrottleFound method.
+     *
+     * @param re desired RosterEntry
+     * @param l  ReadonlyThrottleListener awaiting notification of a found throttle
+     * @return true if the request will continue, false if the request will not
+     *         be made; false may be returned if a the throttle is already in
+     *         use
+     */
+    default public boolean requestReadonlyThrottle(BasicRosterEntry re, ReadonlyThrottleListener l) {
+        throw new UnsupportedOperationException("Readonly throttles not supported");
+    }
+
+    /**
      * Request a throttle, given a decoder address. When the decoder address is
      * located, the ThrottleListener gets a callback via the
      * ThrottleListener.notifyThrottleFound method.
@@ -58,6 +73,24 @@ public interface ThrottleManager {
     public boolean requestThrottle(int address, ThrottleListener l);
 
     /**
+     * Request a readonly throttle, given a decoder address. When the decoder
+     * address is located, the ThrottleListener gets a callback via the
+     * ThrottleListener.notifyThrottleFound method.
+     * <P>
+     * This is a convenience version of the call, which uses system-specific
+     * logic to tell whether the address is a short or long form.
+     *
+     * @param address desired decoder address
+     * @param l       ReadonlyThrottleListener awaiting notification of a found throttle
+     * @return true if the request will continue, false if the request will not
+     *         be made; false may be returned if a the throttle is already in
+     *         use
+     */
+    default public boolean requestReadonlyThrottle(int address, ReadonlyThrottleListener l) {
+        throw new UnsupportedOperationException("Readonly throttles not supported");
+    }
+
+    /**
      * Request a throttle, given a decoder address and whether it is a long or
      * short DCC address. When the decoder address is located, the
      * ThrottleListener gets a callback via the
@@ -71,6 +104,23 @@ public interface ThrottleManager {
      *         use
      */
     public boolean requestThrottle(int address, boolean isLong, ThrottleListener l);
+
+    /**
+     * Request a readonly throttle, given a decoder address and whether it is a
+     * long or short DCC address. When the decoder address is located, the
+     * ThrottleListener gets a callback via the
+     * ThrottleListener.notifyThrottleFound method.
+     *
+     * @param address desired decoder address
+     * @param isLong  true if requesting a DCC long (extended) address
+     * @param l       ReadonlyThrottleListener awaiting notification of a found throttle
+     * @return true if the request will continue, false if the request will not
+     *         be made; false may be returned if a the throttle is already in
+     *         use
+     */
+    default public boolean requestReadonlyThrottle(int address, boolean isLong, ReadonlyThrottleListener l) {
+        throw new UnsupportedOperationException("Readonly throttles not supported");
+    }
 
     /**
      * Request a throttle, given a decoder address. When the decoder address is
@@ -89,6 +139,24 @@ public interface ThrottleManager {
     public boolean requestThrottle(LocoAddress address, ThrottleListener l);
 
     /**
+     * Request a readonly throttle, given a decoder address. When the decoder
+     * address is located, the ThrottleListener gets a callback via the
+     * ThrottleListener.notifyThrottleFound method.
+     * <P>
+     * This is a convenience version of the call, which uses system-specific
+     * logic to tell whether the address is a short or long form.
+     *
+     * @param address desired decoder address
+     * @param l       ReadonlyThrottleListener awaiting notification of a found throttle
+     * @return true if the request will continue, false if the request will not
+     *         be made; false may be returned if a the throttle is already in
+     *         use
+     */
+    default public boolean requestReadonlyThrottle(LocoAddress address, ReadonlyThrottleListener l) {
+        throw new UnsupportedOperationException("Readonly throttles not supported");
+    }
+
+    /**
      * Request a throttle, given a decoder address or a RosterEntry. When the
      * decoder address is located, the ThrottleListener gets a callback via the
      * ThrottleListener.notifyThrottleFound method.
@@ -104,6 +172,25 @@ public interface ThrottleManager {
      *         use
      */
     public boolean requestThrottle(LocoAddress address, BasicRosterEntry re, ThrottleListener l);
+
+    /**
+     * Request a readonly throttle, given a decoder address or a RosterEntry.
+     * When the decoder address is located, the ThrottleListener gets a callback
+     * via the ThrottleListener.notifyThrottleFound method.
+     * <P>
+     * This is a convenience version of the call, which uses system-specific
+     * logic to tell whether the address is a short or long form.
+     *
+     * @param address desired decoder address
+     * @param re      desired RosterEntry
+     * @param l       ReadonlyThrottleListener awaiting notification of a found throttle
+     * @return true if the request will continue, false if the request will not
+     *         be made; false may be returned if a the throttle is already in
+     *         use
+     */
+    default public boolean requestReadonlyThrottle(LocoAddress address, BasicRosterEntry re, ReadonlyThrottleListener l) {
+        throw new UnsupportedOperationException("Readonly throttles not supported");
+    }
 
     /**
      * Cancel a request for a throttle.


### PR DESCRIPTION
This PR is a suggestion to the [discussion](https://github.com/JMRI/JMRI/issues/6155#issuecomment-439721557) in #6155.

A ThrottleManager doesn't need to support a ReadonlyThrottle. The caller that tries to get a read only
throttle needs to handle the UnsupportedOperationException in case the throttle manager doesn't support read only throttles and in that case request a Throttle instead. The reason for this is that the methods for requesting a Throttle uses a ThrottleListener that uses a DccThrottle.