### PR TITLE
Add test of how Roster does locomotive ID

### DIFF
--- a/java/src/jmri/jmrit/roster/Roster.java
+++ b/java/src/jmri/jmrit/roster/Roster.java
@@ -28,8 +28,6 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.ProcessingInstruction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Roster manages and manipulates a roster of locomotives.
@@ -90,8 +88,6 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
     static final public String schemaVersion = ""; // NOI18N
     private String defaultRosterGroup = null;
     private final HashMap<String, RosterGroup> rosterGroups = new HashMap<>();
-    // initialize logging
-    private final static Logger log = LoggerFactory.getLogger(Roster.class);
 
     /**
      * Name of the default roster index file. {@value #DEFAULT_ROSTER_INDEX}
@@ -1363,4 +1359,5 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
         }
     }
 
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Roster.class);
 }

--- a/java/src/jmri/jmrit/roster/swing/RosterFrame.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterFrame.java
@@ -1145,15 +1145,19 @@ public class RosterFrame extends TwoPaneTBWindow implements RosterEntrySelector,
                     if (l2.isEmpty()) {
                         l2 = l;
                     }
-                    //Still more than one possible loco, so check against the decoder family
+                    // Still more than one possible loco, so check against the decoder family
+                    log.trace("Checking against decoder family with mfg {} model {}", mfgId, modelId);
                     List<RosterEntry> l3 = new ArrayList<>();
                     List<DecoderFile> temp = InstanceManager.getDefault(DecoderIndexFile.class).matchingDecoderList(null, null, "" + mfgId, "" + modelId, null, null);
+                    log.trace("found {}", temp.size());
                     ArrayList<String> decoderFam = new ArrayList<>();
                     for (DecoderFile f : temp) {
                         if (!decoderFam.contains(f.getModel())) {
                             decoderFam.add(f.getModel());
                         }
                     }
+                    log.trace("matched {} times", decoderFam.size());
+                    
                     for (RosterEntry _re : l2) {
                         if (decoderFam.contains(_re.getDecoderModel())) {
                             l3.add(_re);

--- a/java/src/jmri/jmrix/easydcc/EasyDccOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccOpsModeProgrammer.java
@@ -64,7 +64,7 @@ public class EasyDccOpsModeProgrammer extends EasyDccProgrammer implements Addre
         startShortTimer();
 
         // send it
-        controller().sendEasyDccMessage(msg, this);
+        tc.sendEasyDccMessage(msg, this);
     }
 
     /** 

--- a/java/src/jmri/jmrix/easydcc/EasyDccProgrammer.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccProgrammer.java
@@ -21,7 +21,7 @@ public class EasyDccProgrammer extends AbstractProgrammer implements EasyDccList
         LONG_TIMEOUT = 180000;
     }
 
-    private EasyDccTrafficController tc = null;
+    protected EasyDccTrafficController tc = null;
 
     /** 
      * {@inheritDoc}

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientSystemConnectionMemo.java
@@ -91,29 +91,17 @@ public class JMRIClientSystemConnectionMemo extends jmri.jmrix.SystemConnectionM
      */
     public void requestAllStatus() {
 
-        getTurnoutManager().getSystemNameList().forEach((t) -> {
-            Turnout turn = getTurnoutManager().getTurnout(t);
-            if (turn != null) {
-               ((JMRIClientTurnout)(turn)).requestUpdateFromLayout();
-            }
+        getTurnoutManager().getNamedBeanSet().forEach((turn) -> {
+            ((JMRIClientTurnout)(turn)).requestUpdateFromLayout();
         }); 
-        getSensorManager().getSystemNameList().forEach((s) -> {
-            Sensor sen = getSensorManager().getSensor(s);
-            if (sen != null) {
-                ((JMRIClientSensor)(sen)).requestUpdateFromLayout();
-            }
+        getSensorManager().getNamedBeanSet().forEach((sen) -> {
+            ((JMRIClientSensor)(sen)).requestUpdateFromLayout();
         }); 
-        getLightManager().getSystemNameList().forEach((l) -> {
-            Light o = getLightManager().getLight(l);
-            if (o != null) {
-                ((JMRIClientLight)o).requestUpdateFromLayout();
-            }
+        getLightManager().getNamedBeanSet().forEach((light) -> {
+            ((JMRIClientLight)light).requestUpdateFromLayout();
         }); 
-        getReporterManager().getSystemNameList().forEach((r) -> {
-            Reporter rep = getReporterManager().getReporter(r);
-            if (rep != null) {
-                ((JMRIClientReporter)(rep)).requestUpdateFromLayout();
-            }
+        getReporterManager().getNamedBeanSet().forEach((rep) -> {
+            ((JMRIClientReporter)(rep)).requestUpdateFromLayout();
         }); 
     }
 

--- a/java/src/jmri/jmrix/nce/NceSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/nce/NceSystemConnectionMemo.java
@@ -63,7 +63,7 @@ public class NceSystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
     public void setNceTrafficController(NceTrafficController tc) {
         nceTrafficController = tc;
         if (tc != null) {
-            tc.setSystemConnectionMemo(this);
+            tc.setAdapterMemo(this);
         }
     }
 

--- a/java/src/jmri/jmrix/roco/z21/Z21CanBusAddress.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21CanBusAddress.java
@@ -1,8 +1,7 @@
 package jmri.jmrix.roco.z21;
 
 import jmri.Manager.NameValidity;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import jmri.ReporterManager;
 
 /**
  * Utility Class supporting parsing and testing of addresses for Z21 CanBus  
@@ -106,7 +105,7 @@ public class Z21CanBusAddress {
         // check for a Reporter 
         if (systemName.charAt(prefix.length() + 1) == 'R') {
             jmri.Reporter r = null;
-            r = jmri.InstanceManager.reporterManagerInstance().getBySystemName(systemName);
+            r = jmri.InstanceManager.getDefault(ReporterManager.class).getBySystemName(systemName);
             if (r != null) {
                 return r.getUserName();
             } else {
@@ -127,6 +126,6 @@ public class Z21CanBusAddress {
         return ("");
     }
 
-    private final static Logger log = LoggerFactory.getLogger(Z21CanBusAddress.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Z21CanBusAddress.class);
 
 }

--- a/java/test/jmri/jmrit/roster/swing/RosterFrameTest.java
+++ b/java/test/jmri/jmrit/roster/swing/RosterFrameTest.java
@@ -6,16 +6,12 @@ import jmri.*;
 import jmri.jmrit.roster.*;
 import jmri.util.*;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 /**
  * Test simple functioning of RosterFrame
  *
- * @author	Paul Bender Copyright (C) 2015,2016
+ * @author	Paul Bender Copyright (C) 2015, 2016
  */
 public class RosterFrameTest {
 
@@ -52,36 +48,32 @@ public class RosterFrameTest {
         prog.resetCv(29, 0);
                 
         operator.pushIdentifyButton();
-        // and wait for message that will come at end:
+        // and wait for message that will come at end because nothing is found
         JUnitUtil.waitFor(() ->{
                 return JUnitAppender.checkForMessage("Read address 3, but no such loco in roster") != null;
             }, "error message at end");
             
-        // to leave visible
-        JUnitUtil.waitFor(5000);
-            
         JUnitUtil.dispose(frame);
     }
-
+    
     @Test
     public void testIdentify3Present() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // add entry to Roster
         Roster roster = Roster.getDefault();
-        RosterEntry re;
-        re = new RosterEntry();
-        re.setId("1st entry");
-        re.setDccAddress("3");
-        roster.addEntry(re);
-        re = new RosterEntry();
-        re.setId("2nd entry");
-        re.setDccAddress("4");
-        roster.addEntry(re);
-        re = new RosterEntry();
-        re.setId("3rd entry");
-        re.setDccAddress("5");
-        roster.addEntry(re);
+        RosterEntry re1 = new RosterEntry();
+        re1.setId("1st entry");
+        re1.setDccAddress("3");
+        roster.addEntry(re1);
+        RosterEntry re2 = new RosterEntry();
+        re2.setId("2nd entry");
+        re2.setDccAddress("4");
+        roster.addEntry(re2);
+        RosterEntry re3 = new RosterEntry();
+        re3.setId("3rd entry");
+        re3.setDccAddress("5");
+        roster.addEntry(re3);
         
         RosterFrame frame = new RosterFrame();
         frame.setVisible(true);
@@ -94,13 +86,13 @@ public class RosterFrameTest {
         prog.resetCv(29, 0);
                 
         operator.pushIdentifyButton();
-        // and wait for message that will come at end:
-        //JUnitUtil.waitFor(() ->{
-        //        return JUnitAppender.checkForMessage("Read address 3, but no such loco in roster") != null;
-        //    }, "error message at end");
-        JUnitUtil.waitFor(5000);
+        
+        JUnitUtil.waitFor(() ->{
+            return frame.getSelectedRosterEntries().length == 1;
+        }, "selection complete");
         RosterEntry[] selected = frame.getSelectedRosterEntries();
         Assert.assertEquals("selected ", 1, selected.length);
+        Assert.assertEquals("selected ", re1, selected[0]);
         
         JUnitUtil.dispose(frame);
     }
@@ -112,21 +104,20 @@ public class RosterFrameTest {
 
         // add entry to Roster
         Roster roster = Roster.getDefault();
-        RosterEntry re;
-        re = new RosterEntry();
-        re.setId("1st entry is 3; mismatched types accepted");
-        re.setDccAddress("3");
-        re.setDecoderModel("Four Function Dual Mode");  // CV8 = 127 Atlas, CV7 = 46
-        re.setDecoderFamily("Four Function Dual Mode"); 
-        roster.addEntry(re);
-        re = new RosterEntry();
-        re.setId("2nd entry");
-        re.setDccAddress("4");
-        roster.addEntry(re);
-        re = new RosterEntry();
-        re.setId("3rd entry");
-        re.setDccAddress("5");
-        roster.addEntry(re);
+        RosterEntry re1 = new RosterEntry();
+        re1.setId("1st entry is 3; mismatched types accepted");
+        re1.setDccAddress("3");
+        re1.setDecoderModel("Four Function Dual Mode");  // CV8 = 127 Atlas, CV7 = 46
+        re1.setDecoderFamily("Four Function Dual Mode"); 
+        roster.addEntry(re1);
+        RosterEntry re2 = new RosterEntry();
+        re2.setId("2nd entry");
+        re2.setDccAddress("4");
+        roster.addEntry(re2);
+        RosterEntry re3 = new RosterEntry();
+        re3.setId("3rd entry");
+        re3.setDccAddress("5");
+        roster.addEntry(re3);
         
         RosterFrame frame = new RosterFrame();
         frame.setVisible(true);
@@ -145,32 +136,38 @@ public class RosterFrameTest {
         //JUnitUtil.waitFor(() ->{
         //        return JUnitAppender.checkForMessage("Read address 3, but no such loco in roster") != null;
         //    }, "error message at end");
-        JUnitUtil.waitFor(5000);
+
+        JUnitUtil.waitFor(() ->{
+            return frame.getSelectedRosterEntries().length == 1;
+        }, "selection complete");
         RosterEntry[] selected = frame.getSelectedRosterEntries();
-        Assert.assertEquals("selected ", 1, selected.length);
+        Assert.assertEquals("selected ", re1, selected[0]);
         
         JUnitUtil.dispose(frame);
     }
 
     @Test
+    @Ignore("RosterFrame doesn't do multiple selection properly yet")
     public void testIdentify3Multiple() {
+    
+        // this is a test of what happens when multiples are selectable
+        
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         // add entry to Roster
         Roster roster = Roster.getDefault();
-        RosterEntry re;
-        re = new RosterEntry();
-        re.setId("1st entry is 3");
-        re.setDccAddress("3");
-        roster.addEntry(re);
-        re = new RosterEntry();
-        re.setId("2nd entry is not 3");
-        re.setDccAddress("4");
-        roster.addEntry(re);
-        re = new RosterEntry();
-        re.setId("3rd entry is 3");
-        re.setDccAddress("3");
-        roster.addEntry(re);
+        RosterEntry re1 = new RosterEntry();
+        re1.setId("1st entry is 3");
+        re1.setDccAddress("3");
+        roster.addEntry(re1);
+        RosterEntry re2 = new RosterEntry();
+        re2.setId("2nd entry is not 3");
+        re2.setDccAddress("4");
+        roster.addEntry(re2);
+        RosterEntry re3 = new RosterEntry();
+        re3.setId("3rd entry is 3");
+        re3.setDccAddress("3");
+        roster.addEntry(re3);
         
         RosterFrame frame = new RosterFrame();
         frame.setVisible(true);
@@ -183,16 +180,17 @@ public class RosterFrameTest {
         prog.resetCv(29, 0);
                  
         operator.pushIdentifyButton();
-        // and wait for message that will come at end:
-        //JUnitUtil.waitFor(() ->{
-        //        return JUnitAppender.checkForMessage("Read address 3, but no such loco in roster") != null;
-        //    }, "error message at end");
-        JUnitUtil.waitFor(5000);
+
+        // right now, nothing is ever selected, because multiple selection 
+        // is not working.  See @Ignore above
+        
+        JUnitUtil.waitFor(() ->{
+            return frame.getSelectedRosterEntries().length == 2;
+        }, "selection complete");
         RosterEntry[] selected = frame.getSelectedRosterEntries();
-        
-        // Following is commented out because multiple selection isn't present yet
-        // Assert.assertEquals("selected ", 1, selected.length);
-        
+        Assert.assertEquals("selected ", re1, selected[0]);
+        Assert.assertEquals("selected ", re3, selected[1]);
+                
         JUnitUtil.dispose(frame);
     }
 
@@ -202,23 +200,22 @@ public class RosterFrameTest {
 
         // add entry to Roster
         Roster roster = Roster.getDefault();
-        RosterEntry re;
-        re = new RosterEntry();
-        re.setId("1st entry is 3 Four Function Dual Mode");
-        re.setDccAddress("3");
-        re.setDecoderModel("Four Function Dual Mode");  // CV8 = 127 Atlas, CV7 = 46
-        re.setDecoderFamily("Four Function Dual Mode"); 
-        roster.addEntry(re);
-        re = new RosterEntry();
-        re.setId("2nd entry in not 3");
-        re.setDccAddress("4");
-        roster.addEntry(re);
-        re = new RosterEntry();
-        re.setId("3rd entry is 3 Dual Mode");
-        re.setDccAddress("3");
-        re.setDecoderModel("Dual Mode");  // CV8 = 127 Atlas, CV7 = 45
-        re.setDecoderFamily("Dual Mode"); 
-        roster.addEntry(re);
+        RosterEntry re1 = new RosterEntry();
+        re1.setId("1st entry is 3 Four Function Dual Mode");
+        re1.setDccAddress("3");
+        re1.setDecoderModel("Four Function Dual Mode");  // CV8 = 127 Atlas, CV7 = 46
+        re1.setDecoderFamily("Four Function Dual Mode"); 
+        roster.addEntry(re1);
+        RosterEntry re2 = new RosterEntry();
+        re2.setId("2nd entry in not 3");
+        re2.setDccAddress("4");
+        roster.addEntry(re2);
+        RosterEntry re3 = new RosterEntry();
+        re3.setId("3rd entry is 3 Dual Mode");
+        re3.setDccAddress("3");
+        re3.setDecoderModel("Dual Mode");  // CV8 = 127 Atlas, CV7 = 45
+        re3.setDecoderFamily("Dual Mode"); 
+        roster.addEntry(re3);
         
         RosterFrame frame = new RosterFrame();
         frame.setVisible(true);
@@ -233,13 +230,13 @@ public class RosterFrameTest {
         prog.resetCv(8, 127); // Atlas
                 
         operator.pushIdentifyButton();
-        // and wait for message that will come at end:
-        //JUnitUtil.waitFor(() ->{
-        //        return JUnitAppender.checkForMessage("Read address 3, but no such loco in roster") != null;
-        //    }, "error message at end");
-        JUnitUtil.waitFor(5000);
+        
+        JUnitUtil.waitFor(() ->{
+            return frame.getSelectedRosterEntries().length == 1;
+        }, "selection complete");
         RosterEntry[] selected = frame.getSelectedRosterEntries();
         Assert.assertEquals("selected ", 1, selected.length);
+        Assert.assertEquals("selected ", re3, selected[0]);  // 2nd address=3 selected by decoder match
         
         JUnitUtil.dispose(frame);
     }
@@ -262,5 +259,5 @@ public class RosterFrameTest {
         JUnitUtil.tearDown();
     }
 
-    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(RosterFrameTest.class);
+    // private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(RosterFrameTest.class);
 }

--- a/java/test/jmri/jmrit/roster/swing/RosterFrameTest.java
+++ b/java/test/jmri/jmrit/roster/swing/RosterFrameTest.java
@@ -1,7 +1,11 @@
 package jmri.jmrit.roster.swing;
 
 import java.awt.GraphicsEnvironment;
-import jmri.util.JUnitUtil;
+
+import jmri.*;
+import jmri.jmrit.roster.*;
+import jmri.util.*;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -33,18 +37,131 @@ public class RosterFrameTest {
         JUnitUtil.dispose(frame);
     }
 
+    @Test
+    public void testIdentify3NotPresent() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
+        RosterFrame frame = new RosterFrame();
+        frame.pack();
+        frame.setVisible(true);
+        RosterFrameScaffold operator = new RosterFrameScaffold(frame.getTitle());
+        
+        // set some CV values
+        jmri.progdebugger.ProgDebugger prog = (jmri.progdebugger.ProgDebugger)InstanceManager.getDefault(GlobalProgrammerManager.class).getGlobalProgrammer();
+        prog.resetCv(1, 3);
+        prog.resetCv(29, 0);
+                
+        operator.pushIdentifyButton();
+        // and wait for message that will come at end:
+        //JUnitUtil.waitFor(() ->{
+        //        return JUnitAppender.checkForMessage("Read address 3, but no such loco in roster") != null;
+        //    }, "error message at end");
+        JUnitUtil.waitFor(5000);
+            
+        JUnitUtil.dispose(frame);
+    }
+
+    @Test
+    public void testIdentify3Present() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
+        // add entry to Roster
+        Roster roster = Roster.getDefault();
+        RosterEntry re;
+        re = new RosterEntry();
+        re.setId("1st entry");
+        re.setDccAddress("3");
+        roster.addEntry(re);
+        re = new RosterEntry();
+        re.setId("2nd entry");
+        re.setDccAddress("4");
+        roster.addEntry(re);
+        re = new RosterEntry();
+        re.setId("3rd entry");
+        re.setDccAddress("5");
+        roster.addEntry(re);
+        
+        RosterFrame frame = new RosterFrame();
+        frame.setVisible(true);
+        frame.pack();
+        RosterFrameScaffold operator = new RosterFrameScaffold(frame.getTitle());
+        
+        // set some CV values
+        jmri.progdebugger.ProgDebugger prog = (jmri.progdebugger.ProgDebugger)InstanceManager.getDefault(GlobalProgrammerManager.class).getGlobalProgrammer();
+        prog.resetCv(1, 3);
+        prog.resetCv(29, 0);
+                
+        operator.pushIdentifyButton();
+        // and wait for message that will come at end:
+        //JUnitUtil.waitFor(() ->{
+        //        return JUnitAppender.checkForMessage("Read address 3, but no such loco in roster") != null;
+        //    }, "error message at end");
+        JUnitUtil.waitFor(5000);
+        RosterEntry[] selected = frame.getSelectedRosterEntries();
+        Assert.assertEquals("selected ", 1, selected.length);
+        
+        JUnitUtil.dispose(frame);
+    }
+
+    @Test
+    public void testIdentify3Multiple() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
+        // add entry to Roster
+        Roster roster = Roster.getDefault();
+        RosterEntry re;
+        re = new RosterEntry();
+        re.setId("1st entry is 3");
+        re.setDccAddress("3");
+        roster.addEntry(re);
+        re = new RosterEntry();
+        re.setId("2nd entry in not 3");
+        re.setDccAddress("4");
+        roster.addEntry(re);
+        re = new RosterEntry();
+        re.setId("3rd entry is 3");
+        re.setDccAddress("3");
+        roster.addEntry(re);
+        
+        RosterFrame frame = new RosterFrame();
+        frame.setVisible(true);
+        frame.pack();
+        RosterFrameScaffold operator = new RosterFrameScaffold(frame.getTitle());
+        
+        // set some CV values
+        jmri.progdebugger.ProgDebugger prog = (jmri.progdebugger.ProgDebugger)InstanceManager.getDefault(GlobalProgrammerManager.class).getGlobalProgrammer();
+        prog.resetCv(1, 3);
+        prog.resetCv(29, 0);
+                
+        operator.pushIdentifyButton();
+        // and wait for message that will come at end:
+        //JUnitUtil.waitFor(() ->{
+        //        return JUnitAppender.checkForMessage("Read address 3, but no such loco in roster") != null;
+        //    }, "error message at end");
+        JUnitUtil.waitFor(5000);
+        RosterEntry[] selected = frame.getSelectedRosterEntries();
+        Assert.assertEquals("selected ", 1, selected.length);
+        
+        JUnitUtil.dispose(frame);
+    }
+
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager();
         JUnitUtil.initDefaultUserMessagePreferences();
         JUnitUtil.initGuiLafPreferencesManager();
         jmri.InstanceManager.setDefault(jmri.jmrix.ConnectionConfigManager.class, new jmri.jmrix.ConnectionConfigManager());
         jmri.InstanceManager.setDefault(jmri.jmrit.symbolicprog.ProgrammerConfigManager.class, new jmri.jmrit.symbolicprog.ProgrammerConfigManager());
         JUnitUtil.initDebugProgrammerManager();
+        Roster.getDefault(); // ensure exists
     }
 
     @After
-    public void tearDown() {        JUnitUtil.tearDown();    }
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
 
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(RosterFrameTest.class);
 }

--- a/java/test/jmri/jmrit/roster/swing/RosterFrameTest.java
+++ b/java/test/jmri/jmrit/roster/swing/RosterFrameTest.java
@@ -53,9 +53,11 @@ public class RosterFrameTest {
                 
         operator.pushIdentifyButton();
         // and wait for message that will come at end:
-        //JUnitUtil.waitFor(() ->{
-        //        return JUnitAppender.checkForMessage("Read address 3, but no such loco in roster") != null;
-        //    }, "error message at end");
+        JUnitUtil.waitFor(() ->{
+                return JUnitAppender.checkForMessage("Read address 3, but no such loco in roster") != null;
+            }, "error message at end");
+            
+        // to leave visible
         JUnitUtil.waitFor(5000);
             
         JUnitUtil.dispose(frame);
@@ -104,6 +106,53 @@ public class RosterFrameTest {
     }
 
     @Test
+    public void testIdentify3WithDecoderTypeMismatch() {
+        // match on address if unique, even if decoder type not right
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
+        // add entry to Roster
+        Roster roster = Roster.getDefault();
+        RosterEntry re;
+        re = new RosterEntry();
+        re.setId("1st entry is 3; mismatched types accepted");
+        re.setDccAddress("3");
+        re.setDecoderModel("Four Function Dual Mode");  // CV8 = 127 Atlas, CV7 = 46
+        re.setDecoderFamily("Four Function Dual Mode"); 
+        roster.addEntry(re);
+        re = new RosterEntry();
+        re.setId("2nd entry");
+        re.setDccAddress("4");
+        roster.addEntry(re);
+        re = new RosterEntry();
+        re.setId("3rd entry");
+        re.setDccAddress("5");
+        roster.addEntry(re);
+        
+        RosterFrame frame = new RosterFrame();
+        frame.setVisible(true);
+        frame.pack();
+        RosterFrameScaffold operator = new RosterFrameScaffold(frame.getTitle());
+        
+        // set some CV values
+        jmri.progdebugger.ProgDebugger prog = (jmri.progdebugger.ProgDebugger)InstanceManager.getDefault(GlobalProgrammerManager.class).getGlobalProgrammer();
+        prog.resetCv(1, 3);
+        prog.resetCv(29, 0);
+        prog.resetCv(7, 45); // Dual Mode (not Four Function Dual Mode)
+        prog.resetCv(8, 127); // Atlas
+                
+        operator.pushIdentifyButton();
+        // and wait for message that will come at end:
+        //JUnitUtil.waitFor(() ->{
+        //        return JUnitAppender.checkForMessage("Read address 3, but no such loco in roster") != null;
+        //    }, "error message at end");
+        JUnitUtil.waitFor(5000);
+        RosterEntry[] selected = frame.getSelectedRosterEntries();
+        Assert.assertEquals("selected ", 1, selected.length);
+        
+        JUnitUtil.dispose(frame);
+    }
+
+    @Test
     public void testIdentify3Multiple() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
@@ -115,7 +164,7 @@ public class RosterFrameTest {
         re.setDccAddress("3");
         roster.addEntry(re);
         re = new RosterEntry();
-        re.setId("2nd entry in not 3");
+        re.setId("2nd entry is not 3");
         re.setDccAddress("4");
         roster.addEntry(re);
         re = new RosterEntry();
@@ -132,6 +181,56 @@ public class RosterFrameTest {
         jmri.progdebugger.ProgDebugger prog = (jmri.progdebugger.ProgDebugger)InstanceManager.getDefault(GlobalProgrammerManager.class).getGlobalProgrammer();
         prog.resetCv(1, 3);
         prog.resetCv(29, 0);
+                 
+        operator.pushIdentifyButton();
+        // and wait for message that will come at end:
+        //JUnitUtil.waitFor(() ->{
+        //        return JUnitAppender.checkForMessage("Read address 3, but no such loco in roster") != null;
+        //    }, "error message at end");
+        JUnitUtil.waitFor(5000);
+        RosterEntry[] selected = frame.getSelectedRosterEntries();
+        
+        // Following is commented out because multiple selection isn't present yet
+        // Assert.assertEquals("selected ", 1, selected.length);
+        
+        JUnitUtil.dispose(frame);
+    }
+
+    @Test
+    public void testIdentify3ViaDecoderId() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
+        // add entry to Roster
+        Roster roster = Roster.getDefault();
+        RosterEntry re;
+        re = new RosterEntry();
+        re.setId("1st entry is 3 Four Function Dual Mode");
+        re.setDccAddress("3");
+        re.setDecoderModel("Four Function Dual Mode");  // CV8 = 127 Atlas, CV7 = 46
+        re.setDecoderFamily("Four Function Dual Mode"); 
+        roster.addEntry(re);
+        re = new RosterEntry();
+        re.setId("2nd entry in not 3");
+        re.setDccAddress("4");
+        roster.addEntry(re);
+        re = new RosterEntry();
+        re.setId("3rd entry is 3 Dual Mode");
+        re.setDccAddress("3");
+        re.setDecoderModel("Dual Mode");  // CV8 = 127 Atlas, CV7 = 45
+        re.setDecoderFamily("Dual Mode"); 
+        roster.addEntry(re);
+        
+        RosterFrame frame = new RosterFrame();
+        frame.setVisible(true);
+        frame.pack();
+        RosterFrameScaffold operator = new RosterFrameScaffold(frame.getTitle());
+        
+        // set some CV values
+        jmri.progdebugger.ProgDebugger prog = (jmri.progdebugger.ProgDebugger)InstanceManager.getDefault(GlobalProgrammerManager.class).getGlobalProgrammer();
+        prog.resetCv(1, 3);
+        prog.resetCv(29, 0);
+        prog.resetCv(7, 45); // Dual Mode (not Four Function Dual Mode)
+        prog.resetCv(8, 127); // Atlas
                 
         operator.pushIdentifyButton();
         // and wait for message that will come at end:

--- a/java/test/jmri/jmrix/nce/NceProgrammerTest.java
+++ b/java/test/jmri/jmrix/nce/NceProgrammerTest.java
@@ -12,9 +12,6 @@ import org.junit.*;
 /**
  * JUnit tests for the NceProgrammer class
  * <p>
- * before conversion to JUnit4, most tests had names starting with x, which 
- * disables them in JUnit3; a note why that was done would have been good!
- * These tests now have a JUnit4 Ignore attribute.
  *
  * @author	Bob Jacobsen
  */
@@ -81,13 +78,12 @@ public class NceProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     }
 
     @Test
-    @Ignore("disabled for some reason in JUnit3")
     public void testWriteCvSequenceBin() throws JmriException {
         // and do the write
         p.writeCV("10", 20, l);
         // correct message sent
         Assert.assertEquals("mode message sent", 1, tc.outbound.size());
-        Assert.assertEquals("write message contents", "A0 00 0A 14",
+        Assert.assertEquals("write message contents", "P010 020",
                 ((tc.outbound.elementAt(0))).toString());
         // reply from programmer arrives
         NceReply r = new NceReply(tc);
@@ -115,7 +111,6 @@ public class NceProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     }
 
     @Test
-    @Ignore("disabled for some reason in JUnit3")
     public void testWriteRegisterSequenceBin() throws JmriException {
         // set register mode
         p.setMode(ProgrammingMode.REGISTERMODE);
@@ -124,7 +119,7 @@ public class NceProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         p.writeCV("3", 12, l);
         // check "prog mode" message sent
         Assert.assertEquals("write message sent", 1, tc.outbound.size());
-        Assert.assertEquals("write message contents", "A6 03 0C",
+        Assert.assertEquals("write message contents", "S3 012",
                 ((tc.outbound.elementAt(0))).toString());
         // reply from programmer arrives
         NceReply r = new NceReply(tc);
@@ -154,14 +149,13 @@ public class NceProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     }
 
     @Test
-    @Ignore("disabled for some reason in JUnit3")
     public void testReadCvSequenceBin() throws JmriException {
         // and do the read
         p.readCV("10", l);
 
         // check "read command" message sent
         Assert.assertEquals("read message sent", 1, tc.outbound.size());
-        Assert.assertEquals("read message contents", "A1 00 0A",
+        Assert.assertEquals("read message contents", "R010",
                 ((tc.outbound.elementAt(0))).toString());
         // reply from programmer arrives
         NceReply r = new NceReply(tc);
@@ -198,7 +192,6 @@ public class NceProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     }
 
     @Test
-    @Ignore("disabled for some reason in JUnit3")
     public void testReadRegisterSequenceBin() throws JmriException {
         // set register mode
         p.setMode(ProgrammingMode.REGISTERMODE);
@@ -208,7 +201,7 @@ public class NceProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
 
         // check "read command" message sent
         Assert.assertEquals("read message sent", 1, tc.outbound.size());
-        Assert.assertEquals("read message contents", "A7 03",
+        Assert.assertEquals("read message contents", "V3",
                 ((tc.outbound.elementAt(0))).toString());
         // reply from programmer arrives
         NceReply r = new NceReply(tc);

--- a/java/test/jmri/jmrix/nce/NceProgrammerTest.java
+++ b/java/test/jmri/jmrix/nce/NceProgrammerTest.java
@@ -78,40 +78,7 @@ public class NceProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     }
 
     @Test
-    public void testWriteCvSequenceBin() throws JmriException {
-        // and do the write
-        p.writeCV("10", 20, l);
-        // correct message sent
-        Assert.assertEquals("mode message sent", 1, tc.outbound.size());
-        Assert.assertEquals("write message contents", "P010 020",
-                ((tc.outbound.elementAt(0))).toString());
-        // reply from programmer arrives
-        NceReply r = new NceReply(tc);
-        tc.sendTestReply(r, p);
-        Assert.assertEquals(" got data value back", 20, l.getRcvdValue());
-        Assert.assertEquals(" listener invoked", 1, l.getRcvdInvoked());
-    }
-
-    @Test
     public void testWriteRegisterSequenceAscii() throws JmriException {
-        // set register mode
-        p.setMode(ProgrammingMode.REGISTERMODE);
-
-        // and do the write
-        p.writeCV("3", 12, l);
-        // check "prog mode" message sent
-        Assert.assertEquals("write message sent", 1, tc.outbound.size());
-        Assert.assertEquals("write message contents", "S3 012",
-                ((tc.outbound.elementAt(0))).toString());
-        // reply from programmer arrives
-        NceReply r = new NceReply(tc);
-        tc.sendTestReply(r, p);
-        Assert.assertEquals(" got data value back", 12, l.getRcvdValue());
-        Assert.assertEquals(" listener invoked", 1, l.getRcvdInvoked());
-    }
-
-    @Test
-    public void testWriteRegisterSequenceBin() throws JmriException {
         // set register mode
         p.setMode(ProgrammingMode.REGISTERMODE);
 
@@ -149,50 +116,7 @@ public class NceProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
     }
 
     @Test
-    public void testReadCvSequenceBin() throws JmriException {
-        // and do the read
-        p.readCV("10", l);
-
-        // check "read command" message sent
-        Assert.assertEquals("read message sent", 1, tc.outbound.size());
-        Assert.assertEquals("read message contents", "R010",
-                ((tc.outbound.elementAt(0))).toString());
-        // reply from programmer arrives
-        NceReply r = new NceReply(tc);
-        r.setElement(0, '0');
-        r.setElement(1, '2');
-        r.setElement(2, '0');
-        tc.sendTestReply(r, p);
-
-        Assert.assertEquals(" programmer listener invoked", 1, l.getRcvdInvoked());
-        Assert.assertEquals(" value read", 20, l.getRcvdValue());
-    }
-
-    @Test
     public void testReadRegisterSequenceAscii() throws JmriException {
-        // set register mode
-        p.setMode(ProgrammingMode.REGISTERMODE);
-
-        // and do the read
-        p.readCV("3", l);
-
-        // check "read command" message sent
-        Assert.assertEquals("read message sent", 1, tc.outbound.size());
-        Assert.assertEquals("read message contents", "V3",
-                ((tc.outbound.elementAt(0))).toString());
-        // reply from programmer arrives
-        NceReply r = new NceReply(tc);
-        r.setElement(0, '0');
-        r.setElement(1, '2');
-        r.setElement(2, '0');
-        tc.sendTestReply(r, p);
-
-        Assert.assertEquals(" programmer listener invoked", 1, l.getRcvdInvoked());
-        Assert.assertEquals(" value read", 20, l.getRcvdValue());
-    }
-
-    @Test
-    public void testReadRegisterSequenceBin() throws JmriException {
         // set register mode
         p.setMode(ProgrammingMode.REGISTERMODE);
 


### PR DESCRIPTION
Adds some tests of how the identify-existing-loco logic works to pick a roster entry via address and decoder-type CVs.

Also, some test and deprecation updates along the way.