### PR TITLE
Remove unwanted blank lines in NCE Monitor.

### DIFF
--- a/java/src/jmri/jmrix/nce/ncemon/NceMonBinary.java
+++ b/java/src/jmri/jmrix/nce/ncemon/NceMonBinary.java
@@ -19,8 +19,6 @@ public class NceMonBinary {
 
     private static final Logger log = LoggerFactory.getLogger(NceMonBinary.class);
 
-    private static final String NEW_LINE = "\n";
-
     private int replyType = REPLY_UNKNOWN;
 
     private static final int REPLY_UNKNOWN = 0;
@@ -44,7 +42,7 @@ public class NceMonBinary {
      * @return the displayable message string
      */
     public String displayMessage(NceMessage m) {
-        return parseMessage(m) + NEW_LINE;
+        return parseMessage(m);
     }
 
     private String parseMessage(NceMessage m) {
@@ -60,8 +58,7 @@ public class NceMonBinary {
             case (NceMessage.SET_CLOCK_CMD):
                 if (m.getNumDataElements() == 3) {
                     return MessageFormat.format(Bundle.getMessage("SET_CLOCK_CMD"),
-                            new Object[]{m.getElement(1), m.getElement(2)})
-                            + NEW_LINE;
+                            new Object[]{m.getElement(1), m.getElement(2)});
                 }
                 break;
             case (NceMessage.CLOCK_1224_CMD):
@@ -490,7 +487,7 @@ public class NceMonBinary {
      * @return the displayable message string
      */
     public String displayReply(NceReply r) {
-        return parseReply(r) + NEW_LINE;
+        return parseReply(r);
     }
 
     private String parseReply(NceReply r) {

--- a/java/src/jmri/jmrix/nce/ncemon/NceMonBinary.java
+++ b/java/src/jmri/jmrix/nce/ncemon/NceMonBinary.java
@@ -37,7 +37,8 @@ public class NceMonBinary {
     private static final int REPLY_OK = '!';   // command completed successfully
 
     /**
-     * Creates a command message for the log, in a human-friendly form if possible.
+     * Creates a command message for the log, in a human-friendly form if
+     * possible.
      *
      * @param m the raw command message
      * @return the displayable message string
@@ -482,10 +483,11 @@ public class NceMonBinary {
     }
 
     /**
-     * Creates a reply message for the log, in a human-friendly form if possible.
+     * Creates a reply message for the log, in a human-friendly form if
+     * possible.
      *
      * @param r the raw reply message
-     * @return  the displayable message string
+     * @return the displayable message string
      */
     public String displayReply(NceReply r) {
         return parseReply(r) + NEW_LINE;
@@ -495,7 +497,7 @@ public class NceMonBinary {
         switch (replyType) {
             case (REPLY_STANDARD):
                 /* standard reply is a single byte
-                 * Errors returned: 
+                 * Errors returned:
                  * '0'= command not supported
                  * '1'= loco/accy/signal address out of range
                  * '2'= cab address or op code out of range

--- a/java/test/jmri/jmrix/nce/NceMessageTest.java
+++ b/java/test/jmri/jmrix/nce/NceMessageTest.java
@@ -99,7 +99,7 @@ public class NceMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     public void testReadPagedCVBinToMonitorString() {
         tc.setCommandOptions(NceTrafficController.OPTION_2006);
         msg = NceMessage.getReadPagedCV(tc, 12);
-        Assert.assertEquals("monitor string compare ", "Read CV 12 in paged mode\n", msg.toMonitorString());
+        Assert.assertEquals("monitor string compare ", "Read CV 12 in paged mode", msg.toMonitorString());
     }
 
     @Test
@@ -113,7 +113,7 @@ public class NceMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     public void testWritePagedCVAsciiToMonitorString() {
         tc.setCommandOptions(NceTrafficController.OPTION_2004);
         msg = NceMessage.getWritePagedCV(tc, 12, 251);
-        Assert.assertEquals("monitor string compare ", "binary cmd: P012 251\n", msg.toMonitorString());
+        Assert.assertEquals("monitor string compare ", "binary cmd: P012 251", msg.toMonitorString());
     }
 
     @Test

--- a/java/test/jmri/jmrix/nce/NceReplyTest.java
+++ b/java/test/jmri/jmrix/nce/NceReplyTest.java
@@ -154,7 +154,7 @@ public class NceReplyTest extends jmri.jmrix.AbstractMessageTestBase {
         msg.setElement(1, 0x34);
         msg.setElement(2, 0x01);
         msg.setElement(3, 0x02);
-        Assert.assertEquals("monitor string value","Reply: 12 34 01 02\n", msg.toMonitorString());
+        Assert.assertEquals("monitor string value","Reply: 12 34 01 02", msg.toMonitorString());
     }
 
     @Test


### PR DESCRIPTION
Remove surplus blank lines that appeared after September 2018 refactoring of monitor code.