### PR TITLE
Fix schema  for RGB SignalHeads

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -389,7 +389,7 @@
 
         <h4>Signal Heads</h4>
             <ul>
-                <li></li>
+                <li>Fix an XML validation problem when reading files with RGB heads</li>
             </ul>
 
         <h4>Signal Masts</h4>

--- a/java/test/jmri/implementation/configurexml/load/RYG-RGB-test.xml
+++ b/java/test/jmri/implementation/configurexml/load/RYG-RGB-test.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="/xml/XSLT/panelfile-2-9-6.xsl" type="text/xsl"?>
+<layout-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/layout-2-9-6.xsd">
+  <jmriversion>
+    <major>4</major>
+    <minor>15</minor>
+    <test>3</test>
+    <modifier>ish</modifier>
+  </jmriversion>
+  <sensors class="jmri.jmrix.internal.configurexml.InternalSensorManagerXml">
+    <defaultInitialState>unknown</defaultInitialState>
+    <sensor inverted="false">
+      <systemName>ISCLOCKRUNNING</systemName>
+    </sensor>
+  </sensors>
+  <turnouts class="jmri.jmrix.internal.configurexml.InternalTurnoutManagerXml">
+    <operations automate="false">
+      <operation name="NoFeedback" class="jmri.configurexml.turnoutoperations.NoFeedbackTurnoutOperationXml" interval="300" maxtries="2" />
+      <operation name="Raw" class="jmri.configurexml.turnoutoperations.RawTurnoutOperationXml" interval="300" maxtries="1" />
+      <operation name="Sensor" class="jmri.configurexml.turnoutoperations.SensorTurnoutOperationXml" interval="300" maxtries="3" />
+    </operations>
+    <defaultclosedspeed>Normal</defaultclosedspeed>
+    <defaultthrownspeed>Restricted</defaultthrownspeed>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT1</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT2</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT3</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT11</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT12</systemName>
+    </turnout>
+    <turnout feedback="DIRECT" inverted="false" automate="Off">
+      <systemName>IT13</systemName>
+    </turnout>
+  </turnouts>
+  <memories class="jmri.managers.configurexml.DefaultMemoryManagerXml">
+    <memory value="8:26 PM">
+      <systemName>IMCURRENTTIME</systemName>
+    </memory>
+    <memory value="1.0">
+      <systemName>IMRATEFACTOR</systemName>
+    </memory>
+  </memories>
+  <signalheads class="jmri.managers.configurexml.AbstractSignalHeadManagerXml">
+    <signalhead class="jmri.implementation.configurexml.TripleTurnoutSignalHeadXml">
+      <systemName>IH1</systemName>
+      <userName>Triple Head RYG</userName>
+      <turnoutname defines="green">IT1</turnoutname>
+      <turnoutname defines="yellow">IT2</turnoutname>
+      <turnoutname defines="red">IT3</turnoutname>
+    </signalhead>
+    <signalhead class="jmri.implementation.configurexml.TripleOutputSignalHeadXml">
+      <systemName>IH2</systemName>
+      <userName>Triple Head RGB</userName>
+      <turnoutname defines="green">IT11</turnoutname>
+      <turnoutname defines="blue">IT12</turnoutname>
+      <turnoutname defines="red">IT13</turnoutname>
+    </signalhead>
+  </signalheads>
+  <signalmasts class="jmri.managers.configurexml.DefaultSignalMastManagerXml" />
+  <signalgroups class="jmri.managers.configurexml.DefaultSignalGroupManagerXml" />
+  <oblocks class="jmri.jmrit.logix.configurexml.OBlockManagerXml" />
+  <warrants class="jmri.jmrit.logix.configurexml.WarrantManagerXml" />
+  <signalmastlogics class="jmri.managers.configurexml.DefaultSignalMastLogicManagerXml">
+    <logicDelay>500</logicDelay>
+  </signalmastlogics>
+  <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Tue Jan 15 20:24:29 PST 2019" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
+</layout-config>

--- a/xml/schema/types/signalheads-2-9-6.xsd
+++ b/xml/schema/types/signalheads-2-9-6.xsd
@@ -117,6 +117,7 @@
                       </xs:simpleType>
                       <xs:simpleType>
                         <xs:restriction base="xs:string">
+                          <xs:enumeration value="blue"/><!-- for RGB signal heads -->
                           <xs:enumeration value="low"/>
                           <xs:enumeration value="high"/>
                           <xs:enumeration value="input1"/>


### PR DESCRIPTION
update schema to add "blue" for RGB SignalHeads. Add a test.  See Issue #6448 for background. Closes #6448 