### PR TITLE
Include NamedBean properties in JSON objects

### DIFF
--- a/java/src/jmri/Block.java
+++ b/java/src/jmri/Block.java
@@ -156,7 +156,7 @@ public class Block extends AbstractNamedBean implements PhysicalLocationReporter
      * Set the sensor by name.
      *
      * @param pName the name of the Sensor to set
-     * @return true if a Sensor is set; false otherwise
+     * @return true if a Sensor is set and is not null; false otherwise
      */
     public boolean setSensor(String pName) {
         if (pName == null || pName.equals("")) {

--- a/java/src/jmri/server/json/JsonNamedBeanHttpService.java
+++ b/java/src/jmri/server/json/JsonNamedBeanHttpService.java
@@ -41,7 +41,7 @@ public abstract class JsonNamedBeanHttpService extends JsonHttpService {
         data.put(JSON.NAME, bean.getSystemName());
         data.put(JSON.USERNAME, bean.getUserName());
         data.put(JSON.COMMENT, bean.getComment());
-        ArrayNode properties = root.putArray(JSON.PROPERTIES);
+        ArrayNode properties = data.putArray(JSON.PROPERTIES);
         bean.getPropertyKeys().stream().forEach((key) -> {
             Object value = bean.getProperty(key);
             if (value != null) {
@@ -50,7 +50,7 @@ public abstract class JsonNamedBeanHttpService extends JsonHttpService {
                 properties.add(mapper.createObjectNode().putNull(key));
             }
         });
-        return data;
+        return root;
     }
 
     /**

--- a/java/src/jmri/server/json/block/JsonBlockHttpService.java
+++ b/java/src/jmri/server/json/block/JsonBlockHttpService.java
@@ -35,35 +35,32 @@ public class JsonBlockHttpService extends JsonNamedBeanHttpService {
 
     @Override
     public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
-        ObjectNode root = mapper.createObjectNode();
         Block block = InstanceManager.getDefault(BlockManager.class).getBlock(name);
-        if (block == null) {
-            throw new JsonException(404, Bundle.getMessage(locale, "ErrorObject", BLOCK, name));
-        }
-        root.put(JSON.TYPE, BLOCK);
-        ObjectNode data = this.getNamedBean(block, name, type, locale);
-        root.set(JSON.DATA, data);
-        switch (block.getState()) {
-            case Block.UNDETECTED:
-                data.put(JSON.STATE, JSON.UNKNOWN);
-                break;
-            default:
-                data.put(JSON.STATE, block.getState());
-        }
-        if (block.getValue() == null) {
-            data.putNull(JSON.VALUE);
-        } else {
-            data.put(JSON.VALUE, block.getValue().toString());
-        }
-        if (block.getSensor() == null) {
-            data.putNull(JsonSensor.SENSOR);
-        } else {
-            data.put(JsonSensor.SENSOR, block.getSensor().getSystemName());
-        }
-        if (block.getReporter() == null) {
-            data.putNull(JsonReporter.REPORTER);
-        } else {
-            data.put(JsonReporter.REPORTER, block.getReporter().getSystemName());
+        ObjectNode root = this.getNamedBean(block, name, type, locale); // throws JsonException if block == null
+        ObjectNode data = root.with(JSON.DATA);
+        if (block != null) {
+            switch (block.getState()) {
+                case Block.UNDETECTED:
+                    data.put(JSON.STATE, JSON.UNKNOWN);
+                    break;
+                default:
+                    data.put(JSON.STATE, block.getState());
+            }
+            if (block.getValue() == null) {
+                data.putNull(JSON.VALUE);
+            } else {
+                data.put(JSON.VALUE, block.getValue().toString());
+            }
+            if (block.getSensor() == null) {
+                data.putNull(JsonSensor.SENSOR);
+            } else {
+                data.put(JsonSensor.SENSOR, block.getSensor().getSystemName());
+            }
+            if (block.getReporter() == null) {
+                data.putNull(JsonReporter.REPORTER);
+            } else {
+                data.put(JsonReporter.REPORTER, block.getReporter().getSystemName());
+            }
         }
         return root;
     }

--- a/java/src/jmri/server/json/block/JsonBlockHttpService.java
+++ b/java/src/jmri/server/json/block/JsonBlockHttpService.java
@@ -102,7 +102,7 @@ public class JsonBlockHttpService extends JsonNamedBeanHttpService {
                 if (sensor != null) {
                     block.setSensor(sensor.getSystemName());
                 } else {
-                    throw new JsonException(404, Bundle.getMessage(locale, "ObjectNotFound", JsonSensor.SENSOR, node.asText()));
+                    throw new JsonException(404, Bundle.getMessage(locale, "ErrorNotFound", JsonSensor.SENSOR, node.asText()));
                 }
             }
         }
@@ -115,7 +115,7 @@ public class JsonBlockHttpService extends JsonNamedBeanHttpService {
                 if (reporter != null) {
                     block.setReporter(reporter);
                 } else {
-                    throw new JsonException(404, Bundle.getMessage(locale, "ObjectNotFound", JsonReporter.REPORTER, node.asText()));
+                    throw new JsonException(404, Bundle.getMessage(locale, "ErrorNotFound", JsonReporter.REPORTER, node.asText()));
                 }
             }
         }

--- a/java/src/jmri/server/json/block/JsonBlockHttpService.java
+++ b/java/src/jmri/server/json/block/JsonBlockHttpService.java
@@ -14,6 +14,8 @@ import jmri.BlockManager;
 import jmri.InstanceManager;
 import jmri.Reporter;
 import jmri.ReporterManager;
+import jmri.Sensor;
+import jmri.SensorManager;
 import jmri.server.json.JSON;
 import jmri.server.json.JsonException;
 import jmri.server.json.JsonNamedBeanHttpService;
@@ -95,21 +97,28 @@ public class JsonBlockHttpService extends JsonNamedBeanHttpService {
                 throw new JsonException(400, Bundle.getMessage(locale, "ErrorUnknownState", BLOCK, state));
         }
         if (!data.path(JsonSensor.SENSOR).isMissingNode()) {
-            if (data.path(JsonSensor.SENSOR).isNull()) {
+            JsonNode node = data.path(JsonSensor.SENSOR);
+            if (node.isNull()) {
                 block.setSensor(null);
             } else {
-                block.setSensor(data.path(JsonSensor.SENSOR).asText());
+                Sensor sensor = InstanceManager.getDefault(SensorManager.class).getBySystemName(node.asText());
+                if (sensor != null) {
+                    block.setSensor(sensor.getSystemName());
+                } else {
+                    throw new JsonException(404, Bundle.getMessage(locale, "ObjectNotFound", JsonSensor.SENSOR, node.asText()));
+                }
             }
         }
         if (!data.path(JsonReporter.REPORTER).isMissingNode()) {
-            if (data.path(JsonReporter.REPORTER).isNull()) {
+            JsonNode node = data.path(JsonReporter.REPORTER);
+            if (node.isNull()) {
                 block.setReporter(null);
             } else {
-                Reporter reporter = InstanceManager.getDefault(ReporterManager.class).getBySystemName(data.path(JsonReporter.REPORTER).asText());
+                Reporter reporter = InstanceManager.getDefault(ReporterManager.class).getBySystemName(node.asText());
                 if (reporter != null) {
                     block.setReporter(reporter);
                 } else {
-                    throw new JsonException(404, Bundle.getMessage(locale, "ObjectNotFound", JsonReporter.REPORTER, data.path(JsonReporter.REPORTER).asText()));
+                    throw new JsonException(404, Bundle.getMessage(locale, "ObjectNotFound", JsonReporter.REPORTER, node.asText()));
                 }
             }
         }

--- a/java/src/jmri/server/json/layoutblock/JsonLayoutBlockHttpService.java
+++ b/java/src/jmri/server/json/layoutblock/JsonLayoutBlockHttpService.java
@@ -2,7 +2,6 @@ package jmri.server.json.layoutblock;
 
 import static jmri.server.json.JSON.DATA;
 import static jmri.server.json.JSON.STATE;
-import static jmri.server.json.JSON.TYPE;
 import static jmri.server.json.layoutblock.JsonLayoutBlock.BLOCK_COLOR;
 import static jmri.server.json.layoutblock.JsonLayoutBlock.EXTRA_COLOR;
 import static jmri.server.json.layoutblock.JsonLayoutBlock.LAYOUTBLOCK;
@@ -24,6 +23,7 @@ import jmri.jmrit.display.layoutEditor.LayoutBlock;
 import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
 import jmri.server.json.JsonException;
 import jmri.server.json.JsonNamedBeanHttpService;
+
 /**
  *
  * @author mstevetodd Copyright (C) 2018 (copied from JsonMemoryHttpService)
@@ -37,23 +37,19 @@ public class JsonLayoutBlockHttpService extends JsonNamedBeanHttpService {
 
     @Override
     public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
-        ObjectNode root = mapper.createObjectNode();
-        root.put(TYPE, LAYOUTBLOCK);
         LayoutBlock layoutBlock = InstanceManager.getDefault(LayoutBlockManager.class).getLayoutBlock(name);
-        if (layoutBlock == null) {
-            throw new JsonException(404, Bundle.getMessage(locale, "ErrorObject", LAYOUTBLOCK, name));
+        ObjectNode root = super.getNamedBean(layoutBlock, name, type, locale); // throws JsonException if layoutBlock == null
+        ObjectNode data = root.with(DATA);
+        if (layoutBlock != null) {
+            data.put(STATE, layoutBlock.getState());
+            data.put(USE_EXTRA_COLOR, layoutBlock.getUseExtraColor());
+            data.put(BLOCK_COLOR, jmri.util.ColorUtil.colorToColorName(layoutBlock.getBlockColor()));
+            data.put(TRACK_COLOR, jmri.util.ColorUtil.colorToColorName(layoutBlock.getBlockTrackColor()));
+            data.put(OCCUPIED_COLOR, jmri.util.ColorUtil.colorToColorName(layoutBlock.getBlockOccupiedColor()));
+            data.put(EXTRA_COLOR, jmri.util.ColorUtil.colorToColorName(layoutBlock.getBlockExtraColor()));
+            data.put(OCCUPANCY_SENSOR, layoutBlock.getOccupancySensor() != null ? layoutBlock.getOccupancySensorName() : null);
+            data.put(OCCUPIED_SENSE, layoutBlock.getOccupiedSense());
         }
-        ObjectNode data = super.getNamedBean(layoutBlock, name, LAYOUTBLOCK, locale);
-        root.set(DATA, data);
-        data.put(STATE, layoutBlock.getState());
-        data.put(USE_EXTRA_COLOR, layoutBlock.getUseExtraColor());
-        data.put(BLOCK_COLOR, jmri.util.ColorUtil.colorToColorName(layoutBlock.getBlockColor()));
-        data.put(TRACK_COLOR, jmri.util.ColorUtil.colorToColorName(layoutBlock.getBlockTrackColor()));
-        data.put(OCCUPIED_COLOR, jmri.util.ColorUtil.colorToColorName(layoutBlock.getBlockOccupiedColor()));
-        data.put(EXTRA_COLOR, jmri.util.ColorUtil.colorToColorName(layoutBlock.getBlockExtraColor()));
-        data.put(OCCUPANCY_SENSOR, layoutBlock.getOccupancySensor() != null ? layoutBlock.getOccupancySensorName() : null);
-        data.put(OCCUPIED_SENSE, layoutBlock.getOccupiedSense());
-
         return root;
     }
 

--- a/java/src/jmri/server/json/light/JsonLightHttpService.java
+++ b/java/src/jmri/server/json/light/JsonLightHttpService.java
@@ -33,11 +33,9 @@ public class JsonLightHttpService extends JsonNamedBeanHttpService {
 
     @Override
     public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
-        ObjectNode root = mapper.createObjectNode();
-        root.put(TYPE, LIGHT);
         Light light = InstanceManager.lightManagerInstance().getLight(name);
-        ObjectNode data = this.getNamedBean(light, name, type, locale);
-        root.set(DATA, data);
+        ObjectNode root = this.getNamedBean(light, name, type, locale);
+        ObjectNode data = root.with(DATA);
         if (light != null) {
             switch (light.getState()) {
                 case Light.ON:

--- a/java/src/jmri/server/json/memory/JsonMemoryHttpService.java
+++ b/java/src/jmri/server/json/memory/JsonMemoryHttpService.java
@@ -30,10 +30,8 @@ public class JsonMemoryHttpService extends JsonNamedBeanHttpService {
     @Override
     public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
         Memory memory = InstanceManager.memoryManagerInstance().getMemory(name);
-        ObjectNode data = this.getNamedBean(memory, name, type, locale);
-        ObjectNode root = mapper.createObjectNode();
-        root.put(TYPE, MEMORY);
-        root.set(DATA, data);
+        ObjectNode root = this.getNamedBean(memory, name, type, locale);
+        ObjectNode data = root.with(DATA);
         if (memory != null) {
             if (memory.getValue() == null) {
                 data.putNull(VALUE);

--- a/java/src/jmri/server/json/route/JsonRouteHttpService.java
+++ b/java/src/jmri/server/json/route/JsonRouteHttpService.java
@@ -30,11 +30,9 @@ public class JsonRouteHttpService extends JsonNamedBeanHttpService {
 
     @Override
     public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
-        ObjectNode root = mapper.createObjectNode();
         Route route = InstanceManager.getDefault(RouteManager.class).getRoute(name);
-        root.put(JSON.TYPE, ROUTE);
-        ObjectNode data = this.getNamedBean(route, name, type, locale); // throws JsonException if route == null
-        root.set(JSON.DATA, data);
+        ObjectNode root = this.getNamedBean(route, name, type, locale); // throws JsonException if route == null
+        ObjectNode data = root.with(JSON.DATA);
         if (route != null) {
             switch (route.getState()) {
                 case Sensor.ACTIVE:

--- a/java/src/jmri/server/json/sensor/JsonSensorHttpService.java
+++ b/java/src/jmri/server/json/sensor/JsonSensorHttpService.java
@@ -30,12 +30,10 @@ public class JsonSensorHttpService extends JsonNamedBeanHttpService {
 
     @Override
     public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
-        ObjectNode root = mapper.createObjectNode();
-        root.put(JSON.TYPE, SENSOR);
         Sensor sensor = InstanceManager.getDefault(SensorManager.class).getSensor(name);
-        ObjectNode data = this.getNamedBean(sensor, name, type, locale); // throws JsonException if sensor == null
+        ObjectNode root = this.getNamedBean(sensor, name, type, locale); // throws JsonException if sensor == null
+        ObjectNode data = root.with(JSON.DATA);
         if (sensor != null) {
-            root.set(JSON.DATA, data);
             switch (sensor.getKnownState()) {
                 case Sensor.ACTIVE:
                     data.put(JSON.STATE, JSON.ACTIVE);

--- a/java/src/jmri/server/json/signalHead/JsonSignalHeadHttpService.java
+++ b/java/src/jmri/server/json/signalHead/JsonSignalHeadHttpService.java
@@ -35,11 +35,9 @@ public class JsonSignalHeadHttpService extends JsonNamedBeanHttpService {
 
     @Override
     public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
-        ObjectNode root = mapper.createObjectNode();
-        root.put(TYPE, SIGNAL_HEAD);
         SignalHead signalHead = InstanceManager.getDefault(jmri.SignalHeadManager.class).getSignalHead(name);
-        ObjectNode data = this.getNamedBean(signalHead, name, type, locale);
-        root.set(DATA, data);
+        ObjectNode root = this.getNamedBean(signalHead, name, type, locale); // throws JsonException if signalHead == null
+        ObjectNode data = root.with(DATA);
         if (signalHead != null) {
             data.put(LIT, signalHead.getLit());
             data.put(APPEARANCE, signalHead.getAppearance());

--- a/java/src/jmri/server/json/signalMast/JsonSignalMastHttpService.java
+++ b/java/src/jmri/server/json/signalMast/JsonSignalMastHttpService.java
@@ -37,11 +37,9 @@ public class JsonSignalMastHttpService extends JsonNamedBeanHttpService {
 
     @Override
     public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
-        ObjectNode root = mapper.createObjectNode();
-        root.put(TYPE, SIGNAL_MAST);
         SignalMast signalMast = InstanceManager.getDefault(jmri.SignalMastManager.class).getSignalMast(name);
-        ObjectNode data = this.getNamedBean(signalMast, name, type, locale);
-        root.set(DATA, data);
+        ObjectNode root = this.getNamedBean(signalMast, name, type, locale);
+        ObjectNode data = root.with(DATA);
         if (signalMast != null) {
             String aspect = signalMast.getAspect();
             if (aspect == null) {

--- a/java/src/jmri/server/json/turnout/JsonTurnoutHttpService.java
+++ b/java/src/jmri/server/json/turnout/JsonTurnoutHttpService.java
@@ -33,11 +33,9 @@ public class JsonTurnoutHttpService extends JsonNamedBeanHttpService {
 
     @Override
     public JsonNode doGet(String type, String name, Locale locale) throws JsonException {
-        ObjectNode root = mapper.createObjectNode();
-        root.put(JSON.TYPE, TURNOUT);
         Turnout turnout = InstanceManager.turnoutManagerInstance().getTurnout(name);
-        ObjectNode data = this.getNamedBean(turnout, name, type, locale); // throws JsonException if turnout == null
-        root.set(JSON.DATA, data);
+        ObjectNode root = this.getNamedBean(turnout, name, type, locale); // throws JsonException if turnout == null
+        ObjectNode data = root.with(JSON.DATA);
         if (turnout != null) {
             data.put(INVERTED, turnout.getInverted());
             switch (turnout.getKnownState()) {

--- a/java/test/jmri/server/json/JsonHttpServiceTestBase.java
+++ b/java/test/jmri/server/json/JsonHttpServiceTestBase.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Locale;
 import jmri.InstanceManager;
+import jmri.jmris.json.JsonServerPreferences;
 import jmri.server.json.schema.JsonSchemaServiceCache;
 import jmri.util.JUnitUtil;
 import org.junit.Assert;
@@ -25,6 +26,9 @@ public class JsonHttpServiceTestBase {
     public void setUp() throws Exception {
         JUnitUtil.setUp();
         this.mapper = new ObjectMapper();
+        // require valid inputs and outputs for tests by default
+        InstanceManager.getDefault(JsonServerPreferences.class).setValidateClientMessages(true);
+        InstanceManager.getDefault(JsonServerPreferences.class).setValidateServerMessages(true);
     }
 
     /**

--- a/java/test/jmri/server/json/block/JsonBlockHttpServiceTest.java
+++ b/java/test/jmri/server/json/block/JsonBlockHttpServiceTest.java
@@ -137,6 +137,50 @@ public class JsonBlockHttpServiceTest extends JsonHttpServiceTestBase {
             Assert.assertEquals(Block.OCCUPIED, block1.getState());
             Assert.assertNotNull(exception);
             Assert.assertEquals(HttpServletResponse.SC_BAD_REQUEST, exception.getCode());
+            // set value
+            message = mapper.createObjectNode().put(JSON.NAME, "IB1").put(JSON.VALUE, "some value");
+            Assert.assertNull("Null block value", block1.getValue());
+            service.doPost(JsonBlock.BLOCK, "IB1", message, locale);
+            Assert.assertEquals("Non-null block value", "some value", block1.getValue());
+            // set null value
+            message = mapper.createObjectNode().put(JSON.NAME, "IB1").putNull(JSON.VALUE);
+            Assert.assertNotNull("Non-null block value", block1.getValue());
+            service.doPost(JsonBlock.BLOCK, "IB1", message, locale);
+            Assert.assertNull("Null block value", block1.getValue());
+            // set non-existing sensor
+            message = mapper.createObjectNode().put(JSON.NAME, "IB1").put(JsonSensor.SENSOR, "IS1");
+            Assert.assertNull("No sensor", block1.getSensor());
+            try {
+                service.doPost(JsonBlock.BLOCK, "IB1", message, locale);
+                Assert.fail("Expected exception not thrown");
+            } catch (JsonException ex) {
+                Assert.assertEquals("404 Not Found", 404, ex.getCode());
+            }
+            // set existing sensor
+            Sensor sensor1 = InstanceManager.getDefault(SensorManager.class).provide("IS1");
+            service.doPost(JsonBlock.BLOCK, "IB1", message, locale);
+            Assert.assertEquals("Block has sensor", sensor1, block1.getSensor());
+            // set null sensor
+            message = mapper.createObjectNode().put(JSON.NAME, "IB1").putNull(JsonSensor.SENSOR);
+            service.doPost(JsonBlock.BLOCK, "IB1", message, locale);
+            Assert.assertNull("Block has no sensor", block1.getSensor());
+            // set non-existing reporter
+            message = mapper.createObjectNode().put(JSON.NAME, "IB1").put(JsonReporter.REPORTER, "IR1");
+            Assert.assertNull("No reporter", block1.getReporter());
+            try {
+                service.doPost(JsonBlock.BLOCK, "IB1", message, locale);
+                Assert.fail("Expected exception not thrown");
+            } catch (JsonException ex) {
+                Assert.assertEquals("404 Not Found", 404, ex.getCode());
+            }
+            // set existing reporter
+            Reporter reporter1 = InstanceManager.getDefault(ReporterManager.class).provide("IR1");
+            service.doPost(JsonBlock.BLOCK, "IB1", message, locale);
+            Assert.assertEquals("Block has reporter", reporter1, block1.getReporter());
+            // set null reporter
+            message = mapper.createObjectNode().put(JSON.NAME, "IB1").putNull(JsonReporter.REPORTER);
+            service.doPost(JsonBlock.BLOCK, "IB1", message, locale);
+            Assert.assertNull("No reporter", block1.getReporter());
         } catch (JsonException ex) {
             Assert.fail(ex.getMessage());
         }


### PR DESCRIPTION
The code had been in place to do this, but without unit tests, the fact that it wasn't actually doing this wasn't caught.

Also:
- Clarify what the result of `Block.setSensor(String)` is.
- Only use an existing Sensor when setting the Sensor for a Block from a JSON message.
- Additional tests for JSON handling of Blocks.