### PR TITLE
Fix changed error message in liusbserver

### DIFF
--- a/java/test/jmri/jmrix/lenz/liusbserver/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/lenz/liusbserver/configurexml/ConnectionConfigXmlTest.java
@@ -35,7 +35,7 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractNet
     @Test
     public void getInstanceTest() {
        super.getInstanceTest();
-       JUnitAppender.assertErrorMessageStartsWith("error opening network connection:");
+       JUnitAppender.assertErrorMessageStartsWith("Error opening network connection:");
        JUnitAppender.assertErrorMessageStartsWith("init (pipe)");
        JUnitAppender.assertErrorMessageStartsWith("Error connecting or configuring port.");
     }


### PR DESCRIPTION
Fixes this error message on Travis and AppVeyor:

```
jmri.jmrix.lenz.liusbserver.configurexml.ConnectionConfigXmlTest.getInstanceTest(jmri.jmrix.lenz.liusbserver.configurexml.ConnectionConfigXmlTest)
Run 1: ConnectionConfigXmlTest.getInstanceTest:38 Looking for ERROR message "error opening network connection:" got "Error opening network connection: Connection refused (Connection refused)"
Run 2: ConnectionConfigXmlTest.tearDown:32 Unexpected ERROR or higher messages emitted
```