### PR TITLE
Update Loconet initialization (for 4.13.6)

### DIFF
--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -220,6 +220,7 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
                 });
 
         // Install configuration manager and Swing error handler
+        // Constructing the JmriConfigurationManager also loads various configuration services
         ConfigureManager cm = InstanceManager.setDefault(ConfigureManager.class, new JmriConfigurationManager());
 
         // record startup

--- a/java/src/jmri/jmrix/loconet/LnDeferProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnDeferProgrammer.java
@@ -1,0 +1,105 @@
+package jmri.jmrix.loconet;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.ArrayList;
+
+import jmri.ProgListener;
+import jmri.Programmer;
+import jmri.ProgrammerException;
+import jmri.ProgrammingMode;
+
+import jmri.jmrix.AbstractProgrammer;
+
+/**
+ * Programmer implementation for Programmer that uses a SlotManager (which is also an AbstractProgrammer)
+ * that might be provided later. This is done by connecting through a LocoNetSystemConnectionMemo.
+ *
+ * @author Bob Jacobsen Copyright (C) 2018
+ */
+public class LnDeferProgrammer extends AbstractProgrammer {
+
+    public LnDeferProgrammer(@Nonnull LocoNetSystemConnectionMemo memo) {
+        this.memo = memo;
+    }
+    
+    LocoNetSystemConnectionMemo memo;
+    
+    @Override
+    @Nonnull public List<ProgrammingMode> getSupportedModes() {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            return m.getSupportedModes();
+        } else {
+            log.warn("getSupportedModes() called without a SlotManager");
+            return new ArrayList<ProgrammingMode>(); // empty
+        }
+    }
+        
+    @Override
+    public boolean getCanRead() {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            return m.getCanRead();
+        } else {
+            log.warn("getCanRead() called without a SlotManager");
+            return true; // being cautious
+        }
+    }
+        
+    @Override
+    @Nonnull
+    public Programmer.WriteConfirmMode getWriteConfirmMode(String addr) {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            return m.getWriteConfirmMode(addr);
+        } else {
+            log.warn("getWriteConfirmMode() called without a SlotManager");
+            return Programmer.WriteConfirmMode.DecoderReply; // being cautious
+        }
+    }
+        
+    @Override
+    protected void timeout() {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            m.timeout();
+        } else {
+            log.warn("timeout called without a SlotManager");
+        }
+    }
+    
+    @Override
+    public void writeCV(int CV, int val, ProgListener p) throws ProgrammerException {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            m.writeCV(CV, val, p);
+        } else {
+            log.warn("writeCV called without a SlotManager");
+        }
+    }
+
+    @Override
+    public void readCV(int CV, ProgListener p) throws ProgrammerException {
+         SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            m.readCV(CV, p);
+        } else {
+            log.warn("readCV called without a SlotManager");
+        }
+   }
+
+    @Override
+    public void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            m.confirmCV(CV, val, p);
+        } else {
+            log.warn("confirmCV called without a SlotManager");
+        }
+    }
+
+    // initialize logging
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SlotManager.class);
+
+}

--- a/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnOpsModeProgrammer.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
  */
 public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener {
 
-    SlotManager mSlotMgr;
     LocoNetSystemConnectionMemo memo;
     int mAddress;
     boolean mLongAddr;
@@ -34,10 +33,8 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
     private javax.swing.Timer bdOpSwAccessTimer = null;
 
 
-    public LnOpsModeProgrammer(SlotManager pSlotMgr,
-            LocoNetSystemConnectionMemo memo,
+    public LnOpsModeProgrammer(LocoNetSystemConnectionMemo memo,
             int pAddress, boolean pLongAddr) {
-        mSlotMgr = pSlotMgr;
         this.memo = memo;
         mAddress = pAddress;
         mLongAddr = pLongAddr;
@@ -46,18 +43,28 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
     }
 
     /**
+     * @deprecated 4.13.6 Use LnOpsModeProgrammer(LocoNetSystemConnectionMemo memo, int, bool) instead
+     */
+    @Deprecated // 4.13.6 Use LnOpsModeProgrammer(LocoNetSystemConnectionMemo memo, int, bool) instead
+    public LnOpsModeProgrammer(SlotManager pSlotMgr,
+            LocoNetSystemConnectionMemo memo,
+            int pAddress, boolean pLongAddr) {
+        this(memo, pAddress, pLongAddr);
+    }
+
+    /**
      * Forward a write request to an ops-mode write operation.
      */
     @Override
     @Deprecated // 4.1.1
     public void writeCV(int CV, int val, ProgListener p) throws ProgrammerException {
-        mSlotMgr.writeCVOpsMode(CV, val, p, mAddress, mLongAddr);
+        memo.getSlotManager().writeCVOpsMode(CV, val, p, mAddress, mLongAddr);
     }
 
     @Override
     @Deprecated // 4.1.1
     public void readCV(int CV, ProgListener p) throws ProgrammerException {
-        mSlotMgr.readCVOpsMode(CV, p, mAddress, mLongAddr);
+        memo.getSlotManager().readCVOpsMode(CV, p, mAddress, mLongAddr);
     }
 
     @Override
@@ -66,8 +73,8 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
         // Check mode
         LocoNetMessage m;
         if (getMode().equals(LnProgrammerManager.LOCONETCSOPSWMODE)) {
-            mSlotMgr.setMode(LnProgrammerManager.LOCONETCSOPSWMODE);
-            mSlotMgr.writeCV(CV, val, pL); // deal with this via service-mode programmer
+            memo.getSlotManager().setMode(LnProgrammerManager.LOCONETCSOPSWMODE);
+            memo.getSlotManager().writeCV(CV, val, pL); // deal with this via service-mode programmer
         } else if (getMode().equals(LnProgrammerManager.LOCONETBDOPSWMODE)) {
             /**
              * CV format is e.g. "113.12" where the first part defines the
@@ -150,8 +157,8 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
         String[] parts;
         LocoNetMessage m;
         if (getMode().equals(LnProgrammerManager.LOCONETCSOPSWMODE)) {
-            mSlotMgr.setMode(LnProgrammerManager.LOCONETCSOPSWMODE);
-            mSlotMgr.readCV(CV, pL); // deal with this via service-mode programmer
+            memo.getSlotManager().setMode(LnProgrammerManager.LOCONETCSOPSWMODE);
+            memo.getSlotManager().readCV(CV, pL); // deal with this via service-mode programmer
         } else if (getMode().equals(LnProgrammerManager.LOCONETBDOPSWMODE)) {
             /**
              * CV format is e.g. "113.12" where the first part defines the
@@ -234,8 +241,8 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
         p = null;
         // Check mode
         if (getMode().equals(LnProgrammerManager.LOCONETCSOPSWMODE)) {
-            mSlotMgr.setMode(LnProgrammerManager.LOCONETCSOPSWMODE);
-            mSlotMgr.readCV(CV, pL); // deal with this via service-mode programmer
+            memo.getSlotManager().setMode(LnProgrammerManager.LOCONETCSOPSWMODE);
+            memo.getSlotManager().readCV(CV, pL); // deal with this via service-mode programmer
         } else if (getMode().equals(LnProgrammerManager.LOCONETBDOPSWMODE)) {
             readCV(CV, pL);
         }
@@ -245,7 +252,7 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
             notifyProgListenerEnd(pL, 0, ProgListener.UnknownError);
         } else {
             // DCC ops mode
-            mSlotMgr.confirmCVOpsMode(CV, val, pL, mAddress, mLongAddr);
+            memo.getSlotManager().confirmCVOpsMode(CV, val, pL, mAddress, mLongAddr);
         }
     }
 
@@ -501,7 +508,7 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
      */
     @Override
     public boolean getCanRead() {
-        if (getMode().equals(ProgrammingMode.OPSBYTEMODE)) return mSlotMgr.getTranspondingAvailable(); // only way can be false
+        if (getMode().equals(ProgrammingMode.OPSBYTEMODE)) return memo.getSlotManager().getTranspondingAvailable(); // only way can be false
         return true;
      }
 
@@ -522,7 +529,7 @@ public class LnOpsModeProgrammer implements AddressedProgrammer, LocoNetListener
 
     @Override
     public String decodeErrorCode(int i) {
-        return mSlotMgr.decodeErrorCode(i);
+        return memo.getSlotManager().decodeErrorCode(i);
     }
 
     @Override

--- a/java/src/jmri/jmrix/loconet/LnProgrammerManager.java
+++ b/java/src/jmri/jmrix/loconet/LnProgrammerManager.java
@@ -14,13 +14,19 @@ import jmri.managers.DefaultProgrammerManager;
  */
 public class LnProgrammerManager extends DefaultProgrammerManager {
 
-    public LnProgrammerManager(SlotManager pSlotManager, LocoNetSystemConnectionMemo memo) {
-        super(pSlotManager, memo);
-        mSlotManager = pSlotManager;
+    public LnProgrammerManager(LocoNetSystemConnectionMemo memo) {
+        super(new LnDeferProgrammer(memo), memo);
         this.memo = memo;
-    }
+     }
 
-    SlotManager mSlotManager;
+    /**
+     * @deprecated 4.13.6 Use LnProgrammerManager(LocoNetSystemConnectionMemo memo) instead
+     */
+    @Deprecated // 4.13.6 Use LnProgrammerManager(LocoNetSystemConnectionMemo memo) instead
+    public LnProgrammerManager(SlotManager pSlotManager, LocoNetSystemConnectionMemo memo) {
+        this(memo);
+     }
+
     LocoNetSystemConnectionMemo memo;
 
     /**
@@ -39,7 +45,7 @@ public class LnProgrammerManager extends DefaultProgrammerManager {
      */
     @Override
     public AddressedProgrammer getAddressedProgrammer(boolean pLongAddress, int pAddress) {
-        return new LnOpsModeProgrammer(mSlotManager, memo, pAddress, pLongAddress);
+        return new LnOpsModeProgrammer(memo, pAddress, pLongAddress);
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
@@ -41,8 +41,7 @@ public class LocoNetSystemConnectionMemo extends SystemConnectionMemo {
 
         this.sm = sm; // doesn't full register, but fine for this purpose.
 
-        // self-register
-        register();
+        // self-registration is deferred until the command station type is set below
                 
         // create and register the ComponentFactory for the GUI
         InstanceManager.store(cf = new LnComponentFactory(this),
@@ -119,7 +118,7 @@ public class LocoNetSystemConnectionMemo extends SystemConnectionMemo {
 
     public DefaultProgrammerManager getProgrammerManager() {
         if (programmerManager == null) {
-            programmerManager = new LnProgrammerManager(getSlotManager(), this);
+            programmerManager = new LnProgrammerManager(this);
         }
         return programmerManager;
     }
@@ -165,6 +164,9 @@ public class LocoNetSystemConnectionMemo extends SystemConnectionMemo {
             // store as CommandStation object
             InstanceManager.store(sm, jmri.CommandStation.class);
         }
+
+        // register this SystemConnectionMemo to connect to rest of system
+        register();
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/locormi/LnMessageClientPollThread.java
+++ b/java/src/jmri/jmrix/loconet/locormi/LnMessageClientPollThread.java
@@ -1,8 +1,8 @@
 package jmri.jmrix.loconet.locormi;
 
 import jmri.jmrix.loconet.LocoNetMessage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
 
 /**
  * @author Alex Shepherd Copyright (c) 2002
@@ -10,9 +10,8 @@ import org.slf4j.LoggerFactory;
 class LnMessageClientPollThread extends Thread {
 
     LnMessageClient parent = null;
-    private final static Logger log = LoggerFactory.getLogger(LnMessageClientPollThread.class);
 
-    LnMessageClientPollThread(LnMessageClient lnParent) {
+    LnMessageClientPollThread(@Nonnull LnMessageClient lnParent) {
         parent = lnParent;
         this.setDaemon(true);
         this.setName("LnMessageClientPollThread "+lnParent);
@@ -24,6 +23,11 @@ class LnMessageClientPollThread extends Thread {
         try {
             Object[] lnMessages = null;
             while (!Thread.interrupted()) {
+                if (parent.lnMessageBuffer == null) {
+                    // no work to do 
+                    return;
+                }
+                
                 lnMessages = parent.lnMessageBuffer.getMessages(parent.pollTimeout);
 
                 if (lnMessages != null) {
@@ -39,4 +43,6 @@ class LnMessageClientPollThread extends Thread {
             log.warn("Exception: ", ex);
         }
     }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LnMessageClientPollThread.class);
 }

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockProgrammerManager.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockProgrammerManager.java
@@ -1,4 +1,3 @@
-/* UhlenbrockProgrammerManager.java */
 package jmri.jmrix.loconet.uhlenbrock;
 
 import jmri.jmrix.loconet.LnProgrammerManager;

--- a/java/src/jmri/profile/Profile.java
+++ b/java/src/jmri/profile/Profile.java
@@ -269,6 +269,10 @@ public class Profile implements Comparable<Profile> {
         return hash;
     }
 
+    /**
+     * {@inheritDoc}
+     * This tests for equal ID values
+     */
     @Override
     public boolean equals(Object obj) {
         if (obj == null) {

--- a/java/test/jmri/jmrix/loconet/LnDeferProgrammerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnDeferProgrammerTest.java
@@ -1,0 +1,339 @@
+package jmri.jmrix.loconet;
+
+import jmri.ProgListener;
+import jmri.ProgrammingMode;
+import jmri.util.JUnitUtil;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Large parts are copied from SlotManagerTest; combining these would be good.
+ *
+ * @author Bob Jacobsen Copyright (C) 2018
+ */
+public class LnDeferProgrammerTest {
+
+    @Test
+    public void testCTor() {
+        LnTrafficController lnis = new LocoNetInterfaceScaffold();
+        SlotManager slotmanager = new SlotManager(lnis);
+        LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo(lnis, slotmanager);
+        LnDeferProgrammer t = new LnDeferProgrammer(memo);
+        Assert.assertNotNull("exists", t);
+        memo.dispose();
+    }
+
+
+    @Test
+    public void testReadCVPaged() throws jmri.ProgrammerException {
+        int CV1 = 12;
+        ProgListener p2 = null;
+        slotmanager.setMode(ProgrammingMode.PAGEMODE);
+        slotmanager.readCV(CV1, p2);
+        Assert.assertEquals("read message",
+                "EF 0E 7C 23 00 00 00 00 00 0B 00 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+    }
+
+    // Test names ending with "String" are for the new writeCV(String, ...)
+    // etc methods.  If you remove the older writeCV(int, ...) tests,
+    // you can rename these. Note that not all (int,...) tests may have a
+    // String(String, ...) test defined, in which case you should create those.
+    @Test
+    public void testReadCVPagedString() throws jmri.ProgrammerException {
+        String CV1 = "12";
+        ProgListener p2 = null;
+        slotmanager.setMode(ProgrammingMode.PAGEMODE);
+        slotmanager.readCV(CV1, p2);
+        Assert.assertEquals("read message",
+                "EF 0E 7C 23 00 00 00 00 00 0B 00 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+    }
+
+    @Test
+    public void testReadCVRegister() throws jmri.ProgrammerException {
+        int CV1 = 2;
+        ProgListener p2 = null;
+        slotmanager.setMode(ProgrammingMode.REGISTERMODE);
+        slotmanager.readCV(CV1, p2);
+        Assert.assertEquals("read message",
+                "EF 0E 7C 13 00 00 00 00 00 01 00 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+    }
+
+    @Test
+    public void testReadCVRegisterString() throws jmri.ProgrammerException {
+        String CV1 = "2";
+        ProgListener p2 = null;
+        slotmanager.setMode(ProgrammingMode.REGISTERMODE);
+        slotmanager.readCV(CV1, p2);
+        Assert.assertEquals("read message",
+                "EF 0E 7C 13 00 00 00 00 00 01 00 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+    }
+
+    @Test
+    public void testReadCVDirect() throws jmri.ProgrammerException {
+        log.debug(".... start testReadCVDirect ...");
+        int CV1 = 29;
+        slotmanager.setMode(ProgrammingMode.DIRECTBYTEMODE);
+        slotmanager.readCV(CV1, lstn);
+        Assert.assertEquals("read message",
+                "EF 0E 7C 2B 00 00 00 00 00 1C 00 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+
+        // LACK received back (DCS240 sequence)
+        log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;
+
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
+        JUnitUtil.waitFor(()->{return startedLongTimer;},"startedLongTimer not set");
+        Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started long timer", startedLongTimer);
+        Assert.assertFalse("didn't start short timer", startedShortTimer);
+
+        // read received back (DCS240 sequence)
+        value = 0;
+        log.debug("send E7 reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x2B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1C, 0x23, 0x7F, 0x7F, 0x3B}));
+        JUnitUtil.waitFor(()->{return value == 35;},"value == 35 not set");
+        log.debug("checking..");
+        Assert.assertEquals("reply status", 0, status);
+        Assert.assertEquals("reply value", 35, value);
+
+        log.debug(".... end testReadCVDirect ...");
+    }
+
+    @Test
+    public void testReadCVDirectString() throws jmri.ProgrammerException {
+        log.debug(".... start testReadCVDirect ...");
+        String CV1 = "29";
+        slotmanager.setMode(ProgrammingMode.DIRECTBYTEMODE);
+        slotmanager.readCV(CV1, lstn);
+        Assert.assertEquals("read message",
+                "EF 0E 7C 2B 00 00 00 00 00 1C 00 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+
+        // LACK received back (DCS240 sequence)
+        log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;
+
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
+        JUnitUtil.waitFor(()->{return startedLongTimer;},"startedLongTimer not set");
+        Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started long timer", startedLongTimer);
+        Assert.assertFalse("didn't start short timer", startedShortTimer);
+
+        // read received back (DCS240 sequence)
+        value = 0;
+        log.debug("send E7 reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x2B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1C, 0x23, 0x7F, 0x7F, 0x3B}));
+        JUnitUtil.waitFor(()->{return value == 35;},"value == 35 not set");
+        log.debug("checking..");
+        Assert.assertEquals("reply status", 0, status);
+        Assert.assertEquals("reply value", 35, value);
+
+        log.debug(".... end testReadCVDirect ...");
+    }
+
+    @Test
+    public void testReadCVOpsModeLong() throws jmri.ProgrammerException {
+        int CV1 = 12;
+        ProgListener p2 = null;
+        slotmanager.readCVOpsMode(CV1, p2, 4 * 128 + 0x23, true);
+        Assert.assertEquals("read message",
+                "EF 0E 7C 2F 00 04 23 00 00 0B 00 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+    }
+
+    @Test
+    public void testReadCVOpsModeShort() throws jmri.ProgrammerException {
+        int CV1 = 12;
+        ProgListener p2 = null;
+        slotmanager.readCVOpsMode(CV1, p2, 22, false);
+        Assert.assertEquals("read message",
+                "EF 0E 7C 2F 00 00 16 00 00 0B 00 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+    }
+
+    @Test
+    public void testWriteCVPaged() throws jmri.ProgrammerException {
+        int CV1 = 12;
+        int val2 = 34;
+        ProgListener p3 = null;
+        slotmanager.setMode(ProgrammingMode.PAGEMODE);
+        slotmanager.writeCV(CV1, val2, p3);
+        Assert.assertEquals("write message",
+                "EF 0E 7C 63 00 00 00 00 00 0B 22 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+    }
+
+    @Test
+    public void testWriteCVPagedString() throws jmri.ProgrammerException {
+        String CV1 = "12";
+        int val2 = 34;
+        ProgListener p3 = null;
+        slotmanager.setMode(ProgrammingMode.PAGEMODE);
+        slotmanager.writeCV(CV1, val2, p3);
+        Assert.assertEquals("write message",
+                "EF 0E 7C 63 00 00 00 00 00 0B 22 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+    }
+
+    @Test
+    public void testWriteCVRegister() throws jmri.ProgrammerException {
+        int CV1 = 2;
+        int val2 = 34;
+        ProgListener p3 = null;
+        slotmanager.setMode(ProgrammingMode.REGISTERMODE);
+        slotmanager.writeCV(CV1, val2, p3);
+        Assert.assertEquals("write message",
+                "EF 0E 7C 53 00 00 00 00 00 01 22 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+    }
+
+    @Test
+    public void testWriteCVRegisterString() throws jmri.ProgrammerException {
+        String CV1 = "2";
+        int val2 = 34;
+        ProgListener p3 = null;
+        slotmanager.setMode(ProgrammingMode.REGISTERMODE);
+        slotmanager.writeCV(CV1, val2, p3);
+        Assert.assertEquals("write message",
+                "EF 0E 7C 53 00 00 00 00 00 01 22 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+    }
+
+    @Test
+    public void testWriteCVDirect() throws jmri.ProgrammerException {
+        int CV1 = 12;
+        int val2 = 34;
+        ProgListener p3 = null;
+        slotmanager.setMode(ProgrammingMode.DIRECTBYTEMODE);
+        slotmanager.writeCV(CV1, val2, p3);
+        Assert.assertEquals("write message",
+                "EF 0E 7C 6B 00 00 00 00 00 0B 22 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+    }
+
+    @Test
+    public void testWriteCVDirectString() throws jmri.ProgrammerException {
+        String CV1 = "12";
+        int val2 = 34;
+        ProgListener p3 = null;
+        slotmanager.setMode(ProgrammingMode.DIRECTBYTEMODE);
+        slotmanager.writeCV(CV1, val2, p3);
+        Assert.assertEquals("write message",
+                "EF 0E 7C 6B 00 00 00 00 00 0B 22 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+    }
+
+    @Test
+    public void testWriteCVDirectStringDCS240() throws jmri.ProgrammerException {
+        log.debug(".... start testWriteCVDirectStringDCS240 ...");
+        String CV1 = "31";
+        int val2 = 16;
+        slotmanager.setMode(ProgrammingMode.DIRECTBYTEMODE);
+        slotmanager.writeCV(CV1, val2, lstn);
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+        Assert.assertEquals("write message",
+                "EF 0E 7C 6B 00 00 00 00 00 1E 10 7F 7F 00",
+                lnis.outbound.elementAt(lnis.outbound.size() - 1).toString());
+        Assert.assertEquals("one message sent", 1, lnis.outbound.size());
+        Assert.assertEquals("initial status", -999, status);
+
+        // LACK received back (DCS240 sequence)
+        log.debug("send LACK back");
+        startedShortTimer = false;
+        startedLongTimer = false;
+        slotmanager.message(new LocoNetMessage(new int[]{0xB4, 0x6F, 0x01, 0x25}));
+        JUnitUtil.waitFor(()->{return startedShortTimer;},"startedShortTimer not set");
+        Assert.assertEquals("post-LACK status", -999, status);
+        Assert.assertTrue("started short timer", startedShortTimer);
+        Assert.assertFalse("didn't start long timer", startedLongTimer);
+
+        // read received back (DCS240 sequence)
+        value = -15;
+        log.debug("send E7 reply back");
+        slotmanager.message(new LocoNetMessage(new int[]{0xE7, 0x0E, 0x7C, 0x6B, 0x00, 0x00, 0x02, 0x47, 0x00, 0x1E, 0x10, 0x7F, 0x7F, 0x4A}));
+        Assert.assertEquals("no immediate reply", -999, status);
+        JUnitUtil.waitFor(()->{return value == -1;},"value == -1 not set");
+        log.debug("checking..");
+        Assert.assertEquals("reply status", 0, status);
+        Assert.assertEquals("reply value", -1, value);
+
+        log.debug(".... end testWriteCVDirectStringDCS240 ...");
+    }
+
+
+    LocoNetInterfaceScaffold lnis;
+    SlotManager slotmanager;
+    int status;
+    int value;
+    boolean startedShortTimer = false;
+    boolean startedLongTimer = false;
+    boolean stoppedTimer = false;
+
+    ProgListener lstn;
+    int releaseTestDelay = 150; // probably needs to be at least 150, see SlotManager.postProgDelay
+
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+
+        // prepare an interface
+        lnis = new LocoNetInterfaceScaffold();
+
+        slotmanager = new SlotManager(lnis) {
+            @Override
+            protected void startLongTimer() {
+                super.startLongTimer();
+                startedLongTimer = true;
+            }
+            @Override
+            protected void startShortTimer() {
+                super.startShortTimer();
+                startedShortTimer = true;
+            }
+            @Override
+            protected void stopTimer() {
+                super.stopTimer();
+                stoppedTimer = true;
+            }
+        };
+
+        status = -999;
+        value = -999;
+        startedShortTimer = false;
+        startedLongTimer = false;
+
+        lstn = new ProgListener(){
+            @Override
+            public void programmingOpReply(int val, int stat) {
+                log.debug("   reply val: {} status: {}", val, stat);
+                status = stat;
+                value = val;
+            }
+        };
+
+    }
+
+    @After
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LnDeferProgrammerTest.class);
+
+}

--- a/java/test/jmri/jmrix/loconet/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/PackageTest.java
@@ -30,6 +30,7 @@ import org.junit.runners.Suite;
         LnSensorAddressTest.class,
         LnSensorManagerTest.class,
         LnCommandStationTypeTest.class,
+        LnDeferProgrammerTest.class,
         BundleTest.class,
         jmri.jmrix.loconet.pr3.PackageTest.class,
         jmri.jmrix.loconet.hexfile.PackageTest.class,

--- a/java/test/jmri/managers/ManagerDefaultSelectorTest.java
+++ b/java/test/jmri/managers/ManagerDefaultSelectorTest.java
@@ -56,6 +56,14 @@ public class ManagerDefaultSelectorTest {
         Assert.assertTrue(mds.isPreferencesValid(profile));
      }
 
+    private LocoNetSystemConnectionMemo getLocoNetTestConnection() {
+        // create a test loconet connection
+        LnTrafficController lnis = new LocoNetInterfaceScaffold();
+        LocoNetSystemConnectionMemo loconet = new LocoNetSystemConnectionMemo(lnis, null);
+        loconet.configureCommandStation(LnCommandStationType.COMMAND_STATION_DCS100, false, false, false);
+        return loconet;
+    }
+    
     @Test
     public void testSingleSystemPreferencesValid() {
         ManagerDefaultSelector mds = new ManagerDefaultSelector();
@@ -71,10 +79,7 @@ public class ManagerDefaultSelectorTest {
         }
         
         // add a LocoNet connection
-        LnTrafficController lnis = new LocoNetInterfaceScaffold();
-        SlotManager slotmanager = new SlotManager(lnis);
-        slotmanager.setCommandStationType(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100);
-        LocoNetSystemConnectionMemo loconet = new LocoNetSystemConnectionMemo(lnis, slotmanager);
+        LocoNetSystemConnectionMemo loconet = getLocoNetTestConnection();
         
         // wait for notifications
         JUnitUtil.waitFor(() -> {return 1 == loconet.getPropertyChangeListeners().length;}, "Registration Complete");
@@ -117,10 +122,7 @@ public class ManagerDefaultSelectorTest {
         }
         
         // add a LocoNet connection
-        LnTrafficController lnis = new LocoNetInterfaceScaffold();
-        SlotManager slotmanager = new SlotManager(lnis);
-        slotmanager.setCommandStationType(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100);
-        LocoNetSystemConnectionMemo loconet = new LocoNetSystemConnectionMemo(lnis, slotmanager);
+        LocoNetSystemConnectionMemo loconet = getLocoNetTestConnection();
 
         // wait for notifications
         JUnitUtil.waitFor(() -> {return 1 == loconet.getPropertyChangeListeners().length;}, "Registration Complete");
@@ -175,20 +177,14 @@ public class ManagerDefaultSelectorTest {
         }
         
         // add a LocoNet connection
-        LnTrafficController lnis = new LocoNetInterfaceScaffold();
-        SlotManager slotmanager = new SlotManager(lnis);
-        slotmanager.setCommandStationType(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100);
-        LocoNetSystemConnectionMemo loconet = new LocoNetSystemConnectionMemo(lnis, slotmanager);
+        LocoNetSystemConnectionMemo loconet = getLocoNetTestConnection();
 
         // wait for notifications
         JUnitUtil.waitFor(() -> {return 1 == loconet.getPropertyChangeListeners().length;}, "Registration Complete");
         new org.netbeans.jemmy.QueueTool().waitEmpty(20);
         
         // add another LocoNet connection
-        LnTrafficController lnis2 = new LocoNetInterfaceScaffold();
-        SlotManager slotmanager2 = new SlotManager(lnis2);
-        slotmanager2.setCommandStationType(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100);
-        LocoNetSystemConnectionMemo loconet2 = new LocoNetSystemConnectionMemo(lnis2, slotmanager2);
+        LocoNetSystemConnectionMemo loconet2 = getLocoNetTestConnection();
 
         // wait for notifications
         JUnitUtil.waitFor(() -> {return 1 == loconet2.getPropertyChangeListeners().length;}, "Registration Complete");


### PR DESCRIPTION
Update LocoNet for proper defaults handling:
- Add a LnDeferProgrammer that doesn't reference SlotManager capabilities until needed
- LocoNetSystemConnection manager now registers only after command station is configured (which now must happen)
- Move away from passing both SlotManager and LocoNetSystemConnection through parameters; the LocoNetSystemConnection is now sufficient
- add a few comments noted while debugging
