### PR TITLE
Dispose of SPROG test threads

### DIFF
--- a/help/en/html/doc/Technical/StartUpScripts.shtml
+++ b/help/en/html/doc/Technical/StartUpScripts.shtml
@@ -162,7 +162,10 @@
             <dd>If true, makes jmri.util.JUnitUtil.checkSetUpTearDownSequence more verbose by also
                 including the current stack trace along with the traces of the most recent setUp and 
                 tearDown calls.</dd>
-      </dl>
+         <dt>jmri.util.JUnitUtil.checkRemnantThreads</dt>
+            <dd>If true, checks for any threads that have not yet been terminated during 
+                the test tearDown processing. If found, the context is logged as a warning.</dd>
+     </dl>
 
       <h2 id="Linux">Linux</h2>
 

--- a/java/src/jmri/jmrix/sprog/SprogTrafficController.java
+++ b/java/src/jmri/jmrix/sprog/SprogTrafficController.java
@@ -66,6 +66,7 @@ public class SprogTrafficController implements SprogInterface, SerialPortEventLi
         tcThread.setName("SPROG TC thread");
         tcThread.setPriority(Thread.MAX_PRIORITY-1);
         tcThread.setDaemon(true);
+        log.debug("starting TC thread from {} in group {}", this, tcThread.getThreadGroup(), jmri.util.Log4JUtil.shortenStacktrace(new Exception("traceback"),6));
         tcThread.start();
     }
 
@@ -288,6 +289,7 @@ public class SprogTrafficController implements SprogInterface, SerialPortEventLi
                 }
             } catch (InterruptedException e) {
                 log.debug("waitingForReply interrupted");
+                return;
             }
             if (!replyAvailable) {
                 // Timed out

--- a/java/test/jmri/jmrix/sprog/SprogSystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/sprog/SprogSystemConnectionMemoTest.java
@@ -38,6 +38,7 @@ public class SprogSystemConnectionMemoTest extends jmri.jmrix.SystemConnectionMe
        m.setSprogMode(SprogMode.SERVICE);
        m.configureCommandStation();
        Assert.assertNotNull("Command Station",m.getCommandStation());
+       tc.dispose();
    }
 
    @Override
@@ -61,16 +62,18 @@ public class SprogSystemConnectionMemoTest extends jmri.jmrix.SystemConnectionMe
     public void setUp() {
         JUnitUtil.setUp();
         SprogSystemConnectionMemo memo = new SprogSystemConnectionMemo(jmri.jmrix.sprog.SprogConstants.SprogMode.OPS);
-        SprogTrafficController stcs = new SprogTrafficControlScaffold(memo);
+        stcs = new SprogTrafficControlScaffold(memo);
         memo.setSprogTrafficController(stcs);
         memo.configureManagers();
         scm = memo;
     }
 
+    private SprogTrafficController stcs;
+    
     @Override
     @After
     public void tearDown() {
-        ((SprogSystemConnectionMemo)scm).getSprogTrafficController().dispose();
+        stcs.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/sprog/pi/pisprognano/ConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprognano/ConnectionConfigTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.pi.pisprognano;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -24,6 +25,15 @@ public class ConnectionConfigTest extends jmri.jmrix.AbstractSerialConnectionCon
 
    @After
    public void tearDown(){
+        if (cc != null) {
+            if (cc.getAdapter() != null) {
+                if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                    if (((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null) {
+                        ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+                    }
+                }
+            }
+        }
         cc=null;
         JUnitUtil.tearDown();
    }

--- a/java/test/jmri/jmrix/sprog/pi/pisprognano/PiSprogNanoSerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprognano/PiSprogNanoSerialDriverAdapterTest.java
@@ -21,7 +21,7 @@ public class PiSprogNanoSerialDriverAdapterTest {
        Assert.assertNotNull(a);
  
        // clean up
-       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
+       a.getSystemConnectionMemo().getSprogTrafficController().dispose();
   }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/sprog/pi/pisprognano/PiSprogNanoSerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprognano/PiSprogNanoSerialDriverAdapterTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.pi.pisprognano;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -18,7 +19,10 @@ public class PiSprogNanoSerialDriverAdapterTest {
    public void ConstructorTest(){
        PiSprogNanoSerialDriverAdapter a = new PiSprogNanoSerialDriverAdapter();
        Assert.assertNotNull(a);
-   }
+ 
+       // clean up
+       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
+  }
 
     // The minimal setup for log4J
     @Before

--- a/java/test/jmri/jmrix/sprog/pi/pisprognano/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprognano/configurexml/ConnectionConfigXmlTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.sprog.pi.pisprognano.configurexml;
 
 import jmri.util.JUnitUtil;
 import org.junit.*;
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.jmrix.sprog.pi.pisprognano.ConnectionConfig;
 
 /**
@@ -23,6 +24,14 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSer
 
     @After
     public void tearDown() {
+        // if we've started a traffic controller, dispose of it
+        if (cc.getAdapter() != null) {
+            if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                if ( ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null)
+                    ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+            }
+        }
+
         JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;

--- a/java/test/jmri/jmrix/sprog/pi/pisprogone/ConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprogone/ConnectionConfigTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.pi.pisprogone;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -24,6 +25,15 @@ public class ConnectionConfigTest extends jmri.jmrix.AbstractSerialConnectionCon
 
    @After
    public void tearDown(){
+        if (cc != null) {
+            if (cc.getAdapter() != null) {
+                if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                    if (((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null) {
+                        ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+                    }
+                }
+            }
+        }
         cc=null;
         JUnitUtil.tearDown();
    }

--- a/java/test/jmri/jmrix/sprog/pi/pisprogone/PiSprogOneSerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprogone/PiSprogOneSerialDriverAdapterTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.pi.pisprogone;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -18,6 +19,9 @@ public class PiSprogOneSerialDriverAdapterTest {
    public void ConstructorTest(){
        PiSprogOneSerialDriverAdapter a = new PiSprogOneSerialDriverAdapter();
        Assert.assertNotNull(a);
+
+       // clean up
+       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
    }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/sprog/pi/pisprogone/PiSprogOneSerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprogone/PiSprogOneSerialDriverAdapterTest.java
@@ -21,7 +21,7 @@ public class PiSprogOneSerialDriverAdapterTest {
        Assert.assertNotNull(a);
 
        // clean up
-       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
+       a.getSystemConnectionMemo().getSprogTrafficController().dispose();
    }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/sprog/pi/pisprogone/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprogone/configurexml/ConnectionConfigXmlTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.sprog.pi.pisprogone.configurexml;
 
 import jmri.util.JUnitUtil;
 import org.junit.*;
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.jmrix.sprog.pi.pisprogone.ConnectionConfig;
 
 /**
@@ -23,6 +24,14 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSer
 
     @After
     public void tearDown() {
+        // if we've started a traffic controller, dispose of it
+        if (cc.getAdapter() != null) {
+            if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                if ( ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null)
+                    ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+            }
+        }
+
         JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;

--- a/java/test/jmri/jmrix/sprog/pi/pisprogonecs/ConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprogonecs/ConnectionConfigTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.pi.pisprogonecs;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -24,6 +25,15 @@ public class ConnectionConfigTest extends jmri.jmrix.AbstractSerialConnectionCon
 
    @After
    public void tearDown(){
+        if (cc != null) {
+            if (cc.getAdapter() != null) {
+                if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                    if (((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null) {
+                        ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+                    }
+                }
+            }
+        }
         cc=null;
         JUnitUtil.tearDown();
    }

--- a/java/test/jmri/jmrix/sprog/pi/pisprogonecs/PiSprogOneCSSerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprogonecs/PiSprogOneCSSerialDriverAdapterTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.pi.pisprogonecs;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -18,7 +19,10 @@ public class PiSprogOneCSSerialDriverAdapterTest {
    public void ConstructorTest(){
        PiSprogOneCSSerialDriverAdapter a = new PiSprogOneCSSerialDriverAdapter();
        Assert.assertNotNull(a);
-   }
+ 
+       // clean up
+       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
+  }
 
     // The minimal setup for log4J
     @Before

--- a/java/test/jmri/jmrix/sprog/pi/pisprogonecs/PiSprogOneCSSerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprogonecs/PiSprogOneCSSerialDriverAdapterTest.java
@@ -21,7 +21,7 @@ public class PiSprogOneCSSerialDriverAdapterTest {
        Assert.assertNotNull(a);
  
        // clean up
-       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
+       a.getSystemConnectionMemo().getSprogTrafficController().dispose();
   }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/sprog/pi/pisprogonecs/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprogonecs/configurexml/ConnectionConfigXmlTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.sprog.pi.pisprogonecs.configurexml;
 
 import jmri.util.JUnitUtil;
 import org.junit.*;
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.jmrix.sprog.pi.pisprogonecs.ConnectionConfig;
 
 /**
@@ -23,6 +24,14 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSer
 
     @After
     public void tearDown() {
+        // if we've started a traffic controller, dispose of it
+        if (cc.getAdapter() != null) {
+            if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                if ( ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null)
+                    ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+            }
+        }
+
         JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;

--- a/java/test/jmri/jmrix/sprog/serialdriver/ConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/sprog/serialdriver/ConnectionConfigTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.serialdriver;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -24,6 +25,15 @@ public class ConnectionConfigTest extends jmri.jmrix.AbstractSerialConnectionCon
 
    @After
    public void tearDown(){
+        if (cc != null) {
+            if (cc.getAdapter() != null) {
+                if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                    if (((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null) {
+                        ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+                    }
+                }
+            }
+        }
         cc=null;
         JUnitUtil.tearDown();
    }

--- a/java/test/jmri/jmrix/sprog/serialdriver/SerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/serialdriver/SerialDriverAdapterTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.serialdriver;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -17,6 +18,9 @@ public class SerialDriverAdapterTest {
    public void ConstructorTest(){
        SerialDriverAdapter a = new SerialDriverAdapter();
        Assert.assertNotNull(a);
+
+       // clean up
+       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
    }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/sprog/serialdriver/SerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/serialdriver/SerialDriverAdapterTest.java
@@ -20,7 +20,7 @@ public class SerialDriverAdapterTest {
        Assert.assertNotNull(a);
 
        // clean up
-       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
+       a.getSystemConnectionMemo().getSprogTrafficController().dispose();
    }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/sprog/serialdriver/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/sprog/serialdriver/configurexml/ConnectionConfigXmlTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.sprog.serialdriver.configurexml;
 
 import jmri.util.JUnitUtil;
 import org.junit.*;
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.jmrix.sprog.serialdriver.ConnectionConfig;
 
 /**
@@ -21,6 +22,14 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSer
 
     @After
     public void tearDown() {
+        // if we've started a traffic controller, dispose of it
+        if (cc.getAdapter() != null) {
+            if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                if ( ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null)
+                    ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+            }
+        }
+
         JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;

--- a/java/test/jmri/jmrix/sprog/simulator/ConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/sprog/simulator/ConnectionConfigTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.simulator;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -24,6 +25,15 @@ public class ConnectionConfigTest extends jmri.jmrix.AbstractSerialConnectionCon
 
    @After
    public void tearDown(){
+        if (cc != null) {
+            if (cc.getAdapter() != null) {
+                if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                    if (((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null) {
+                        ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+                    }
+                }
+            }
+        }
         cc=null;
         JUnitUtil.tearDown();
    }

--- a/java/test/jmri/jmrix/sprog/simulator/SimulatorAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/simulator/SimulatorAdapterTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.simulator;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -17,6 +18,9 @@ public class SimulatorAdapterTest {
    public void ConstructorTest(){
        SimulatorAdapter a = new SimulatorAdapter();
        Assert.assertNotNull(a);
+
+       // clean up
+       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
    }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/sprog/simulator/SimulatorAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/simulator/SimulatorAdapterTest.java
@@ -20,7 +20,7 @@ public class SimulatorAdapterTest {
        Assert.assertNotNull(a);
 
        // clean up
-       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
+       a.getSystemConnectionMemo().getSprogTrafficController().dispose();
    }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/sprog/simulator/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/sprog/simulator/configurexml/ConnectionConfigXmlTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.sprog.simulator.configurexml;
 
 import jmri.util.JUnitUtil;
 import org.junit.*;
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.jmrix.sprog.simulator.ConnectionConfig;
 
 /**
@@ -21,6 +22,14 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSim
 
     @After
     public void tearDown() {
+        // if we've started a traffic controller, dispose of it
+        if (cc.getAdapter() != null) {
+            if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                if ( ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null)
+                    ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+            }
+        }
+
         JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;

--- a/java/test/jmri/jmrix/sprog/sprog/ConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/sprog/sprog/ConnectionConfigTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.sprog.sprog;
 
 import jmri.util.JUnitUtil;
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -24,6 +25,16 @@ public class ConnectionConfigTest extends jmri.jmrix.AbstractSerialConnectionCon
 
    @After
    public void tearDown(){
+        if (cc != null) {
+            if (cc.getAdapter() != null) {
+                if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                    if (((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null) {
+                        ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+                    }
+                }
+            }
+        }
+
         cc=null;
         JUnitUtil.tearDown();
    }

--- a/java/test/jmri/jmrix/sprog/sprog/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/sprog/sprog/configurexml/ConnectionConfigXmlTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.sprog.sprog.configurexml;
 
 import jmri.util.JUnitUtil;
 import org.junit.*;
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.jmrix.sprog.sprog.ConnectionConfig;
 
 /**
@@ -23,6 +24,14 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSer
 
     @After
     public void tearDown() {
+        // if we've started a traffic controller, dispose of it
+        if (cc.getAdapter() != null) {
+            if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                if ( ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null)
+                    ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+            }
+        }
+
         JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;

--- a/java/test/jmri/jmrix/sprog/sprogCS/ConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/sprog/sprogCS/ConnectionConfigTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.sprogCS;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -24,6 +25,15 @@ public class ConnectionConfigTest extends jmri.jmrix.AbstractSerialConnectionCon
 
    @After
    public void tearDown(){
+        if (cc != null) {
+            if (cc.getAdapter() != null) {
+                if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                    if (((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null) {
+                        ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+                    }
+                }
+            }
+        }
         cc=null;
         JUnitUtil.tearDown();
    }

--- a/java/test/jmri/jmrix/sprog/sprogCS/SprogCSSerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/sprogCS/SprogCSSerialDriverAdapterTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.sprogCS;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -18,6 +19,9 @@ public class SprogCSSerialDriverAdapterTest {
    public void ConstructorTest(){
        SprogCSSerialDriverAdapter a = new SprogCSSerialDriverAdapter();
        Assert.assertNotNull(a);
+
+       // clean up
+       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
    }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/sprog/sprogCS/SprogCSSerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/sprogCS/SprogCSSerialDriverAdapterTest.java
@@ -21,7 +21,7 @@ public class SprogCSSerialDriverAdapterTest {
        Assert.assertNotNull(a);
 
        // clean up
-       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
+       a.getSystemConnectionMemo().getSprogTrafficController().dispose();
    }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/sprog/sprogCS/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/sprog/sprogCS/configurexml/ConnectionConfigXmlTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.sprog.sprogCS.configurexml;
 
 import jmri.util.JUnitUtil;
 import org.junit.*;
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.jmrix.sprog.sprogCS.ConnectionConfig;
 
 /**
@@ -23,6 +24,14 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSer
 
     @After
     public void tearDown() {
+        // if we've started a traffic controller, dispose of it
+        if (cc.getAdapter() != null) {
+            if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                if ( ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null)
+                    ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+            }
+        }
+
         JUnitUtil.tearDown();
         xmlAdapter = null;
         cc = null;

--- a/java/test/jmri/jmrix/sprog/sprognano/ConnectionConfigTest.java
+++ b/java/test/jmri/jmrix/sprog/sprognano/ConnectionConfigTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.sprog.sprognano;
 
 import jmri.util.JUnitUtil;
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -24,6 +25,15 @@ public class ConnectionConfigTest extends jmri.jmrix.AbstractSerialConnectionCon
 
    @After
    public void tearDown(){
+        if (cc != null) {
+            if (cc.getAdapter() != null) {
+                if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                    if (((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null) {
+                        ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+                    }
+                }
+            }
+        }
         cc=null;
         JUnitUtil.tearDown();
    }

--- a/java/test/jmri/jmrix/sprog/sprognano/SprogNanoSerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/sprognano/SprogNanoSerialDriverAdapterTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.sprog.sprognano;
 
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -18,6 +19,9 @@ public class SprogNanoSerialDriverAdapterTest {
    public void ConstructorTest(){
        SprogNanoSerialDriverAdapter a = new SprogNanoSerialDriverAdapter();
        Assert.assertNotNull(a);
+
+       // clean up
+       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
    }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/sprog/sprognano/SprogNanoSerialDriverAdapterTest.java
+++ b/java/test/jmri/jmrix/sprog/sprognano/SprogNanoSerialDriverAdapterTest.java
@@ -21,7 +21,7 @@ public class SprogNanoSerialDriverAdapterTest {
        Assert.assertNotNull(a);
 
        // clean up
-       ((SprogSystemConnectionMemo)a.getSystemConnectionMemo()).getSprogTrafficController().dispose();
+       a.getSystemConnectionMemo().getSprogTrafficController().dispose();
    }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/sprog/sprognano/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/sprog/sprognano/configurexml/ConnectionConfigXmlTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.sprog.sprognano.configurexml;
 
 import jmri.util.JUnitUtil;
 import org.junit.*;
+import jmri.jmrix.sprog.SprogSystemConnectionMemo;
 import jmri.jmrix.sprog.sprognano.ConnectionConfig;
 
 /**
@@ -13,6 +14,7 @@ import jmri.jmrix.sprog.sprognano.ConnectionConfig;
  */
 public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSerialConnectionConfigXmlTestBase {
 
+    // need to override this to retain
     // The minimal setup for log4J
     @Before
     public void setUp() {
@@ -22,9 +24,21 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSer
     }
 
     @After
+    @Override
     public void tearDown() {
-        JUnitUtil.tearDown();
+
+        // if we've started a traffic controller, dispose of it
+        if (cc.getAdapter() != null) {
+            if (cc.getAdapter().getSystemConnectionMemo() != null) {
+                if ( ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController() != null)
+                    ((SprogSystemConnectionMemo)cc.getAdapter().getSystemConnectionMemo()).getSprogTrafficController().dispose();
+            }
+        }
+ 
         xmlAdapter = null;
         cc = null;
+        JUnitUtil.tearDown();
     }
+    
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ConnectionConfigXmlTest.class);
 }

--- a/java/test/jmri/jmrix/sprog/sprognano/configurexml/ConnectionConfigXmlTest.java
+++ b/java/test/jmri/jmrix/sprog/sprognano/configurexml/ConnectionConfigXmlTest.java
@@ -40,5 +40,5 @@ public class ConnectionConfigXmlTest extends jmri.jmrix.configurexml.AbstractSer
         JUnitUtil.tearDown();
     }
     
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ConnectionConfigXmlTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ConnectionConfigXmlTest.class);
 }

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -12,29 +12,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import javax.annotation.Nonnull;
-import jmri.AddressedProgrammerManager;
-import jmri.ConditionalManager;
-import jmri.ConfigureManager;
-import jmri.GlobalProgrammerManager;
-import jmri.InstanceManager;
-import jmri.JmriException;
-import jmri.LightManager;
-import jmri.LogixManager;
-import jmri.MemoryManager;
-import jmri.NamedBean;
-import jmri.PowerManager;
-import jmri.PowerManagerScaffold;
-import jmri.ReporterManager;
-import jmri.RouteManager;
-import jmri.SensorManager;
-import jmri.ShutDownManager;
-import jmri.ShutDownTask;
-import jmri.SignalHeadManager;
-import jmri.SignalMastLogicManager;
-import jmri.SignalMastManager;
-import jmri.TurnoutManager;
-import jmri.TurnoutOperationManager;
-import jmri.UserPreferencesManager;
+import jmri.*;
 import jmri.implementation.JmriConfigurationManager;
 import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
 import jmri.jmrit.logix.OBlockManager;
@@ -153,6 +131,13 @@ public class JUnitUtil {
      * Set from the jmri.util.JUnitUtil.checkSequenceDumpsStack environment variable.
      */
     static boolean checkSequenceDumpsStack =    Boolean.getBoolean("jmri.util.JUnitUtil.checkSequenceDumpsStack"); // false unless set true
+
+    /**
+     * Check for any threads left behind after a test calls {@link tearDown}.
+     * <p>
+     * Set from the jmri.util.JUnitUtil.checkRemnantThreads environment variable.
+     */
+    static boolean checkRemnantThreads =    Boolean.getBoolean("jmri.util.JUnitUtil.checkRemnantThreads"); // false unless set true
 
     static private int threadCount = 0;
     
@@ -280,8 +265,10 @@ public class JUnitUtil {
         JUnitAppender.resetUnexpectedMessageFlags(severity);
         Assert.assertFalse("Unexpected "+severity+" or higher messages emitted", unexpectedMessageSeen);
         
-        // Optionally, check that no threads were left running (could be controlled by environment var?)
-        // checkThreads(false);  // true means stop on 1st extra thread
+        // Optionally, check that no threads were left running (controlled by jmri.util.JUnitUtil.checkRemnantThreads environment var)
+        if (checkRemnantThreads) {
+            checkThreads();
+        }
         
         // Optionally, print whatever is on the Swing queue to see what's keeping things alive
         //Object entry = java.awt.Toolkit.getDefaultToolkit().getSystemEventQueue().peekEvent();
@@ -1070,14 +1057,14 @@ public class JUnitUtil {
      * providing a traceback if any new ones are still around.
      * <p>
      * First implementation is rather simplistic.
-     * @param stop If true, this stop execution after the 1st new thread is found
      */
-    static void checkThreads(boolean stop) {
+    static void checkThreads() {
         // now check for extra threads
         threadCount = 0;
         Thread.getAllStackTraces().keySet().forEach((t) -> 
             {
                 if (threadsSeen.contains(t)) return;
+                if (t.getState() == Thread.State.TERMINATED) return; // going away, just not cleaned up yet
                 String name = t.getName();
                 if (! (threadNames.contains(name)
                      || name.startsWith("RMI TCP Accept")
@@ -1093,25 +1080,21 @@ public class JUnitUtil {
                         )
                     )) {  
                     
+                        // if still running, wait to see if being terminated
+                        
                         threadCount++;
                         threadsSeen.add(t);
-                        System.out.println("New thread \""+t.getName()+"\" group \""+ (t.getThreadGroup()!=null ? t.getThreadGroup().getName() : "(null)")+"\"");
-                    
+                        
                         // for anonymous threads, show the traceback in hopes of finding what it is
                         if (name.startsWith("Thread-")) {
-                            for (StackTraceElement e : Thread.getAllStackTraces().get(t)) {
-                                if (! e.toString().startsWith("java")) System.out.println("    "+e);
-                            }
+                            Exception ex = new Exception("traceback");
+                            ex.setStackTrace(Thread.getAllStackTraces().get(t));
+                            log.warn("Found remnant thread \"{}\" in group \"{}\" after {}", t.getName(), t.getThreadGroup().getName(), getTestClassName(), ex);
+                        } else {
+                            log.warn("Found remnant thread \"{}\" in group \"{}\" after {}", t.getName(), t.getThreadGroup().getName(), getTestClassName());
                         }
                 }
             });
-        if (threadCount > 0) {
-            //Thread.getAllStackTraces().keySet().forEach((t) -> System.err.println("  thread "+t+" "+t.getName()));
-            if (stop) {
-                new Exception("Stopping by request on 1st extra thread").printStackTrace();
-                System.exit(0);
-            }
-        }
     }
 
     /* GraphicsEnvironment utility methods */


### PR DESCRIPTION
This calls `dispose()` to end various SPROG test threads cleanly.