### PR TITLE
Reduce unnecessary HeartBeat messages

### DIFF
--- a/java/src/jmri/jmrix/lenz/XNetHeartBeat.java
+++ b/java/src/jmri/jmrix/lenz/XNetHeartBeat.java
@@ -1,0 +1,96 @@
+package jmri.jmrix.lenz;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * XNet specific class to send heartbeat messages to
+ * the XNet.  Heartbeat messages are only required if
+ * no other messages are sent for a specific period
+ * of time, so any outgoing message should restart
+ * the timer.
+ *
+ * @author	Paul Bender Copyright (C) 2019 
+ */
+public class XNetHeartBeat implements XNetListener {
+
+    private javax.swing.Timer keepAliveTimer; // Timer used to periodically
+    // send a message to both
+    // ports to keep the ports
+    // open
+    private static final int keepAliveTimeoutValue = 30000; // Interval
+    // to send a message
+    // Must be < 60s.
+    private XNetTrafficController tc;
+    private XNetSystemConnectionMemo memo;
+
+    public XNetHeartBeat(XNetSystemConnectionMemo memo) {
+        this.memo = memo;
+        tc = memo.getXNetTrafficController();
+        tc.addXNetListener(~0,this);
+        keepAliveTimer();
+    }
+
+    /*
+     * Set up the keepAliveTimer, and start it.
+     */
+    private void keepAliveTimer() {
+        if (keepAliveTimer == null) {
+            keepAliveTimer = new javax.swing.Timer(keepAliveTimeoutValue, new java.awt.event.ActionListener() {
+                @Override
+                public void actionPerformed(java.awt.event.ActionEvent e) {
+                    // If the timer times out, and we are not currently 
+                    // programming, send a request for status
+                    jmri.jmrix.lenz.XNetProgrammer p = null;
+                    if(memo.provides(jmri.GlobalProgrammerManager.class)){
+                        p = (jmri.jmrix.lenz.XNetProgrammer) (memo.getProgrammerManager().getGlobalProgrammer());
+                    }
+                    if (p == null || !(p.programmerBusy())) {
+                       tc.sendXNetMessage(
+                        jmri.jmrix.lenz.XNetMessage.getCSStatusRequestMessage(),
+                        null);
+                    }
+                }
+            });
+        }
+        keepAliveTimer.stop();
+        keepAliveTimer.setInitialDelay(keepAliveTimeoutValue);
+        keepAliveTimer.setRepeats(true);
+        keepAliveTimer.start();
+    }
+
+    public void dispose(){
+       keepAliveTimer.stop();
+       keepAliveTimer = null;
+    }
+
+    // XNetListener methods.
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void message(XNetReply msg){
+        // this class doesn't care about incoming messages.
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void message(XNetMessage msg){
+       // if we see any outgoing message, restart the timer
+       keepAliveTimer.restart();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void notifyTimeout(XNetMessage msg){
+        // this class doesn't care about timeouts.
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(XNetHeartBeat.class);
+
+}

--- a/java/src/jmri/jmrix/lenz/XNetHeartBeat.java
+++ b/java/src/jmri/jmrix/lenz/XNetHeartBeat.java
@@ -1,8 +1,5 @@
 package jmri.jmrix.lenz;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * XNet specific class to send heartbeat messages to
  * the XNet.  Heartbeat messages are only required if
@@ -90,7 +87,5 @@ public class XNetHeartBeat implements XNetListener {
     public void notifyTimeout(XNetMessage msg){
         // this class doesn't care about timeouts.
     }
-
-    private final static Logger log = LoggerFactory.getLogger(XNetHeartBeat.class);
 
 }

--- a/java/src/jmri/jmrix/lenz/liusbethernet/LIUSBEthernetAdapter.java
+++ b/java/src/jmri/jmrix/lenz/liusbethernet/LIUSBEthernetAdapter.java
@@ -22,14 +22,6 @@ public class LIUSBEthernetAdapter extends XNetNetworkPortController {
     static final int COMMUNICATION_TCP_PORT = 5550;
     static final String DEFAULT_IP_ADDRESS = "192.168.0.200";
 
-    private java.util.TimerTask keepAliveTimer; // Timer used to periodically
-    // send a message to both
-    // ports to keep the ports 
-    // open
-    private static final int keepAliveTimeoutValue = 30000; // Interval 
-    // to send a message
-    // Must be < 60s.
-
     public LIUSBEthernetAdapter() {
         super();
         log.debug("Constructor Called");
@@ -75,37 +67,7 @@ public class LIUSBEthernetAdapter extends XNetNetworkPortController {
         this.getSystemConnectionMemo().setXNetTrafficController(packets);
 
         new XNetInitializationManager(this.getSystemConnectionMemo());
-        keepAliveTimer();
-    }
-
-    /**
-     * Set up the keepAliveTimer, and start it.
-     */
-    private void keepAliveTimer() {
-        if (keepAliveTimer == null) {
-            keepAliveTimer = new java.util.TimerTask() {
-                @Override
-                public void run() {
-                    // If the timer times out, and we are not currently 
-                    // programming, send a request for status
-                    jmri.jmrix.lenz.XNetSystemConnectionMemo m = LIUSBEthernetAdapter.this
-                            .getSystemConnectionMemo();
-                    XNetTrafficController t = m.getXNetTrafficController();
-                    jmri.jmrix.lenz.XNetProgrammer p = null;
-                    if(m.provides(jmri.GlobalProgrammerManager.class)){
-                        p = (jmri.jmrix.lenz.XNetProgrammer) (m.getProgrammerManager().getGlobalProgrammer());
-                    }
-                    if (p == null || !(p.programmerBusy())) {
-                       t.sendXNetMessage(
-                        jmri.jmrix.lenz.XNetMessage.getCSStatusRequestMessage(),
-                        null);
-                    }
-                }
-            };
-        } else {
-            keepAliveTimer.cancel();
-        }
-        jmri.util.TimerUtil.schedule(keepAliveTimer, keepAliveTimeoutValue, keepAliveTimeoutValue);
+        new jmri.jmrix.lenz.XNetHeartBeat(this.getSystemConnectionMemo());
     }
 
     private boolean mDNSConfigure = false;

--- a/java/src/jmri/jmrix/roco/z21/Z21Adapter.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21Adapter.java
@@ -20,14 +20,6 @@ public class Z21Adapter extends jmri.jmrix.AbstractNetworkPortController {
     protected static int COMMUNICATION_UDP_PORT = java.lang.Integer.parseInt(rb.getString("z21UDPPort1"));
     protected static String DEFAULT_IP_ADDRESS = rb.getString("defaultZ21IPAddress");
 
-    private javax.swing.Timer keepAliveTimer; // Timer used to periodically
-    // send a message to both
-    // ports to keep the ports
-    // open
-    private static final int keepAliveTimeoutValue = 30000; // Interval
-    // to send a message
-    // Must be < 60s.
-
     private DatagramSocket socket = null;
 
     public Z21Adapter() {
@@ -91,8 +83,6 @@ public class Z21Adapter extends jmri.jmrix.AbstractNetworkPortController {
                     m_HostName, ConnectionStatus.CONNECTION_UP);
         }
 
-        keepAliveTimer();
-
     }
 
     /*
@@ -125,33 +115,9 @@ public class Z21Adapter extends jmri.jmrix.AbstractNetworkPortController {
     protected void resetupConnection() {
     }
 
-    /*
-     * Set up the keepAliveTimer, and start it.
-     */
-    private void keepAliveTimer() {
-        if (keepAliveTimer == null) {
-            keepAliveTimer = new javax.swing.Timer(keepAliveTimeoutValue, new java.awt.event.ActionListener() {
-                @Override
-                public void actionPerformed(java.awt.event.ActionEvent e) {
-                    // If the timer times out, send a request for status
-                    Z21Adapter.this.getSystemConnectionMemo().getTrafficController()
-                            .sendz21Message(
-                                    jmri.jmrix.roco.z21.Z21Message.getSerialNumberRequestMessage(),
-                                    null);
-                }
-            });
-        }
-        keepAliveTimer.stop();
-        keepAliveTimer.setInitialDelay(keepAliveTimeoutValue);
-        keepAliveTimer.setRepeats(true);
-        keepAliveTimer.start();
-    }
-
     @Override
     public void dispose(){
        super.dispose();
-       keepAliveTimer.stop();
-       keepAliveTimer = null;
        socket.close();
        opened = false;
        allowConnectionRecovery = false; // disposing of the object should 

--- a/java/src/jmri/jmrix/roco/z21/Z21HeartBeat.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21HeartBeat.java
@@ -1,0 +1,79 @@
+package jmri.jmrix.roco.z21;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Z21 specific class to send heartbeat messages to
+ * the Z21.  Heartbeat messages are only required if
+ * no other messages are sent for a specific period
+ * of time, so any outgoing message should restart
+ * the timer.
+ *
+ * @author	Paul Bender Copyright (C) 2019 
+ */
+public class Z21HeartBeat implements Z21Listener {
+
+    private javax.swing.Timer keepAliveTimer; // Timer used to periodically
+    // send a message to both
+    // ports to keep the ports
+    // open
+    private static final int keepAliveTimeoutValue = 30000; // Interval
+    // to send a message
+    // Must be < 60s.
+    private Z21TrafficController tc;
+
+    public Z21HeartBeat(Z21SystemConnectionMemo memo) {
+        tc = memo.getTrafficController();
+        tc.addz21Listener(this);
+        keepAliveTimer();
+    }
+
+    /*
+     * Set up the keepAliveTimer, and start it.
+     */
+    private void keepAliveTimer() {
+        if (keepAliveTimer == null) {
+            keepAliveTimer = new javax.swing.Timer(keepAliveTimeoutValue, new java.awt.event.ActionListener() {
+                @Override
+                public void actionPerformed(java.awt.event.ActionEvent e) {
+                    // If the timer times out, send a request for status
+                    tc.sendz21Message(
+                       jmri.jmrix.roco.z21.Z21Message.getSerialNumberRequestMessage(),
+                       null);
+                }
+            });
+        }
+        keepAliveTimer.stop();
+        keepAliveTimer.setInitialDelay(keepAliveTimeoutValue);
+        keepAliveTimer.setRepeats(true);
+        keepAliveTimer.start();
+    }
+
+    public void dispose(){
+       keepAliveTimer.stop();
+       keepAliveTimer = null;
+    }
+
+    // Z21Listener methods.
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void reply(Z21Reply msg){
+        // this class doesn't care about incoming messages.
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void message(Z21Message msg){
+       // if we see any outgoing message, restart the timer
+       keepAliveTimer.restart();
+    }
+
+    private final static Logger log = LoggerFactory.getLogger(Z21HeartBeat.class);
+
+}

--- a/java/src/jmri/jmrix/roco/z21/Z21HeartBeat.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21HeartBeat.java
@@ -1,8 +1,5 @@
 package jmri.jmrix.roco.z21;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Z21 specific class to send heartbeat messages to
  * the Z21.  Heartbeat messages are only required if
@@ -73,7 +70,5 @@ public class Z21HeartBeat implements Z21Listener {
        // if we see any outgoing message, restart the timer
        keepAliveTimer.restart();
     }
-
-    private final static Logger log = LoggerFactory.getLogger(Z21HeartBeat.class);
 
 }

--- a/java/src/jmri/jmrix/roco/z21/Z21SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21SystemConnectionMemo.java
@@ -287,7 +287,9 @@ public class Z21SystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
     @Override
     public void dispose() {
-        heartBeat.dispose();
+        if(heartBeat!=null) {
+           heartBeat.dispose();
+        }
         shutdownTunnel();
         InstanceManager.deregister(this, Z21SystemConnectionMemo.class);
         super.dispose();

--- a/java/src/jmri/jmrix/roco/z21/Z21SystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21SystemConnectionMemo.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2010 copied from NCE into PowerLine for
  * multiple connections by
  * @author	Ken Cameron Copyright (C) 2011 copied from PowerLine into z21 by
- * @author	Paul Bender Copyright (C) 2013
+ * @author	Paul Bender Copyright (C) 2013,2019
  */
 public class Z21SystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
@@ -206,6 +206,9 @@ public class Z21SystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
         // setup the MultiMeter
         getMultiMeter();
 
+        // setup the HeartBeat
+        getHeartBeat();
+
    }
 
     @Override
@@ -260,6 +263,20 @@ public class Z21SystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
     private Z21MultiMeter meter = null;
 
+    /**
+     * Provide access to the Z21HeartBeat instance for this connection.
+     * <p>
+     * NOTE: HeartBeat defaults to NULL
+     */
+    public Z21HeartBeat getHeartBeat() {
+        if(heartBeat == null){
+           heartBeat = new Z21HeartBeat(this);
+        }
+        return heartBeat;
+    }
+    
+    private Z21HeartBeat heartBeat = null;
+
 
     void shutdownTunnel(){
         if (_xnettunnel!=null) {
@@ -270,6 +287,7 @@ public class Z21SystemConnectionMemo extends jmri.jmrix.SystemConnectionMemo {
 
     @Override
     public void dispose() {
+        heartBeat.dispose();
         shutdownTunnel();
         InstanceManager.deregister(this, Z21SystemConnectionMemo.class);
         super.dispose();

--- a/java/test/jmri/jmrix/lenz/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/PackageTest.java
@@ -53,6 +53,7 @@ import org.junit.runners.Suite;
         AbstractXNetSerialConnectionConfigTest.class,
         AbstractXNetInitializationManagerTest.class,
         XNetAddressTest.class,
+        XNetHeartBeatTest.class,
 })
 
 /**

--- a/java/test/jmri/jmrix/lenz/XNetHeartBeatTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetHeartBeatTest.java
@@ -1,0 +1,46 @@
+package jmri.jmrix.lenz;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * XNetHeartBeat.java
+ *
+ * Description: tests for the jmri.jmrix.lenz.XNetHeartBeat class
+ *
+ * @author  Paul Bender Copyright (C) 2019
+ */
+public class XNetHeartBeatTest {
+
+    private XNetHeartBeat hb = null;
+
+    @Test
+    public void testCtor(){
+       Assert.assertNotNull(hb);
+    }
+
+    @Before
+    public void setUp(){
+
+       jmri.util.JUnitUtil.setUp();
+
+       XNetSystemConnectionMemo memo = new XNetSystemConnectionMemo(
+                                             new XNetInterfaceScaffold(
+                                             new LenzCommandStation()));
+
+       hb = new XNetHeartBeat(memo);
+
+    }
+  
+    @After
+    public void tearDown(){
+       hb.dispose();
+       hb = null;
+       jmri.util.JUnitUtil.tearDown();
+    }
+
+}


### PR DESCRIPTION
This was prompted by #6400.  

For both the Roco Z21 and any XpressNet system connected via a Lenz LIUSB-Ethernet in Ethernet mode, the changes here delay the next keepalive messages for the specified interval after any outgoing message is sent.  The remainder of the heartbeat process remains the same, but it has been moved to a new class. 