### PR TITLE
Fix Sprog initial configuration issue (4.13.6)

### DIFF
--- a/java/src/jmri/jmrix/sprog/pi/pisprognano/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/pi/pisprognano/ConnectionConfig.java
@@ -31,16 +31,6 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     }
 
     @Override
-    public String getManufacturer() {
-        return adapter.getManufacturer();
-    }
-
-    @Override
-    public void setManufacturer(String manu) {
-        adapter.setManufacturer(manu);
-    }
-
-    @Override
     protected String[] getPortFriendlyNames() {
         if (SystemType.isWindows()) {
             return new String[]{"SPROG"};

--- a/java/src/jmri/jmrix/sprog/pi/pisprogone/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/pi/pisprogone/ConnectionConfig.java
@@ -31,26 +31,6 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     }
 
     @Override
-    public String getManufacturer() {
-        return adapter.getManufacturer();
-    }
-
-    @Override
-    public void setManufacturer(String manu) {
-        adapter.setManufacturer(manu);
-    }
-    /*@Override
-     protected Vector<String> getPortFriendlyNames() {
-     System.out.println("Port names called");
-     Vector<String> portNameVector = new Vector<String>();
-     if(System.getProperty("os.name").toLowerCase().contains("windows")){
-     portNameVector.add("SPROG");
-     }
-     System.out.println("Port names called" + portNameVector);
-     return portNameVector;
-     }*/
-
-    @Override
     protected String[] getPortFriendlyNames() {
         if (SystemType.isWindows()) {
             return new String[]{"SPROG"};

--- a/java/src/jmri/jmrix/sprog/pi/pisprogonecs/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/pi/pisprogonecs/ConnectionConfig.java
@@ -31,26 +31,6 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     }
 
     @Override
-    public String getManufacturer() {
-        return adapter.getManufacturer();
-    }
-
-    @Override
-    public void setManufacturer(String manu) {
-        adapter.setManufacturer(manu);
-    }
-    /*@Override
-     protected Vector<String> getPortFriendlyNames() {
-     System.out.println("Port names called");
-     Vector<String> portNameVector = new Vector<String>();
-     if(System.getProperty("os.name").toLowerCase().contains("windows")){
-     portNameVector.add("SPROG");
-     }
-     System.out.println("Port names called" + portNameVector);
-     return portNameVector;
-     }*/
-
-    @Override
     protected String[] getPortFriendlyNames() {
         if (SystemType.isWindows()) {
             return new String[]{"SPROG"};

--- a/java/src/jmri/jmrix/sprog/sprogCS/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/sprogCS/ConnectionConfig.java
@@ -31,26 +31,6 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     }
 
     @Override
-    public String getManufacturer() {
-        return adapter.getManufacturer();
-    }
-
-    @Override
-    public void setManufacturer(String manu) {
-        adapter.setManufacturer(manu);
-    }
-    /*@Override
-     protected Vector<String> getPortFriendlyNames() {
-     System.out.println("Port names called");
-     Vector<String> portNameVector = new Vector<String>();
-     if(System.getProperty("os.name").toLowerCase().contains("windows")){
-     portNameVector.add("SPROG");
-     }
-     System.out.println("Port names called" + portNameVector);
-     return portNameVector;
-     }*/
-
-    @Override
     protected String[] getPortFriendlyNames() {
         if (SystemType.isWindows()) {
             return new String[]{"SPROG"};

--- a/java/src/jmri/jmrix/sprog/sprognano/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/sprog/sprognano/ConnectionConfig.java
@@ -31,15 +31,6 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
     }
 
     @Override
-    public String getManufacturer() {
-        return adapter.getManufacturer();
-    }
-
-    @Override
-    public void setManufacturer(String manu) {
-        adapter.setManufacturer(manu);
-    }
-    @Override
     protected String[] getPortFriendlyNames() {
         if (SystemType.isWindows()) {
             return new String[]{"SPROG"};


### PR DESCRIPTION
This is an PR to 4.13.6 to fix a problem where Sprog configuration fails to show the port list.

Will be merged to master separately.