### PR TITLE
DCC++: Fix backgroup function refreshing

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -2483,6 +2483,9 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
 
         if (!isFunctionMessage() || !other.isFunctionMessage())
             return false;
+        
+        if (this.getValueInt(1) != other.getValueInt(1))
+            return false;
 
         return getFuncBaseByte1(this.getFuncByte1Int()) == getFuncBaseByte1(other.getFuncByte1Int());
     }


### PR DESCRIPTION
Correctly implement equals() on DCCppMessage. Before it was removing the same function group irrespective of the address, so only the latest changes would be refreshed. The patch adds a check on the address of the two messages too.