### PR TITLE
Code updates

### DIFF
--- a/java/src/jmri/jmrit/audio/DefaultAudioManager.java
+++ b/java/src/jmri/jmrit/audio/DefaultAudioManager.java
@@ -3,6 +3,7 @@ package jmri.jmrit.audio;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import jmri.Audio;
 import jmri.AudioException;
 import jmri.InstanceManager;
@@ -109,12 +110,11 @@ public class DefaultAudioManager extends AbstractAudioManager {
 
     @Override
     public List<String> getSystemNameList(char subType) {
-        List<String> tempList = getSystemNameList();
+        Set<Audio> tempSet = getNamedBeanSet();
         List<String> out = new ArrayList<>();
-        tempList.stream().forEach((tempList1) -> {
-            Audio audio = this.getBySystemName(tempList1);
+        tempSet.stream().forEach((audio) -> {
             if (audio.getSubType() == subType) {
-                out.add(tempList1);
+                out.add(audio.getSystemName());
             }
         });
         return out;

--- a/java/src/jmri/jmrit/beantable/SectionTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SectionTableAction.java
@@ -359,7 +359,7 @@ public class SectionTableAction extends AbstractTableAction<Section> {
     @Override
     protected void addPressed(ActionEvent e) {
         editMode = false;
-        if ((blockManager.getSystemNameList().size()) > 0) {
+        if ((blockManager.getNamedBeanSet().size()) > 0) {
             addEditPressed();
         } else {
             JOptionPane.showMessageDialog(null, rbx

--- a/java/src/jmri/jmrit/beantable/TransitTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TransitTableAction.java
@@ -392,7 +392,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
     protected void addPressed(ActionEvent e) {
         editMode = false;
         duplicateMode = false;
-        if ((sectionManager.getSystemNameList().size()) > 0) {
+        if ((sectionManager.getNamedBeanSet().size()) > 0) {
             addEditPressed();
         } else {
             JOptionPane.showMessageDialog(null, rbx

--- a/java/src/jmri/jmrit/dispatcher/DispatcherAction.java
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherAction.java
@@ -24,7 +24,7 @@ public class DispatcherAction extends AbstractAction {
     @Override
     public void actionPerformed(ActionEvent e) {
         // check that Transits have been defined and are available
-        if (InstanceManager.getDefault(jmri.TransitManager.class).getSystemNameList().size() <= 0) {
+        if (InstanceManager.getDefault(jmri.TransitManager.class).getNamedBeanSet().size() == 0) {
             // Inform the user that there are no Transits available, and don't open the window
             javax.swing.JOptionPane.showMessageDialog(null, Bundle.getMessage("NoTransitsMessage"));
             return;

--- a/java/src/jmri/jmrit/display/SignalMastIcon.java
+++ b/java/src/jmri/jmrit/display/SignalMastIcon.java
@@ -326,7 +326,7 @@ public class SignalMastIcon extends PositionableIcon implements java.beans.Prope
     }
 
     private void addTransitPopup(JPopupMenu popup) {
-        if ((InstanceManager.getDefault(jmri.SectionManager.class).getSystemNameList().size()) > 0
+        if ((InstanceManager.getDefault(jmri.SectionManager.class).getNamedBeanSet().size()) > 0
                 && jmri.InstanceManager.getDefault(jmri.jmrit.display.layoutEditor.LayoutBlockManager.class).isAdvancedRoutingEnabled()) {
 
             if (tct == null) {

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -864,7 +864,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
             if (_drawMenu != null) {
                 _menuBar.remove(_drawMenu);
             }
-            if (InstanceManager.getDefault(jmri.jmrit.logix.OBlockManager.class).getSystemNameList().size() > 1) {
+            if (InstanceManager.getDefault(jmri.jmrit.logix.OBlockManager.class).getNamedBeanSet().size() > 1) {
                 makeWarrantMenu(edit);
             }
             if (_markerMenu == null) {

--- a/java/src/jmri/jmrit/logix/WarrantTableAction.java
+++ b/java/src/jmri/jmrit/logix/WarrantTableAction.java
@@ -111,7 +111,7 @@ public class WarrantTableAction extends AbstractAction {
      * @return a menu containing warrant actions
      */
     synchronized public static JMenu makeWarrantMenu(boolean edit) {
-        if (jmri.InstanceManager.getDefault(OBlockManager.class).getSystemNameList().size() > 1) {
+        if (jmri.InstanceManager.getDefault(OBlockManager.class).getNamedBeanSet().size() > 1) {
             _edit = edit;
             _warrantMenu = new JMenu(Bundle.getMessage("MenuWarrant"));
             updateWarrantMenu();

--- a/java/src/jmri/jmrix/loconet/LnPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizer.java
@@ -487,6 +487,7 @@ public class LnPacketizer extends LnTrafficController {
     /**
      * End threads, intended for testing only
      */
+    @SuppressWarnings("deprecation") // stop() is deprecated, but it's not going away
     public void dispose() {
         if (xmtThread != null) {
             xmtThread.stop(); // interrupt not sufficient?

--- a/java/src/jmri/util/Log4JUtil.java
+++ b/java/src/jmri/util/Log4JUtil.java
@@ -271,8 +271,9 @@ public class Log4JUtil {
         int i;
         for (i = originalTrace.length-1; i>0; i--) { // search from deepest
             String name = originalTrace[i].getClassName();
-            if (name.equals("jmri.util.junit.TestClassMainMethod")) continue; // special case
-            if (name.startsWith("jmri") || name.startsWith("apps")) break;
+            if (name.equals("jmri.util.junit.TestClassMainMethod")) continue; // special case to ignore high up in stack
+            if (name.equals("apps.tests.AllTest")) continue;                 // special case to ignore high up in stack
+            if (name.startsWith("jmri") || name.startsWith("apps")) break;  // keep those
         }
         return shortenStacktrace(t, i+1);
     }


### PR DESCRIPTION
- Fix a problem shortening stack traces that was causing the Java9 through Java11 Jenkins test runs to have an error
- update some uses of deprecated Manager.getSystemNameList() method
- annotate away a warning on using Thread.stop()