### PR TITLE
MERG CBUS Event Table Update

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusBundle.properties
+++ b/java/src/jmri/jmrix/can/cbus/CbusBundle.properties
@@ -162,6 +162,11 @@ CommentColTip           = Editable comments.
 EmptyTableDialogString  = Your Event Table is empty and cannot be saved.
 EventNameAdded          = Event Name {0} added.
 NodeNameAdded           = Node Name {0} added.
+evColMenuName           = Event Columns
+evStatMenuName          = Stat Columns
+evFbMenuName            = Feedback Columns
+evJmMenuName            = JMRI Columns
+UpdateCols              = Refresh Columns
 
 ColumnEventDelete       = Delete
 ColumnEventDeleteTip    = Delete Event from Table
@@ -222,6 +227,16 @@ ImportError            = ERROR Importing file, check your main JMRI Console.
 ImportComplete         = Completed Importing xml.
 ImportFound            = found in file.
 ImportMenuMergFcu147   = Import MERG FCU events
+JmriOnEv               = On Event JMRI Links
+JmriOffEv              = Off Event JMRI Links
+StlrOnTip              = Sensors, Turnouts or Lights linked to the On event
+StlrOffTip             = Sensors, Turnouts or Lights linked to the Off event
+cbSensActive           = Sensor Active :{0} 
+cbSensInactive         = Sensor Inactive :{0} 
+cbTurnClosed           = Turnout Closed :{0} 
+cbTurnThrown           = Turnout Thrown :{0} 
+cbLightOn              = Light On :{0} 
+cbLightOff             = Light Off :{0} 
 
 # Node Config
 ChooseNode            = Select Node

--- a/java/src/jmri/jmrix/can/cbus/CbusLight.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusLight.java
@@ -105,6 +105,33 @@ public class CbusLight extends AbstractLight
             setState(OFF);
         }
     }
+    
+    /**
+     * Package method returning CanMessage for the On Light Address
+     */    
+    public CanMessage getAddrOn(){
+        CanMessage m;
+        m = addrOn.makeMessage(tc.getCanid());
+        return m;
+    }
+    
+    /**
+     * Package method returning CanMessage for the Off Light Address
+     */    
+    public CanMessage getAddrOff(){
+        CanMessage m;
+        m = addrOff.makeMessage(tc.getCanid());
+        return m;
+    }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void dispose() {
+        tc.removeCanListener(this);
+        super.dispose();
+    }    
+    
     private static final Logger log = LoggerFactory.getLogger(CbusLight.class);
 }

--- a/java/src/jmri/jmrix/can/cbus/CbusSensor.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensor.java
@@ -129,6 +129,32 @@ public class CbusSensor extends AbstractSensor implements CanListener {
     }    
     
     /**
+     * Package method returning CanMessage for the Active Sensor Address
+     */    
+    public CanMessage getAddrActive(){
+        CanMessage m;
+        if (getInverted()){
+            m = addrInactive.makeMessage(tc.getCanid());              
+        } else {
+            m = addrActive.makeMessage(tc.getCanid());
+        }
+        return m;
+    }
+    
+    /**
+     * Package method returning CanMessage for the Inactive Sensor Address
+     */    
+    public CanMessage getAddrInactive(){
+        CanMessage m;
+        if (getInverted()){
+            m = addrActive.makeMessage(tc.getCanid());              
+        } else {
+            m = addrInactive.makeMessage(tc.getCanid());
+        }
+        return m;
+    }    
+    
+    /**
      * Track layout status from messages being sent to CAN
      *
      */

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
@@ -112,7 +112,32 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
             tc.sendCanMessage(m, this);
         }
     }
-
+    
+    /**
+     * Package method returning CanMessage for the Thrown Turnout Address
+     */    
+    public CanMessage getAddrThrown(){
+        CanMessage m;
+        if (getInverted()){
+            m = addrClosed.makeMessage(tc.getCanid());
+        } else {
+            m = addrThrown.makeMessage(tc.getCanid());
+        }
+        return m;
+    }
+    
+    /**
+     * Package method returning CanMessage for the Closed Turnout Address
+     */    
+    public CanMessage getAddrClosed(){
+        CanMessage m;
+        if (getInverted()){
+            m = addrThrown.makeMessage(tc.getCanid());
+        } else {
+            m = addrClosed.makeMessage(tc.getCanid());
+        }
+        return m;
+    }
     
     /**
      * {@inheritDoc}
@@ -155,5 +180,15 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void dispose() {
+        tc.removeCanListener(this);
+        super.dispose();
+    }    
+    
+    
     private final static Logger log = LoggerFactory.getLogger(CbusTurnout.class);
 }


### PR DESCRIPTION
Added new methods to CbusSensor, CbusTurnout and CbusLight to access their CAN messages
Added override to dispose on CbusTurnout and CbusLight to remove can listener

Changed static model / view for better Instances
Column list selection moved to menu dropdown
Added columns to show name of JMRI Sensors / Turnouts / Lights linked to on & off events
Added method to populate and refresh these columns