### PR TITLE
Fix deadlock during macOS testing

### DIFF
--- a/java/test/jmri/jmrit/operations/rollingstock/cars/tools/ImportCarsTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/tools/ImportCarsTest.java
@@ -73,24 +73,16 @@ public class ImportCarsTest extends OperationsTestCase {
 
         // do import
 
-        Thread mb = new ImportCars();
+        Thread mb = new ImportCars(){
+            protected File getFile() {
+                // replace JFileChooser with fixed file to avoid threading issues
+                return new File(OperationsXml.getFileLocation()+OperationsXml.getOperationsDirectoryName() + File.separator + ExportCars.getOperationsFileName());
+            }
+        };
         mb.setName("Test Import Cars"); // NOI18N
         mb.start();
 
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return mb.getState().equals(Thread.State.WAITING);
-        }, "wait for file chooser");
-
-        // opens file chooser path "operations" "JUnitTest"
-        JFileChooserOperator fco = new JFileChooserOperator();
-        String path = OperationsXml.getOperationsDirectoryName();
-        fco.chooseFile(path + File.separator + ExportCars.getOperationsFileName());
-
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return mb.getState().equals(Thread.State.WAITING);
-        }, "wait for dialog");
-
-        // import complete 
+        // wait for import complete and acknowledge
         JemmyUtil.pressDialogButton(Bundle.getMessage("SuccessfulImport"), Bundle.getMessage("ButtonOK"));
 
         try {

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/tools/ImportEnginesTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/tools/ImportEnginesTest.java
@@ -72,22 +72,14 @@ public class ImportEnginesTest extends OperationsTestCase {
         Assert.assertEquals("engines", 0, emanager.getNumEntries());
 
         // do import      
-        Thread mb = new ImportEngines();
+        Thread mb = new ImportEngines(){
+            protected File getFile() {
+                // replace JFileChooser with fixed file to avoid threading issues
+                return new File(OperationsXml.getFileLocation()+OperationsXml.getOperationsDirectoryName() + File.separator + ExportEngines.getOperationsFileName());
+            }
+        };
         mb.setName("Test Import Engines"); // NOI18N
         mb.start();
-
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return mb.getState().equals(Thread.State.WAITING);
-        }, "wait for file chooser");
-
-        // opens file chooser path "operations" "JUnitTest"
-        JFileChooserOperator fco = new JFileChooserOperator();
-        String path = OperationsXml.getOperationsDirectoryName();
-        fco.chooseFile(path + File.separator + ExportEngines.getOperationsFileName());
-        
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return mb.getState().equals(Thread.State.WAITING);
-        }, "wait for dialog");
 
         // dialog windows should now open asking to add 2 models
         JemmyUtil.pressDialogButton(Bundle.getMessage("engineAddModel"), Bundle.getMessage("ButtonYes"));
@@ -167,22 +159,14 @@ public class ImportEnginesTest extends OperationsTestCase {
         lmanager.deregister(loc);
 
         // do import      
-        Thread mb = new ImportEngines();
+        Thread mb = new ImportEngines(){
+            protected File getFile() {
+                // replace JFileChooser with fixed file to avoid threading issues
+                return new File(OperationsXml.getFileLocation()+OperationsXml.getOperationsDirectoryName() + File.separator + ExportEngines.getOperationsFileName());
+            }
+        };
         mb.setName("Test Import Engines"); // NOI18N
         mb.start();
-
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return mb.getState().equals(Thread.State.WAITING);
-        }, "wait for file chooser");
-
-        // opens file chooser path "operations" "JUnitTest"
-        JFileChooserOperator fco = new JFileChooserOperator();
-        String path = OperationsXml.getOperationsDirectoryName();
-        fco.chooseFile(path + File.separator + ExportEngines.getOperationsFileName());
-        
-        jmri.util.JUnitUtil.waitFor(() -> {
-            return mb.getState().equals(Thread.State.WAITING);
-        }, "wait for dialog window to appear");
 
         // dialog windows should now open asking to add 2 models
         JemmyUtil.pressDialogButton(Bundle.getMessage("engineAddModel"), Bundle.getMessage("ButtonYes"));


### PR DESCRIPTION
Update three operations tests to avoid a deadlock during testing on macOS.

The change is to bypass use of a JFileChooser to determine the input file for import operations.  This is involved from a non-Swing thread, which (at least on macOS) means that Jemmy sometimes deadlocks will attempting to set the JFileChooser contents.  It also sometimes just hangs, leaving the  JFileChooser open without a selection.