### PR TITLE
HTML scan should skip releasenotes/

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1999,7 +1999,7 @@
         <exec executable="./scripts/tidy-check.sh"
               osFamily="unix"
               failonerror="true">
-            <arg value="help/en/*/*/"/>
+            <arg value="help/en/*/*"/>
         </exec>
             
     </target>

--- a/scripts/tidy-check.sh
+++ b/scripts/tidy-check.sh
@@ -1,15 +1,15 @@
 #! /bin/bash
 # scan the help files for HMTL errors, used in 'ant html'
-# if an argument is provided, i.e. "help/en/*/" scan there, otherwise scan all the help
+# if an argument is provided, i.e. "help/en/*/*" scan there, otherwise scan all the help
 
 if [[ "$@" == "" ]] ; then
-    WHERE=help/*/*/
+    WHERE=help/*/*
 else
     WHERE=$@
 fi
 
 # first, scan for whether there's an issue (omitting known fragment files)
-find ${WHERE} -name \*html ! -name Sidebar.shtml -exec echo Filename: {} \;  ! -exec tidy -eq -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | awk -f scripts/tidy.awk | grep Warning 1>&2
+find ${WHERE} -name \*html ! -path 'help/en/releasenotes/*' ! -name Sidebar.shtml -exec echo Filename: {} \;  ! -exec tidy -eq -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | awk -f scripts/tidy.awk | grep Warning 1>&2
 
 # swap return code from grep
 if [ $? -eq 0 ]; then

--- a/scripts/tidy-scan.sh
+++ b/scripts/tidy-scan.sh
@@ -1,13 +1,13 @@
 #! /bin/bash
 # scan the help files for HMTL errors, used in Jenkins as "tidy-scan.sh help/en/*/*"
 # formats output for Jenkins presentation
-# if an argument is provided, i.e. "help/en/*/" scan there, otherwise scan all the help
+# if an argument is provided, i.e. "help/en/*/*" scan there, otherwise scan all the help
 
 if [[ "$@" == "" ]] ; then
-    WHERE=help/*/*/
+    WHERE=help/*/*
 else
     WHERE=$@
 fi
 
 # first, scan for whether there's an issue (omitting known fragment files)
-find ${WHERE}  -name \*html ! -name Sidebar.shtml -exec echo Filename: {} \; -exec tidy -e -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | tr '<' '&lt;' | tr '>' '&gt;' | awk -f scripts/tidy.awk
+find ${WHERE}  -name \*html ! -path 'help/en/releasenotes/*' ! -name Sidebar.shtml -exec echo Filename: {} \; -exec tidy -e -access 0 {} \; 2>&1 | grep -v '<table> lacks "summary" attribute' | grep -v '<img> lacks "alt" attribute' | tr '<' '&lt;' | tr '>' '&gt;' | awk -f scripts/tidy.awk


### PR DESCRIPTION
The SHTML files in help/en/releasenotes are fragments for inclusion elsewhere, so shouldn't be scanned for HTML errors (at least until we work out how to scan fragments that are missing their open/close HTML tags).  This suppresses those in the scripts/tidy-check and scripts/tidy-scan tools, and via `ant scan help`