### PR TITLE
System names for signal groups are not loaded from panel files (4.13.7)

### DIFF
--- a/java/src/jmri/managers/configurexml/DefaultSignalGroupManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultSignalGroupManagerXml.java
@@ -141,11 +141,7 @@ public class DefaultSignalGroupManagerXml
 
             String sys = getSystemName(e);
 
-            m = sgm.newSignalGroup(sys);
-
-            if (getUserName(e) != null) {
-                m.setUserName(getUserName(e));
-            }
+            m = sgm.provideSignalGroup(sys, getUserName(e));
 
             //loadCommon(m, e); // would store comment, now a separate element
             loadComment(m, e);


### PR DESCRIPTION
Merges @balazsracz's fix for #6310 "System names for signal groups are not loaded from panel files" into the release-4.13.7 branch:

When a panel file is loaded, signal groups are loaded slightly incorrectly.
The system name stored in the panel file is ignored, and it is always replaced with an IG:AUTO:#### value during load. (I think, but would need to confirm, that already existing IG:AUTO:#### values are also ignored and replaced with a different #### value).
User names are loaded fine.

Bug was introduced Nov 2018.
