### PR TITLE
Sort backup dirs in restore dialog.

### DIFF
--- a/java/src/jmri/jmrit/operations/setup/BackupBase.java
+++ b/java/src/jmri/jmrit/operations/setup/BackupBase.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import jmri.jmrit.XmlFile;
@@ -151,6 +152,7 @@ public abstract class BackupBase {
         // This is a bit of a kludge for now, until I learn more about dynamic
         // sets
         File[] dirs = getBackupRoot().listFiles();
+        Arrays.sort(dirs);
         BackupSet[] sets = new BackupSet[dirs.length];
 
         for (int i = 0; i < dirs.length; i++) {


### PR DESCRIPTION
Sorts backup directories by name when trying to restore operations settings.

Since backup directories are by default called yyyy-mm-dd-00 etc the
default lexicographic order is okay.