### PR TITLE
Reporter takes a Report instead of an Object

### DIFF
--- a/java/src/jmri/IdTag.java
+++ b/java/src/jmri/IdTag.java
@@ -25,7 +25,7 @@ import org.jdom2.Element;
  * @author Matthew Harris Copyright (C) 2011
  * @since 2.11.4
  */
-public interface IdTag extends NamedBean {
+public interface IdTag extends NamedBean, Report {
 
     /**
      * Constant representing an "unseen" state, indicating that the ID tag has

--- a/java/src/jmri/Report.java
+++ b/java/src/jmri/Report.java
@@ -1,0 +1,13 @@
+package jmri;
+
+/**
+ * Report is a message sent to a Reporter.
+ *
+ * @author Daniel Bergqvist Copyright (C) 2019
+ * @since 4.13
+ */
+public interface Report {
+
+    public String getString();
+    
+}

--- a/java/src/jmri/Reporter.java
+++ b/java/src/jmri/Reporter.java
@@ -15,7 +15,7 @@ package jmri;
  * <P>
  * In contrast to Sensors, a Reporter provides more detailed information. A
  * Sensor provides a status of ACTIVE or INACTIVE, while a Reporter returns an
- * Object. The real type of that object can be whatever a particular Reporter
+ * Report. The real type of that report can be whatever a particular Reporter
  * finds useful to report. Typical values might be a String or Int, both of
  * which can be displayed, printed, equated, etc.
  * <P>
@@ -47,23 +47,23 @@ public interface Reporter extends NamedBean {
      * Query the last report. This will return a value even if there's no
      * current report available. If there is a current report, both this and the
      * current report will be equal. If nothing has ever been reported, this
-     * will return a null object.
+     * will return null.
      *
      * @return the last report or null
      */
-    public Object getLastReport();
+    public Report getLastReport();
 
     /**
      * Query the current report. If there is no current report available (e.g.
      * the reporting hardware says no information is currently available) this
-     * will return a null object.
+     * will return null.
      *
      * @return the current report or null
      */
-    public Object getCurrentReport();
+    public Report getCurrentReport();
 
     /**
-     * Set the report to an arbitrary object.
+     * Set the report.
      * <P>
      * A Reporter object will usually just "report"; its contents usually come
      * from the layout, and hence are only set by lower-level implementation
@@ -73,7 +73,7 @@ public interface Reporter extends NamedBean {
      *
      * @param r the report
      */
-    public void setReport(Object r);
+    public void setReport(Report r);
 
     /**
      * Provide an integer form of the last report.

--- a/java/src/jmri/implementation/AbstractIdTag.java
+++ b/java/src/jmri/implementation/AbstractIdTag.java
@@ -57,6 +57,12 @@ public abstract class AbstractIdTag extends AbstractNamedBean implements IdTag {
         }
     }
 
+    @Override
+    public String getString() {
+        String userName = getUserName();
+        return (userName == null || userName.isEmpty()) ? getTagID() : userName;
+    }
+
     // note that this doesn't properly implement the 
     // contract in {@link NamedBean.toString()}, 
     // which means things like tables and persistance 

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -218,6 +218,8 @@ public abstract class AbstractNamedBean implements NamedBean {
     @Nonnull
     @Override
     public String toString() {
+        jmri.IdTag a;
+        jmri.Reporter r;
         return getSystemName();
     }
 

--- a/java/src/jmri/implementation/AbstractReporter.java
+++ b/java/src/jmri/implementation/AbstractReporter.java
@@ -1,5 +1,6 @@
 package jmri.implementation;
 
+import jmri.Report;
 import jmri.Reporter;
 
 /**
@@ -32,12 +33,12 @@ public abstract class AbstractReporter extends AbstractNamedBean implements Repo
     }
     
     @Override
-    public Object getCurrentReport() {
+    public Report getCurrentReport() {
         return _currentReport;
     }
 
     @Override
-    public Object getLastReport() {
+    public Report getLastReport() {
         return _lastReport;
     }
 
@@ -45,12 +46,12 @@ public abstract class AbstractReporter extends AbstractNamedBean implements Repo
      * Provide a general method for updating the report.
      */
     @Override
-    public void setReport(Object r) {
+    public void setReport(Report r) {
         if (r == _currentReport) {
             return;
         }
-        Object old = _currentReport;
-        Object oldLast = _lastReport;
+        Report old = _currentReport;
+        Report oldLast = _lastReport;
         _currentReport = r;
         if (r != null) {
             _lastReport = r;
@@ -62,7 +63,7 @@ public abstract class AbstractReporter extends AbstractNamedBean implements Repo
     }
 
     // internal data members
-    protected Object _lastReport = null;
-    protected Object _currentReport = null;
+    protected Report _lastReport = null;
+    protected Report _currentReport = null;
 
 }

--- a/java/src/jmri/implementation/StringReport.java
+++ b/java/src/jmri/implementation/StringReport.java
@@ -1,0 +1,28 @@
+package jmri.implementation;
+
+import jmri.Report;
+
+/**
+ * A Report that has a String.
+ * 
+ * @author Daniel Bergqvist Copyright 2019
+ */
+public class StringReport implements Report {
+
+    private final String _str;
+    
+    public StringReport(String str) {
+        _str = str;
+    }
+    
+    @Override
+    public String getString() {
+        return _str;
+    }
+    
+    @Override
+    public String toString() {
+        return getString();
+    }
+    
+}

--- a/java/src/jmri/jmris/AbstractReporterServer.java
+++ b/java/src/jmri/jmris/AbstractReporterServer.java
@@ -7,7 +7,9 @@ import java.util.HashMap;
 import java.util.Map;
 import jmri.InstanceManager;
 import jmri.JmriException;
+import jmri.Report;
 import jmri.Reporter;
+import jmri.implementation.StringReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +31,7 @@ abstract public class AbstractReporterServer {
     /*
      * Protocol Specific Abstract Functions
      */
-    abstract public void sendReport(String reporter, Object r) throws IOException;
+    abstract public void sendReport(String reporter, Report r) throws IOException;
 
     abstract public void sendErrorStatus(String reporter) throws IOException;
 
@@ -65,9 +67,9 @@ abstract public class AbstractReporterServer {
      * Set the report state of a reporter
      * 
      * @parm reporterName - the name of a reporter
-     * @parm r - the object containing the report (currently a string).
+     * @parm r - the report.
      */
-    public void setReporterReport(String reporterName, Object r) {
+    public void setReporterReport(String reporterName, Report r) {
         Reporter reporter;
         // load address from reporterAddrTextField
         try {
@@ -114,7 +116,7 @@ abstract public class AbstractReporterServer {
                     now = null;
                 }
                 try {
-                    sendReport(name, now);
+                    sendReport(name, new StringReport(now));
                 } catch (IOException ie) {
                     log.debug("Error Sending Status");
                     // if we get an error, de-register

--- a/java/src/jmri/jmris/simpleserver/SimpleReporterServer.java
+++ b/java/src/jmri/jmris/simpleserver/SimpleReporterServer.java
@@ -5,7 +5,9 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import jmri.InstanceManager;
 import jmri.JmriException;
+import jmri.Report;
 import jmri.Reporter;
+import jmri.implementation.StringReport;
 import jmri.jmris.AbstractReporterServer;
 import jmri.jmris.JmriConnection;
 
@@ -36,7 +38,7 @@ public class SimpleReporterServer extends AbstractReporterServer {
      * Protocol Specific Abstract Functions
      */
     @Override
-    public void sendReport(String reporterName, Object r) throws IOException {
+    public void sendReport(String reporterName, Report r) throws IOException {
         addReporterToList(reporterName);
         if (r != null) {
             this.sendMessage("REPORTER " + reporterName + " " + r.toString() + "\n");
@@ -62,7 +64,7 @@ public class SimpleReporterServer extends AbstractReporterServer {
         // where xxxxxx is the reporter identifier and REPORTSTRING is
         // the report, which may contain spaces.
         if (index2 > 0 && ( newlinepos - (index2 + 1) > 0)) {
-            setReporterReport(reporterName, statusString.substring(index2 + 1,newlinepos));
+            setReporterReport(reporterName, new StringReport(statusString.substring(index2 + 1,newlinepos)));
             // setReporterReport ALSO triggers sending the status report, so 
             // no further action is required to echo the status to the client.
         } else {

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -20,6 +20,7 @@ import javax.swing.JTextField;
 import javax.swing.SpinnerNumberModel;
 import jmri.InstanceManager;
 import jmri.Manager;
+import jmri.Report;
 import jmri.Reporter;
 import jmri.ReporterManager;
 import jmri.util.ConnectionNameFromSystemName;
@@ -135,7 +136,7 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
             public void setValueAt(Object value, int row, int col) {
                 if (col == VALUECOL) {
                     Reporter t = getBySystemName(sysNameList.get(row));
-                    t.setReport(value);
+                    t.setReport((Report)value);
                     fireTableRowsUpdated(row, row);
                 }
                 if (col == LASTREPORTCOL) {

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
@@ -707,9 +707,9 @@ public class VSDecoderManager implements PropertyChangeListener {
                         return;
                     }
                     if (blk.isReportingCurrent()) {
-                        repVal = (String) blk.getReporter().getCurrentReport();
+                        repVal = blk.getReporter().getCurrentReport().getString();
                     } else {
-                        repVal = (String) blk.getReporter().getLastReport();
+                        repVal = blk.getReporter().getLastReport().getString();
                     }
                 } else {
                     log.debug("Ignoring report. not an OCCUPIED event.");

--- a/java/src/jmri/jmrix/internal/TrackReporter.java
+++ b/java/src/jmri/jmrix/internal/TrackReporter.java
@@ -2,6 +2,7 @@ package jmri.jmrix.internal;
 
 import java.util.Deque;
 import java.util.ArrayDeque;
+import jmri.Report;
 import jmri.implementation.AbstractReporter;
 import jmri.CollectingReporter;
 
@@ -15,28 +16,28 @@ import jmri.CollectingReporter;
  */
 public class TrackReporter extends AbstractReporter implements CollectingReporter {
 
-    private Deque collection = null;
+    private Deque<Report> collection = null;
 
     public TrackReporter(String systemName) {
         super(systemName.toUpperCase());
-        collection = new ArrayDeque<Object>();
+        collection = new ArrayDeque<>();
     }
 
     public TrackReporter(String systemName, String userName) {
         super(systemName.toUpperCase(), userName);
-        collection = new ArrayDeque<Object>();
+        collection = new ArrayDeque<>();
     }
 
     /**
      * Provide a general method for updating the report.
      */
     @Override
-    public void setReport(Object r) {
+    public void setReport(Report r) {
         if (r == _currentReport) {
             return;
         }
-        Object old = _currentReport;
-        Object oldLast = _lastReport;
+        Report old = _currentReport;
+        Report oldLast = _lastReport;
         _currentReport = r;
         if (r != null) {
             _lastReport = r;
@@ -70,7 +71,7 @@ public class TrackReporter extends AbstractReporter implements CollectingReporte
     // these methods record the order of reports seen.
 
     @SuppressWarnings("unchecked")
-    public void pushEast(Object o){
+    public void pushEast(Report o){
          if(o != null) {
             collection.addFirst(o);
             setReport(o);
@@ -78,21 +79,21 @@ public class TrackReporter extends AbstractReporter implements CollectingReporte
     }
 
     @SuppressWarnings("unchecked")
-    public void pushWest(Object o){
+    public void pushWest(Report o){
          if(o != null) {
             collection.addLast(o);
             setReport(o);
          }
     }
 
-    public Object pullEast(){
-       Object retval = collection.removeFirst();
+    public Report pullEast(){
+       Report retval = collection.removeFirst();
        setReport(collection.peekFirst());
        return retval;
     }
 
-    public Object pullWest(){
-       Object retval = collection.removeLast();
+    public Report pullWest(){
+       Report retval = collection.removeLast();
        setReport(collection.peekLast());
        return retval;
     }

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientReporter.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientReporter.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.jmriclient;
 
+import jmri.Report;
 import jmri.implementation.AbstractReporter;
+import jmri.implementation.StringReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +61,7 @@ public class JMRIClientReporter extends AbstractReporter implements JMRIClientLi
         } else {
             String text = "REPORTER " + transmitName + "\n";
             if (!message.equals(text)) {
-                String report = message.substring(text.length());
+                Report report = new StringReport(message.substring(text.length()));
                 log.debug("setting report to " + report);
                 setReport(report);  // this is an update of the report.
             } else {

--- a/java/src/jmri/jmrix/loconet/LnReporter.java
+++ b/java/src/jmri/jmrix/loconet/LnReporter.java
@@ -6,6 +6,7 @@ import jmri.DccLocoAddress;
 import jmri.LocoAddress;
 import jmri.PhysicalLocationReporter;
 import jmri.implementation.AbstractReporter;
+import jmri.implementation.StringReport;
 import jmri.util.PhysicalLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,7 +89,7 @@ public class LnReporter extends AbstractReporter implements LocoNetListener, Phy
         }
 
         lastLoco = (enter ? loco : -1);
-        setReport("" + loco + (enter ? " enter" : " exits")); // NOI18N
+        setReport(new StringReport("" + loco + (enter ? " enter" : " exits"))); // NOI18N
     }
 
     /**
@@ -108,7 +109,7 @@ public class LnReporter extends AbstractReporter implements LocoNetListener, Phy
         boolean north = ((l.getElement(3) & 0x20) == 0);
 
         // get loco address
-        setReport("" + loco + " seen " + (north ? "northbound" : "southbound")); // NOI18N
+        setReport(new StringReport("" + loco + " seen " + (north ? "northbound" : "southbound"))); // NOI18N
 
     }
 

--- a/java/src/jmri/jmrix/rps/RpsReporter.java
+++ b/java/src/jmri/jmrix/rps/RpsReporter.java
@@ -8,6 +8,7 @@ import jmri.DccLocoAddress;
 import jmri.LocoAddress;
 import jmri.PhysicalLocationReporter;
 import jmri.implementation.AbstractReporter;
+import jmri.implementation.StringReport;
 import jmri.util.PhysicalLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,7 +85,7 @@ public class RpsReporter extends AbstractReporter implements MeasurementListener
      */
     void notifyLeaving(Integer id) {
         firePropertyChange("Leaving", null, id);
-        setReport("");
+        setReport(new StringReport(""));
     }
 
     /**
@@ -93,7 +94,7 @@ public class RpsReporter extends AbstractReporter implements MeasurementListener
      */
     void notifyArriving(Integer id) {
         firePropertyChange("Arriving", null, id);
-        setReport("" + id);
+        setReport(new StringReport("" + id));
     }
 
     /**

--- a/java/src/jmri/server/json/reporter/JsonReporterHttpService.java
+++ b/java/src/jmri/server/json/reporter/JsonReporterHttpService.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletResponse;
 import jmri.InstanceManager;
 import jmri.Reporter;
 import jmri.ReporterManager;
+import jmri.implementation.StringReport;
 import jmri.server.json.JsonException;
 import jmri.server.json.JsonHttpService;
 
@@ -75,7 +76,7 @@ public class JsonReporterHttpService extends JsonHttpService {
             if (data.path(REPORT).isNull()) {
                 reporter.setReport(null);
             } else {
-                reporter.setReport(data.path(REPORT).asText());
+                reporter.setReport(new StringReport(data.path(REPORT).asText()));
             }
         }
         return this.doGet(type, name, locale);

--- a/java/test/jmri/BlockTest.java
+++ b/java/test/jmri/BlockTest.java
@@ -1,5 +1,6 @@
 package jmri;
 
+import jmri.implementation.StringReport;
 import jmri.jmrix.internal.InternalSensorManager;
 import jmri.util.JUnitUtil;
 
@@ -300,7 +301,7 @@ public class BlockTest {
             }
         };
         b.setReporter(rm.provideReporter("IR22"));
-        rm.provideReporter("IR22").setReport("report");
+        rm.provideReporter("IR22").setReport(new StringReport("report"));
         // For each report, there are two PropertyChangeEvents -
         // "currentReport" and "lastReport"
         Assert.assertEquals("count of detected changes", 2, count);
@@ -319,7 +320,7 @@ public class BlockTest {
             }
         };
         b.setReporter(rm.provideReporter("IR22"));
-        rm.provideReporter("IR22").setReport("report");
+        rm.provideReporter("IR22").setReport(new StringReport("report"));
         // Only detecting "currentReport" PropertyChangeEvent
         Assert.assertEquals("count of detected changes", 1, count);
 
@@ -341,7 +342,7 @@ public class BlockTest {
             }
         };
         b.setReporter(rm.provideReporter("IR22"));
-        rm.provideReporter("IR22").setReport("report");
+        rm.provideReporter("IR22").setReport(new StringReport("report"));
         // Only detecting "lastReport" PropertyChangeEvent
         Assert.assertEquals("count of detected changes", 1, count);
 

--- a/java/test/jmri/implementation/AbstractRailComReporterTest.java
+++ b/java/test/jmri/implementation/AbstractRailComReporterTest.java
@@ -2,6 +2,7 @@ package jmri.implementation;
 
 import jmri.util.JUnitUtil;
 import jmri.IdTag;
+import jmri.Report;
 import org.junit.*;
 /**
  *
@@ -10,7 +11,7 @@ import org.junit.*;
 public class AbstractRailComReporterTest extends AbstractReporterTestBase {
 
     @Override
-    protected Object generateObjectToReport(){
+    protected Report generateObjectToReport(){
         return new DefaultRailCom("ID1234", "Test Tag");
     }
 

--- a/java/test/jmri/implementation/AbstractReporterTestBase.java
+++ b/java/test/jmri/implementation/AbstractReporterTestBase.java
@@ -1,5 +1,6 @@
 package jmri.implementation;
 
+import jmri.Report;
 import jmri.Reporter;
 import org.junit.*;
 
@@ -26,7 +27,7 @@ abstract public class AbstractReporterTestBase {
     protected Reporter r = null; 
 
     // concrete classes should generate an appropriate report.
-    abstract protected Object generateObjectToReport();
+    abstract protected Report generateObjectToReport();
 
     @Test
     public void testCtor() {

--- a/java/test/jmri/implementation/ReporterTest.java
+++ b/java/test/jmri/implementation/ReporterTest.java
@@ -38,50 +38,19 @@ public class ReporterTest {
     @Test
     public void testReportStringObject() {
         // Report a String
-        r.setReport("Something To Report");
+        r.setReport(new StringReport("Something To Report"));
         // Check that both CurrentReport and LastReport are String objects
-        Assert.assertTrue("CurrentReport Object is 'String'", r.getCurrentReport() instanceof String);
-        Assert.assertTrue("LastReport Object is 'String'", r.getLastReport() instanceof String);
+        Assert.assertTrue("CurrentReport Object is 'StringReport'", r.getCurrentReport() instanceof StringReport);
+        Assert.assertTrue("LastReport Object is 'StringReport'", r.getLastReport() instanceof StringReport);
         // Check the value of both CurrentReport and LastReport
-        Assert.assertEquals("CurrentReport String is 'Something To Report'", "Something To Report", r.getCurrentReport());
-        Assert.assertEquals("LastReport String is 'Something To Report'", "Something To Report", r.getLastReport());
+        Assert.assertEquals("CurrentReport String is 'Something To Report'", "Something To Report", r.getCurrentReport().getString());
+        Assert.assertEquals("LastReport String is 'Something To Report'", "Something To Report", r.getLastReport().getString());
 
         // Nothing to report now
         r.setReport(null);
         // Check that CurrentReport returns a null value, but LastReport returns the reported String
         Assert.assertEquals("After null report, CurrentReport String is null", null, r.getCurrentReport());
         Assert.assertEquals("After null report, LastReport String is 'Something To Report'", "Something To Report", r.getLastReport());
-    }
-
-    @Test
-    public void testReportOtherObject() {
-        // Create an ObjectToReport object to report
-        ObjectToReport otr = new ObjectToReport(42);
-        // and report it.
-        r.setReport(otr);
-
-        // Check that both CurrentReport and LastReport are ObjectToReport objects
-        Assert.assertTrue("CurrentReport Object is 'ObjectToReport'", r.getCurrentReport() instanceof ObjectToReport);
-        Assert.assertTrue("LastReport Object is 'ObjectToReport'", r.getLastReport() instanceof ObjectToReport);
-        // Check the value of the ObjectToReport objects
-        Assert.assertEquals("CurrentReport value is '42'", 42, ((ObjectToReport) r.getCurrentReport()).getValue());
-        Assert.assertEquals("LastReport value is '42'", 42, ((ObjectToReport) r.getLastReport()).getValue());
-        // Check that the returned object is the earlier created ObjectToReport
-        Assert.assertSame("CurrentReport Object is identical to otr", otr, r.getCurrentReport());
-        Assert.assertSame("LastReport Object is identical to otr", otr, r.getCurrentReport());
-
-        // Create a new ObjectToReport with an identical value
-        ObjectToReport otr2 = new ObjectToReport(42);
-        // Check that the returned object is different to this new one
-        Assert.assertNotSame("CurrentReport Object is different", otr2, r.getCurrentReport());
-        Assert.assertNotSame("LastReport Object is different", otr2, r.getCurrentReport());
-
-        // Nothing to report now
-        r.setReport(null);
-        // Check that CurrentReport returns a null value, but LastReport returns the first created ObjectToReport
-        Assert.assertEquals("After null report, CurrentReport Object is null", null, r.getCurrentReport());
-        Assert.assertEquals("After null report, LastReport value is '42'", 42, ((ObjectToReport) r.getLastReport()).getValue());
-        Assert.assertSame("After null report, LastReport Object is identical to otr", otr, r.getLastReport());
     }
 
     @Before

--- a/java/test/jmri/implementation/StringReportTest.java
+++ b/java/test/jmri/implementation/StringReportTest.java
@@ -1,0 +1,40 @@
+package jmri.implementation;
+
+import jmri.Report;
+import org.junit.*;
+
+/**
+ * Tests for StringReport
+ * 
+ * @author Daniel Bergqvist Copyright (c) 2019
+ */
+public class StringReportTest {
+    
+    @Test
+    public void testCtor() {
+        Report report = new StringReport("A report");
+        Assert.assertNotNull("AbstractStringIO constructor return", report);
+    }
+    
+    @Test
+    public void testStringReport() {
+        Report report = new StringReport("A report");
+        Assert.assertTrue("string is correct",
+                "A report".equals(report.getString()));
+        
+        report = new StringReport("Another report");
+        Assert.assertTrue("string is correct",
+                "Another report".equals(report.getString()));
+    }
+    
+    @Before
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        jmri.util.JUnitUtil.tearDown();
+    }
+
+}

--- a/java/test/jmri/jmris/simpleserver/SimpleReporterServerTest.java
+++ b/java/test/jmri/jmris/simpleserver/SimpleReporterServerTest.java
@@ -1,5 +1,6 @@
 package jmri.jmris.simpleserver;
 
+import jmri.implementation.StringReport;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -151,7 +152,7 @@ public class SimpleReporterServerTest {
         SimpleReporterServer a = new SimpleReporterServer(input, output);
         try {
             a.initReporter("IR1");
-            a.sendReport("IR1","Hello World");
+            a.sendReport("IR1",new StringReport("Hello World"));
             Assert.assertEquals("sendErrorStatus check","REPORTER IR1 Hello World\n",sb.toString());
         } catch(java.io.IOException ioe){
             Assert.fail("Exception sending Error Status");

--- a/java/test/jmri/jmrit/display/ReporterIconTest.java
+++ b/java/test/jmri/jmrit/display/ReporterIconTest.java
@@ -4,6 +4,7 @@ import java.awt.GraphicsEnvironment;
 import javax.swing.JFrame;
 import jmri.InstanceManager;
 import jmri.ReporterManager;
+import jmri.implementation.StringReport;
 import jmri.jmrit.catalog.NamedIcon;
 import jmri.jmrit.display.panelEditor.PanelEditor;
 import jmri.util.JUnitUtil;
@@ -61,7 +62,7 @@ public class ReporterIconTest extends PositionableTestBase {
             // create objects to test
             InstanceManager.getDefault(ReporterManager.class).provideReporter("IR1");
             to.setReporter("IR1");
-            InstanceManager.getDefault(ReporterManager.class).provideReporter("IR1").setReport("data");
+            InstanceManager.getDefault(ReporterManager.class).provideReporter("IR1").setReport(new StringReport("data"));
             NamedIcon icon = new NamedIcon("resources/icons/redTransparentBox.gif", "box"); // 13x13
             to.setIcon(icon);
         }

--- a/java/test/jmri/jmrix/can/cbus/CbusReporterTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusReporterTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.can.cbus;
 
+import jmri.Report;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.util.JUnitUtil;
 import org.junit.After;
@@ -14,7 +15,7 @@ import org.junit.Test;
 public class CbusReporterTest extends jmri.implementation.AbstractReporterTestBase {
 
     @Override
-    protected Object generateObjectToReport(){
+    protected Report generateObjectToReport(){
         return new jmri.implementation.DefaultIdTag("ID0413276BC1", "Test Tag");
     }
 

--- a/java/test/jmri/jmrix/internal/TrackReporterTest.java
+++ b/java/test/jmri/jmrix/internal/TrackReporterTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.internal;
 
+import jmri.implementation.StringReport;
 import jmri.util.JUnitUtil;
 import org.junit.*;
 
@@ -15,13 +16,13 @@ public class TrackReporterTest extends jmri.implementation.AbstractRailComReport
    public void testSingleEndedTrackEast(){
        // this track should work like a stack, add or remove from one end only.
        TrackReporter tr = (TrackReporter)r;
-       tr.pushEast("Hello");
-       Assert.assertEquals("after 1st push","Hello",tr.getCurrentReport());
-       tr.pushEast("World");
-       Assert.assertEquals("after 2nd push","World",tr.getCurrentReport());
-       Assert.assertEquals("pull last entered","World",tr.pullEast());
-       Assert.assertEquals("last report","Hello",tr.getCurrentReport());
-       Assert.assertEquals("pull first entered","Hello",tr.pullEast());
+       tr.pushEast(new StringReport("Hello"));
+       Assert.assertEquals("after 1st push","Hello",tr.getCurrentReport().getString());
+       tr.pushEast(new StringReport("World"));
+       Assert.assertEquals("after 2nd push","World",tr.getCurrentReport().getString());
+       Assert.assertEquals("pull last entered","World",tr.pullEast().getString());
+       Assert.assertEquals("last report","Hello",tr.getCurrentReport().getString());
+       Assert.assertEquals("pull first entered","Hello",tr.pullEast().getString());
        Assert.assertNull("last report",tr.getCurrentReport());
    }
 
@@ -29,13 +30,13 @@ public class TrackReporterTest extends jmri.implementation.AbstractRailComReport
    public void testSingleEndedTrackWest(){
        // this track should work like a stack, add or remove from one end only.
        TrackReporter tr = (TrackReporter)r;
-       tr.pushWest("Hello");
-       Assert.assertEquals("after 1st push","Hello",tr.getCurrentReport());
-       tr.pushWest("World");
-       Assert.assertEquals("after 2nd push","World",tr.getCurrentReport());
-       Assert.assertEquals("pull last entered","World",tr.pullWest());
-       Assert.assertEquals("last report","Hello",tr.getCurrentReport());
-       Assert.assertEquals("pull first entered","Hello",tr.pullWest());
+       tr.pushWest(new StringReport("Hello"));
+       Assert.assertEquals("after 1st push","Hello",tr.getCurrentReport().getString());
+       tr.pushWest(new StringReport("World"));
+       Assert.assertEquals("after 2nd push","World",tr.getCurrentReport().getString());
+       Assert.assertEquals("pull last entered","World",tr.pullWest().getString());
+       Assert.assertEquals("last report","Hello",tr.getCurrentReport().getString());
+       Assert.assertEquals("pull first entered","Hello",tr.pullWest().getString());
        Assert.assertNull("last report",tr.getCurrentReport());
    }
 
@@ -43,13 +44,13 @@ public class TrackReporterTest extends jmri.implementation.AbstractRailComReport
    public void testDoubleEndedTrack(){
        // this track should work like a queue, add from one end remove from the other.
        TrackReporter tr = (TrackReporter)r;
-       tr.pushWest("Hello");
-       Assert.assertEquals("after 1st push","Hello",tr.getCurrentReport());
-       tr.pushWest("World");
-       Assert.assertEquals("after 2nd push","World",tr.getCurrentReport());
-       Assert.assertEquals("pull first entered","Hello",tr.pullEast());
-       Assert.assertEquals("last report","World",tr.getCurrentReport());
-       Assert.assertEquals("pull last entered","World",tr.pullEast());
+       tr.pushWest(new StringReport("Hello"));
+       Assert.assertEquals("after 1st push","Hello",tr.getCurrentReport().getString());
+       tr.pushWest(new StringReport("World"));
+       Assert.assertEquals("after 2nd push","World",tr.getCurrentReport().getString());
+       Assert.assertEquals("pull first entered","Hello",tr.pullEast().getString());
+       Assert.assertEquals("last report","World",tr.getCurrentReport().getString());
+       Assert.assertEquals("pull last entered","World",tr.pullEast().getString());
        Assert.assertNull("last report",tr.getCurrentReport());
    }
 

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientReporterTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientReporterTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.jmriclient;
 
+import jmri.Report;
 import jmri.util.JUnitUtil;
 import org.junit.*;
 
@@ -13,7 +14,7 @@ import org.junit.*;
 public class JMRIClientReporterTest extends jmri.implementation.AbstractReporterTestBase{
 
     @Override
-    protected Object generateObjectToReport(){
+    protected Report generateObjectToReport(){
         return new jmri.implementation.DefaultIdTag("ID0413276BC1", "Test Tag");
     }
 

--- a/java/test/jmri/jmrix/loconet/LnReporterTest.java
+++ b/java/test/jmri/jmrix/loconet/LnReporterTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.loconet;
 
 import jmri.LocoAddress;
+import jmri.Report;
+import jmri.implementation.StringReport;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -15,8 +17,8 @@ import org.junit.Test;
 public class LnReporterTest extends jmri.implementation.AbstractReporterTestBase {
 
     @Override
-    protected Object generateObjectToReport(){
-        return "3 enter";
+    protected Report generateObjectToReport(){
+        return new StringReport("3 enter");
     }
 
     @Test

--- a/java/test/jmri/jmrix/rfid/RfidReporterTest.java
+++ b/java/test/jmri/jmrix/rfid/RfidReporterTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.rfid;
 
 import org.junit.*;
 import jmri.IdTag;
+import jmri.Report;
 
 /**
  * RfidReporterTest.java
@@ -13,7 +14,7 @@ import jmri.IdTag;
 public class RfidReporterTest extends jmri.implementation.AbstractReporterTestBase {
 
     @Override
-    protected Object generateObjectToReport(){
+    protected Report generateObjectToReport(){
         return new jmri.implementation.DefaultIdTag("ID0413276BC1", "Test Tag");
     }
 

--- a/java/test/jmri/jmrix/rps/RpsReporterTest.java
+++ b/java/test/jmri/jmrix/rps/RpsReporterTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.rps;
 
+import jmri.Report;
+import jmri.implementation.StringReport;
 import jmri.util.JUnitUtil;
 import org.junit.*;
 
@@ -10,8 +12,8 @@ import org.junit.*;
 public class RpsReporterTest extends jmri.implementation.AbstractReporterTestBase {
 
     @Override
-    protected Object generateObjectToReport(){
-        return "3";
+    protected Report generateObjectToReport(){
+        return new StringReport("3");
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/server/json/reporter/JsonReporterHttpServiceTest.java
+++ b/java/test/jmri/server/json/reporter/JsonReporterHttpServiceTest.java
@@ -10,6 +10,7 @@ import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.Reporter;
 import jmri.ReporterManager;
+import jmri.implementation.StringReport;
 import jmri.server.json.JSON;
 import jmri.server.json.JsonException;
 import jmri.util.JUnitUtil;
@@ -38,11 +39,11 @@ public class JsonReporterHttpServiceTest  {
             Assert.assertEquals("IR1", result.path(JSON.DATA).path(JSON.NAME).asText());
             // JSON node has the text "null" if reporter is null
             Assert.assertEquals("null", result.path(JSON.DATA).path(JsonReporter.REPORT).asText());
-            reporter1.setReport("throw");
+            reporter1.setReport(new StringReport("throw"));
             result = service.doGet(REPORTER, "IR1", Locale.ENGLISH);
             Assert.assertNotNull(result);
             Assert.assertEquals("throw", result.path(JSON.DATA).path(JsonReporter.REPORT).asText());
-            reporter1.setReport("close");
+            reporter1.setReport(new StringReport("close"));
             result = service.doGet(REPORTER, "IR1", Locale.ENGLISH);
             Assert.assertNotNull(result);
             Assert.assertEquals("close", result.path(JSON.DATA).path(JsonReporter.REPORT).asText());
@@ -63,13 +64,13 @@ public class JsonReporterHttpServiceTest  {
             // set off
             message = mapper.createObjectNode().put(JSON.NAME, "IR1").put(JsonReporter.REPORT, "close");
             result = service.doPost(REPORTER, "IR1", message, Locale.ENGLISH);
-            Assert.assertEquals("close", reporter1.getCurrentReport());
+            Assert.assertEquals("close", reporter1.getCurrentReport().getString());
             Assert.assertNotNull(result);
             Assert.assertEquals("close", result.path(JSON.DATA).path(JsonReporter.REPORT).asText());
             // set on
             message = mapper.createObjectNode().put(JSON.NAME, "IR1").put(JsonReporter.REPORT, "throw");
             result = service.doPost(REPORTER, "IR1", message, Locale.ENGLISH);
-            Assert.assertEquals("throw", reporter1.getCurrentReport());
+            Assert.assertEquals("throw", reporter1.getCurrentReport().getString());
             Assert.assertNotNull(result);
             Assert.assertEquals("throw", result.path(JSON.DATA).path(JsonReporter.REPORT).asText());
             // set null

--- a/java/test/jmri/server/json/reporter/JsonReporterSocketServiceTest.java
+++ b/java/test/jmri/server/json/reporter/JsonReporterSocketServiceTest.java
@@ -8,6 +8,7 @@ import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.Reporter;
 import jmri.ReporterManager;
+import jmri.implementation.StringReport;
 import jmri.server.json.JSON;
 import jmri.server.json.JsonException;
 import jmri.server.json.JsonMockConnection;
@@ -36,16 +37,16 @@ public class JsonReporterSocketServiceTest {
             // TODO: test that service is listener in ReporterManager
             // default null value of memory1 has text representation "null" in JSON
             Assert.assertEquals("null", connection.getMessage().path(JSON.DATA).path(JsonReporter.REPORT).asText());
-            memory1.setReport("throw");
+            memory1.setReport(new StringReport("throw"));
             JUnitUtil.waitFor(() -> {
-                return memory1.getCurrentReport().equals("throw");
+                return memory1.getCurrentReport().getString().equals("throw");
             }, "Reporter to throw");
             Assert.assertEquals("throw", connection.getMessage().path(JSON.DATA).path(JsonReporter.REPORT).asText());
-            memory1.setReport("close");
+            memory1.setReport(new StringReport("close"));
             JUnitUtil.waitFor(() -> {
-                return memory1.getCurrentReport().equals("close");
+                return memory1.getCurrentReport().getString().equals("close");
             }, "Reporter to close");
-            Assert.assertEquals("close", memory1.getCurrentReport());
+            Assert.assertEquals("close", memory1.getCurrentReport().getString());
             Assert.assertEquals("close", connection.getMessage().path(JSON.DATA).path(JsonReporter.REPORT).asText());
             service.onClose();
             // TODO: test that service is no longer a listener in ReporterManager
@@ -65,16 +66,16 @@ public class JsonReporterSocketServiceTest {
             // Reporter "close"
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1").put(JsonReporter.REPORT, "close");
             service.onMessage(JsonReporter.REPORTER, message, JSON.POST, Locale.ENGLISH);
-            Assert.assertEquals("close", memory1.getCurrentReport());
+            Assert.assertEquals("close", memory1.getCurrentReport().getString());
             // Reporter "throw"
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1").put(JsonReporter.REPORT, "throw");
             service.onMessage(JsonReporter.REPORTER, message, JSON.POST, Locale.ENGLISH);
-            Assert.assertEquals("throw", memory1.getCurrentReport());
+            Assert.assertEquals("throw", memory1.getCurrentReport().getString());
             // Reporter UNKNOWN - remains ON
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1").putNull(JsonReporter.REPORT);
             service.onMessage(JsonReporter.REPORTER, message, JSON.POST, Locale.ENGLISH);
             Assert.assertEquals(null, memory1.getCurrentReport());
-            memory1.setReport("throw");
+            memory1.setReport(new StringReport("throw"));
             // Reporter no value
             message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IR1");
             JsonException exception = null;
@@ -83,7 +84,7 @@ public class JsonReporterSocketServiceTest {
             } catch (JsonException ex) {
                 exception = ex;
             }
-            Assert.assertEquals("throw", memory1.getCurrentReport());
+            Assert.assertEquals("throw", memory1.getCurrentReport().getString());
             Assert.assertNull(exception);
         } catch (IOException | JmriException | JsonException ex) {
             Assert.fail(ex.getMessage());


### PR DESCRIPTION
This PR creates the interface `Report` and let `IdTag` extend `Report`. It also creates the class `StringReport` that takes a `String`.

The interface `Reporter` uses a `Report` instead of an `Object`.