### PR TITLE
getSupportedModes() is non null

### DIFF
--- a/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
@@ -422,7 +422,6 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
     protected ProgrammingMode mode = ProgrammingMode.OPSBYTEMODE;
 
     @Override
-    @Nonnull
     public final void setMode(ProgrammingMode m) {
         if (getSupportedModes().contains(m)) {
             mode = m;
@@ -441,6 +440,7 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
      * Types implemented here.
      */
     @Override
+    @Nonnull
     public List<ProgrammingMode> getSupportedModes() {
         List<ProgrammingMode> ret = new ArrayList<>(4);
         ret.add(ProgrammingMode.OPSBYTEMODE);

--- a/java/src/jmri/progdebugger/ProgDebugger.java
+++ b/java/src/jmri/progdebugger/ProgDebugger.java
@@ -244,7 +244,6 @@ public class ProgDebugger implements AddressedProgrammer {
     protected ProgrammingMode mode;
 
     @Override
-    @Nonnull
     public final void setMode(ProgrammingMode m) {
         log.debug("Setting mode from {} to {}", mode, m);
         if (getSupportedModes().contains(m)) {
@@ -262,6 +261,7 @@ public class ProgDebugger implements AddressedProgrammer {
     }
 
     @Override
+    @Nonnull
     public List<ProgrammingMode> getSupportedModes() {
         if (address >= 0) {
             // addressed programmer


### PR DESCRIPTION
It appears that in a couple of places in 15391a1, `void setMode(ProgrammingMode)` was inadvertently marked nonnull instead of `List<ProgrammingMode> getSupportedModes()`.