### PR TITLE
Move release note

### DIFF
--- a/help/en/html/doc/Technical/gitadmin.shtml
+++ b/help/en/html/doc/Technical/gitadmin.shtml
@@ -53,7 +53,7 @@
         <li>They have passed all the CI tests
         <li>They have no outstanding reviews
         <li>If in a new area, large or from a new contributor, 
-            they have been in-cue for at least a day or so to allow people to take a look at them
+            they have been in-queue for at least a day or so to allow people to take a look at them
         <li>Don't appear to have any un-resolved controversies in the comments
       </ul>
       

--- a/help/en/html/doc/Technical/gitdeveloper.shtml
+++ b/help/en/html/doc/Technical/gitdeveloper.shtml
@@ -140,6 +140,20 @@
     ask for help:  There are ways of doing everything you want done
     without risking the loss of other people's work.
     </ul>
+    
+    <p>As you work, we encourage you to add a brief 
+    description of your changes to the 
+    draft release note, which 
+    can be found in the 
+    <a href="../../../releasenotes">help/en/releasenotes</a>
+    directory
+    as the 
+    <a href="../../../releasenotes/draft-release-note.shtml">help/en/releasenotes/draft-release-note.shtml</a> 
+    file. When you eventually 
+    contribute your changes, this will be how other JMRI users find out 
+    about them.  You can also cut&amp;paste this into 
+    your pull request (see below) to help explain your change to the people reviewing it.
+    
 <h3>Commit Changes to Your Local Repository</h3>
       You should
       commit your changes into your local repository often.
@@ -277,7 +291,10 @@ To push the current branch and set the remote as upstream, use
         <li>Fill out the forms. A short title that describes the
         feature you've written helps other people find it. A few
         lines in the comment about what it does, how you added it,
-        etc is also very helpful.</li>
+        etc helps users understand the value of your feature.
+        If you've already 
+        made an entry in the draft release note (see above),
+        that can be a used here.</li>
 
         <li>Click "Create pull request". That submits all the info,
         starts the 

--- a/help/en/releasenotes/README.md
+++ b/help/en/releasenotes/README.md
@@ -1,0 +1,2 @@
+This directory contains the "recent changes" section of the current draft release note, along with some related files.
+

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -1,0 +1,464 @@
+
+    <h3>Hardware Support</h3>
+
+        <ul>
+          <li></li>
+        </ul>
+
+	    <h4>Anyma DMX512</h4>
+            <ul>
+                <li></li>
+            </ul>
+		
+	    <h4>Bachrus Speedo</h4>
+            <ul>
+                <li></li>
+            </ul>
+		
+        <h4>C/MRI</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>DCC++</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>DCC4pc</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Direct</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>ESU</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>JMRI Simple Server/JMRI Client</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>LocoNet</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Maple</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Marklin CS2</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>MERG CBUS</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>MQTT</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>MRC</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>NCE</h4>
+            <ul>
+                <li><li>
+            </ul>
+
+        <h4>Oak Tree</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4><a href="http://openlcb.org">OpenLCB</a></h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>RFID</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Roco z21/Z21</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Secsi</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>SPROG</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>TAMS</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>TMCC</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Uhlenbrock Intellibox</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Zimo MXULF</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>ZTC</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+    <h3>New / Updated decoder definitions</h3>
+      <ul>
+        <li></li>
+     </ul>
+
+        <h4>Arnold</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Bachmann</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>BLI</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>BNM Hobbies</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Digikeijs (Digirails)</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Digitrax</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Doehler &amp; Haas</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>ESU</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Hornby</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Kuehn</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>LaisDCC</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4><a href="http://www.ldhtrenes.com.ar">LDH</a></h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Lenz</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>MGP</h4>
+             <ul>
+                <li></li>
+             </ul>
+
+        <h4>Mistral Train Models</h4>
+             <ul>
+                <li></li>
+             </ul>
+
+        <h4>MTH</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>MRC</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>NCE</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Norsk Modelljernbane (NJM)</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>QSI</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Rautenhaus</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>RR-CirKits</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>SoundTraxx</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>TCS</h4>
+            <ul>
+                <li></li>
+            </ul>
+	    
+	    <h4>Team Digital</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Technologistic (train-O-matic)</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Trix Modelleisenbahn</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Uhlenbrock</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Umelec</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Viessmann</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Wangrow</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>ZIMO</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Miscellaneous</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+    <h3>DecoderPro</h3>
+        <a id="DecoderPro" name="DecoderPro"/>
+        <ul>
+          <li></li>
+        </ul>
+
+   <h3>Dispatcher</h3>
+        <a id="Dispatcher" name="Dispatcher"/>
+        <ul>
+             <li></li>
+        </ul>
+
+   <h3>Internationalization</h3>
+        <a id="I18N" name="I18N"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Layout Editor</h3>
+        <a id="LE" name="LE"/>
+        <ul>
+	        <li></li>
+        </ul>
+
+    <h3>Logix</h3>
+        <a id="Logix" name="Logix"/>
+        <ul>
+          <li></li>
+        </ul>
+
+    <h3>Operations</h3>
+        <a id="Operations" name="Operations"/>
+        <ul>
+            <li></li>
+        </ul>
+
+   <h3>Panel Editors</h3>
+        <a id="PE" name="PE"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Preferences</h3>
+        <a id="Preferences" name="Preferences"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Resources</h3>
+        <a id="Resources" name="Resources"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Roster</h3>
+        <a id="Roster" name="Roster"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Turnouts, Lights, Sensors and other elements</h3>
+        <a id="TLae" name="TLae"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Scripting</h3>
+        <a id="Scripting" name="Scripting"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Signals</h3>
+        <a id="Signals" name="Signals"/>
+        <ul>
+            <li></li>
+        </ul>
+        <h4>Signal Systems</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Signal Heads</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Signal Masts</h4>
+            <ul>
+                <li></li>
+            </ul>
+            
+    	<h4>Signal Groups</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+    	<h4>Simple Signal Logic</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+	    <h4>NX Entry/Exit Logic</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+	    <h4>USS CTC Logic</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+   <h3>Switchboard Editor</h3>
+        <a id="SW" name="SW"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Timetable</h3>
+        <a id="Timetable" name="Timetable"/>
+        <span class="since">since 4.13.4</span>
+        <ul>
+            <li></li>
+        </ul>
+
+   <h3>Warrants</h3>
+        <a id="Wt" name="Wt"/>
+        <ul>
+            <li></li>
+        </ul>
+
+   <h3>Web Access</h3>
+        <a id="WA" name="WA"/>
+        <ul>
+            <li> </li>
+        </ul>
+
+   <h3>WiThrottle Server</h3>
+        <a id="WS" name="WS"/>
+        <ul>
+            <li></li>
+        </ul>
+        
+   <h3>Virtual Sound Decoder</h3>
+        <a id="VSD" name="VSD"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Miscellaneous</h3>
+        <a id="Misc" name="Misc"/>
+        <ul>
+            <li>We're building the release note a
+                <a href="/help/en/html/doc/Technical/gitdeveloper.shtml">different way</a>
+                starting with this release.</li>
+        </ul>
+

--- a/help/en/releasenotes/jmri4.15-master.shtml
+++ b/help/en/releasenotes/jmri4.15-master.shtml
@@ -1,0 +1,462 @@
+
+    <h3>Hardware Support</h3>
+
+        <ul>
+          <li></li>
+        </ul>
+
+	    <h4>Anyma DMX512</h4>
+            <ul>
+                <li></li>
+            </ul>
+		
+	    <h4>Bachrus Speedo</h4>
+            <ul>
+                <li></li>
+            </ul>
+		
+        <h4>C/MRI</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>DCC++</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>DCC4pc</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Direct</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>ESU</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>JMRI Simple Server/JMRI Client</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>LocoNet</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Maple</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Marklin CS2</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>MERG CBUS</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>MQTT</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>MRC</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>NCE</h4>
+            <ul>
+                <li><li>
+            </ul>
+
+        <h4>Oak Tree</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4><a href="http://openlcb.org">OpenLCB</a></h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>RFID</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Roco z21/Z21</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Secsi</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>SPROG</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>TAMS</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>TMCC</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Uhlenbrock Intellibox</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Zimo MXULF</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>ZTC</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+    <h3>New / Updated decoder definitions</h3>
+      <ul>
+        <li></li>
+     </ul>
+
+        <h4>Arnold</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Bachmann</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>BLI</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>BNM Hobbies</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Digikeijs (Digirails)</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Digitrax</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Doehler &amp; Haas</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>ESU</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Hornby</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Kuehn</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>LaisDCC</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4><a href="http://www.ldhtrenes.com.ar">LDH</a></h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Lenz</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>MGP</h4>
+             <ul>
+                <li></li>
+             </ul>
+
+        <h4>Mistral Train Models</h4>
+             <ul>
+                <li></li>
+             </ul>
+
+        <h4>MTH</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>MRC</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>NCE</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Norsk Modelljernbane (NJM)</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>QSI</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Rautenhaus</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>RR-CirKits</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>SoundTraxx</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>TCS</h4>
+            <ul>
+                <li></li>
+            </ul>
+	    
+	    <h4>Team Digital</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Technologistic (train-O-matic)</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Trix Modelleisenbahn</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Uhlenbrock</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Umelec</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Viessmann</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Wangrow</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>ZIMO</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Miscellaneous</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+    <h3>DecoderPro</h3>
+        <a id="DecoderPro" name="DecoderPro"/>
+        <ul>
+          <li></li>
+        </ul>
+
+   <h3>Dispatcher</h3>
+        <a id="Dispatcher" name="Dispatcher"/>
+        <ul>
+             <li></li>
+        </ul>
+
+   <h3>Internationalization</h3>
+        <a id="I18N" name="I18N"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Layout Editor</h3>
+        <a id="LE" name="LE"/>
+        <ul>
+	        <li></li>
+        </ul>
+
+    <h3>Logix</h3>
+        <a id="Logix" name="Logix"/>
+        <ul>
+          <li></li>
+        </ul>
+
+    <h3>Operations</h3>
+        <a id="Operations" name="Operations"/>
+        <ul>
+            <li></li>
+        </ul>
+
+   <h3>Panel Editors</h3>
+        <a id="PE" name="PE"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Preferences</h3>
+        <a id="Preferences" name="Preferences"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Resources</h3>
+        <a id="Resources" name="Resources"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Roster</h3>
+        <a id="Roster" name="Roster"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Turnouts, Lights, Sensors and other elements</h3>
+        <a id="TLae" name="TLae"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Scripting</h3>
+        <a id="Scripting" name="Scripting"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Signals</h3>
+        <a id="Signals" name="Signals"/>
+        <ul>
+            <li></li>
+        </ul>
+        <h4>Signal Systems</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Signal Heads</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+        <h4>Signal Masts</h4>
+            <ul>
+                <li></li>
+            </ul>
+            
+    	<h4>Signal Groups</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+    	<h4>Simple Signal Logic</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+	    <h4>NX Entry/Exit Logic</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+	    <h4>USS CTC Logic</h4>
+            <ul>
+                <li></li>
+            </ul>
+
+   <h3>Switchboard Editor</h3>
+        <a id="SW" name="SW"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Timetable</h3>
+        <a id="Timetable" name="Timetable"/>
+        <span class="since">since 4.13.4</span>
+        <ul>
+            <li></li>
+        </ul>
+
+   <h3>Warrants</h3>
+        <a id="Wt" name="Wt"/>
+        <ul>
+            <li></li>
+        </ul>
+
+   <h3>Web Access</h3>
+        <a id="WA" name="WA"/>
+        <ul>
+            <li> </li>
+        </ul>
+
+   <h3>WiThrottle Server</h3>
+        <a id="WS" name="WS"/>
+        <ul>
+            <li></li>
+        </ul>
+        
+   <h3>Virtual Sound Decoder</h3>
+        <a id="VSD" name="VSD"/>
+        <ul>
+            <li></li>
+        </ul>
+
+    <h3>Miscellaneous</h3>
+        <a id="Misc" name="Misc"/>
+        <ul>
+            <li></li>
+        </ul>
+

--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -203,7 +203,7 @@ git push github
 
 - Check that the correct milestone is on all merged pulls. This is needed for the release note. Start with the list of PRs merged since the last test release was started:
 ```
-https://github.com/JMRI/JMRI/pulls?q=is%3Apr+is%3Aclosed+merged%3A%3E2016-08-13+no%3Amilestone
+https://github.com/JMRI/JMRI/pulls?q=is%3Apr+is%3Aclosed+merged%3A%3E2018-12-13+no%3Amilestone
 ```
 where the date at the end should be the date (and optionally time) of the last release. For each, if it doesn't have the right milestone set, and is a change to the release code (e.g. isn't just a change to the CI settings or similar), add the current milestone.  
 
@@ -386,9 +386,9 @@ Checksums:
 
 File | SHA256 checksum
 ---|---
-[JMRI.4.13.6+Rcb07def.dmg](https://github.com/JMRI/JMRI/releases/download/v4.13.6/JMRI.4.13.6+Rcb07def.dmg) | 6deb881792c4cf03a3088196a2d19f9d303999d2aa31e0e913a61fd4312f5f13
-[JMRI.4.13.6+Rcb07def.exe](https://github.com/JMRI/JMRI/releases/download/v4.13.6/JMRI.4.13.6+Rcb07def.exe) | 21ebcac7d872f02a353f482e954b0d2ecec0df0a3eac3fdc20bd2f168fa4ebaa
-[JMRI.4.13.6+Rcb07def.tgz](https://github.com/JMRI/JMRI/releases/download/v4.13.6/JMRI.4.13.6+Rcb07def.tgz) | dfc165645ffc13b2b5f88b2c29a4510ec70204244a5a84b77a0e4425806ae38a
+[JMRI.4.15.2+Rfda0762.dmg](https://github.com/JMRI/JMRI/releases/download/v4.15.2/JMRI.4.15.2+Rfda0762.dmg) | 3a9bf1dc406e9e22a49dad149d9eda5f514bde046730e2de6f78bc391827bddd
+[JMRI.4.15.2+Rfda0762.exe](https://github.com/JMRI/JMRI/releases/download/v4.15.2/JMRI.4.15.2+Rfda0762.exe) | 9ef30f469a5390dfa9586c3a8c7174f5a224f2091f2e95011c80dd8a603856a4
+[JMRI.4.15.2+Rfda0762.tgz](https://github.com/JMRI/JMRI/releases/download/v4.15.2/JMRI.4.15.2+Rfda0762.tgz) | e03646519f020ad1421bc78c22ed85ce082191b8f91c40d7d722105d1d6f0633
 ```
 
 - Attach files by selecting them or dragging them in. Make sure that the Linux one is .tgz, not .tar.
@@ -440,7 +440,7 @@ If there are any changes in other files, do both of:
 This is the next release in the 4.16 cycle. It's intended to be released around (July 12) from HEAD of master.
 ```
 
-- Confirm that the tag for the current release (v4.15.2 for release 4.15.2) is in place via the [tags page](https://github.com/JMRI/JMRI/tags), then manually delete the current release branch (release-4.15.2) via the [GitHub branches page](https://github.com/JMRI/JMRI/branches).  (N.B. We are experimenting with having the `release*` branches protected, in which case you may have to go to Setting; Branches; then edit the Release* branch name to ReleaseX* to disable the protection before removing the branch.  If you do that, remember to replace the protection!)
+- Confirm that the tag for the current release (v4.15.2 for release 4.15.2) is in place via the [tags page](https://github.com/JMRI/JMRI/tags), then manually delete the current release branch (release-4.15.2) via the [GitHub branches page](https://github.com/JMRI/JMRI/branches).  (N.B. We are experimenting with having the `release*` branches protected, in which case you may have to go to Setting; Branches; then edit the release* branch name to releaseX* to disable the protection before removing the branch.  If you do that, remember to replace the protection!)
 
 - Go to the GitHub PR and Issues [labels list](https://github.com/JMRI/JMRI/labels) and remove any "afterNextTestRelease" (and "afterNextProductionRelease" if appropriate) labels from done items
 

--- a/scripts/HOWTO-distribution.md
+++ b/scripts/HOWTO-distribution.md
@@ -183,6 +183,10 @@ git push github
 
 - Merge all relevant [PRs in the JMRI/website repository](https://github.com/JMRI/website/pulls) to ensure release note draft is up to date
 
+- Copy the release note body from help/en/releasenotes/current-draft-note.shtml in the JMRI/JMRI repository into the actual release note in website repository:
+     JMRI/help/en/releasenotes/current-draft-note.shtml
+     website/releasenote/jmri4.15.3.shtml
+     
 - Create the _next_ release note, so that people will document new (overlapping) changes there. Best way to do this is to copy the current release note now, before you prune out all the headers and other info where changes weren't made. (We need to work through automation of version number values below) (If you're creating a production version, its release note is made from a merge of the features of all the test releases; also create the *.*.1 note for the next test release)
 
 ```    
@@ -254,6 +258,17 @@ Jenkins will be creating files shortly at the [CI server](http://builds.jmri.org
 
 If you're developing any additional (post-4.15.2) changes that you want in the JMRI 4.16 production release, please start from this branch, i.e. do `git checkout -b release-4.15.2` to start your work.
 ```
+
+- Copy the release note body from help/en/releasenotes/current-draft-note.shtml in the JMRI/JMRI repository into the actual release note in website repository:
+     JMRI/help/en/releasenotes/current-draft-note.shtml
+     website/releasenote/jmri4.15.3.shtml
+
+- Create a new current-draft-note
+     cp help/en/releasenotes/jmri4.15-master.shtml help/en/releasenotes/current-draft-note.shtml
+     
+- Commit the release note changes on both repositories and push directly
+
+- Pull back to make sure your repository is fully up to date
 
 ================================================================================
 ## Build Files with Jenkins
@@ -498,7 +513,7 @@ If you are currently using JMRI 4.9.6 or earlier, we strongly recommend that you
 
 If you use JMRI on Linux or Mac and are updating from JMRI 4.7.3 or earlier, there’s a necessary migration step. (Not needed on Windows) Please see the JMRI 4.12 release note for details: <http://jmri.org/releasenotes/jmri4.12.shtml#migration>
 
-For more information on the issues, new features and bug fixes in 4.15.2 please see the release note:
+For more information on the issues, new features and bug fixes in 4.15.2 please see the release note:   
 <http://jmri.org/releasenotes/jmri4.15.2.shtml>
 
 Note that JMRI is made available under the GNU General Public License. For more information, please see our copyright and licensing page.


### PR DESCRIPTION
This moves the draft release note to help/en/releasenotes/current-draft-note.shtml so that people can edit and commit there as part of a single PR.  Includes updates to the instructions.  Intended for first use in JMRI 4.15.3

Requires that PR JMRI/website#304 be merged before this will take effect.