### PR TITLE
Fix Dispatching Throttle

### DIFF
--- a/java/src/jmri/ThrottleManager.java
+++ b/java/src/jmri/ThrottleManager.java
@@ -375,4 +375,12 @@ public interface ThrottleManager {
      */
     public String getUserName();
 
+    /**
+     * Get the number of Throttles sharing the throttle for a ddcaddress.
+     *
+     * @param la - DccLocoAddress of the loco you want the throttle usage count for.
+     * @return number of throttles for this address, or 0 if throttle does not exist
+     */
+    public int getThrottleUsageCount(DccLocoAddress la);
+
 }

--- a/java/src/jmri/ThrottleManager.java
+++ b/java/src/jmri/ThrottleManager.java
@@ -289,8 +289,35 @@ public interface ThrottleManager {
      */
     public Object getThrottleInfo(LocoAddress la, String item);
 
+    /**
+     * 
+     * @param la - Loco address to test
+     * @return - true, its still required, false its not.
+     */
     public boolean addressStillRequired(LocoAddress la);
 
+    /**
+     * 
+     * @param address - Loco number to test.
+     * @param addressIsLong - true if long address.
+     * @return - true, its still required, false its not.
+     */
+    public boolean addressStillRequired(int address, boolean addressIsLong);
+    /**
+     * 
+     * @param address - Loco number to test
+     * @return - true, its still required, false its not.
+     */
+    public boolean addressStillRequired(int address);
+
+    /**
+     * 
+     * @param re - roster entry to test
+     * @return - true, its still required, false its not.
+     */
+    public boolean addressStillRequired(BasicRosterEntry re);
+
+    
     /**
      * The specified Throttle Listener has finished using a given throttle and
      * no longer requires access to it.
@@ -378,9 +405,34 @@ public interface ThrottleManager {
     /**
      * Get the number of Throttles sharing the throttle for a ddcaddress.
      *
-     * @param la - DccLocoAddress of the loco you want the throttle usage count for.
+     * @param la - LocoAddress of the loco you want the throttle usage count for.
      * @return number of throttles for this address, or 0 if throttle does not exist
      */
-    public int getThrottleUsageCount(DccLocoAddress la);
+    public int getThrottleUsageCount(LocoAddress la);
+
+    /**
+     * Get the number of Throttles sharing the throttle for a ddcaddress.
+     *
+     * @param address - number of the loco you want the throttle usage count for.
+     * @param isLongAddress - indicates whether the address is long or not.
+     * @return number of throttles for this address, or 0 if throttle does not exist
+     */
+     public int getThrottleUsageCount(int address, boolean isLongAddress);
+
+    /**
+     * Get the number of Throttles sharing the throttle for a ddcaddress.
+     *
+     * @param address - number of the loco you want the throttle usage count for.
+     * @return number of throttles for this address, or 0 if throttle does not exist
+     */
+    public int getThrottleUsageCount(int address);
+
+    /**
+     * Get the number of Throttles sharing the throttle for a ddcaddress.
+     *
+     * @param re - BasicRosterEntry of the loco you want the throttle usage count for.
+     * @return number of throttles for this address, or 0 if throttle does not exist
+     */
+    public int getThrottleUsageCount(BasicRosterEntry re);
 
 }

--- a/java/src/jmri/jmrit/throttle/AddressPanel.java
+++ b/java/src/jmri/jmrit/throttle/AddressPanel.java
@@ -535,7 +535,7 @@ public class AddressPanel extends JInternalFrame implements ThrottleListener, Pr
      */
     public void dispatchAddress() {
         if (throttle != null) {
-            int usageCount  = InstanceManager.throttleManagerInstance().getThrottleUsageCount((DccLocoAddress)throttle.getLocoAddress()) - 1;
+            int usageCount  = InstanceManager.throttleManagerInstance().getThrottleUsageCount(throttle.getLocoAddress()) - 1;
 
             if ( usageCount != 0 ) {
                 JOptionPane.showMessageDialog(mainPanel, Bundle.getMessage("CannotDisptach", usageCount));

--- a/java/src/jmri/jmrit/throttle/AddressPanel.java
+++ b/java/src/jmri/jmrit/throttle/AddressPanel.java
@@ -535,6 +535,12 @@ public class AddressPanel extends JInternalFrame implements ThrottleListener, Pr
      */
     public void dispatchAddress() {
         if (throttle != null) {
+            int usageCount  = InstanceManager.throttleManagerInstance().getThrottleUsageCount((DccLocoAddress)throttle.getLocoAddress()) - 1;
+
+            if ( usageCount != 0 ) {
+                JOptionPane.showMessageDialog(mainPanel, Bundle.getMessage("CannotDisptach", usageCount));
+                return;
+            }
             InstanceManager.throttleManagerInstance().dispatchThrottle(throttle, this);
             if (consistThrottle != null) {
                 InstanceManager.throttleManagerInstance().dispatchThrottle(consistThrottle, this);

--- a/java/src/jmri/jmrit/throttle/ThrottleBundle.properties
+++ b/java/src/jmri/jmrit/throttle/ThrottleBundle.properties
@@ -44,7 +44,7 @@ NoLocoSelected = <No Loco Selected>
 NoConsistSelected = <No Consist Selected>
 ButtonProgram = Program
 AddressInUse = Address out of range or in use by another throttle.
-
+CannotDisptach = Cannot Dispatch as throttle is still in use {0} times
 # ControlPanelPropertyEditor
 ControlPanelProperties =  Properties
 TitleEditSpeedControlPanel = Edit Speed Control Panel

--- a/java/src/jmri/jmrix/AbstractThrottleManager.java
+++ b/java/src/jmri/jmrix/AbstractThrottleManager.java
@@ -628,6 +628,14 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
         releaseThrottle(t, l);
     }
 
+    @Override
+    public int getThrottleUsageCount(DccLocoAddress la) {
+        if (addressThrottles.containsKey(la)) {
+            return addressThrottles.get(la).getUseCount();
+        }
+        return 0;
+    }
+
     protected boolean addressReleased(DccLocoAddress la, ThrottleListener l) {
         if (addressThrottles.containsKey(la)) {
             if (addressThrottles.get(la).containsListener(l)) {

--- a/java/src/jmri/jmrix/AbstractThrottleManager.java
+++ b/java/src/jmri/jmrix/AbstractThrottleManager.java
@@ -119,7 +119,7 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
      * This allows more than one ThrottleLister to request a throttle at a time,
      * the entries in this Hashmap are only valid during the throttle setup process.
      */
-    private HashMap<LocoAddress, ArrayList<WaitingThrottle>> throttleListeners = new HashMap<LocoAddress, ArrayList<WaitingThrottle>>(5);
+    private final HashMap<LocoAddress, ArrayList<WaitingThrottle>> throttleListeners = new HashMap<>(5);
 
     static class WaitingThrottle {
 
@@ -155,7 +155,7 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
      * notification of changes to a throttle that hasn't yet been created/ The
      * entries in this Hashmap are only valid during the throttle setup process.
      */
-    private HashMap<DccLocoAddress, ArrayList<WaitingThrottle>> listenerOnly = new HashMap<DccLocoAddress, ArrayList<WaitingThrottle>>(5);
+    private final HashMap<DccLocoAddress, ArrayList<WaitingThrottle>> listenerOnly = new HashMap<>(5);
 
     //This keeps a map of all the current active DCC loco Addresses that are in use.
     /**
@@ -163,11 +163,12 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
      * subclass of the throttle assigned to an address and the number of
      * requests and active users for this address.
      */
-    private Hashtable<DccLocoAddress, Addresses> addressThrottles = new Hashtable<DccLocoAddress, Addresses>();
+    private final Hashtable<DccLocoAddress, Addresses> addressThrottles = new Hashtable<>();
 
     /**
      * Does this DCC system allow a Throttle (e.g. an address) to be used by
      * only one user at a time?
+     * @return - true or false
      */
     protected boolean singleUse() {
         return true;
@@ -277,12 +278,15 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
     /**
      * Abstract member to actually do the work of configuring a new throttle,
      * usually via interaction with the DCC system
+     * @param a - address
+     * @param control - false  - read only.
      */
     abstract public void requestThrottleSetup(LocoAddress a, boolean control);
 
     /**
      * Abstract member to actually do the work of configuring a new throttle,
      * usually via interaction with the DCC system
+     * @param a - address.
      */
     public void requestThrottleSetup(LocoAddress a) {
         requestThrottleSetup(a, true);
@@ -453,6 +457,8 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
      * <P>
      * This method creates a throttle for all ThrottleListeners of that address
      * and notifies them via the ThrottleListener.notifyThrottleFound method.
+     * @param throttle - throttle object
+     * @param addr - address.
      */
     public void notifyThrottleKnown(DccThrottle throttle, LocoAddress addr) {
         log.debug("notifyThrottleKnown for " + addr);
@@ -595,6 +601,26 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
     }
 
     @Override
+    public boolean addressStillRequired(int address, boolean isLongAddress) {
+        DccLocoAddress la = new DccLocoAddress(address, isLongAddress);
+        return addressStillRequired(la);
+    }
+
+    @Override
+    public boolean addressStillRequired(int address) {
+        boolean isLong = true;
+        if (canBeShortAddress(address)) {
+            isLong = false;
+        }
+        return addressStillRequired(address, isLong);
+    }
+
+    @Override
+    public boolean addressStillRequired(BasicRosterEntry re) {
+        return addressStillRequired(re.getDccLocoAddress());
+    }
+
+    @Override
     public void releaseThrottle(DccThrottle t, ThrottleListener l) {
         log.debug("AbstractThrottleManager.releaseThrottle: {}, {}", t, l);
         disposeThrottle(t, l);
@@ -629,11 +655,30 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
     }
 
     @Override
-    public int getThrottleUsageCount(DccLocoAddress la) {
-        if (addressThrottles.containsKey(la)) {
+    public int getThrottleUsageCount(LocoAddress la) {
+        if (addressThrottles.containsKey( la)) {
             return addressThrottles.get(la).getUseCount();
         }
         return 0;
+    }
+
+    @Override
+    public int getThrottleUsageCount(int address, boolean isLongAddress) {
+        DccLocoAddress la = new DccLocoAddress(address, isLongAddress);
+        return getThrottleUsageCount(la);
+    }
+
+    @Override
+    public int getThrottleUsageCount(int address) {
+        boolean isLong = true;
+        if (canBeShortAddress(address)) {
+            isLong = false;
+        }
+        return getThrottleUsageCount(address, isLong);
+    }
+    @Override
+    public int getThrottleUsageCount(BasicRosterEntry re) {
+        return getThrottleUsageCount(re.getDccLocoAddress());
     }
 
     protected boolean addressReleased(DccLocoAddress la, ThrottleListener l) {
@@ -752,7 +797,7 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
 
         int useActiveCount = 0;
         DccThrottle throttle = null;
-        ArrayList<ThrottleListener> listeners = new ArrayList<ThrottleListener>();
+        ArrayList<ThrottleListener> listeners = new ArrayList<>();
         BasicRosterEntry re = null;
 
         protected Addresses(DccThrottle throttle) {

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -1,7 +1,7 @@
 package jmri.jmrix.loconet;
 
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.Hashtable;
+import java.util.concurrent.LinkedBlockingQueue;
 import jmri.DccLocoAddress;
 import jmri.DccThrottle;
 import jmri.LocoAddress;
@@ -155,7 +155,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
 
     volatile Thread retrySetupThread;
 
-    Hashtable<Integer, Thread> waitingForNotification = new Hashtable<Integer, Thread>(5);
+    Hashtable<Integer, Thread> waitingForNotification = new Hashtable<>(5);
 
     Hashtable<Integer, LocoNetSlot> slotForAddress;
     LinkedBlockingQueue<ThrottleRequest> requestList;
@@ -396,7 +396,7 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
         // Use slot to dispatch, then release
         if (t instanceof LocoNetThrottle) {
             // only dispatch if its the last throttle use
-            if (super.getThrottleUsageCount((DccLocoAddress) t.getLocoAddress()) == 1)  {
+            if (super.getThrottleUsageCount(t.getLocoAddress()) == 1)  {
                 ((LocoNetThrottle) t).dispatchThrottle(t, l);
             } else {
                 return;

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -384,7 +384,8 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
      * Generally, this will cause the slot to be made "common" and then linked via
      * the "Dispatch" slot.
      * <p>
-     * After disposal, the throttle may not be used to control the loco.
+     * After dispatching, the throttle may not be used to control the loco.
+     * You should check getUsageCountBefore calling as it will fail if not 1
      *
      * @param t is a throttle to be disposed of
      * @param l is the listener for the throttle
@@ -392,11 +393,16 @@ public class LnThrottleManager extends AbstractThrottleManager implements Thrott
     @Override
     public void dispatchThrottle(DccThrottle t, ThrottleListener l) {
         log.debug("dispatchThrottle - throttle {}", t.getLocoAddress());
-        // set status to common
+        // Use slot to dispatch, then release
         if (t instanceof LocoNetThrottle) {
-            ((LocoNetThrottle) t).dispatchThrottle(t, l);
+            // only dispatch if its the last throttle use
+            if (super.getThrottleUsageCount((DccLocoAddress) t.getLocoAddress()) == 1)  {
+                ((LocoNetThrottle) t).dispatchThrottle(t, l);
+            } else {
+                return;
+            }
         }
-        // super.releaseThrottle(t, l);
+        super.releaseThrottle(t, l);
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -803,19 +803,10 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
             LocoNetThrottle lnt = (LocoNetThrottle) t;
             LocoNetSlot tSlot = lnt.getLocoNetSlot();
             if (tSlot.slotStatus() != LnConstants.LOCO_COMMON) {
-                log.debug("dispatchThrottle is writing slot {} status to {}",
-                        tSlot,
-                        LnConstants.LOCO_COMMON);
-                network.sendLocoNetMessage(
-                        tSlot.writeStatus(LnConstants.LOCO_COMMON));
-            }
-
-            jmri.util.ThreadingUtil.runOnLayoutDelayed( ()-> {
                 // and dispatch to slot 0
-                    log.debug("dispatchThrottle is dispatching slot {}", tSlot);
-                    network.sendLocoNetMessage(tSlot.dispatchSlot());
-                },
-                32);
+                log.debug("dispatchThrottle is dispatching slot {}", tSlot);
+                network.sendLocoNetMessage(tSlot.dispatchSlot());
+            }
         }
     }
 

--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -798,15 +798,16 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
      */
     public void dispatchThrottle(DccThrottle t, ThrottleListener l) {
         log.debug("dispatchThrottle - throttle {}", t.getLocoAddress());
-        // set status to common
+        // set status to common & dispatch slot
+        // needs to be done one after another with no delay.
         if (t instanceof LocoNetThrottle){
             LocoNetThrottle lnt = (LocoNetThrottle) t;
             LocoNetSlot tSlot = lnt.getLocoNetSlot();
             if (tSlot.slotStatus() != LnConstants.LOCO_COMMON) {
-                // and dispatch to slot 0
-                log.debug("dispatchThrottle is dispatching slot {}", tSlot);
-                network.sendLocoNetMessage(tSlot.dispatchSlot());
+                network.sendLocoNetMessage(tSlot.writeStatus(LnConstants.LOCO_COMMON));
             }
+            log.debug("dispatchThrottle is dispatching slot {}", tSlot);
+                network.sendLocoNetMessage(tSlot.dispatchSlot());
         }
     }
 

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -527,9 +527,11 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
                 break;
 
             case LnConstants.OPC_MOVE_SLOTS:  // No follow on for some moves
-                i = m.getElement(1);
-                return i;
-
+                if (m.getElement(1) != 0) {
+                    i = m.getElement(1);
+                    return i;
+                }
+                break;
             default:
                 // nothing here for us
                 return i;

--- a/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnThrottleManagerTest.java
@@ -169,17 +169,20 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
 
         throttle.dispatch(throtListen);
 
-        Assert.assertEquals("Expect the slot to be dispatched",
-                "BA 11 00 00",
-                lnis.outbound.elementAt(4).toString());
-
         Assert.assertEquals("slot is set to 'common' status",
                 "B5 11 10 00",
+                lnis.outbound.elementAt(4).toString());
+
+        Assert.assertEquals("Expect the slot to be dispatched",
+                "BA 11 00 00",
                 lnis.outbound.elementAt(5).toString());
+        // common is sent twice due to the way the release works.
+        Assert.assertEquals("slot is set to 'common' status",
+                "B5 11 10 00",
+                lnis.outbound.elementAt(6).toString());
 
-        JUnitUtil.waitFor(()->{return 5 < lnis.outbound.size();},"didn't get the 5th LocoNet message");
-        Assert.assertEquals("check count of sent messages", 5, lnis.outbound.size()-1);
-
+        JUnitUtil.waitFor(()->{return 6 < lnis.outbound.size();},"didn't get the 5th LocoNet message");
+        Assert.assertEquals("check count of sent messages", 6, lnis.outbound.size()-1);
 
         Assert.assertEquals("slot speed not zeroed", 26, memo.getSlotManager()._slots[17].speed());
     }
@@ -743,8 +746,14 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
         tm.dispatchThrottle(throttle2, throtListen2);
         Assert.assertFalse("Address no longer required",
                 InstanceManager.throttleManagerInstance().addressStillRequired(new DccLocoAddress(260, true)));
+        Assert.assertEquals("slot is set to 'common' status",
+                "B5 09 10 00",
+                lnis.outbound.elementAt(4).toString());
+        Assert.assertEquals("Expect the slot to be dispatched",
+                "BA 09 00 00",
+                lnis.outbound.elementAt(5).toString());
 
-        Assert.assertEquals("No more loconet messages sent at throttle release", 5, lnis.outbound.size()-1);
+        Assert.assertEquals("No more loconet messages sent at throttle release", 6, lnis.outbound.size()-1);
 
         throtListen = null;
         throtListen2 = null;
@@ -1026,6 +1035,7 @@ public class LnThrottleManagerTest extends jmri.managers.AbstractThrottleManager
     LocoNetSystemConnectionMemo memo;
 
     // The minimal setup for log4J
+    @Override
     @Before
     public void setUp() {
         JUnitUtil.setUp();


### PR DESCRIPTION
#6197 Prevent throttle being dispatch if in use on more than one throttle.
Correctly release throttle after dispatch