### PR TITLE
DCC++ background refresh fixes

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -87,6 +87,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
         setTimeout(DCCppMessageTimeout);
         myRegex = message.myRegex;
         myMessage = message.myMessage;
+        toStringCache = message.toStringCache;
     }
 
     /**
@@ -118,6 +119,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
         setRetries(_nRetries);
         setTimeout(DCCppMessageTimeout);
         myMessage = new StringBuilder(s); // yes, copy... or... maybe not.
+        toStringCache = s;
         // gather bytes in result
         setRegex();
         _nDataChars = myMessage.length();
@@ -312,37 +314,37 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
             case DCCppConstants.ACCESSORY_CMD:
                 myRegex = DCCppConstants.ACCESSORY_CMD_REGEX; break;
             case DCCppConstants.TURNOUT_CMD:
-                if ((match(myMessage.toString(), DCCppConstants.TURNOUT_ADD_REGEX, "ctor")) != null) {
+                if ((match(toString(), DCCppConstants.TURNOUT_ADD_REGEX, "ctor")) != null) {
                 myRegex = DCCppConstants.TURNOUT_ADD_REGEX;
-                } else if ((match(myMessage.toString(), DCCppConstants.TURNOUT_DELETE_REGEX, "ctor")) != null) {
+                } else if ((match(toString(), DCCppConstants.TURNOUT_DELETE_REGEX, "ctor")) != null) {
                     myRegex = DCCppConstants.TURNOUT_DELETE_REGEX;
-                } else if ((match(myMessage.toString(), DCCppConstants.TURNOUT_LIST_REGEX, "ctor")) != null) {
+                } else if ((match(toString(), DCCppConstants.TURNOUT_LIST_REGEX, "ctor")) != null) {
                     myRegex = DCCppConstants.TURNOUT_LIST_REGEX;
-                } else if ((match(myMessage.toString(), DCCppConstants.TURNOUT_CMD_REGEX, "ctor")) != null) {
+                } else if ((match(toString(), DCCppConstants.TURNOUT_CMD_REGEX, "ctor")) != null) {
                     myRegex = DCCppConstants.TURNOUT_CMD_REGEX;
                 } else {
                     myRegex = "";
                 }
                 break;
             case DCCppConstants.SENSOR_CMD:
-                if ((match(myMessage.toString(), DCCppConstants.SENSOR_ADD_REGEX, "ctor")) != null) {
+                if ((match(toString(), DCCppConstants.SENSOR_ADD_REGEX, "ctor")) != null) {
                 myRegex = DCCppConstants.SENSOR_ADD_REGEX;
-                } else if ((match(myMessage.toString(), DCCppConstants.SENSOR_DELETE_REGEX, "ctor")) != null) {
+                } else if ((match(toString(), DCCppConstants.SENSOR_DELETE_REGEX, "ctor")) != null) {
                     myRegex = DCCppConstants.SENSOR_DELETE_REGEX;
-                } else if ((match(myMessage.toString(), DCCppConstants.SENSOR_LIST_REGEX, "ctor")) != null) {
+                } else if ((match(toString(), DCCppConstants.SENSOR_LIST_REGEX, "ctor")) != null) {
                     myRegex = DCCppConstants.SENSOR_LIST_REGEX;
                 } else {
                     myRegex = "";
                 }
                 break;
             case DCCppConstants.OUTPUT_CMD:
-                if ((match(myMessage.toString(), DCCppConstants.OUTPUT_ADD_REGEX, "ctor")) != null) {
+                if ((match(toString(), DCCppConstants.OUTPUT_ADD_REGEX, "ctor")) != null) {
                 myRegex = DCCppConstants.OUTPUT_ADD_REGEX;
-                } else if ((match(myMessage.toString(), DCCppConstants.OUTPUT_DELETE_REGEX, "ctor")) != null) {
+                } else if ((match(toString(), DCCppConstants.OUTPUT_DELETE_REGEX, "ctor")) != null) {
                     myRegex = DCCppConstants.OUTPUT_DELETE_REGEX;
-                } else if ((match(myMessage.toString(), DCCppConstants.OUTPUT_LIST_REGEX, "ctor")) != null) {
+                } else if ((match(toString(), DCCppConstants.OUTPUT_LIST_REGEX, "ctor")) != null) {
                     myRegex = DCCppConstants.OUTPUT_LIST_REGEX;
-                } else if ((match(myMessage.toString(), DCCppConstants.OUTPUT_CMD_REGEX, "ctor")) != null) {
+                } else if ((match(toString(), DCCppConstants.OUTPUT_CMD_REGEX, "ctor")) != null) {
                     myRegex = DCCppConstants.OUTPUT_CMD_REGEX;
                 } else {
                     myRegex = "";
@@ -386,6 +388,8 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
         }
     }
     
+    private String toStringCache = null;
+    
     /**
      * Converts DCCppMessage to String format (without the {@code <>} brackets)
      * 
@@ -393,7 +397,10 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      */
     @Override
     public String toString() {
-        return(myMessage.toString());
+        if (toStringCache==null)
+            toStringCache = myMessage.toString();
+        
+        return toStringCache;
         /*
         String s = Character.toString(opcode);
         for (int i = 0; i < valueList.size(); i++) {
@@ -578,6 +585,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
         } else if (n > 0) {
             myMessage.setCharAt(n,c);
         }
+        toStringCache = null;
     }
     // For DCC++, the opcode is the first character in the
     // command (after the < ).
@@ -593,6 +601,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
         }
         opcode = (char) (i & 0xFF);
         myMessage.setCharAt(0, opcode);
+        toStringCache = null;
     }
 
     @Override
@@ -611,12 +620,12 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     }
    
     private int getGroupCount(){
-        Matcher m = match(myMessage.toString(), myRegex, "gvs");
+        Matcher m = match(toString(), myRegex, "gvs");
         return m.groupCount();
     }
  
     public String getValueString(int idx) {
-        Matcher m = match(myMessage.toString(), myRegex, "gvs");
+        Matcher m = match(toString(), myRegex, "gvs");
         if (m == null) {
             log.error("No match!");
             return("");
@@ -629,7 +638,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     }
     
     public int getValueInt(int idx) {
-        Matcher m = match(myMessage.toString(), myRegex, "gvi");
+        Matcher m = match(toString(), myRegex, "gvi");
         if (m == null) {
             log.error("No match!");
             return(0);
@@ -642,8 +651,8 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     }
     
     public boolean getValueBool(int idx) {
-        log.debug("msg = {}, regex = {}", myMessage.toString(), myRegex);
-        Matcher m = match(myMessage.toString(), myRegex, "gvi");
+        log.debug("msg = {}, regex = {}", toString(), myRegex);
+        Matcher m = match(toString(), myRegex, "gvi");
         
         if (m == null) {
             log.error("No Match!");
@@ -2514,7 +2523,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     }
 
     public int hashCode() {
-        return myMessage.hashCode();
+        return toString().hashCode();
     }
     
     /**

--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -2470,9 +2470,12 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
      */
     @Override
     public boolean equals(final Object obj) {
-        if (obj == null) return false;
-        if (! (obj instanceof DCCppMessage)) return false;
-        
+        if (obj == null)
+            return false;
+
+        if (!(obj instanceof DCCppMessage))
+            return false;
+
         final DCCppMessage other = (DCCppMessage) obj;
 
         final String myCmd = this.toString();
@@ -2481,13 +2484,33 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
         if (myCmd.equals(otherCmd))
             return true;
 
-        if (!isFunctionMessage() || !other.isFunctionMessage())
-            return false;
-        
-        if (this.getValueInt(1) != other.getValueInt(1))
+        if (!(myCmd.charAt(0) == DCCppConstants.FUNCTION_CMD) || !(otherCmd.charAt(0) == DCCppConstants.FUNCTION_CMD))
             return false;
 
-        return getFuncBaseByte1(this.getFuncByte1Int()) == getFuncBaseByte1(other.getFuncByte1Int());
+        final int mySpace1 = myCmd.indexOf(' ', 2);
+        final int otherSpace1 = otherCmd.indexOf(' ', 2);
+
+        if (mySpace1 != otherSpace1)
+            return false;
+
+        if (!myCmd.subSequence(2, mySpace1).equals(otherCmd.subSequence(2, otherSpace1)))
+            return false;
+
+        int mySpace2 = myCmd.indexOf(' ', mySpace1 + 1);
+        if (mySpace2 < 0)
+            mySpace2 = myCmd.length();
+
+        int otherSpace2 = otherCmd.indexOf(' ', otherSpace1 + 1);
+        if (otherSpace2 < 0)
+            otherSpace2 = otherCmd.length();
+
+        final int myBaseFunction = Integer.parseInt(myCmd.substring(mySpace1 + 1, mySpace2));
+        final int otherBaseFunction = Integer.parseInt(otherCmd.substring(otherSpace1 + 1, otherSpace2));
+
+        if (myBaseFunction == otherBaseFunction)
+            return true;
+
+        return getFuncBaseByte1(myBaseFunction) == getFuncBaseByte1(otherBaseFunction);
     }
 
     public int hashCode() {

--- a/java/src/jmri/jmrix/dccpp/serial/SerialDCCppPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/serial/SerialDCCppPacketizer.java
@@ -68,6 +68,7 @@ public class SerialDCCppPacketizer extends DCCppPacketizer {
     private final class RefreshThread extends Thread {
         public RefreshThread() {
             setDaemon(true);
+            setPriority(Thread.MIN_PRIORITY);
             setName("SerialDCCppPacketizer.bkg_refresh");
         }
 
@@ -78,12 +79,14 @@ public class SerialDCCppPacketizer extends DCCppPacketizer {
                     final DCCppMessage message = resendFunctions.take();
 
                     if (message != null) {
-                        message.setRetries(1);
+                        message.setRetries(0);
                         sendDCCppMessage(message, null);
 
                         // At 115200 baud only ~1k messages/s can be sent.
-                        // Be nice and don't overload the wire.
-                        sleep(1);
+                        // The limit is however how many messages DCC++ BaseStation can process.
+                        // At more than 25Hz random functions get activated and replies go missing.
+                        // Keeping a conservative value of 20Hz to be on the safe side.
+                        sleep(50);
                     }
 
                     setName("SerialDCCppPacketizer.bkg_refresh (" + resendFunctions.size() + " msg)");

--- a/java/src/jmri/jmrix/dccpp/serial/SerialDCCppPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/serial/SerialDCCppPacketizer.java
@@ -85,8 +85,9 @@ public class SerialDCCppPacketizer extends DCCppPacketizer {
                         // At 115200 baud only ~1k messages/s can be sent.
                         // The limit is however how many messages DCC++ BaseStation can process.
                         // At more than 25Hz random functions get activated and replies go missing.
-                        // Keeping a conservative value of 20Hz to be on the safe side.
-                        sleep(50);
+                        // Further on, reading CVs on the programming track is much slower.
+                        // The lowest common denominator between all modes is 4Hz, at this rate everything seems to work fine.
+                        sleep(250);
                     }
 
                     setName("SerialDCCppPacketizer.bkg_refresh (" + resendFunctions.size() + " msg)");


### PR DESCRIPTION
The background function refresh rate has to be reduced due to two main factors:
- DCC++ BaseStation's ability to handle the rate. Above 20Hz it starts behaving erratically, in particular not answering to commands requiring confirmation.
- Reading CVs from the programming track. Above 4Hz of background commands some of the read commands again time out.

This patch lowers the refresh rate to 4Hz not to interfere with other operations any more.

Some improvement were made to the DCCppMessage to speed up the lookup of equivalent messages in the background refresh queue.

Cheers,

.costin