### PR TITLE
WIP: Updates

### DIFF
--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -1173,7 +1173,7 @@
         <a href=
         "http://junit.sourceforge.net/javadoc/org/junit/Ignore.html">
         Ignore</a> - mark a test to be unconditionally ignored. For
-        example, a test that isn't fully implemented yet can be marked to be ignored:<br>
+        example, a test that is failing because it's not fully implemented can be marked to be ignored:<br>
 <pre style="font-family: monospace;">
         @Ignore("not done yet")
         @Test
@@ -1181,12 +1181,19 @@
             // some code that compiles but doesn't run
         }
 </pre><br>
-        You should provide the reason for ignoring this test in the <code>@Ignore</code> argument. 
+        <ul>
+        <li>You should provide the reason for ignoring this test in the <code>@Ignore</code> argument. 
         <code>@Ignore</code> without an argument
         will compile, but Jenkins will mark it as an error.
         In general, we'd rather have working tests rather than ignored ones, so
         we track the number that have been ignored in a Jenkins job, see the image 
-        to the right.        
+        to the right.
+        <li>Don't use <code>@Ignore</code> to suppress a part-class (i.e. abstract base)
+        test that will never be relevant, as <code>@Ignore</code> means
+        that there's a problem that should eventually be fixed.  
+        Instead, just provide an empty body for the test with a 
+        comment as to why the test isn't relevant.
+        </ul>
       </ul>
 
       <p><a href=

--- a/java/src/jmri/InstanceManager.java
+++ b/java/src/jmri/InstanceManager.java
@@ -568,6 +568,7 @@ public final class InstanceManager {
      */
     @Deprecated
     static public BlockManager blockManagerInstance() {
+        jmri.util.Log4JUtil.warnOnce(log, "blockManagerInstance is deprecated, please replace this call", new Exception("traceback"));
         return getDefault(BlockManager.class);
     }
 
@@ -579,6 +580,7 @@ public final class InstanceManager {
      */
     @Deprecated
     static public PowerManager powerManagerInstance() {
+        jmri.util.Log4JUtil.warnOnce(log, "powerManagerInstance is deprecated, please replace this call", new Exception("traceback"));
         return getDefault(PowerManager.class);
     }
 
@@ -590,6 +592,7 @@ public final class InstanceManager {
      */
     @Deprecated
     static public ReporterManager reporterManagerInstance() {
+        jmri.util.Log4JUtil.warnOnce(log, "reporterManagerInstance is deprecated, please replace this call", new Exception("traceback"));
         return getDefault(ReporterManager.class);
     }
 
@@ -601,6 +604,7 @@ public final class InstanceManager {
      */
     @Deprecated
     static public RouteManager routeManagerInstance() {
+        jmri.util.Log4JUtil.warnOnce(log, "routeManagerInstance is deprecated, please replace this call", new Exception("traceback"));
         return getDefault(RouteManager.class);
     }
 
@@ -612,6 +616,7 @@ public final class InstanceManager {
      */
     @Deprecated
     static public SectionManager sectionManagerInstance() {
+        jmri.util.Log4JUtil.warnOnce(log, "sectionManagerInstance is deprecated, please replace this call", new Exception("traceback"));
         return getDefault(SectionManager.class);
     }
 
@@ -647,6 +652,7 @@ public final class InstanceManager {
      */
     @Deprecated
     static public void setSignalHeadManager(SignalHeadManager p) {
+        jmri.util.Log4JUtil.warnOnce(log, "setSignalHeadManager is deprecated, please replace this call", new Exception("traceback"));
         setDefault(SignalHeadManager.class, p);
     }
 
@@ -657,6 +663,7 @@ public final class InstanceManager {
      */
     @Deprecated
     static public void setCommandStation(CommandStation p) {
+        jmri.util.Log4JUtil.warnOnce(log, "setCommandStation is deprecated, please replace this call", new Exception("traceback"));
         store(p, CommandStation.class);
     }
 
@@ -667,7 +674,7 @@ public final class InstanceManager {
      */
     @Deprecated
     static public void setConfigureManager(ConfigureManager p) {
-        log.debug(" setConfigureManager");
+        jmri.util.Log4JUtil.warnOnce(log, "setConfigureManager is deprecated, please replace this call", new Exception("traceback"));
         setDefault(ConfigureManager.class, p);
     }
 
@@ -678,6 +685,7 @@ public final class InstanceManager {
      */
     @Deprecated
     static public void setConsistManager(ConsistManager p) {
+        jmri.util.Log4JUtil.warnOnce(log, "setConsistManager is deprecated, please replace this call", new Exception("traceback"));
         store(p, ConsistManager.class);
     }
 
@@ -703,6 +711,7 @@ public final class InstanceManager {
      */
     @Deprecated
     static public void setAddressedProgrammerManager(AddressedProgrammerManager p) {
+        jmri.util.Log4JUtil.warnOnce(log, "setAddressedProgrammerManager is deprecated, please replace this call", new Exception("traceback"));
         store(p, AddressedProgrammerManager.class);
     }
 

--- a/java/src/jmri/implementation/AbstractStringIO.java
+++ b/java/src/jmri/implementation/AbstractStringIO.java
@@ -38,7 +38,6 @@ public abstract class AbstractStringIO extends AbstractNamedBean implements Stri
      * The string [u]must not[/u] be longer than the value of getMaximumLength()
      * unless that value is zero. Some microcomputers have little memory and
      * it's very important that this method is never called with too long strings.
-     * @param value
      * @throws JmriException 
      */
     abstract protected void sendStringToLayout(String value) throws JmriException;

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -488,11 +488,14 @@ abstract public class AbstractProxyManager<E extends NamedBean> implements Provi
     }
 
     private ArrayList<String> addedOrderList = null;
+    
     protected void updateOrderList() {
         if (addedOrderList == null) return; // only maintain if requested
         addedOrderList.clear();
         for (Manager<E> m : mgrs) {
-            addedOrderList.addAll(m.getSystemNameAddedOrderList());
+            @SuppressWarnings("deprecation") // getSystemNameAddedOrderList() call needed until deprecated code removed
+            List<String> t = m.getSystemNameAddedOrderList();
+            addedOrderList.addAll(t);
         }
     }
 

--- a/java/src/jmri/managers/configurexml/AbstractAudioManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractAudioManagerConfigXML.java
@@ -60,6 +60,7 @@ public abstract class AbstractAudioManagerConfigXML extends AbstractNamedBeanMan
         setStoreElementClass(audio);
         AudioManager am = (AudioManager) o;
         if (am != null) {
+            @SuppressWarnings("deprecation") // getSystemNameAddedOrderList() call needed until deprecated code removed
             java.util.Iterator<String> iter
                     = am.getSystemNameAddedOrderList().iterator();
 
@@ -80,7 +81,9 @@ public abstract class AbstractAudioManagerConfigXML extends AbstractNamedBeanMan
             int vsdObjectCount = 0;
 
             // count all VSD objects
-            for (String sname : am.getSystemNameAddedOrderList()) {
+            @SuppressWarnings("deprecation") // getSystemNameAddedOrderList() call needed until deprecated code removed
+            List<String> t = am.getSystemNameAddedOrderList();
+            for (String sname : t) {
                 if (log.isDebugEnabled()) {
                     log.debug("Check if " + sname + " is a VSD object");
                 }

--- a/java/src/jmri/managers/configurexml/AbstractLightManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractLightManagerConfigXML.java
@@ -40,6 +40,7 @@ public abstract class AbstractLightManagerConfigXML extends AbstractNamedBeanMan
         setStoreElementClass(lights);
         LightManager tm = (LightManager) o;
         if (tm != null) {
+            @SuppressWarnings("deprecation") // getSystemNameAddedOrderList() call needed until deprecated code removed
             java.util.Iterator<String> iter
                     = tm.getSystemNameAddedOrderList().iterator();
 

--- a/java/src/jmri/managers/configurexml/AbstractMemoryManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractMemoryManagerConfigXML.java
@@ -39,6 +39,7 @@ public abstract class AbstractMemoryManagerConfigXML extends AbstractNamedBeanMa
         setStoreElementClass(memories);
         MemoryManager tm = (MemoryManager) o;
         if (tm != null) {
+            @SuppressWarnings("deprecation") // getSystemNameAddedOrderList() call needed until deprecated code removed
             java.util.Iterator<String> iter
                     = tm.getSystemNameAddedOrderList().iterator();
 

--- a/java/src/jmri/managers/configurexml/AbstractReporterManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractReporterManagerConfigXML.java
@@ -37,6 +37,7 @@ public abstract class AbstractReporterManagerConfigXML extends AbstractNamedBean
         setStoreElementClass(reporters);
         ReporterManager tm = (ReporterManager) o;
         if (tm != null) {
+            @SuppressWarnings("deprecation") // getSystemNameAddedOrderList() call needed until deprecated code removed
             java.util.Iterator<String> iter
                     = tm.getSystemNameAddedOrderList().iterator();
 

--- a/java/src/jmri/managers/configurexml/AbstractSensorManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractSensorManagerConfigXML.java
@@ -48,6 +48,7 @@ public abstract class AbstractSensorManagerConfigXML extends AbstractNamedBeanMa
             sensors.addContent(elem);
         }
 
+        @SuppressWarnings("deprecation") // getSystemNameAddedOrderList() call needed until deprecated code removed
         java.util.Iterator<String> iter = tm.getSystemNameAddedOrderList().iterator();
 
         // don't return an element if there are not sensors to include

--- a/java/src/jmri/managers/configurexml/AbstractTurnoutManagerConfigXML.java
+++ b/java/src/jmri/managers/configurexml/AbstractTurnoutManagerConfigXML.java
@@ -48,6 +48,7 @@ public abstract class AbstractTurnoutManagerConfigXML extends AbstractNamedBeanM
             TurnoutOperationManagerXml tomx = new TurnoutOperationManagerXml();
             Element opElem = tomx.store(InstanceManager.getDefault(TurnoutOperationManager.class));
             turnouts.addContent(opElem);
+            @SuppressWarnings("deprecation") // getSystemNameAddedOrderList() call needed until deprecated code removed
             java.util.Iterator<String> iter
                     = tm.getSystemNameAddedOrderList().iterator();
 

--- a/java/test/jmri/BlockTest.java
+++ b/java/test/jmri/BlockTest.java
@@ -282,14 +282,14 @@ public class BlockTest {
 
     @Test
     public void testReporterAdd() {
-        ReporterManager rm = jmri.InstanceManager.reporterManagerInstance();
+        ReporterManager rm = jmri.InstanceManager.getDefault(ReporterManager.class);
         Block b = new Block("SystemName");
         b.setReporter(rm.provideReporter("IR22"));
     }
 
     @Test
     public void testReporterInvokeAll() {
-        ReporterManager rm = jmri.InstanceManager.reporterManagerInstance();
+        ReporterManager rm = jmri.InstanceManager.getDefault(ReporterManager.class);
         count = 0;
         Block b = new Block("SystemName") {
             @Override
@@ -306,7 +306,7 @@ public class BlockTest {
 
     @Test
     public void testReporterInvokeCurrent() {
-        ReporterManager rm = jmri.InstanceManager.reporterManagerInstance();
+        ReporterManager rm = jmri.InstanceManager.getDefault(ReporterManager.class);
         count = 0;
         Block b = new Block("SystemName") {
             @Override
@@ -328,7 +328,7 @@ public class BlockTest {
 
     @Test
     public void testReporterInvokeLast() {
-        ReporterManager rm = jmri.InstanceManager.reporterManagerInstance();
+        ReporterManager rm = jmri.InstanceManager.getDefault(ReporterManager.class);
         count = 0;
         Block b = new Block("SystemName") {
             @Override

--- a/java/test/jmri/jmrix/dccpp/DCCppReplyTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppReplyTest.java
@@ -42,13 +42,11 @@ public class DCCppReplyTest extends jmri.jmrix.AbstractMessageTestBase {
 
     // check get service mode CV Number response code.
     @Test
-    @Ignore("Method is not implemented")
     public void testGetServiceModeCVNumber() {
     }
 
     // check get service mode CV Value response code.
     @Test
-    @Ignore("Method is not implemented")
     public void testGetServiceModeCVValue() {
     }
     

--- a/java/test/jmri/jmrix/easydcc/EasyDccPowerManagerTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccPowerManagerTest.java
@@ -88,13 +88,12 @@ public class EasyDccPowerManagerTest extends AbstractPowerManagerTestBase {
     // state readback by sending messages & getting a reply
     @Override
     @Test
-    @Ignore("no unsolicited messages, so skip test")
     public void testStateOn() throws JmriException {
     }
 
     @Override
     @Test
-    @Ignore("no unsolicited messages, so skip test")
+    // no unsolicited messages, so suppress test
     public void testStateOff() throws JmriException {
     }
 

--- a/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
@@ -524,7 +524,7 @@ public class OlcbClockControlTest {
 
     @Test(timeout=1000)
     public void thisTestDidNotKillJemmy() throws Exception {
-        new org.netbeans.jemmy.QueueTool().waitEmpty(100);
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
     }
 
     private final static Logger log = LoggerFactory.getLogger(OlcbClockControlTest.class);

--- a/java/test/jmri/jmrix/pi/configurexml/RaspberryPiConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/pi/configurexml/RaspberryPiConnectionConfigXmlTest.java
@@ -27,7 +27,6 @@ public class RaspberryPiConnectionConfigXmlTest extends jmri.jmrix.configurexml.
     }
 
     @Test
-    @Ignore("needs mock pi setup")
     public void getInstanceTest() {
     }
 

--- a/java/test/jmri/jmrix/roco/RocoXNetThrottleTest.java
+++ b/java/test/jmri/jmrix/roco/RocoXNetThrottleTest.java
@@ -60,91 +60,91 @@ public class RocoXNetThrottleTest extends jmri.jmrix.lenz.XNetThrottleTest {
 
     // Test the initilization sequence.
     @Override
-    @Ignore("parent class method creates a new throttle")
+    // empty override because parent class method creates a new throttle
     @Test(timeout=1000)
     public void testInitSequenceNormalUnitSpeedStep128() throws Exception {
     }
 
     @Override
-    @Ignore("parent class method creates a new throttle")
+    // empty override because parent class method creates a new throttle
     @Test(timeout=1000)
     public void initSequenceNormalUnitSpeedStep14() throws Exception {
     }
 
     @Override
-    @Ignore("parent class method creates a new throttle")
+    // empty override because parent class method creates a new throttle
     @Test(timeout=1000)
     public void initSequenceMUAddress28SpeedStep() throws Exception {
     }
 
     @Override
-    @Ignore("parent class method creates a new throttle")
+    // empty override because parent class method creates a new throttle
     @Test(timeout=1000)
     public void initSequenceMuedUnitSpeedStep128() throws Exception {
     }
 
     @Override
-    @Ignore("parent class method creates a new throttle")
+    // empty override because parent class method creates a new throttle
     @Test(timeout=1000)
     public void initSequenceDHUnitSpeedStep27() throws Exception {
     }
 
     @Override
-    @Ignore("only one software version for Roco")
+    // empty override because only one software version for Roco
     @Test(timeout=1000)
     public void testSendFunctionGroup5v35() throws Exception {
     }
 
     @Override
-    @Ignore("only one software version for Roco")
+    // empty override because only one software version for Roco
     @Test(timeout=1000)
     public void testSendFunctionGroup4v35() {
     }
 
     @Override
-    @Ignore("not supported by Roco")
+    // empty override because not supported by Roco
     @Test(timeout=1000)
     public void testSendMomentaryFunctionGroup1() {
     } 
 
     @Override
-    @Ignore("not supported by Roco")
+    // empty override because not supported by Roco
     @Test(timeout=1000)
     public void testSendMomentaryFunctionGroup2() {
     } 
 
     @Override
-    @Ignore("not supported by Roco")
+    // empty override because not supported by Roco
     @Test(timeout=1000)
     public void testSendMomentaryFunctionGroup3() {
     } 
 
     @Override
-    @Ignore("not supported by Roco")
+    // empty override because not supported by Roco
     @Test(timeout=1000)
     public void testSendMomentaryFunctionGroup4() {
     } 
 
     @Override
-    @Ignore("not supported by Roco")
+    // empty override because not supported by Roco
     @Test(timeout=1000)
     public void testSendMomentaryFunctionGroup5() {
     } 
 
     @Override
-    @Ignore("not supported by Roco")
+    // empty override because not supported by Roco
     @Test(timeout=1000)
     public void testSendFunctionHighMomentaryStatusRequest() throws Exception {
     } 
 
     @Override
-    @Ignore("never sent by Roco throttle support")
+    // empty override because not supported by Roco
     @Test(timeout=1000)
     public void testSendFunctionStatusInformationRequest() {
     } 
 
     @Override
-    @Ignore("never sent by Roco throttle support")
+    // empty override because not supported by Roco
     @Test(timeout=1000)
     public void testSendFunctionHighStatusInformationRequest() {
     } 


### PR DESCRIPTION
- Try `jemmy.QueueTool().waitEmpty()` instead of `jemmy.QueueTool().waitEmpty(100)` to fix consistent OpenLCB clock CI fails
- fix some deprecated method calls
- add `warnOnce` on some deprecated methods that will eventually be removed
- Remove some `@Ignore` notations on empty tests, made docs clearer
