### PR TITLE
Support non-base-2^N radix storage in decoder definitions

### DIFF
--- a/help/en/html/apps/DecoderPro/CreateDecoder.shtml
+++ b/help/en/html/apps/DecoderPro/CreateDecoder.shtml
@@ -323,7 +323,16 @@
             that are not to be included. It's best to have eight
             characters, as that makes it clearer what's going on.
             If the variable is a full byte, this attribute can be
-            omitted.</li>
+            omitted.
+            
+            <p>
+            As a special case, this can also be used (along with 
+            some other attributes) to handle CVs that are coded in
+            bases other than binary:  Ones that store their 
+            parts as decimal digits, or even base 3 or 5.
+            That's a bit more technical, it's rarely needed, but 
+            if you do need it see the 
+            <a href="http://jmri.org/JavaDoc/doc/jmri/jmrit/symbolicprog/VariableValue.html">javadoc for more details</a>.
 
             <li><dfn>default</dfn> - The default value for this
             variable. This is used for a new decoder, or when you

--- a/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
@@ -129,7 +129,7 @@ public class DecVariableValue extends VariableValue
         } catch (java.lang.NumberFormatException ex) {
             newVal = 0;
         }
-        int newCv = newValue(oldCv, newVal, getMask());
+        int newCv = setValueInCV(oldCv, newVal, getMask());
         if (oldCv != newCv) {
             cv.setValue(newCv);
         }
@@ -395,7 +395,7 @@ public class DecVariableValue extends VariableValue
         } else if (e.getPropertyName().equals("Value")) {
             // update value of Variable
             CvValue cv = _cvMap.get(getCvNum());
-            int newVal = (cv.getValue() & maskValAsInt(getMask())) >>> offsetVal(getMask());
+            int newVal = getValueInCV(cv.getValue(), getMask());
             setValue(newVal);  // check for duplicate done inside setVal
         }
     }

--- a/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
@@ -395,7 +395,7 @@ public class DecVariableValue extends VariableValue
         } else if (e.getPropertyName().equals("Value")) {
             // update value of Variable
             CvValue cv = _cvMap.get(getCvNum());
-            int newVal = (cv.getValue() & maskVal(getMask())) >>> offsetVal(getMask());
+            int newVal = (cv.getValue() & maskValAsInt(getMask())) >>> offsetVal(getMask());
             setValue(newVal);  // check for duplicate done inside setVal
         }
     }

--- a/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
@@ -129,7 +129,7 @@ public class DecVariableValue extends VariableValue
         } catch (java.lang.NumberFormatException ex) {
             newVal = 0;
         }
-        int newCv = setValueInCV(oldCv, newVal, getMask());
+        int newCv = setValueInCV(oldCv, newVal, getMask(), _maxVal);
         if (oldCv != newCv) {
             cv.setValue(newCv);
         }
@@ -395,7 +395,7 @@ public class DecVariableValue extends VariableValue
         } else if (e.getPropertyName().equals("Value")) {
             // update value of Variable
             CvValue cv = _cvMap.get(getCvNum());
-            int newVal = getValueInCV(cv.getValue(), getMask());
+            int newVal = getValueInCV(cv.getValue(), getMask(), _maxVal);
             setValue(newVal);  // check for duplicate done inside setVal
         }
     }

--- a/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
@@ -502,7 +502,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
             case "Value": {
                 // update value of Variable
                 CvValue cv = _cvMap.get(getCvNum());
-                int newVal = (cv.getValue() & maskVal(getMask())) >>> offsetVal(getMask());
+                int newVal = (cv.getValue() & maskValAsInt(getMask())) >>> offsetVal(getMask());
                 setValue(newVal);  // check for duplicate done inside setVal
                 break;
             }

--- a/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
@@ -502,7 +502,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
             case "Value": {
                 // update value of Variable
                 CvValue cv = _cvMap.get(getCvNum());
-                int newVal = getValueInCV(cv.getValue(), getMask(), _maxVal);
+                int newVal = getValueInCV(cv.getValue(), getMask(), _maxVal-1); // _maxVal is number of values here, not the index of top one
                 setValue(newVal);  // check for duplicate done inside setVal
                 break;
             }

--- a/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
@@ -192,7 +192,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
         // compute new cv value by combining old and request
         int oldCv = cv.getValue();
         int newVal = getIntValue();
-        int newCv = setValueInCV(oldCv, newVal, getMask(), _maxVal);
+        int newCv = setValueInCV(oldCv, newVal, getMask(), _maxVal-1);
         if (newCv != oldCv) {
             cv.setValue(newCv);  // to prevent CV going EDITED during loading of decoder file
 
@@ -502,7 +502,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
             case "Value": {
                 // update value of Variable
                 CvValue cv = _cvMap.get(getCvNum());
-                int newVal = getValueInCV(cv.getValue(), getMask(), _maxVal-1); // _maxVal is number of values here, not the index of top one
+                int newVal = getValueInCV(cv.getValue(), getMask(), _maxVal-1); // _maxVal value is count of possibles, i.e. radix
                 setValue(newVal);  // check for duplicate done inside setVal
                 break;
             }

--- a/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
@@ -192,7 +192,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
         // compute new cv value by combining old and request
         int oldCv = cv.getValue();
         int newVal = getIntValue();
-        int newCv = setValueInCV(oldCv, newVal, getMask());
+        int newCv = setValueInCV(oldCv, newVal, getMask(), _maxVal);
         if (newCv != oldCv) {
             cv.setValue(newCv);  // to prevent CV going EDITED during loading of decoder file
 
@@ -502,7 +502,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
             case "Value": {
                 // update value of Variable
                 CvValue cv = _cvMap.get(getCvNum());
-                int newVal = getValueInCV(cv.getValue(), getMask());
+                int newVal = getValueInCV(cv.getValue(), getMask(), _maxVal);
                 setValue(newVal);  // check for duplicate done inside setVal
                 break;
             }

--- a/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/EnumVariableValue.java
@@ -192,7 +192,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
         // compute new cv value by combining old and request
         int oldCv = cv.getValue();
         int newVal = getIntValue();
-        int newCv = newValue(oldCv, newVal, getMask());
+        int newCv = setValueInCV(oldCv, newVal, getMask());
         if (newCv != oldCv) {
             cv.setValue(newCv);  // to prevent CV going EDITED during loading of decoder file
 
@@ -502,7 +502,7 @@ public class EnumVariableValue extends VariableValue implements ActionListener {
             case "Value": {
                 // update value of Variable
                 CvValue cv = _cvMap.get(getCvNum());
-                int newVal = (cv.getValue() & maskValAsInt(getMask())) >>> offsetVal(getMask());
+                int newVal = getValueInCV(cv.getValue(), getMask());
                 setValue(newVal);  // check for duplicate done inside setVal
                 break;
             }

--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -54,9 +54,9 @@ public class SplitVariableValue extends VariableValue
         _value.addFocusListener(this);
         mSecondCV = pSecondCV;
 
-        lowerbitmask = maskVal(mask);
+        lowerbitmask = maskValAsInt(mask);
         lowerbitoffset = offsetVal(mask);
-        upperbitmask = maskVal(uppermask);
+        upperbitmask = maskValAsInt(uppermask);
 
         // upper bit offset includes lower bit offset, and MSB bits missing from upper part
         upperbitoffset = offsetVal(uppermask);

--- a/java/src/jmri/jmrit/symbolicprog/VariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableValue.java
@@ -448,7 +448,8 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
             return (Cv & maskValAsInt(maskString)) >>> offsetVal(maskString);
         } else {
             int radix = Integer.parseInt(maskString);
-            return (Cv/radix) % maxVal;
+            log.trace("get value {} radix {} returns {}", Cv, radix, Cv/radix);
+            return (Cv/radix) % (maxVal+1);
         }
     }
     /**
@@ -466,7 +467,8 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
         } else {
             int radix = Integer.parseInt(maskString);
             int lowPart = oldCv % radix;
-            int highPart = (oldCv / (radix * maxVal))*(radix * maxVal);
+            int highPart = (oldCv / (radix*(maxVal+1)) ) * (radix * (maxVal+1));
+            log.trace("Set sees oldCv {} radix {}, lowPart {}, newVal {}, highPart {}, does {}", oldCv, radix, lowPart, newVal, highPart, highPart+newVal*radix+lowPart);
             return highPart+newVal*radix+lowPart;
         }
     }

--- a/java/src/jmri/jmrit/symbolicprog/VariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableValue.java
@@ -434,13 +434,19 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
     }
 
     /**
+     * Get the current value from the CV, using the mask as needed
+     */
+    protected int getValueInCV(int Cv, String maskString) {
+        return (Cv & maskValAsInt(maskString)) >>> offsetVal(maskString);
+    }
+    /**
      *
      * @param oldCv      Value of the CV before this update is applied
      * @param newVal     Value for this variable (e.g. not the CV value)
      * @param maskString The bit mask for this variable in character form
      * @return int new value for the CV
      */
-    protected int newValue(int oldCv, int newVal, String maskString) {
+    protected int setValueInCV(int oldCv, int newVal, String maskString) {
         int mask = maskValAsInt(maskString);
         int offset = offsetVal(maskString);
         return (oldCv & ~mask) + ((newVal << offset) & mask);

--- a/java/src/jmri/jmrit/symbolicprog/VariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableValue.java
@@ -434,7 +434,7 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
                     mask = mask | 1;
                 }
             } catch (StringIndexOutOfBoundsException e) {
-                log.error("mask \"{}\" could not be handled for variable ", label());
+                log.error("mask \"{}\" could not be handled for variable {}", maskString, label());
             }
         }
         return mask;

--- a/java/src/jmri/jmrit/symbolicprog/VariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/VariableValue.java
@@ -397,8 +397,11 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
     }
     private boolean _busy = false;
 
-    // tool to handle masking, updating
-    protected int maskVal(String maskString) {
+    /**
+     * Convert a String mask like XXXVVVXX
+     * to an int like 0b00011100
+     */
+    protected int maskValAsInt(String maskString) {
         // convert String mask to int
         int mask = 0;
         for (int i = 0; i < maskString.length(); i++) {
@@ -438,7 +441,7 @@ public abstract class VariableValue extends AbstractValue implements java.beans.
      * @return int new value for the CV
      */
     protected int newValue(int oldCv, int newVal, String maskString) {
-        int mask = maskVal(maskString);
+        int mask = maskValAsInt(maskString);
         int offset = offsetVal(maskString);
         return (oldCv & ~mask) + ((newVal << offset) & mask);
     }

--- a/java/test/jmri/jmrit/symbolicprog/DecVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/DecVariableValueTest.java
@@ -44,14 +44,14 @@ public class DecVariableValueTest extends AbstractVariableValueTestBase {
 
     // end of abstract members
     
-    // test the handling of offset (base) masks
-    public void testBaseMasks() {
+    // test the handling of radix masks
+    public void testBaseMasks3() {
         HashMap<String, CvValue> v = createCvMap();
         CvValue cv = new CvValue("81", p);
         cv.setValue(0);
         v.put("81", cv);
         // create a variable pointed at CV 81, check name
-        VariableValue variable = makeVar("label", "comment", "", false, false, false, false, "81", "9", 0, 3, v, null, null);
+        VariableValue variable = makeVar("label", "comment", "", false, false, false, false, "81", "9", 0, 2, v, null, null);
         checkValue(variable, "value object initially contains ", "0");
 
         // pretend you've edited the value & manually notify
@@ -73,6 +73,39 @@ public class DecVariableValueTest extends AbstractVariableValueTestBase {
         checkValue(variable, "value object contains ", "1");
         Assert.assertEquals("cv value", 3+9+81, cv.getValue());
                        
+    }
+
+    public void testBaseMasksBCD() {
+        HashMap<String, CvValue> v = createCvMap();
+        CvValue cv = new CvValue("81", p);
+        cv.setValue(0);
+        v.put("81", cv);
+        // create a variable pointed at CV 81, check name
+        VariableValue variableU = makeVar("upper", "comment", "", false, false, false, false, "81", "10", 0, 9, v, null, null);
+        VariableValue variableL = makeVar("lower", "comment", "", false, false, false, false, "81",  "1", 0, 9, v, null, null);
+        checkValue(variableU, "upper initially contains ", "0");
+        checkValue(variableL, "lower initially contains ", "0");
+        Assert.assertEquals("cv value", 0, cv.getValue());
+
+        // pretend you've edited the upper value & manually notify
+        setValue(variableU, "2");
+        // see if the CV was updated
+        Assert.assertEquals("cv value", 20, cv.getValue());
+        // check variable values
+        checkValue(variableU, "value object contains ", "2");
+        checkValue(variableL, "value object contains ", "0");
+        
+        // set CV value
+        cv.setValue(31);
+        checkValue(variableU, "value object contains ", "3");
+        checkValue(variableL, "value object contains ", "1");
+
+        setValue(variableL, "9");
+        // check variable values
+        checkValue(variableU, "value object contains ", "3");
+        checkValue(variableL, "value object contains ", "9");
+        // see if the CV was updated
+        Assert.assertEquals("cv value", 39, cv.getValue());
     }
     
     // from here down is testing infrastructure

--- a/java/test/jmri/jmrit/symbolicprog/DecVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/DecVariableValueTest.java
@@ -75,7 +75,7 @@ public class DecVariableValueTest extends AbstractVariableValueTestBase {
                        
     }
 
-    public void testBaseMasksBCD() {
+    public void testBaseMasksDecimalValues() {
         HashMap<String, CvValue> v = createCvMap();
         CvValue cv = new CvValue("81", p);
         cv.setValue(0);

--- a/java/test/jmri/jmrit/symbolicprog/DecVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/DecVariableValueTest.java
@@ -43,6 +43,38 @@ public class DecVariableValueTest extends AbstractVariableValueTestBase {
     }
 
     // end of abstract members
+    
+    // test the handling of offset (base) masks
+    public void testBaseMasks() {
+        HashMap<String, CvValue> v = createCvMap();
+        CvValue cv = new CvValue("81", p);
+        cv.setValue(0);
+        v.put("81", cv);
+        // create a variable pointed at CV 81, check name
+        VariableValue variable = makeVar("label", "comment", "", false, false, false, false, "81", "9", 0, 3, v, null, null);
+        checkValue(variable, "value object initially contains ", "0");
+
+        // pretend you've edited the value & manually notify
+        setValue(variable, "2");
+        // check variable value
+        checkValue(variable, "value object contains ", "2");
+        // see if the CV was updated
+        Assert.assertEquals("cv value", 18, cv.getValue());
+        
+        // now check that other parts are maintained
+        cv.setValue(3+2*9+81);
+        // check variable value
+        checkValue(variable, "value object contains ", "2");
+        // see if the CV was updated
+        Assert.assertEquals("cv value", 3+2*9+81, cv.getValue());
+
+        // and try setting another value
+        setValue(variable, "1");
+        checkValue(variable, "value object contains ", "1");
+        Assert.assertEquals("cv value", 3+9+81, cv.getValue());
+                       
+    }
+    
     // from here down is testing infrastructure
     public DecVariableValueTest(String s) {
         super(s);

--- a/java/test/jmri/jmrit/symbolicprog/EnumVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/EnumVariableValueTest.java
@@ -169,27 +169,42 @@ public class EnumVariableValueTest extends AbstractVariableValueTestBase {
         cv.setValue(0);
         v.put("81", cv);
         // create a variable pointed at CV 81, check name
-        VariableValue variable = makeVar("label", "comment", "", false, false, false, false, "81", "9", 0, 2, v, null, null);
-        checkValue(variable, "value object initially contains ", "0");
+        EnumVariableValue variable = new EnumVariableValue("label", "comment", "", false, false, false, false, "81", "9", 0, 3, v, null, null);
+        variable.nItems(3);
+        variable.addItem("A");
+        variable.addItem("B");
+        variable.addItem("C");
+        variable.lastItem();
+        
+        checkValue(variable, "value object initially contains ", "A");
+        Assert.assertEquals("cv value", 0*9, cv.getValue());
+
+        setValue(variable, "B");
+        checkValue(variable, "value object contains ", "B");
+        Assert.assertEquals("cv value", 1*9, cv.getValue());
+
+        setValue(variable, "A");
+        checkValue(variable, "value object contains ", "A");
+        Assert.assertEquals("cv value", 0*9, cv.getValue());
 
         // pretend you've edited the value & manually notify
-        setValue(variable, "2");
+        setValue(variable, "C");   // 3rd choice, value = 2
         // check variable value
-        checkValue(variable, "value object contains ", "2");
+        checkValue(variable, "value object contains ", "C");
         // see if the CV was updated
         Assert.assertEquals("cv value", 18, cv.getValue());
         
         // now check that other parts are maintained
-        cv.setValue(3+2*9+81);
+        cv.setValue(3+1*9+81);
         // check variable value
-        checkValue(variable, "value object contains ", "2");
+        checkValue(variable, "value object contains ", "B");
         // see if the CV was updated
-        Assert.assertEquals("cv value", 3+2*9+81, cv.getValue());
+        Assert.assertEquals("cv value", 3+1*9+81, cv.getValue());
 
         // and try setting another value
-        setValue(variable, "1");
-        checkValue(variable, "value object contains ", "1");
-        Assert.assertEquals("cv value", 3+9+81, cv.getValue());
+        setValue(variable, "B");
+        Assert.assertEquals("cv value", 3+1*9+81, cv.getValue());
+        checkValue(variable, "value object contains ", "B");
                        
     }
 

--- a/java/test/jmri/jmrit/symbolicprog/EnumVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/EnumVariableValueTest.java
@@ -163,6 +163,36 @@ public class EnumVariableValueTest extends AbstractVariableValueTestBase {
         return v1;
     }
 
+    public void testBaseMasks3() {
+        HashMap<String, CvValue> v = createCvMap();
+        CvValue cv = new CvValue("81", p);
+        cv.setValue(0);
+        v.put("81", cv);
+        // create a variable pointed at CV 81, check name
+        VariableValue variable = makeVar("label", "comment", "", false, false, false, false, "81", "9", 0, 2, v, null, null);
+        checkValue(variable, "value object initially contains ", "0");
+
+        // pretend you've edited the value & manually notify
+        setValue(variable, "2");
+        // check variable value
+        checkValue(variable, "value object contains ", "2");
+        // see if the CV was updated
+        Assert.assertEquals("cv value", 18, cv.getValue());
+        
+        // now check that other parts are maintained
+        cv.setValue(3+2*9+81);
+        // check variable value
+        checkValue(variable, "value object contains ", "2");
+        // see if the CV was updated
+        Assert.assertEquals("cv value", 3+2*9+81, cv.getValue());
+
+        // and try setting another value
+        setValue(variable, "1");
+        checkValue(variable, "value object contains ", "1");
+        Assert.assertEquals("cv value", 3+9+81, cv.getValue());
+                       
+    }
+
     // from here down is testing infrastructure
     public EnumVariableValueTest(String s) {
         super(s);

--- a/java/test/jmri/jmrit/symbolicprog/HexVariableValueTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/HexVariableValueTest.java
@@ -48,6 +48,37 @@ public class HexVariableValueTest extends AbstractVariableValueTestBase {
     }
 
     // end of abstract members
+
+    // test the handling of radix masks
+    public void testBaseMasks20() {
+        HashMap<String, CvValue> v = createCvMap();
+        CvValue cv = new CvValue("81", p);
+        cv.setValue(0);
+        v.put("81", cv);
+        // create a variable pointed at CV 81, check name
+        VariableValue variable = makeVar("label", "comment", "", false, false, false, false, "81", "3", 0, 19, v, null, null);
+        checkValue(variable, "value object initially contains ", "0");
+
+        // pretend you've edited the value & manually notify
+        setValue(variable, "2");
+        // check variable value
+        checkValue(variable, "value object contains ", "2");
+        // see if the CV was updated
+        Assert.assertEquals("cv value", 6, cv.getValue());
+        
+        // now check that other parts are maintained
+        cv.setValue(1+2*3+3*3*20);
+        // check variable value
+        checkValue(variable, "value object contains ", "2");
+        // see if the CV was updated
+        Assert.assertEquals("cv value", (1+2*3+3*3*20), cv.getValue());
+
+        // and try setting another value
+        setValue(variable, "15");
+        checkValue(variable, "value object contains ", "15");
+        Assert.assertEquals("cv value", (1+15*3+3*3*20), cv.getValue());                
+    }
+
     // from here down is testing infrastructure
     public HexVariableValueTest(String s) {
         super(s);

--- a/xml/schema/decoder-4-13-3.xsd
+++ b/xml/schema/decoder-4-13-3.xsd
@@ -978,14 +978,23 @@
   <xs:simpleType name="maskType">
     <xs:annotation>
         <xs:documentation>
-          Type for CV mask values: 8 or 16 characters of either V (valid bit) or X (ignore bit).
+          Type for CV mask values in one of two forms: 
+            8 or 16 characters of either V (valid bit) or X (ignore bit).
+            Decimal integer less than or equal to 128 which is the base. (in that case, max value is needed)
         </xs:documentation>
     </xs:annotation>
-    <xs:restriction base="xs:normalizedString">
-      <xs:pattern value="(V|X)*"/>
-      <xs:minLength value="8"/>
-      <xs:maxLength value="16"/>
-    </xs:restriction>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:normalizedString">
+          <xs:pattern value="(V|X)*"/>
+          <xs:minLength value="8"/>
+          <xs:maxLength value="16"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:nonNegativeInteger" />
+      </xs:simpleType>
+    </xs:union>
   </xs:simpleType>
 
   <xs:simpleType name="modeType">

--- a/xml/schema/decoder-4-13-3.xsd
+++ b/xml/schema/decoder-4-13-3.xsd
@@ -978,12 +978,13 @@
   <xs:simpleType name="maskType">
     <xs:annotation>
         <xs:documentation>
-          Type for CV mask values: 8 or 16 characters of either V (valid bit) or X (ignore bit).
+          Type for CV mask values: 8 or 16 characters of either V (valid bit) or X (ignore bit) with the V's consecutive.
         </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:normalizedString">
-      <xs:pattern value="(V|X)*"/>
-      <xs:minLength value="16"/>
+      <xs:pattern value="X*V+X*"/>
+      <xs:minLength value="8"/>
+      <xs:maxLength value="16"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -978,13 +978,23 @@
   <xs:simpleType name="maskType">
     <xs:annotation>
         <xs:documentation>
-          Type for CV mask values: 8 or 16 characters of either V (valid bit) or X (ignore bit).
+          Type for CV mask values in one of two forms: 
+            8 or 16 characters of either V (valid bit) or X (ignore bit).
+            Decimal integer less than or equal to 128 which is the base. (in that case, max value is needed)
         </xs:documentation>
     </xs:annotation>
-    <xs:restriction base="xs:normalizedString">
-      <xs:pattern value="(V|X)*"/>
-      <xs:minLength value="16"/>
-    </xs:restriction>
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:normalizedString">
+          <xs:pattern value="(V|X)*"/>
+          <xs:minLength value="8"/>
+          <xs:maxLength value="16"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:nonNegativeInteger" />
+      </xs:simpleType>
+    </xs:union>
   </xs:simpleType>
 
   <xs:simpleType name="modeType">

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -986,7 +986,7 @@
     <xs:union>
       <xs:simpleType>
         <xs:restriction base="xs:normalizedString">
-          <xs:pattern value="(V|X)*"/>
+          <xs:pattern value="X*V+X*"/>
           <xs:minLength value="8"/>
           <xs:maxLength value="16"/>
         </xs:restriction>


### PR DESCRIPTION
This PR adds support non-base-2^N radix storage in decoder definitions. That lets decoder definitions access non-bit-aligned fields in CVs. Yes, that's meant to sound technical.  This features only needs to be used when the decoder manufacturer has some something particularly obscure, and shouldn't be otherwise used.

For development background, see the associated [JMRI-developers thread](https://jmri-developers.groups.io/g/jmri/topic/cvs_coded_in_base_3_ternary/28912113?p=,,,20,0,0,0::recentpostdate%2Fsticky,,,20,2,0,28912113)
