### PR TITLE
fix performance and correctness problem in AbstractProxyManager.getNamedBeanSet()

### DIFF
--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -185,9 +185,9 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
         registerUserName(s);
 
         // notifications
-        firePropertyChange("length", null, _beans.size());
         int position = getPosition(s);
         fireDataListenersAdded(position, position, s);
+        firePropertyChange("length", null, _beans.size());
         // listen for name and state changes to forward
         s.addPropertyChangeListener(this, "", "Manager");
     }


### PR DESCRIPTION
Fixes two problems in AbstractProxyManager:
- the namedBeanSet is promised in the API contract to be live following
  updates, but in reality the object reference was re-created each time
  it was accessed, causing only the last caller to have a live object,
  and all others to have a dead one.
- optimizes the most typical use-case when children of the proxy manager
  are adding beans one by one. Avoids costly re-creation of the entire set
  in this case to optimize XML load performance.