### PR TITLE
Migrate newSignalGroup method to better name

### DIFF
--- a/java/src/jmri/SignalGroupManager.java
+++ b/java/src/jmri/SignalGroupManager.java
@@ -37,12 +37,26 @@ public interface SignalGroupManager extends Manager<SignalGroup> {
      * User GUI, to allow the auto generation of systemNames, where the user can
      * optionally supply a username.
      *
-     * @param sys user name for the new group
+     * @param userName User name for the new group
      * @return null if a Group with the same userName already exists or if there
      *         is trouble creating a new Group
      */
     @Nonnull
-    public SignalGroup newSignalGroup(@Nonnull String sys);
+    public SignalGroup newSignaGroupWithUserName(@Nonnull String userName);
+    
+    /**
+     * Create a new Signal group if the group does not exist. Intended for use with
+     * User GUI, to allow the auto generation of systemNames, where the user can
+     * optionally supply a username.
+     *
+     * @param userName User name for the new group
+     * @return null if a Group with the same userName already exists or if there
+     *         is trouble creating a new Group
+     * @deprecated 4.15.2 use newSignaGroupWithUserName
+     */
+    @Nonnull
+    @Deprecated //  4.15.2 use newSignaGroupWithUserName
+    public SignalGroup newSignalGroup(@Nonnull String userName);
 
     /**
      * Create a new SignalGroup if the group does not exist.

--- a/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
@@ -916,7 +916,7 @@ public class SignalGroupTableAction extends AbstractTableAction<SignalGroup> imp
         if (_autoSystemName.isSelected() && !inEditMode) {
             // create new Signal Group with auto system name
             log.debug("SignalGroupTableAction checkNamesOK new autogroup");
-            g = InstanceManager.getDefault(jmri.SignalGroupManager.class).newSignalGroup(uName);
+            g = InstanceManager.getDefault(jmri.SignalGroupManager.class).newSignaGroupWithUserName(uName);
         } else {
             if (sName.length() == 0) { // show warning in status bar
                 status1.setText(Bundle.getMessage("AddBeanStatusEnter"));

--- a/java/src/jmri/managers/DefaultSignalGroupManager.java
+++ b/java/src/jmri/managers/DefaultSignalGroupManager.java
@@ -129,12 +129,25 @@ public class DefaultSignalGroupManager extends AbstractManager<SignalGroup>
 
     /**
      * {@inheritDoc}
+     * @deprecated 4.15.2 use newSignaGroupWithUserName
+     */
+    @Nonnull
+    @Override
+    @Deprecated //  4.15.2 use newSignaGroupWithUserName
+    public SignalGroup newSignalGroup(@Nonnull String userName) {
+        jmri.util.Log4JUtil.deprecationWarning(log, "newSignalGroup");
+        return newSignaGroupWithUserName(userName);
+    }
+    
+    /**
+     * {@inheritDoc}
      *
      * Keep autostring in line with {@link #provideSignalGroup(String, String)},
      * {@link #getSystemPrefix()} and {@link #typeLetter()}
      */
+    @Nonnull
     @Override
-    public SignalGroup newSignalGroup(String userName) {
+    public SignalGroup newSignaGroupWithUserName(String userName) {
         int nextAutoGroupRef = lastAutoGroupRef + 1;
         StringBuilder b = new StringBuilder("IG:AUTO:");
         String nextNumber = paddedNumber.format(nextAutoGroupRef);


### PR DESCRIPTION
See comments in #6310: The newSignalGroup method has an error-prone name, as it doesn't do what other newBeanName methods do.  This deprecates that method (name) and creates a better one to prevent future confusion.

Closes #6310