### PR TITLE
Make AbstractNamedBean.getFullyFormattedDisplayName() final

### DIFF
--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -97,16 +97,11 @@ public abstract class AbstractNamedBean implements NamedBean {
         }
     }
 
-    /**
-     * <p>
-     * It would be good to eventually make this final to 
-     * keep it consistent system-wide, but 
-     * we have some existing classes to update first.
-     */
+    /** {@inheritDoc} */
     @Override
-    public String getFullyFormattedDisplayName() {
+    final public String getFullyFormattedDisplayName() {
         String name = getUserName();
-        if (name != null && name.length() > 0 && !name.equals(getSystemName())) {
+        if (name != null && !name.isEmpty() && !name.equals(getSystemName())) {
             name = getSystemName() + "(" + name + ")";
         } else {
             name = getSystemName();
@@ -203,6 +198,7 @@ public abstract class AbstractNamedBean implements NamedBean {
         return pcs.getPropertyChangeListeners();
     }
 
+    /** {@inheritDoc} */
     @Override
     final public String getSystemName() {
         return mSystemName;


### PR DESCRIPTION
I also tested to make AbstractNamedBean.toString() final, but that method has a lot of different implementations and I'm afraid to break things if I change that.

The classes with different toString() implementations are:
[jmri.jmrit.logix.Portal](https://github.com/JMRI/JMRI/blob/master/java/src/jmri/jmrit/logix/Portal.java)
[jmri.implementation.AbstractAudio](https://github.com/JMRI/JMRI/blob/master/java/src/jmri/implementation/AbstractAudio.java)
[jmri.implementation.AbstractIdTag](https://github.com/JMRI/JMRI/blob/master/java/src/jmri/implementation/AbstractIdTag.java)
[jmri.implementation.AbstractStringIO](https://github.com/JMRI/JMRI/blob/master/java/src/jmri/implementation/AbstractStringIO.java) - This is created by me and new so changing it will probably not break anything.
[jmri.implementation.DefaultRailCom](https://github.com/JMRI/JMRI/blob/master/java/src/jmri/implementation/DefaultRailCom.java)
[jmri.implementation.DefaultSignalSystem](https://github.com/JMRI/JMRI/blob/master/java/src/jmri/implementation/DefaultSignalSystem.java)
[jmri.jmrit.audio.AbstractAudioListener](https://github.com/JMRI/JMRI/blob/master/java/src/jmri/jmrit/audio/AbstractAudioListener.java)
[jmri.jmrit.audio.AbstractAudioSource](https://github.com/JMRI/JMRI/blob/master/java/src/jmri/jmrit/audio/AbstractAudioSource.java)
[jmri.jmrit.audio.JavaSoundAudioBuffer](https://github.com/JMRI/JMRI/blob/master/java/src/jmri/jmrit/audio/JavaSoundAudioBuffer.java)
[jmri.jmrit.audio.JoalAudioBuffer](https://github.com/JMRI/JMRI/blob/master/java/src/jmri/jmrit/audio/JoalAudioBuffer.java)
[jmri.jmrit.audio.NullAudioBuffer](https://github.com/JMRI/JMRI/blob/master/java/src/jmri/jmrit/audio/NullAudioBuffer.java)
