### PR TITLE
Change default LocoNet slot monitor display

### DIFF
--- a/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
+++ b/java/src/jmri/jmrix/loconet/slotmon/SlotMonPane.java
@@ -193,7 +193,8 @@ public class SlotMonPane extends jmri.jmrix.loconet.swing.LnPanel {
             public boolean include(RowFilter.Entry<? extends SlotMonDataModel, ? extends Integer> entry) {
                 int slotNum = entry.getIdentifier();
                 // default filter is IN-USE and regular systems slot
-                boolean include = entry.getModel().getSlot(entry.getIdentifier()).slotStatus() == LnConstants.LOCO_IN_USE && (slotNum > 0 && slotNum < 121);
+                boolean include = entry.getModel().getSlot(entry.getIdentifier()).slotStatus() != LnConstants.LOCO_FREE && (slotNum > 0 && slotNum < 121);
+                
                 if (!include && showUnusedCheckBox.isSelected() && (slotNum > 0 && slotNum < 121)) {
                     include = true;
                 }


### PR DESCRIPTION
JMRI 4.11.1 reduced the number of slots shown by default in the LocoNet Slot Monitor.

This PR changes it again, to show all (within range) slots that are not in FREE status.

See this [jmriusers discussion](https://groups.io/g/jmriusers/topic/possible_bug_loconet_slot/28323960?p=,,,20,0,0,0::recentpostdate%2Fsticky,,,20,2,0,28323960)