### PR TITLE
Fix flaky rosterservice test

### DIFF
--- a/java/test/jmri/server/json/roster/JsonRosterSocketServiceTest.java
+++ b/java/test/jmri/server/json/roster/JsonRosterSocketServiceTest.java
@@ -72,6 +72,7 @@ public class JsonRosterSocketServiceTest {
         Roster.getDefault().getEntriesInGroup(Roster.ALLENTRIES).stream().forEach((entry) -> {
             Assert.assertEquals(3, entry.getPropertyChangeListeners().length);
         });
+
         // list the groups in a JSON message for assertions
         this.connection.sendMessage((JsonNode) null);
         instance.onMessage(JsonRoster.ROSTER_GROUPS, this.connection.getObjectMapper().createObjectNode(), JSON.GET, Locale.ENGLISH);
@@ -82,6 +83,7 @@ public class JsonRosterSocketServiceTest {
         Assert.assertEquals("Two groups exist", 2, message.size());
         Assert.assertTrue("Contains group TestGroup1", message.findValuesAsText(JSON.NAME).contains("testGroup1"));
         Assert.assertTrue("Contains group AllEntries", message.findValuesAsText(JSON.NAME).contains(Roster.allEntries(Locale.ENGLISH)));
+
         // add a roster group and verify message sent by listener
         this.connection.sendMessage((JsonNode) null);
         Roster.getDefault().addRosterGroup("NewRosterGroup");
@@ -92,6 +94,7 @@ public class JsonRosterSocketServiceTest {
         Assert.assertTrue("Contains group TestGroup1", message.findValuesAsText(JSON.NAME).contains("testGroup1"));
         Assert.assertTrue("Contains group AllEntries", message.findValuesAsText(JSON.NAME).contains(Roster.allEntries(Locale.ENGLISH)));
         Assert.assertTrue("Contains group NewRosterGroup", message.findValuesAsText(JSON.NAME).contains("NewRosterGroup"));
+
         // rename a roster group and verify message sent by listener
         this.connection.sendMessage((JsonNode) null);
         Roster.getDefault().getRosterGroups().get("NewRosterGroup").setName("AgedRosterGroup");
@@ -103,6 +106,7 @@ public class JsonRosterSocketServiceTest {
         Assert.assertTrue("Contains group AllEntries", message.findValuesAsText(JSON.NAME).contains(Roster.allEntries(Locale.ENGLISH)));
         Assert.assertTrue("Contains group AgedRosterGroup", message.findValuesAsText(JSON.NAME).contains("AgedRosterGroup"));
         Assert.assertFalse("Contains group NewRosterGroup", message.findValuesAsText(JSON.NAME).contains("NewRosterGroup"));
+
         // remove a roster group and verify message sent by listener
         this.connection.sendMessage((JsonNode) null);
         Roster.getDefault().removeRosterGroup(Roster.getDefault().getRosterGroups().get("AgedRosterGroup"));
@@ -114,6 +118,7 @@ public class JsonRosterSocketServiceTest {
         Assert.assertTrue("Contains group AllEntries", message.findValuesAsText(JSON.NAME).contains(Roster.allEntries(Locale.ENGLISH)));
         Assert.assertFalse("Contains group NewRosterGroup", message.findValuesAsText(JSON.NAME).contains("AgedRosterGroup"));
         Assert.assertFalse("Contains group NewRosterGroup", message.findValuesAsText(JSON.NAME).contains("NewRosterGroup"));
+
         // Set unknown roster group directly as attribute of RosterEntry
         this.connection.sendMessage((JsonNode) null);
         RosterEntry re = Roster.getDefault().getEntryForId("testEntry1");
@@ -124,6 +129,7 @@ public class JsonRosterSocketServiceTest {
         }, "Expected message not sent");
         Assert.assertEquals("One message sent", 1, this.connection.getMessages().size());
         Assert.assertEquals("Message contains rosterEntry", JsonRoster.ROSTER_ENTRY, this.connection.getMessage().path(JSON.TYPE).asText());
+
         // Set known roster group directly as attribute of RosterEntry
         Roster.getDefault().addRosterGroup("NewRosterGroup");
         JUnitUtil.waitFor(() -> {
@@ -144,6 +150,7 @@ public class JsonRosterSocketServiceTest {
         Assert.assertArrayEquals("Objects are 1 rosterEntry and 4 rosterGroup",
                 new String[]{JsonRoster.ROSTER_ENTRY, JsonRoster.ROSTER_GROUP, JsonRoster.ROSTER_GROUP, JsonRoster.ROSTER_GROUP, JsonRoster.ROSTER_GROUP},
                 values.toArray(new String[5]));
+
         // Remove known roster group directly as attribute of RosterEntry
         this.connection.sendMessage((JsonNode) null); // clear out messages
         re.deleteAttribute(Roster.ROSTER_GROUP_PREFIX + "NewRosterGroup"); // remove group from roster entry

--- a/java/test/jmri/server/json/roster/JsonRosterSocketServiceTest.java
+++ b/java/test/jmri/server/json/roster/JsonRosterSocketServiceTest.java
@@ -120,7 +120,7 @@ public class JsonRosterSocketServiceTest {
         Assert.assertEquals("instance is listening to RosterEntry", 3, re.getPropertyChangeListeners().length);
         re.putAttribute(Roster.ROSTER_GROUP_PREFIX + "attribute", "yes");
                 JUnitUtil.waitFor(() -> {
-            return this.connection.getMessages().size() == 1;
+            return this.connection.getMessages().size() >= 1;
         }, "Expected message not sent");
         Assert.assertEquals("One message sent", 1, this.connection.getMessages().size());
         Assert.assertEquals("Message contains rosterEntry", JsonRoster.ROSTER_ENTRY, this.connection.getMessage().path(JSON.TYPE).asText());
@@ -133,7 +133,7 @@ public class JsonRosterSocketServiceTest {
         re.putAttribute(Roster.ROSTER_GROUP_PREFIX + "NewRosterGroup", "yes"); // add new group to roster entry
         // wait for all expected messages to be sent before testing messages are as expected
         JUnitUtil.waitFor(() -> {
-            return this.connection.getMessages().size() == 3;
+            return this.connection.getMessages().size() >= 3;
         }, "Three expected messages not sent");
         // Sent updated rosterEntry, rosterGroup, array of rosterGroup
         ArrayNode messages = this.connection.getMessages();
@@ -149,7 +149,7 @@ public class JsonRosterSocketServiceTest {
         re.deleteAttribute(Roster.ROSTER_GROUP_PREFIX + "NewRosterGroup"); // remove group from roster entry
         // wait for all expected messages to be sent before testing messages are as expected
         JUnitUtil.waitFor(() -> {
-            return this.connection.getMessages().size() == 3;
+            return this.connection.getMessages().size() >= 3;
         }, "Three expected messages not sent");
         // Sent updated rosterEntry, rosterGroup, array of rosterGroup
         messages = this.connection.getMessages();

--- a/java/test/jmri/server/json/roster/JsonRosterSocketServiceTest.java
+++ b/java/test/jmri/server/json/roster/JsonRosterSocketServiceTest.java
@@ -73,6 +73,10 @@ public class JsonRosterSocketServiceTest {
             Assert.assertEquals(3, entry.getPropertyChangeListeners().length);
         });
 
+        // wait for the initial Bean update notifications to drain from the queue. These generate
+        // output messages that we then throw away.
+        new org.netbeans.jemmy.QueueTool().waitEmpty();
+
         // list the groups in a JSON message for assertions
         this.connection.sendMessage((JsonNode) null);
         instance.onMessage(JsonRoster.ROSTER_GROUPS, this.connection.getObjectMapper().createObjectNode(), JSON.GET, Locale.ENGLISH);


### PR DESCRIPTION
Fixes JsonRosterSocketServiceTest having random failures on CI in the testListen method.

The problem was that during the initialization some property update notifications are enqueued
to the AWT thread. If the AWT thread falls behind due to random kernel scheudling,
these property update notifications turned into JSON messages which caused havoc
against the expectations.

Due to a too strict wording of the waitFor condition (size == 1 instead of size >=1),
the error was "message not sent" when in fact there were too many messages sent.