### PR TITLE
Fix MultiIndex CV write sequence NumberFormatException 

### DIFF
--- a/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
+++ b/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
@@ -182,11 +182,11 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
 
             // non-indexed operation
             state = ProgState.PROGRAMMING;
-            prog.writeCV(CV, val, this);
+            prog.writeCV(_cv, val, this);
         } else if (useCachePiSi()) {
             // indexed operation with set values is same as non-indexed operation
             state = ProgState.PROGRAMMING;
-            prog.writeCV(CV, val, this);
+            prog.writeCV(_cv, val, this);
         } else {
             lastValuePI = valuePI;  // after check in 'if' statement
             lastValueSI = valueSI;
@@ -232,11 +232,11 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
 
             // non-indexed operation
             state = ProgState.PROGRAMMING;
-            prog.confirmCV(CV, val, this);
+            prog.confirmCV(_cv, val, this);
         } else if (useCachePiSi()) {
             // indexed operation with set values is same as non-indexed operation
             state = ProgState.PROGRAMMING;
-            prog.confirmCV(CV, val, this);
+            prog.confirmCV(_cv, val, this);
         } else {
             lastValuePI = valuePI;  // after check in 'if' statement
             lastValueSI = valueSI;


### PR DESCRIPTION
Fix a problem when SI is cached on multiple writes. 

(See also #6293 for application to JMRI 4.13.7)