### PR TITLE
Fix for mask value errors

### DIFF
--- a/xml/decoders/Kuehn_N45.xml
+++ b/xml/decoders/Kuehn_N45.xml
@@ -14,8 +14,10 @@
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
     <version author="ronald@wirkuhns.de" version="1" lastUpdated="2016/04/10"/>
-    <version author="Alain Le Marchand" version="2" lastUpdated="2018/12/203"/>
+    <version author="Alain Le Marchand" version="2" lastUpdated="2018/12/23"/>
+    <version author="Alain Le Marchand" version="3" lastUpdated="2019/01/09"/>
     <!-- Version 2 - Clarify CV55 name and tooltip + added Reset (Alain Le Marchand) -->
+    <!-- Version 3 - Split CV27 in 2 items and fix mask value (Alain Le Marchand) -->
     <decoder>
     <family name="NMRA-DCC/Motorola" mfg="Kuehn Ing.">
     <model model="N45" numOuts="6" numFns="14" maxMotorCurrent="0.8 A" maxTotalCurrent="0.8 A">
@@ -166,49 +168,78 @@
       <comment xml:lang="cs">Meze 0 / 1</comment>
       <tooltip xml:lang="cs">&lt;html&gt;15,6 kHz = Vysoká frekvence pro řízení moderních DC a coreless motorů.&lt;br&gt; 120 Hz = Nízká frekvence pro řízení starších DC motorů a AC/univerzálních motorů.&lt;/html&gt;</tooltip>
     </variable>
-    <variable CV="27" mask="XXVVXXVV" default="16" item="Direction Dependent stops with asymmetrical DCC">
+    <variable CV="27" mask="XXXXXXVV" default="0" item="Direction Dependent stop with asymmetrical DCC">
     <enumVal>
-    <enumChoice choice="Does Not Stop">
-    <choice>Does Not Stop</choice>
-    <choice xml:lang="it">Non si ferma</choice>
-    <choice xml:lang="de">Kein Bremsen</choice>
-    <choice xml:lang="cs">Nezastaví</choice>
+    <enumChoice choice="Does Not Brake">
+        <choice>No Braking</choice>
+        <choice xml:lang="it">Non si ferma</choice>
+        <choice xml:lang="de">Kein Bremsen</choice>
+        <choice xml:lang="cs">Nezastaví</choice>
     </enumChoice>
-    <enumChoice choice="Stops when Right rail is higher voltage">
-    <choice>Stops when Right rail is higher voltage</choice>
-    <choice xml:lang="it">Si ferma se rotaia destra ha tensione più alta</choice>
-    <choice xml:lang="de">Bremsen, wenn rechte Schienenspannung höher</choice>
-    <choice xml:lang="cs">Zastaví pokud pravá kolejnice má vyšší napětí</choice>
+    <enumChoice choice="Brakes when Right rail is higher voltage">
+        <choice>Brakes when Right rail is higher voltage</choice>
+        <choice xml:lang="it">Si ferma se rotaia destra ha tensione più alta</choice>
+        <choice xml:lang="de">Bremsen, wenn rechte Schienenspannung höher</choice>
+        <choice xml:lang="cs">Zastaví pokud pravá kolejnice má vyšší napětí</choice>
     </enumChoice>
-    <enumChoice choice="Stops when Left rail is higher voltage">
-    <choice>Stops when Left rail is higher voltage</choice>
-    <choice xml:lang="it">Si ferma se rotaia sinistra ha tensione più alta</choice>
-    <choice xml:lang="de">Bremsen, wenn linke Schienenspannung höher</choice>
-    <choice xml:lang="cs">Zastaví pokud levá kolejnice má vyšší napětí</choice>
+    <enumChoice choice="Brakes when Left rail is higher voltage">
+        <choice>Brakes when Left rail is higher voltage</choice>
+        <choice xml:lang="it">Si ferma se rotaia sinistra ha tensione più alta</choice>
+        <choice xml:lang="de">Bremsen, wenn linke Schienenspannung höher</choice>
+        <choice xml:lang="cs">Zastaví pokud levá kolejnice má vyšší napětí</choice>
     </enumChoice>
-    <enumChoice choice="Stops in Both Directions">
-    <choice>Stops in Both Directions</choice>
-    <choice xml:lang="it">Si ferma in entrambe le direzioni</choice>
-    <choice xml:lang="de">Bremsen in beiden Richtungen</choice>
-    <choice xml:lang="cs">Zastaví v obou směrech</choice>
-    </enumChoice>
-    <enumChoice choice="On DC contrary" value="16">
-    <choice>On DC contrary</choice>
-    <choice xml:lang="de">Bremsen bei DC entgegen Fahrtrichtung</choice>
-    <choice xml:lang="cs">Zastaví na DC v protisměru jízdy</choice>
-    </enumChoice>
-    <enumChoice choice="On DC in direction" value="32">
-    <choice>On DC in direction</choice>
-    <choice xml:lang="de">Bremsen bei DC in Fahrtrichtung</choice>
-    <choice xml:lang="cs">Zastaví na DC ve směru jízdy</choice>
+    <enumChoice choice="Brakes in Both Directions">
+        <choice>Brakes in Both Directions</choice>
+        <choice xml:lang="it">Si ferma in entrambe le direzioni</choice>
+        <choice xml:lang="de">Bremsen in beiden Richtungen</choice>
+        <choice xml:lang="cs">Zastaví v obou směrech</choice>
     </enumChoice>
     </enumVal>
-      <label>Brake configuration</label>
-      <label xml:lang="de">Bremskonfiguration</label>
-      <label xml:lang="cs">Konfigurace brždění</label>
-      <tooltip>Brake on DC detect</tooltip>
-      <tooltip xml:lang="de">Bremskonfiguration mittels asymmetrischer DCC-Digitalspannung</tooltip>
-      <tooltip xml:lang="cs">Konfigurace brždění v závislosti asymetrického napětí DCC.</tooltip>
+      <label>Brake configuration (asymmetrical DCC)</label>
+      <label xml:lang="de">Bremskonfiguration (asymmetrischer DCC)</label>
+      <label xml:lang="cs">Konfigurace brždění (asymetrický DCC)</label>
+      <tooltip>&lt;html&gt;Brake configuration with asymmetrical DCC. &lt;br&gt; Lenz-ABC default is higher voltage on right rail.&lt;/html&gt;</tooltip>
+      <tooltip xml:lang="de">&lt;html&gt;Bremskonfiguration mittels asymmetrischer DCC-Digitalspannung&lt;br&gt; Lenz-ABC Grundeinstellung ist wenn rechte Schienenspannung höher.&lt;/html&gt;</tooltip>
+      <tooltip xml:lang="cs">&lt;html&gt;Konfigurace brždění v závislosti asymetrického napětí DCC.&lt;br&gt; Lenz-ABC default is higher voltage on right rail.&lt;/html&gt;</tooltip>
+    </variable>
+    <variable CV="27" mask="XXVVXXXX" default="0" item="Direction Dependent stop with DC polarity">
+    <enumVal>
+    <enumChoice choice="In DC contrary">
+        <choice>Brakes in Reverse DC polarity</choice>
+        <choice xml:lang="de">Bremsen bei DC entgegen Fahrtrichtung</choice>
+        <choice xml:lang="cs">Zastaví na DC v protisměru jízdy</choice>
+    </enumChoice>
+    <enumChoice choice="In DC contrary">
+        <choice>Brakes in Reverse DC polarity even after polarity change</choice>
+        <choice xml:lang="de">Bremsen bei Gleichspg. entgegen Fahrtricht.auch nach Spgs.wechsel</choice>
+        <choice xml:lang="cs">Zastaví na DC v protisměru jízdy i po změně napětí</choice>
+    </enumChoice>
+    <enumChoice choice="On DC in direction">
+        <choice>Brakes in Forward DC polarity</choice>
+        <choice xml:lang="de">Bremsen bei Gleichspannung in Fahrtrichtung</choice>
+        <choice xml:lang="cs">Zastaví na DC ve směru jízdy</choice>
+    </enumChoice>
+    <enumChoice choice="On DC both directions">
+        <choice>Brakes with DC in both directions</choice>
+        <choice xml:lang="de">Bremsen bei Gleichspannung in beiden Richtungen</choice>
+        <choice xml:lang="cs">Zastaví na DC v obou směrech</choice>
+    </enumChoice>
+    </enumVal>
+      <label>Brake configuration (DC polarity)</label>
+      <label xml:lang="de">Bremskonfiguration (Gleichspannung)</label>
+      <label xml:lang="cs">Konfigurace brždění (Polarita DC)</label>
+      <tooltip>&lt;html&gt;Brake on DC polarity detection. &lt;br&gt;
+                By braking at DC voltage in both directions, even locomotives &lt;br&gt;
+                in DCC format can safely stop on Märklin® braking distances.&lt;br&gt;
+                &lt;/html&gt;</tooltip>
+      <tooltip xml:lang="de">&lt;html&gt;Bremsen bei Gleichspannung entgegen order in Fahrtrichtung. &lt;br&gt;
+                            Durch das Bremsen bei Gleichspannung in und entgegen der Fahrtrichtung &lt;br&gt;
+                            können auch Loks im DCC-Format auf Märklin®-Bremsstrecken sicher anhalten.&lt;br&gt;
+                            &lt;/html&gt;</tooltip>
+      <tooltip xml:lang="cs">&lt;html&gt;Konfigurace brždění na stejnosměrný proud ve směru jízdy nebo ve směru jízdy. &lt;br&gt;
+                            Brzdným účinkem stejnosměrného proudu ve směru jízdy a proti směru jízdy &lt;br&gt;
+                            se mohou i lokomotivy ve formátu DCC bezpečně zastavit na brzdných vzdálenostech Märklin®.&lt;br&gt;
+                            &lt;/html&gt;</tooltip>
     </variable>
     <variable CV="28" mask="XXXXXXXV" default="0" item="RailCom channel 1 (Broadcast)">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OffOn.xml"/>

--- a/xml/decoders/MERG_12A.xml
+++ b/xml/decoders/MERG_12A.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
-<!-- Copyright (C) JMRI 2005 All rights reserved -->
+<!-- Copyright (C) JMRI 2005, 2019 All rights reserved -->
 <!-- $Id$ -->
 <!--                                                                        -->
 <!-- JMRI is free software; you can redistribute it and/or modify it under  -->
@@ -14,6 +14,8 @@
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
   <version author="Len Royles len@len-royles.co.uk" version="2" lastUpdated="20050204"/>
+  <version author="Alain Le Marchand" version="3" lastUpdated="20190109"/>  
+  <!-- Version 3: Fix error on bit mapping for CV51 RO and FO -->
   <!-- This is for the MERG Decod12A decoder with the new MERG(165) mfg. -->
   <decoder>
     <family name="MERG HF PWM decoders" mfg="MERG" lowVersionID="133">
@@ -307,11 +309,11 @@
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 ML</label>
       </variable>
-      <variable item="F1 RO" CV="51" mask="XXXXXXXX">
+      <variable item="F1 RO" CV="51" mask="XXXXVXXX">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 RO</label>
       </variable>
-      <variable item="F1 FO" CV="51" mask="XXXXVXXX">
+      <variable item="F1 FO" CV="51" mask="XXXVXXXX">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F1 FO</label>
       </variable>

--- a/xml/decoders/TD_SC8.xml
+++ b/xml/decoders/TD_SC8.xml
@@ -13,12 +13,14 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="Alain Le Marchand" version="1.4" lastUpdated="20190111"/>
   <version author="B. Milhaupt" version="1.3" lastUpdated="20180823"/>
   <version author="td@teamdigital1.com" version="1.2" lastUpdated="20120221"/>
   <!-- Version 1 initial release 2/18/11-->
   <!-- Version 1.1 release 3/14/11 corrected ops mode enable and speed to position-->
   <!-- Version 1.2 release 2/21/12 corrected CV28 options and added startup delay-->
   <!-- Version 1.3 release, added "LOCONETOPSBOARD" programming token to allow LocoNet-connected boards to read CV values -->
+  <!-- Version 1.3 corrected mask CV82, 83, 84 2019/01/11 -->
   <decoder>
     <family name="Stationary Decoder" mfg="Team Digital" type="stationary">
       <model model="SC8" lowVersionID="1" comment="SC8 is a stationary decoder, but it can be programmed in the usual way"/>
@@ -938,7 +940,7 @@
         </enumVal>
         <label>Reverse</label>
       </variable>
-      <variable item="Beh2" CV="82" mask="VXXXXXVX" default="0">
+      <variable item="Beh2" CV="82" mask="XXXXXXVX" default="0">
         <enumVal>
           <enumChoice choice="no">
           </enumChoice>
@@ -956,7 +958,7 @@
         </enumVal>
         <label>Reverse</label>
       </variable>
-      <variable item="Beh3" CV="83" mask="VXXXXXVX" default="0">
+      <variable item="Beh3" CV="83" mask="XXXXXXVX" default="0">
         <enumVal>
           <enumChoice choice="no">
           </enumChoice>
@@ -974,7 +976,7 @@
         </enumVal>
         <label>Reverse</label>
       </variable>
-      <variable item="Beh4" CV="84" mask="VXXXXXVX" default="0">
+      <variable item="Beh4" CV="84" mask="XXXXXXVX" default="0">
         <enumVal>
           <enumChoice choice="no">
           </enumChoice>

--- a/xml/decoders/TD_SMC4.xml
+++ b/xml/decoders/TD_SMC4.xml
@@ -14,8 +14,11 @@
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" showEmptyPanes="no" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
   <version author="td@teamdigital1.com" version="1.1" lastUpdated="20090622"/>
+  <version author="Alain Le Marchand" version="1.2" lastUpdated="20190111"/>
   <!-- Version 1 initial release -->
   <!-- Version 1.1 corrected CV29 2009/06/22 -->
+  <!-- Version 1.2 corrected mask CV72, 73, 74
+                   added 2 more choices for CV71 to 74  -->
   <decoder>
     <family name="Stationary Decoder" mfg="Team Digital" type="stationary">
       <model model="SMC4" lowVersionID="1" comment="SMC4 is a stationary decoder, but it can be programmed in the usual way"/>
@@ -610,7 +613,7 @@
         <decVal min="1" max="127"/>
         <label>Servo 4 Move Speed</label>
       </variable>
-      <variable item="Servo 1 Behavior" CV="71" mask="XXXXXXVV" default="0">
+      <variable item="Servo 1 Behavior" CV="71" mask="XXXXVVVV" default="0">
         <enumVal>
           <enumChoice choice="None" value="0">
             <choice>None</choice>
@@ -620,6 +623,12 @@
           </enumChoice>
           <enumChoice choice="Speed to Position" value="2">
             <choice>Speed to Position</choice>
+          </enumChoice>
+          <enumChoice choice="Dash Pot Speed Dir. 1" value="4">
+            <choice>Dash Pot Speed Dir. 1</choice>
+          </enumChoice>
+          <enumChoice choice="Dash Pot Speed Dir. 2" value="8">
+            <choice>Dash Pot Speed Dir. 2</choice>
           </enumChoice>
         </enumVal>
         <label>Servo 1 Behavior</label>
@@ -635,7 +644,7 @@
         </enumVal>
         <label>Reverse</label>
       </variable>
-      <variable item="Servo 2 Behavior" CV="72" mask="VXXXXXVV" default="0">
+      <variable item="Servo 2 Behavior" CV="72" mask="XXXXVVVV" default="0">
         <enumVal>
           <enumChoice choice="None" value="0">
             <choice>None</choice>
@@ -645,6 +654,12 @@
           </enumChoice>
           <enumChoice choice="Speed to Position" value="2">
             <choice>Speed to Position</choice>
+          </enumChoice>
+          <enumChoice choice="Dash Pot Speed Dir. 1" value="4">
+            <choice>Dash Pot Speed Dir. 1</choice>
+          </enumChoice>
+          <enumChoice choice="Dash Pot Speed Dir. 2" value="8">
+            <choice>Dash Pot Speed Dir. 2</choice>
           </enumChoice>
         </enumVal>
         <label>Servo 2 Behavior</label>
@@ -660,7 +675,7 @@
         </enumVal>
         <label>Reverse</label>
       </variable>
-      <variable item="Servo 3 Behavior" CV="73" mask="VXXXXXVV" default="0">
+      <variable item="Servo 3 Behavior" CV="73" mask="XXXXVVVV" default="0">
         <enumVal>
           <enumChoice choice="None" value="0">
             <choice>None</choice>
@@ -670,6 +685,12 @@
           </enumChoice>
           <enumChoice choice="Speed to Position" value="2">
             <choice>Speed to Position</choice>
+          </enumChoice>
+          <enumChoice choice="Dash Pot Speed Dir. 1" value="4">
+            <choice>Dash Pot Speed Dir. 1</choice>
+          </enumChoice>
+          <enumChoice choice="Dash Pot Speed Dir. 2" value="8">
+            <choice>Dash Pot Speed Dir. 2</choice>
           </enumChoice>
         </enumVal>
         <label>Servo 3 Behavior</label>
@@ -685,7 +706,7 @@
         </enumVal>
         <label>Reverse</label>
       </variable>
-      <variable item="Servo 4 Behavior" CV="74" mask="VXXXXXVV" default="0">
+      <variable item="Servo 4 Behavior" CV="74" mask="XXXXVVVV" default="0">
         <enumVal>
           <enumChoice choice="None" value="0">
             <choice>None</choice>
@@ -695,6 +716,12 @@
           </enumChoice>
           <enumChoice choice="Speed to Position" value="2">
             <choice>Speed to Position</choice>
+          </enumChoice>
+          <enumChoice choice="Dash Pot Speed Dir. 1" value="4">
+            <choice>Dash Pot Speed Dir. 1</choice>
+          </enumChoice>
+          <enumChoice choice="Dash Pot Speed Dir. 2" value="8">
+            <choice>Dash Pot Speed Dir. 2</choice>
           </enumChoice>
         </enumVal>
         <label>Servo 4 Behavior</label>

--- a/xml/decoders/Zimo_MX620_v1-3.xml
+++ b/xml/decoders/Zimo_MX620_v1-3.xml
@@ -1347,7 +1347,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX620_v5.xml
+++ b/xml/decoders/Zimo_MX620_v5.xml
@@ -1310,7 +1310,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX620_v6.xml
+++ b/xml/decoders/Zimo_MX620_v6.xml
@@ -1304,7 +1304,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX620_v7-8.xml
+++ b/xml/decoders/Zimo_MX620_v7-8.xml
@@ -15,15 +15,16 @@
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
   <version author="Mark Waters mark16w-jmri@yahoo.co.uk" version="1.02" lastUpdated="20090626"/>
   <version author="Nigel Cliffe ncliffe@btinternet.com and Mark Waters mark16w-jmri@yahoo.co.uk" version="1.01" lastUpdated="20090222"/>
-  <!-- 
+  <version author="Alain Le Marchand" version="1.01" lastUpdated="20190110"/>
+  <!--
      This decoder configuration file is based the Zimo_MX620_v6.xml V 1.01 file, dated 20080328.
      Re-instating CV 116 (bug fixed by Zimo in v7), Modified CV124, Extended CV 161,
-     Extended CVs 125-132 and CVs 181-2.  
+     Extended CVs 125-132 and CVs 181-2.
 
      Based on the "SW-Version 9.1 2008 10 18" English version of the ZIMO MX620
      decoder manual (with thanks to Art Luescher of ZIMO Agency of North America
      for the translations!).
-     
+
      This decoder XML is meant to be used with the "Comprehensive" programmer format.
      Continued the practice of using unrelated "item" names to place Zimo unique
      variables on the proper pane of the Comprehensive programmer.
@@ -31,6 +32,7 @@
   <!-- V 1 new file -->
   <!-- V 1.01 Fixed error in CV161 mask -->
   <!-- V 1.02 added CV's 129 & 130, corrected CV161 masks -->
+  <!-- V 1.03 corrected CV124 mask for bits 2,6 -->
   <decoder>
     <family name="Zimo MX620" mfg="Zimo">
       <model model="MX620 version 7-8" lowVersionID="7" highVersionID="8" maxInputVolts="12-22V" maxMotorCurrent="0.8A, peak=2A for 5 sec." maxTotalCurrent="0.8A" formFactor="N" numOuts="6" numFns="14">
@@ -1302,7 +1304,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX620_v9.xml
+++ b/xml/decoders/Zimo_MX620_v9.xml
@@ -1301,7 +1301,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX620_v9dot12.xml
+++ b/xml/decoders/Zimo_MX620_v9dot12.xml
@@ -1258,7 +1258,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX62_v22+.xml
+++ b/xml/decoders/Zimo_MX62_v22+.xml
@@ -1309,7 +1309,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3" value="16" value="16">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX62_v22+.xml
+++ b/xml/decoders/Zimo_MX62_v22+.xml
@@ -1309,7 +1309,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX63_MX64H_v22-30.xml
+++ b/xml/decoders/Zimo_MX63_MX64H_v22-30.xml
@@ -1404,7 +1404,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX640_v1-2.xml
+++ b/xml/decoders/Zimo_MX640_v1-2.xml
@@ -1544,7 +1544,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX640_v3.xml
+++ b/xml/decoders/Zimo_MX640_v3.xml
@@ -1548,7 +1548,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX640_v4.xml
+++ b/xml/decoders/Zimo_MX640_v4.xml
@@ -1406,7 +1406,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX640_v4.xml
+++ b/xml/decoders/Zimo_MX640_v4.xml
@@ -1691,7 +1691,7 @@
         <label>Servo Control Signal</label>
         <label xml:lang="it">Segnale controllo Servo</label>
       </variable>
-      <variable item="Servo Centering" CV="161" mask="VVVVVXVV" default="0">
+      <variable item="Servo Centering" CV="161" mask="XXXXXVXX" default="0">
         <enumVal>
           <enumChoice choice="Moves to centre in dual key if both Fn's off">
             <choice>Moves to centre in dual key if both Fn's off</choice>

--- a/xml/decoders/Zimo_MX640_v4dot17.xml
+++ b/xml/decoders/Zimo_MX640_v4dot17.xml
@@ -1390,7 +1390,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/Zimo_MX640_v4dot17.xml
+++ b/xml/decoders/Zimo_MX640_v4dot17.xml
@@ -1650,7 +1650,7 @@
         <decVal min="0" max="255"/>
         <label>Differential value</label>
       </variable>
-      <variable CV="149" mask="VVVVVVVX" default="0" item="EMF Enable">
+      <variable CV="149" mask="XXXXXXXV" default="0" item="EMF Enable">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-OnOff.xml"/>
         <label>Adaptive proportional value</label>
       </variable>
@@ -1677,7 +1677,7 @@
         <label>Servo Control Signal</label>
         <label xml:lang="it">Segnale controllo Servo</label>
       </variable>
-      <variable item="Servo Centering" CV="161" mask="VVVVVXVV" default="0">
+      <variable item="Servo Centering" CV="161" mask="XXXXXVXX" default="0">
         <enumVal>
           <enumChoice choice="Moves to centre in dual key if both Fn's off">
             <choice>Moves to centre in dual key if both Fn's off</choice>

--- a/xml/decoders/Zimo_MX66-2000-11.xml
+++ b/xml/decoders/Zimo_MX66-2000-11.xml
@@ -361,7 +361,7 @@
         <label>F3 controls output 5</label>
         <label xml:lang="it">F3 controlla uscita 5</label>
       </variable>
-      <variable item="F3 controls output 6" CV="37" mask="XXVXVXXX" minOut="6" minFn="3">
+      <variable item="F3 controls output 6" CV="37" mask="XXXXVXXX" minOut="6" minFn="3">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
         <label>F3 controls output 6</label>
         <label xml:lang="it">F3 controlla uscita 6</label>

--- a/xml/decoders/Zimo_MX69MX690.xml
+++ b/xml/decoders/Zimo_MX69MX690.xml
@@ -1704,12 +1704,12 @@
         <label>Motor Backlash Control</label>
         <label xml:lang="it">Controllo Rinculo Motore</label>
       </variable>
-      <variable item="Servo Protocol" CV="161" mask="VVVVVVVX" default="0">
+      <variable item="Servo Protocol" CV="161" mask="XXXXXXXV" default="0">
         <xi:include href="http://jmri.org/xml/decoders/parts/enum-NegPosPulse.xml"/>
         <label>Servo Protocol</label>
         <label xml:lang="it">Protocollo Servo</label>
       </variable>
-      <variable item="Servo Control Wire Active" CV="161" mask="VVVVVVXV" default="0">
+      <variable item="Servo Control Wire Active" CV="161" mask="XXXXXXVX" default="0">
         <enumVal>
           <enumChoice choice="Only during movement">
             <choice>Only during movement</choice>
@@ -1723,7 +1723,7 @@
         <label>Servo Control Wire Active</label>
         <label xml:lang="it">Filo attivo controllo Servo</label>
       </variable>
-      <variable item="Servo Centering" CV="161" mask="VVVVVXVV" default="0">
+      <variable item="Servo Centering" CV="161" mask="XXXXXVXX" default="0">
         <enumVal>
           <enumChoice choice="Moves to centre in dual key if both Fn's off">
             <choice>Moves to centre in dual key if both Fn's off</choice>

--- a/xml/decoders/Zimo_MX69MX690.xml
+++ b/xml/decoders/Zimo_MX69MX690.xml
@@ -1408,7 +1408,7 @@
           <enumChoice choice="F4">
             <choice>F4</choice>
           </enumChoice>
-          <enumChoice choice="F3">
+          <enumChoice choice="F3" value="16">
             <choice>F3</choice>
           </enumChoice>
         </enumVal>

--- a/xml/decoders/kuehn/PaneABC.xml
+++ b/xml/decoders/kuehn/PaneABC.xml
@@ -1,15 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
 <!-- version 1 - for Unified Software -->
+<!-- version 2 - separate assymetrical and DC polarity -->
 <pane xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <name>ABC</name>
+  <name>Braking</name>
+  <name xml:lang="fr">Freinage</name>
+  <name xml:lang="de">Bremsen</name>
+  <name xml:lang="cs">Brždění</name>
   <column>
     <display item="MAN Key Extension (Disable HLU or ABC signal control)" label="Set Function Key to Disable ABC Signal Control">
        <label>Set Function Key to Disable ABC Signal Control</label>
        <label xml:lang="it">Tasto funzione per disabilitare controllo segnale ABC</label>
        <label xml:lang="cs">Nastavení funkční klávesy pro znepřístupnění řízení signálem ABC</label>
     </display>
-    <display item="Direction Dependent stops with asymmetrical DCC"/>
+    <display item="Direction Dependent stop with asymmetrical DCC"/>
+    <label>
+      <text> </text>
+    </label>
+    <display item="Direction Dependent stop with DC polarity"/>
     <label>
       <text> </text>
     </label>

--- a/xml/decoders/zimo/CV100-CV152.xml
+++ b/xml/decoders/zimo/CV100-CV152.xml
@@ -371,7 +371,7 @@
       <enumChoice choice="F4">
         <choice>F4</choice>
       </enumChoice>
-      <enumChoice choice="F3">
+      <enumChoice choice="F3" value="16">
         <choice>F3</choice>
       </enumChoice>
     </enumVal>

--- a/xml/decoders/zimo/CV100-CV152.xml
+++ b/xml/decoders/zimo/CV100-CV152.xml
@@ -763,7 +763,7 @@
     <label xml:lang="it">Valore differenziale</label>
     <label xml:lang="cs">Diferenciální složka</label>
   </variable>
-  <variable CV="149" mask="VVVVVVVX" default="0" item="EMF Enable">
+  <variable CV="149" mask="XXXXXXXV" default="0" item="EMF Enable">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OnOff.xml"/>
     <label>Adaptive proportional value</label>
     <label xml:lang="it">Valore proprzionale adattabile</label>

--- a/xml/decoders/zimo/CV100-CV152version30.xml
+++ b/xml/decoders/zimo/CV100-CV152version30.xml
@@ -1474,7 +1474,7 @@
     <label xml:lang="cs">Diferenciální složka</label>
     <label xml:lang="de">EMK - D-Wert</label>
   </variable>
-  <variable CV="149" mask="VVVVVVVX" default="0" item="EMF Enable" exclude="228,226,232,235,247,MX689_v30">
+  <variable CV="149" mask="XXXXXXXV" default="0" item="EMF Enable" exclude="228,226,232,235,247,MX689_v30">
     <xi:include href="http://jmri.org/xml/decoders/parts/enum-OnOff.xml"/>
     <label>Adaptive proportional value</label>
     <label xml:lang="it">Valore proprzionale adattabile</label>

--- a/xml/decoders/zimo/CV100-CV152version30.xml
+++ b/xml/decoders/zimo/CV100-CV152version30.xml
@@ -949,7 +949,7 @@
       <enumChoice choice="F4">
         <choice>F4</choice>
       </enumChoice>
-      <enumChoice choice="F3">
+      <enumChoice choice="F3" value="16">
         <choice>F3</choice>
       </enumChoice>
     </enumVal>

--- a/xml/decoders/zimo/CV161-CV185Servo.xml
+++ b/xml/decoders/zimo/CV161-CV185Servo.xml
@@ -34,7 +34,7 @@
     <label xml:lang="cs">Řídící signál serva</label>
     <label xml:lang="de">Servo Steuersignal</label>
   </variable>
-  <variable item="Servo Centering" CV="161" mask="VVVVVXVV" default="0">
+  <variable item="Servo Centering" CV="161" mask="XXXXXVXX" default="0">
     <enumVal>
       <enumChoice choice="Moves to centre in dual key if both Fn's off">
         <choice>Moves to centre in dual key if both Fn's off</choice>


### PR DESCRIPTION
Fix for errors listed in #6407

MERG 12a update
- Fix error on bit mapping for CV51 RO and FO

Kuehn N45
- Fix error on mask values and split CV27 (braking)