### PR TITLE
Fixes ConcurrentModificationExceptions in *ConnectionConfigXmlTestBase

### DIFF
--- a/java/test/jmri/jmrix/configurexml/AbstractConnectionConfigXmlTestBase.java
+++ b/java/test/jmri/jmrix/configurexml/AbstractConnectionConfigXmlTestBase.java
@@ -3,6 +3,8 @@ package jmri.jmrix.configurexml;
 import org.junit.*;
 import org.jdom2.Element;
 import jmri.jmrix.ConnectionConfig;
+import jmri.util.ThreadingUtil;
+
 import javax.swing.JPanel;
 
 /**
@@ -39,8 +41,11 @@ abstract public class AbstractConnectionConfigXmlTestBase extends jmri.configure
         jmri.util.JUnitUtil.resetProfileManager();
         // This test requires a configure manager.
         jmri.util.JUnitUtil.initConfigureManager();
-        cc.loadDetails(new JPanel());
-        cc.setDisabled(true); // so we don't try to start the connection on load.
+        // Running this on the UI thread fixes some ConcurrentModificationExceptions errors.
+        ThreadingUtil.runOnGUI(()-> {
+                    cc.loadDetails(new JPanel());
+                    cc.setDisabled(true); // so we don't try to start the connection on load.
+                });
         Element e = xmlAdapter.store(cc);
         try {
            //load what we just produced.

--- a/java/test/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXmlTestBase.java
+++ b/java/test/jmri/jmrix/configurexml/AbstractSerialConnectionConfigXmlTestBase.java
@@ -40,10 +40,12 @@ abstract public class AbstractSerialConnectionConfigXmlTestBase extends Abstract
         // This test requires a configure manager.
         jmri.util.JUnitUtil.initConfigureManager();
         // Running this on the UI thread fixes some ConcurrentModificationExceptions errors.
-        ThreadingUtil.runOnGUI(()->{cc.loadDetails(new JPanel());});
+        ThreadingUtil.runOnGUI(()->{
+            cc.loadDetails(new JPanel());
+            cc.setDisabled(true); // so we don't try to start the connection on load.
+        });
         // load details MAY produce an error message if no ports are found.
         jmri.util.JUnitAppender.suppressErrorMessage("No usable ports returned");
-        cc.setDisabled(true); // so we don't try to start the connection on load.
         Element e = xmlAdapter.store(cc);
         //load what we just produced.
         xmlAdapter.load(e,e);


### PR DESCRIPTION
Makes the different flavors of ConnectionConfigXmlTestBase be consistent in how they invoke the
code under test. Some of these generate ConcurrentModificationExceptions, while
others have been fixed.

These appeared as random failures in CI.