### PR TITLE
MERG CBUS STL Priority / Turnout mode support

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusLight.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusLight.java
@@ -77,9 +77,11 @@ public class CbusLight extends AbstractLight
         CanMessage m;
         if (newState == ON) {
             m = addrOn.makeMessage(tc.getCanid());
+            CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
             tc.sendCanMessage(m, this);
         } else if (newState == OFF) {
             m = addrOff.makeMessage(tc.getCanid());
+            CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
             tc.sendCanMessage(m, this);
         } else {
             log.warn("illegal state requested for Light: " + getSystemName());
@@ -98,6 +100,7 @@ public class CbusLight extends AbstractLight
         else {
             m.setOpCode(CbusConstants.CBUS_AREQ);
         }
+        CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
         tc.sendCanMessage(m, this);
     }
     

--- a/java/src/jmri/jmrix/can/cbus/CbusMessage.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusMessage.java
@@ -94,7 +94,7 @@ public class CbusMessage {
      * @return the node number
      */
     public static int getNodeNumber(CanMessage m) {
-        if (isEvent(m)) {
+        if (isEvent(m) && !isShort(m) ) {
             return m.getElement(1) * 256 + m.getElement(2);
         } else {
             return 0;
@@ -305,7 +305,7 @@ public class CbusMessage {
      * @return the node number
      */
     public static int getNodeNumber(CanReply r) {
-        if (isEvent(r)) {
+        if (isEvent(r) && !isShort(r) ) {
             return r.getElement(1) * 256 + r.getElement(2);
         } else {
             return 0;

--- a/java/src/jmri/jmrix/can/cbus/CbusSensor.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensor.java
@@ -79,6 +79,7 @@ public class CbusSensor extends AbstractSensor implements CanListener {
         else {
             m.setOpCode(CbusConstants.CBUS_AREQ);
         }
+        CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
         tc.sendCanMessage(m, this);
     }
 
@@ -101,6 +102,7 @@ public class CbusSensor extends AbstractSensor implements CanListener {
                 m = addrActive.makeMessage(tc.getCanid());
                 setOwnState(Sensor.ACTIVE);
             }
+            CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
             tc.sendCanMessage(m, this);
         } else if (s == Sensor.INACTIVE) {
             if (getInverted()){
@@ -110,6 +112,7 @@ public class CbusSensor extends AbstractSensor implements CanListener {
                 m = addrInactive.makeMessage(tc.getCanid());
                 setOwnState(Sensor.INACTIVE);
             }
+            CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
             tc.sendCanMessage(m, this);
         }
         if (s == Sensor.UNKNOWN){

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
@@ -80,6 +80,7 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
         else {
             m.setOpCode(CbusConstants.CBUS_AREQ);
         }
+        CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
         tc.sendCanMessage(m, this);
     }
     
@@ -97,6 +98,7 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
             } else {
                 m = addrThrown.makeMessage(tc.getCanid());
             }
+            CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
             tc.sendCanMessage(m, this);
         } 
         if (s == Turnout.CLOSED) {
@@ -106,6 +108,7 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
             else {
                 m = addrClosed.makeMessage(tc.getCanid());
             }
+            CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
             tc.sendCanMessage(m, this);
         }
     }

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.can.cbus;
 
+import jmri.Sensor;
 import jmri.Turnout;
 import jmri.jmrix.can.CanListener;
 import jmri.jmrix.can.CanMessage;
@@ -82,6 +83,15 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
         }
         CbusMessage.setPri(m, CbusConstants.DEFAULT_DYNAMIC_PRIORITY * 4 + CbusConstants.DEFAULT_MINOR_PRIORITY);
         tc.sendCanMessage(m, this);
+        
+        if (getFeedbackMode() == ONESENSOR || getFeedbackMode() == TWOSENSOR) {
+            Sensor s1 = getFirstSensor();
+            if (s1 != null) s1.requestUpdateFromLayout();
+        }
+        if (getFeedbackMode() == TWOSENSOR) {
+            Sensor s2 = getSecondSensor();
+            if (s2 != null) s2.requestUpdateFromLayout();
+        }
     }
     
     /**
@@ -145,9 +155,23 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
     @Override
     public void message(CanMessage f) {
         if (addrThrown.match(f)) {
-            newCommandedState(!getInverted() ? THROWN : CLOSED);
+            int state = (!getInverted() ? THROWN : CLOSED);
+            newCommandedState(state);
+            if (_activeFeedbackType == DIRECT) {
+                newKnownState(state);
+            } else if (_activeFeedbackType == DELAYED) {
+                newKnownState(INCONSISTENT);
+                jmri.util.ThreadingUtil.runOnLayoutDelayed( () -> { newKnownState(state); },DELAYED_FEEDBACK_INTERVAL );
+            }
         } else if (addrClosed.match(f)) {
-            newCommandedState(!getInverted() ? CLOSED : THROWN);
+            int state = (!getInverted() ? CLOSED : THROWN);
+            newCommandedState(state);
+            if (_activeFeedbackType == DIRECT) {
+                newKnownState(state);
+            } else if (_activeFeedbackType == DELAYED) {
+                newKnownState(INCONSISTENT);
+                jmri.util.ThreadingUtil.runOnLayoutDelayed( () -> { newKnownState(state); },DELAYED_FEEDBACK_INTERVAL );
+            }
         }
     }
     
@@ -159,9 +183,23 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
         // convert response events to normal
         f = CbusMessage.opcRangeToStl(f);
         if (addrThrown.match(f)) {
-            newCommandedState(!getInverted() ? THROWN : CLOSED);
+            int state = (!getInverted() ? THROWN : CLOSED);
+            newCommandedState(state);
+            if (_activeFeedbackType == DIRECT) {
+                newKnownState(state);
+            } else if (_activeFeedbackType == DELAYED) {
+                newKnownState(INCONSISTENT);
+                jmri.util.ThreadingUtil.runOnLayoutDelayed( () -> { newKnownState(state); },DELAYED_FEEDBACK_INTERVAL );
+            }
         } else if (addrClosed.match(f)) {
-            newCommandedState(!getInverted() ? CLOSED : THROWN);
+            int state = (!getInverted() ? CLOSED : THROWN);
+            newCommandedState(state);
+            if (_activeFeedbackType == DIRECT) {
+                newKnownState(state);
+            } else if (_activeFeedbackType == DELAYED) {
+                newKnownState(INCONSISTENT);
+                jmri.util.ThreadingUtil.runOnLayoutDelayed( () -> { newKnownState(state); },DELAYED_FEEDBACK_INTERVAL );
+            }
         }
     }
     

--- a/java/test/jmri/jmrix/can/cbus/CbusLightTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusLightTest.java
@@ -30,14 +30,14 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
     
     @Override
     public void checkOnMsgSent() {
-        Assert.assertEquals("ON message", "[78] 90 01 C8 01 41",
+        Assert.assertEquals("ON message", "[5f8] 90 01 C8 01 41",
         tcis.outbound.elementAt(tcis.outbound.size() - 1).toString());
         Assert.assertEquals("ON state", jmri.Light.ON, t.getState());
     }
 
     @Override
     public void checkOffMsgSent() {
-        Assert.assertEquals("OFF message", "[78] 91 01 C8 01 41",
+        Assert.assertEquals("OFF message", "[5f8] 91 01 C8 01 41",
         tcis.outbound.elementAt(tcis.outbound.size() - 1).toString());
         Assert.assertEquals("OFF state", jmri.Light.OFF, t.getState());
     }    
@@ -415,12 +415,12 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
     }
 
     public void checkStatusRequestMsgSent() {
-        Assert.assertEquals("same object", ("[78] 92 01 C8 01 41"), 
+        Assert.assertEquals("same object", ("[5f8] 92 01 C8 01 41"), 
             (tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
     }    
 
     public void checkShortStatusRequestMsgSent() {
-        Assert.assertEquals("same object", ("[78] 9A 00 00 D4 31"), 
+        Assert.assertEquals("same object", ("[5f8] 9A 00 00 D4 31"), 
             (tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
     } 
 
@@ -454,11 +454,11 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
         Assert.assertTrue(0 == t.getCurrentIntensity());
         t.setTargetIntensity(1);
         Assert.assertTrue(1.0 == t.getCurrentIntensity());
-        Assert.assertEquals("intensity on","[78] 90 01 C8 01 41" , 
+        Assert.assertEquals("intensity on","[5f8] 90 01 C8 01 41" , 
             (tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()) );
         t.setTargetIntensity(0.0);
         Assert.assertTrue(0 == t.getCurrentIntensity());
-        Assert.assertEquals("intensity on","[78] 91 01 C8 01 41" , 
+        Assert.assertEquals("intensity on","[5f8] 91 01 C8 01 41" , 
             (tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()) );        
         
          // t.setTargetIntensity(0.25); not currently defined for CBUS

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorTest.java
@@ -27,23 +27,23 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
 
     @Override
     public void checkOnMsgSent() {
-        Assert.assertTrue(("[78] 98 00 00 00 01").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
+        Assert.assertEquals(("[5f8] 98 00 00 00 01"),(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
     }
 
     @Override
     public void checkOffMsgSent() {
-        Assert.assertTrue(("[78] 99 00 00 00 01").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
+        Assert.assertEquals(("[5f8] 99 00 00 00 01"),(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
     }
 
     @Override
     public void checkStatusRequestMsgSent() {
-        Assert.assertTrue(("[78] 9A 00 00 00 01").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
+        Assert.assertEquals(("[5f8] 9A 00 00 00 01"),(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
     }
     
     // X923039D431
     
     public void checkLongStatusRequestMsgSent() {
-        Assert.assertTrue(("[78] 92 30 39 D4 31").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
+        Assert.assertEquals(("[5f8] 92 30 39 D4 31"),(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
     }
     
     public void checkNoMsgSent() {

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutTest.java
@@ -27,12 +27,12 @@ public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
 
     @Override
     public void checkClosedMsgSent() {
-        Assert.assertTrue(("[78] 99 00 00 00 01").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
+        Assert.assertTrue(("[5f8] 99 00 00 00 01").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
     }
 
     @Override
     public void checkThrownMsgSent() {
-        Assert.assertTrue(("[78] 98 00 00 00 01").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
+        Assert.assertTrue(("[5f8] 98 00 00 00 01").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
     }
 
     @Override
@@ -45,11 +45,11 @@ public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
     }
     
     public void checkStatusRequestMsgSent() {
-        Assert.assertTrue(("[78] 9A 00 00 00 01").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
+        Assert.assertTrue(("[5f8] 9A 00 00 00 01").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
     }    
 
     public void checkLongStatusRequestMsgSent() {
-        Assert.assertTrue(("[78] 92 30 39 D4 31").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
+        Assert.assertTrue(("[5f8] 92 30 39 D4 31").equals(tcis.outbound.elementAt(tcis.outbound.size() - 1).toString()));
     } 
     
     @Test


### PR DESCRIPTION
Adds CBUS priority to outgoing STL CanMessage
Adds CBUS Turnout support for DIRECT / DELAYED modes
Raised in response to user issue on MERG forum, also JMRI users [https://groups.io/g/jmriusers/message/155946](https://groups.io/g/jmriusers/message/155946)

Also adds short event check to get node number
Also added query sensors on turnout requestupdate if using sensors for turnout feedback