### PR TITLE
VSDecoder: enable headless mode

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderCreationAction.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderCreationAction.java
@@ -19,9 +19,11 @@ package jmri.jmrit.vsdecoder;
  * 
  */
 import java.awt.event.ActionEvent;
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import javax.swing.AbstractAction;
 import javax.swing.JFrame;
+import javax.swing.UIManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +46,9 @@ public class VSDecoderCreationAction extends AbstractAction {
     public VSDecoderCreationAction(String s, Boolean ng) {
         super(s);
         _useNewGUI = ng;
+        if (GraphicsEnvironment.isHeadless()) {
+            log.info("GUI lookAndFeel: {}", UIManager.getLookAndFeel().getName());
+        }
     }
 
     public VSDecoderCreationAction() {
@@ -61,18 +66,21 @@ public class VSDecoderCreationAction extends AbstractAction {
         String fp = null, fn = null;
         JFrame tf = null;
         if (_useNewGUI == true) {
-            tf = VSDecoderManager.instance().provideManagerFrame();
+            tf = VSDecoderManager.instance().provideManagerFrame(); // headless will return null
         } else {
-            tf = new VSDecoderFrame();
+            tf = new VSDecoderFrame(); // old gui
         }
-        if (VSDecoderManager.instance().getVSDecoderPreferences().isAutoLoadingDefaultVSDFile()) {
+        if (VSDecoderManager.instance().getVSDecoderPreferences().isAutoLoadingDefaultVSDFile() && !GraphicsEnvironment.isHeadless()) {
             // Force load of a VSD file
             fp = VSDecoderManager.instance().getVSDecoderPreferences().getDefaultVSDFilePath();
             fn = VSDecoderManager.instance().getVSDecoderPreferences().getDefaultVSDFileName();
-            log.debug("Loading VSD File: " + fp + File.separator + fn);
+            log.debug("Loading VSD File: {}", fp + File.separator + fn);
             LoadVSDFileAction.loadVSDFile(fp + File.separator + fn);
         }
-        tf.toFront();
+        // headless returns tf = null
+        if (tf != null) {
+            tf.toFront();
+        }
     }
 
     private final static Logger log = LoggerFactory.getLogger(VSDecoderCreationAction.class);

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
@@ -12,10 +12,14 @@ import java.util.Set;
 import jmri.Block;
 import jmri.IdTag;
 import jmri.LocoAddress;
+import jmri.DccLocoAddress;
 import jmri.Manager;
 import jmri.NamedBean;
 import jmri.PhysicalLocationReporter;
 import jmri.Reporter;
+import jmri.jmrit.roster.Roster;
+import jmri.jmrit.roster.RosterEntry;
+import jmri.jmrit.vsdecoder.VSDConfig;
 import jmri.jmrit.vsdecoder.listener.ListeningSpot;
 import jmri.jmrit.vsdecoder.listener.VSDListener;
 import jmri.jmrit.vsdecoder.swing.VSDManagerFrame;
@@ -24,6 +28,7 @@ import jmri.util.JmriJFrame;
 import jmri.util.PhysicalLocation;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.GraphicsEnvironment;
 import javax.swing.Timer;
 import org.jdom2.Element;
 import org.slf4j.Logger;
@@ -174,9 +179,46 @@ public class VSDecoderManager implements PropertyChangeListener {
 
     public JmriJFrame provideManagerFrame() {
         if (managerFrame == null) {
-            managerFrame = new VSDManagerFrame();
+            if (GraphicsEnvironment.isHeadless()) {
+                String vsdRosterGroup = "VSD";
+                if (Roster.getDefault().getRosterGroupList().contains(vsdRosterGroup)) {
+                    List<RosterEntry> rosterList;
+                    rosterList = Roster.getDefault().getEntriesInGroup(vsdRosterGroup);
+                    // Allow <max_decoder> roster entries
+                    int entry_counter = 0;
+                    for (RosterEntry entry : rosterList) {
+                        if (entry_counter < max_decoder) {
+                            VSDConfig config = new VSDConfig();
+                            config.setLocoAddress(entry.getDccLocoAddress());
+                            log.debug("Roster entry VSD address: {}", config.getLocoAddress());
+                            boolean is_loaded = LoadVSDFileAction.loadVSDFile(entry.getAttribute("VSDecoder_Path"));
+                            if (!is_loaded) {
+                                log.error("loading VSD file {}: {}", entry.getAttribute("VSDecoder_Path"), is_loaded);
+                            }
+                            log.debug(" entry full VSD path: {}", entry.getAttribute("VSDecoder_Path"));
+                            config.setProfileName(entry.getAttribute("VSDecoder_Profile"));
+                            log.debug(" entry VSD profile: {}", entry.getAttribute("VSDecoder_Profile"));
+                            VSDecoder newDecoder = VSDecoderManager.instance().getVSDecoder(config);
+                            if (newDecoder != null) {
+                                log.info("VSD profile {} loaded", config.getProfileName());
+                            }
+                            entry_counter++;
+                        } else {
+                            log.warn("Only {} roster entries allowed. Disgarded {}", max_decoder, rosterList.size() - max_decoder);
+                        }
+                    }
+                    if (entry_counter == 0) {
+                        log.info("No Roster entry found in Roster Group {}", vsdRosterGroup);
+                    }
+                } else {
+                    log.warn("Roster group \"{}\" not found", vsdRosterGroup);
+                }
+            } else {
+                // Run VSDecoder with GUI
+                managerFrame = new VSDManagerFrame();
+            }
         } else {
-            log.warn("Virtual Sound Decoder Manager is already running");
+            log.warn("Virtual Sound Decoder Manager is already running"); // VSDManagerFrameTitle?
         }
         return managerFrame;
     }
@@ -890,7 +932,9 @@ public class VSDecoderManager implements PropertyChangeListener {
             }
         }
 
-        fireMyEvent(new VSDManagerEvent(this, VSDManagerEvent.EventType.PROFILE_LIST_CHANGE, new_entries));
+        if (!GraphicsEnvironment.isHeadless()) {
+            fireMyEvent(new VSDManagerEvent(this, VSDManagerEvent.EventType.PROFILE_LIST_CHANGE, new_entries));
+        }
     }
 
     void initSoundPositionTimer(VSDecoder d) {

--- a/java/src/jmri/jmrit/vsdecoder/swing/DieselPane.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/DieselPane.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.vsdecoder.swing;
 
+import java.awt.GraphicsEnvironment;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -165,7 +166,11 @@ public class DieselPane extends EnginePane {
             buttonModel.setArmed(false);
             buttonModel.setPressed(false);
             buttonModel.setSelected(false);
-            JOptionPane.showMessageDialog(null, Bundle.getMessage("EngineStartSpeedMessage"));
+            if (GraphicsEnvironment.isHeadless()) {
+                log.info(Bundle.getMessage("EngineStartSpeedMessage"));
+            } else {
+                JOptionPane.showMessageDialog(null, Bundle.getMessage("EngineStartSpeedMessage"));
+            }
         }
     }
 
@@ -226,6 +231,6 @@ public class DieselPane extends EnginePane {
         lastSpeed = s;
     }
 
-    // private static final Logger log = LoggerFactory.getLogger(DieselPane.class);
+    private static final Logger log = LoggerFactory.getLogger(DieselPane.class);
 
 }


### PR DESCRIPTION
I've tested VSD headless on Windows 7 in simulator mode and with JMRI webThrottle. Running ```ant jmrifaceless``` allowed me to quit PanelPro with ```Ctrl+C```.
I haven't a RasPi, so I hope it's working there too. And for other Operating Systems.

VSD faceless is not working on Windows 7 with LookAndFeel "Windows"! All the others are working.