### PR TITLE
Fast Clock - OpenLCB fixes and more startup customization

### DIFF
--- a/java/src/jmri/Timebase.java
+++ b/java/src/jmri/Timebase.java
@@ -4,7 +4,6 @@ import java.beans.PropertyChangeListener;
 import java.time.Instant;
 import java.util.Date;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Provide access to clock capabilities in hardware or software.
@@ -118,13 +117,21 @@ public interface Timebase extends NamedBean {
 
     public boolean use12HourDisplay();
 
-    // methods for start up with clock stopped option
-    public void setStartStopped(boolean stopped);
-    public boolean getStartStopped();
-    // methods for start up with clock running option. If neither stopped nor running is set, the
-    // clock run state will not change at startup.
-    public void setStartRunning(boolean running);
-    public boolean getStartRunning();
+    /**
+     * Defines what to do with the fast clock when JMRI starts up.
+     */
+    enum ClockInitialRunState {
+        // Changes the clock to stopped when JMRI starts.
+        DO_STOP,
+        // Changes the clock to running when JMRI starts.
+        DO_START,
+        // Does not change the clock when JMRI starts.
+        DO_NOTHING
+    }
+
+    // methods for start up with clock stopped/started/nochange option
+    public void setClockInitialRunState(ClockInitialRunState initialState);
+    public ClockInitialRunState getClockInitialRunState();
 
     // methods for start up with start/stop button displayed
     public void setShowStopButton(boolean displayed);

--- a/java/src/jmri/Timebase.java
+++ b/java/src/jmri/Timebase.java
@@ -4,6 +4,7 @@ import java.beans.PropertyChangeListener;
 import java.time.Instant;
 import java.util.Date;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Provide access to clock capabilities in hardware or software.
@@ -119,8 +120,11 @@ public interface Timebase extends NamedBean {
 
     // methods for start up with clock stopped option
     public void setStartStopped(boolean stopped);
-
     public boolean getStartStopped();
+    // methods for start up with clock running option. If neither stopped nor running is set, the
+    // clock run state will not change at startup.
+    public void setStartRunning(boolean running);
+    public boolean getStartRunning();
 
     // methods for start up with start/stop button displayed
     public void setShowStopButton(boolean displayed);
@@ -131,6 +135,14 @@ public interface Timebase extends NamedBean {
     public void setStartSetTime(boolean set, Date time);
 
     public boolean getStartSetTime();
+
+    // What to set the rate at startup.
+    public void setStartRate(double factor);
+    public double getStartRate();
+
+    // If true, the rate at startup will be set to the value of getStartRate().
+    public void setSetRateAtStart(boolean set);
+    public boolean getSetRateAtStart();
 
     @Nonnull
     public Date getStartTime();

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle.properties
@@ -14,8 +14,19 @@ NewTime = Fast Clock Time:
 
 BoxLabelStartUp = Start Up Options
 StartStopped = Start with Fast Clock Stopped
+
+StartBoxLabel = Start with Fast Clock
+# These are combobox options
+StartSelectRunning = Running
+StartSelectStopped = Stopped
+StartSelectNoChange = Don't change
+TipStartRunSelect = Select whether you want to start or stop the clock when loading the \
+  configuration. You can also choose to not change the running of the clock, which is useful \
+  when JMRI is not the clock master.
+
 StartSetTime = Set Fast Clock Time to
-StartClock = Start Selected Clock
+StartSetSpeedUpFactor = Set Fast Clock Rate to
+StartClock = Display Selected Clock
 DisplayOnOff = Display Start/Stop button on clock
 # None key repeated here from jmrit.Bundle to cover French specific form
 None = None
@@ -34,11 +45,11 @@ TipSetRateButton = Click to set Fast Clock Rate to entered value.
 TipHoursField = Enter hours (0-23) for a 24-hour clock time.
 TipMinutesField = Enter minutes (0-59) for a 24-hour clock time.
 TipSetTimeButton = Click to set Fast Clock Time to entered value.
-TipStartStopped = Check if clock is to be stopped when configuration is loaded.
 TipStartSetTime = Check after entering start time at right if time should be set at start up.
 TipStartHours = Enter start time hours (0-23) for a 24-hour clock.
 TipStartMinutes = Enter start time minutes (0-59) for a 24-hour clock.
 TipSetStartTimeButton = Click to set start up Fast Clock Time to entered value.
+TipStartSetRate = Click to set the rate of clock at startup to the entered value.
 TipClockStartOption = Select the fast clock display you want started automatically at start up.
 TipStartButton = Click to start Fast Clock.
 TipStopButton = Click to stop Fast Clock.

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_de.properties
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockBundle_de.properties
@@ -16,7 +16,7 @@ NewTime = Zeit Spieluhr:
 BoxLabelStartUp = Aufstartoptionen
 StartStopped = Mit angehaltener Spieluhr starten
 StartSetTime = Setze Spieluhr auf
-StartClock = Starte gew\u00e4hlte Spieluhr
+StartClock = Spieluhr anzeigen
 DisplayOnOff = Zeige Start/Stop Knopf mit Uhr
 None = Keine
 

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
@@ -643,6 +643,7 @@ public class SimpleClockFrame extends JmriJFrame
                 clock.setStartStopped(false);
                 clock.setStartRunning(true);
                 break;
+            default:
             case START_NORUNCHANGE:
                 clock.setStartStopped(false);
                 clock.setStartRunning(false);

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
@@ -8,7 +8,7 @@ import java.awt.event.FocusEvent;
 import java.text.DecimalFormat;
 import java.util.Date;
 
-import javax.annotation.Nullable;
+import javax.annotation.CheckForNull;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -490,7 +490,7 @@ public class SimpleClockFrame extends JmriJFrame
      * @return null if the rate could not be parsed, negative, or an unsupported fraction.
      * Otherwise the fraction value.
      */
-    @Nullable Double parseRate(String fieldEntry) {
+    @CheckForNull Double parseRate(String fieldEntry) {
         double rate = 1.0;
         try {
             char decimalSeparator = threeDigits.getDecimalFormatSymbols().getDecimalSeparator() ;

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
@@ -233,12 +233,15 @@ public class SimpleClockFrame extends JmriJFrame
         startRunBox.addItem(Bundle.getMessage("StartSelectStopped"));
         startRunBox.addItem(Bundle.getMessage("StartSelectNoChange"));
         startRunBox.setToolTipText(Bundle.getMessage("TipStartRunSelect"));
-        if (clock.getStartStopped()) {
-            startRunBox.setSelectedIndex(START_STOPPED);
-        } else if (clock.getStartRunning()) {
-            startRunBox.setSelectedIndex(START_RUNNING);
-        } else {
-            startRunBox.setSelectedIndex(START_NORUNCHANGE);
+        switch (clock.getClockInitialRunState()) {
+            case DO_STOP:
+                startRunBox.setSelectedIndex(START_STOPPED);
+                break;
+            case DO_START:
+                startRunBox.setSelectedIndex(START_RUNNING);
+                break;
+            case DO_NOTHING:
+                startRunBox.setSelectedIndex(START_NORUNCHANGE);
         }
         startRunBox.addActionListener(new ActionListener() {
             @Override
@@ -636,17 +639,14 @@ public class SimpleClockFrame extends JmriJFrame
     private void startRunBoxChanged() {
         switch (startRunBox.getSelectedIndex()) {
             case START_STOPPED:
-                clock.setStartStopped(true);
-                clock.setStartRunning(false);
+                clock.setClockInitialRunState(Timebase.ClockInitialRunState.DO_STOP);
                 break;
             case START_RUNNING:
-                clock.setStartStopped(false);
-                clock.setStartRunning(true);
+                clock.setClockInitialRunState(Timebase.ClockInitialRunState.DO_START);
                 break;
             default:
             case START_NORUNCHANGE:
-                clock.setStartStopped(false);
-                clock.setStartRunning(false);
+                clock.setClockInitialRunState(Timebase.ClockInitialRunState.DO_NOTHING);
                 break;
         }
         changed = true;

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
@@ -394,7 +394,6 @@ public class SimpleClockFrame extends JmriJFrame
      */
     void updateRate() {
         factorField.setText(threeDigits.format(clock.userGetRate()));
-        changed = true;
     }
 
     /**

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
@@ -1,8 +1,14 @@
 package jmri.jmrit.simpleclock;
 
 import java.awt.Container;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
 import java.text.DecimalFormat;
 import java.util.Date;
+
+import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -11,7 +17,6 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
-import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -43,16 +48,21 @@ public class SimpleClockFrame extends JmriJFrame
 
     protected JComboBox<String> timeSourceBox = null;
     protected JComboBox<String> clockStartBox = null;
+    protected JComboBox<String> startRunBox = null;
+    // These are the indexes into the start run box.
+    private final static int START_STOPPED = 0;
+    private final static int START_RUNNING = 1;
+    private final static int START_NORUNCHANGE = 2;
 
     protected JCheckBox synchronizeCheckBox = null;
     protected JCheckBox correctCheckBox = null;
     protected JCheckBox displayCheckBox = null;
-    protected JCheckBox showStartupCheckBox = null;
-    protected JCheckBox startStoppedCheckBox = null;
     protected JCheckBox startSetTimeCheckBox = null;
+    protected JCheckBox startSetRateCheckBox = null;
     protected JCheckBox displayStartStopButton = null;
 
     protected JTextField factorField = new JTextField(5);
+    protected JTextField startFactorField = new JTextField(5);
     protected JTextField hoursField = new JTextField(2);
     protected JTextField minutesField = new JTextField(2);
     protected JTextField startHoursField = new JTextField(2);
@@ -214,20 +224,30 @@ public class SimpleClockFrame extends JmriJFrame
         contentPane.add(panel2);
 
         // Set up startup options panel
-        JPanel panel6 = new JPanel();
-        panel6.setLayout(new BoxLayout(panel6, BoxLayout.Y_AXIS));
+        JPanel startupOptionsPane = new JPanel();
+        startupOptionsPane.setLayout(new BoxLayout(startupOptionsPane, BoxLayout.Y_AXIS));
         JPanel panel61 = new JPanel();
-        startStoppedCheckBox = new JCheckBox(Bundle.getMessage("StartStopped"));
-        startStoppedCheckBox.setToolTipText(Bundle.getMessage("TipStartStopped"));
-        startStoppedCheckBox.setSelected(clock.getStartStopped());
-        startStoppedCheckBox.addActionListener(new java.awt.event.ActionListener() {
+        panel61.add(new JLabel(Bundle.getMessage("StartBoxLabel") + " "));
+        startRunBox = new JComboBox<>();
+        startRunBox.addItem(Bundle.getMessage("StartSelectRunning"));
+        startRunBox.addItem(Bundle.getMessage("StartSelectStopped"));
+        startRunBox.addItem(Bundle.getMessage("StartSelectNoChange"));
+        startRunBox.setToolTipText(Bundle.getMessage("TipStartRunSelect"));
+        if (clock.getStartStopped()) {
+            startRunBox.setSelectedIndex(START_STOPPED);
+        } else if (clock.getStartRunning()) {
+            startRunBox.setSelectedIndex(START_RUNNING);
+        } else {
+            startRunBox.setSelectedIndex(START_NORUNCHANGE);
+        }
+        startRunBox.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
-                startStoppedChanged();
+            public void actionPerformed(ActionEvent actionEvent) {
+                startRunBoxChanged();
             }
         });
-        panel61.add(startStoppedCheckBox);
-        panel6.add(panel61);
+        panel61.add(startRunBox);
+        startupOptionsPane.add(panel61);
 
         JPanel panel62 = new JPanel();
         startSetTimeCheckBox = new JCheckBox(Bundle.getMessage("StartSetTime"));
@@ -256,7 +276,41 @@ public class SimpleClockFrame extends JmriJFrame
             }
         });
         panel62.add(setStartTimeButton);
-        panel6.add(panel62);
+        startupOptionsPane.add(panel62);
+
+        JPanel panelStartSetRate = new JPanel();
+        startSetRateCheckBox = new JCheckBox(Bundle.getMessage("StartSetSpeedUpFactor") + " ");
+        startSetRateCheckBox.setToolTipText(Bundle.getMessage("TipStartSetRate"));
+        startSetRateCheckBox.setSelected(clock.getSetRateAtStart());
+        startSetRateCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent e) {
+                startSetRateChanged();
+            }
+        });
+        panelStartSetRate.add(startSetRateCheckBox);
+        panelStartSetRate.add(startFactorField);
+        startFactorField.setText(threeDigits.format(clock.getStartRate()));
+        startFactorField.setToolTipText(Bundle.getMessage("TipFactorField"));
+        startFactorField.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                startFactorFieldChanged();
+            }
+        });
+        startFactorField.addFocusListener(new FocusAdapter() {
+            @Override
+            public void focusLost(FocusEvent focusEvent) {
+                if (!focusEvent.isTemporary()) {
+                    startFactorFieldChanged();
+                }
+                super.focusLost(focusEvent);
+            }
+        });
+        panelStartSetRate.add(new JLabel(":1 "));
+        startupOptionsPane.add(panelStartSetRate);
+
+
         JPanel panel63 = new JPanel();
         panel63.add(new JLabel(Bundle.getMessage("StartClock") + " "));
         clockStartBox = new JComboBox<String>();
@@ -284,7 +338,7 @@ public class SimpleClockFrame extends JmriJFrame
                 setClockStartChanged();
             }
         });
-        panel6.add(panel63);
+        startupOptionsPane.add(panel63);
         JPanel panel64 = new JPanel();
         displayStartStopButton= new JCheckBox(Bundle.getMessage("DisplayOnOff"));
         displayStartStopButton.setSelected(clock.getShowStopButton());
@@ -295,13 +349,13 @@ public class SimpleClockFrame extends JmriJFrame
             }
         });
         panel64.add(displayStartStopButton);
-        panel6.add(panel64);
+        startupOptionsPane.add(panel64);
 
         Border panel6Border = BorderFactory.createEtchedBorder();
         Border panel6Titled = BorderFactory.createTitledBorder(panel6Border,
                 Bundle.getMessage("BoxLabelStartUp"));
-        panel6.setBorder(panel6Titled);
-        contentPane.add(panel6);
+        startupOptionsPane.setBorder(panel6Titled);
+        contentPane.add(startupOptionsPane);
 
         // Set up clock information panel
         JPanel panel3 = new JPanel();
@@ -389,6 +443,20 @@ public class SimpleClockFrame extends JmriJFrame
         return;
     }
 
+    private void startFactorFieldChanged() {
+        Double v = parseRate(startFactorField.getText());
+        if (v != null && !v.equals(clock.getStartRate())) {
+            clock.setStartRate(v);
+            changed = true;
+        }
+        startFactorField.setText(threeDigits.format(clock.getStartRate()));
+    }
+
+    private void startSetRateChanged() {
+        clock.setSetRateAtStart(startSetRateCheckBox.isSelected());
+        changed = true;
+    }
+
     /**
      * Adjust to rate changes.
      */
@@ -414,40 +482,52 @@ public class SimpleClockFrame extends JmriJFrame
     }
 
     /**
-     * Handle Set Rate button
+     * Converts a user-entered rate to a double, possibly throwing up warning dialogs.
+     * @param fieldEntry value from text field where the user entered a rate.
+     * @return null if the rate could not be parsed, negative, or an unsupported fraction.
+     * Otherwise the fraction value.
      */
-    public void setRateButtonActionPerformed() {
+    @Nullable Double parseRate(String fieldEntry) {
         double rate = 1.0;
         try {
-            String factorFieldText = factorField.getText() ;
             char decimalSeparator = threeDigits.getDecimalFormatSymbols().getDecimalSeparator() ;
             if (decimalSeparator != '.') {
-                factorFieldText = factorFieldText.replace(decimalSeparator, '.') ;
+                fieldEntry = fieldEntry.replace(decimalSeparator, '.') ;
             }
-            rate = Double.valueOf(factorFieldText).doubleValue();
+            rate = Double.valueOf(fieldEntry);
         } catch (Exception e) {
             JOptionPane.showMessageDialog(this, (Bundle.getMessage("ParseRateError") + "\n" + e),
                     Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
-            log.error("Exception when parsing Rate Field: " + e);
-            return;
+            log.error("Exception when parsing user-entered rate: " + e);
+            return null;
         }
         if (rate < 0.0) {
             JOptionPane.showMessageDialog(this, Bundle.getMessage("NegativeRateError"),
                     Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
-            factorField.setText(threeDigits.format(clock.userGetRate()));
-            return;
+            return null;
         }
         if (InstanceManager.getDefault(jmri.ClockControl.class).requiresIntegerRate()) {
             double frac = rate - (int) rate;
             if (frac > 0.001) {
                 JOptionPane.showMessageDialog(this, Bundle.getMessage("NonIntegerError"),
                         Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
-                factorField.setText(threeDigits.format(clock.userGetRate()));
-                return;
+                return null;
             }
         }
+        return rate;
+    }
+
+    /**
+     * Handle Set Rate button
+     */
+    public void setRateButtonActionPerformed() {
+        Double parsedRate = parseRate(factorField.getText());
+        if (parsedRate == null) {
+            factorField.setText(threeDigits.format(clock.userGetRate()));
+            return;
+        }
         try {
-            clock.userSetRate(rate);
+            clock.userSetRate(parsedRate);
         } catch (Exception e) {
             JOptionPane.showMessageDialog(this, (Bundle.getMessage("SetRateError") + "\n" + e),
                     Bundle.getMessage("ErrorTitle"), JOptionPane.ERROR_MESSAGE);
@@ -551,10 +631,23 @@ public class SimpleClockFrame extends JmriJFrame
     }
 
     /**
-     * Handle start stopped check box change
+     * Handle start run combo box change
      */
-    private void startStoppedChanged() {
-        clock.setStartStopped(startStoppedCheckBox.isSelected());
+    private void startRunBoxChanged() {
+        switch (startRunBox.getSelectedIndex()) {
+            case START_STOPPED:
+                clock.setStartStopped(true);
+                clock.setStartRunning(false);
+                break;
+            case START_RUNNING:
+                clock.setStartStopped(false);
+                clock.setStartRunning(true);
+                break;
+            case START_NORUNCHANGE:
+                clock.setStartStopped(false);
+                clock.setStartRunning(false);
+                break;
+        }
         changed = true;
     }
 

--- a/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
@@ -380,12 +380,28 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
 
     @Override
     public void setStartStopped(boolean stopped) {
+        if (stopped) {
+            startRunning = false;
+        }
         startStopped = stopped;
     }
 
     @Override
     public boolean getStartStopped() {
         return startStopped;
+    }
+
+    @Override
+    public void setStartRunning(boolean running) {
+        if (running) {
+            startStopped = false;
+        }
+        startRunning = running;
+    }
+
+    @Override
+    public boolean getStartRunning() {
+        return startRunning;
     }
 
     @Override
@@ -407,6 +423,31 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
     @Override
     public boolean getStartSetTime() {
         return startSetTime;
+    }
+
+    @Override
+    public void setStartRate(double factor) {
+        startupFactor = factor;
+        haveStartupFactor = true;
+    }
+
+    @Override
+    public double getStartRate() {
+        if (haveStartupFactor) {
+            return startupFactor;
+        } else {
+            return userGetRate();
+        }
+    }
+
+    @Override
+    public void setSetRateAtStart(boolean set) {
+        startSetRate = set;
+    }
+
+    @Override
+    public boolean getSetRateAtStart() {
+        return startSetRate;
     }
 
     @Override
@@ -527,6 +568,11 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
     private double hardwareFactor = 1.0;  // this is the rate factor for the hardware clock
     //  The above is necessary to support hardware clock Time Sources that fiddle with mFactor to
     //      synchronize, instead of sending over a new time to synchronize.
+    private double startupFactor = 1.0;     // this is the rate requested at startup
+    private boolean startSetRate = true; // if true, the hardware rate will be set to
+    private boolean haveStartupFactor = false; // true if startup factor was ever set.
+    // startupFactor at startup.
+
     private Date startAtTime;
     private Date setTimeValue;
     private Date pauseTime;   // null value indicates clock is running
@@ -541,6 +587,7 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
     private boolean correctHardware = false;    // true indicates hardware correction requested
     private boolean display12HourClock = false; // true if 12-hour clock display is requested
     private boolean startStopped = false;    // true indicates start up with clock stopped requested
+    private boolean startRunning = true;     // true indicates start up with clock running requested
     private boolean startSetTime = false;    // true indicates set fast clock to specified time at
     //start up requested
     private Date startTime = new Date(); // specified time for setting fast clock at start up

--- a/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleTimebase.java
@@ -379,29 +379,13 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
     }
 
     @Override
-    public void setStartStopped(boolean stopped) {
-        if (stopped) {
-            startRunning = false;
-        }
-        startStopped = stopped;
+    public void setClockInitialRunState(ClockInitialRunState state) {
+        initialState = state;
     }
 
     @Override
-    public boolean getStartStopped() {
-        return startStopped;
-    }
-
-    @Override
-    public void setStartRunning(boolean running) {
-        if (running) {
-            startStopped = false;
-        }
-        startRunning = running;
-    }
-
-    @Override
-    public boolean getStartRunning() {
-        return startRunning;
+    public ClockInitialRunState getClockInitialRunState() {
+        return initialState;
     }
 
     @Override
@@ -496,6 +480,7 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
      */
     @Override
     public void initializeHardwareClock() {
+        boolean startStopped = (initialState == ClockInitialRunState.DO_STOP);
         if (synchronizeWithHardware || correctHardware) {
             if (startStopped) {
                 // Note if there are multiple hardware clocks, this should be a loop over all hardware clocks
@@ -586,8 +571,7 @@ public class SimpleTimebase extends jmri.implementation.AbstractNamedBean implem
     private boolean synchronizeWithHardware = false;  // true indicates need to synchronize
     private boolean correctHardware = false;    // true indicates hardware correction requested
     private boolean display12HourClock = false; // true if 12-hour clock display is requested
-    private boolean startStopped = false;    // true indicates start up with clock stopped requested
-    private boolean startRunning = true;     // true indicates start up with clock running requested
+    private ClockInitialRunState initialState = ClockInitialRunState.DO_START;    // what to do with the clock running state at startup
     private boolean startSetTime = false;    // true indicates set fast clock to specified time at
     //start up requested
     private Date startTime = new Date(); // specified time for setting fast clock at start up

--- a/java/src/jmri/jmrit/simpleclock/configurexml/SimpleTimebaseXml.java
+++ b/java/src/jmri/jmrit/simpleclock/configurexml/SimpleTimebaseXml.java
@@ -9,6 +9,10 @@ import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static jmri.Timebase.ClockInitialRunState.DO_NOTHING;
+import static jmri.Timebase.ClockInitialRunState.DO_START;
+import static jmri.Timebase.ClockInitialRunState.DO_STOP;
+
 /**
  * Handle XML persistance of SimpleTimebase objects.
  *
@@ -36,7 +40,7 @@ public class SimpleTimebaseXml extends jmri.configurexml.AbstractXmlAdapter {
         elem.setAttribute("time", clock.getStartTime().toString());
         elem.setAttribute("rate", "" + clock.userGetRate());
         elem.setAttribute("startrate", "" + clock.getStartRate());
-        elem.setAttribute("run", (!clock.getStartStopped() ? "yes" : "no"));
+        elem.setAttribute("run", (clock.getClockInitialRunState() == DO_START ? "yes" : "no"));
         elem.setAttribute("master", (clock.getInternalMaster() ? "yes" : "no"));
         if (!clock.getInternalMaster()) {
             elem.setAttribute("mastername", clock.getMasterName());
@@ -44,8 +48,8 @@ public class SimpleTimebaseXml extends jmri.configurexml.AbstractXmlAdapter {
         elem.setAttribute("sync", (clock.getSynchronize() ? "yes" : "no"));
         elem.setAttribute("correct", (clock.getCorrectHardware() ? "yes" : "no"));
         elem.setAttribute("display", (clock.use12HourDisplay() ? "yes" : "no"));
-        elem.setAttribute("startstopped", (clock.getStartStopped() ? "yes" : "no"));
-        elem.setAttribute("startrunning", (clock.getStartRunning() ? "yes" : "no"));
+        elem.setAttribute("startstopped", (clock.getClockInitialRunState() == DO_STOP ? "yes" : "no"));
+        elem.setAttribute("startrunning", ((clock.getClockInitialRunState() == DO_START) ? "yes" : "no"));
         elem.setAttribute("startsettime", (clock.getStartSetTime() ? "yes" : "no"));
         elem.setAttribute("startclockoption", Integer.toString(
                 clock.getStartClockOption()));
@@ -110,28 +114,23 @@ public class SimpleTimebaseXml extends jmri.configurexml.AbstractXmlAdapter {
         }
         if ("yes".equals(shared.getAttributeValue("startrunning"))) {
             clock.setRun(true);
-            clock.setStartStopped(false);
-            clock.setStartRunning(true);
+            clock.setClockInitialRunState(DO_START);
         } else if ("yes".equals(shared.getAttributeValue("startstopped"))) {
             clock.setRun(false);
-            clock.setStartStopped(true);
-            clock.setStartRunning(false);
+            clock.setClockInitialRunState(DO_STOP);
         } else if (shared.getAttribute("startrunning") != null){
-            clock.setStartStopped(false);
-            clock.setStartRunning(false);
+            clock.setClockInitialRunState(DO_NOTHING);
         } else {
             // legacy XML
             if (shared.getAttribute("run") != null) {
                 val = shared.getAttributeValue("run");
                 if (val.equals("yes")) {
                     clock.setRun(true);
-                    clock.setStartStopped(false);
-                    clock.setStartRunning(true);
+                    clock.setClockInitialRunState(DO_START);
                 }
                 if (val.equals("no")) {
                     clock.setRun(false);
-                    clock.setStartStopped(true);
-                    clock.setStartRunning(false);
+                    clock.setClockInitialRunState(DO_STOP);
                 }
             }
         }

--- a/java/src/jmri/jmrix/openlcb/OlcbClockControl.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbClockControl.java
@@ -130,7 +130,7 @@ public class OlcbClockControl extends DefaultClockControl {
         // OpenLCB rates are 0.25 resolution, so we use half of that as minimum threshold.
         if (Math.abs(hardwareClock.getRate() - newRate) > 0.12) {
             hardwareClock.requestSetRate(newRate);
-        } else {
+        } else if (Math.abs(hardwareClock.getRate() - newRate) > 0.0001) {
             // Trigger update notification that we rejected the change, but not inline.
             ThreadingUtil.runOnLayoutDelayed(new ThreadingUtil.ThreadAction() {
                 @Override

--- a/java/src/jmri/jmrix/openlcb/OlcbClockControl.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbClockControl.java
@@ -115,13 +115,11 @@ public class OlcbClockControl extends DefaultClockControl {
 
     @Override
     public void stopHardwareClock() {
-        new Exception().printStackTrace();
         hardwareClock.requestStop();
     }
 
     @Override
     public void startHardwareClock(Date now) {
-        new Exception().printStackTrace();
         hardwareClock.requestSetTime(now.getTime());
         hardwareClock.requestStart();
     }

--- a/java/src/jmri/jmrix/openlcb/OlcbClockControl.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbClockControl.java
@@ -115,11 +115,13 @@ public class OlcbClockControl extends DefaultClockControl {
 
     @Override
     public void stopHardwareClock() {
+        new Exception().printStackTrace();
         hardwareClock.requestStop();
     }
 
     @Override
     public void startHardwareClock(Date now) {
+        new Exception().printStackTrace();
         hardwareClock.requestSetTime(now.getTime());
         hardwareClock.requestStart();
     }

--- a/java/src/jmri/jmrix/openlcb/OlcbClockControl.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbClockControl.java
@@ -15,6 +15,7 @@ import java.util.Date;
 import jmri.Timebase;
 import jmri.TimebaseRateException;
 import jmri.implementation.DefaultClockControl;
+import jmri.util.ThreadingUtil;
 
 /**
  * Implementation of the ClockControl interface for JMRI using the OpenLCB clock listener or generator.
@@ -129,7 +130,16 @@ public class OlcbClockControl extends DefaultClockControl {
         // OpenLCB rates are 0.25 resolution, so we use half of that as minimum threshold.
         if (Math.abs(hardwareClock.getRate() - newRate) > 0.12) {
             hardwareClock.requestSetRate(newRate);
+        } else {
+            // Trigger update notification that we rejected the change, but not inline.
+            ThreadingUtil.runOnLayoutDelayed(new ThreadingUtil.ThreadAction() {
+                @Override
+                public void run() {
+                    clockUpdate(TimeProtocol.PROP_RATE_UPDATE, null);
+                }
+            }, 50);
         }
+
     }
 
     @Override

--- a/java/src/jmri/jmrix/openlcb/OlcbClockControl.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbClockControl.java
@@ -58,7 +58,7 @@ public class OlcbClockControl extends DefaultClockControl {
             jmriClock.setRun(hardwareClock.isRunning());
         } else if (property.equals(TimeProtocol.PROP_RATE_UPDATE)) {
             try {
-                jmriClock.setRate(hardwareClock.getRate());
+                jmriClock.userSetRate(hardwareClock.getRate());
             } catch (TimebaseRateException e) {
                 log.warn("Failed to set OpenLCB rate to internal clock.");
             }
@@ -126,7 +126,10 @@ public class OlcbClockControl extends DefaultClockControl {
 
     @Override
     public void setRate(double newRate) {
-        hardwareClock.requestSetRate(newRate);
+        // OpenLCB rates are 0.25 resolution, so we use half of that as minimum threshold.
+        if (Math.abs(hardwareClock.getRate() - newRate) > 0.12) {
+            hardwareClock.requestSetRate(newRate);
+        }
     }
 
     @Override

--- a/java/test/jmri/jmrit/simpleclock/configurexml/SimpleTimebaseXmlTest.java
+++ b/java/test/jmri/jmrit/simpleclock/configurexml/SimpleTimebaseXmlTest.java
@@ -1,8 +1,14 @@
 package jmri.jmrit.simpleclock.configurexml;
 
+import jmri.InstanceManager;
+import jmri.Timebase;
 import jmri.util.JUnitUtil;
+
+import org.jdom2.Element;
 import org.junit.After;
 import org.junit.Assert;
+
+import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,6 +35,37 @@ public class SimpleTimebaseXmlTest {
         JUnitUtil.tearDown();
     }
 
-    // private final static Logger log = LoggerFactory.getLogger(SimpleTimebaseXmlTest.class);
+    @Test
+    public void testUpgrade() {
+        // Checks what happens when we don't have the new attributes in the XML that we are loading.
+        Element e = new Element("timebase");
+        // Example XML:
+        // <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Fri Dec
+        // 07 10:50:00 CET 2018" rate="13.0" run="no" master="no" mastername="OpenLCB Clock
+        // Consumer for Default Fast Clock" sync="no" correct="no" display="no"
+        // startstopped="yes" startsettime="no" startclockoption="2" showbutton="yes" />
+        e.setAttribute("rate", "13.0");
+        e.setAttribute("run", "no");
+        e.setAttribute("master", "no");
+        e.setAttribute("mastername", "OpenLCB Clock Consumer for Default Fast Clock");
+        e.setAttribute("sync", "no");
+        e.setAttribute("correct", "no");
+        e.setAttribute("display", "no");
+        e.setAttribute("startstopped", "yes");
+        e.setAttribute("startsettime", "no");
+        e.setAttribute("startclockoption", "0");
+        e.setAttribute("showbutton", "yes");
 
+        SimpleTimebaseXml t = new SimpleTimebaseXml();
+        t.load(e, new Element("foo"));
+        Timebase tb = InstanceManager.getDefault(Timebase.class);
+
+        // Checks that the new properties have values equivalent of legacy behavior.
+        assertEquals(false, tb.getStartRunning());
+        assertEquals(true, tb.getStartStopped());
+        assertEquals(13.0d, tb.getStartRate(), 0.01);
+        assertEquals(true, tb.getSetRateAtStart());
+    }
+
+    // private final static Logger log = LoggerFactory.getLogger(SimpleTimebaseXmlTest.class);
 }

--- a/java/test/jmri/jmrit/simpleclock/configurexml/SimpleTimebaseXmlTest.java
+++ b/java/test/jmri/jmrit/simpleclock/configurexml/SimpleTimebaseXmlTest.java
@@ -61,8 +61,7 @@ public class SimpleTimebaseXmlTest {
         Timebase tb = InstanceManager.getDefault(Timebase.class);
 
         // Checks that the new properties have values equivalent of legacy behavior.
-        assertEquals(false, tb.getStartRunning());
-        assertEquals(true, tb.getStartStopped());
+        assertEquals(Timebase.ClockInitialRunState.DO_STOP, tb.getClockInitialRunState());
         assertEquals(13.0d, tb.getStartRate(), 0.01);
         assertEquals(true, tb.getSetRateAtStart());
     }

--- a/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.sql.Time;
 import java.util.Calendar;
 
 import org.mockito.Mockito;
@@ -23,6 +22,9 @@ import jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 
+import static jmri.Timebase.ClockInitialRunState.DO_NOTHING;
+import static jmri.Timebase.ClockInitialRunState.DO_START;
+import static jmri.Timebase.ClockInitialRunState.DO_STOP;
 import static org.junit.Assert.*;
 import static jmri.jmrix.openlcb.OlcbConfigurationManager.*;
 import static org.mockito.Mockito.mock;
@@ -305,8 +307,7 @@ public class OlcbClockControlTest {
         tb.setInternalMaster(false, false);
         tb.setStartClockOption(Timebase.NONE);
         tb.setSetRateAtStart(false);
-        assertEquals(true, tb.getStartRunning());
-        assertEquals(false, tb.getStartStopped());
+        assertEquals(DO_START, tb.getClockInitialRunState());
         Element store = new SimpleTimebaseXml().store(null);
 
         // Simulates a new start of JMRI.
@@ -353,8 +354,7 @@ public class OlcbClockControlTest {
         tb.setInternalMaster(false, false);
         tb.setStartClockOption(Timebase.NONE);
         tb.setSetRateAtStart(false);
-        tb.setStartRunning(false);
-        tb.setStartStopped(false);
+        tb.setClockInitialRunState(Timebase.ClockInitialRunState.DO_NOTHING);
         Element store = new SimpleTimebaseXml().store(null);
 
         // Simulates a new start of JMRI.
@@ -419,12 +419,11 @@ public class OlcbClockControlTest {
     }
 
     @Test
-    public void loadAndRestartWithRunAndRate() throws Exception {
+    public void loadAndRestartWithStopAndRate() throws Exception {
         runLoadRestartTest(new LoadRestartModule() {
             @Override
             public void setTimebaseOptions(Timebase tb) {
-                tb.setStartStopped(true);
-                tb.setStartRunning(false);
+                tb.setClockInitialRunState(DO_STOP);
                 tb.setSetRateAtStart(true);
                 tb.setStartRate(13.0);
             }
@@ -444,12 +443,11 @@ public class OlcbClockControlTest {
     }
 
     @Test
-    public void loadAndRestartWithRunAndNoRate() throws Exception {
+    public void loadAndRestartWithStopAndNoRate() throws Exception {
         runLoadRestartTest(new LoadRestartModule() {
             @Override
             public void setTimebaseOptions(Timebase tb) {
-                tb.setStartStopped(true);
-                tb.setStartRunning(false);
+                tb.setClockInitialRunState(DO_STOP);
                 tb.setSetRateAtStart(false);
                 tb.setStartRate(13.0);
             }
@@ -473,8 +471,7 @@ public class OlcbClockControlTest {
         runLoadRestartTest(new LoadRestartModule() {
             @Override
             public void setTimebaseOptions(Timebase tb) {
-                tb.setStartStopped(false);
-                tb.setStartRunning(false);
+                tb.setClockInitialRunState(DO_NOTHING);
                 tb.setSetRateAtStart(false);
                 tb.setStartRate(13.0);
             }
@@ -503,8 +500,7 @@ public class OlcbClockControlTest {
         runLoadRestartTest(new LoadRestartModule() {
             @Override
             public void setTimebaseOptions(Timebase tb) {
-                tb.setStartStopped(false);
-                tb.setStartRunning(false);
+                tb.setClockInitialRunState(DO_NOTHING);
                 tb.setSetRateAtStart(false);
                 tb.setStartRate(13.0);
             }

--- a/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
@@ -222,6 +222,53 @@ public class OlcbClockControlTest {
     }
 
     @Test
+    public void rateListenerMasterRounding() throws Exception {
+        initializeWithClockMaster();
+        Timebase tb = InstanceManager.getDefault(Timebase.class);
+        MockPropertyChangeListener ml = new MockPropertyChangeListener();
+        tb.addPropertyChangeListener(ml);
+
+        clock.setRate(13.33);
+        iface.assertSentMessage(":X195B4C4CN0101000001034035;");
+
+        Mockito.verify(ml.m).onChange("rate", 13.25d);
+
+        Mockito.verifyNoMoreInteractions(ml.m);
+    }
+
+    @Test
+    public void rateListenerMasterRoundingAtZero() throws Exception {
+        initializeWithClockMaster();
+        Timebase tb = InstanceManager.getDefault(Timebase.class);
+        MockPropertyChangeListener ml = new MockPropertyChangeListener();
+        tb.addPropertyChangeListener(ml);
+
+        // A small but positive rate will be rounded up to 0.25.
+        clock.setRate(0.001);
+        iface.assertSentMessage(":X195B4C4CN0101000001034001;");
+
+        Mockito.verify(ml.m).onChange("rate", 0.25d);
+
+        Mockito.verifyNoMoreInteractions(ml.m);
+    }
+
+    @Test
+    public void rateListenerSlaveRounding() throws Exception {
+        initializeWithClockSlave();
+        Timebase tb = InstanceManager.getDefault(Timebase.class);
+        MockPropertyChangeListener ml = new MockPropertyChangeListener();
+        tb.addPropertyChangeListener(ml);
+
+        clock.setRate(13.33);
+        iface.assertSentMessage(":X195B4C4CN010100000102C035;");
+
+        Mockito.verifyNoMoreInteractions(ml.m);
+
+        iface.sendMessage(":X195B4123N0101000001024035;");
+        Mockito.verify(ml.m).onChange("rate", 13.25d);
+    }
+
+    @Test
     public void setTime() throws Exception {
         initializeWithClockSlave();
         Calendar c = Calendar.getInstance();

--- a/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
@@ -439,8 +439,8 @@ public class OlcbClockControlTest {
                 iface.flush();
                 gen.requestStart();
                 iface.flush();
-                assertEquals(true, tb2.getRun());
                 assertEquals(true, gen.isRunning());
+                assertEquals(true, tb2.getRun());
             }
 
             @Override
@@ -466,6 +466,9 @@ public class OlcbClockControlTest {
             public void setGeneratorStateBeforeLoad(TimeBroadcastGenerator gen, Timebase tb2) {
                 gen.requestSetRate(2.0);
                 gen.requestStop();
+                iface.flush();
+                assertEquals(false, gen.isRunning());
+                assertEquals(false, tb2.getRun());
             }
 
             @Override

--- a/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
@@ -522,5 +522,10 @@ public class OlcbClockControlTest {
         });
     }
 
+    @Test(timeout=1000)
+    public void thisTestDidNotKillJemmy() throws Exception {
+        new org.netbeans.jemmy.QueueTool().waitEmpty(100);
+    }
+
     private final static Logger log = LoggerFactory.getLogger(OlcbClockControlTest.class);
 }

--- a/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
@@ -337,7 +337,7 @@ public class OlcbClockControlTest {
         void setTimebaseOptions(Timebase tb);
         void setGeneratorStateBeforeLoad(TimeBroadcastGenerator gen, Timebase tb2);
         void checkFinalState(TimeBroadcastGenerator gen, Timebase tb2);
-    };
+    }
 
     private void runLoadRestartTest(LoadRestartModule m) {
         initializeWithClockSlave();

--- a/java/test/jmri/jmrix/openlcb/OlcbTestInterface.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTestInterface.java
@@ -106,7 +106,16 @@ public class OlcbTestInterface {
      * Asserts that no message was sent to the bus.
      */
     public void assertNoSentMessages() {
+        flush();
         Assert.assertNull(tc.rcvMessage);
+    }
+
+    /**
+     * Resets the traffic controller to forget about sent messages.
+     */
+    public void clearSentMessages() {
+        flush();
+        tc.rcvMessage = null;
     }
 
     /**


### PR DESCRIPTION
This fixes https://github.com/JMRI/JMRI/issues/6256:
- Ensures that when an openlcb network participant sets the rate, the JMRI fast clock display gets updated.
- Adds a user-selectable option to define whether the rate of the clock gets overwritten during the startup. Makes the "startup rate" a separate dialog box line, so that when the user changes the rate, the next save will not necessarily overwrite the startup rate.
- Makes the "start clock stopped" into a three-way selectable option, with options for stopped, running and no-change. This is necessary when starting a client in a peer-to-peer network.
The new behavior is implemented both in the UI, the implementation and the XML save/load logic. The XML load logic is prepared for loading older version that do not have the new attributes.
Unit tests cover the load/save logic, the loading of old XMLs, and the openlcb behavior.