### PR TITLE
Fix named current reply regex being too broad

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppConstants.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppConstants.java
@@ -134,8 +134,8 @@ public final class DCCppConstants {
     public final static String LIST_SENSORS_REPLY_REGEX = "\\s*Q\\s*(\\d+)\\s+(\\d+)\\s+([0,1])\\s*";
     public final static String PROGRAM_REPLY_REGEX = "\\s*r\\s*(\\d+)\\|(\\d+)\\|(\\d+)\\s+([-]*\\d+)\\s*";
     public final static String PROGRAM_BIT_REPLY_REGEX = "\\s*r\\s*(\\d+)\\|(\\d+)\\|(\\d+)\\s+(\\d+)\\s+(\\d+)\\s*";
-    public final static String CURRENT_REPLY_REGEX = "\\s*a\\s*(\\d+)";
-    public final static String CURRENT_REPLY_NAMED_REGEX = "\\s*a\\s*(\\w+)\\s*(\\d+)";
+    public final static String CURRENT_REPLY_REGEX = "\\s*a\\s*(\\d+)\\s*";
+    public final static String CURRENT_REPLY_NAMED_REGEX = "\\s*a\\s*(\\w*?[a-zA-Z])\\s*(\\d+)\\s*";
     public final static String TRACK_POWER_REPLY_REGEX = "\\s*p\\s*([0,1])\\s*";
     public final static String TRACK_POWER_REPLY_NAMED_REGEX = "\\s*p\\s*(\\d+)\\s+(\\w+)\\s*";
     public final static String SENSOR_REPLY_REGEX = "\\s*[Qq]\\s*(\\d+)\\s*";

--- a/java/test/jmri/jmrix/dccpp/DCCppReplyTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppReplyTest.java
@@ -95,14 +95,40 @@ public class DCCppReplyTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testNamedCurrentReply() {
         DCCppReply l = DCCppReply.parseDCCppReply("a MAIN 0");
+        Assert.assertTrue(l.isCurrentReply());
         Assert.assertTrue(l.isNamedCurrentReply());
         Assert.assertEquals('a', l.getOpCodeChar());
         Assert.assertEquals("0", l.getCurrentString());
 
         l = DCCppReply.parseDCCppReply("a MAIN 100");
+        Assert.assertTrue(l.isCurrentReply());
         Assert.assertTrue(l.isNamedCurrentReply());
         Assert.assertEquals('a', l.getOpCodeChar());
         Assert.assertEquals("100", l.getCurrentString());
+
+        l = DCCppReply.parseDCCppReply("aMAIN0");
+        Assert.assertTrue(l.isCurrentReply());
+        Assert.assertTrue(l.isNamedCurrentReply());
+        Assert.assertEquals('a', l.getOpCodeChar());
+        Assert.assertEquals("0", l.getCurrentString());
+
+        l = DCCppReply.parseDCCppReply("aMAIN41");
+        Assert.assertTrue(l.isCurrentReply());
+        Assert.assertTrue(l.isNamedCurrentReply());
+        Assert.assertEquals('a', l.getOpCodeChar());
+        Assert.assertEquals("41", l.getCurrentString());
+
+        l = DCCppReply.parseDCCppReply("a41");
+        Assert.assertTrue(l.isCurrentReply());
+        Assert.assertFalse(l.isNamedCurrentReply());
+        Assert.assertEquals('a', l.getOpCodeChar());
+        Assert.assertEquals("41", l.getCurrentString());
+
+        l = DCCppReply.parseDCCppReply("a 41");
+        Assert.assertTrue(l.isCurrentReply());
+        Assert.assertFalse(l.isNamedCurrentReply());
+        Assert.assertEquals('a', l.getOpCodeChar());
+        Assert.assertEquals("41", l.getCurrentString());
     }
 
     // The minimal setup for log4J


### PR DESCRIPTION
The `DCCppConstants.CURRENT_REPLY_NAMED_REGEX` was too broad, so it captured both named and unnamed current replies, making `DCCppReply.isNamedCurrentReply()` always return true for any current reply. Also added tests to `DCCppReplyTest` to verify this in the future. Fixes #6159.