### PR TITLE
 Allow checking for optional CVs in IdentifyDecoder.

### DIFF
--- a/java/src/jmri/jmrit/AbstractIdentify.java
+++ b/java/src/jmri/jmrit/AbstractIdentify.java
@@ -22,23 +22,23 @@ public abstract class AbstractIdentify implements jmri.ProgListener {
 
     static final int RETRY_COUNT = 2;
 
-    abstract public boolean test1();  // no argument to start
+    public abstract boolean test1();  // no argument to start
 
-    abstract public boolean test2(int value);
+    public abstract boolean test2(int value);
 
-    abstract public boolean test3(int value);
+    public abstract boolean test3(int value);
 
-    abstract public boolean test4(int value);
+    public abstract boolean test4(int value);
 
-    abstract public boolean test5(int value);
+    public abstract boolean test5(int value);
 
-    abstract public boolean test6(int value);
+    public abstract boolean test6(int value);
 
-    abstract public boolean test7(int value);
+    public abstract boolean test7(int value);
 
-    abstract public boolean test8(int value);
+    public abstract boolean test8(int value);
 
-    abstract public boolean test9(int value);
+    public abstract boolean test9(int value);
 
     protected AbstractIdentify(Programmer p) {
         this.programmer = p;
@@ -52,7 +52,7 @@ public abstract class AbstractIdentify implements jmri.ProgListener {
      *
      * @param status the new status
      */
-    abstract protected void statusUpdate(String status);
+    protected abstract void statusUpdate(String status);
 
     /**
      * Start the identification state machine.
@@ -93,6 +93,9 @@ public abstract class AbstractIdentify implements jmri.ProgListener {
      * Internal method to handle the programmer callbacks, e.g. when a CV read
      * request terminates. Each will reduce (if possible) the list of consistent
      * decoders, and starts the next step.
+     *
+     * @param value  the value returned
+     * @param status the status reported
      */
     @Override
     public void programmingOpReply(int value, int status) {
@@ -207,9 +210,9 @@ public abstract class AbstractIdentify implements jmri.ProgListener {
     }
 
     /**
-     * Abstract routine to notify of errors
+     * Abstract routine to notify of errors.
      */
-    abstract protected void error();
+    protected abstract void error();
 
     /**
      * To check if running now.
@@ -221,13 +224,13 @@ public abstract class AbstractIdentify implements jmri.ProgListener {
     }
 
     /**
-     * State of the internal sequence
+     * State of the internal sequence.
      */
     int state = 0;
     int retry = 0;
 
     /**
-     * Access a single CV for the next step.
+     * Read a single CV for the next step.
      *
      * @param cv the CV to read
      */
@@ -243,6 +246,13 @@ public abstract class AbstractIdentify implements jmri.ProgListener {
         }
     }
 
+    /**
+     * Write a single CV for the next step.
+     *
+     * @param cv    the CV to write
+     * @param value to write to the CV
+     *
+     */
     protected void writeCV(String cv, int value) {
         if (programmer == null) {
             statusUpdate("No programmer connected");

--- a/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
+++ b/java/src/jmri/jmrit/decoderdefn/IdentifyDecoder.java
@@ -27,9 +27,9 @@ import org.slf4j.LoggerFactory;
  * <li>ESU: (mfgID == 151, modelID == 255) use RailCom&reg; Product ID CVs;
  * write {@literal 0=>CV31}, write {@literal 255=>CV32}, then CVs 261 (lowest)
  * to 264 (highest) are a four byte ID</li>
- * <li>DIY: (mfgID == 13) CV47 is the highest byte, CV48 is high byte, CV49 is 
- * low byte, CV50 is the lowest byte; (CV47 == 1) is reserved for 
- * the Czech Republic</li>
+ * <li>DIY: (mfgID == 13) CV47 is the highest byte, CV48 is high byte, CV49 is
+ * low byte, CV50 is the lowest byte; (CV47 == 1) is reserved for the Czech
+ * Republic</li>
  * </ul>
  *
  * TODO:
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * @see jmri.jmrit.symbolicprog.CombinedLocoSelPane
  * @see jmri.jmrit.symbolicprog.NewLocoSelPane
  */
-abstract public class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
+public abstract class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
 
     public IdentifyDecoder(jmri.Programmer programmer) {
         super(programmer);
@@ -168,12 +168,10 @@ abstract public class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
         } else if (mfgID == 48) {  // Hornby
             productIDhigh = value;
             productID = (productIDhigh << 8) | productIDlow;
-            log.info("Decoder returns mfgID:" + mfgID + ";modelID:" + modelID + ";productID:" + productID);
             return true;
         } else if (mfgID == 141 && (modelID == 70 || modelID == 71)) {  // SoundTraxx
             productIDlow = value;
             productID = (productIDhigh << 8) | productIDlow;
-            log.info("Decoder returns mfgID:" + mfgID + ";modelID:" + modelID + ";productID:" + productID);
             return true;
         } else if (mfgID == 98) {  // Harman
             productIDlow = value;
@@ -227,8 +225,8 @@ abstract public class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
             readCV("263");
             return false;
         } else if (mfgID == 13) {  // DIY
-            productIDlowest = value;            
-            productID = (((((productIDhighest << 8) | productIDhigh) << 8) | productIDlow) << 8) | productIDlowest ;
+            productIDlowest = value;
+            productID = (((((productIDhighest << 8) | productIDhigh) << 8) | productIDlow) << 8) | productIDlowest;
             return true;
         }
         log.error("unexpected step 7 reached with value: " + value);
@@ -255,7 +253,6 @@ abstract public class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
     public boolean test9(int value) {
         if (mfgID == 151) {  // ESU
             productID = productID + (value * 256 * 256 * 256);
-            log.info("Decoder returns mfgID:" + mfgID + ";modelID:" + modelID + ";productID:" + productID);
             return true;
         }
         log.error("unexpected step 9 reached with value: " + value);
@@ -267,6 +264,7 @@ abstract public class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
         message(s);
         if (s.equals("Done")) {
             done(mfgID, modelID, productID);
+            log.info("Decoder returns mfgID:" + mfgID + ";modelID:" + modelID + ";productID:" + productID);
         } else if (log.isDebugEnabled()) {
             log.debug("received status: " + s);
         }
@@ -279,14 +277,14 @@ abstract public class IdentifyDecoder extends jmri.jmrit.AbstractIdentify {
      * @param modelID   identified model identity
      * @param productID identified product identity
      */
-    abstract protected void done(int mfgID, int modelID, int productID);
+    protected abstract void done(int mfgID, int modelID, int productID);
 
     /**
      * Provide a user-readable message about progress.
      *
      * @param m the message to provide
      */
-    abstract protected void message(String m);
+    protected abstract void message(String m);
 
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(IdentifyDecoder.class);

--- a/java/src/jmri/jmrix/nce/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/nce/simulator/SimulatorAdapter.java
@@ -38,58 +38,57 @@ import org.slf4j.LoggerFactory;
  * <p>
  * For a complete description of Binary Commands see:
  * www.ncecorporation.com/pdf/ bincmds.pdf
- * <p>
- *
- {@literal
-  Command Description #bytes rtn Responses 
-  0x80 NOP, dummy instruction (1) !    
-  0x81 xx xx yy assign loco xxxx to cab cc (1) !, 1,2  
-  0x82 read clock (2) <hours><minutes> 
-  0x83 Clock stop (1) !   
-  0x84 Clock start (1) !  
-  0x85 xx xx Set clock hr./min (1) !,3   
-  0x86 xx Set clock 12/24 (1) !,3  
-  0x87 xx Set clock ratio (1) !,3 
-  0x88 xxxx Dequeue packet by loco addr (1) !, 1,2 
-  0x89 Enable main trk, kill prog (1) !   
-  0x8A yy Return status of AIU yy (4) <current hi byte> <current lo byte> <change hi byte> <change lo byte>
-  0x8B Kill main trk, enable prog (1) !
-  0x8C dummy inst. returns "!" followed CR/LF(3) !0x0D, 0x0A <br>
-  0x8D xxxx mm Set speed mode of loco xxxx to mode mm, 1=14, 2=28, 3=128 (1) !, 1,3<speed mode, 0 to 3>
-  0x8E aaaa nn<16 data bytes> Write nn bytes, start at aaaa Must have 16 data bytes, pad them out to 16 if necessary (1) !,4  
-  0x8F aaaa Read 16 bytes, start at aaaa(16) 16 bytes
-  0x90 cc xx... Send 16 char message to Cab ccLCD line 3. xx = 16 ASCII char (1) ! ,2  
-  0x91 cc xx Send 16 char message to cab cc LCD line 4. xx=16 ASCII (1) !,2
-  0x92 cc xx Send 8 char message to cab cc LCD line 2 right xx=8 char (1) !,2
-  0x93 ss<3 byte packet> Queue 3 byte packet to temp _Q send ss times (1) !
-  0x94 ss<4 byte packet> Queue 4 byte packet to temp _Q send ss times (1) !
-  0x95 ss<5 byte packet> Queue 5 byte packet to temp_Q send ss times (1) !  
-  0x96 ss<6 byte packet> Queue 6 byte packet to temp _Q send ss times (1) !
-  0x97 aaaa xx Write 1 byte to aaaa (1) !
-  0x98 aaaa xx xxWrite 2 bytes to aaaa (1) !
-  0x99 aaaa<4 data bytes> Write 4 bytes to aaaa (1) !
-  0x9A aaaa<8 data bytes> Write 8 bytes to aaaa (1) !
-  0x9B yy Return status of AIU yy (short form of command 0x8A) (2) <current hi byte><current lo byte><br>
-  0x9C xx Execute macro number xx (1) !, 0,3
-  0x9D aaaa Read 1 byte from aaaa (1) 1 byte
-  0x9E Enter programming track mode(1) !=success 3=short circuit
-  0x9F Exit programming track mode (1) !=success
-  0xA0 aaaa xx Program CV aa with data xx in paged mode (1) !=success 0=program track
-  0xA1 aaaa Read CV aaaa in paged mode Note: cv data followed by ! for OK. 0xFF followed by 3 for can't read CV (2) !, 0,3
-  0xA2<4 data bytes> Locomotive control command (1) !,1
-  0xA3<3 bytepacket> Queue 3 byte packet to TRK _Q (replaces any packet with same address if it exists) (1) !,1
-  0xA4<4 byte packet> Queue 4 byte packet to TRK _Q (1) !,1
-  0xA5<5 byte packet> Queue 5 byte packet to TRK _Q (1) !,1
-  0xA6 rr dd Program register rr with dd (1) !=success 0=no program track
-  0xA7 rr Read register rr. Note: cv data followed by ! for OK. 0xFF followed by 3 for can't read CV (2) !,3 0=no program track 
-  0xA8 aaaa dd Program CV aaaa with dd in direct mode. (1) !=success 0=no program track
-  0xA9 aaaa Read CV aaaa in direct mode. Note: cv data followed by ! for OK.
-  0xFF followed by 3 for can't read CV (2) !,3 
-  0xAA Return software revision number. Format: VV.MM.mm (3) 3 data bytes
-  0xAB Perform soft reset of command station (like cycling power) (0) Returns nothing
-  0xAC Perform hard reset of command station. Reset to factory defaults (Note: will change baud rate to 9600)(0) Returns nothing
-  0xAD <4 data bytes>Accy/signal and macro commands (1) !,1 
-}
+ * <br><br>
+ * <pre>{@literal
+ * Command Description (#bytes rtn) Responses
+ * 0x80 NOP, dummy instruction (1) !
+ * 0x81 xx xx yy assign loco xxxx to cab cc (1) !, 1,2
+ * 0x82 read clock (2) <hours><minutes>
+ * 0x83 Clock stop (1) !
+ * 0x84 Clock start (1) !
+ * 0x85 xx xx Set clock hr./min (1) !,3
+ * 0x86 xx Set clock 12/24 (1) !,3
+ * 0x87 xx Set clock ratio (1) !,3
+ * 0x88 xxxx Dequeue packet by loco addr (1) !, 1,2
+ * 0x89 Enable main trk, kill prog (1) !
+ * 0x8A yy Return status of AIU yy (4) <current hi byte> <current lo byte> <change hi byte> <change lo byte>
+ * 0x8B Kill main trk, enable prog (1) !
+ * 0x8C dummy inst. returns "!" followed CR/LF(3) !, 0x0D, 0x0A
+ * 0x8D xxxx mm Set speed mode of loco xxxx to mode mm, 1=14, 2=28, 3=128 (1) !, 1,3<speed mode, 0 to 3>
+ * 0x8E aaaa nn<16 data bytes> Write nn bytes, start at aaaa Must have 16 data bytes, pad them out to 16 if necessary (1) !,4
+ * 0x8F aaaa Read 16 bytes, start at aaaa(16) 16 bytes
+ * 0x90 cc xx... Send 16 char message to Cab ccLCD line 3. xx = 16 ASCII char (1) ! ,2
+ * 0x91 cc xx Send 16 char message to cab cc LCD line 4. xx=16 ASCII (1) !,2
+ * 0x92 cc xx Send 8 char message to cab cc LCD line 2 right xx=8 char (1) !,2
+ * 0x93 ss<3 byte packet> Queue 3 byte packet to temp _Q send ss times (1) !
+ * 0x94 ss<4 byte packet> Queue 4 byte packet to temp _Q send ss times (1) !
+ * 0x95 ss<5 byte packet> Queue 5 byte packet to temp_Q send ss times (1) !
+ * 0x96 ss<6 byte packet> Queue 6 byte packet to temp _Q send ss times (1) !
+ * 0x97 aaaa xx Write 1 byte to aaaa (1) !
+ * 0x98 aaaa xx xxWrite 2 bytes to aaaa (1) !
+ * 0x99 aaaa<4 data bytes> Write 4 bytes to aaaa (1) !
+ * 0x9A aaaa<8 data bytes> Write 8 bytes to aaaa (1) !
+ * 0x9B yy Return status of AIU yy (short form of command 0x8A) (2) <current hi byte><current lo byte><br>
+ * 0x9C xx Execute macro number xx (1) !, 0,3
+ * 0x9D aaaa Read 1 byte from aaaa (1) 1 byte
+ * 0x9E Enter programming track mode(1) !=success 3=short circuit
+ * 0x9F Exit programming track mode (1) !=success
+ * 0xA0 aaaa xx Program CV aa with data xx in paged mode (1) !=success 0=program track
+ * 0xA1 aaaa Read CV aaaa in paged mode Note: cv data followed by ! for OK. 0xFF followed by 3 for can't read CV (2) !, 0,3
+ * 0xA2<4 data bytes> Locomotive control command (1) !,1
+ * 0xA3<3 bytepacket> Queue 3 byte packet to TRK _Q (replaces any packet with same address if it exists) (1) !,1
+ * 0xA4<4 byte packet> Queue 4 byte packet to TRK _Q (1) !,1
+ * 0xA5<5 byte packet> Queue 5 byte packet to TRK _Q (1) !,1
+ * 0xA6 rr dd Program register rr with dd (1) !=success 0=no program track
+ * 0xA7 rr Read register rr. Note: cv data followed by ! for OK. 0xFF followed by 3 for can't read CV (2) !,3 0=no program track
+ * 0xA8 aaaa dd Program CV aaaa with dd in direct mode. (1) !=success 0=no program track
+ * 0xA9 aaaa Read CV aaaa in direct mode. Note: cv data followed by ! for OK.
+ * 0xFF followed by 3 for can't read CV (2) !,3
+ * 0xAA Return software revision number. Format: VV.MM.mm (3) 3 data bytes
+ * 0xAB Perform soft reset of command station (like cycling power) (0) Returns nothing
+ * 0xAC Perform hard reset of command station. Reset to factory defaults (Note: will change baud rate to 9600)(0) Returns nothing
+ * 0xAD <4 data bytes>Accy/signal and macro commands (1) !,1
+ * }</pre>
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2002
  * @author Paul Bender, Copyright (C) 2009
@@ -126,8 +125,7 @@ public class SimulatorAdapter extends NcePortController implements
     }
 
     /**
-     * {@inheritDoc}
-     * Simulated input/output pipes.
+     * {@inheritDoc} Simulated input/output pipes.
      */
     @Override
     public String openPort(String portName, String appName) {
@@ -178,7 +176,6 @@ public class SimulatorAdapter extends NcePortController implements
     }
 
     // Base class methods for the NcePortController interface.
-
     /**
      * {@inheritDoc}
      */
@@ -226,7 +223,7 @@ public class SimulatorAdapter extends NcePortController implements
     }
 
     @Override
-    public String getCurrentPortName(){
+    public String getCurrentPortName() {
         return "";
     }
 
@@ -296,8 +293,8 @@ public class SimulatorAdapter extends NcePortController implements
     }
 
     /**
-     * This is the heart of the simulation. It translates an
-     * incoming NceMessage into an outgoing NceReply.
+     * This is the heart of the simulation. It translates an incoming NceMessage
+     * into an outgoing NceReply.
      */
     private NceReply generateReply(NceMessage m) {
         NceReply reply = new NceReply(this.getSystemConnectionMemo().getNceTrafficController());
@@ -363,7 +360,6 @@ public class SimulatorAdapter extends NcePortController implements
             case NceMessage.READ_PAGED_CV_CMD:
             case NceMessage.READ_REG_CMD:
                 reply.setElement(0, 123);   // dummy data
-                //reply.setElement(1,NCE_DATA_OUT_OF_RANGE);  // forces fail
                 reply.setElement(1, NCE_OKAY);  // forces succeed
                 break;
             default:
@@ -403,7 +399,7 @@ public class SimulatorAdapter extends NcePortController implements
      * memory is 256 bytes and starts at memory address 0xEC00. The macro memory
      * is 256*20 or 5120 bytes and starts at memory address 0xC800. The consist
      * memory is 256*6 or 1536 bytes and starts at memory address 0xF500.
-     * 
+     *
      */
     private NceReply readMemory(NceMessage m, NceReply reply, int num) {
         if (num > 16) {
@@ -518,7 +514,7 @@ public class SimulatorAdapter extends NcePortController implements
                 write = (byte) (write + setMask); // set bit if closed
             }
             turnoutMemory[offset] = write;
-            //log.debug("wrote:"+Integer.toHexString(write)); 
+            //log.debug("wrote:"+Integer.toHexString(write));
         }
         reply.setElement(0, NCE_OKAY);   // Nce okay reply!
         return reply;

--- a/java/src/jmri/jmrix/nce/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/nce/simulator/SimulatorAdapter.java
@@ -361,6 +361,19 @@ public class SimulatorAdapter extends NcePortController implements
             case NceMessage.READ_REG_CMD:
                 reply.setElement(0, 123);   // dummy data
                 reply.setElement(1, NCE_OKAY);  // forces succeed
+                // Sample code to modify simulator response for testing purposes.
+                // Uncomment and modify as desired.
+//                int cvnum = (m.getElement(1) << 8) | (m.getElement(2));
+//                if (cvnum == 7) {
+//                    reply.setElement(0, 88);  // forces fail
+//                }
+//                if (cvnum == 8) {
+//                    reply.setElement(0, 48);  // forces Hornby
+//                }
+//                if (cvnum == 159) {
+//                    reply.setElement(0, 145);
+//                    reply.setElement(1, NCE_DATA_OUT_OF_RANGE);  // forces fail
+//                }
                 break;
             default:
                 reply.setElement(0, NCE_OKAY);   // Nce okay reply!

--- a/java/test/jmri/jmrit/AbstractIdentifyTest.java
+++ b/java/test/jmri/jmrit/AbstractIdentifyTest.java
@@ -12,8 +12,8 @@ import org.junit.Assert;
  * Test the AbstractIdentify class. Since that's an abstract base class, we
  * define a local subclass here for the tests.
  *
- * @author	Bob Jacobsen Copyright 2001
-  */
+ * @author Bob Jacobsen Copyright 2001
+ */
 public class AbstractIdentifyTest extends TestCase {
 
     public void testFullSequence() {
@@ -120,7 +120,10 @@ public class AbstractIdentifyTest extends TestCase {
 
     // internal class for testing
     class AITest extends AbstractIdentify {
-        public AITest(Programmer p) { super(p);}
+
+        public AITest(Programmer p) {
+            super(p);
+        }
 
         @Override
         public boolean test1() {
@@ -226,5 +229,5 @@ public class AbstractIdentifyTest extends TestCase {
         JUnitUtil.tearDown();
     }
 
-	// private final static Logger log = LoggerFactory.getLogger(AbstractIdentifyTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(AbstractIdentifyTest.class);
 }

--- a/java/test/jmri/jmrit/AbstractIdentifyTest.java
+++ b/java/test/jmri/jmrit/AbstractIdentifyTest.java
@@ -118,6 +118,19 @@ public class AbstractIdentifyTest extends TestCase {
 
     }
 
+    public void testOptionalCv() {
+        // walk through just 4 steps
+        AITest a = new AITest(new jmri.ProgrammerScaffold(ProgrammingMode.DIRECTMODE));
+
+        a.setOptionalCv(true);
+        Assert.assertEquals("Test setOptionalCv(true)", a.isOptionalCv(), true);
+        a.setOptionalCv(false);
+        Assert.assertEquals("Test setOptionalCv(true)", a.isOptionalCv(), false);
+        a.setOptionalCv(true);
+        Assert.assertEquals("Test setOptionalCv(true)", a.isOptionalCv(), true);
+
+    }
+
     // internal class for testing
     class AITest extends AbstractIdentify {
 

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -2,6 +2,7 @@ package jmri.jmrit.decoderdefn;
 
 import jmri.GlobalProgrammerManager;
 import jmri.InstanceManager;
+import jmri.ProgrammingMode;
 import jmri.managers.DefaultProgrammerManager;
 import jmri.progdebugger.ProgDebugger;
 import jmri.util.JUnitUtil;
@@ -293,6 +294,82 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("found product ID ", 144, i.productID);
     }
 
+    /**
+     * Test Hornby decoder with CV159 not available, hence productID is -1.
+     */
+    @Test
+    public void testIdentifyHornby4() { // CV159 not available hence productID is -1
+        // create our test object
+        IdentifyDecoder i = new IdentifyDecoder(p) {
+            @Override
+            public void done(int mfgID, int modelID, int productID) {
+            }
+
+            @Override
+            public void message(String m) {
+            }
+
+            @Override
+            public void error() {
+            }
+        };
+
+        Assert.assertEquals("found mfg ID ", -1, i.mfgID);
+        Assert.assertEquals("found model ID ", -1, i.modelID);
+        Assert.assertEquals("found product ID ", -1, i.productID);
+        Assert.assertEquals("Test isOptionalCv() before start", i.isOptionalCv(), false);
+        Assert.assertEquals("Programming mode before start", ProgrammingMode.DIRECTMODE, p.getMode());
+
+        i.start();
+        Assert.assertEquals("step 1 reads CV ", 8, cvRead);
+        Assert.assertEquals("running after 1 ", true, i.isRunning());
+        Assert.assertEquals("Test isOptionalCv() after 1", i.isOptionalCv(), false);
+
+        // simulate 2 retries on CV8, start 7
+        i.programmingOpReply(21, 2);
+        i.programmingOpReply(31, 2);
+        i.programmingOpReply(48, 0);
+        Assert.assertEquals("step 2 reads CV ", 7, cvRead);
+        Assert.assertEquals("running after 2 ", true, i.isRunning());
+        Assert.assertEquals("Test isOptionalCv() after 2", i.isOptionalCv(), false);
+        Assert.assertEquals("Programming mode after 2", ProgrammingMode.DIRECTMODE, p.getMode());
+
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found model ID ", -1, i.modelID);
+        Assert.assertEquals("found product ID ", -1, i.productID);
+
+        // simulate 7 retries on CV7, start 159
+        i.programmingOpReply(22, 2);
+        i.programmingOpReply(32, 2);
+        i.programmingOpReply(42, 2);
+        i.programmingOpReply(52, 2);
+        i.programmingOpReply(62, 2);
+        i.programmingOpReply(88, 0);
+        Assert.assertEquals("step 3 reads CV ", 159, cvRead);
+        Assert.assertEquals("running after 3 ", true, i.isRunning());
+        Assert.assertEquals("Test isOptionalCv() after 3", i.isOptionalCv(), true);
+        Assert.assertEquals("Programming mode after 3", ProgrammingMode.PAGEMODE, p.getMode());
+
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found model ID ", 88, i.modelID);
+        Assert.assertEquals("found product ID ", -1, i.productID);
+
+        // simulate CV read read fail on CV159, ends
+        i.programmingOpReply(145, 2);
+        i.programmingOpReply(145, 2);
+        i.programmingOpReply(145, 2);
+        Assert.assertEquals("running after 4 ", false, i.isRunning());
+        Assert.assertEquals("Test isOptionalCv() after 4", i.isOptionalCv(), true);
+        Assert.assertEquals("Programming mode after 4", ProgrammingMode.DIRECTMODE, p.getMode());
+
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found model ID ", 88, i.modelID);
+        Assert.assertEquals("found product ID ", -1, i.productID);
+    }
+
+    /**
+     * Initialize the system.
+     */
     @Before
     public void setUp() {
         JUnitUtil.setUp();
@@ -302,6 +379,7 @@ public class IdentifyDecoderTest {
                 cvRead = CV;
             }
         };
+        p.setMode(ProgrammingMode.DIRECTMODE);
         DefaultProgrammerManager dpm = new DefaultProgrammerManager(p);
         InstanceManager.setAddressedProgrammerManager(dpm);
         InstanceManager.store(dpm, GlobalProgrammerManager.class);

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -11,17 +11,20 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * IdentifyDecoderTest.java
+ * IdentifyDecoderTest.java.
  * <p>
- * Description:	tests for the jmrit.roster.IdentifyDecoder class
+ * Description: tests for the jmrit.roster.IdentifyDecoder class
  *
- * @author	Bob Jacobsen
+ * @author Bob Jacobsen
  */
 public class IdentifyDecoderTest {
 
     static int cvRead = -1;
     private ProgDebugger p;
 
+    /**
+     * Test standard decoder without productID.
+     */
     @Test
     public void testIdentifyStandard() {
         // create our test object
@@ -53,9 +56,13 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("running after 2 ", false, i.isRunning());
         Assert.assertEquals("found mfg ID ", 0x12, i.mfgID);
         Assert.assertEquals("found model ID ", 123, i.modelID);
+        Assert.assertEquals("found product ID ", -1, i.productID);
 
     }
 
+    /**
+     * Test Harman decoder with productID in CV112 and CV113.
+     */
     @Test
     public void testIdentifyHarman() {
         // create our test object
@@ -102,6 +109,9 @@ public class IdentifyDecoderTest {
 
     }
 
+    /**
+     * Test Tsunami2 decoder with productID in CV253 and CV256.
+     */
     @Test
     public void testIdentifyTsu2() {
         // create our test object
@@ -148,8 +158,12 @@ public class IdentifyDecoderTest {
 
     }
 
+    /**
+     * Test Hornby decoder with CV159 = 143, productIDlow in CV159 and
+     * productIDhigh in CV153.
+     */
     @Test
-    public void testIdentifyHornby1() { // CV159 == 143, hence productIDlow in CV159 and productIDhigh in CV153
+    public void testIdentifyHornby1() {
         // create our test object
         IdentifyDecoder i = new IdentifyDecoder(p) {
             @Override
@@ -193,8 +207,11 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("found product ID ", (2 * 256) + 143, i.productID);
     }
 
+    /**
+     * Test Hornby decoder with CV159 &lt; 143, hence productID in CV159.
+     */
     @Test
-    public void testIdentifyHornby2() { // CV159 < 143, hence productID in CV159
+    public void testIdentifyHornby2() {
         // create our test object
         IdentifyDecoder i = new IdentifyDecoder(p) {
             @Override
@@ -233,8 +250,11 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("found product ID ", 142, i.productID);
     }
 
+    /**
+     * Test Hornby decoder with CV159 &gt; 143, hence productID in CV159.
+     */
     @Test
-    public void testIdentifyHornby3() { // CV159 > 143, hence productID in CV159
+    public void testIdentifyHornby3() {
         // create our test object
         IdentifyDecoder i = new IdentifyDecoder(p) {
             @Override
@@ -276,7 +296,6 @@ public class IdentifyDecoderTest {
     @Before
     public void setUp() {
         JUnitUtil.setUp();
-        // initialize the system
         p = new ProgDebugger() {
             @Override
             public void readCV(int CV, jmri.ProgListener p) throws jmri.ProgrammerException {
@@ -288,6 +307,9 @@ public class IdentifyDecoderTest {
         InstanceManager.store(dpm, GlobalProgrammerManager.class);
     }
 
+    /**
+     * Tear down the system.
+     */
     @After
     public void tearDown() {
         p = null;


### PR DESCRIPTION
Some decoders support different productID CVs, but the difference cannot be determined from mfgID and versionID. An example is Hornby.

This PR enables the setting of a flag before checking an optional CV to allow the identification to continue, with a possible change of course. The JavaDoc explains the procedure.

Also fixes a bug in the existing retry code that was likely to produce a misidentification.

Prompted by this [jmriusers](https://groups.io/g/jmriusers/topic/28653288) thread.