### PR TITLE
Update to location of new jmri-developers list

### DIFF
--- a/help/en/html/doc/Technical/TechRoadMap.shtml
+++ b/help/en/html/doc/Technical/TechRoadMap.shtml
@@ -35,7 +35,7 @@
       for JMRI's future develpoment, including changes to our use
       of Java technologies. It is maintained and updated through
       continuing discussion on the <a href=
-      "http://sourceforge.net/mailarchive/forum.php?forum_name=jmri-developers">
+      "https://jmri-developers.groups.io/g/jmri/topics">
       jmri-developers mailing list</a>.
 
       <p>There's also a <a href="TechRoadMapOlder.shtml">page

--- a/help/en/html/doc/Technical/index.shtml
+++ b/help/en/html/doc/Technical/index.shtml
@@ -115,9 +115,9 @@
       the software is being written)</h2>Much of the discussion
       about JMRI development takes place on the JMRI-Developers
       mailing list: <a href=
-      "https://lists.sourceforge.net/lists/listinfo/jmri-developers">
+      "https://jmri-developers.groups.io/g/jmri/join">
       Subscribe</a>, <a href=
-      "http://sourceforge.net/mailarchive/forum.php?forum_name=jmri-developers">
+      "https://jmri-developers.groups.io/g/jmri/topics">
       Archive</a>
 
       <p><a href="http://GitHub.com">GitHub</a> provides our

--- a/help/fr/html/doc/Technical/index.shtml
+++ b/help/fr/html/doc/Technical/index.shtml
@@ -104,8 +104,8 @@ Il y a plusieurs fa&#231;ons de modifier JMRI:
 <h2>Renseignements sur le projet JMRI (Pour les personnes int&#233;ress&#233;es &#224; la fa&#231;on dont le logiciel est en cours d'&#233;criture</h2>
 
 Une grande partie des discussion sur le d&#233;veloppement JMRI a lieu sur la liste de diffusion JMRI-Developers:
-<a href="https://lists.sourceforge.net/lists/listinfo/jmri-developers"> Abonnez-vous </a>,
-<a href="http://sourceforge.net/mailarchive/forum.php?forum_name=jmri-developers"> Archive </a>
+<a href="https://jmri-developers.groups.io/g/jmri/join"> Abonnez-vous </a>,
+<a href="https://jmri-developers.groups.io/g/jmri/topics"> Archive </a>
 
 <p>
 <a href="http://GitHub.com">GitHub</a> fournit nos r&#233;pertoires logiciels via l'

--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -282,7 +282,7 @@ If you're developing any additional (post-4.13.6) changes that you want in the J
 
 - Change the release note to point to the just-built files (in CI or where you put them), commit, wait (or force via ["Build Now"](http://builds.jmri.org/jenkins/job/Web%20Site/job/Website%20from%20JMRI%20GitHub%20website%20repository/) update). Confirm visible on web.
 
-- Announce the file set via email to jmri-developers@lists.sf.net with a subject line 
+- Announce the file set via email to jmri@jmri-developers.groups.io with a subject line 
 
 ```
 "First 4.13.6 files available":


### PR DESCRIPTION
This updates (most) references to the jmri-developers list ready for when we move it to Groups.io