### PR TITLE
Loconet updates (4.13.7)

### DIFF
--- a/java/src/jmri/jmrix/AbstractProgrammer.java
+++ b/java/src/jmri/jmrix/AbstractProgrammer.java
@@ -104,13 +104,15 @@ public abstract class AbstractProgrammer implements Programmer {
     /** {@inheritDoc} */
     @Override
     @SuppressWarnings("deprecation") // this is a migration call, to be removed when writeCV(int, int, ProgListener) is removed
+                                     // so that the underlying subclass has to implement
     public void writeCV(String CV, int val, ProgListener p) throws ProgrammerException {
         writeCV(Integer.parseInt(CV), val, p);
     }
 
     /** {@inheritDoc} */
     @Override
-    @SuppressWarnings("deprecation") // this is a migration call, to be removed when readCV(int, ProgListener) is removed
+    @SuppressWarnings("deprecation") // this is a migration call, to be removed when readCV(int, int, ProgListener) is removed
+                                     // so that the underlying subclass has to implement
     public void readCV(String CV, ProgListener p) throws ProgrammerException {
         readCV(Integer.parseInt(CV), p);
     }

--- a/java/src/jmri/jmrix/loconet/LnDeferProgrammer.java
+++ b/java/src/jmri/jmrix/loconet/LnDeferProgrammer.java
@@ -3,13 +3,12 @@ package jmri.jmrix.loconet;
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.ArrayList;
+import java.beans.PropertyChangeListener;
 
 import jmri.ProgListener;
 import jmri.Programmer;
 import jmri.ProgrammerException;
 import jmri.ProgrammingMode;
-
-import jmri.jmrix.AbstractProgrammer;
 
 /**
  * Programmer implementation for Programmer that uses a SlotManager (which is also an AbstractProgrammer)
@@ -17,7 +16,7 @@ import jmri.jmrix.AbstractProgrammer;
  *
  * @author Bob Jacobsen Copyright (C) 2018
  */
-public class LnDeferProgrammer extends AbstractProgrammer {
+public class LnDeferProgrammer implements Programmer {
 
     public LnDeferProgrammer(@Nonnull LocoNetSystemConnectionMemo memo) {
         this.memo = memo;
@@ -25,6 +24,73 @@ public class LnDeferProgrammer extends AbstractProgrammer {
     
     LocoNetSystemConnectionMemo memo;
     
+    
+    /** {@inheritDoc} */
+    @Override
+    public void writeCV(String CV, int val, ProgListener p) throws ProgrammerException {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            m.writeCV(CV, val, p);
+        } else {
+            log.warn("writeCV called without a SlotManager");
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void writeCV(int CV, int val, ProgListener p) throws ProgrammerException {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            m.writeCV(CV, val, p);
+        } else {
+            log.warn("writeCV called without a SlotManager");
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void readCV(String CV, ProgListener p) throws ProgrammerException {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            m.readCV(CV, p);
+        } else {
+            log.warn("readCV called without a SlotManager");
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void readCV(int CV, ProgListener p) throws ProgrammerException {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            m.readCV(CV, p);
+        } else {
+            log.warn("readCV called without a SlotManager");
+        }
+   }
+
+    /** {@inheritDoc} */
+    @Override
+    public void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            m.confirmCV(CV, val, p);
+        } else {
+            log.warn("confirmCV called without a SlotManager");
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void confirmCV(int CV, int val, ProgListener p) throws ProgrammerException {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            m.confirmCV(CV, val, p);
+        } else {
+            log.warn("confirmCV called without a SlotManager");
+        }
+    }
+
     @Override
     @Nonnull public List<ProgrammingMode> getSupportedModes() {
         SlotManager m = memo.getSlotManager();
@@ -35,7 +101,28 @@ public class LnDeferProgrammer extends AbstractProgrammer {
             return new ArrayList<ProgrammingMode>(); // empty
         }
     }
-        
+
+    @Override
+    public void setMode(ProgrammingMode p) {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            m.setMode(p);
+        } else {
+            log.warn("setMode() called without a SlotManager");
+        }
+    }
+
+    @Override
+    public ProgrammingMode getMode() {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            return m.getMode();
+        } else {
+            log.warn("getMode() called without a SlotManager");
+            return ProgrammingMode.ADDRESSMODE; // being cautious
+        }
+    }
+
     @Override
     public boolean getCanRead() {
         SlotManager m = memo.getSlotManager();
@@ -48,6 +135,39 @@ public class LnDeferProgrammer extends AbstractProgrammer {
     }
         
     @Override
+    public boolean getCanRead(String addr) {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            return m.getCanRead(addr);
+        } else {
+            log.warn("getCanRead(String) called without a SlotManager");
+            return true; // being cautious
+        }
+    }
+        
+    @Override
+    public boolean getCanWrite() {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            return m.getCanWrite();
+        } else {
+            log.warn("getCanWrite() called without a SlotManager");
+            return true; // being cautious
+        }
+    }
+        
+    @Override
+    public boolean getCanWrite(String addr) {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            return m.getCanWrite(addr);
+        } else {
+            log.warn("getCanWrite(String) called without a SlotManager");
+            return true; // being cautious
+        }
+    }
+ 
+    @Override
     @Nonnull
     public Programmer.WriteConfirmMode getWriteConfirmMode(String addr) {
         SlotManager m = memo.getSlotManager();
@@ -59,43 +179,45 @@ public class LnDeferProgrammer extends AbstractProgrammer {
         }
     }
         
+
     @Override
-    protected void timeout() {
+    public void notifyProgListenerEnd(ProgListener p, int value, int status) {
         SlotManager m = memo.getSlotManager();
         if (m!=null) {
-            m.timeout();
+            m.notifyProgListenerEnd(p, value, status);
         } else {
-            log.warn("timeout called without a SlotManager");
-        }
-    }
-    
-    @Override
-    public void writeCV(int CV, int val, ProgListener p) throws ProgrammerException {
-        SlotManager m = memo.getSlotManager();
-        if (m!=null) {
-            m.writeCV(CV, val, p);
-        } else {
-            log.warn("writeCV called without a SlotManager");
+            log.warn("notifyProgListenerEnd called without a SlotManager");
         }
     }
 
     @Override
-    public void readCV(int CV, ProgListener p) throws ProgrammerException {
-         SlotManager m = memo.getSlotManager();
-        if (m!=null) {
-            m.readCV(CV, p);
-        } else {
-            log.warn("readCV called without a SlotManager");
-        }
-   }
-
-    @Override
-    public void confirmCV(String CV, int val, ProgListener p) throws ProgrammerException {
+    public void addPropertyChangeListener(PropertyChangeListener p) {
         SlotManager m = memo.getSlotManager();
         if (m!=null) {
-            m.confirmCV(CV, val, p);
+            m.addPropertyChangeListener(p);
         } else {
-            log.warn("confirmCV called without a SlotManager");
+            log.warn("addPropertyChangeListener called without a SlotManager");
+        }
+    }
+
+    @Override
+    public void removePropertyChangeListener(PropertyChangeListener p) {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            m.removePropertyChangeListener(p);
+        } else {
+            log.warn("removePropertyChangeListener called without a SlotManager");
+        }
+    }
+
+    @Override
+    public String decodeErrorCode(int i) {
+        SlotManager m = memo.getSlotManager();
+        if (m!=null) {
+            return m.decodeErrorCode(i);
+        } else {
+            log.warn("decodeErrorCode called without a SlotManager");
+            return "<unknown>"; // being cautious
         }
     }
 

--- a/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
@@ -54,9 +54,6 @@ public class LocoNetSystemConnectionMemo extends SystemConnectionMemo {
     public LocoNetSystemConnectionMemo() {
         super("L", "LocoNet"); // NOI18N
 
-        // self-register
-        register();
-
         // create and register the ComponentFactory for the GUI
         InstanceManager.store(cf = new LnComponentFactory(this),
                 ComponentFactory.class);

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -1155,7 +1155,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
      */
     @Override
     public void readCV(String cvNum, jmri.ProgListener p) throws jmri.ProgrammerException {
-        log.debug("readCV(string): cvNum={}", cvNum);
+        log.debug("readCV(string): cvNum={} mode={}", cvNum, getMode());
         if (getMode().equals(csOpSwProgrammingMode)) {
             log.debug("cvOpSw mode!");
             //handle Command Station OpSw programming here

--- a/java/test/jmri/jmrix/loconet/loconetovertcp/ClientRxHandlerTest.java
+++ b/java/test/jmri/jmrix/loconet/loconetovertcp/ClientRxHandlerTest.java
@@ -29,10 +29,12 @@ public class ClientRxHandlerTest {
     public void setUp() {
         JUnitUtil.setUp();
         JUnitUtil.resetInstanceManager();
+
         LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo();
-        // provide a memo in order to later use InstanceManager.getDefault()
+        // ensure memo exists in order to later use InstanceManager.getDefault()
         lnis = new LocoNetInterfaceScaffold(memo);
-        // memo.setLnTrafficController(lnis);
+        memo.setLnTrafficController(lnis);
+        memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100, true, false, true);
     }
 
     @After

--- a/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpServerFrameTest.java
+++ b/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpServerFrameTest.java
@@ -41,8 +41,10 @@ public class LnTcpServerFrameTest {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
         memo = new LocoNetSystemConnectionMemo();
+        // ensure memo exists in order to later use InstanceManager.getDefault()
         lnis = new LocoNetInterfaceScaffold(memo);
         memo.setLnTrafficController(lnis);
+        memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100, true, false, true);
     }
 
     @After

--- a/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpServerTest.java
+++ b/java/test/jmri/jmrix/loconet/loconetovertcp/LnTcpServerTest.java
@@ -27,8 +27,9 @@ public class LnTcpServerTest {
         JUnitUtil.resetProfileManager();
         LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo();
         // ensure memo exists in order to later use InstanceManager.getDefault()
-        new LocoNetInterfaceScaffold(memo);  // does this register? or is it now redundant?
-        // memo.setLnTrafficController(lnis);
+        LocoNetInterfaceScaffold lnis = new LocoNetInterfaceScaffold(memo);
+        memo.setLnTrafficController(lnis);
+        memo.configureCommandStation(jmri.jmrix.loconet.LnCommandStationType.COMMAND_STATION_DCS100, true, false, true);
     }
 
     @After


### PR DESCRIPTION
- Properly handle deprecations in Programmer, AbstractProgrammer - fixes problem with Command Station reads and mode selection
- Minor comment, debug updates
- Don't self-register the default ctor LocoNetSystemConnectionMemo, which fixes the problem with duplicates in the Default preferences pane
- Fix test initializations for LocoNetOverTcp to suppress warnings in CI