### PR TITLE
WIP CAN + CBUS Tests

### DIFF
--- a/java/test/jmri/jmrix/can/CanMessageTest.java
+++ b/java/test/jmri/jmrix/can/CanMessageTest.java
@@ -41,6 +41,7 @@ public class CanMessageTest extends CanMRCommonTestBase {
     }
 
     @Test
+    @SuppressWarnings("unlikely-arg-type") // Both CanReply and CanMessage are CanFrame with custom equals
     public void testEqualsReply() {
         CanMessage m1 = new CanMessage(0, 0x12);
         m1.setExtended(true);
@@ -84,11 +85,23 @@ public class CanMessageTest extends CanMRCommonTestBase {
     }
 
     @Test
+    @SuppressWarnings("unlikely-arg-type") // Both CanReply and CanMessage are CanFrame with custom equals
+    public void testMessageFromReply() {
+        CanReply r = new CanReply(0x555);
+        r.setNumDataElements(2);
+        r.setElement(0, 0x01);
+        r.setElement(1, 0x82);
+        
+        CanMessage m = new CanMessage(r);
+        Assert.assertTrue("Header 0x555", m.getHeader() == 0x555);
+        Assert.assertTrue("2 Elements", m.getNumDataElements() == 2);
+        Assert.assertTrue("equals same", m.equals(r));
+    }
+
+    @Test
     public void testHeaderAccessors() {
         CanMessage m = new CanMessage(0x555);
-
         Assert.assertTrue("Header 0x555", m.getHeader() == 0x555);
-
     }
 
     @Test

--- a/java/test/jmri/jmrix/can/CanReplyTest.java
+++ b/java/test/jmri/jmrix/can/CanReplyTest.java
@@ -47,6 +47,7 @@ public class CanReplyTest extends CanMRCommonTestBase {
     }
 
     @Test
+    @SuppressWarnings("unlikely-arg-type") // Both CanReply and CanMessage are CanFrame with custom equals
     public void testEqualsMessage() {
         CanReply m1 = new CanReply();
         m1.setExtended(true);
@@ -86,6 +87,20 @@ public class CanReplyTest extends CanMRCommonTestBase {
         Assert.assertTrue("equals copy", m1.equals(new CanReply(m1)));
         Assert.assertTrue("equals same", m1.equals(m2));
         Assert.assertTrue("not equals diff Ext", !m1.equals(m3));
+    }
+
+    @Test
+    @SuppressWarnings("unlikely-arg-type") // Both CanReply and CanMessage are CanFrame with custom equals
+    public void testReplyFromMessage() {
+        CanMessage m = new CanMessage(0x555);
+        m.setNumDataElements(2);
+        m.setElement(0, 0x01);
+        m.setElement(1, 0x82);
+        
+        CanReply r = new CanReply(m);
+        Assert.assertTrue("Header 0x555", r.getHeader() == 0x555);
+        Assert.assertTrue("2 Elements", r.getNumDataElements() == 2);
+        Assert.assertTrue("equals same", r.equals(m));
     }
 
     @Test

--- a/java/test/jmri/jmrix/can/cbus/CbusMessageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusMessageTest.java
@@ -1,5 +1,8 @@
 package jmri.jmrix.can.cbus;
 
+import jmri.jmrix.can.CanMessage;
+import jmri.jmrix.can.CanReply;
+import jmri.jmrix.can.cbus.CbusConstants;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -8,7 +11,8 @@ import org.junit.Test;
 
 /**
  *
- * @author Paul Bender Copyright (C) 2017	
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2018
  */
 public class CbusMessageTest {
 
@@ -17,7 +21,256 @@ public class CbusMessageTest {
         CbusMessage t = new CbusMessage();
         Assert.assertNotNull("exists",t);
     }
+    
+    @Test
+    public void testOpcRangeToSTL() {
+        CanReply r = new CanReply();
+        r.setNumDataElements(1);
+        r.setElement(0, 0x93); // ARON OPC
+        CanReply m = CbusMessage.opcRangeToStl(r);
+        Assert.assertTrue("ARON OPC Changed", m.getElement(0) == 0x90); // ACON OPC
 
+        r = new CanReply();
+        r.setNumDataElements(1);
+        r.setElement(0, 0x94); // AROF OPC
+        m = CbusMessage.opcRangeToStl(r);
+        Assert.assertTrue("AROF OPC Changed", m.getElement(0) == 0x91); // ACOF OPC
+
+        r = new CanReply();
+        r.setNumDataElements(1);
+        r.setElement(0, 0x9d); // ARSON OPC
+        m = CbusMessage.opcRangeToStl(r);
+        Assert.assertTrue("ARSON OPC Changed", m.getElement(0) == 0x98); // ASON OPC
+
+        r = new CanReply();
+        r.setNumDataElements(1);
+        r.setElement(0, 0x9e); // ARSOF OPC
+        m = CbusMessage.opcRangeToStl(r);
+        Assert.assertTrue("ARSOF OPC Changed", m.getElement(0) == 0x99); // ASOF OPC
+        
+        r = new CanReply();
+        r.setNumDataElements(1);
+        r.setElement(0, 0x95); // EVULN OPC
+        m = CbusMessage.opcRangeToStl(r);
+        Assert.assertTrue("Other OPCs do not change", m.getElement(0) == 0x95); // EVULN OPC
+    }    
+    
+    @Test
+    public void testgetNodeNumberMessage() {
+        CanMessage m = new CanMessage(0x12);
+        m.setNumDataElements(5);
+        m.setElement(0, 0x90); // ACON OPC
+        m.setElement(1, 0xee);
+        m.setElement(2, 0x56);
+        m.setElement(3, 0x11);
+        m.setElement(4, 0x16);
+        Assert.assertTrue("Node calculated OK", CbusMessage.getNodeNumber(m) == 61014);
+        m.setElement(0, 0x95); // EVULN OPC
+        Assert.assertTrue("Not an event returns node 0", CbusMessage.getNodeNumber(m) == 0 );
+    }
+    
+    @Test
+    public void testgetNodeNumberReply() {
+        CanReply r = new CanReply();
+        r.setNumDataElements(5);
+        r.setElement(0, 0x90); // ACON OPC
+        r.setElement(1, 0xee);
+        r.setElement(2, 0x56);
+        r.setElement(3, 0x11);
+        r.setElement(4, 0x16);
+        Assert.assertTrue("Node calculated OK", CbusMessage.getNodeNumber(r) == 61014);
+        r.setElement(0, 0x95); // EVULN OPC
+        Assert.assertTrue("Not an event returns node 0", CbusMessage.getNodeNumber(r) == 0 );
+    }
+
+    @Test
+    public void testgetEventMessage() {
+        CanMessage m = new CanMessage(0x12);
+        m.setNumDataElements(5);
+        m.setElement(0, 0x90); // ACON OPC
+        m.setElement(1, 0xee);
+        m.setElement(2, 0x56);
+        m.setElement(3, 0x11);
+        m.setElement(4, 0x16);
+        Assert.assertTrue("Event calculated OK", CbusMessage.getEvent(m) == 4374);
+        m.setElement(0, 0x95); // EVULN OPC
+        Assert.assertTrue("Not an event returns node 0", CbusMessage.getEvent(m) == 0 );
+    }
+    
+    @Test
+    public void testgetEventReply() {
+        CanReply r = new CanReply();
+        r.setNumDataElements(5);
+        r.setElement(0, 0x90); // ACON OPC
+        r.setElement(1, 0xee);
+        r.setElement(2, 0x56);
+        r.setElement(3, 0x11);
+        r.setElement(4, 0x16);
+        Assert.assertTrue("Event calculated OK", CbusMessage.getEvent(r) == 4374);
+        r.setElement(0, 0x95); // EVULN OPC
+        Assert.assertTrue("Not an event returns node 0", CbusMessage.getEvent(r) == 0 );
+    }
+
+    @Test
+    public void testgetEventTypeMessage() {
+        CanMessage m = new CanMessage(0x12);
+        m.setNumDataElements(1);
+        m.setElement(0, 0x90); // ACON OPC
+        Assert.assertTrue("Event Type On", CbusMessage.getEventType(m) == CbusConstants.EVENT_ON);
+        m.setElement(0, 0x99); // ASOF OPC
+        Assert.assertTrue("Event Type Off", CbusMessage.getEventType(m) == CbusConstants.EVENT_OFF );
+    }
+
+    @Test
+    public void testgetEventTypeReply() {
+        CanReply r = new CanReply();
+        r.setNumDataElements(1);
+        r.setElement(0, 0x90); // ACON OPC
+        Assert.assertTrue("Event Type On", CbusMessage.getEventType(r) == CbusConstants.EVENT_ON);
+        r.setElement(0, 0x99); // ASOF OPC
+        Assert.assertTrue("Event Type Off", CbusMessage.getEventType(r) == CbusConstants.EVENT_OFF );
+    }
+
+    @Test
+    public void testisEventMessage() {
+        CanMessage m = new CanMessage(0x12);
+        m.setNumDataElements(1);
+        m.setElement(0, 0x90); // ACON OPC
+        Assert.assertTrue("Is Event", CbusMessage.isEvent(m) == true);
+        m.setElement(0, 0x95); // EVULN OPC
+        Assert.assertTrue("Is Not Event", CbusMessage.isEvent(m) == false );
+    }
+
+    @Test
+    public void testisEventReply() {
+        CanReply r = new CanReply(0x12);
+        r.setNumDataElements(1);
+        r.setElement(0, 0x90); // ACON OPC
+        Assert.assertTrue("Is Event", CbusMessage.isEvent(r) == true);
+        r.setElement(0, 0x95); // EVULN OPC
+        Assert.assertTrue("Is Not Event", CbusMessage.isEvent(r) == false );
+    }
+
+    @Test
+    public void testisShortMessage() {
+        CanMessage m = new CanMessage(0x12);
+        m.setNumDataElements(1);
+        m.setElement(0, 0x90); // ACON OPC
+        Assert.assertTrue("Is Not Short", CbusMessage.isShort(m) == false);
+        m.setElement(0, 0x99); // ASOF OPC
+        Assert.assertTrue("Is Short", CbusMessage.isShort(m) == true );
+    }
+
+    @Test
+    public void testisShortReply() {
+        CanReply r = new CanReply(0x12);
+        r.setNumDataElements(1);
+        r.setElement(0, 0x90); // ACON OPC
+        Assert.assertTrue("Is Not Short", CbusMessage.isShort(r) == false);
+        r.setElement(0, 0x99); // ASOF OPC
+        Assert.assertTrue("Is Short", CbusMessage.isShort(r) == true );
+    }
+
+    @Test
+    public void testtoAddressMessage() {
+        CanMessage m = new CanMessage(0x12);
+        m.setNumDataElements(5);
+        m.setElement(0, 0x90); // ACON OPC
+        m.setElement(1, 0xdd);
+        m.setElement(2, 0xab);
+        m.setElement(3, 0x4b);
+        m.setElement(4, 0xb3);
+
+        Assert.assertEquals("string toAddressMessageAcon", CbusMessage.toAddress(m),"+n56747e19379");
+        m.setElement(0, 0x91); // ACOF OPC
+        Assert.assertEquals("toAddressMessageAcof", CbusMessage.toAddress(m),"-n56747e19379" );
+        m.setElement(0, 0x98); // ASON OPC
+        Assert.assertEquals("toAddressMessageAson", CbusMessage.toAddress(m),"+19379" );
+        m.setElement(0, 0x99); // ASOF OPC
+        Assert.assertEquals("toAddressMessageAsof", CbusMessage.toAddress(m),"-19379" );
+        m.setElement(0, 0x9e); // ARSON OPC
+        Assert.assertEquals("toAddressMessageArson", CbusMessage.toAddress(m),"X9EDDAB4BB3" );
+    }
+    
+    @Test
+    public void testtoAddressReply() {
+        CanReply r = new CanReply(0x12);
+        r.setNumDataElements(5);
+        r.setElement(0, 0x90); // ACON OPC
+        r.setElement(1, 0xdd);
+        r.setElement(2, 0xab);
+        r.setElement(3, 0x4b);
+        r.setElement(4, 0xb3);
+
+        Assert.assertEquals("toAddressReplyAcon", CbusMessage.toAddress(r),"+n56747e19379");
+        r.setElement(0, 0x91); // ACOF OPC
+        Assert.assertEquals("toAddressReplyAcof", CbusMessage.toAddress(r),"-n56747e19379" );
+        r.setElement(0, 0x98); // ASON OPC
+        Assert.assertEquals("toAddressReplyAson", CbusMessage.toAddress(r),"+19379" );
+        r.setElement(0, 0x99); // ASOF OPC
+        Assert.assertEquals("toAddressReplyAsof", CbusMessage.toAddress(r),"-19379" );
+        r.setElement(0, 0x9e); // ARSON OPC
+        Assert.assertEquals("toAddressReplyArson", CbusMessage.toAddress(r),"X9EDDAB4BB3" );
+    }    
+    
+    @Test
+    public void testisRequestTrackOffMessage() {
+        CanMessage m = new CanMessage(0x12,1);
+        m.setElement(0, 0x08); // RTOF OPC
+        Assert.assertEquals("isRequestTrackOff Good Message", CbusMessage.isRequestTrackOff(m),true);
+        m = new CanMessage(0x12,1);
+        m.setElement(0, 0x09); // RTON OPC    
+        Assert.assertEquals("isRequestTrackOff Bad Message", CbusMessage.isRequestTrackOff(m),false);
+    }
+    
+    @Test
+    public void testisRequestTrackOnMessage() {
+        CanMessage m = new CanMessage(0x12,1);
+        m.setElement(0, 0x09); // RTON OPC
+        Assert.assertEquals("isRequestTrackOn Good Message", CbusMessage.isRequestTrackOn(m),true);
+        m = new CanMessage(0x12,1);
+        m.setElement(0, 0x08); // RTOF OPC    
+        Assert.assertEquals("isRequestTrackOn Bad Message", CbusMessage.isRequestTrackOn(m),false);
+    }
+
+    @Test
+    public void testisTrackOnReply() {
+        CanReply r = new CanReply(0x12);
+        r.setNumDataElements(1);
+        r.setElement(0, 0x05); // TON OPC
+        Assert.assertEquals("isRequestTrackOn Good Reply", CbusMessage.isTrackOn(r),true);
+        r = new CanReply(0x12);
+        r.setNumDataElements(1);
+        r.setElement(0, 0x04); // TOF OPC    
+        Assert.assertEquals("isRequestTrackOn Bad Reply", CbusMessage.isTrackOn(r),false);
+    }
+
+    @Test
+    public void testisTrackOffReply() {
+        CanReply r = new CanReply(0x12);
+        r.setNumDataElements(1);
+        r.setElement(0, 0x04); // TOF OPC
+        Assert.assertEquals("isRequestTrackOff Good Reply", CbusMessage.isTrackOff(r),true);
+        r = new CanReply(0x12);
+        r.setNumDataElements(1);
+        r.setElement(0, 0x05); // TON OPC    
+        Assert.assertEquals("isRequestTrackOff Bad Reply", CbusMessage.isTrackOff(r),false);
+    }    
+    
+    @Test
+    public void testgetRequestTrackOnMessage() {
+        CanMessage m = CbusMessage.getRequestTrackOn(0x12);
+        Assert.assertTrue("getRequestTrackOn OPC", m.getElement(0) == 0x09); // RTON OPC
+        Assert.assertTrue("getRequestTrackOn Length", m.getNumDataElements() == 1);
+    }
+    
+    @Test
+    public void testgetRequestTrackOffMessage() {
+        CanMessage m = CbusMessage.getRequestTrackOff(0x12);
+        Assert.assertTrue("getRequestTrackOff OPC", m.getElement(0) == 0x08); // RTON OPC
+        Assert.assertTrue("getRequestTrackOff Length", m.getNumDataElements() == 1);
+    }
+    
     // The minimal setup for log4J
     @Before
     public void setUp() {

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.can.cbus;
 
 import jmri.Sensor;
 import jmri.jmrix.can.CanMessage;
+import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.TestTrafficController;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.util.JUnitUtil;
@@ -33,7 +34,17 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
     }
 
     @Override
-    public void checkStatusRequestMsgSent() {}
+    public void checkStatusRequestMsgSent() {
+        Assert.assertTrue(new CbusAddress("X9A00000001").match(tc.rcvMessage));
+    }
+    
+    public void checkLongStatusRequestMsgSent() {
+        Assert.assertTrue(new CbusAddress("X923039D431").match(tc.rcvMessage));
+    }
+    
+    public void checkNoMsgSent() {
+        Assert.assertNull(tc.rcvMessage);
+    }
 
     @Test
     public void testIncomingChange() {
@@ -67,6 +78,31 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
         t.setKnownState(Sensor.INACTIVE);
         Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
         checkOffMsgSent();
+        
+        tc.rcvMessage = null;
+        t.setKnownState(Sensor.UNKNOWN);
+        Assert.assertTrue(t.getKnownState() == Sensor.UNKNOWN);
+        checkNoMsgSent();        
+
+        tc.rcvMessage = null;
+        t.setInverted(true);
+        t.setKnownState(Sensor.ACTIVE);
+        Assert.assertTrue(t.getKnownState() == Sensor.ACTIVE);
+        checkOffMsgSent();  
+
+        tc.rcvMessage = null;
+        t.setInverted(true);
+        t.setKnownState(Sensor.INACTIVE);
+        Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
+        checkOnMsgSent();
+        
+        tc.rcvMessage = null;
+        t.requestUpdateFromLayout();
+        checkStatusRequestMsgSent();
+
+        t = new CbusSensor("MS","+N12345E54321",tc);
+        t.requestUpdateFromLayout();
+        checkLongStatusRequestMsgSent();
     }
 
     @Test
@@ -74,69 +110,85 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
         Assert.assertTrue("create MSX0A;+N15E6", null != new CbusSensor("MS", "X0A;+N15E6", tc));
     }
 
-    
+    @Test
+    public void testNullEvent() {
+        try {
+            new CbusSensor("MS",null,tc);
+            Assert.fail("Should have thrown an exception");
+        } catch (NullPointerException e) {
+            Assert.assertTrue(true);
+        }
+    }
+
+
     @Test
     public void testCTorShortEventSingle() {
-        CbusSensor t = new CbusSensor("MS","+7",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","+7",tc);
+        Assert.assertNotNull("exists",t);
+    }
+    
+    @Test
+    public void testCTorShortEventSingleNegative() {
+        CbusSensor t = new CbusSensor("MS","-7",tc);
         Assert.assertNotNull("exists",t);
     }
     
     @Test
     public void testCTorShortEventDouble() {
-        CbusSensor t = new CbusSensor("MS","+1;-1",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","+1;-1",tc);
         Assert.assertNotNull("exists",t);
     }
 
 
     @Test
     public void testLongEventSingleNoN() {
-        CbusSensor t = new CbusSensor("MS","+654e321",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","+654e321",tc);
         Assert.assertNotNull("exists",t);
     }    
 
 
     @Test
     public void testLongEventDoubleNoN() {
-        CbusSensor t = new CbusSensor("MS","-654e321;+123e456",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","-654e321;+123e456",tc);
         Assert.assertNotNull("exists",t);
     }    
 
     
     @Test
     public void testCTorLongEventSingle() {
-        CbusSensor t = new CbusSensor("MS","+n654e321",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","+n654e321",tc);
         Assert.assertNotNull("exists",t);
     }    
     
     @Test
     public void testCTorLongEventDouble() {
-        CbusSensor t = new CbusSensor("MS","+N299E17;-N123E456",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","+N299E17;-N123E456",tc);
         Assert.assertNotNull("exists",t);
     }
     
     @Test
     public void testCTorHexEventJustOpsCode() {
-        CbusSensor t = new CbusSensor("MS","X04;X05",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","X04;X05",tc);
         Assert.assertNotNull("exists",t);
     }
 
     @Test
     public void testCTorHexEventOneByte() {
-        CbusSensor t = new CbusSensor("MS","X2301;X30FF",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","X2301;X30FF",tc);
         Assert.assertNotNull("exists",t);
     }
     
     
     @Test
     public void testCTorHexEventTwoByte() {
-        CbusSensor t = new CbusSensor("MS","X410001;X56FFFF",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","X410001;X56FFFF",tc);
         Assert.assertNotNull("exists",t);
     }
 
     
     @Test
     public void testCTorHexEventThreeByte() {
-        CbusSensor t = new CbusSensor("MS","X6000010001;X72FFFFFF",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","X6000010001;X72FFFFFF",tc);
         Assert.assertNotNull("exists",t);
     }    
     
@@ -144,32 +196,182 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
     
     @Test
     public void testCTorHexEventFourByte() {
-        CbusSensor t = new CbusSensor("MS","X9000010001;X91FFFFFFFF",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","X9000010001;X91FFFFFFFF",tc);
         Assert.assertNotNull("exists",t);
     }
 
 
     @Test
     public void testCTorHexEventFiveByte() {
-        CbusSensor t = new CbusSensor("MS","XB00D60010001;XB1FFFAAFFFFF",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","XB00D60010001;XB1FFFAAFFFFF",tc);
         Assert.assertNotNull("exists",t);
     }
 
 
     @Test
     public void testCTorHexEventSixByte() {
-        CbusSensor t = new CbusSensor("MS","XD00D0060010001;XD1FFFAAAFFFFFE",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","XD00D0060010001;XD1FFFAAAFFFFFE",tc);
         Assert.assertNotNull("exists",t);
     }
     
     
     @Test
     public void testCTorHexEventSevenByte() {
-        CbusSensor t = new CbusSensor("MS","XF00D0A0600100601;XF1FFFFAAFAFFFFFE",new TrafficControllerScaffold());
+        CbusSensor t = new CbusSensor("MS","XF00D0A0600100601;XF1FFFFAAFAFFFFFE",tc);
         Assert.assertNotNull("exists",t);
     }
     
-    
+    @Test
+    public void testShortEventSinglegetAddrActive() {
+        CbusSensor t = new CbusSensor("MS","+7",tc);
+        CanMessage m1 = t.getAddrActive();
+        CanMessage m2 = new CanMessage(tc.getCanid());
+        m2.setNumDataElements(5);
+        m2.setElement(0, 0x98); // ASON OPC
+        m2.setElement(1, 0x00);
+        m2.setElement(2, 0x00);
+        m2.setElement(3, 0x00);
+        m2.setElement(4, 0x07);
+        Assert.assertTrue("equals same", m1.equals(m2));
+    }
+
+    @Test
+    public void testShortEventSinglegetAddrInactive() {
+        CbusSensor t = new CbusSensor("MS","+7",tc);
+        CanMessage m1 = t.getAddrInactive();
+        CanMessage m2 = new CanMessage(tc.getCanid());
+        m2.setNumDataElements(5);
+        m2.setElement(0, 0x99); // ASOF OPC
+        m2.setElement(1, 0x00);
+        m2.setElement(2, 0x00);
+        m2.setElement(3, 0x00);
+        m2.setElement(4, 0x07);
+        Assert.assertTrue("equals same", m1.equals(m2));
+    }
+
+    @Test
+    public void testLongEventgetAddrActive() {
+        CbusSensor t = new CbusSensor("MS","+N54321E12345",tc);
+        CanMessage m1 = t.getAddrActive();
+        CanMessage m2 = new CanMessage(tc.getCanid());
+        m2.setNumDataElements(5);
+        m2.setElement(0, 0x90); // ACON OPC
+        m2.setElement(1, 0xd4);
+        m2.setElement(2, 0x31);
+        m2.setElement(3, 0x30);
+        m2.setElement(4, 0x39);
+        Assert.assertTrue("equals same", m1.equals(m2));
+    }
+
+    @Test
+    public void testLongEventgetAddrInactive() {
+        CbusSensor t = new CbusSensor("MS","+N54321E12345",tc);
+        CanMessage m1 = t.getAddrInactive();
+        CanMessage m2 = new CanMessage(tc.getCanid());
+        m2.setNumDataElements(5);
+        m2.setElement(0, 0x91); // ACOF OPC
+        m2.setElement(1, 0xd4);
+        m2.setElement(2, 0x31);
+        m2.setElement(3, 0x30);
+        m2.setElement(4, 0x39);
+        Assert.assertTrue("equals same", m1.equals(m2));
+        m2.setElement(0, 0x90); // ACON OPC
+        Assert.assertFalse("not equals same", m1.equals(m2));
+    }
+
+    @Test
+    public void testLongEventgetAddrActiveInverted() {
+        CbusSensor t = new CbusSensor("MS","+N54321E12345",tc);
+        t.setInverted(true);
+        CanMessage m1 = t.getAddrActive();
+        CanMessage m2 = new CanMessage(tc.getCanid());
+        m2.setNumDataElements(5);
+        m2.setElement(0, 0x91); // ACOF OPC
+        m2.setElement(1, 0xd4);
+        m2.setElement(2, 0x31);
+        m2.setElement(3, 0x30);
+        m2.setElement(4, 0x39);
+        Assert.assertTrue("equals same", m1.equals(m2));
+    }
+
+    @Test
+    public void testLongEventgetAddrInactiveInverted() {
+        CbusSensor t = new CbusSensor("MS","+N54321E12345",tc);
+        t.setInverted(true);
+        CanMessage m1 = t.getAddrInactive();
+        CanMessage m2 = new CanMessage(tc.getCanid());
+        m2.setNumDataElements(5);
+        m2.setElement(0, 0x90); // ACON OPC
+        m2.setElement(1, 0xd4);
+        m2.setElement(2, 0x31);
+        m2.setElement(3, 0x30);
+        m2.setElement(4, 0x39);
+        Assert.assertTrue("equals same", m1.equals(m2));
+    }
+
+    @Test
+    public void testSensorCanMessage() throws jmri.JmriException {
+        CbusSensor t = new CbusSensor("MS","+N54321E12345",tc);
+        CanMessage m = new CanMessage(tc.getCanid());
+        m.setNumDataElements(5);
+        m.setElement(0, 0x95); // EVULN OPC
+        m.setElement(1, 0xd4);
+        m.setElement(2, 0x31);
+        m.setElement(3, 0x30);
+        m.setElement(4, 0x39);
+        t.message(m);
+        Assert.assertTrue(t.getKnownState() == Sensor.UNKNOWN); 
+        
+        m.setElement(0, 0x90); // ACON OPC
+        t.message(m);
+        Assert.assertTrue(t.getKnownState() == Sensor.ACTIVE);
+        
+        m.setElement(0, 0x91); // ACOF OPC
+        t.message(m);
+        Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
+        
+        t.setInverted(true);
+        t.setKnownState(Sensor.UNKNOWN);
+        t.message(m);
+        Assert.assertTrue(t.getKnownState() == Sensor.ACTIVE);
+        
+        m.setElement(0, 0x90); // ACON OPC
+        t.setInverted(true);
+        t.message(m);
+        Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);    
+    }
+
+    @Test
+    public void testSensorCanReply() throws jmri.JmriException {
+        CbusSensor t = new CbusSensor("MS","+N54321E12345",tc);
+        CanReply r = new CanReply(tc.getCanid());
+        r.setNumDataElements(5);
+        r.setElement(0, 0x95); // EVULN OPC
+        r.setElement(1, 0xd4);
+        r.setElement(2, 0x31);
+        r.setElement(3, 0x30);
+        r.setElement(4, 0x39);
+        t.reply(r);
+        Assert.assertTrue(t.getKnownState() == Sensor.UNKNOWN);        
+        
+        r.setElement(0, 0x90); // ACON OPC
+        t.reply(r);
+        Assert.assertTrue(t.getKnownState() == Sensor.ACTIVE);
+        
+        r.setElement(0, 0x91); // ACOF OPC
+        t.reply(r);
+        Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
+        
+        t.setInverted(true);
+        t.setKnownState(Sensor.UNKNOWN);
+        t.reply(r);
+        Assert.assertTrue(t.getKnownState() == Sensor.ACTIVE);
+        
+        r.setElement(0, 0x90); // ACON OPC
+        t.setInverted(true);
+        t.reply(r);
+        Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);    
+    }
     
     // The minimal setup for log4J
     @Override
@@ -184,8 +386,8 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
     @Override
     @After
     public void tearDown() {
-	t.dispose();
-	tc=null;
+        t.dispose();
+        tc=null;
         JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutTest.java
@@ -1,7 +1,13 @@
 package jmri.jmrix.can.cbus;
 
+
+import jmri.jmrix.can.CanMessage;
+import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.Turnout;
 import jmri.util.JUnitUtil;
+// import jmri.util.PropertyChangeListenerScaffold;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -13,132 +19,264 @@ import org.junit.Test;
 /**
  *
  * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2018
  */
-public class CbusTurnoutTest { 
-// public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
+public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase {
 
+    private TrafficControllerScaffold tcis = null;
+    // protected PropertyChangeListenerScaffold l; 
+
+    @Override
+    public void checkClosedMsgSent() {
+        Assert.assertTrue(("[78] 99 00 00 00 01").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
+    }
+
+    @Override
+    public void checkThrownMsgSent() {
+        Assert.assertTrue(("[78] 98 00 00 00 01").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
+    }
+
+    @Override
+    public int numListeners() {
+        return tcis.numListeners();
+    }
+    
+    public void checkNoMsgSent(int previousSize) {
+        Assert.assertTrue( previousSize == tcis.outbound.size() );
+    }
+    
+    public void checkStatusRequestMsgSent() {
+        Assert.assertTrue(("[78] 9A 00 00 00 01").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
+    }    
+
+    public void checkLongStatusRequestMsgSent() {
+        Assert.assertTrue(("[78] 92 30 39 D4 31").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
+    } 
+    
+    @Test
+    @Override
+    public void testRequestUpdate() {
+
+        t.requestUpdateFromLayout();
+        checkStatusRequestMsgSent();
+
+        t = new CbusTurnout("MT","-N12345E54321",tcis);
+        t.requestUpdateFromLayout();
+        checkLongStatusRequestMsgSent();
+
+    }
+    
     @Test
     public void testNullEvent() {
         try {
-            new CbusTurnout("MT",null,new TrafficControllerScaffold());
+            new CbusTurnout("MT",null,tcis);
             Assert.fail("Should have thrown an exception");
         } catch (NullPointerException e) {
             Assert.assertTrue(true);
         }
     }
     
-    
     @Test
     public void testCTorShortEventSingle() {
-        CbusTurnout t = new CbusTurnout("MT","+7",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","+7",tcis);
         Assert.assertNotNull("exists",t);
     }
 
     @Test
     public void testCTorShortEventSinglePlus() {
-        CbusTurnout t = new CbusTurnout("MT","+2",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","+2",tcis);
         Assert.assertNotNull("exists",t);
     }
 
     @Test
     public void testCTorShortEventSingleMinus() {
-        CbusTurnout t = new CbusTurnout("MT","-2",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","-2",tcis);
         Assert.assertNotNull("exists",t);
     }    
     
     @Test
     public void testCTorShortEventDouble() {
-        CbusTurnout t = new CbusTurnout("MT","+1;-1",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","+1;-1",tcis);
         Assert.assertNotNull("exists",t);
     }
     
     
     @Test
     public void testLongEventSingleNoN() {
-        CbusTurnout t = new CbusTurnout("MT","+654e321",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","+654e321",tcis);
         Assert.assertNotNull("exists",t);
     }    
-
 
     @Test
     public void testLongEventDoubleNoN() {
-        CbusTurnout t = new CbusTurnout("MT","-654e321;+123e456",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","-654e321;+123e456",tcis);
         Assert.assertNotNull("exists",t);
     }    
     
-    
     @Test
     public void testCTorLongEventSingle() {
-        CbusTurnout t = new CbusTurnout("MT","+n654e321",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","+n654e321",tcis);
         Assert.assertNotNull("exists",t);
     }    
     
     @Test
     public void testCTorLongEventDouble() {
-        CbusTurnout t = new CbusTurnout("MT","+N299E17;-N123E456",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","+N299E17;-N123E456",tcis);
         Assert.assertNotNull("exists",t);
     }
     
     @Test
     public void testCTorHexEventJustOpsCode() {
-        CbusTurnout t = new CbusTurnout("MT","X04;X05",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","X04;X05",tcis);
         Assert.assertNotNull("exists",t);
     }
 
     @Test
     public void testCTorHexEventOneByte() {
-        CbusTurnout t = new CbusTurnout("MT","X2301;X30FF",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","X2301;X30FF",tcis);
         Assert.assertNotNull("exists",t);
     }
     
     @Test
     public void testCTorHexEventTwoByte() {
-        CbusTurnout t = new CbusTurnout("MT","X410001;X56FFFF",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","X410001;X56FFFF",tcis);
         Assert.assertNotNull("exists",t);
     }
 
     @Test
     public void testCTorHexEventThreeByte() {
-        CbusTurnout t = new CbusTurnout("MT","X6000010001;X72FFFFFF",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","X6000010001;X72FFFFFF",tcis);
         Assert.assertNotNull("exists",t);
     }    
     
     @Test
     public void testCTorHexEventFourByte() {
-        CbusTurnout t = new CbusTurnout("MT","X9000010001;X91FFFFFFFF",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","X9000010001;X91FFFFFFFF",tcis);
         Assert.assertNotNull("exists",t);
     }
     
     @Test
     public void testCTorHexEventFiveByte() {
-        CbusTurnout t = new CbusTurnout("MT","XB00D60010001;XB1FFFAAFFFFF",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","XB00D60010001;XB1FFFAAFFFFF",tcis);
         Assert.assertNotNull("exists",t);
     }
 
     @Test
     public void testCTorHexEventSixByte() {
-        CbusTurnout t = new CbusTurnout("MT","XD00D0060010001;XD1FFFAAAFFFFFE",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","XD00D0060010001;XD1FFFAAAFFFFFE",tcis);
         Assert.assertNotNull("exists",t);
     }
     
     @Test
     public void testCTorHexEventSevenByte() {
-        CbusTurnout t = new CbusTurnout("MT","XF00D0A0600100601;XF1FFFFAAFAFFFFFE",new TrafficControllerScaffold());
+        CbusTurnout t = new CbusTurnout("MT","XF00D0A0600100601;XF1FFFFAAFAFFFFFE",tcis);
         Assert.assertNotNull("exists",t);
     }
 
-    
+    @Test
+    public void testShortEventSinglegetAddrThrown() {
+        CbusTurnout t = new CbusTurnout("MT","+7",tcis);
+        CanMessage m1 = t.getAddrThrown();
+        CanMessage m2 = new CanMessage(tcis.getCanid());
+        m2.setNumDataElements(5);
+        m2.setElement(0, 0x98); // ASON OPC
+        m2.setElement(1, 0x00);
+        m2.setElement(2, 0x00);
+        m2.setElement(3, 0x00);
+        m2.setElement(4, 0x07);
+        Assert.assertTrue("equals same", m1.equals(m2));
+    }
+
+    @Test
+    public void testShortEventSinglegetAddrClosed() {
+        CbusTurnout t = new CbusTurnout("MT","+7",tcis);
+        CanMessage m1 = t.getAddrClosed();
+        CanMessage m2 = new CanMessage(tcis.getCanid());
+        m2.setNumDataElements(5);
+        m2.setElement(0, 0x99); // ASOF OPC
+        m2.setElement(1, 0x00);
+        m2.setElement(2, 0x00);
+        m2.setElement(3, 0x00);
+        m2.setElement(4, 0x07);
+        Assert.assertTrue("equals same", m1.equals(m2));
+    }
+
+    @Test
+    public void testLongEventgetAddrThrown() {
+        CbusTurnout t = new CbusTurnout("MT","+N54321E12345",tcis);
+        CanMessage m1 = t.getAddrThrown();
+        CanMessage m2 = new CanMessage(tcis.getCanid());
+        m2.setNumDataElements(5);
+        m2.setElement(0, 0x90); // ACON OPC
+        m2.setElement(1, 0xd4);
+        m2.setElement(2, 0x31);
+        m2.setElement(3, 0x30);
+        m2.setElement(4, 0x39);
+        Assert.assertTrue("equals same", m1.equals(m2));
+    }
+
+    @Test
+    public void testLongEventgetAddrClosed() {
+        CbusTurnout t = new CbusTurnout("MT","+N54321E12345",tcis);
+        CanMessage m1 = t.getAddrClosed();
+        CanMessage m2 = new CanMessage(tcis.getCanid());
+        m2.setNumDataElements(5);
+        m2.setElement(0, 0x91); // ACOF OPC
+        m2.setElement(1, 0xd4);
+        m2.setElement(2, 0x31);
+        m2.setElement(3, 0x30);
+        m2.setElement(4, 0x39);
+        Assert.assertTrue("equals same", m1.equals(m2));
+        m2.setElement(0, 0x90); // ACON OPC
+        Assert.assertFalse("not equals same", m1.equals(m2));
+    }
+
+    @Test
+    public void testLongEventgetAddrThrownInverted() {
+        CbusTurnout t = new CbusTurnout("MT","+N54321E12345",tcis);
+        t.setInverted(true);
+        CanMessage m1 = t.getAddrThrown();
+        CanMessage m2 = new CanMessage(tcis.getCanid());
+        m2.setNumDataElements(5);
+        m2.setElement(0, 0x91); // ACOF OPC
+        m2.setElement(1, 0xd4);
+        m2.setElement(2, 0x31);
+        m2.setElement(3, 0x30);
+        m2.setElement(4, 0x39);
+        Assert.assertTrue("equals same", m1.equals(m2));
+    }
+
+    @Test
+    public void testLongEventgetAddrClosedInverted() {
+        CbusTurnout t = new CbusTurnout("MT","+N54321E12345",tcis);
+        t.setInverted(true);
+        CanMessage m1 = t.getAddrClosed();
+        CanMessage m2 = new CanMessage(tcis.getCanid());
+        m2.setNumDataElements(5);
+        m2.setElement(0, 0x90); // ACON OPC
+        m2.setElement(1, 0xd4);
+        m2.setElement(2, 0x31);
+        m2.setElement(3, 0x30);
+        m2.setElement(4, 0x39);
+        Assert.assertTrue("equals same", m1.equals(m2));
+    }
+
     // The minimal setup for log4J
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        // load dummy TrafficController
+        tcis = new TrafficControllerScaffold();
+        t = new CbusTurnout("MT", "+1;-1", tcis);
+        // l = new PropertyChangeListenerScaffold();
     }
 
     @After
     public void tearDown() {
+        t.dispose();
+        tcis=null;
+        // l = null;
         JUnitUtil.tearDown();
     }
-
     // private final static Logger log = LoggerFactory.getLogger(CbusTurnoutTest.class);
-
 }


### PR DESCRIPTION
A first attempt at test writing, wondering which is preferred?

[java.test.jmri.jmrix.can.TestTrafficController](https://github.com/JMRI/JMRI/blob/master/java/test/jmri/jmrix/can/TestTrafficController.java) or
[java.test.jmri.jmrix.can.TrafficControllerScaffold](https://github.com/JMRI/JMRI/blob/master/java/test/jmri/jmrix/can/TrafficControllerScaffold.java)

( both extend TrafficController )

Ideally I was looking for a loopback so that tests could send CanMessages ( and CanReply ), 
with a listener being attached to turnouts etc. similar to the openlcb turnout tests.

I did try adding notifyMessage(m, l); to the CanMessage methods in the tc's but they didn't forward the message.
Assuming it needs a system memo, is there a good example to use for a test environment?
I see olcb uses an interface model, should I create one of these for CBUS?