### PR TITLE
Junit3 -> JUnit4 migration: remove static main()

### DIFF
--- a/help/en/Acknowledgements.shtml
+++ b/help/en/Acknowledgements.shtml
@@ -29,6 +29,9 @@
       number of people have contributed their effort to JMRI. They
       are listed below in alphabetical order and deserve our
       thanks.
+      See the  
+      <a href="http://jmri.org/Copyright.html">JMRI copyright and licensing page</a>
+      for the terms under which they make their work available to others.
 
       <p>In addition, a large number of people have donated to the
       project. For more information, or to donate, please see

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -460,5 +460,6 @@
             <li>We're building the release note a
                 <a href="/help/en/html/doc/Technical/gitdeveloper.shtml">different way</a>
                 starting with this release.</li>
+            <li>All the PackageList test files were updated to JUnit4 form, without a separate main()</li>
         </ul>
 

--- a/java/test/apps/configurexml/PackageTest.java
+++ b/java/test/apps/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package apps.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -23,20 +20,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/apps/startup/configurexml/PackageTest.java
+++ b/java/test/apps/startup/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package apps.startup.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,20 +17,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/implementation/configurexml/PackageTest.java
+++ b/java/test/jmri/implementation/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.implementation.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -32,20 +29,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/audio/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/audio/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.audio.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/blockboss/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/blockboss/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.blockboss.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/catalog/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/catalog/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.catalog.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.display.controlPanelEditor.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/display/controlPanelEditor/shape/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/display/controlPanelEditor/shape/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.display.controlPanelEditor.shape.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -22,20 +19,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/display/layoutEditor/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.display.layoutEditor.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -27,20 +24,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/display/panelEditor/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/display/panelEditor/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.display.panelEditor.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/entryexit/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/entryexit/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.entryexit.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/logix/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/logix/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.logix.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/operations/trains/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/operations/trains/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.operations.trains.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/revhistory/PackageTest.java
+++ b/java/test/jmri/jmrit/revhistory/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.revhistory;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/revhistory/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/revhistory/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.revhistory.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/roster/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/roster/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.roster.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrit/symbolicprog/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrit/symbolicprog/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrit.symbolicprog.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/acela/acelamon/PackageTest.java
+++ b/java/test/jmri/jmrix/acela/acelamon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.acela.acelamon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/acela/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/acela/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.acela.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/acela/nodeconfig/PackageTest.java
+++ b/java/test/jmri/jmrix/acela/nodeconfig/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.acela.nodeconfig;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/acela/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/acela/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.acela.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/acela/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/acela/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.acela.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/acela/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/acela/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.acela.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/anyma/PackageTest.java
+++ b/java/test/jmri/jmrix/anyma/PackageTest.java
@@ -4,8 +4,6 @@ import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -27,19 +25,4 @@ import org.slf4j.LoggerFactory;
  * @since 4.9.6
  */
 public class PackageTest {
-
-// Main entry point
-    static public void main(String[] args) {
-        Result result = JUnitCore.runClasses(PackageTest.class);
-        for (org.junit.runner.notification.Failure fail : result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log
-            = LoggerFactory.getLogger(PackageTest.class);
 }

--- a/java/test/jmri/jmrix/anyma/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/anyma/configurexml/PackageTest.java
@@ -4,8 +4,6 @@ import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,19 +17,4 @@ import org.slf4j.LoggerFactory;
  * @since 4.9.6
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        Result result = JUnitCore
-                .runClasses(PackageTest.class);
-        for (org.junit.runner.notification.Failure fail : result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
 }

--- a/java/test/jmri/jmrix/bachrus/PackageTest.java
+++ b/java/test/jmri/jmrix/bachrus/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.bachrus;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -30,20 +28,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/bachrus/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/bachrus/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.bachrus.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/bachrus/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/bachrus/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.bachrus.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/can2usbino/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/can2usbino/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.can2usbino;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/can2usbino/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/can2usbino/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.can2usbino.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/can2usbino/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/can2usbino/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.can2usbino.serialdriver.configurexml
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.canrs.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/canrs/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.canrs.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/canusb/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/canusb/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.canusb;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/canusb/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/canusb/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.canusb.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/canusb/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/canusb/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.canusb.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/lccbuffer/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/lccbuffer/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.lccbuffer;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/lccbuffer/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/lccbuffer/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.lccbuffer.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/lccbuffer/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/lccbuffer/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.lccbuffer.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/net/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/net/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.net;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -21,20 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/gridconnect/net/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/gridconnect/net/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.gridconnect.net.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/lawicell/canusb/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/lawicell/canusb/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.lawicell.canusb;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/lawicell/canusb/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/lawicell/canusb/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.lawicell.canusb.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/lawicell/canusb/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/lawicell/canusb/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.lawicell.canusb.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/loopback/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/loopback/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.loopback;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,20 +17,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/adapters/loopback/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/can/adapters/loopback/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.adapters.loopback.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/cbus/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.cbus.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.can.cbus.swing;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -26,20 +24,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/cbusslotmonitor/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.can.cbus.swing.cbusslotmonitor;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +17,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/configtool/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/configtool/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.can.cbus.swing.configtool;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/console/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/console/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.can.cbus.swing.console;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,20 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/eventtable/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/eventtable/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.can.cbus.swing.eventtable;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +17,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/nodeconfig/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.can.cbus.swing.nodeconfig;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +17,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/simulator/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/simulator/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.can.cbus.swing.simulator;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -21,20 +19,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/nmranet/PackageTest.java
+++ b/java/test/jmri/jmrix/can/nmranet/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.nmranet;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/nmranet/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/can/nmranet/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.nmranet.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -15,20 +12,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/nmranet/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/can/nmranet/swing/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.nmranet.swing;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/can/swing/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.swing;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -22,20 +19,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/swing/monitor/PackageTest.java
+++ b/java/test/jmri/jmrix/can/swing/monitor/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.swing.monitor;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/can/swing/send/PackageTest.java
+++ b/java/test/jmri/jmrix/can/swing/send/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.can.swing.send;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/PackageTest.java
@@ -2,10 +2,6 @@ package jmri.jmrix.cmri.serial;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-
 
 /**
  * Tests for the jmri.jmrix.cmri.serial package.
@@ -46,20 +42,4 @@ import org.slf4j.LoggerFactory;
 })
 
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/assignment/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/assignment/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.cmri.serial.assignment;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/cmrinetmanager/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/cmrinetmanager/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.cmri.serial.cmrinetmanager;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,20 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author  Chuck Catania	Copyright (C) 2017, 2018
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/cmrinetmetrics/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/cmrinetmetrics/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.cmri.serial.cmrinetmetrics;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author  Chuck Catania	Copyright (C) 2017
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class.getName());
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.cmri.serial.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/diagnostic/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/diagnostic/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.cmri.serial.diagnostic;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/networkdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/networkdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.cmri.serial.networkdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/networkdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/networkdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.cmri.serial.networkdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/nodeconfig/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/nodeconfig/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.cmri.serial.nodeconfig;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/nodeconfigmanager/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/nodeconfigmanager/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.cmri.serial.nodeconfigmanager;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,20 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author  Chuck Catania Copyright (C) 2017
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/nodeiolist/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/nodeiolist/PackageTest.java
@@ -2,10 +2,6 @@ package jmri.jmrix.cmri.serial.nodeiolist;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-
 
 /**
  * Tests for the jmri.jmrix.cmri.serial.nodeiolist package.
@@ -21,20 +17,4 @@ import org.slf4j.LoggerFactory;
 })
 
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.cmri.serial.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.cmri.serial.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.cmri.serial.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/serialmon/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/serialmon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.cmri.serial.serialmon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,20 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/sim/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/sim/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.cmri.serial.sim;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/cmri/serial/sim/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/sim/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.cmri.serial.sim.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dcc/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/dcc/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.dcc.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dcc4pc/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.dcc4pc.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dcc4pc/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.dcc4pc.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dcc4pc/swing/boardlists/PackageTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/swing/boardlists/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.dcc4pc.swing.boardlists;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dcc4pc/swing/monitor/PackageTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/swing/monitor/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.dcc4pc.swing.monitor;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dcc4pc/swing/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/dcc4pc/swing/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.dcc4pc.swing.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dccpp/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.dccpp.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dccpp/dccppovertcp/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/dccppovertcp/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.dccpp.dccppovertcp;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -23,20 +20,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dccpp/dccppovertcp/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/dccppovertcp/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.dccpp.dccppovertcp.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dccpp/network/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/network/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.dccpp.network.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dccpp/serial/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/serial/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.dccpp.serial;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,20 +17,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dccpp/serial/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/serial/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.dccpp.serial.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dccpp/simulator/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/simulator/PackageTest.java
@@ -19,20 +19,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dccpp/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/simulator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.dccpp.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dccpp/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/swing/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.dccpp.swing;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -23,20 +21,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dccpp/swing/mon/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/swing/mon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.dccpp.swing.mon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/dccpp/swing/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/dccpp/swing/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.dccpp.swing.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/direct/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/direct/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.direct.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -15,20 +12,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/direct/serial/PackageTest.java
+++ b/java/test/jmri/jmrix/direct/serial/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.direct.serial;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/direct/serial/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/direct/serial/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.direct.serial.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/direct/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/direct/simulator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.direct.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/easydcc/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/easydcc/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.easydcc.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/easydcc/networkdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/easydcc/networkdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.easydcc.networkdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/easydcc/networkdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/easydcc/networkdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.easydcc.networkdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/easydcc/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/easydcc/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.easydcc.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/easydcc/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/easydcc/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.easydcc.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/easydcc/simulator/PackageTest.java
+++ b/java/test/jmri/jmrix/easydcc/simulator/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.easydcc.simulator;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,20 +17,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/easydcc/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/easydcc/simulator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.easydcc.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ecos/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.ecos.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,20 +17,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ecos/networkdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/networkdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.ecos.networkdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ecos/networkdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/networkdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.ecos.networkdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ecos/swing/monitor/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/swing/monitor/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.ecos.swing.monitor;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ecos/swing/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/swing/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.ecos.swing.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ecos/swing/preferences/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/swing/preferences/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.ecos.swing.preferences;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +17,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ecos/swing/statusframe/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/swing/statusframe/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.ecos.swing.statusframe;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ecos/utilities/PackageTest.java
+++ b/java/test/jmri/jmrix/ecos/utilities/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.ecos.utilities;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -21,20 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/grapevine/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/grapevine/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.grapevine.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/grapevine/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/grapevine/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.grapevine.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/grapevine/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/grapevine/simulator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.grapevine.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ieee802154/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/ieee802154/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.ieee802154.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ieee802154/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/ieee802154/swing/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.ieee802154.swing;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -21,20 +19,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ieee802154/swing/mon/PackageTest.java
+++ b/java/test/jmri/jmrix/ieee802154/swing/mon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.ieee802154.swing.mon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ieee802154/swing/nodeconfig/PackageTest.java
+++ b/java/test/jmri/jmrix/ieee802154/swing/nodeconfig/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.ieee802154.swing.nodeconfig;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,20 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ieee802154/swing/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/ieee802154/swing/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.ieee802154.swing.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ieee802154/xbee/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.ieee802154.xbee.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ieee802154/xbee/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/swing/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.ieee802154.xbee.swing;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,22 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        jmri.util.JUnitUtil.setUp();
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ieee802154/xbee/swing/nodeconfig/PackageTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/swing/nodeconfig/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.ieee802154.xbee.swing.nodeconfig;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -22,20 +20,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/jmriclient/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/jmriclient/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.jmriclient.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/jmriclient/networkdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/jmriclient/networkdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.jmriclient.networkdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/jmriclient/networkdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/jmriclient/networkdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.jmriclient.networkdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/jmriclient/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/jmriclient/swing/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.jmriclient.swing;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,22 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        jmri.util.JUnitUtil.setUp();
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/jmriclient/swing/mon/PackageTest.java
+++ b/java/test/jmri/jmrix/jmriclient/swing/mon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.jmriclient.swing.mon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/jmriclient/swing/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/jmriclient/swing/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.jmriclient.swing.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/lenz/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.lenz.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/lenz/hornbyelite/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.lenz.hornbyelite.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/lenz/li100/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/li100/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.lenz.li100.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/lenz/li100f/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/li100f/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.lenz.li100f.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/lenz/li101/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/li101/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.lenz.li101.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/lenz/liusb/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/liusb/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.lenz.liusb.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/lenz/liusbethernet/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/liusbethernet/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.lenz.liusbethernet.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/lenz/liusbserver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/liusbserver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.lenz.liusbserver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/lenz/xnetsimulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/xnetsimulator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.lenz.xnetsimulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/lenz/xntcp/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/xntcp/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.lenz.xntcp.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/lenz/ztc640/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/lenz/ztc640/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.lenz.ztc640.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/Intellibox/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/Intellibox/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.Intellibox;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -21,20 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/Intellibox/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/Intellibox/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.Intellibox.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/bluetooth/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/bluetooth/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.bluetooth;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/bluetooth/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/bluetooth/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.bluetooth.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -21,20 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/hexfile/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/hexfile/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.hexfile.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/locobuffer/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/locobuffer/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.locobuffer;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/locobuffer/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/locobuffer/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.locobuffer.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/locobufferii/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/locobufferii/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.locobufferii;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/locobufferii/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/locobufferii/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.locobufferii.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/locobufferusb/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/locobufferusb/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.locobufferusb;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/locobufferusb/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/locobufferusb/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.locobufferusb.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/loconetovertcp/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/loconetovertcp/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.loconetovertcp.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/locormi/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/locormi/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.locormi;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -24,20 +21,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/locormi/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/locormi/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.locormi.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/ms100/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/ms100/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.ms100;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/ms100/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/ms100/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.ms100.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/pr2/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/pr2/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.pr2;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -22,20 +19,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/pr2/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/pr2/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.pr2.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/pr3/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/pr3/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.pr3.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/uhlenbrock/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/uhlenbrock/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.uhlenbrock;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -24,20 +21,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/loconet/uhlenbrock/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/loconet/uhlenbrock/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.loconet.uhlenbrock.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/maple/assignment/PackageTest.java
+++ b/java/test/jmri/jmrix/maple/assignment/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.maple.assignment;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/maple/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/maple/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.maple.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/maple/nodeconfig/PackageTest.java
+++ b/java/test/jmri/jmrix/maple/nodeconfig/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.maple.nodeconfig;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/maple/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/maple/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.maple.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/maple/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/maple/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.maple.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/maple/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/maple/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.maple.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/maple/serialmon/PackageTest.java
+++ b/java/test/jmri/jmrix/maple/serialmon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.maple.serialmon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/maple/simulator/PackageTest.java
+++ b/java/test/jmri/jmrix/maple/simulator/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.maple.simulator;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/maple/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/maple/simulator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.maple.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/marklin/PackageTest.java
+++ b/java/test/jmri/jmrix/marklin/PackageTest.java
@@ -3,9 +3,6 @@ package jmri.jmrix.marklin;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -34,21 +31,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
-
 }

--- a/java/test/jmri/jmrix/marklin/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/marklin/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.marklin.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/marklin/networkdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/marklin/networkdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.marklin.networkdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/marklin/networkdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/marklin/networkdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.marklin.networkdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/marklin/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/marklin/swing/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.marklin.swing;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -21,20 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/marklin/swing/monitor/PackageTest.java
+++ b/java/test/jmri/jmrix/marklin/swing/monitor/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.marklin.swing.monitor;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,19 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/marklin/swing/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/marklin/swing/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.marklin.swing.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,19 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/mqtt/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/mqtt/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.mqtt.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/mrc/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/mrc/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.mrc.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/mrc/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/mrc/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.mrc.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/mrc/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/mrc/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.mrc.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/mrc/simulator/PackageTest.java
+++ b/java/test/jmri/jmrix/mrc/simulator/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.mrc.simulator;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/mrc/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/mrc/simulator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.mrc.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/boosterprog/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/boosterprog/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.nce.boosterprog;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/cab/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/cab/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.nce.cab;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.nce.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/macro/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/macro/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.nce.macro;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,20 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/ncemon/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/ncemon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.nce.ncemon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/networkdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/networkdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.nce.networkdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/networkdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/networkdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.nce.networkdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/packetgen/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.nce.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2017
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.nce.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.nce.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/simulator/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/simulator/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.nce.simulator;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/simulator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.nce.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/usbdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/usbdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.nce.usbdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/usbdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/usbdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.nce.usbdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/nce/usbinterface/PackageTest.java
+++ b/java/test/jmri/jmrix/nce/usbinterface/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.nce.usbinterface;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/ncemonitor/PackageTest.java
+++ b/java/test/jmri/jmrix/ncemonitor/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.ncemonitor;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/oaktree/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/oaktree/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.oaktree.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/oaktree/nodeconfig/PackageTest.java
+++ b/java/test/jmri/jmrix/oaktree/nodeconfig/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.oaktree.nodeconfig;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/oaktree/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/oaktree/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.oaktree.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/oaktree/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/oaktree/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.oaktree.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/oaktree/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/oaktree/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.oaktree.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/oaktree/serialmon/PackageTest.java
+++ b/java/test/jmri/jmrix/oaktree/serialmon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.oaktree.serialmon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/oaktree/simulator/PackageTest.java
+++ b/java/test/jmri/jmrix/oaktree/simulator/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.oaktree.simulator;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/oaktree/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/oaktree/simulator/configurexml/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.oaktree.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -15,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/pi/PackageTest.java
+++ b/java/test/jmri/jmrix/pi/PackageTest.java
@@ -3,7 +3,6 @@ package jmri.jmrix.pi;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
    RaspberryPiConnectionConfigTest.class,
@@ -23,12 +22,4 @@ import org.junit.runners.Suite;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.JUnitCore.main(PackageTest.class.getName());
-    }
-
-    // private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/cm11/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/cm11/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.powerline.cm11;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -27,20 +24,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/cm11/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/cm11/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.powerline.cm11.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.powerline.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/cp290/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/cp290/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.powerline.cp290;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -26,20 +23,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/cp290/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/cp290/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.powerline.cp290.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/insteon2412s/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/insteon2412s/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.powerline.insteon2412s;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -29,20 +26,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/insteon2412s/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/insteon2412s/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.powerline.insteon2412s.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.powerline.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.powerline.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/simulator/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/simulator/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.powerline.simulator;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -27,20 +24,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/simulator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.powerline.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/swing/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.powerline.swing;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -21,20 +18,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/swing/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/swing/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.powerline.swing.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/powerline/swing/serialmon/PackageTest.java
+++ b/java/test/jmri/jmrix/powerline/swing/serialmon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.powerline.swing.serialmon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/qsi/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/qsi/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.qsi.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/qsi/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/qsi/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.qsi.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rfid/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/rfid/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.rfid.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rfid/generic/PackageTest.java
+++ b/java/test/jmri/jmrix/rfid/generic/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.rfid.generic;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rfid/generic/standalone/PackageTest.java
+++ b/java/test/jmri/jmrix/rfid/generic/standalone/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.rfid.generic.standalone;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -22,20 +19,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rfid/generic/standalone/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/rfid/generic/standalone/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.rfid.generic.standalone.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rfid/merg/PackageTest.java
+++ b/java/test/jmri/jmrix/rfid/merg/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.rfid.merg;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rfid/merg/concentrator/PackageTest.java
+++ b/java/test/jmri/jmrix/rfid/merg/concentrator/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.rfid.merg.concentrator;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -22,20 +19,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rfid/merg/concentrator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/rfid/merg/concentrator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.rfid.merg.concentrator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rfid/networkdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/rfid/networkdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.rfid.networkdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rfid/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/rfid/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.rfid.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rfid/swing/serialmon/PackageTest.java
+++ b/java/test/jmri/jmrix/rfid/swing/serialmon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.rfid.swing.serialmon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/roco/z21/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/roco/z21/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.roco.z21.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/roco/z21/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/roco/z21/simulator/configurexml/PackageTest.java
@@ -17,20 +17,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/roco/z21/swing/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/roco/z21/swing/packetgen/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.roco.z21.swing.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rps/aligntable/PackageTest.java
+++ b/java/test/jmri/jmrix/rps/aligntable/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.rps.aligntable;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rps/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/rps/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.rps.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rps/serial/PackageTest.java
+++ b/java/test/jmri/jmrix/rps/serial/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.rps.serial;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,5 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
 
 }

--- a/java/test/jmri/jmrix/rps/serial/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/rps/serial/configurexml/PackageTest.java
@@ -16,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/rps/swing/soundset/PackageTest.java
+++ b/java/test/jmri/jmrix/rps/swing/soundset/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.rps.swing.soundset;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/secsi/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/secsi/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.secsi.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/secsi/nodeconfig/PackageTest.java
+++ b/java/test/jmri/jmrix/secsi/nodeconfig/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.secsi.nodeconfig;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/secsi/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/secsi/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.secsi.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/secsi/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/secsi/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.secsi.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/secsi/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/secsi/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.secsi.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/secsi/serialmon/PackageTest.java
+++ b/java/test/jmri/jmrix/secsi/serialmon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.secsi.serialmon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/secsi/simulator/PackageTest.java
+++ b/java/test/jmri/jmrix/secsi/simulator/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.secsi.simulator;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/secsi/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/secsi/simulator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.secsi.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/serialsensor/PackageTest.java
+++ b/java/test/jmri/jmrix/serialsensor/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.serialsensor;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.sprog.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/console/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/console/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.sprog.console;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,19 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.sprog.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,19 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/pi/pisprognano/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprognano/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.sprog.pi.pisprognano.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/pi/pisprogone/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprogone/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.sprog.pi.pisprogone.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/pi/pisprogonecs/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/pi/pisprogonecs/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.sprog.pi.pisprogonecs.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.sprog.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/simulator/configurexml/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.sprog.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 @RunWith(Suite.class)
@@ -16,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/sprog/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/sprog/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.sprog.sprog.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/sprogCS/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/sprogCS/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.sprog.sprogCS.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/sprogmon/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/sprogmon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.sprog.sprogmon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,19 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/sprognano/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/sprognano/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.sprog.sprognano.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/sprogslotmon/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/sprogslotmon/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.sprog.sprogslotmon;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,19 +17,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/sprog/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/sprog/swing/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.sprog.swing;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/srcp/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/srcp/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.srcp.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/srcp/networkdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/srcp/networkdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.srcp.networkdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/srcp/networkdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/srcp/networkdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.srcp.networkdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tams/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/tams/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.tams.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tams/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/tams/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.tams.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tams/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/tams/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.tams.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tams/simulator/PackageTest.java
+++ b/java/test/jmri/jmrix/tams/simulator/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.tams.simulator;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tams/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/tams/simulator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.tams.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tams/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/tams/swing/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.tams.swing;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -22,20 +19,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tams/swing/locodatabase/PackageTest.java
+++ b/java/test/jmri/jmrix/tams/swing/locodatabase/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.tams.swing.locodatabase;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,19 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tams/swing/monitor/PackageTest.java
+++ b/java/test/jmri/jmrix/tams/swing/monitor/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.tams.swing.monitor;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,19 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tams/swing/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/tams/swing/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.tams.swing.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,19 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tams/swing/statusframe/PackageTest.java
+++ b/java/test/jmri/jmrix/tams/swing/statusframe/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.tams.swing.statusframe;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,19 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tmcc/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/tmcc/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.tmcc.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tmcc/packetgen/PackageTest.java
+++ b/java/test/jmri/jmrix/tmcc/packetgen/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.tmcc.packetgen;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tmcc/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/tmcc/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.tmcc.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -20,20 +17,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tmcc/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/tmcc/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.tmcc.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tmcc/simulator/PackageTest.java
+++ b/java/test/jmri/jmrix/tmcc/simulator/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.tmcc.simulator;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/tmcc/simulator/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/tmcc/simulator/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.tmcc.simulator.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/wangrow/PackageTest.java
+++ b/java/test/jmri/jmrix/wangrow/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.wangrow;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/wangrow/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/wangrow/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.wangrow.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/wangrow/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/wangrow/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.wangrow.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/xpa/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/xpa/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.xpa.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/xpa/serialdriver/PackageTest.java
+++ b/java/test/jmri/jmrix/xpa/serialdriver/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.xpa.serialdriver;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/xpa/serialdriver/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/xpa/serialdriver/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.xpa.serialdriver.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/zimo/mx1/PackageTest.java
+++ b/java/test/jmri/jmrix/zimo/mx1/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.zimo.mx1;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/zimo/mx1/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/zimo/mx1/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.zimo.mx1.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/zimo/mxulf/PackageTest.java
+++ b/java/test/jmri/jmrix/zimo/mxulf/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.zimo.mxulf;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -19,20 +16,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/zimo/mxulf/configurexml/PackageTest.java
+++ b/java/test/jmri/jmrix/zimo/mxulf/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.jmrix.zimo.mxulf.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/jmrix/zimo/swing/monitor/PackageTest.java
+++ b/java/test/jmri/jmrix/zimo/swing/monitor/PackageTest.java
@@ -2,8 +2,6 @@ package jmri.jmrix.zimo.swing.monitor;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author  Paul Bender	Copyright (C) 2016
  */
 public class PackageTest{
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/util/com/PackageTest.java
+++ b/java/test/jmri/util/com/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.util.com;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -18,20 +15,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/util/com/rbnb/PackageTest.java
+++ b/java/test/jmri/util/com/rbnb/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.util.com.rbnb;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/util/datatransfer/PackageTest.java
+++ b/java/test/jmri/util/datatransfer/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.util.datatransfer;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/util/davidflanagan/PackageTest.java
+++ b/java/test/jmri/util/davidflanagan/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.util.davidflanagan;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -17,20 +14,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/util/docbook/configurexml/PackageTest.java
+++ b/java/test/jmri/util/docbook/configurexml/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.util.docbook.configurexml;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }

--- a/java/test/jmri/util/javamail/PackageTest.java
+++ b/java/test/jmri/util/javamail/PackageTest.java
@@ -2,9 +2,6 @@ package jmri.util.javamail;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
@@ -16,20 +13,4 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (C) 2016
  */
 public class PackageTest {
-
-    // Main entry point
-    static public void main(String[] args) {
-        org.junit.runner.Result result = org.junit.runner.JUnitCore
-                 .runClasses(PackageTest.class);
-        for(org.junit.runner.notification.Failure fail: result.getFailures()) {
-            log.error(fail.toString());
-        }
-        //junit.textui.TestRunner.main(testCaseName);
-        if (result.wasSuccessful()) {
-            log.info("Success");
-        }
-    }
-
-    private final static Logger log = LoggerFactory.getLogger(PackageTest.class);
-
 }


### PR DESCRIPTION
JUnit3 -> JUnit4 migration of the PackageTest files: remove the `static void main(..)` method.  This lets `./runtest.csh` properly handle these.