### PR TITLE
Re: Jemmy waitEmpty

### DIFF
--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -1037,9 +1037,14 @@
             if you want to intermix Swing and test operations you can 
             synchronize the threads by calling 
 <pre style="font-family: monospace;">
-        new org.netbeans.jemmy.QueueTool().waitEmpty(20);
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
 </pre>
-            on the test thread. The argument (in this example 20) is
+            on the test thread. 
+            <p>
+            In some rare cases, you need to wait for the Swing
+            queue to stay empty for a non-zero interval.
+            In that case, use <code>waitEmpty(20)</code>.
+            where the argument (in this example 20) is
             how many milliseconds the queue has to remain empty before 
             proceeding.  We're not sure what the best value is; see
             <a href="https://github.com/JMRI/JMRI/issues/5321">Issue #5321</a> for some background discussion.

--- a/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbClockControlTest.java
@@ -524,7 +524,7 @@ public class OlcbClockControlTest {
 
     @Test(timeout=1000)
     public void thisTestDidNotKillJemmy() throws Exception {
-        new org.netbeans.jemmy.QueueTool().waitEmpty(100);
+        new org.netbeans.jemmy.QueueTool().waitEmpty();  // using 100 as argument has a high fail rate 2018-12-15
     }
 
     private final static Logger log = LoggerFactory.getLogger(OlcbClockControlTest.class);


### PR DESCRIPTION
- Update developer doc to recommend `waitEmpty()` over `waitEmpty(20)`

- Change to `waitEmpty()` in `OlcbClockControlTest` to reduce the number of false-negative results in CI tests.   See [this jmri-developers thread](https://jmri-developers.groups.io/g/jmri/message/742) and #5321 for background.