### PR TITLE
Flag Unread Field cases in SpotBugs

### DIFF
--- a/.spotbugs-check.xml
+++ b/.spotbugs-check.xml
@@ -39,7 +39,6 @@
            <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD" />
            <Bug pattern="UCF_USELESS_CONTROL_FLOW" />
            <Bug pattern="UC_USELESS_CONDITION" />
-           <Bug pattern="URF_UNREAD_FIELD" />
            <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" />
            <Bug pattern="UW_UNCOND_WAIT" />
            <Bug pattern="WA_NOT_IN_LOOP" />
@@ -87,8 +86,8 @@
      <Match>
        <!-- JMRI code is often written to trust weird from other classes,
             so the question of "malicious" is complicated. The rules in
-            this category should be restored in small batches  -->
-       <Bug category="MALICIOUS_CODE" />
+            this category should be restored in small batches  
+       <Bug category="MALICIOUS_CODE" /> -->
      </Match>
 
     <!-- items we're unlikely to restore -->


### PR DESCRIPTION
- turn off URF_UNREAD_FIELD exception in SpotBugs configuration
- this also serves as a test of the AppVeyor config change to reduce duplicate builds