### PR TITLE
More headroom building .dmg file.

### DIFF
--- a/scripts/diskimage.sh
+++ b/scripts/diskimage.sh
@@ -54,7 +54,7 @@ rm -f temp.dmg $IMAGEFILE
 # create disk image and mount
 
 jmrisize=`du -ms "$INPUT" | awk '{print $1}'`
-imagesize=`expr $jmrisize + 10`
+imagesize=`expr $jmrisize + 30`
 
 if [ "$SYSTEM" = "MACOSX" ]
 then


### PR DESCRIPTION
For a long time I've had to do this manually to prevent `Write to restore size failed` errors as `hdutil` adds files to .dmg image when building `package-macosx` on almost all of my build environments.

Change to actual .dmg size is insignificant (~100 bytes).