### PR TITLE
Update for issue on master from PR6121

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
@@ -2569,6 +2569,7 @@ public class LayoutTurnout extends LayoutTrack {
             }
             if (block_count == 0) {
                 jmi = popup.add(Bundle.getMessage("NoBlock"));
+                jmi.setEnabled(false);
             }
 
             // if there are any track connections


### PR DESCRIPTION
After PR #6121 was merged, SpotBugs started rejecting the master branch due to a dead store in line 2571 of LayoutTurnout (2nd from bottom in following snippet):

```
                if (getLayoutBlockD() != null) {
                    jmi = popup.add(Bundle.getMessage("MakeLabel", Bundle.getMessage("Block_ID", "D")) + getLayoutBlockD().getDisplayName());
                    jmi.setEnabled(false);
                    block_count++;  // bump block count
                }
            }
            if (block_count == 0) {
                jmi = popup.add(Bundle.getMessage("NoBlock"));
            }
```

This wasn't found previously because SpotBugs started failing this error after this PR made it's first pass through CI.

There are two possible changes, depending on the intent of this code (and what side-effects `popup.add(..)` has):
- the assignment in the `if (block_count)` section.  It seems that `popup.add(..)` puts an item on a pop-up menu, so removing the assigment allows it to still be called
- but it seems more likely that this is just a copy-and-not-paste error, with the called to `jmri.setenabled(..)` missing.  So I've added that line.

