### PR TITLE
Fixes schema problems with timebase (4.15.1)

### DIFF
--- a/java/test/jmri/configurexml/load/TimebaseTest-4.13.4.xml
+++ b/java/test/jmri/configurexml/load/TimebaseTest-4.13.4.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-2-9-6.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-2-9-6.xsd">
+  <jmriversion>
+    <major>4</major>
+    <minor>13</minor>
+    <test>4</test>
+    <modifier />
+  </jmriversion>
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
+    <defaultInitialState>unknown</defaultInitialState>
+    <sensor inverted="false">
+      <systemName>ISCLOCKRUNNING</systemName>
+    </sensor>
+  </sensors>
+  <memories class="jmri.managers.configurexml.DefaultMemoryManagerXml">
+    <memory value="2:06 PM">
+      <systemName>IMCURRENTTIME</systemName>
+    </memory>
+    <memory value="1.0">
+      <systemName>IMRATEFACTOR</systemName>
+    </memory>
+  </memories>
+  <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
+  <signalgroups class="jmri.managers.configurexml.DefaultSignalGroupManagerXml" />
+  <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
+  <warrants class="jmri.jmrit.logix.configurexml.WarrantManagerXml" />
+  <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
+    <logicDelay>500</logicDelay>
+  </signalmastlogics>
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Dec 15 14:06:39 CET 2018" rate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startsettime="no" startclockoption="0" showbutton="no" />
+  <filehistory>
+    <operation>
+      <type>app</type>
+      <date>Sat Dec 15 14:06:05 CET 2018</date>
+      <filename>JMRI program</filename>
+    </operation>
+    <operation>
+      <type>Store</type>
+      <date>Sat Dec 15 14:06:57 CET 2018</date>
+      <filename />
+    </operation>
+  </filehistory>
+  <!--Written by JMRI version 4.13.4+R49e7a86 on Sat Dec 15 14:06:57 CET 2018-->
+</layout-config>

--- a/java/test/jmri/configurexml/load/TimebaseTest.xml
+++ b/java/test/jmri/configurexml/load/TimebaseTest.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-2-9-6.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-2-9-6.xsd">
+  <jmriversion>
+    <major>4</major>
+    <minor>13</minor>
+    <test>7</test>
+    <modifier>ish</modifier>
+  </jmriversion>
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
+    <defaultInitialState>unknown</defaultInitialState>
+    <sensor inverted="false">
+      <systemName>ISCLOCKRUNNING</systemName>
+    </sensor>
+  </sensors>
+  <memories class="jmri.managers.configurexml.DefaultMemoryManagerXml">
+    <memory value="12:14 PM">
+      <systemName>IMCURRENTTIME</systemName>
+    </memory>
+    <memory value="1.0">
+      <systemName>IMRATEFACTOR</systemName>
+    </memory>
+  </memories>
+  <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
+  <signalgroups class="jmri.managers.configurexml.DefaultSignalGroupManagerXml" />
+  <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
+  <warrants class="jmri.jmrit.logix.configurexml.WarrantManagerXml" />
+  <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
+    <logicDelay>500</logicDelay>
+  </signalmastlogics>
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Dec 15 12:14:34 CET 2018" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+  <filehistory>
+    <operation>
+      <type>app</type>
+      <date>Sat Dec 15 12:14:34 CET 2018</date>
+      <filename>JMRI program</filename>
+    </operation>
+    <operation>
+      <type>Store</type>
+      <date>Sat Dec 15 12:14:51 CET 2018</date>
+      <filename />
+    </operation>
+  </filehistory>
+  <!--Written by JMRI version 4.13.7ish+bracz+20181215T1114Z+R832d51c822 on Sat Dec 15 12:14:51 CET 2018-->
+</layout-config>

--- a/xml/schema/types/timebase.xsd
+++ b/xml/schema/types/timebase.xsd
@@ -40,6 +40,7 @@
       <xs:attribute name="class" type="classType" use="required"/>
       <xs:attribute name="time" type="xs:string"/>
       <xs:attribute name="rate" type="xs:float"/>
+      <xs:attribute name="startrate" type="xs:float"/>
       <xs:attribute name="run" type="yesNoType"/>
       <xs:attribute name="master" type="yesNoType"/>
       <xs:attribute name="mastername" type="xs:string"/>
@@ -48,7 +49,9 @@
       <xs:attribute name="display" type="yesNoType"/>
       <xs:attribute name="showbutton" type="yesNoType"/>
       <xs:attribute name="startstopped" type="yesNoType"/>
+      <xs:attribute name="startrunning" type="yesNoType"/>
       <xs:attribute name="startsettime" type="yesNoType"/>
+      <xs:attribute name="startsetrate" type="yesNoType"/>
       <xs:attribute name="startclockoption" type="xs:nonNegativeInteger"/>
     </xs:complexType>
 


### PR DESCRIPTION
#6270 introduced a problem: panel files saved with that version do not pass validation anymore.

This PR updates the schema file and adds test files for the validation to pass.