### PR TITLE
Handle deprecated methods

### DIFF
--- a/java/src/jmri/SectionManager.java
+++ b/java/src/jmri/SectionManager.java
@@ -261,9 +261,7 @@ public class SectionManager extends AbstractManager<Section> implements Property
             }
         }
         jmri.SignalHeadManager shManager = InstanceManager.getDefault(jmri.SignalHeadManager.class);
-        List<String> signalList = shManager.getSystemNameList();
-        for (int j = 0; j < signalList.size(); j++) {
-            SignalHead sh = shManager.getBySystemName(signalList.get(j));
+        for (SignalHead sh : shManager.getNamedBeanSet()) {
             if (!cUtil.removeSensorsFromSignalHeadLogic(sensorList, sh)) {
                 numErrors++;
             }
@@ -275,9 +273,7 @@ public class SectionManager extends AbstractManager<Section> implements Property
      * Initialize all blocking sensors that exist - sets them to 'ACTIVE'
      */
     public void initializeBlockingSensors() {
-        List<String> list = getSystemNameList();
-        for (int i = 0; i < list.size(); i++) {
-            Section s = getBySystemName(list.get(i));
+        for (Section s : getNamedBeanSet()) {
             try {
                 if (s.getForwardBlockingSensor() != null) {
                     s.getForwardBlockingSensor().setState(Sensor.ACTIVE);

--- a/java/src/jmri/jmrit/beantable/Maintenance.java
+++ b/java/src/jmri/jmrit/beantable/Maintenance.java
@@ -67,6 +67,7 @@ public class Maintenance {
      *
      * @param parent Frame to check
      */
+    @SuppressWarnings("deprecation") // requires JUnit tests before can reliably redo getSystemNameList-using algorithms
     public static void findOrphansPressed(Frame parent) {
         Vector<String> display = new Vector<String>();
         Vector<String> names = new Vector<String>();
@@ -249,6 +250,7 @@ public class Maintenance {
      *
      * @param parent Frame to check
      */
+    @SuppressWarnings("deprecation") // requires JUnit tests before can reliably redo getSystemNameList-using algorithms
     public static void findEmptyPressed(Frame parent) {
         Vector<String> display = new Vector<String>();
         Vector<String> names = new Vector<String>();
@@ -431,6 +433,7 @@ public class Maintenance {
      * @param text body of the message to be displayed reporting the result
      * @return true if name is found at least once as a bean name
      */
+    @SuppressWarnings("deprecation") // requires JUnit tests before can reliably redo getSystemNameList-using algorithms
     static boolean search(String name, JTextArea text) {
         String[] names = getTypeAndNames(name);
         if (log.isDebugEnabled()) {

--- a/java/src/jmri/jmrit/logix/configurexml/WarrantManagerXml.java
+++ b/java/src/jmri/jmrit/logix/configurexml/WarrantManagerXml.java
@@ -44,10 +44,8 @@ public class WarrantManagerXml //extends XmlFile
         Element warrants = new Element("warrants");
         warrants.setAttribute("class","jmri.jmrit.logix.configurexml.WarrantManagerXml");
         WarrantManager manager = (WarrantManager) o;
-        Iterator<String> iter = manager.getSystemNameList().iterator();
-        while (iter.hasNext()) {
-            String sname = iter.next();
-            Warrant warrant = manager.getBySystemName(sname);
+        for (Warrant warrant : manager.getNamedBeanSet()) {
+            String sname = warrant.getSystemName();
             String uname = warrant.getUserName();
             if (log.isDebugEnabled())
                 log.debug("Warrant: sysName= {}, userName= {}", sname, uname);

--- a/java/src/jmri/jmrit/operations/trains/tools/TrainsTableSetColorFrame.java
+++ b/java/src/jmri/jmrit/operations/trains/tools/TrainsTableSetColorFrame.java
@@ -41,12 +41,19 @@ public class TrainsTableSetColorFrame extends OperationsFrame implements java.be
 
     // combo boxes
     JComboBox<Train> trainBox = InstanceManager.getDefault(TrainManager.class).getTrainComboBox();
+    
+    @SuppressWarnings("deprecation") // JColorChooser is replacement for getRowColorComboBox, but has different layout
     JComboBox<String> colorBox = InstanceManager.getDefault(TrainManager.class).getRowColorComboBox();
+    @SuppressWarnings("deprecation") // JColorChooser is replacement for getRowColorComboBox, but has different layout
     JComboBox<String> colorResetBox = InstanceManager.getDefault(TrainManager.class).getRowColorComboBox();
 
+    @SuppressWarnings("deprecation") // JColorChooser is replacement for getRowColorComboBox, but has different layout
     JComboBox<String> colorBuiltBox = InstanceManager.getDefault(TrainManager.class).getRowColorComboBox();
+    @SuppressWarnings("deprecation") // JColorChooser is replacement for getRowColorComboBox, but has different layout
     JComboBox<String> colorBuildFailedBox = InstanceManager.getDefault(TrainManager.class).getRowColorComboBox();
+    @SuppressWarnings("deprecation") // JColorChooser is replacement for getRowColorComboBox, but has different layout
     JComboBox<String> colorTrainEnRouteBox = InstanceManager.getDefault(TrainManager.class).getRowColorComboBox();
+    @SuppressWarnings("deprecation") // JColorChooser is replacement for getRowColorComboBox, but has different layout
     JComboBox<String> colorTerminatedBox = InstanceManager.getDefault(TrainManager.class).getRowColorComboBox();
 
     // display panels based on which option is selected

--- a/java/src/jmri/jmrix/loconet/Intellibox/IBLnPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/Intellibox/IBLnPacketizer.java
@@ -5,8 +5,7 @@ import java.util.NoSuchElementException;
 import jmri.jmrix.loconet.LnPacketizer;
 import jmri.jmrix.loconet.LocoNetMessage;
 import jmri.jmrix.loconet.LocoNetMessageException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 
 /**
  * Converts Stream-based I/O to/from LocoNet messages. The "LocoNetInterface"
@@ -36,8 +35,8 @@ public class IBLnPacketizer extends LnPacketizer {
     @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
             justification = "Only used during system initialization")
     public IBLnPacketizer() {
+        super(new LocoNetSystemConnectionMemo());
         echo = true;
-        //self = this;
     }
 
     /**
@@ -293,5 +292,5 @@ public class IBLnPacketizer extends LnPacketizer {
 
     }
 
-    private final static Logger log = LoggerFactory.getLogger(IBLnPacketizer.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(IBLnPacketizer.class);
 }

--- a/java/src/jmri/jmrix/loconet/LnTrafficRouter.java
+++ b/java/src/jmri/jmrix/loconet/LnTrafficRouter.java
@@ -24,8 +24,6 @@ public class LnTrafficRouter extends LnTrafficController implements LocoNetListe
      * @deprecated since 4.11.6, use LnTrafficRouter(LocoNetSystemConnectionMemo) instead
      */
     @Deprecated
-    @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
-            justification = "Only used during system initialization") // NOI18N
     public LnTrafficRouter() {
     }
 

--- a/java/src/jmri/jmrix/loconet/locormi/LnMessageClient.java
+++ b/java/src/jmri/jmrix/loconet/locormi/LnMessageClient.java
@@ -37,8 +37,8 @@ public class LnMessageClient extends LnTrafficRouter {
     LnMessageClientPollThread pollThread = null;
 
     public LnMessageClient() {
-        super();
-        clientMemo = new LocoNetSystemConnectionMemo();
+        super(new LocoNetSystemConnectionMemo());
+        clientMemo = new LocoNetSystemConnectionMemo();  // client is separate?
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/pr2/LnPr2Packetizer.java
+++ b/java/src/jmri/jmrix/loconet/pr2/LnPr2Packetizer.java
@@ -2,6 +2,7 @@ package jmri.jmrix.loconet.pr2;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jmri.jmrix.loconet.LnPacketizer;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 
 /**
  * Special LnPr2Packetizer implementation for PR2.
@@ -14,11 +15,10 @@ public class LnPr2Packetizer extends LnPacketizer {
     @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD", // NOI18N
             justification = "Only used during system initialization") // NOI18N
     public LnPr2Packetizer() {
-        super();
-        //self = this;
+        super(new LocoNetSystemConnectionMemo());
         echo = true;
     }
 
-//    private final static Logger log = LoggerFactory.getLogger(LnPr2Packetizer.class);
+//    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LnPr2Packetizer.class);
 
 }

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockPacketizer.java
@@ -8,6 +8,7 @@ import jmri.jmrix.loconet.LnPacketizer;
 import jmri.jmrix.loconet.LocoNetInterface;
 import jmri.jmrix.loconet.LocoNetMessage;
 import jmri.jmrix.loconet.LocoNetMessageException;
+import jmri.jmrix.loconet.LocoNetSystemConnectionMemo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,7 @@ public class UhlenbrockPacketizer extends LnPacketizer implements LocoNetInterfa
     @SuppressFBWarnings(value = "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
             justification = "Only used during system initialization")
     public UhlenbrockPacketizer() {
-        super();
+        super(new LocoNetSystemConnectionMemo());
         log.debug("UhlenbrockPacketizer instantiated");
     }
 


### PR DESCRIPTION
Update or annotate additional method calls.

In one case, remove a SpotBugs annotation that was no longer needed
