### PR TITLE
Updates for CI runtime errors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ install:
 # following need to be done after PATH is set
   - java -version
   - javac -version
-  - ant -version
   - mvn -version
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,7 @@ version: '{build}'
 clone_depth: 50
 install:
 # Available choices on https://www.appveyor.com/docs/windows-images-software/#java
-#  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-  - SET JAVA_HOME=C:\Program Files\Java\jdk9
+  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
 #  - echo JAVA_HOME %JAVA_HOME%
   - SET GECKODRIVER=C:\Tools\WebDriver
   - SET CHROMEDRIVER=C:\Tools\WebDriver\chromedriver.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,13 @@ install:
 #  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
   - SET JAVA_HOME=C:\Program Files\Java\jdk11
 #  - echo JAVA_HOME %JAVA_HOME%
-  - java -version
-#  - javac -version
   - SET GECKODRIVER=C:\Tools\WebDriver
   - SET CHROMEDRIVER=C:\Tools\WebDriver\chromedriver.exe
   - SET PATH=%JAVA_HOME%\bin;%GECKODRIVER%;%CHROMEDRIVER%;%PATH%
 #  - echo PATH %PATH%
+# following need to be done after PATH is set
+  - java -version
+  - javac -version
   - mvn -version
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ clone_depth: 50
 install:
 # Available choices on https://www.appveyor.com/docs/windows-images-software/#java
 #  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-  - SET JAVA_HOME=C:\Program Files\Java\jdk11
+  - SET JAVA_HOME=C:\Program Files\Java\jdk10
 #  - echo JAVA_HOME %JAVA_HOME%
   - SET GECKODRIVER=C:\Tools\WebDriver
   - SET CHROMEDRIVER=C:\Tools\WebDriver\chromedriver.exe
@@ -12,6 +12,7 @@ install:
 # following need to be done after PATH is set
   - java -version
   - javac -version
+  - ant -version
   - mvn -version
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,16 @@
 version: '{build}'
 clone_depth: 50
 install:
-  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+# Available choices on https://www.appveyor.com/docs/windows-images-software/#java
+#  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+  - SET JAVA_HOME=C:\Program Files\Java\jdk11
+#  - echo JAVA_HOME %JAVA_HOME%
+  - java -version
+#  - javac -version
   - SET GECKODRIVER=C:\Tools\WebDriver
   - SET CHROMEDRIVER=C:\Tools\WebDriver\chromedriver.exe
   - SET PATH=%JAVA_HOME%\bin;%GECKODRIVER%;%CHROMEDRIVER%;%PATH%
 #  - echo PATH %PATH%
-#  - echo JAVA_HOME %JAVA_HOME%
-  - java -version
-#  - javac -version
   - mvn -version
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ clone_depth: 50
 install:
 # Available choices on https://www.appveyor.com/docs/windows-images-software/#java
 #  - SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-  - SET JAVA_HOME=C:\Program Files\Java\jdk10
+  - SET JAVA_HOME=C:\Program Files\Java\jdk9
 #  - echo JAVA_HOME %JAVA_HOME%
   - SET GECKODRIVER=C:\Tools\WebDriver
   - SET CHROMEDRIVER=C:\Tools\WebDriver\chromedriver.exe

--- a/java/src/jmri/jmrix/jinput/TreeModel.java
+++ b/java/src/jmri/jmrix/jinput/TreeModel.java
@@ -101,7 +101,7 @@ public final class TreeModel extends DefaultTreeModel {
     }
 
     // intended for test routines only
-    void terminateThreads() throws InterruptedException {
+    public void terminateThreads() throws InterruptedException {
         if (runner == null) {
             return;
         }

--- a/java/src/jmri/jmrix/loconet/LnPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizer.java
@@ -95,8 +95,7 @@ public class LnPacketizer extends LnTrafficController {
      */
     @Override
     public void sendLocoNetMessage(LocoNetMessage m) {
-        
-        log.warn("debugging RcvHandler sendLocoNetMessage", new Exception("debug traceback"));
+
         // update statistics
         transmittedMsgCount++;
 

--- a/java/src/jmri/jmrix/loconet/LnPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizer.java
@@ -68,11 +68,8 @@ public class LnPacketizer extends LnTrafficController {
 
     /**
      * Synchronized list used as a transmit queue.
-     * <p>
-     * This is public to allow access from the internal class(es) when compiling
-     * with Java 1.1
      */
-    public LinkedList<byte[]> xmtList = new LinkedList<byte[]>();
+    protected LinkedList<byte[]> xmtList = new LinkedList<byte[]>();
 
     /**
      * XmtHandler (a local class) object to implement the transmit thread.
@@ -98,6 +95,8 @@ public class LnPacketizer extends LnTrafficController {
      */
     @Override
     public void sendLocoNetMessage(LocoNetMessage m) {
+        
+        log.warn("debugging RcvHandler sendLocoNetMessage", new Exception("debug traceback"));
         // update statistics
         transmittedMsgCount++;
 
@@ -462,26 +461,43 @@ public class LnPacketizer extends LnTrafficController {
         log.debug("startThreads current priority = {} max available = {} default = {} min available = {}", // NOI18N
                 priority, Thread.MAX_PRIORITY, Thread.NORM_PRIORITY, Thread.MIN_PRIORITY);
 
+        // start the RcvHandler in a thread of its own
+        if (rcvHandler == null) {
+            rcvHandler = new RcvHandler(this);
+        }
+        rcvThread = new Thread(rcvHandler, "LocoNet receive handler"); // NOI18N
+        rcvThread.setDaemon(true);
+        rcvThread.setPriority(Thread.MAX_PRIORITY);
+        rcvThread.start();
+
         // make sure that the xmt priority is no lower than the current priority
         int xmtpriority = (Thread.MAX_PRIORITY - 1 > priority ? Thread.MAX_PRIORITY - 1 : Thread.MAX_PRIORITY);
         // start the XmtHandler in a thread of its own
-        Thread xmtThread = new Thread(xmtHandler, "LocoNet transmit handler"); // NOI18N
+        xmtThread = new Thread(xmtHandler, "LocoNet transmit handler"); // NOI18N
         log.debug("Xmt thread starts at priority {}", xmtpriority); // NOI18N
         xmtThread.setDaemon(true);
         xmtThread.setPriority(Thread.MAX_PRIORITY - 1);
         xmtThread.start();
 
-        // start the RcvHandler in a thread of its own
-        if (rcvHandler == null) {
-            rcvHandler = new RcvHandler(this);
-        }
-        Thread rcvThread = new Thread(rcvHandler, "LocoNet receive handler"); // NOI18N
-        rcvThread.setDaemon(true);
-        rcvThread.setPriority(Thread.MAX_PRIORITY);
-        rcvThread.start();
         log.info("lnPacketizer Started");
     }
 
+    Thread rcvThread;
+    Thread xmtThread;
+    
+    /**
+     * End threads, intended for testing only
+     */
+    public void dispose() throws InterruptedException {
+        if (xmtThread != null) {
+            xmtThread.stop(); // interrupt not sufficient?
+            xmtThread.join();
+        }
+        if (rcvThread != null) {
+            rcvThread.interrupt();
+            rcvThread.join();
+        }   
+    }
     private final static Logger log = LoggerFactory.getLogger(LnPacketizer.class);
 
 }

--- a/java/src/jmri/jmrix/loconet/LnPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizer.java
@@ -487,15 +487,20 @@ public class LnPacketizer extends LnTrafficController {
     /**
      * End threads, intended for testing only
      */
-    public void dispose() throws InterruptedException {
+    public void dispose() {
         if (xmtThread != null) {
             xmtThread.stop(); // interrupt not sufficient?
-            xmtThread.join();
+            try {
+                xmtThread.join();
+            } catch (InterruptedException e) { log.warn("unexpected InterruptedException", e);}
         }
         if (rcvThread != null) {
             rcvThread.interrupt();
-            rcvThread.join();
-        }   
+            try {
+                rcvThread.join();
+            } catch (InterruptedException e) { log.warn("unexpected InterruptedException", e);}
+        }
+        super.dispose();
     }
     private final static Logger log = LoggerFactory.getLogger(LnPacketizer.class);
 

--- a/java/src/jmri/jmrix/loconet/LnTrafficController.java
+++ b/java/src/jmri/jmrix/loconet/LnTrafficController.java
@@ -119,7 +119,7 @@ public abstract class LnTrafficController implements LocoNetInterface {
      * <p>
      * The object can't be used after this.
      */
-    public void dispose() {};
+    public void dispose() {}
 
     /**
      * Monitor the number of LocoNet messages received across the interface.

--- a/java/src/jmri/jmrix/loconet/LnTrafficController.java
+++ b/java/src/jmri/jmrix/loconet/LnTrafficController.java
@@ -115,6 +115,13 @@ public abstract class LnTrafficController implements LocoNetInterface {
     }
 
     /**
+     * Clean up any resources, particularly threads.
+     * <p>
+     * The object can't be used after this.
+     */
+    public void dispose() {};
+
+    /**
      * Monitor the number of LocoNet messages received across the interface.
      * This includes the messages this client has sent.
      *

--- a/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSystemConnectionMemo.java
@@ -71,6 +71,7 @@ public class LocoNetSystemConnectionMemo extends SystemConnectionMemo {
 
     ComponentFactory cf = null;
     private LnTrafficController lt;
+    protected LocoNetThrottledTransmitter tm;
     private SlotManager sm;
     private LnMessageManager lnm = null;
 
@@ -262,8 +263,6 @@ public class LocoNetSystemConnectionMemo extends SystemConnectionMemo {
         return super.get(T);
     }
 
-    protected LocoNetThrottledTransmitter tm;
-
     /**
      * Configure the common managers for LocoNet connections. This puts the
      * common manager config in one place.
@@ -410,25 +409,28 @@ public class LocoNetSystemConnectionMemo extends SystemConnectionMemo {
 
     @Override
     public void dispose() {
-        lt = null;
-        sm = null;
         InstanceManager.deregister(this, LocoNetSystemConnectionMemo.class);
         if (cf != null) {
             InstanceManager.deregister(cf, ComponentFactory.class);
         }
         if (powerManager != null) {
+            powerManager.dispose();
             InstanceManager.deregister(powerManager, LnPowerManager.class);
         }
         if (turnoutManager != null) {
+            turnoutManager.dispose();
             InstanceManager.deregister(turnoutManager, LnTurnoutManager.class);
         }
         if (lightManager != null) {
+            lightManager.dispose();
             InstanceManager.deregister(lightManager, LnLightManager.class);
         }
         if (sensorManager != null) {
+            sensorManager.dispose();
             InstanceManager.deregister(sensorManager, LnSensorManager.class);
         }
         if (reporterManager != null) {
+            reporterManager.dispose();
             InstanceManager.deregister(reporterManager, LnReporterManager.class);
         }
         if (throttleManager != null) {
@@ -446,6 +448,9 @@ public class LocoNetSystemConnectionMemo extends SystemConnectionMemo {
         }
         if (sm != null){
             sm.dispose();
+        }
+        if (lt != null){
+            lt.dispose();
         }
         super.dispose();
     }

--- a/java/src/jmri/jmrix/loconet/hexfile/HexFileFrame.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/HexFileFrame.java
@@ -130,7 +130,7 @@ public class HexFileFrame extends JmriJFrame {
     @InvokeOnGuiThread
     public void dispose() {
         // leaves the LocoNet Packetizer (e.g. the simulated connection)
-        // running.
+        // running so that the application can keep pretending to run with the window closed.
         super.dispose();
     }
 
@@ -151,7 +151,7 @@ public class HexFileFrame extends JmriJFrame {
         port.load(inputFileChooser.getSelectedFile());
 
         // wake copy
-        sourceThread.interrupt();
+        sourceThread.interrupt();  // really should be using notifyAll instead....
 
         // reach here while file runs.  Need to return so GUI still acts,
         // but that normally lets the button go back to default.
@@ -253,7 +253,7 @@ public class HexFileFrame extends JmriJFrame {
         }
     }
 
-    private Thread sourceThread;
+    Thread sourceThread;  // tests need access
 
     public void setAdapter(LnHexFilePort adapter) {
         port = adapter;

--- a/java/src/jmri/jmrix/loconet/pr2/PR2SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/loconet/pr2/PR2SystemConnectionMemo.java
@@ -2,7 +2,9 @@ package jmri.jmrix.loconet.pr2;
 
 import jmri.GlobalProgrammerManager;
 import jmri.InstanceManager;
+import jmri.jmrix.debugthrottle.DebugThrottleManager;
 import jmri.jmrix.loconet.LnPr2ThrottleManager;
+import jmri.jmrix.loconet.LnPowerManager;
 import jmri.jmrix.loconet.LnTrafficController;
 import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import jmri.jmrix.loconet.SlotManager;
@@ -121,6 +123,12 @@ public class PR2SystemConnectionMemo extends LocoNetSystemConnectionMemo {
     @Override
     public void dispose() {
         InstanceManager.deregister(this, PR2SystemConnectionMemo.class);
+
+        if (powerPr2Manager != null) {
+            powerPr2Manager.dispose();
+            InstanceManager.deregister(powerPr2Manager, LnPowerManager.class);
+        }
+
         super.dispose();
     }
 

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -324,7 +324,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
     @Override
     @Deprecated  // will be removed when Manager method is removed due to @Override
     public String[] getSystemNameArray() {
-        // jmri.util.Log4JUtil.deprecationWarning(log, "getSystemNameArray");        commented due to number of uses
+        jmri.util.Log4JUtil.deprecationWarning(log, "getSystemNameArray");
         if (log.isTraceEnabled()) log.trace("Manager#getSystemNameArray() called", new Exception("traceback"));
 
         if (cachedSystemNameArray == null) {
@@ -338,6 +338,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
     @Override
     @Deprecated  // will be removed when Manager method is removed due to @Override
     public List<String> getSystemNameList() {
+        // jmri.util.Log4JUtil.deprecationWarning(log, "getSystemNameList");
         if (cachedSystemNameList == null) {
             cachedSystemNameList = new ArrayList<>();
             for (E b : _beans) {
@@ -352,6 +353,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
     @Override
     @Deprecated  // will be removed when Manager method is removed due to @Override
     public List<String> getSystemNameAddedOrderList() {
+        jmri.util.Log4JUtil.deprecationWarning(log, "getSystemNameList");
         return Collections.unmodifiableList(_originalOrderList);
     }
 
@@ -360,6 +362,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
     @Override
     @Deprecated  // will be removed when Manager method is removed due to @Override
     public List<E> getNamedBeanList() {
+        jmri.util.Log4JUtil.deprecationWarning(log, "getNamedBeanList");
         if (cachedNamedBeanList == null) {
             cachedNamedBeanList = new ArrayList<>(_beans);
         }

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -352,6 +352,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
     /** {@inheritDoc} */
     @Override
     @Deprecated  // will be removed when Manager method is removed due to @Override
+                 // Only used in ConfigureXML
     public List<String> getSystemNameAddedOrderList() {
         //jmri.util.Log4JUtil.deprecationWarning(log, "getSystemNameAddedOrderList");
         return Collections.unmodifiableList(_originalOrderList);

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -353,7 +353,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
     @Override
     @Deprecated  // will be removed when Manager method is removed due to @Override
     public List<String> getSystemNameAddedOrderList() {
-        jmri.util.Log4JUtil.deprecationWarning(log, "getSystemNameList");
+        //jmri.util.Log4JUtil.deprecationWarning(log, "getSystemNameAddedOrderList");
         return Collections.unmodifiableList(_originalOrderList);
     }
 

--- a/java/src/jmri/managers/DefaultIdTagManager.java
+++ b/java/src/jmri/managers/DefaultIdTagManager.java
@@ -416,8 +416,7 @@ public class DefaultIdTagManager extends AbstractManager<IdTag> implements IdTag
 
             // Loop through RfidTags
             root.addContent(values = new Element("idtags")); // NOI18N
-            List<IdTag> idTagList = manager.getNamedBeanList();
-            for (IdTag t : idTagList) {
+            for (IdTag t : manager.getNamedBeanSet()) {
                 log.debug("Writing IdTag: {}", t.getSystemName());
                 values.addContent(t.store(manager.isStateStored()));
             }

--- a/java/src/jmri/managers/DefaultLogixManager.java
+++ b/java/src/jmri/managers/DefaultLogixManager.java
@@ -142,7 +142,7 @@ public class DefaultLogixManager extends AbstractManager<Logix>
         }
         // iterate thru all Logixs that exist
         java.util.Iterator<Logix> iter
-                = getNamedBeanList().iterator();
+                = getNamedBeanSet().iterator();
         while (iter.hasNext()) {
             // get the next Logix
             x = iter.next();

--- a/java/src/jmri/util/Log4JUtil.java
+++ b/java/src/jmri/util/Log4JUtil.java
@@ -259,7 +259,29 @@ public class Log4JUtil {
     }
 
     /**
-     * Shorten this stack trace in a Throwable.  If you then pass it to 
+     * Shorten this stack trace in a Throwable to start with the first JMRI method.  
+     * <p>
+     * If you then pass it to 
+     * Log4J for logging, it'll take up less space.
+     * @param t The Throwable to truncate and return
+     * @param len The number of stack trace entries to keep.
+     * @return The original object with truncated stack trace
+     */
+    public  @Nonnull static <T extends Throwable> T shortenStacktrace(@Nonnull T t) {
+        StackTraceElement[]	originalTrace = t.getStackTrace();
+        int i;
+        for (i = originalTrace.length-1; i>0; i--) { // search from deepest
+            String name = originalTrace[i].getClassName();
+            if (name.equals("jmri.util.junit.TestClassMainMethod")) continue; // special case
+            if (name.startsWith("jmri") || name.startsWith("apps")) break;
+        }
+        return shortenStacktrace(t, i+1);
+    }
+
+    /**
+     * Shorten this stack trace in a Throwable to a fixed length.
+     * <p>
+     * If you then pass it to 
      * Log4J for logging, it'll take up less space.
      * @param t The Throwable to truncate and return
      * @param len The number of stack trace entries to keep.
@@ -267,8 +289,9 @@ public class Log4JUtil {
      */
     public  @Nonnull static <T extends Throwable> T shortenStacktrace(@Nonnull T t, int len) {
         StackTraceElement[]	originalTrace = t.getStackTrace();
-        StackTraceElement[] newTrace = new StackTraceElement[len];
-        for (int i = 0; i < len; i++) newTrace[i] = originalTrace[i];
+        int newLen = Math.min(len, originalTrace.length);
+        StackTraceElement[] newTrace = new StackTraceElement[newLen];
+        for (int i = 0; i < newLen; i++) newTrace[i] = originalTrace[i];
         t.setStackTrace(newTrace);
         return t;
     }

--- a/java/src/jmri/util/Log4JUtil.java
+++ b/java/src/jmri/util/Log4JUtil.java
@@ -97,7 +97,7 @@ public class Log4JUtil {
      */
      static public void deprecationWarning(@Nonnull Logger logger, @Nonnull String methodName) {
         if (logDeprecations) {
-            warnOnce(logger, "{} is deprecated, please remove references to it", methodName, new Exception("traceback"));
+            warnOnce(logger, "{} is deprecated, please remove references to it", methodName, shortenStacktrace(new Exception("traceback")));
         }
      }
      

--- a/java/src/jmri/util/Log4JUtil.java
+++ b/java/src/jmri/util/Log4JUtil.java
@@ -264,7 +264,6 @@ public class Log4JUtil {
      * If you then pass it to 
      * Log4J for logging, it'll take up less space.
      * @param t The Throwable to truncate and return
-     * @param len The number of stack trace entries to keep.
      * @return The original object with truncated stack trace
      */
     public  @Nonnull static <T extends Throwable> T shortenStacktrace(@Nonnull T t) {
@@ -285,7 +284,7 @@ public class Log4JUtil {
      * Log4J for logging, it'll take up less space.
      * @param t The Throwable to truncate and return
      * @param len The number of stack trace entries to keep.
-     * @return THe original object with truncated stack trace
+     * @return The original object with truncated stack trace
      */
     public  @Nonnull static <T extends Throwable> T shortenStacktrace(@Nonnull T t, int len) {
         StackTraceElement[]	originalTrace = t.getStackTrace();

--- a/java/test/jmri/jmrit/beantable/MaintenanceTest.java
+++ b/java/test/jmri/jmrit/beantable/MaintenanceTest.java
@@ -89,7 +89,7 @@ public class MaintenanceTest {
     }
    
     @Test
-    public void testDeviceReportPressed(){
+    public void testDeviceReportPressed() throws InterruptedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
@@ -101,10 +101,11 @@ public class MaintenanceTest {
         ThreadingUtil.runOnGUI(() -> {
             Maintenance.deviceReportPressed("IS1",new jmri.util.JmriJFrame("DeviceReportParent"));
         });
+        t.join(); // only proceed when all done
     }
 
     @Test
-    public void testFindOrphansPressed(){
+    public void testFindOrphansPressed() throws InterruptedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
@@ -116,10 +117,11 @@ public class MaintenanceTest {
         ThreadingUtil.runOnGUI(() -> {
             Maintenance.findOrphansPressed(new jmri.util.JmriJFrame("FindOrphansParent"));
         });
+        t.join(); // only proceed when all done
     }
 
     //@Test
-    public void testFindEmptyPressed(){
+    public void testFindEmptyPressed() throws InterruptedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         Thread t = new Thread(() -> {
             // constructor for jdo will wait until the dialog is visible
@@ -131,6 +133,7 @@ public class MaintenanceTest {
         ThreadingUtil.runOnGUI(() -> {
             Maintenance.findEmptyPressed(new jmri.util.JmriJFrame("FindEmptyParent"));
         });
+        t.join(); // only proceed when all done
     }
 
 

--- a/java/test/jmri/jmrix/dccpp/dccppovertcp/ClientRxHandlerTest.java
+++ b/java/test/jmri/jmrix/dccpp/dccppovertcp/ClientRxHandlerTest.java
@@ -13,9 +13,13 @@ import org.junit.Test;
 public class ClientRxHandlerTest {
     
     @Test
-    public void testCTor() {
+    public void testCTor() throws InterruptedException {
         ClientRxHandler t = new ClientRxHandler("127.0.0.1",new java.net.Socket());
         Assert.assertNotNull("exists",t);
+        
+        // clean up started thread
+        t.interrupt();
+        t.join();
     }
     
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
@@ -99,7 +99,6 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         Assert.assertEquals("type 1", Manager.ManagerDataEvent.INTERVAL_ADDED, lastType);
         Assert.assertEquals("start == end 1", lastEvent0, lastEvent1);
         Assert.assertEquals("index 1", 1, lastEvent0);
-        Assert.assertEquals("content at index 1", s2, l.getNamedBeanList().get(lastEvent0));
 
         // add an item
         Sensor s3 = l.newSensor("IS3", "Sensor 3");
@@ -114,7 +113,6 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         Assert.assertEquals("type 2", Manager.ManagerDataEvent.INTERVAL_ADDED, lastType);
         Assert.assertEquals("start == end 2", lastEvent0, lastEvent1);
         Assert.assertEquals("index 2", 2, lastEvent0);
-        Assert.assertEquals("content at index 2", s3, l.getNamedBeanList().get(lastEvent0));
     }
 
     @Test
@@ -126,7 +124,6 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         l.provideSensor("IS3");
         
         l.addDataListener(this);
-        List<Sensor> tlist = l.getNamedBeanList();
 
         l.deregister(s2);
     
@@ -136,7 +133,6 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         Assert.assertEquals("type", Manager.ManagerDataEvent.INTERVAL_REMOVED, lastType);
         Assert.assertEquals("start == end 2", lastEvent0, lastEvent1);
         Assert.assertEquals("index", 1, lastEvent0);
-        Assert.assertEquals("content at index", s2, tlist.get(lastEvent0));       
     }
 
     @Test
@@ -146,7 +142,6 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         
         List<String> orderedList = l.getSystemNameAddedOrderList();
         List<String> sortedList = l.getSystemNameList();
-        List<Sensor> beanList = l.getNamedBeanList();
         SortedSet<Sensor> beanSet = l.getNamedBeanSet();
         String[] sortedArray = l.getSystemNameArray();  // deprecated, but we test until removed
         jmri.util.JUnitAppender.suppressWarnMessage("Manager#getSystemNameArray() is deprecated");
@@ -158,10 +153,6 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         Assert.assertEquals("sorted list length", 2, sortedList.size());
         Assert.assertEquals("sorted list 1st", "IS2", sortedList.get(0));
         Assert.assertEquals("sorted list 2nd", "IS4", sortedList.get(1));
-
-        Assert.assertEquals("bean list length", 2, beanList.size());
-        Assert.assertEquals("bean list 1st", s2, beanList.get(0));
-        Assert.assertEquals("bean list 2nd", s4, beanList.get(1));
 
         Assert.assertEquals("bean set length", 2, beanSet.size());
         Iterator<Sensor> iter = beanSet.iterator();
@@ -186,10 +177,6 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         Assert.assertEquals("sorted list 1st", "IS2", sortedList.get(0));
         Assert.assertEquals("sorted list 2nd", "IS4", sortedList.get(1));
 
-        Assert.assertEquals("bean list length", 2, beanList.size());
-        Assert.assertEquals("bean list 1st", s2, beanList.get(0));
-        Assert.assertEquals("bean list 2nd", s4, beanList.get(1));
-
         Assert.assertEquals("bean set length", 4, beanSet.size());
         iter = beanSet.iterator();
         Assert.assertEquals("bean set 1st", s1, iter.next());
@@ -204,7 +191,6 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         // update and test update
         orderedList = l.getSystemNameAddedOrderList();
         sortedList = l.getSystemNameList();
-        beanList = l.getNamedBeanList();
         beanSet = l.getNamedBeanSet();
         sortedArray = l.getSystemNameArray();
         
@@ -219,12 +205,6 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         Assert.assertEquals("sorted list 2nd", "IS2", sortedList.get(1));
         Assert.assertEquals("sorted list 3rd", "IS3", sortedList.get(2));
         Assert.assertEquals("sorted list 4th", "IS4", sortedList.get(3));
-
-        Assert.assertEquals("bean list length", 4, beanList.size());
-        Assert.assertEquals("bean list 1st", s1, beanList.get(0));
-        Assert.assertEquals("bean list 2nd", s2, beanList.get(1));
-        Assert.assertEquals("bean list 3rd", s3, beanList.get(2));
-        Assert.assertEquals("bean list 4th", s4, beanList.get(3));
 
         Assert.assertEquals("bean set length", 4, beanSet.size());
         iter = beanSet.iterator();
@@ -247,15 +227,9 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         l.provideSensor("IS2");
         
         List<String> nameList = l.getSystemNameList();
-        List<Sensor> beanList = l.getNamedBeanList();
 
         try {
             nameList.add("Foo");
-            Assert.fail("Should have thrown");
-        } catch (UnsupportedOperationException e) { /* this is OK */}
-
-        try {
-            beanList.add(s1);
             Assert.fail("Should have thrown");
         } catch (UnsupportedOperationException e) { /* this is OK */}
 

--- a/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
@@ -101,7 +101,7 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
         Assert.assertEquals("index 1", 1, lastEvent0);
 
         // add an item
-        Sensor s3 = l.newSensor("IS3", "Sensor 3");
+        l.newSensor("IS3", "Sensor 3");
 
         // property listener should have been immediately invoked
         Assert.assertEquals("propertyListenerCount", 3, propertyListenerCount);
@@ -223,7 +223,7 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
 
     @Test
     public void testUnmodifiable() {
-        Sensor s1 = l.provideSensor("IS1");
+        l.provideSensor("IS1");
         l.provideSensor("IS2");
         
         List<String> nameList = l.getSystemNameList();

--- a/java/test/jmri/jmrix/jinput/TreeModelTest.java
+++ b/java/test/jmri/jmrix/jinput/TreeModelTest.java
@@ -26,11 +26,14 @@ public class TreeModelTest {
         try {
             Assert.assertNotNull("exists", TreeModel.instance());
         } catch (Throwable e) {
-            if (e instanceof ClassNotFoundException) {
+            log.warn("TreeModelTest caught "+e);
+            if (e instanceof UnsatisfiedLinkError) {
+                log.info("TreeModel.instance threw UnsatisfiedLinkError, which means we can't test on this platform");
+                return;
+            } else if (e instanceof ClassNotFoundException) {
                 log.info("TreeModel.instance threw ClassNotFoundException, which means we can't test on this platform");
                 return;
             } else {
-                log.error("instance threw", e);
                 Assert.fail("instance threw "+e);
             }
         }

--- a/java/test/jmri/jmrix/jinput/TreeModelTest.java
+++ b/java/test/jmri/jmrix/jinput/TreeModelTest.java
@@ -23,7 +23,17 @@ public class TreeModelTest {
     @Test
     public void testInstance() throws InterruptedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        Assert.assertNotNull("exists", TreeModel.instance());
+        try {
+            Assert.assertNotNull("exists", TreeModel.instance());
+        } catch (Throwable e) {
+            if (e instanceof ClassNotFoundException) {
+                log.info("TreeModel.instance threw ClassNotFoundException, which means we can't test on this platform");
+                return;
+            } else {
+                log.error("instance threw", e);
+                Assert.fail("instance threw "+e);
+            }
+        }
         // then kill the thread
         TreeModel.instance().terminateThreads();
     }
@@ -34,5 +44,9 @@ public class TreeModelTest {
     }
 
     @After
-    public void tearDown() {        JUnitUtil.tearDown();    }
+    public void tearDown() {        
+        JUnitUtil.tearDown();
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TreeModelTest.class);
 }

--- a/java/test/jmri/jmrix/jinput/treecontrol/TreePanelTest.java
+++ b/java/test/jmri/jmrix/jinput/treecontrol/TreePanelTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.jinput.treecontrol;
 
+import jmri.jmrix.jinput.TreeModel;
 import jmri.util.JUnitUtil;
 import org.junit.*;
 
@@ -11,9 +12,24 @@ import org.junit.*;
 public class TreePanelTest {
 
     @Test
-    public void testCtor() {
-        TreePanel action = new TreePanel();
-        Assert.assertNotNull("exists", action);
+    public void testCtor() throws InterruptedException {
+        try {
+            // just checking for failure to construct
+            new TreePanel();
+        } catch (Throwable e) {
+            log.warn("TreeModelTest caught "+e);
+            if (e instanceof UnsatisfiedLinkError) {
+                log.info("TreeModel.instance threw UnsatisfiedLinkError, which means we can't test on this platform");
+                return;
+            } else if (e instanceof ClassNotFoundException) {
+                log.info("TreeModel.instance threw ClassNotFoundException, which means we can't test on this platform");
+                return;
+            } else {
+                Assert.fail("instance threw "+e);
+            }
+        }
+        // then kill the thread
+        TreeModel.instance().terminateThreads();
     }
 
     @Before
@@ -22,5 +38,9 @@ public class TreePanelTest {
     }
 
     @After
-    public void tearDown() {        JUnitUtil.tearDown();    }
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TreePanelTest.class);
 }

--- a/java/test/jmri/jmrix/loconet/LnClockControlTest.java
+++ b/java/test/jmri/jmrix/loconet/LnClockControlTest.java
@@ -20,15 +20,20 @@ public class LnClockControlTest {
         LnTrafficController lnis = new LocoNetInterfaceScaffold();
         SlotManager slotmanager = new SlotManager(lnis);
         LocoNetSystemConnectionMemo c = new LocoNetSystemConnectionMemo(lnis, slotmanager);
+
         LnClockControl t = new LnClockControl(c);
         Assert.assertNotNull("exists",t);
+        
+        c.dispose();
     }
-
+    
     @Test
     public void testCtorTwoArg() {
         LnTrafficController lnis = new LocoNetInterfaceScaffold();
         SlotManager slotmanager = new SlotManager(lnis);
+ 
         LnClockControl t = new LnClockControl(slotmanager,lnis);
+ 
         Assert.assertNotNull("exists",t);
     }
 
@@ -56,6 +61,8 @@ public class LnClockControlTest {
         Assert.assertEquals("sent", 2, lnis.outbound.size());
         Assert.assertEquals("message 1", "EF 0E 7B 01 7B 78 43 07 68 01 00 00 00 00", lnis.outbound.get(0).toString());
         Assert.assertEquals("message 2", "BB 7B 00 00", lnis.outbound.get(1).toString());     
+        
+        c.dispose();
     }
     
     @Test
@@ -83,6 +90,8 @@ public class LnClockControlTest {
         Assert.assertEquals("sent", 2, lnis.outbound.size());
         Assert.assertEquals("message 1", "EF 0E 7B 01 7B 78 43 06 68 01 00 00 00 00", lnis.outbound.get(0).toString());
         Assert.assertEquals("message 2", "BB 7B 00 00", lnis.outbound.get(1).toString());     
+        
+        c.dispose();
     }
 
     @Before

--- a/java/test/jmri/jmrix/loconet/LocoNetMessageTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetMessageTest.java
@@ -353,9 +353,9 @@ public class LocoNetMessageTest {
         Assert.assertEquals("Sensor L2S1853 (brightly) is Low.  (BDL16 # 116, DS13; DS54/DS64 # 232, AuxC/A3).\n", m.toMonitorString("L2"));
 
         lntm.dispose();
-
-
-
+        lntm2.dispose();
+        lnsm.dispose();
+        lnsm2.dispose();
     }
 
     @Test

--- a/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnIPLImplementationTest.java
+++ b/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnIPLImplementationTest.java
@@ -1615,5 +1615,8 @@ public class LnIPLImplementationTest {
     }
 
     @After
-    public void tearDown() {        JUnitUtil.tearDown();    }
+    public void tearDown() {        
+        memo.dispose();
+        JUnitUtil.tearDown();
+    }
 }

--- a/java/test/jmri/jmrix/loconet/hexfile/HexFileFrameTest.java
+++ b/java/test/jmri/jmrix/loconet/hexfile/HexFileFrameTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.loconet.hexfile;
 
 import java.awt.GraphicsEnvironment;
+import jmri.jmrix.loconet.LnPacketizer;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import jmri.util.*;
 import org.junit.After;
 import org.junit.Assert;
@@ -15,16 +17,27 @@ import org.junit.Test;
 public class HexFileFrameTest {
 
     @Test
-    public void testCTor() {
+    public void testCTor() throws InterruptedException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        LnHexFilePort p = new LnHexFilePort();
+        
+        HexFileFrame f = new HexFileFrame();
+
         ThreadingUtil.runOnGUI( ()-> {
-            HexFileFrame t = new HexFileFrame();
-            LnHexFilePort p = new LnHexFilePort();
-            t.setAdapter(p);
-            t.initComponents();
-            t.configure();
-            t.dispose();
-        });
+            f.setAdapter(p);
+            f.initComponents();
+            f.configure();
+       });
+
+        ThreadingUtil.runOnGUI( ()-> {
+            f.dispose();
+       });
+            
+        ((LnPacketizer)
+                ((LocoNetSystemConnectionMemo)p.getSystemConnectionMemo())
+                    .getLnTrafficController()
+            ).dispose();
+        p.dispose();
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/loconet/hexfile/HexFileFrameTest.java
+++ b/java/test/jmri/jmrix/loconet/hexfile/HexFileFrameTest.java
@@ -33,10 +33,11 @@ public class HexFileFrameTest {
             f.dispose();
        });
             
-        ((LnPacketizer)p.getSystemConnectionMemo().getLnTrafficController())
-            .dispose();
+        p.getSystemConnectionMemo().dispose();
         p.dispose();
-    }
+        f.sourceThread.stop();
+        f.sourceThread.join();
+ }   
 
     // The minimal setup for log4J
     @Before

--- a/java/test/jmri/jmrix/loconet/hexfile/HexFileFrameTest.java
+++ b/java/test/jmri/jmrix/loconet/hexfile/HexFileFrameTest.java
@@ -33,10 +33,8 @@ public class HexFileFrameTest {
             f.dispose();
        });
             
-        ((LnPacketizer)
-                ((LocoNetSystemConnectionMemo)p.getSystemConnectionMemo())
-                    .getLnTrafficController()
-            ).dispose();
+        ((LnPacketizer)p.getSystemConnectionMemo().getLnTrafficController())
+            .dispose();
         p.dispose();
     }
 

--- a/java/test/jmri/jmrix/loconet/locomon/LocoMonPaneTest.java
+++ b/java/test/jmri/jmrix/loconet/locomon/LocoMonPaneTest.java
@@ -103,6 +103,9 @@ public class LocoMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
          f.dispose();
     }
 
+    jmri.TurnoutManager l;
+    jmri.SensorManager s;
+    jmri.ReporterManager r;
     
     // The minimal setup for log4J
     @Override
@@ -117,15 +120,15 @@ public class LocoMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
         jmri.jmrix.loconet.LocoNetInterfaceScaffold lnis = new jmri.jmrix.loconet.LocoNetInterfaceScaffold();
         // create and register the manager object
         jmri.util.JUnitUtil.initInternalTurnoutManager();
-        jmri.TurnoutManager l = new jmri.jmrix.loconet.LnTurnoutManager(lnis, lnis, "L", false);
+        l = new jmri.jmrix.loconet.LnTurnoutManager(lnis, lnis, "L", false);
         jmri.InstanceManager.setTurnoutManager(l);
 
         jmri.util.JUnitUtil.initInternalSensorManager();
-        jmri.SensorManager s = new jmri.jmrix.loconet.LnSensorManager(lnis, "L");
+        s = new jmri.jmrix.loconet.LnSensorManager(lnis, "L");
         jmri.InstanceManager.setSensorManager(s);
 
         jmri.util.JUnitUtil.initReporterManager();
-        jmri.ReporterManager r = new jmri.jmrix.loconet.LnReporterManager(lnis, "L");
+        r = new jmri.jmrix.loconet.LnReporterManager(lnis, "L");
         jmri.InstanceManager.setReporterManager(r);
 
         // pane for AbstractMonFrameTestBase, panel for JmriPanelTest
@@ -139,6 +142,10 @@ public class LocoMonPaneTest extends jmri.jmrix.AbstractMonPaneTestBase {
     public void tearDown() {
         pane.dispose();
         
+        l.dispose();
+        s.dispose();
+        r.dispose();
+
         jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrix/loconet/pr2/PR2SystemConnectionMemoTest.java
+++ b/java/test/jmri/jmrix/loconet/pr2/PR2SystemConnectionMemoTest.java
@@ -27,6 +27,7 @@ public class PR2SystemConnectionMemoTest extends jmri.jmrix.SystemConnectionMemo
     @Override
     @After
     public void tearDown() {
+        scm.dispose();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/managers/ManagerDefaultSelectorTest.java
+++ b/java/test/jmri/managers/ManagerDefaultSelectorTest.java
@@ -106,6 +106,8 @@ public class ManagerDefaultSelectorTest {
         // loconet gone, auto internal is by itself, so OK
         Assert.assertTrue(mds.isPreferencesValid(profile));
         
+        loconet.dispose();
+        
     }
 
     @Test
@@ -161,6 +163,8 @@ public class ManagerDefaultSelectorTest {
 
         // loconet gone, auto internal is by itself, so OK
         Assert.assertTrue(mds.isPreferencesValid(profile));
+        
+        loconet.dispose();
     }
 
     @Test
@@ -213,6 +217,9 @@ public class ManagerDefaultSelectorTest {
 
         // loconet and loconet2 gone, auto internal is by itself, so OK
         Assert.assertTrue(mds.isPreferencesValid(profile));
+        
+        loconet.dispose();
+        loconet2.dispose();
     }
     
     @Test

--- a/java/test/jmri/server/json/layoutblock/JsonLayoutBlockSocketServiceTest.java
+++ b/java/test/jmri/server/json/layoutblock/JsonLayoutBlockSocketServiceTest.java
@@ -132,7 +132,7 @@ public class JsonLayoutBlockSocketServiceTest {
         Assert.assertEquals("LayoutBlock1 has 2 listeners", 2, lb1.getPropertyChangeListeners().length);
         JsonNode message = connection.getMessage();
         Assert.assertTrue("Message is an array", message.isArray());
-        Assert.assertEquals("All LayoutBlocks are listed", manager.getNamedBeanList().size(), message.size());
+        Assert.assertEquals("All LayoutBlocks are listed", manager.getNamedBeanSet().size(), message.size());
     }
 
     /**

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1051,10 +1051,12 @@ public class JUnitUtil {
         "RMI TCP Accept",
         "TimerQueue",
         "Java Sound Event Dispatcher",
-        "Aqua L&F",                         // macOS only
+        "Aqua L&F",                         // macOS
         "AppKit Thread",
         "JMRI Common Timer",
-        "BluecoveAsynchronousShutdownThread" // from LocoNet BlueTooth implementation
+        "BluecoveAsynchronousShutdownThread", // from LocoNet BlueTooth implementation
+        "Keep-Alive-Timer",                 // from "system" group
+        "process reaper"                    // observed in macOS JRE
     }));
     static List<Thread> threadsSeen = new ArrayList<>();
 
@@ -1094,7 +1096,7 @@ public class JUnitUtil {
                         
                         // for anonymous threads, show the traceback in hopes of finding what it is
                         if (name.startsWith("Thread-")) {
-                            Exception ex = new Exception("traceback");
+                            Exception ex = new Exception("traceback of numbered thread");
                             ex.setStackTrace(Thread.getAllStackTraces().get(t));
                             log.warn("Found remnant thread \"{}\" in group \"{}\" after {}", t.getName(), t.getThreadGroup().getName(), getTestClassName(), ex);
                         } else {

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -7,10 +7,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import javax.annotation.Nonnull;
 import jmri.*;
 import jmri.implementation.JmriConfigurationManager;
@@ -1037,7 +1034,7 @@ public class JUnitUtil {
         return null;
     }
 
-    static List<String> threadNames = new ArrayList<>(Arrays.asList(new String[]{
+    static SortedSet<String> threadNames = new TreeSet<>(Arrays.asList(new String[]{
         // names we know about from normal running
         "main",
         "Java2D Disposer",
@@ -1046,7 +1043,7 @@ public class JUnitUtil {
         "GC Daemon",
         "Finalizer",
         "Reference Handler",
-        "Signal Dispatcher",
+        "Signal Dispatcher",                // POSIX signals in JRE
         "Java2D Queue Flusher",
         "Time-limited test",
         "WindowMonitor-DispatchThread",
@@ -1054,8 +1051,10 @@ public class JUnitUtil {
         "RMI TCP Accept",
         "TimerQueue",
         "Java Sound Event Dispatcher",
-        "Aqua L&F",
-        "AppKit Thread"
+        "Aqua L&F",                         // macOS only
+        "AppKit Thread",
+        "JMRI Common Timer",
+        "BluecoveAsynchronousShutdownThread" // from LocoNet BlueTooth implementation
     }));
     static List<Thread> threadsSeen = new ArrayList<>();
 
@@ -1080,7 +1079,8 @@ public class JUnitUtil {
                      || name.startsWith("Image Fetcher ")
                      || name.startsWith("JmDNS(")
                      || name.startsWith("SocketListener(")
-                     || (name.startsWith("Timer-") && 
+                     || name.startsWith("SocketListener(")
+                     || (name.startsWith("SwingWorker-pool-1-thread-") && 
                             ( t.getThreadGroup() != null && 
                                 (t.getThreadGroup().getName().contains("FailOnTimeoutGroup") || t.getThreadGroup().getName().contains("main") )
                             ) 

--- a/java/test/jmri/util/Log4JUtilTest.java
+++ b/java/test/jmri/util/Log4JUtilTest.java
@@ -104,12 +104,31 @@ public class Log4JUtilTest {
         Assert.assertTrue(jmri.util.JUnitAppender.verifyNoBacklog());
     }
     
+    private IllegalArgumentException getTraceBack() { return new IllegalArgumentException("for test"); }
+    
     @Test
     public void testShortenStacktrace() {
-        IllegalArgumentException ex = new IllegalArgumentException("for test");
+        IllegalArgumentException ex = getTraceBack();
         Assert.assertTrue("Needs long enough trace for test", ex.getStackTrace().length > 3);
         
         Assert.assertEquals(3, Log4JUtil.shortenStacktrace(ex, 3).getStackTrace().length);
+    }
+
+    @Test
+    public void testShortenStacktraceTooLong() {
+        IllegalArgumentException ex = getTraceBack();
+        Assert.assertTrue("Need short enough trace for test", ex.getStackTrace().length < 3000);
+        // make sure it doesn't throw an exception
+        int len = ex.getStackTrace().length;
+        Assert.assertEquals(len, Log4JUtil.shortenStacktrace(ex, 3010).getStackTrace().length);
+    }
+
+    @Test
+    public void testShortenStacktraceNoArg() {
+        IllegalArgumentException ex = getTraceBack();
+        Assert.assertTrue("Needs long enough trace for test", ex.getStackTrace().length > 3);
+        
+        Assert.assertEquals(2, Log4JUtil.shortenStacktrace(ex).getStackTrace().length);
     }
 
     // The minimal setup for log4J

--- a/web/js/jquery.jmri.js
+++ b/web/js/jquery.jmri.js
@@ -895,7 +895,9 @@
                 $("#no-websockets").addClass("show").removeClass("hidden");
             }
             $(window).unload(function() {
-                jmri.socket.close();
+                if (jmri.socket != null) { 
+                    jmri.socket.close();
+                }
                 jmri.socket = null;
                 jmri = null;
             });


### PR DESCRIPTION
- Catch and process exception when `jinput` doesn't find platform-specific libraries during tests
- Clean up DCCpp test thread; keep test alive, hence InstanceManager alive, until that thread completes to avoid interference.
- Add another stacktrace-shortening utility and tests to Log4JUtil
- Update the JUnitUtil thread logging
- Fix all termination for LocoNet tests; now all end cleanly
- join on thread in beantable/MaintenanceTest to make sure it terminates before going to next test
- add protection against null socket ref during close-down in jquery.jmri.js