### PR TITLE
Fixes flakiness in WarrantTest that caused random failures in CI

### DIFF
--- a/java/test/jmri/jmrit/logix/WarrantTest.java
+++ b/java/test/jmri/jmrit/logix/WarrantTest.java
@@ -197,7 +197,7 @@ public class WarrantTest {
 
         jmri.util.JUnitUtil.waitFor(() -> {
             String m =  warrant.getRunningMessage();
-            return m.endsWith("Cmd #2.");
+            return m.endsWith("Cmd #2.") || m.endsWith("Cmd #3.");
         }, "Train starts to move after 2nd command");
         jmri.util.JUnitUtil.releaseThread(this, 100); // What should we specifically waitFor?
 


### PR DESCRIPTION
Fixes flakiness in WarrantTest that caused random failures in CI for the last several years.

The issue was that the warrant proceeds through `Cmd #1`, `Cmd #2`, to `Cmd #3`,
automatically, and if the CPU load is too high, the `waitFor()` loop never
noticed the intermediate state `Cmd #2`.

Tested:
```
$ seq 3000 3499 | taskset -c 0,1,2,3 xargs -n 1 -P 200 -INN -- bash -c "./runtest.csh jmri.jmrit.logix.WarrantTest --settingsdir=/tmp/xset.NN > /tmp/xrun.NN 2>/tmp/xerr.NN"
$ grep -l failure /tmp/xrun.3*
```