### PR TITLE
Add tooltip to radio buttons setting default managers

### DIFF
--- a/java/test/apps/ManagerDefaultsConfigPaneTest.java
+++ b/java/test/apps/ManagerDefaultsConfigPaneTest.java
@@ -14,7 +14,6 @@ import org.junit.Test;
 public class ManagerDefaultsConfigPaneTest {
 
     @Test
-    @Ignore("needs more setup")
     public void testCTor() {
         ManagerDefaultsConfigPane t = new ManagerDefaultsConfigPane();
         Assert.assertNotNull("exists",t);
@@ -24,6 +23,9 @@ public class ManagerDefaultsConfigPaneTest {
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.resetPreferencesProviders();
+        JUnitUtil.initConfigureManager();
     }
 
     @After

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -590,7 +590,7 @@ public class JUnitUtil {
     public static void resetInstanceManager() {
         // clear all instances from the static InstanceManager
         InstanceManager.getDefault().clearAll();
-        // ensure the auto-defeault UserPreferencesManager is not created
+        // ensure the auto-default UserPreferencesManager is not created
         InstanceManager.setDefault(UserPreferencesManager.class, new TestUserPreferencesManager());
     }
 


### PR DESCRIPTION
On the Defaults pane of the Preferences, add tooltip text to the radio buttons so that screen readers can help vision-impaired JMRI users navigate the screen.

![image](https://user-images.githubusercontent.com/2774117/50739828-31d21c80-119a-11e9-96bb-45c919dd1156.png)
