### PR TITLE
Add jmri.StringIO interface

### DIFF
--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -36,6 +36,7 @@ BeanNameWarrant         = Warrant
 BeanNameOBlock          = Occupancy Block
 BeanNamePortal          = Portal
 BeanNameEntryExit       = Entry Exit
+BeanNameStringIO        = String I/O
 # not a real bean but form for LogixTableAction
 EntryExit               = Entry Exit
 FastClock               = Fast Clock

--- a/java/src/jmri/StringIO.java
+++ b/java/src/jmri/StringIO.java
@@ -1,9 +1,11 @@
 package jmri;
 
+import javax.annotation.Nonnull;
+
 /**
  * Represent an string I/O on the layout.
  * <P>
- * A StringIO could for example being a display connected to an Arduino
+ * A StringIO could for example be a display connected to an Arduino
  * microcomputer that shows train departures of a station.
  *
  * @author Daniel Bergqvist Copyright (c) 2018
@@ -11,31 +13,33 @@ package jmri;
 public interface StringIO extends NamedBean {
 
     /**
-     * Change the commanded state, which results in the relevant command(s)
+     * Change the commanded value, which results in the relevant command(s)
      * being sent to the hardware. The exception is thrown if there are problems
      * communicating with the layout hardware.
      *
      * @param value the desired string value
-     * @throws jmri.JmriException general error when setting the state fails
+     * @throws jmri.JmriException general error when setting the value fails
      */
-    public void setCommandedStringValue(String value) throws JmriException;
+    public void setCommandedStringValue(@Nonnull String value) throws JmriException;
 
     /**
      * Query the commanded string. This is a bound parameter, so you can also
      * register a listener to be informed of changes.
      *
-     * @return the analog value
+     * @return the string value
      */
+    @Nonnull
     public String getCommandedStringValue();
 
     /**
-     * Query the known analog value. This is a bound parameter, so you can also
+     * Query the known string value. This is a bound parameter, so you can also
      * register a listener to be informed of changes. A result is always
-     * returned; if no other feedback method is available, the commanded state
+     * returned; if no other feedback method is available, the commanded value
      * will be used.
      *
-     * @return the known analog value
+     * @return the known string value
      */
+    @Nonnull
     default public String getKnownStringValue() {
         return getCommandedStringValue();
     }

--- a/java/src/jmri/StringIO.java
+++ b/java/src/jmri/StringIO.java
@@ -1,0 +1,58 @@
+package jmri;
+
+/**
+ * Represent an string I/O on the layout.
+ * <P>
+ * A StringIO could for example being a display connected to an Arduino
+ * microcomputer that shows train departures of a station.
+ *
+ * @author Daniel Bergqvist Copyright (c) 2018
+ */
+public interface StringIO extends NamedBean {
+
+    /**
+     * Change the commanded state, which results in the relevant command(s)
+     * being sent to the hardware. The exception is thrown if there are problems
+     * communicating with the layout hardware.
+     *
+     * @param value the desired string value
+     * @throws jmri.JmriException general error when setting the state fails
+     */
+    public void setCommandedStringValue(String value) throws JmriException;
+
+    /**
+     * Query the commanded string. This is a bound parameter, so you can also
+     * register a listener to be informed of changes.
+     *
+     * @return the analog value
+     */
+    public String getCommandedStringValue();
+
+    /**
+     * Query the known analog value. This is a bound parameter, so you can also
+     * register a listener to be informed of changes. A result is always
+     * returned; if no other feedback method is available, the commanded state
+     * will be used.
+     *
+     * @return the known analog value
+     */
+    default public String getKnownStringValue() {
+        return getCommandedStringValue();
+    }
+
+    /**
+     * Get the maximum length of string that this StringIO can handle.
+     * @return the maximum length or 0 if arbitrary lengths are accepted.
+     */
+    default public int getMaximumLength() {
+        return 0;
+    }
+
+    /**
+     * Request an update from the layout soft/hardware. May not even happen, and
+     * if it does it will happen later; listen for the result.
+     */
+    default public void requestUpdateFromLayout() {
+    }
+
+}

--- a/java/src/jmri/implementation/AbstractStringIO.java
+++ b/java/src/jmri/implementation/AbstractStringIO.java
@@ -1,0 +1,119 @@
+package jmri.implementation;
+
+import jmri.JmriException;
+import jmri.NamedBean;
+import jmri.StringIO;
+
+/**
+ * Base implementation of the StringIO interface.
+ *
+ * @author Daniel Bergqvist Copyright (c) 2018
+ */
+public abstract class AbstractStringIO extends AbstractNamedBean implements StringIO {
+
+    private String _commandedString = "";
+    private String _knownString = "";
+
+    /**
+     * Abstract constructor for new StringIO with system name
+     * 
+     * @param systemName StringIO system name
+     */
+    public AbstractStringIO(String systemName) {
+        super(systemName);
+    }
+
+    /**
+     * Abstract constructor for new StringIO with system name and user name
+     *
+     * @param systemName StringIO system name
+     * @param userName   StringIO user name
+     */
+    public AbstractStringIO(String systemName, String userName) {
+        super(systemName, userName);
+    }
+
+    /**
+     * Sends the string to the layout.
+     * The string [u]must not[/u] be longer than the value of getMaximumLength()
+     * unless that value is zero. Some microcomputers have little memory and
+     * it's very important that this method is never called with too long strings.
+     * @param value
+     * @throws JmriException 
+     */
+    abstract protected void sendStringToLayout(String value) throws JmriException;
+
+    /**
+     * Set the string of this StringIO.
+     * Called from the implementation class when the layout updates this StringIO.
+     */
+    protected void setString(String newValue) {
+        Object _old = this._knownString;
+        this._knownString = newValue;
+        firePropertyChange("State", _old, _knownString); //NOI18N
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setCommandedStringValue(String value) throws JmriException {
+        int maxLength = getMaximumLength();
+        if ((maxLength > 0) && (value.length() > maxLength)) {
+            if (cutLongStrings()) {
+                value = value.substring(0, maxLength);
+            } else {
+                throw new JmriException("String too long");
+            }
+        }
+        _commandedString = value;
+        sendStringToLayout(_commandedString);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getCommandedStringValue() {
+        return _commandedString;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getKnownStringValue() {
+        return _knownString;
+    }
+
+    /**
+     * Cut long strings instead of throwing an exception?
+     * For example, if the StringIO is a display, it could be desired to
+     * accept too long strings.
+     * On the other hand, if the StringIO is used to send a command, a too
+     * long string is an error.
+     * 
+     * @return true if long strings should be cut
+     */
+    abstract protected boolean cutLongStrings();
+
+    /** {@inheritDoc} */
+    @Override
+    public int getState() {
+        // A StringIO doesn't have a state
+        return NamedBean.UNKNOWN;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setState(int newState) {
+        // A StringIO doesn't have a state
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getBeanType() {
+        return Bundle.getMessage("BeanNameStringIO");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return this.getClass().getName() + " (" + this.getSystemName() + ")"; //NOI18N
+    }
+
+}

--- a/java/test/jmri/PackageTest.java
+++ b/java/test/jmri/PackageTest.java
@@ -25,6 +25,7 @@ import org.junit.runners.Suite;
     SectionTest.class,
     SignalGroupTest.class,
     SignalMastLogicTest.class,
+    StringIOTest.class,
     TransitTest.class,
     TransitSectionTest.class,
     TransitSectionActionTest.class,

--- a/java/test/jmri/StringIOTest.java
+++ b/java/test/jmri/StringIOTest.java
@@ -4,7 +4,7 @@ import jmri.implementation.AbstractNamedBean;
 import org.junit.*;
 
 /**
- * Tests for the Light class
+ * Tests for the StringIO class
  *
  * @author	Daniel Bergqvist Copyright (C) 2018
  */

--- a/java/test/jmri/StringIOTest.java
+++ b/java/test/jmri/StringIOTest.java
@@ -1,0 +1,72 @@
+package jmri;
+
+import jmri.implementation.AbstractNamedBean;
+import org.junit.*;
+
+/**
+ * Tests for the Light class
+ *
+ * @author	Daniel Bergqvist Copyright (C) 2018
+ */
+public class StringIOTest {
+
+    @Test
+    public void testStringIO() throws JmriException {
+        StringIO stringIO = new MyStringIO("String");
+        stringIO.setCommandedStringValue("One string");
+        Assert.assertTrue("StringIO has value 'One string'", "One string".equals(stringIO.getCommandedStringValue()));
+        stringIO.setCommandedStringValue("Other string");
+        Assert.assertTrue("StringIO has value 'Other string'", "Other string".equals(stringIO.getCommandedStringValue()));
+        stringIO.setCommandedStringValue("One string");
+        Assert.assertTrue("StringIO has value 'One string'", "One string".equals(stringIO.getKnownStringValue()));
+        stringIO.setCommandedStringValue("Other string");
+        Assert.assertTrue("StringIO has value 'Other string'", "Other string".equals(stringIO.getKnownStringValue()));
+    }
+    
+    @Before
+    public void setUp() {
+          jmri.util.JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+          jmri.util.JUnitUtil.tearDown();
+    }
+
+    
+    private class MyStringIO extends AbstractNamedBean implements StringIO {
+
+        String _value = "";
+        
+        public MyStringIO(String sys) {
+            super(sys);
+        }
+        
+        @Override
+        public void setState(int s) throws JmriException {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public int getState() {
+            throw new UnsupportedOperationException("Not supported.");
+        }
+
+        @Override
+        public String getBeanType() {
+            return "StringIO";
+        }
+
+        @Override
+        public void setCommandedStringValue(String value) throws JmriException {
+            _value = value;
+        }
+
+        @Override
+        public String getCommandedStringValue() {
+            return _value;
+        }
+
+    }
+    
+}

--- a/java/test/jmri/implementation/AbstractStringIOTest.java
+++ b/java/test/jmri/implementation/AbstractStringIOTest.java
@@ -1,0 +1,97 @@
+package jmri.implementation;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import jmri.JmriException;
+import org.junit.*;
+
+/**
+ * Tests for AbstractStringIO
+ * 
+ * @author Daniel Bergqvist Copyright (c) 2018
+ */
+public class AbstractStringIOTest {
+    
+    AtomicBoolean exceptionThrown = new AtomicBoolean(false);
+    
+    @Test
+    public void testCtor() {
+        MyAbstractStringIO stringIO = new MyAbstractStringIO();
+        Assert.assertNotNull("AbstractStringIO constructor return", stringIO);
+    }
+    
+    @Test
+    public void testStringIO() throws JmriException {
+        MyAbstractStringIO myStringIO = new MyAbstractStringIO();
+        myStringIO.setCommandedStringValue("8:20. Train 21 to Vaxjo");
+        Assert.assertTrue("string is correct",
+                "8:20. Train 21 to Vaxjo".equals(myStringIO.getKnownStringValue()));
+        
+        myStringIO = new MyAbstractStringIO(22, false);
+        exceptionThrown.set(false);
+        try {
+            myStringIO.setCommandedStringValue("8:20. Train 21 to Vaxjo");
+        } catch (JmriException e) {
+            exceptionThrown.set(true);
+        }
+        Assert.assertTrue("string is too long", exceptionThrown.get() == true);
+        
+        myStringIO = new MyAbstractStringIO(23, false);
+        myStringIO.setCommandedStringValue("8:20. Train 21 to Vaxjo");
+        Assert.assertTrue("string is correct and has valid length",
+                "8:20. Train 21 to Vaxjo".equals(myStringIO.getKnownStringValue()));
+        
+        myStringIO = new MyAbstractStringIO(10, true);
+        myStringIO.setCommandedStringValue("8:20. Train 21 to Vaxjo");
+        Assert.assertTrue("string is cut",
+                "8:20. Trai".equals(myStringIO.getKnownStringValue()));
+        
+        Assert.assertTrue("toString() matches",
+                "jmri.implementation.AbstractStringIOTest$MyAbstractStringIO (MySystemName)".equals(myStringIO.toString()));
+        
+        Assert.assertTrue("getBeanType() matches", "String I/O".equals(myStringIO.getBeanType()));
+    }
+    
+    @Before
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
+    
+    
+    private class MyAbstractStringIO extends AbstractStringIO {
+        
+        private int _maxLen = 0;
+        private boolean _cut = false;
+        
+        MyAbstractStringIO() {
+            super("MySystemName");
+        }
+
+        MyAbstractStringIO(int maxLen, boolean cut) {
+            super("MySystemName");
+            _maxLen = maxLen;
+            _cut = cut;
+        }
+
+        @Override
+        protected void sendStringToLayout(String value) throws JmriException {
+            this.setString(value);
+        }
+
+        @Override
+        public int getMaximumLength() {
+            return _maxLen;
+        }
+
+        @Override
+        public boolean cutLongStrings() {
+            return _cut;
+        }
+
+    }
+    
+}

--- a/java/test/jmri/implementation/PackageTest.java
+++ b/java/test/jmri/implementation/PackageTest.java
@@ -11,6 +11,7 @@ import org.junit.runners.Suite;
         // implementations
         AbstractAudioTest.class,
         AbstractSensorTest.class,
+        AbstractStringIOTest.class,
         AccessoryOpsModeProgrammerFacadeTest.class,
         OpsModeDelayedProgrammerFacadeTest.class,
         AddressedHighCvProgrammerFacadeTest.class,


### PR DESCRIPTION
This is a continuation of DigitalIO and AnalogIO.

StringIO defines a NamedBean that supports string input/output. An example is an Arduino with a display that shows the trains that are going to departure from a station. A StringIO could then be used to send a message like "12.34: Train 34 to Alvesta and Malmo". This information could be fetched from the time table in JMRI and synchronized with the fast clock.

I added the class AbstractStringIO since some small microcomputers like Arduino has a very small amount of memory and AbstractStringIO ensures that too long strings are not sent to the layout.

The method cutLongStrings() in AbstractStringIO allows cutting the string instead of throwing an exception if the string is too long. Should this method be in the abstract class or in the interface StringIO? If it is in the interface, the caller can see if too long strings are accepted. On the other hand, the caller knows how long strings are accepted anyway by the method StringIO.getMaximumLength().

This PR is "After next production release".