### PR TITLE
Update how user names are handled by the CAN-bus adapters

### DIFF
--- a/java/src/jmri/jmrix/AbstractNetworkConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractNetworkConnectionConfig.java
@@ -522,6 +522,7 @@ abstract public class AbstractNetworkConnectionConfig extends AbstractConnection
 
     @Override
     public void setManufacturer(String manufacturer) {
+        setInstance();
         adapter.setManufacturer(manufacturer);
     }
 

--- a/java/src/jmri/jmrix/AbstractSerialConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractSerialConnectionConfig.java
@@ -506,9 +506,8 @@ abstract public class AbstractSerialConnectionConfig extends AbstractConnectionC
 
     @Override
     public void setManufacturer(String manufacturer) {
-        if (adapter != null) {
-            adapter.setManufacturer(manufacturer);
-        }
+        setInstance();
+        adapter.setManufacturer(manufacturer);
     }
 
     @Override

--- a/java/src/jmri/jmrix/AbstractSimulatorConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractSimulatorConnectionConfig.java
@@ -253,6 +253,7 @@ abstract public class AbstractSimulatorConnectionConfig extends AbstractConnecti
 
     @Override
     public void setManufacturer(String manufacturer) {
+        setInstance();
         adapter.setManufacturer(manufacturer);
     }
 

--- a/java/src/jmri/jmrix/AbstractStreamConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractStreamConnectionConfig.java
@@ -240,6 +240,7 @@ abstract public class AbstractStreamConnectionConfig extends AbstractConnectionC
 
     @Override
     public void setManufacturer(String manufacturer) {
+        setInstance();
         adapter.setManufacturer(manufacturer);
     }
 

--- a/java/src/jmri/jmrix/AbstractUsbConnectionConfig.java
+++ b/java/src/jmri/jmrix/AbstractUsbConnectionConfig.java
@@ -415,10 +415,9 @@ abstract public class AbstractUsbConnectionConfig extends AbstractConnectionConf
 
     @Override
     public void setManufacturer(String manufacturer) {
+        setInstance();
         log.debug("*	setManufacturer('{}')", manufacturer);
-        if (adapter != null) {
-            adapter.setManufacturer(manufacturer);
-        }
+        adapter.setManufacturer(manufacturer);
     }
 
     @Override

--- a/java/src/jmri/jmrix/JmrixConfigPane.java
+++ b/java/src/jmri/jmrix/JmrixConfigPane.java
@@ -280,8 +280,9 @@ public class JmrixConfigPane extends JPanel implements PreferencesPanel {
                 ccCurrent.dispose();
             }
             ccCurrent = classConnectionList[current];
-            classConnectionList[current].loadDetails(details);
-            classConnectionList[current].setManufacturer((String) manuBox.getSelectedItem());
+            ccCurrent.setInstance();
+            ccCurrent.setManufacturer((String) manuBox.getSelectedItem());
+            ccCurrent.loadDetails(details);
         } else {
             if (ccCurrent != null) {
                 ccCurrent.dispose();

--- a/java/src/jmri/jmrix/JmrixConfigPane.java
+++ b/java/src/jmri/jmrix/JmrixConfigPane.java
@@ -280,7 +280,6 @@ public class JmrixConfigPane extends JPanel implements PreferencesPanel {
                 ccCurrent.dispose();
             }
             ccCurrent = classConnectionList[current];
-            ccCurrent.setInstance();
             ccCurrent.setManufacturer((String) manuBox.getSelectedItem());
             ccCurrent.loadDetails(details);
         } else {

--- a/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
@@ -27,9 +27,11 @@ import jmri.profile.ProfileManager;
  * @author Kevin Dickerson Copyright (C) 2012
  */
 public class CanSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
+    // This user name will be overwritten by the adapter and saved to the connection config.
+    public static String DEFAULT_USERNAME = "CAN";
 
     public CanSystemConnectionMemo() {
-        super("M", "MERG");
+        super("M", DEFAULT_USERNAME);
         register(); // registers general type
         InstanceManager.store(this, CanSystemConnectionMemo.class); // also register as specific type
     }

--- a/java/src/jmri/jmrix/can/adapters/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/can/adapters/ConnectionConfig.java
@@ -6,6 +6,7 @@ import java.util.ResourceBundle;
 import javax.swing.JComboBox;
 import javax.swing.JPanel;
 
+import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.ConfigurationManager;
 import jmri.jmrix.openlcb.swing.protocoloptions.ConfigPaneHelper;
 
@@ -62,15 +63,15 @@ abstract public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnecti
     }
 
     void updateUserNameField() {
-        String selection = options.get("Protocol").getItem();
-        String newUserName = "MERG";
-        if (ConfigurationManager.OPENLCB.equals(selection)) {
-            newUserName = "OpenLCB";
-        } else if (ConfigurationManager.RAWCAN.equals(selection)) {
-            newUserName = "CANraw";
-        } else if (ConfigurationManager.TEST.equals(selection)) {
-            newUserName = "CANtest";
+        if (!CanSystemConnectionMemo.DEFAULT_USERNAME.equals(adapter.getSystemConnectionMemo()
+                .getUserName())) {
+            // User name already set; do not overwrite it.
+            log.debug("Avoid overwriting user name {}.", adapter.getSystemConnectionMemo()
+                    .getUserName());
+            return;
         }
+        log.debug("New user name based on manufacturer {}", getManufacturer());
+        String newUserName = getManufacturer();
         connectionNameField.setText(newUserName);
 
         if (!adapter.getSystemConnectionMemo().setUserName(newUserName)) {

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/net/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/net/ConnectionConfig.java
@@ -6,6 +6,7 @@ import java.util.ResourceBundle;
 import javax.swing.JComboBox;
 import javax.swing.JPanel;
 
+import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.ConfigurationManager;
 import jmri.jmrix.openlcb.swing.protocoloptions.ConfigPaneHelper;
 
@@ -74,15 +75,15 @@ public class ConnectionConfig extends jmri.jmrix.AbstractNetworkConnectionConfig
     }
 
     void updateUserNameField() {
-        String selection = options.get("Protocol").getItem();
-        String newUserName = "MERG";
-        if (ConfigurationManager.OPENLCB.equals(selection)) {
-            newUserName = "OpenLCB";
-        } else if (ConfigurationManager.RAWCAN.equals(selection)) {
-            newUserName = "CANraw";
-        } else if (ConfigurationManager.TEST.equals(selection)) {
-            newUserName = "CANtest";
+        if (!CanSystemConnectionMemo.DEFAULT_USERNAME.equals(adapter.getSystemConnectionMemo()
+                .getUserName())) {
+            // User name already set; do not overwrite it.
+            log.debug("Avoid overwriting user name {}.", adapter.getSystemConnectionMemo()
+                    .getUserName());
+            return;
         }
+        log.debug("New user name based on manufacturer {}", getManufacturer());
+        String newUserName = getManufacturer();
         connectionNameField.setText(newUserName);
 
         if (!adapter.getSystemConnectionMemo().setUserName(newUserName)) {

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/net/NetworkDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/net/NetworkDriverAdapter.java
@@ -24,7 +24,6 @@ public class NetworkDriverAdapter extends jmri.jmrix.AbstractNetworkPortControll
         options.put(option1Name, new Option(Bundle.getMessage("ConnectionGateway"), new String[]{"Pass All", "Filtering"}));
         option2Name = "Protocol"; // NOI18N
         options.put(option2Name, new Option(Bundle.getMessage("ConnectionProtocol"), jmri.jmrix.can.ConfigurationManager.getSystemOptions(), false));
-        this.getSystemConnectionMemo().setUserName("OpenLCB");
         setManufacturer(jmri.jmrix.openlcb.OlcbConnectionTypeList.OPENLCB);
         allowConnectionRecovery = true;
     }

--- a/java/test/jmri/jmrix/can/adapters/lawicell/canusb/serialdriver/ConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/can/adapters/lawicell/canusb/serialdriver/ConnectionConfigTest.java
@@ -20,6 +20,7 @@ public class ConnectionConfigTest extends jmri.jmrix.AbstractSerialConnectionCon
 
         JUnitUtil.initDefaultUserMessagePreferences();
         cc = new ConnectionConfig();
+        cc.setManufacturer("Lawicell");
    }
 
    @After

--- a/java/test/jmri/jmrix/can/adapters/lawicell/canusb/serialdriver/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/can/adapters/lawicell/canusb/serialdriver/configurexml/ConnectionConfigXmlTest.java
@@ -19,6 +19,7 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSer
         JUnitUtil.setUp();
         xmlAdapter = new ConnectionConfigXml();
         cc = new ConnectionConfig();
+        cc.setManufacturer("Lawicell");
     }
 
     @After

--- a/java/test/jmri/jmrix/can/adapters/loopback/ConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/can/adapters/loopback/ConnectionConfigTest.java
@@ -20,6 +20,7 @@ public class ConnectionConfigTest extends jmri.jmrix.AbstractSerialConnectionCon
 
         JUnitUtil.initDefaultUserMessagePreferences();
         cc = new ConnectionConfig();
+        cc.setManufacturer("MERG");
    }
 
    @After

--- a/java/test/jmri/jmrix/can/adapters/loopback/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/can/adapters/loopback/configurexml/ConnectionConfigXmlTest.java
@@ -19,6 +19,7 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSim
         JUnitUtil.setUp();
         xmlAdapter = new ConnectionConfigXml();
         cc = new ConnectionConfig();
+        cc.setManufacturer("MERG");
     }
 
     @After


### PR DESCRIPTION
Update how user names are handled by the CAN-bus adapters:
- avoid overwriting user name that was edited by the user and saved to
  the profile.xml
- make user names be created from the manufacturer name to simplify code.
- remove discrepancies regarding usernames between the codepaths of the
  different adapters.

Ensures that the manufacturer is correctly set when an adapter is being created
by the JmrixConfigPane.