### PR TITLE
Tests - Unlikely argument annotation

### DIFF
--- a/java/test/jmri/BlockTest.java
+++ b/java/test/jmri/BlockTest.java
@@ -26,6 +26,7 @@ public class BlockTest {
     }
 
     @Test
+    @SuppressWarnings("unlikely-arg-type") // String / StringBuffer seems to be unrelated to Block
     public void testEquals() {
         Block b1 = new Block("SystemName1");
         Block b2 = new Block("SystemName2");
@@ -43,7 +44,8 @@ public class BlockTest {
         Assert.assertFalse(b1.equals(null));
 
         // check another type
-        Assert.assertFalse(b1.equals(new StringBuffer("foo")));        
+        Assert.assertFalse(b1.equals(new StringBuffer("foo")));
+        Assert.assertFalse(b1.equals("foo"));
     }
 
     @Test

--- a/java/test/jmri/TurnoutOperationTest.java
+++ b/java/test/jmri/TurnoutOperationTest.java
@@ -14,6 +14,7 @@ import org.junit.Assert;
  */
 public class TurnoutOperationTest extends TestCase {
 
+    @SuppressWarnings("unlikely-arg-type") // String unrelated when testing Wrong type
     public void testEquals() {
         TurnoutOperation to1 = new TurnoutOperation("to1"){
             @Override

--- a/java/test/jmri/implementation/AbstractSignalHeadTestBase.java
+++ b/java/test/jmri/implementation/AbstractSignalHeadTestBase.java
@@ -27,6 +27,7 @@ public abstract class AbstractSignalHeadTestBase {
         Assert.assertTrue("set again", s.getLit());
     }
 
+    @SuppressWarnings("unlikely-arg-type") // Unlikely argument type int for contains(Object) on a Collection<int[]>
     private boolean validAppearance(int appearance, SignalHead s) {
         return Arrays.asList(s.getValidStates()).contains(SignalHead.RED);
     }

--- a/java/test/jmri/implementation/LightControlTest.java
+++ b/java/test/jmri/implementation/LightControlTest.java
@@ -29,6 +29,7 @@ public class LightControlTest {
     }
     
     @Test
+    @SuppressWarnings("unlikely-arg-type") // String seems to be unrelated to LightControl
     public void testEquals() {
         Light o = new AbstractLight("IL1","test light"){
         };

--- a/java/test/jmri/jmrit/logix/OPathTest.java
+++ b/java/test/jmri/jmrit/logix/OPathTest.java
@@ -73,6 +73,7 @@ public class OPathTest {
     }
 
     @Test
+    @SuppressWarnings("unlikely-arg-type") // String seems to be unrelated to OPath
     public void testEquals() {
         Block b1 = new Block("IB1");
 

--- a/java/test/jmri/jmrix/loconet/LocoNetMessageTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetMessageTest.java
@@ -212,6 +212,7 @@ public class LocoNetMessageTest {
     }
 
     @Test
+    @SuppressWarnings("unlikely-arg-type") // int[] seems to be unrelated to LocoNetMessage
     public void testEqualsFromInt() {
         int[] t1 = new int[]{0x81, 0x01, 0x02, 0x02};
         int[] t2 = new int[]{0x81, 0x01, 0x02, 0x02, 0x03};

--- a/java/test/jmri/jmrix/openlcb/OlcbAddressTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbAddressTest.java
@@ -23,6 +23,7 @@ public class OlcbAddressTest extends TestCase {
 
     }
 
+    @SuppressWarnings("unlikely-arg-type") // String seems to be unrelated to OpenLcbLocoAddress
     public void testAddressNotOK() {
         assertTrue(!new OlcbAddress("+0A1").check());
         assertTrue(!new OlcbAddress("- 001").check());

--- a/java/test/jmri/jmrix/openlcb/OpenLcbLocoAddressTest.java
+++ b/java/test/jmri/jmrix/openlcb/OpenLcbLocoAddressTest.java
@@ -29,6 +29,7 @@ public class OpenLcbLocoAddressTest extends TestCase {
         Assert.assertTrue(!a.equals(new OpenLcbLocoAddress(new NodeID(new byte[]{1, 2, 3, 4, 0, 0}))));
     }
 
+    @SuppressWarnings("unlikely-arg-type") // OpenLcbLocoAddress seems to be unrelated to String
     public void testEqualsWrongType() {
         OpenLcbLocoAddress a = new OpenLcbLocoAddress(new NodeID(new byte[]{1, 2, 3, 4, 5, 6}));
         Assert.assertTrue(!a.equals("foo"));

--- a/java/test/jmri/profile/ProfileTest.java
+++ b/java/test/jmri/profile/ProfileTest.java
@@ -161,6 +161,7 @@ public class ProfileTest {
      * Test of equals method, of class Profile.
      */
     @Test
+    @SuppressWarnings("unlikely-arg-type") // String seems to be unrelated to Profile
     public void testEquals() {
         try {
             File rootFolder = folder.newFolder(Profile.PROFILE);


### PR DESCRIPTION
When running tests-warnings-check locally, there are a small number of "Unlikely argument type messages" shown as INFO messages in the logging and are described at the bottom of the run as "problems".
These make it awkward to spot the actual errors when reading through.

This PR leaves 2 remaining which I'm hesitant to suppress the info message on,

Unlikely argument type for equals(): LnDplxGrpInfoImplTest seems to be unrelated to PropertyChangeListener
https://github.com/JMRI/JMRI/blob/master/java/test/jmri/jmrix/loconet/duplexgroup/swing/LnDplxGrpInfoImplTest.java line 65

and

Unlikely argument type Integer for contains(Object) on a Collection<String>
https://github.com/JMRI/JMRI/blob/master/java/test/jmri/util/com/dictiography/collections/IndexedTreeSetTest.java line 92
