### PR TITLE
disable automatic creation of internal Z21 Reporter by default; user can still create manually.

### DIFF
--- a/java/src/jmri/jmrix/roco/z21/Z21ReporterManager.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21ReporterManager.java
@@ -16,6 +16,11 @@ import org.slf4j.LoggerFactory;
 public class Z21ReporterManager extends jmri.managers.AbstractReporterManager implements Z21Listener {
 
     private Z21SystemConnectionMemo _memo = null;
+    private boolean autoCreateInternalReporter = false;  // disable automatic 
+                                            // creation of the internal reporter
+                                            // by default.  It interferes with
+                                            // reports from the Roco 10808
+                                            // which it preceeds in the circuit.  
 
     /**
      * Create a new Z21ReporterManager
@@ -88,7 +93,7 @@ public class Z21ReporterManager extends jmri.managers.AbstractReporterManager im
     public void reply(Z21Reply msg){
          // LAN_RAILCOM_DATACHANGED messages are related to the built in
          // reporter.
-         if(msg.isRailComDataChangedMessage()){
+         if(autoCreateInternalReporter && msg.isRailComDataChangedMessage()){
             log.debug("Received RailComDatachanged message");
             Z21Reporter r = (Z21Reporter) getBySystemName(getSystemPrefix()+typeLetter()+1); // there is only one built in reporter.
            if ( null == r ) {
@@ -134,6 +139,14 @@ public class Z21ReporterManager extends jmri.managers.AbstractReporterManager im
     @Override
     public void message(Z21Message msg){
          // we don't need to handle outgoing messages, so just ignore them.
+    }
+
+    /**
+     * Enable automatic creation of the Internal Z21 Reporter from messages.  
+     * Defaults to disabled.
+     */
+    public void enableInternalReporterCreationFromMessages(){
+       autoCreateInternalReporter = true;
     }
 
     private static final Logger log = LoggerFactory.getLogger(Z21ReporterManager.class);

--- a/java/test/jmri/jmrix/roco/z21/Z21ReporterManagerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21ReporterManagerTest.java
@@ -21,6 +21,7 @@ public class Z21ReporterManagerTest extends jmri.managers.AbstractReporterMgrTes
    @Test
    public void testAutomaticCreateFromRailComReply(){
        Z21ReporterManager zr = (Z21ReporterManager) l;
+       zr.enableInternalReporterCreationFromMessages();  // defautls to disabled.
        byte msg[]={(byte)0x11,(byte)0x00,(byte)0x88,(byte)0x00,(byte)0x00,(byte)0x01,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x01,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x05,(byte)0x06,(byte)0x07,(byte)0x08};
        Z21Reply reply = new Z21Reply(msg,17);
        Assert.assertNull("No reporter before message",zr.getReporter("ZR1"));


### PR DESCRIPTION
Follow up to #6389 addressing the interference between the Z21 internal reporter and Roco 10808 reports that are connected to the track circuit after the Z21.