### PR TITLE
Update destination SignalMast warning message

### DIFF
--- a/java/src/jmri/implementation/DefaultSignalMastLogic.java
+++ b/java/src/jmri/implementation/DefaultSignalMastLogic.java
@@ -145,7 +145,8 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
     @Override
     public void setDestinationMast(SignalMast dest) {
         if (destList.containsKey(dest)) {
-            log.warn("Destination mast '{}' was already defined in SML with this source mast", dest.getDisplayName());
+            // if already present, not a change
+            log.debug("Destination mast '{}' was already defined in SML with this source mast", dest.getDisplayName());
             return;
         }
         int oldSize = destList.size();


### PR DESCRIPTION
It's OK to re-add same destination mast, so lower message logged in that case from WARN to DEBUG.