### PR TITLE
Improve CI test running time

### DIFF
--- a/help/en/html/doc/Technical/Threads.shtml
+++ b/help/en/html/doc/Technical/Threads.shtml
@@ -136,6 +136,7 @@
     See the discussion on the 
     <a href="SpotBugs.html#annotations">JMRI SpotBugs page</a>.
 
+<a id="ending" name="ending"></a>
 <h3>Ending Threads</h3>
 
     This is really about interrupt() and our use of it.
@@ -170,6 +171,27 @@
     For more background, please read 
     <a href="https://www.ibm.com/developerworks/library/j-jtp05236/index.html">this article</a>.
 
+<a id="timer" name="timer"></a>
+<h3>Timed Events</h3> 
+    The <a href="http://jmri.org/JavaDoc/doc/jmri/util/ThreadingUtil.html">jmri.util.ThreadingUtil</a>
+    class provides the
+    <a href="http://jmri.org/JavaDoc/doc/jmri/util/ThreadingUtil.html#runOnGUIDelayed-jmri.util.ThreadingUtil.ThreadAction-int-">runOnGUIDelayed</a>
+    and
+    <a href="http://jmri.org/JavaDoc/doc/jmri/util/ThreadingUtil.html#runOnLayoutDelayed-jmri.util.ThreadingUtil.ThreadAction-int-">runOnLayoutDelayed</a>
+    methods to make it easy to run some code after a delay.
+    In general, you should use these whenever possible instead of explicit 
+    javax.swing.Timer or java.util.Timer objects.
+    <p>
+    We recommend you not use the java.util.Timer class directly because of significant issues:
+    <ul>
+        <li>Each Timer object creates and keeps its own thread, which is very hard to end.
+            This can cause significant memory use if not handled carefully.
+        <li>The requested operation is run on the Timer's own thread, which isn't the layout or GUI thread.
+    </ul>
+    
+   The <a href="http://jmri.org/JavaDoc/doc/jmri/util/TimerUtil.html">jmri.util.TimerUtil</a>
+   can help with the first of these.
+    
 <h3>Other Items of Interest</h3>    
 
     <p>

--- a/java/src/jmri/implementation/AbstractMultiMeter.java
+++ b/java/src/jmri/implementation/AbstractMultiMeter.java
@@ -1,7 +1,6 @@
 package jmri.implementation;
 
 import java.beans.PropertyChangeListener;
-import java.util.Timer;
 import java.util.TimerTask;
 import jmri.MultiMeter;
 import jmri.beans.Bean;
@@ -20,7 +19,6 @@ abstract public class AbstractMultiMeter extends Bean implements MultiMeter {
 
     //private boolean is_enabled = false;
     private UpdateTask intervalTask = null;
-    private Timer intervalTimer = null;
     private int sleepInterval = 10000; // default to 10 second sleep interval.
 
     public AbstractMultiMeter(int interval){
@@ -28,16 +26,14 @@ abstract public class AbstractMultiMeter extends Bean implements MultiMeter {
     }
 
     protected void initTimer() {
-        if(intervalTimer!=null) {
-           intervalTimer.cancel();
+        if(intervalTask!=null) {
+           intervalTask.cancel();
            intervalTask = null;
-           intervalTimer = null;
         }
         intervalTask = new UpdateTask();
-        intervalTimer = new Timer("MultiMeter Update Timer", true);
         // At some point this will be dynamic intervals...
         log.debug("Starting Meter Timer");
-        intervalTimer.scheduleAtFixedRate(intervalTask,
+        jmri.util.TimerUtil.scheduleAtFixedRate(intervalTask,
                 sleepInterval, sleepInterval);
     }
 
@@ -155,10 +151,9 @@ abstract public class AbstractMultiMeter extends Bean implements MultiMeter {
      */
     @Override
     public void dispose(){
-        if(intervalTimer!=null) {
-           intervalTimer.cancel();
+        if(intervalTask!=null) {
+           intervalTask.cancel();
            intervalTask = null;
-           intervalTimer = null;
         }
     }
 

--- a/java/src/jmri/jmrit/logix/OBlockManager.java
+++ b/java/src/jmri/jmrit/logix/OBlockManager.java
@@ -40,8 +40,9 @@ public class OBlockManager extends AbstractManager<OBlock>
         return jmri.Manager.OBLOCKS;
     }
 
-    @Nonnull@Override
- public String getSystemPrefix() {
+    @Nonnull
+    @Override
+    public String getSystemPrefix() {
         return "O";
     }
 

--- a/java/src/jmri/jmrit/ussctc/CodeLine.java
+++ b/java/src/jmri/jmrit/ussctc/CodeLine.java
@@ -118,7 +118,7 @@ public class CodeLine {
     
     void startExternalCodeLine() {
         hStartTO.getBean().setCommandedState(Turnout.THROWN);
-        new Timer("Codeline Timer").schedule(new TimerTask() {  // NOI18N
+        jmri.util.TimerUtil.schedule(new TimerTask() {
             @Override
             public void run() {
                 hStartTO.getBean().setCommandedState(Turnout.CLOSED);

--- a/java/src/jmri/jmrit/ussctc/SignalHeadSection.java
+++ b/java/src/jmri/jmrit/ussctc/SignalHeadSection.java
@@ -282,7 +282,7 @@ public class SignalHeadSection implements Section<CodeGroupThreeBits, CodeGroupT
         // start the timer for the signals to change
         if (currentIndication != lastIndication) {
             log.debug("codeValueDelivered started timer for return indication"); // NOI18N
-            new Timer("Signal Section Timer").schedule(new TimerTask() { // NOI18N
+            jmri.util.TimerUtil.schedule(new TimerTask() { // NOI18N
                 @Override
                 public void run() {
                     jmri.util.ThreadingUtil.runOnGUI( ()->{

--- a/java/src/jmri/jmrix/dccpp/network/DCCppEthernetAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/network/DCCppEthernetAdapter.java
@@ -28,7 +28,7 @@ public class DCCppEthernetAdapter extends DCCppNetworkPortController {
     // send a message to both
     // ports to keep the ports 
     // open
-    private static final int keepAliveTimeoutValue = 30000; // Interval 
+    private static final long keepAliveTimeoutValue = 30000; // Interval 
     // to send a message
     // Must be < 60s.
     
@@ -110,7 +110,7 @@ public class DCCppEthernetAdapter extends DCCppNetworkPortController {
         } else {
             keepAliveTimer.cancel();
         }
-        new java.util.Timer("DCC++ Keepalive Timer").schedule(keepAliveTimer,keepAliveTimeoutValue,keepAliveTimeoutValue);
+        jmri.util.TimerUtil.schedule(keepAliveTimer, keepAliveTimeoutValue, keepAliveTimeoutValue);
     }
     
     private boolean mDNSConfigure = false;

--- a/java/src/jmri/jmrix/lenz/XNetThrottle.java
+++ b/java/src/jmri/jmrix/lenz/XNetThrottle.java
@@ -2,7 +2,6 @@ package jmri.jmrix.lenz;
 
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.Timer;
 
 import jmri.DccLocoAddress;
 import jmri.DccThrottle;
@@ -22,8 +21,6 @@ import org.slf4j.LoggerFactory;
 public class XNetThrottle extends AbstractThrottle implements XNetListener {
 
     protected boolean isAvailable;  // Flag  stating if the throttle is in use or not.
-
-    static protected AtomicReference<Timer> statusTimer = new AtomicReference<>(); // Shared Timer used for status
 
     protected java.util.TimerTask statusTask;   // Timer Task used to periodically get current
                                                 // status of the throttle when throttle not available.
@@ -1391,12 +1388,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
     protected void startStatusTimer() {
         log.debug("Status Timer Started");
 
-        // atomically make sure there's a timer available
-        statusTimer.updateAndGet(timer -> {
-            if (timer == null) return new java.util.Timer("XPressNet Throttle Status Timer", true);
-            else return timer;
-        });
-        
         if (statusTask != null) {
             statusTask.cancel();
             statusTask = null;
@@ -1410,7 +1401,7 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
             }
         };
         
-        statusTimer.get().schedule(statusTask, statTimeoutValue, statTimeoutValue);
+        jmri.util.TimerUtil.schedule(statusTask, statTimeoutValue, statTimeoutValue);
     }
 
     /**

--- a/java/src/jmri/jmrix/lenz/liusbethernet/LIUSBEthernetAdapter.java
+++ b/java/src/jmri/jmrix/lenz/liusbethernet/LIUSBEthernetAdapter.java
@@ -105,7 +105,7 @@ public class LIUSBEthernetAdapter extends XNetNetworkPortController {
         } else {
             keepAliveTimer.cancel();
         }
-        new java.util.Timer("LIUSB Ethernet Keepalive timer").schedule(keepAliveTimer, keepAliveTimeoutValue, keepAliveTimeoutValue);
+        jmri.util.TimerUtil.schedule(keepAliveTimer, keepAliveTimeoutValue, keepAliveTimeoutValue);
     }
 
     private boolean mDNSConfigure = false;

--- a/java/src/jmri/jmrix/lenz/liusbserver/LIUSBServerAdapter.java
+++ b/java/src/jmri/jmrix/lenz/liusbserver/LIUSBServerAdapter.java
@@ -404,13 +404,13 @@ public class LIUSBServerAdapter extends XNetNetworkPortController {
                         //puts the command station into service mode.
                         log.error("Communications port dropped", ex);
                     }
-                }
+                }   
             };
         }
         else {
            keepAliveTimer.cancel();
         }
-        new java.util.Timer("LIUSB Keepalive Timer").schedule(keepAliveTimer,keepAliveTimeoutValue,keepAliveTimeoutValue);
+        jmri.util.TimerUtil.schedule(keepAliveTimer,keepAliveTimeoutValue,keepAliveTimeoutValue);
     }
 
     private final static Logger log = LoggerFactory.getLogger(LIUSBServerAdapter.class);

--- a/java/src/jmri/jmrix/loconet/LnTurnout.java
+++ b/java/src/jmri/jmrix/loconet/LnTurnout.java
@@ -147,7 +147,7 @@ public class LnTurnout extends AbstractTurnout implements LocoNetListener {
                     }
                 }
             };
-            meterTimer.schedule(meterTask, METERINTERVAL);
+            jmri.util.TimerUtil.schedule(meterTask, METERINTERVAL);
         }
     }
 
@@ -208,7 +208,7 @@ public class LnTurnout extends AbstractTurnout implements LocoNetListener {
                     }
                 }
             };
-            consistencyTimer.schedule(consistencyTask, CONSISTENCYTIMER);
+            jmri.util.TimerUtil.schedule(consistencyTask, CONSISTENCYTIMER);
         }
     }
 
@@ -427,11 +427,9 @@ public class LnTurnout extends AbstractTurnout implements LocoNetListener {
     }
 
     static final int METERINTERVAL = 100;  // msec wait before closed
-    static java.util.Timer meterTimer = new java.util.Timer("LocoNet Turnout Meter Timer",true);
     private java.util.TimerTask meterTask = null;
 
     static final int CONSISTENCYTIMER = 3000; // msec wait for command to take effect
-    static java.util.Timer consistencyTimer = new java.util.Timer("LocoNet Turnout Consistency Timer");
     int noConsistencyTimersRunning = 0;
     private java.util.TimerTask consistencyTask = null;
 

--- a/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
@@ -210,6 +210,7 @@ public class LocoNetSystemConnectionMemo extends SystemConnectionMemo {
         if (type.equals(CommandStation.class)) {
             return true;
         }
+
         return super.provides(type);
     }
 
@@ -442,6 +443,9 @@ public class LocoNetSystemConnectionMemo extends SystemConnectionMemo {
         }
         if (tm != null){
             tm.dispose();
+        }
+        if (sm != null){
+            sm.dispose();
         }
         super.dispose();
     }

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -1538,6 +1538,13 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
         return adaptermemo;
     }
 
+    /**
+     * Dispose of this by stopped it's ongoing actions
+     */
+    public void dispose() {
+        if (staleSlotCheckTimer != null) staleSlotCheckTimer.stop();
+    }
+
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(SlotManager.class);
 

--- a/java/src/jmri/jmrix/marklin/MarklinTurnout.java
+++ b/java/src/jmri/jmrix/marklin/MarklinTurnout.java
@@ -130,7 +130,7 @@ public class MarklinTurnout extends AbstractTurnout
         MarklinMessage m = MarklinMessage.getSetTurnout(getCANAddress(), (newstate ? 1 : 0), 0x01);
         tc.sendMarklinMessage(m, this);
 
-        meterTimer.schedule(new java.util.TimerTask() {
+        jmri.util.TimerUtil.schedule(new java.util.TimerTask() {
             boolean state = newstate;
 
             @Override
@@ -193,7 +193,6 @@ public class MarklinTurnout extends AbstractTurnout
     }
 
     static final int METERINTERVAL = 100;  // msec wait before closed
-    static java.util.Timer meterTimer = new java.util.Timer("Marklin Turnout Meter Timer",true);
 
     private final static Logger log = LoggerFactory.getLogger(MarklinTurnout.class);
 }

--- a/java/src/jmri/jmrix/openlcb/OlcbConfigurationManager.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbConfigurationManager.java
@@ -605,6 +605,10 @@ public class OlcbConfigurationManager extends jmri.jmrix.can.ConfigurationManage
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     new Thread(() -> {
+                        // N.B. during JUnit testing, the following call tends to hang
+                        // on semaphore acquisition in org.openlcb.can.CanInterface.initialize()
+                        // near line 109 in openlcb lib 0.7.22, which leaves
+                        // the thread hanging around forever.
                         olcbCanInterface.initialize();
                     }, "olcbCanInterface.initialize").start();
                 }

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -262,24 +262,24 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
 
     /** {@inheritDoc} */
     @Override
-    public void setDefaultSensorDebounceGoingActive(long timer) {
-        if (timer == sensorDebounceGoingActive) {
+    public void setDefaultSensorDebounceGoingActive(long time) {
+        if (time == sensorDebounceGoingActive) {
             return;
         }
-        sensorDebounceGoingActive = timer;
+        sensorDebounceGoingActive = time;
         Enumeration<String> en = _tsys.keys();
         while (en.hasMoreElements()) {
             Sensor sen = _tsys.get(en.nextElement());
             if (sen.getUseDefaultTimerSettings()) {
-                sen.setSensorDebounceGoingActiveTimer(timer);
+                sen.setSensorDebounceGoingActiveTimer(time);
             }
         }
     }
 
     /** {@inheritDoc} */
     @Override
-    public void setDefaultSensorDebounceGoingInActive(long timer) {
-        if (timer == sensorDebounceGoingInActive) {
+    public void setDefaultSensorDebounceGoingInActive(long time) {
+        if (time == sensorDebounceGoingInActive) {
             return;
         }
         sensorDebounceGoingInActive = timer;
@@ -287,7 +287,7 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
         while (en.hasMoreElements()) {
             Sensor sen = _tsys.get(en.nextElement());
             if (sen.getUseDefaultTimerSettings()) {
-                sen.setSensorDebounceGoingInActiveTimer(timer);
+                sen.setSensorDebounceGoingInActiveTimer(time);
             }
         }
     }

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -282,7 +282,7 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
         if (time == sensorDebounceGoingInActive) {
             return;
         }
-        sensorDebounceGoingInActive = timer;
+        sensorDebounceGoingInActive = time;
         Enumeration<String> en = _tsys.keys();
         while (en.hasMoreElements()) {
             Sensor sen = _tsys.get(en.nextElement());

--- a/java/src/jmri/script/ScriptOutput.java
+++ b/java/src/jmri/script/ScriptOutput.java
@@ -27,7 +27,8 @@ public class ScriptOutput {
      * <P>
      * The output JTextArea is not created until this is invoked, so that code
      * that doesn't use this feature can run on GUI-less machines.
-     *
+     * <p>
+     * This creates a "ScriptOutput PipeListener" thread which is not normally terminated.
      * @return component containing script output
      */
     public JTextArea getOutputArea() {
@@ -49,6 +50,8 @@ public class ScriptOutput {
                 // Swing TextArea data model
                 PipedReader pr = new PipedReader(pw);
                 PipeListener pl = new PipeListener(pr, output);
+                pl.setName("ScriptOutput PipeListener");
+                pl.setDaemon(true);
                 pl.start();
             } catch (IOException e) {
                 log.error("Exception creating script output area", e);

--- a/java/src/jmri/swing/JmriJTablePersistenceManager.java
+++ b/java/src/jmri/swing/JmriJTablePersistenceManager.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.Timer;
 import java.util.TimerTask;
 import javax.annotation.Nonnull;
 import javax.swing.JTable;
@@ -566,7 +565,6 @@ public class JmriJTablePersistenceManager extends AbstractPreferencesManager imp
 
         private final JTable table;
         private final JmriJTablePersistenceManager manager;
-        private Timer delay = null;
 
         public JTableListener(JTable table, JmriJTablePersistenceManager manager) {
             this.table = table;
@@ -656,6 +654,8 @@ public class JmriJTablePersistenceManager extends AbstractPreferencesManager imp
             log.trace("Got columnSelectionChanged for {} ({} -> {})", this.table.getName(), e.getFirstIndex(), e.getLastIndex());
         }
 
+        TimerTask delay;
+        
         protected void cancelDelay() {
             if (this.delay != null) {
                 this.delay.cancel(); // cancel complete before dropping reference
@@ -673,8 +673,7 @@ public class JmriJTablePersistenceManager extends AbstractPreferencesManager imp
          */
         private void saveState() {
             cancelDelay();
-            delay = new Timer("JmriJTablePersistenceManager save delay");
-            delay.schedule(new TimerTask() {
+            jmri.util.TimerUtil.schedule(delay = new TimerTask() {
                 @Override
                 public void run() {
                     JTableListener.this.manager.cacheState(JTableListener.this.table);

--- a/java/src/jmri/util/TimerUtil.java
+++ b/java/src/jmri/util/TimerUtil.java
@@ -133,7 +133,7 @@ final public class TimerUtil {
     }
    
    
-    static Timer commonTimer = new Timer("JMRI Common Timer", true);
+    final static Timer commonTimer = new Timer("JMRI Common Timer", true);
     
     // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimerUtil.class);
 }

--- a/java/src/jmri/util/TimerUtil.java
+++ b/java/src/jmri/util/TimerUtil.java
@@ -1,0 +1,139 @@
+package jmri.util;
+
+import java.util.Date;
+import java.util.Timer;
+import java.util.TimerTask;
+import javax.annotation.Nonnull;
+
+import jmri.util.ThreadingUtil;
+
+/**
+ * Common utility methods for working with (@link java.util.Timer)
+ * <P>
+ * Each {@link java.util.Timer} uses a thread, which means that they're
+ * not throw-away timers:  You either track when you can destroy them 
+ * (and that destruction is not obvious), or they stick around consuming
+ * resources.
+ * <p>
+ * This class provides most of the functionality of a Timer.
+ * Some differences:
+ * <ul>
+ * <li>When migrating code that uses Timer.cancel() to end operation, you have to
+ *     retain references to the individual TimerTask objects and cancel them instead.
+ * </ul>
+ * <p>
+ * For convenience, this also provides methods to ensure that the task is invoked
+ * on a specific JMRI thread.
+ * <p>
+ * Please note the comment in the {@link Timer} Javadoc about how
+ * {@link java.util.concurrent.ScheduledThreadPoolExecutor} might provide a better
+ * underlying implementation.
+ *
+ * @author Bob Jacobsen Copyright 2018
+ */
+@javax.annotation.concurrent.Immutable
+final public class TimerUtil {
+
+    // Timer implementation methods
+    
+    static public void schedule(@Nonnull TimerTask task, @Nonnull Date time) {
+        commonTimer.schedule(task, time);
+    }
+
+    static public void schedule(@Nonnull TimerTask task, @Nonnull Date firstTime, long period) {
+        commonTimer.schedule(task, firstTime, period);
+    }
+    
+    static public void schedule(@Nonnull TimerTask task, long delay) {
+        commonTimer.schedule(task, delay);
+    }
+    
+    static public void schedule(@Nonnull TimerTask task, long delay, long period) {
+        commonTimer.schedule(task, delay, period);
+    }
+    
+    static public void scheduleAtFixedRate(@Nonnull TimerTask task, @Nonnull Date firstTime, long period) {
+        commonTimer.schedule(task, firstTime, period);
+    }
+    
+    static public void scheduleAtFixedRate(@Nonnull TimerTask task, long delay, long period) {
+        commonTimer.schedule(task, delay, period);
+    }
+   
+   
+    // GUI-thread implementation methods
+    
+    // arrange to run on GUI thread
+    static private TimerTask gtask(TimerTask task) {
+        return new TimerTask(){
+                @Override
+                public void run() {
+                    ThreadingUtil.runOnGUIEventually(() -> {task.run();});
+                }
+        };
+    }
+
+    static public void scheduleOnGUIThread(@Nonnull TimerTask task, @Nonnull Date time) {
+        commonTimer.schedule(gtask(task), time);
+    }
+
+    static public void scheduleOnGUIThread(@Nonnull TimerTask task, @Nonnull Date firstTime, long period) {
+        commonTimer.schedule(gtask(task), firstTime, period);
+    }
+    
+    static public void scheduleOnGUIThread(@Nonnull TimerTask task, long delay) {
+        commonTimer.schedule(gtask(task), delay);
+    }
+    
+    static public void scheduleOnGUIThread(@Nonnull TimerTask task, long delay, long period) {
+        commonTimer.schedule(gtask(task), delay, period);
+    }
+    
+    static public void scheduleAtFixedRateOnGUIThread(@Nonnull TimerTask task, @Nonnull Date firstTime, long period) {
+        commonTimer.schedule(gtask(task), firstTime, period);
+    }
+    
+    static public void scheduleAtFixedRateOnGUIThread(@Nonnull TimerTask task, long delay, long period) {
+        commonTimer.schedule(gtask(task), delay, period);
+    }
+   
+   
+    // arrange to run on layout thread
+    static private TimerTask ltask(TimerTask task) {
+        return new TimerTask(){
+                @Override
+                public void run() {
+                    ThreadingUtil.runOnLayoutEventually(() -> {task.run();});
+                }
+        };
+    }
+    
+    static public void scheduleOnLayoutThread(@Nonnull TimerTask task, @Nonnull Date time) {
+        commonTimer.schedule(ltask(task), time);
+    }
+
+    static public void scheduleOnLayoutThread(@Nonnull TimerTask task, @Nonnull Date firstTime, long period) {
+        commonTimer.schedule(ltask(task), firstTime, period);
+    }
+    
+    static public void scheduleOnLayoutThread(@Nonnull TimerTask task, long delay) {
+        commonTimer.schedule(ltask(task), delay);
+    }
+    
+    static public void scheduleOnLayoutThread(@Nonnull TimerTask task, long delay, long period) {
+        commonTimer.schedule(ltask(task), delay, period);
+    }
+    
+    static public void scheduleAtFixedRateOnLayoutThread(@Nonnull TimerTask task, @Nonnull Date firstTime, long period) {
+        commonTimer.schedule(ltask(task), firstTime, period);
+    }
+    
+    static public void scheduleAtFixedRateOnLayoutThread(@Nonnull TimerTask task, long delay, long period) {
+        commonTimer.schedule(ltask(task), delay, period);
+    }
+   
+   
+    static Timer commonTimer = new Timer("JMRI Common Timer", true);
+    
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimerUtil.class);
+}

--- a/java/test/jmri/jmrit/automat/SigletTest.java
+++ b/java/test/jmri/jmrit/automat/SigletTest.java
@@ -39,6 +39,7 @@ public class SigletTest {
         is1.setState(Sensor.ACTIVE);
         
         JUnitUtil.waitFor( ()->{ return output; }, "setOutput run again"); 
+        t.stop();
     }
 
 
@@ -58,6 +59,7 @@ public class SigletTest {
         t.start();
 
         jmri.util.JUnitAppender.assertErrorMessage("Siglet start invoked (without a name), but no inputs provided"); 
+        t.stop();
     }
 
     @Test
@@ -79,6 +81,7 @@ public class SigletTest {
         t.start();
 
         jmri.util.JUnitAppender.assertErrorMessage("Siglet start invoked for \"foo\", but no inputs provided"); 
+        t.stop();
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
+++ b/java/test/jmri/jmrit/blockboss/BlockBossLogicTest.java
@@ -17,29 +17,11 @@ import org.junit.Test;
  * @author	Bob Jacobsen
  */
 public class BlockBossLogicTest {
-
-    protected void startLogic(BlockBossLogic b) {
-        p.start();
-    }
-
-    protected void stopLogic() {
-        if (p!=null) {
-            p.stop();
-            p=null;
-        }
-    }
-
-    BlockBossLogic p;
-    void setupSimpleBlock() {
-        p = new BlockBossLogic("IH1");
-        p.setMode(BlockBossLogic.SINGLEBLOCK);
-        p.setWatchedSignal1("IH2", false);
-    }
     
     // test creation
     @Test
     public void testCreate() {
-        BlockBossLogic p = new BlockBossLogic("IH2");
+        p = new BlockBossLogic("IH2");
         Assert.assertEquals("driven signal name", "IH2", p.getDrivenSignal());
     }
 
@@ -47,7 +29,7 @@ public class BlockBossLogicTest {
     @Test
     public void testSimpleBlock() {
         setupSimpleBlock();
-        startLogic(p);
+        startLogic();
         Assert.assertEquals("driven signal name", "IH1", p.getDrivenSignal());
         
         JUnitUtil.setBeanStateAndWait(h2, SignalHead.YELLOW);
@@ -63,7 +45,7 @@ public class BlockBossLogicTest {
     // test that initial conditions are set right
     public void testSimpleBlockInitial() {
         setupSimpleBlock();
-        startLogic(p);
+        startLogic();
 
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "initial red sets yellow");  // wait and test
     }
@@ -73,7 +55,7 @@ public class BlockBossLogicTest {
     public void testSimpleBlockOccupancy() throws jmri.JmriException {
         setupSimpleBlock();
         p.setSensor1("IS1");
-        startLogic(p);
+        startLogic();
         JUnitUtil.setBeanState(s1, Sensor.INACTIVE);
         
         JUnitUtil.setBeanStateAndWait(h2, SignalHead.YELLOW);
@@ -91,7 +73,7 @@ public class BlockBossLogicTest {
     public void testSimpleBlockDistant() {
         setupSimpleBlock();
         p.setDistantSignal(true);
-        startLogic(p);
+        startLogic();
 
         Assert.assertEquals("driven signal name", "IH1", p.getDrivenSignal());
 
@@ -111,7 +93,7 @@ public class BlockBossLogicTest {
     public void testSimpleBlockLimited() {
         setupSimpleBlock();
         p.setLimitSpeed1(true);
-        startLogic(p);
+        startLogic();
 
         JUnitUtil.setBeanStateAndWait(h2, SignalHead.RED);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "red sets yellow");  // wait and test
@@ -129,7 +111,7 @@ public class BlockBossLogicTest {
         setupSimpleBlock();
         p.setDistantSignal(true);
         p.setLimitSpeed1(true);
-        startLogic(p);
+        startLogic();
 
         JUnitUtil.setBeanStateAndWait(h2, SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "yellow sets yellow");  // wait and test
@@ -149,7 +131,7 @@ public class BlockBossLogicTest {
         setupSimpleBlock();
         p.setSensor1("IS1");
         p.setRestrictingSpeed1(true);
-        startLogic(p);
+        startLogic();
         
         JUnitUtil.setBeanStateAndWait(h2, SignalHead.YELLOW);
         JUnitUtil.waitFor(()->{return SignalHead.FLASHRED == h1.getAppearance();}, "yellow sets flashing red");  // wait and test
@@ -170,7 +152,7 @@ public class BlockBossLogicTest {
         p = new BlockBossLogic("IH1");
         p.setSensor1("1");
         p.setMode(BlockBossLogic.SINGLEBLOCK);
-        startLogic(p);
+        startLogic();
 
         JUnitUtil.waitFor(()->{return SignalHead.GREEN == h1.getAppearance();}, "missing signal is green");  // wait and test
     }
@@ -185,7 +167,7 @@ public class BlockBossLogicTest {
         p.setSensor1("1");
         p.setLimitSpeed1(true);
 
-        startLogic(p);
+        startLogic();
 
         JUnitUtil.waitFor(()->{return SignalHead.YELLOW == h1.getAppearance();}, "missing signal is green, show yellow");  // wait and test
     }
@@ -201,9 +183,6 @@ public class BlockBossLogicTest {
         }
         jmri.util.JUnitAppender.assertWarnMessage("Signal Head \"null\" was not found");
     }
-
-    Thread testThread = null;
-    boolean forceInterrupt = false;
 
     // test interruption
     @Test
@@ -224,7 +203,7 @@ public class BlockBossLogicTest {
         p.setSensor1("1");
         p.setLimitSpeed1(true);
 
-        startLogic(p);
+        startLogic();
 
         JUnitUtil.waitFor(()->{return p.isRunning();}, "is running");
                 
@@ -329,11 +308,31 @@ public class BlockBossLogicTest {
 
     }
 
-    // from here down is testing infrastructure
-    // Ensure minimal setup for log4J
     Turnout t1, t2, t3;
     Sensor s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
     SignalHead h1, h2, h3, h4;
+    BlockBossLogic p;
+
+    Thread testThread = null;
+    boolean forceInterrupt = false;
+
+    protected void startLogic() {
+        if (p != null) {
+            p.start();
+        }
+    }
+
+    protected void stopLogic() {
+        if (p != null) {
+            p.stop();
+        }
+    }
+
+    void setupSimpleBlock() {
+        p = new BlockBossLogic("IH1");
+        p.setMode(BlockBossLogic.SINGLEBLOCK);
+        p.setWatchedSignal1("IH2", false);
+    }
 
     /**
      * Test-by test initialization. Does log4j for standalone use, and then
@@ -383,6 +382,10 @@ public class BlockBossLogicTest {
 
     @After
     public void tearDown() {
+        t1=t2=t3=null;
+        s1=s2=s3=s4=s5=s6=s7=s8=s9=s10=null;
+        h1=h2=h3=h4=null;
+        testThread = null;
         stopLogic();
         // reset InstanceManager
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorTest.java
+++ b/java/test/jmri/jmrit/display/switchboardEditor/SwitchboardEditorTest.java
@@ -37,7 +37,6 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         // defaults to false.
         Assert.assertFalse("isDirty", swe.isDirty());
-        JUnitUtil.dispose(swe);
     }
 
     @Test
@@ -91,10 +90,11 @@ public class SwitchboardEditorTest extends AbstractEditorTestBase {
     @After
     public void tearDown() {
         if (swe != null) {
-            JUnitUtil.dispose(swe);
+            // dispose on Swing thread
             JUnitUtil.dispose(swe.getTargetFrame());
-            e = swe = null;
+            JUnitUtil.dispose(swe);
         }
+        e = swe = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/cmri/serial/SerialAddressTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialAddressTest.java
@@ -63,8 +63,11 @@ public class SerialAddressTest extends TestCase {
     protected void tearDown() throws Exception {
         super.tearDown();
         JUnitUtil.tearDown();
+        if (stcs != null) stcs.terminateThreads();
         stcs = null;
         memo = null;
+        n10 = null;
+        n18 = null;
     }
 
     public void testValidateSystemNameFormat() {

--- a/java/test/jmri/jmrix/cmri/serial/SerialAddressTwoSystemTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialAddressTwoSystemTest.java
@@ -89,8 +89,12 @@ public class SerialAddressTwoSystemTest extends TestCase {
     protected void tearDown() throws Exception {
         super.tearDown();
         JUnitUtil.tearDown();
+        if (stcs1 != null) stcs1.terminateThreads();
         stcs1 = null;
         memo1 = null;
+        if (stcs2 != null) stcs2.terminateThreads();
+        stcs2 = null;
+        memo2 = null;
     }
 
     public void testValidateSystemNameFormat() {

--- a/java/test/jmri/jmrix/cmri/serial/SerialLightManagerTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialLightManagerTest.java
@@ -35,6 +35,9 @@ public class SerialLightManagerTest {
     @After
     public void tearDown() {
         JUnitUtil.tearDown();
+        if (tcis != null) tcis.terminateThreads();
+        tcis = null;
+        memo = null;
     }
 
 }

--- a/java/test/jmri/jmrix/cmri/serial/SerialLightTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialLightTest.java
@@ -101,6 +101,9 @@ public class SerialLightTest {
     @After
     public void tearDown() {
         JUnitUtil.tearDown();
+        if (tcis != null) tcis.terminateThreads();
+        tcis = null;
+        memo = null;
     }
 
 }

--- a/java/test/jmri/jmrix/cmri/serial/SerialNodeListTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialNodeListTest.java
@@ -45,6 +45,7 @@ public class SerialNodeListTest {
     @After
     public void tearDown() {
         JUnitUtil.tearDown();
+        if (stcs != null) stcs.terminateThreads();
         stcs = null;
         memo = null;
     }

--- a/java/test/jmri/jmrix/cmri/serial/SerialNodeTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialNodeTest.java
@@ -377,6 +377,7 @@ public class SerialNodeTest extends TestCase {
     @Override
     protected void tearDown() {
         JUnitUtil.tearDown();
+        if (stcs != null) stcs.terminateThreads();
         stcs = null;
         memo = null;
     }

--- a/java/test/jmri/jmrix/cmri/serial/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialSensorManagerTest.java
@@ -114,6 +114,7 @@ public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest
     public void tearDown() {
         l.dispose();
         JUnitUtil.tearDown();
+        if (stcs != null) stcs.terminateThreads();
         stcs = null;
         memo = null;
     }

--- a/java/test/jmri/jmrix/cmri/serial/SerialSensorTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialSensorTest.java
@@ -108,6 +108,9 @@ public class SerialSensorTest extends jmri.implementation.AbstractSensorTestBase
     @After
     public void tearDown() {
         JUnitUtil.tearDown();
+        if (tcis != null) tcis.terminateThreads();
+        tcis = null;
+        memo = null;
     }
 
 }

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutManagerTest.java
@@ -40,6 +40,7 @@ public class SerialTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTe
     @After
     public void tearDown() {
         JUnitUtil.tearDown();
+        if (stcs != null) stcs.terminateThreads();
         stcs = null;
         memo = null;
     }

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
@@ -42,6 +42,9 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
     @After
     public void tearDown() {
         jmri.util.JUnitUtil.tearDown();
+        if (tcis != null) tcis.terminateThreads();
+        tcis = null;
+        memo = null;
     }
 
     int startingNumListeners; // number at creation, before tests start allocating them.

--- a/java/test/jmri/jmrix/cmri/swing/CMRIComponentFactoryTest.java
+++ b/java/test/jmri/jmrix/cmri/swing/CMRIComponentFactoryTest.java
@@ -35,6 +35,9 @@ public class CMRIComponentFactoryTest {
     @After
     public void tearDown() {
         JUnitUtil.tearDown();
+        if (tcis != null) tcis.terminateThreads();
+        tcis = null;
+        memo = null;
     }
 
     // private final static Logger log = LoggerFactory.getLogger(CMRIComponentFactoryTest.class);

--- a/java/test/jmri/util/PackageTest.java
+++ b/java/test/jmri/util/PackageTest.java
@@ -71,6 +71,7 @@ import org.junit.runners.Suite;
         SocketUtilTest.class,
         SystemNameComparatorTest.class,
         SystemTypeTest.class,
+        TimerUtilTest.class,
         XmlFilenameFilterTest.class,
         JmriJFrameActionTest.class,
         JLogoutputFrameTest.class,

--- a/java/test/jmri/util/PipeListenerTest.java
+++ b/java/test/jmri/util/PipeListenerTest.java
@@ -37,6 +37,7 @@ public class PipeListenerTest {
         PipedWriter wr = new PipedWriter();
         PipedReader pr = new PipedReader(wr,1);
         PipeListener t = new PipeListener(pr,jta);
+        t.setName("PipeListenerTest thread");
         t.start();
         
         String testString = "Test String";

--- a/java/test/jmri/util/TimerUtilTest.java
+++ b/java/test/jmri/util/TimerUtilTest.java
@@ -1,0 +1,70 @@
+package jmri.util;
+
+import java.util.TimerTask;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Bob Jacobsen Copyright (C) 2018
+ */
+public class TimerUtilTest {
+
+    @Test
+    public void testCTor() {
+        TimerUtil t = new TimerUtil();
+        Assert.assertNotNull("exists",t);
+    }
+    
+    @Test
+    public void testScheduleDate() {
+        TimerUtil.schedule(task, 10);
+        Assert.assertTrue(JUnitUtil.waitFor(() -> {return taskRan;}));
+    }
+
+    @Test
+    public void testScheduleDateOnLayout() {
+        TimerUtil.scheduleOnLayoutThread(task, 10);
+        Assert.assertTrue(JUnitUtil.waitFor(() -> {return taskRan;}));
+        Assert.assertTrue(taskRanOnLayout);
+    }
+
+    @Test
+    public void testScheduleDateOnGUI() {
+        TimerUtil.scheduleOnGUIThread(task, 10);
+        Assert.assertTrue(JUnitUtil.waitFor(() -> {return taskRan;}));
+        Assert.assertTrue(taskRanOnGUI);
+    }
+
+    boolean taskRan = false;
+    boolean taskRanOnGUI = false;
+    boolean taskRanOnLayout = false;
+
+    final TimerTask task = new TimerTask(){
+        @Override
+        public void run() {
+            taskRanOnLayout = ThreadingUtil.isGUIThread();
+            taskRanOnGUI = ThreadingUtil.isLayoutThread();
+            taskRan = true;
+        }
+    };
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+        taskRan = false;
+        taskRanOnGUI = false;
+        taskRanOnLayout = false;        
+    }
+
+    @After
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimerUtilTest.class);
+
+}

--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -149,6 +149,11 @@ We roll some general code maintenance items into the release process.
         grep -lr '\t' jython/ | grep '\.py'
 ```
 
+- Check for code that's using native Java Timers; see jmri.util.TimerUtil for background (requires that the code has been built):
+```
+        grep -rl 'java.util.Timer\x01' target/
+```
+
 - Run "ant alltest"; make sure they all pass; fix problems and commit back
 
 - Run "ant decoderpro"; check for no startup errors, right version, help index present and working OK. Fix problems and commit back.


### PR DESCRIPTION
- Provide common java.util.Timer support through a new TimerUtil class to reduce the number of Timer threads left around
- Track down some left-running test threads and terminate them
- JUnit4 holds on to test-class references until it terminates; update dispose() methods and null out a few references to reduce static memory load
- Minor syntax cleanup