### PR TITLE
WIP catch recursion in logix evaluation

### DIFF
--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -43,6 +43,7 @@ import jmri.jmrit.audio.AudioSource;
 import jmri.jmrit.entryexit.DestinationPoints;
 import jmri.jmrit.logix.OBlock;
 import jmri.jmrit.logix.Warrant;
+import jmri.managers.DefaultConditionalManager;
 import jmri.script.JmriScriptEngineManager;
 import jmri.script.ScriptOutput;
 import org.slf4j.Logger;
@@ -342,10 +343,11 @@ public class DefaultConditional extends AbstractNamedBean
     }
 
     protected String descriptionForUser() {
-        return Bundle.getMessage("DescriptionForDefaultConditional", "", getUserName(), getSystemName());
+        String logixDisplayName = InstanceManager.getDefault(DefaultConditionalManager.class).getParentLogix(getSystemName()).getDisplayName();
+        return Bundle.getMessage("DescriptionForDefaultConditional", logixDisplayName, getDisplayName(), getSystemName());
     }
 
-    private String describeAction(ConditionalAction action) {
+    protected String describeAction(ConditionalAction action) {
         return action.description(_triggerActionsOnChange);
     }
 

--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -343,7 +343,7 @@ public class DefaultConditional extends AbstractNamedBean
     }
 
     protected String descriptionForUser() {
-        String logixDisplayName = InstanceManager.getDefault(DefaultConditionalManager.class).getParentLogix(getSystemName()).getDisplayName();
+        String logixDisplayName = InstanceManager.getDefault(ConditionalManager.class).getParentLogix(getSystemName()).getDisplayName();
         return Bundle.getMessage("DescriptionForDefaultConditional", logixDisplayName, getDisplayName(), getSystemName());
     }
 

--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -621,7 +621,7 @@ public class DefaultConditional extends AbstractNamedBean
         return dp;
     }
 
-    private class ActionStats {
+    private static class ActionStats {
         int actionCount = 0;
         int actionNeeded = 0;
     }
@@ -633,9 +633,6 @@ public class DefaultConditional extends AbstractNamedBean
      * Conditional
      */
     @SuppressWarnings({"deprecation", "fallthrough"})  // NOI18N
-    @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH")  // NOI18N
-    // it's unfortunate that this is such a huge method, because these annotation
-    // have to apply to more than 500 lines of code - jake
     private void takeActionIfNeeded() {
         if (log.isTraceEnabled()) {
             log.trace("takeActionIfNeeded starts for " + getSystemName());  // NOI18N
@@ -643,8 +640,6 @@ public class DefaultConditional extends AbstractNamedBean
         ActionStats stats = new ActionStats();
         stats.actionCount = 0;
         stats.actionNeeded = 0;
-        int act = 0;
-        int state = 0;
         ArrayList<String> errorList = new ArrayList<>();
         // Use a local copy of state to guarantee the entire list of actions will be fired off
         // before a state change occurs that may block their completion.
@@ -678,6 +673,9 @@ public class DefaultConditional extends AbstractNamedBean
         }
     }
 
+    @SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH")  // NOI18N
+    // it's unfortunate that this is such a huge method, because these annotation
+    // have to apply to more than 500 lines of code - jake
     private void takeSingleActionIfNeeded(ActionStats stats, ArrayList<String> errorList, int
             currentState, int actionIndex, ConditionalAction action) {
         int act;
@@ -735,7 +733,7 @@ public class DefaultConditional extends AbstractNamedBean
                     break;
                 case Conditional.ACTION_RESET_DELAYED_TURNOUT:
                     action.stopTimer();
-                // fall through
+                //$FALL-THROUGH$
                 case Conditional.ACTION_DELAYED_TURNOUT:
                     if (!action.isTimerActive()) {
                         // Create a timer if one does not exist
@@ -877,7 +875,7 @@ public class DefaultConditional extends AbstractNamedBean
                     break;
                 case Conditional.ACTION_RESET_DELAYED_SENSOR:
                     action.stopTimer();
-                // fall through
+                //$FALL-THROUGH$
                 case Conditional.ACTION_DELAYED_SENSOR:
                     if (!action.isTimerActive()) {
                         // Create a timer if one does not exist

--- a/java/src/jmri/implementation/ImplementationBundle.properties
+++ b/java/src/jmri/implementation/ImplementationBundle.properties
@@ -50,4 +50,4 @@ ErrorDialogButtonEditConnections = Edit connections
 # 2=system name.
 DescriptionForDefaultConditional = Logix "{0}" Conditional "{1}" ({2})
 # Sensor group conditional description
-DescriptionForSGConditional = Logix "{0}" Conditional "{1}" ({2})
+DescriptionForSGConditional = SensorGroupConditional "{0}" ({1})

--- a/java/src/jmri/implementation/ImplementationBundle.properties
+++ b/java/src/jmri/implementation/ImplementationBundle.properties
@@ -44,3 +44,10 @@ ErrorDialogButtonExitProgram = Exit program
 ErrorDialogButtonRestartProgram = Restart program
 ErrorDialogButtonNewProfile = Start with new profile
 ErrorDialogButtonEditConnections = Edit connections
+
+## Logix recursion messages
+# This description is used for describing a conditional. 0=logix name, 1=conditional user name
+# 2=system name.
+DescriptionForDefaultConditional = Logix "{0}" Conditional "{1}" ({2})
+# Sensor group conditional description
+DescriptionForSGConditional = Logix "{0}" Conditional "{1}" ({2})

--- a/java/src/jmri/implementation/ImplementationBundle.properties
+++ b/java/src/jmri/implementation/ImplementationBundle.properties
@@ -49,5 +49,5 @@ ErrorDialogButtonEditConnections = Edit connections
 # This description is used for describing a conditional. 0=logix name, 1=conditional user name
 # 2=system name.
 DescriptionForDefaultConditional = Logix "{0}" Conditional "{1}" ({2})
-# Sensor group conditional description
-DescriptionForSGConditional = SensorGroupConditional "{0}" ({1})
+# Sensor group conditional description 0=user name 1=system name
+DescriptionForSGConditional = Sensor Group Conditional "{0}" ({1})

--- a/java/src/jmri/implementation/LogixRecursionException.java
+++ b/java/src/jmri/implementation/LogixRecursionException.java
@@ -55,4 +55,10 @@ class LogixRecursionException extends RuntimeException {
     public void stopCollectingStack() {
         isCollectingStack = false;
     }
+
+    @Override
+    public String toString() {
+        return "Logix encountered recursive loop: " + getStackExplanation() + "\n" + super
+                .toString();
+    }
 }

--- a/java/src/jmri/implementation/LogixRecursionException.java
+++ b/java/src/jmri/implementation/LogixRecursionException.java
@@ -1,0 +1,58 @@
+package jmri.implementation;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Created by bracz on 12/4/18.
+ */
+
+class LogixRecursionException extends RuntimeException {
+    // Stores the this reference to the object which detected the recursion and first thrown the
+    // exception.
+    private final Object triggerSource;
+    private boolean isCollectingStack = true;
+    private LinkedList<String> description = new LinkedList<>();
+
+    public LogixRecursionException(Object triggerSource, String explanationForUser) {
+        this.triggerSource = triggerSource;
+        this.description.add(explanationForUser);
+    }
+
+    /**
+     * Add some explanation for the user on why this recursion has happened. Calling this
+     * repeatedly will prepend the explanation, as it is expected to be called as the stack frame
+     * is unwound.
+     * @param explanationForUser text that describes the current stack frame; will be printed for
+     *                          the user.
+     */
+    public void prependDescription(String explanationForUser) {
+        description.addFirst(explanationForUser);
+    }
+
+    /**
+     * @return The full user-visible explanation of the recursion stack.
+     */
+    public String getStackExplanation() {
+        return String.join(" -> ", description);
+    }
+
+    /**
+     * @return object that detected the recursion at first.
+     */
+    public Object getTriggerSource() {
+        return triggerSource;
+    }
+
+    /**
+     * @return true if we are still collecting information about the stack for the user.
+     */
+    public boolean isCollectingStack() {
+        return this.isCollectingStack;
+    }
+
+    public void stopCollectingStack() {
+        isCollectingStack = false;
+    }
+}

--- a/java/src/jmri/implementation/SensorGroupConditional.java
+++ b/java/src/jmri/implementation/SensorGroupConditional.java
@@ -46,27 +46,63 @@ public class SensorGroupConditional extends DefaultConditional {
         if (Sensor.INACTIVE == ((Integer) evt.getNewValue()).intValue()) {
             return currentState;
         }
-        for (int i = 0; i < _actionList.size(); i++) {
-            ConditionalAction action = _actionList.get(i);
-            Sensor sn = InstanceManager.sensorManagerInstance().getSensor(action.getDeviceName());
-            if (sn == null) {
-                log.error("invalid sensor name in action - " + action.getDeviceName());
-                return currentState;
-            }
-            if (sn != evtSensor) { // don't change who triggered the action
-                // find the old one and reset it
-                if (sn.getState() != action.getActionData()) {
-                    try {
-                        sn.setKnownState(action.getActionData());
-                    } catch (JmriException e) {
-                        log.warn("Exception setting sensor " + action.getDeviceName() + " in action");
-                    }
+        try {
+            synchronized (this) {
+                ++_currentConditionalNesting;
+                if (_currentConditionalNesting >= CONDITIONAL_NESTING_LIMIT) {
+                    // throw exception.
+                    // @todo maybe the toString is not a good representation for the user.
+                    throw new LogixRecursionException(this, toString());
                 }
+            }
+            try {
+                if (takeAction(evtSensor)) return currentState;
+            } catch (LogixRecursionException e) {
+                if (e.isCollectingStack()) {
+                    e.prependDescription(toString());
+                }
+                if (e.getTriggerSource() == this) {
+                    // if we threw this exception and we are catching, we have unwound one
+                    // iteration of the loop.
+                    e.stopCollectingStack();
+                }
+                // re-throw to collect and unwind more stack frames.
+                throw e;
+            }
+        } finally {
+            synchronized (this) {
+                --_currentConditionalNesting;
             }
         }
         log.debug("SGConditional \"" + getUserName() + "\" (" + getSystemName() + "), state= " + currentState
                 + "has set the group actions for " + listener);
         return currentState;
+    }
+
+    private boolean takeAction(Sensor evtSensor) {
+        for (int i = 0; i < _actionList.size(); i++) {
+            ConditionalAction action = _actionList.get(i);
+            Sensor sn = InstanceManager.sensorManagerInstance().getSensor(action.getDeviceName());
+            if (sn == null) {
+                log.error("invalid sensor name in action - " + action.getDeviceName());
+                return true;
+            }
+            setSensorGroupSensor(evtSensor, action, sn);
+        }
+        return false;
+    }
+
+    private void setSensorGroupSensor(Sensor evtSensor, ConditionalAction action, Sensor sn) {
+        if (sn != evtSensor) { // don't change who triggered the action
+            // find the old one and reset it
+            if (sn.getState() != action.getActionData()) {
+                try {
+                    sn.setKnownState(action.getActionData());
+                } catch (JmriException e) {
+                    log.warn("Exception setting sensor " + action.getDeviceName() + " in action");
+                }
+            }
+        }
     }
 
     private final static Logger log = LoggerFactory.getLogger(SensorGroupConditional.class);

--- a/java/src/jmri/implementation/SensorGroupConditional.java
+++ b/java/src/jmri/implementation/SensorGroupConditional.java
@@ -33,7 +33,7 @@ public class SensorGroupConditional extends DefaultConditional {
 
     @Override
     protected String descriptionForUser() {
-        return Bundle.getMessage("DescriptionForSGConditional", "", getUserName(), getSystemName());
+        return Bundle.getMessage("DescriptionForSGConditional", getDisplayName(), getSystemName());
     }
     @Override
     public int calculate(boolean enabled, PropertyChangeEvent evt) {
@@ -63,7 +63,9 @@ public class SensorGroupConditional extends DefaultConditional {
             if (sn == null) {
                 log.error("invalid sensor name in action - " + action.getDeviceName());
             }
-            setSensorGroupSensor(evtSensor, action, sn);
+            guardRecursionStageHelper(
+                    ()->{setSensorGroupSensor(evtSensor, action, sn);},
+                    ()-> {return describeAction(action);});
         }
     }
 

--- a/java/test/jmri/implementation/LogixRecursionExceptionTest.java
+++ b/java/test/jmri/implementation/LogixRecursionExceptionTest.java
@@ -1,0 +1,41 @@
+package jmri.implementation;
+
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import jmri.util.JUnitUtil;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by bracz on 12/9/18.
+ */
+public class LogixRecursionExceptionTest {
+    @Before
+    public void setUp() throws Exception {
+        JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        JUnitUtil.tearDown();
+    }
+
+    @Test
+    public void testCtor() throws Exception {
+        Object o = new Object();
+        LogixRecursionException e = new LogixRecursionException(o, "asdfgh");
+        assertSame(o, e.getTriggerSource());
+        assertThat(e.toString(), Matchers.containsString("asdfgh"));
+    }
+
+    @Test
+    public void prependDescription() throws Exception {
+        Object o = new Object();
+        LogixRecursionException e = new LogixRecursionException(o, "asdfgh");
+        e.prependDescription("qwer");
+        assertThat(e.toString(), Matchers.containsString("qwer"));
+    }
+}

--- a/java/test/jmri/implementation/LogixRecursionExceptionTest.java
+++ b/java/test/jmri/implementation/LogixRecursionExceptionTest.java
@@ -1,6 +1,6 @@
 package jmri.implementation;
 
-import org.hamcrest.Matchers;
+import static org.hamcrest.core.StringContains.containsString;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -10,7 +10,7 @@ import jmri.util.JUnitUtil;
 import static org.junit.Assert.*;
 
 /**
- * Created by bracz on 12/9/18.
+ * @author Balazs Racz (C) 2018
  */
 public class LogixRecursionExceptionTest {
     @Before
@@ -28,7 +28,7 @@ public class LogixRecursionExceptionTest {
         Object o = new Object();
         LogixRecursionException e = new LogixRecursionException(o, "asdfgh");
         assertSame(o, e.getTriggerSource());
-        assertThat(e.toString(), Matchers.containsString("asdfgh"));
+        assertThat(e.toString(), containsString("asdfgh"));
     }
 
     @Test
@@ -36,6 +36,6 @@ public class LogixRecursionExceptionTest {
         Object o = new Object();
         LogixRecursionException e = new LogixRecursionException(o, "asdfgh");
         e.prependDescription("qwer");
-        assertThat(e.toString(), Matchers.containsString("qwer"));
+        assertThat(e.toString(), containsString("qwer"));
     }
 }

--- a/java/test/jmri/implementation/PackageTest.java
+++ b/java/test/jmri/implementation/PackageTest.java
@@ -39,6 +39,7 @@ import org.junit.runners.Suite;
         NmraConsistTest.class,
         MatrixSignalMastTest.class,
         DefaultRailComTest.class,
+        LogixRecursionExceptionTest.class,
 
         // sub-packages
         jmri.implementation.swing.PackageTest.class,


### PR DESCRIPTION
Motivation:
Currently it is possible to create a logix conditionals that trigger each other and cause an infinite recursion by flipflopping some state variable between each other. Loops can also happen through more than two conditionals and through sensor groups as well. They are generally caused by mistakes in programming the logix (mistyping sensor names or incorrectly assigning triggering property to antecedents), unintended side-effects, or misunderstanding of the underlying data / programming / triggering model. It is not a valid use-case that needs to be supported.
The consequence of a logix loop is pretty severe today. JMRI usually crashes in some way or another, by running out of heap space, a stack overflow error, an exception saying "cannot start a new thread", or sometimes with a JVM segfault (=> all windows disappearing without any error message). The common theme is that the error does not actually tell where the user has to go look for the problem.
A quick survey on the users list showed that even the most advanced users run into logix recursion problems time and again and they usually struggle to find the cause. The most useful advice I got given was to restore the panel file to the last known good version.

Solution:
Identify at run-time when infinite loops happen, and terminate the recursion well before java crashes. Collect information about the path of the recursion to help the user in finding, debugging and fixing the misconfiguration problem.
1. Keep a scoped-incrementing counter for each conditional that counts up during the execution of the action block only. 
2. If this counter is > 1, there is a recursion. Throw an exception to stop it.
3. As the exception unwinds, record metadata about the path of the looping recursion by catching the exception, annotating it with the current conditional's context, then re-throwing it.
4. Once the loop was identified, unroll the stack to the UncaughtExceptionHandler to allow JMRI to continue.

I'm looking for feedback about two specific questions:
- What should we be doing after an infinite loop was identified and stopped? Is there a meaningful way to proceed afterwards, or unrolling to the UncaughtExceptionHandler is the best recovery path?
- How should we present the error to the user? Is it possible to open a dialog box on the UI from a catch(...) block? Is displaying the error to the system console sufficient for this use-case?

The PR is WIP for the following reasons:
- I need to write tests.
- I'm sure there will be problems around findbugs annotations.
