### PR TITLE
Dotted-hex event IDs in OpenLCB CAN send frame.

### DIFF
--- a/java/src/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPane.java
@@ -397,7 +397,8 @@ public class OpenLcbCanSendPane extends jmri.jmrix.can.swing.CanPanel implements
     }
 
     EventID eventID() {
-        return new EventID(jmri.util.StringUtil.bytesFromHexString(sendEventField.getText()));
+        return new EventID(jmri.util.StringUtil.bytesFromHexString(sendEventField.getText()
+                .replace(".", " ")));
     }
 
     public void sendVerifyNodeGlobal(java.awt.event.ActionEvent e) {

--- a/java/test/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPaneTest.java
+++ b/java/test/jmri/jmrix/openlcb/swing/send/OpenLcbCanSendPaneTest.java
@@ -2,8 +2,11 @@ package jmri.jmrix.openlcb.swing.send;
 
 import jmri.util.JUnitUtil;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openlcb.EventID;
+
 /**
  * @author Bob Jacobsen Copyright 2013
  * @author Paul Bender Copyright (C) 2016
@@ -25,6 +28,25 @@ public class OpenLcbCanSendPaneTest extends jmri.util.swing.JmriPanelTest {
         // for now, just makes ure there isn't an exception.
         ((OpenLcbCanSendPane)panel).initContext(memo);
     }
+
+    @Test
+    public void testEventId() throws Exception {
+        OpenLcbCanSendPane p = (OpenLcbCanSendPane) panel;
+
+        p.sendEventField.setText("05 01 01 01 14 FF 01 02");
+        EventID expected = new EventID(new byte[]{05, 01, 01, 01, 0x14, (byte) 0xff, 01, 02});
+        Assert.assertEquals(expected, p.eventID());
+    }
+
+    @Test
+    public void testEventIdDotted() throws Exception {
+        OpenLcbCanSendPane p = (OpenLcbCanSendPane) panel;
+
+        p.sendEventField.setText("05.01.01.01.14.FF.01.02");
+        EventID expected = new EventID(new byte[]{05, 01, 01, 01, 0x14, (byte) 0xff, 01, 02});
+        Assert.assertEquals(expected, p.eventID());
+    }
+
 
     // The minimal setup for log4J
     @Before


### PR DESCRIPTION
Enables dotted-hex format for user to insert an event ID in the SendCanFrame window.

Fixes https://github.com/JMRI/JMRI/issues/5432.