### PR TITLE
Improve Roster handling of historic time stamps

### DIFF
--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -520,7 +520,13 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
             } catch (ParseException ex2) {
                 // then try with a specific format to handle e.g. "Apr 1, 2016 9:13:36 AM"
                 DateFormat customFmt = new SimpleDateFormat ("MMM dd, yyyy hh:mm:ss a");
-                setDateModified(customFmt.parse(date));
+                try {
+                    setDateModified(customFmt.parse(date));
+                } catch (ParseException ex3) {
+                    // then try with a specific format to handle e.g. "01-Oct-2016 9:13:36"
+                    customFmt = new SimpleDateFormat ("dd-MMM-yyyy hh:mm:ss");
+                    setDateModified(customFmt.parse(date));
+                }
             }
         } catch (IllegalArgumentException ex2) {
             // warn that there's perhaps something wrong with the classpath

--- a/java/test/jmri/jmrit/roster/RosterEntryTest.java
+++ b/java/test/jmri/jmrit/roster/RosterEntryTest.java
@@ -148,6 +148,23 @@ public class RosterEntryTest {
     }
 
     @Test
+    public void testDateFormatHistoric() {
+        RosterEntry r = new RosterEntry("file here");
+
+        r.setId("test Id");
+        TimeZone tz = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("GMT-7"));
+            r.setDateUpdated("03-Oct-2015 11:19:12"); // this is in local time
+        } finally {
+            TimeZone.setDefault(tz);
+        }
+        
+        Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog()); 
+        Assert.assertEquals("2015-10-03T18:19:12Z", r.getDateUpdated());
+    }
+
+    @Test
     public void testDateFormatISO() {
         RosterEntry r = new RosterEntry("file here");
 
@@ -155,7 +172,7 @@ public class RosterEntryTest {
         r.setDateUpdated("2018-03-05T02:34:55Z");
         
         Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog()); 
-        Assert.assertEquals("2018-03-05T02:34:55Z", r.getDateUpdated().toString());
+        Assert.assertEquals("2018-03-05T02:34:55Z", r.getDateUpdated());
     }
 
     @Test


### PR DESCRIPTION
Improves time handling in Roster to remove warnings like:
```
2018-12-13 13:58:57,890 roster.RosterEntry                    WARN  - Unable to parse "31-May-2016 21:47:45" as a date in roster entry "WM 763". [main]
```