### PR TITLE
Add Accept All buttons to full-roster import

### DIFF
--- a/java/src/jmri/NamedBeanBundle.properties
+++ b/java/src/jmri/NamedBeanBundle.properties
@@ -252,6 +252,7 @@ FailedProfile           = (Profile Loading Failed)
 
 # Buttons used in multiple jmri.* packages
 ButtonOK                = OK
+ButtonAcceptAll         = Accept All
 ButtonCancel            = Cancel
 ButtonDelete            = Delete
 ButtonClear             = Clear

--- a/java/src/jmri/jmrit/roster/FullBackupImportAction.java
+++ b/java/src/jmri/jmrit/roster/FullBackupImportAction.java
@@ -15,20 +15,16 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 import jmri.util.FileUtil;
 import jmri.util.swing.WindowInterface;
 import org.jdom2.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Reload the JMRI Roster ({@link jmri.jmrit.roster.Roster}) from a file
+ * Reload the entire JMRI Roster ({@link jmri.jmrit.roster.Roster}) from a file
  * previously stored by {@link jmri.jmrit.roster.FullBackupExportAction}.
  * <p>
  * Does not currently handle importing the group(s) that the entry belongs to.
  *
- * @author Bob Jacobsen Copyright 2014
+ * @author Bob Jacobsen Copyright 2014, 2018
  */
 public class FullBackupImportAction extends ImportRosterItemAction {
-
-    private final static Logger log = LoggerFactory.getLogger(FullBackupImportAction.class);
 
     //private Component _who;
     public FullBackupImportAction(String s, WindowInterface wi) {
@@ -74,7 +70,7 @@ public class FullBackupImportAction extends ImportRosterItemAction {
         }
 
         String filename = chooser.getSelectedFile().getAbsolutePath();
-
+        
         try {
 
             inputfile = new FileInputStream(filename);
@@ -89,6 +85,9 @@ public class FullBackupImportAction extends ImportRosterItemAction {
             // entry call will return a ZipEntry for each file in the
             // stream
             ZipEntry entry;
+            boolean acceptAll = false; // skip prompting for each entry and accept all
+            boolean acceptAllDup = false;  // skip prompting for dups and accept all
+            
             while ((entry = zipper.getNextEntry()) != null) {
                 log.debug(String.format("Entry: %s len %d added %TD",
                         entry.getName(), entry.getSize(),
@@ -106,7 +105,9 @@ public class FullBackupImportAction extends ImportRosterItemAction {
                     mToID = lroot.getChild("locomotive").getAttributeValue("id");
 
                     // see if user wants to do it
-                    int retval = JOptionPane.showOptionDialog(mParent,
+                    int retval = 2; // accept if acceptall
+                    if (!acceptAll) {
+                        retval = JOptionPane.showOptionDialog(mParent,
                             Bundle.getMessage("ConfirmImportID", mToID),
                             Bundle.getMessage("ConfirmImport"),
                             0,
@@ -114,20 +115,29 @@ public class FullBackupImportAction extends ImportRosterItemAction {
                             null,
                             new Object[]{Bundle.getMessage("CancelImports"),
                                 Bundle.getMessage("Skip"),
-                                Bundle.getMessage("ButtonOK")},
+                                Bundle.getMessage("ButtonOK"),
+                                Bundle.getMessage("ButtonAcceptAll")},
                             null);
+                    }
                     if (retval == 0) {
+                        // cancel case
                         break;
                     }
                     if (retval == 1) {
+                        // skip case
                         continue;
+                    }
+                    if (retval == 3) {
+                        // accept all case
+                        acceptAll = true;
                     }
 
                     // see if duplicate
                     RosterEntry currentEntry = Roster.getDefault().getEntryForId(mToID);
 
                     if (currentEntry != null) {
-                        retval = JOptionPane.showOptionDialog(mParent,
+                        if (!acceptAllDup) {
+                            retval = JOptionPane.showOptionDialog(mParent,
                                 Bundle.getMessage("ConfirmImportDup", mToID),
                                 Bundle.getMessage("ConfirmImport"),
                                 0,
@@ -135,13 +145,21 @@ public class FullBackupImportAction extends ImportRosterItemAction {
                                 null,
                                 new Object[]{Bundle.getMessage("CancelImports"),
                                     Bundle.getMessage("Skip"),
-                                    Bundle.getMessage("ButtonOK")},
+                                    Bundle.getMessage("ButtonOK"),
+                                    Bundle.getMessage("ButtonAcceptAll")},
                                 null);
+                        }
                         if (retval == 0) {
+                            // cancel case
                             break;
                         }
                         if (retval == 1) {
+                            // skip case
                             continue;
+                        }
+                        if (retval == 3) {
+                            // accept all case
+                            acceptAllDup = true;
                         }
 
                         // turn file into backup
@@ -178,4 +196,6 @@ public class FullBackupImportAction extends ImportRosterItemAction {
         }
 
     }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FullBackupImportAction.class);
 }


### PR DESCRIPTION
Adds two Accept All buttons to the process for importing an entire roster:
- On the import dialog:  Clicking Accept All is the equivalent of clicking "OK" for the rest of the roster entries in that file
- On the duplicate-entry dialog: Clicking Accept All is the equivalent of clicking "OK" for the rest of the duplicate entries in that file

