### PR TITLE
Add the concept of a "collecting" reporter

### DIFF
--- a/java/src/jmri/CollectingReporter.java
+++ b/java/src/jmri/CollectingReporter.java
@@ -1,0 +1,30 @@
+package jmri;
+
+/**
+ * This is an extension of a reporter device that is capable of collecting 
+ * multiple reports in a collection.  The type of collection is not specified 
+ * by the interface, since that may be determined by the application.
+ * <BR>
+ * <hr>
+ * This file is part of JMRI.
+ * <P>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * </P><P>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * </P>
+ *
+ * @author Paul Bender Copyright (C) 2019
+ * @see jmri.Reporter
+ */
+public interface CollectingReporter extends Reporter {
+
+     /**
+      * @return the collection of elements associated with this reporter.
+      */
+     public java.util.Collection getCollection();
+
+}

--- a/java/src/jmri/implementation/AbstractRailComReporter.java
+++ b/java/src/jmri/implementation/AbstractRailComReporter.java
@@ -8,6 +8,7 @@ import jmri.IdTagListener;
 import jmri.InstanceManager;
 import jmri.LocoAddress;
 import jmri.PhysicalLocationReporter;
+import jmri.RailCom;
 import jmri.ReporterManager;
 import jmri.util.PhysicalLocation;
 import org.slf4j.Logger;
@@ -80,20 +81,10 @@ public class AbstractRailComReporter extends AbstractReporter
     @Override
     public LocoAddress getLocoAddress(String rep) {
         // For now, we assume the current report.
-        // IdTag.getTagID() is a system-name-ized version of the loco address. I think.
-        // Matcher.group(1) : loco address (I think)
-        IdTag cr = (IdTag) this.getCurrentReport();
-        ReporterManager rm = InstanceManager.getDefault(jmri.ReporterManager.class);
-        Pattern p = Pattern.compile("" + rm.getSystemPrefix() + rm.typeLetter() + "(\\d+)");
-        Matcher m = p.matcher(cr.getTagID());
-        if (m.find()) {
-            log.debug("Parsed address: " + m.group(1));
-            // I have no idea what kind of loco address an Ecos reporter uses,
-            // so we'll default to DCC for now.
-            return (new DccLocoAddress(Integer.parseInt(m.group(1)), LocoAddress.Protocol.DCC));
-        } else {
-            return (null);
-        }
+        // IdTags passed by RailCom reporters are actually jmri.RailCom objects
+        // so we use properties of the RailCom object here.
+        RailCom cr = (RailCom) this.getCurrentReport();
+        return cr.getDccLocoAddress();
     }
 
     /**

--- a/java/src/jmri/implementation/AbstractReporter.java
+++ b/java/src/jmri/implementation/AbstractReporter.java
@@ -62,7 +62,7 @@ public abstract class AbstractReporter extends AbstractNamedBean implements Repo
     }
 
     // internal data members
-    private Object _lastReport = null;
-    private Object _currentReport = null;
+    protected Object _lastReport = null;
+    protected Object _currentReport = null;
 
 }

--- a/java/src/jmri/jmrix/internal/InternalReporterManager.java
+++ b/java/src/jmri/jmrix/internal/InternalReporterManager.java
@@ -12,24 +12,13 @@ import jmri.implementation.AbstractReporter;
 public class InternalReporterManager extends jmri.managers.AbstractReporterManager {
 
     /**
-     * Create an internal (dummy) reporter object
+     * Create an internal TrackReporter object
      *
      * @return new null
      */
     @Override
     protected Reporter createNewReporter(String systemName, String userName) {
-        return new AbstractReporter(systemName, userName) {
-            @Override
-            public int getState() {
-                return state;
-            }
-
-            @Override
-            public void setState(int s) {
-                state = s;
-            }
-            int state = 0;
-        };
+        return new TrackReporter(systemName, userName);
     }
 
     @Override

--- a/java/src/jmri/jmrix/internal/TrackReporter.java
+++ b/java/src/jmri/jmrix/internal/TrackReporter.java
@@ -1,0 +1,100 @@
+package jmri.jmrix.internal;
+
+import java.util.Deque;
+import java.util.ArrayDeque;
+import jmri.implementation.AbstractReporter;
+import jmri.CollectingReporter;
+
+/**
+ * Extension of the AbstractReporter class that implements CollectingReporter
+ * and represents the contents of a track.  This is an internal construct that
+ * does not correspond to a physical reporter.
+ * <P>
+ *
+ * @author Paul Bender Copyright (C) 2019
+ */
+public class TrackReporter extends AbstractReporter implements CollectingReporter {
+
+    private Deque collection = null;
+
+    public TrackReporter(String systemName) {
+        super(systemName.toUpperCase());
+        collection = new ArrayDeque<Object>();
+    }
+
+    public TrackReporter(String systemName, String userName) {
+        super(systemName.toUpperCase(), userName);
+        collection = new ArrayDeque<Object>();
+    }
+
+    /**
+     * Provide a general method for updating the report.
+     */
+    @Override
+    public void setReport(Object r) {
+        if (r == _currentReport) {
+            return;
+        }
+        Object old = _currentReport;
+        Object oldLast = _lastReport;
+        _currentReport = r;
+        if (r != null) {
+            _lastReport = r;
+            // notify
+            firePropertyChange("lastReport", oldLast, _lastReport);
+        }
+        // notify
+        firePropertyChange("currentReport", old, _currentReport);
+    }
+            
+    @Override
+    public int getState() {
+       return state;
+    }
+
+    @Override
+    public void setState(int s) {
+       state = s;
+    }
+    int state = 0;
+
+    //CollectingReporter Interface Method(s)
+    /**
+     * @return the collection of elements associated with this reporter.
+     */
+    public java.util.Collection getCollection(){
+       return(collection);
+    }
+
+    // Special methods to set the report from the ends of the track
+    // these methods record the order of reports seen.
+
+    @SuppressWarnings("unchecked")
+    public void pushEast(Object o){
+         if(o != null) {
+            collection.addFirst(o);
+            setReport(o);
+         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void pushWest(Object o){
+         if(o != null) {
+            collection.addLast(o);
+            setReport(o);
+         }
+    }
+
+    public Object pullEast(){
+       Object retval = collection.removeFirst();
+       setReport(collection.peekFirst());
+       return retval;
+    }
+
+    public Object pullWest(){
+       Object retval = collection.removeLast();
+       setReport(collection.peekLast());
+       return retval;
+    }
+
+}

--- a/java/src/jmri/jmrix/roco/z21/Z21CanReporter.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21CanReporter.java
@@ -1,5 +1,8 @@
 package jmri.jmrix.roco.z21;
 
+import java.util.ArrayList;
+import java.util.function.Predicate;
+import jmri.CollectingReporter;
 import jmri.DccLocoAddress;
 import jmri.InstanceManager;
 import jmri.RailCom;
@@ -15,13 +18,15 @@ import org.slf4j.LoggerFactory;
  *
  * @author Paul Bender Copyright (C) 2016
  */
-public class Z21CanReporter extends jmri.implementation.AbstractRailComReporter implements Z21Listener {
+public class Z21CanReporter extends jmri.implementation.AbstractRailComReporter implements Z21Listener,CollectingReporter {
 
     private Z21SystemConnectionMemo _memo = null;
 
     private int networkID=0; // CAN network ID associated with this reporter's module.
     private int moduleAddress=-1; // User assigned address associated with this reporter's module.
     private int port; // module port (0-7) associated with this reporter.
+
+    private ArrayList<RailCom> idTags;
 
     /**  
      * Create a new Z21CanReporter.
@@ -39,37 +44,31 @@ public class Z21CanReporter extends jmri.implementation.AbstractRailComReporter 
         //Address format passed is in the form of moduleAddress:pin 
         int seperator = systemName.indexOf(":");
         int start = _memo.getSystemPrefix().length() + 1;
-           try {
-              try{
-                 moduleAddress = (Integer.parseInt(systemName.substring(start,seperator)));
-              } catch (NumberFormatException ex) {
-                 // didn't parse as a decimal, check to see if network ID 
-                 // was used instead.
-                 networkID = (Integer.parseInt(systemName.substring(start,seperator),16));
-                 
-              }
-              port = (Integer.parseInt(systemName.substring(seperator + 1)));
+        try {
+           try{
+              moduleAddress = (Integer.parseInt(systemName.substring(start,seperator)));
            } catch (NumberFormatException ex) {
-              log.debug("Unable to convert " + systemName + " into the cab and input format of nn:xx");
-              throw new IllegalArgumentException("requires mm:pp format address.");
+              // didn't parse as a decimal, check to see if network ID 
+              // was used instead.
+              networkID = (Integer.parseInt(systemName.substring(start,seperator),16));
            }
-        // request an update from the layout.
-        //requestUpdateFromLayout();  // leave commented out for now, causing 
-                                      // loop that needs investigation.
-    //    if(networkID!=0){
-    // leave commented out for now, causing loop that needs investigation.
-    //       _memo.getTrafficController().sendz21Message(Z21Message.getLanCanDetector(networkID),this);
-    //    }
+           port = (Integer.parseInt(systemName.substring(seperator + 1)));
+        } catch (NumberFormatException ex) {
+           log.debug("Unable to convert " + systemName + " into the cab and input format of nn:xx");
+           throw new IllegalArgumentException("requires mm:pp format address.");
+        }
+        idTags = new ArrayList<RailCom>();
+        // request an update from the layout
+        //if(networkID!=0){
+        //leave commented out for now, causing loop that needs investigation.
+        //   _memo.getTrafficController().sendz21Message(Z21Message.getLanCanDetector(networkID),this);
+        //}
     }
 
     // the Z21 Listener interface
 
     /**
-     * Member function that will be invoked by a z21Interface implementation to
-     * forward a z21 message from the layout.
-     *
-     * @param msg The received z21 reply. Note that this same object may be
-     * presented to multiple users. It should not be modified here.
+     * { @inheritDoc }
      */
     @Override
     public void reply(Z21Reply msg){
@@ -88,18 +87,47 @@ public class Z21CanReporter extends jmri.implementation.AbstractRailComReporter 
             int type = ( msg.getElement(9) & 0xFF);
             log.debug("reporter message type {}",type);
             if (type >= 0x11 && type <= 0x1f) {
+               int index = (type - 0x11)*2; // two reports per message.
                int value1 = (msg.getElement(10)&0xFF) + ((msg.getElement(11)&0xFF) << 8);
                int value2 = (msg.getElement(12)&0xFF) + ((msg.getElement(13)&0xFF) << 8);
-               log.debug("value 1: {}; value 2: {}",value1,value2);
+               log.debug("value {}: {}; value {}: {}",index,value1,index+1,value2);
                RailCom tag = getRailComTagFromValue(msg,value1);
                if(tag != null ) {
                   notify(tag);
+                  idTags.add(index,tag);
+                  // add the tag to the collection
                   tag = getRailComTagFromValue(msg,value2);
                   if(tag != null ) {
                      notify(tag);
+                     // add the tag to idTags
+                     idTags.add(index+1,tag);
+                  } else {
+                     // remove the tag from idTags
+                     // end of list found, remove all remaining tags.
+                     try{
+                        for(int i=idTags.size()-1;i>=index+1;i--){
+                            idTags.remove(i);
+                        }
+                     } catch (java.lang.IndexOutOfBoundsException iob) {
+                        // shouldn't happen, and not an error in this case.
+                        log.trace("attempted to remove end of list, but already cleared");
+                     }
                   }
                } else if(type==0x11) { // address is 0 and first in list.
+                  // clear the idTags list.
+                  idTags.removeIf(Predicate.isEqual(null).negate());
+                  // and the report.
                   notify(null);
+               } else {
+                  // end of list found, remove all remaining tags.
+                  try{
+                     for(int i=idTags.size()-1;i>=index;i--){
+                         idTags.remove(i);
+                     }
+                  } catch (java.lang.IndexOutOfBoundsException iob) {
+                     // shouldn't happen, and not an error in this case.
+                     log.trace("attempted to remove end of list, but already cleared");
+                  }
                }
             } else if( type == 0x01 ) {
                 // status message, not a railcom value, so no report.
@@ -137,12 +165,7 @@ public class Z21CanReporter extends jmri.implementation.AbstractRailComReporter 
     }
 
     /**
-     * Member function that will be invoked by a z21Interface implementation to
-     * forward a z21 message sent to the layout. Normally, this function will do
-     * nothing.
-     *
-     * @param msg The received z21 message. Note that this same object may be
-     * presented to multiple users. It should not be modified here.
+     * { @inheritDoc }
      */
     @Override
     public void message(Z21Message msg){
@@ -152,6 +175,15 @@ public class Z21CanReporter extends jmri.implementation.AbstractRailComReporter 
     @Override
     public void dispose(){
         super.dispose();
+    }
+
+    // the CollectingReporter interface.
+    /**
+     * { @inheritDoc }
+     */
+    @Override 
+    public java.util.Collection getCollection(){
+        return idTags;
     }
 
     private static final Logger log = LoggerFactory.getLogger(Z21CanReporter.class);

--- a/java/test/jmri/jmrix/internal/TrackReporterTest.java
+++ b/java/test/jmri/jmrix/internal/TrackReporterTest.java
@@ -1,0 +1,71 @@
+package jmri.jmrix.internal;
+
+import jmri.util.JUnitUtil;
+import org.junit.*;
+
+/**
+ * Tests for TrackReporter class.
+ *
+ * @author Paul Bender Copyright (C) 2016
+ **/
+
+public class TrackReporterTest extends jmri.implementation.AbstractRailComReporterTest {
+
+   @Test
+   public void testSingleEndedTrackEast(){
+       // this track should work like a stack, add or remove from one end only.
+       TrackReporter tr = (TrackReporter)r;
+       tr.pushEast("Hello");
+       Assert.assertEquals("after 1st push","Hello",tr.getCurrentReport());
+       tr.pushEast("World");
+       Assert.assertEquals("after 2nd push","World",tr.getCurrentReport());
+       Assert.assertEquals("pull last entered","World",tr.pullEast());
+       Assert.assertEquals("last report","Hello",tr.getCurrentReport());
+       Assert.assertEquals("pull first entered","Hello",tr.pullEast());
+       Assert.assertNull("last report",tr.getCurrentReport());
+   }
+
+   @Test
+   public void testSingleEndedTrackWest(){
+       // this track should work like a stack, add or remove from one end only.
+       TrackReporter tr = (TrackReporter)r;
+       tr.pushWest("Hello");
+       Assert.assertEquals("after 1st push","Hello",tr.getCurrentReport());
+       tr.pushWest("World");
+       Assert.assertEquals("after 2nd push","World",tr.getCurrentReport());
+       Assert.assertEquals("pull last entered","World",tr.pullWest());
+       Assert.assertEquals("last report","Hello",tr.getCurrentReport());
+       Assert.assertEquals("pull first entered","Hello",tr.pullWest());
+       Assert.assertNull("last report",tr.getCurrentReport());
+   }
+
+   @Test
+   public void testDoubleEndedTrack(){
+       // this track should work like a queue, add from one end remove from the other.
+       TrackReporter tr = (TrackReporter)r;
+       tr.pushWest("Hello");
+       Assert.assertEquals("after 1st push","Hello",tr.getCurrentReport());
+       tr.pushWest("World");
+       Assert.assertEquals("after 2nd push","World",tr.getCurrentReport());
+       Assert.assertEquals("pull first entered","Hello",tr.pullEast());
+       Assert.assertEquals("last report","World",tr.getCurrentReport());
+       Assert.assertEquals("pull last entered","World",tr.pullEast());
+       Assert.assertNull("last report",tr.getCurrentReport());
+   }
+
+   @Override
+   @Before
+   public void setUp() {
+        JUnitUtil.setUp();
+        r = new TrackReporter("TrackR1","hello world");
+
+   }
+
+   @Override
+   @After
+   public void tearDown(){
+	   r = null;
+       JUnitUtil.tearDown();
+   }
+
+}

--- a/java/test/jmri/jmrix/roco/z21/Z21CanReporterTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21CanReporterTest.java
@@ -49,6 +49,67 @@ public class Z21CanReporterTest extends jmri.implementation.AbstractRailComRepor
         Assert.assertFalse("LastReport seen after empty list", lastReportSeen);
     }
 
+    @Test
+    public void testCollectionAfterMessage() {
+       Z21CanReporter zr = (Z21CanReporter) r;
+       zr.addPropertyChangeListener(new TestReporterListener());
+       byte msg[]={(byte)0x0E,(byte)0x00,(byte)0xC4,(byte)0x00,(byte)0xcd,(byte)0xab,(byte)0x01,(byte)0x00,(byte)0x01,(byte)0x11,(byte)0x01,(byte)0x00,(byte)0x00,(byte)0x00};
+       Z21Reply reply = new Z21Reply(msg,14);
+       zr.reply(reply);
+       // Check that the collection has one element.
+       Assert.assertEquals("Collection Size 1 after message", 1, zr.getCollection().size());
+
+       byte msg2[]={(byte)0x0E,(byte)0x00,(byte)0xC4,(byte)0x00,(byte)0xcd,(byte)0xab,(byte)0x01,(byte)0x00,(byte)0x01,(byte)0x11,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00};
+       reply = new Z21Reply(msg2,14);
+       zr.reply(reply);
+       // Check that the collection wass cleared.
+       Assert.assertEquals("Collection Size 0 after clear message", 0, zr.getCollection().size());
+       Assert.assertTrue("Collection Empty", zr.getCollection().isEmpty());
+   }
+    
+   @Test
+   public void testCollectionAfterMessageWith2Tags() {
+      Z21CanReporter zr = (Z21CanReporter) r;
+      zr.addPropertyChangeListener(new TestReporterListener());
+      byte msg[]={(byte)0x0E,(byte)0x00,(byte)0xC4,(byte)0x00,(byte)0xcd,(byte)0xab,(byte)0x01,(byte)0x00,(byte)0x01,(byte)0x11,(byte)0x01,(byte)0x00,(byte)0x02,(byte)0x00};
+      Z21Reply reply = new Z21Reply(msg,14);
+      zr.reply(reply);
+      byte msg2[]={(byte)0x0E,(byte)0x00,(byte)0xC4,(byte)0x00,(byte)0xcd,(byte)0xab,(byte)0x01,(byte)0x00,(byte)0x01,(byte)0x12,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00}; // end of list, but second pair.
+      reply = new Z21Reply(msg2,14);
+      zr.reply(reply);
+      // Check that the collection has two element.
+      Assert.assertEquals("Collection Size 2 after message", 2, zr.getCollection().size());
+
+      byte msg3[]={(byte)0x0E,(byte)0x00,(byte)0xC4,(byte)0x00,(byte)0xcd,(byte)0xab,(byte)0x01,(byte)0x00,(byte)0x01,(byte)0x11,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00};
+      reply = new Z21Reply(msg3,14);
+      zr.reply(reply);
+      // Check that the collection wass cleared.
+      Assert.assertEquals("Collection Size 0 after clear message", 0, zr.getCollection().size());
+      Assert.assertTrue("Collection Empty", zr.getCollection().isEmpty());
+   }
+
+   @Test
+   public void testCollectionAfterMessageWith3Tags() {
+      Z21CanReporter zr = (Z21CanReporter) r;
+      zr.addPropertyChangeListener(new TestReporterListener());
+      byte msg[]={(byte)0x0E,(byte)0x00,(byte)0xC4,(byte)0x00,(byte)0xcd,(byte)0xab,(byte)0x01,(byte)0x00,(byte)0x01,(byte)0x11,(byte)0x01,(byte)0x00,(byte)0x02,(byte)0x00};
+      Z21Reply reply = new Z21Reply(msg,14);
+      zr.reply(reply);
+      byte msg2[]={(byte)0x0E,(byte)0x00,(byte)0xC4,(byte)0x00,(byte)0xcd,(byte)0xab,(byte)0x01,(byte)0x00,(byte)0x01,(byte)0x12,(byte)0x03,(byte)0x00,(byte)0x00,(byte)0x00}; // end of list, but second pair.
+      reply = new Z21Reply(msg2,14);
+      zr.reply(reply);
+      // Check that the collection has two element.
+      JUnitUtil.waitFor( () -> { return ( zr.getCollection().size() > 2); });
+      Assert.assertEquals("Collection Size 3 after message", 3, zr.getCollection().size());
+
+      byte msg3[]={(byte)0x0E,(byte)0x00,(byte)0xC4,(byte)0x00,(byte)0xcd,(byte)0xab,(byte)0x01,(byte)0x00,(byte)0x01,(byte)0x11,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00};
+      reply = new Z21Reply(msg3,14);
+      zr.reply(reply);
+      // Check that the collection wass cleared.
+      Assert.assertEquals("Collection Size 0 after clear message", 0, zr.getCollection().size());
+      Assert.assertTrue("Collection Empty", zr.getCollection().isEmpty());
+   }
+
    @Override
    @Before
    public void setUp() {


### PR DESCRIPTION
This PR adds two examples of what I am calling a "Collecting Reporter".

The Collecting Reporter collects a report in a collection and makes the collection available for use by other processes.

The CollectingReporter interface adds one additional operation to a reporter, which allows retrieval of the underlying collection.

Two examples of CollectingReporters are included here:
The Can based reporters on the Z21 (the Roco 10808, for example) are allowed to report up to 32 individual addresses at a time.  The JMRI code for the Roco Z21 Can Reporters have been extended to use an ArrayList to collect the data provided by the command station.  The value of CurrentReport is the last value seen by JMRI, and should corespond to the last of the addresses sent by the command station.  addresses are stored in the order they were sent by the command station.

A new Internal Reporter called a TrackReporter has been created.  

The intention behind the TrackReporter is that a single real reporter (the initial application in the thought process was an RFID reader) could be placed at the beginning of a yard throat and (using either logix or a script ) switch positions could be used to push the car into an internal reporter on a specified track.

Having the collection available allows applications such as operations to get the list of cars as they stand on the specified track.  The collection used here is a Deque (double ended queue) because tracks can be double ended and you can add or remove from either end (and not typically in the middle).

In order to use the collection as designed, 4 new operations were added to the TrackReporter:
pushEast
pullEast
pushWest
pullWest

The push operations allow pushing "cars" onto a track from the East and West ends (Railroad East/West.  We could also use North/Sourth)
The pull operations allow pulling "cars" from a track from the East and West ends.

If you always push and pull from one end, the TrackReporter represents a stub ended track (and acts like a stack ).  In this case, the currentReport shows the first "car" available.

If you can push and pull from both ends, the Track Reporter represents a double ended track.  The current report represents the last car added to the track (in the case of a push operation) or the last car exposed on the track (in the case of a pull operation).