### PR TITLE
Add Reportable interface.

### DIFF
--- a/java/src/jmri/Reportable.java
+++ b/java/src/jmri/Reportable.java
@@ -18,6 +18,7 @@ package jmri;
  *
  * @author Paul Bender Copyright (C) 2019
  * @see jmri.Reporter
+ * @since 4.15.3
  */
 public interface Reportable {
 

--- a/java/src/jmri/Reportable.java
+++ b/java/src/jmri/Reportable.java
@@ -1,0 +1,36 @@
+package jmri;
+
+/**
+ * This interface specifies that an object provides a report value suitable
+ * for display in an on-screen reporter.
+ * <BR>
+ * <hr>
+ * This file is part of JMRI.
+ * <P>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * </P><P>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * </P>
+ *
+ * @author Paul Bender Copyright (C) 2019
+ * @see jmri.Reporter
+ */
+public interface Reportable {
+
+     /**
+      * Provide a string representation of the object, possibly including state
+      * information, suitable for display in an on-screen reporter. A default 
+      * impelmentation provided here calls toString(), which may not be 
+      * appropriate in all cases. 
+      *
+      * @return a report string representing the Object.
+      */
+     public default String toReportString(){
+        return toString();
+     }
+
+}

--- a/java/src/jmri/implementation/AbstractIdTag.java
+++ b/java/src/jmri/implementation/AbstractIdTag.java
@@ -58,12 +58,8 @@ public abstract class AbstractIdTag extends AbstractNamedBean implements IdTag,R
         }
     }
 
-    // note that this doesn't properly implement the 
-    // contract in {@link NamedBean.toString()}, 
-    // which means things like tables and persistance 
-    // might not behave properly.
     @Override
-    public String toString() {
+    public String toReportString() {
         String userName = getUserName();
         return (userName == null || userName.isEmpty()) ? getTagID() : userName;
     }

--- a/java/src/jmri/implementation/AbstractIdTag.java
+++ b/java/src/jmri/implementation/AbstractIdTag.java
@@ -2,11 +2,12 @@ package jmri.implementation;
 
 import java.util.Date;
 import jmri.IdTag;
+import jmri.Reportable;
 import jmri.Reporter;
 
 /**
  * Abstract implementation of {@link jmri.IdTag} containing code common to all
- * concrete implementations.
+ * concrete implementations.  This implementation also implements {@link jmri.Reportable}.
  * <hr>
  * This file is part of JMRI.
  * <P>
@@ -22,7 +23,7 @@ import jmri.Reporter;
  * @author  Matthew Harris Copyright (C) 2011
  * @since 2.11.4
  */
-public abstract class AbstractIdTag extends AbstractNamedBean implements IdTag {
+public abstract class AbstractIdTag extends AbstractNamedBean implements IdTag,Reportable  {
 
     protected Reporter whereLastSeen = null;
 

--- a/java/src/jmri/implementation/DefaultRailCom.java
+++ b/java/src/jmri/implementation/DefaultRailCom.java
@@ -284,12 +284,8 @@ public class DefaultRailCom extends DefaultIdTag implements jmri.RailCom {
 
     Hashtable<Integer, Integer> cvValues = new Hashtable<>();
 
-    // note that this doesn't properly implement the 
-    // contract in {@link NamedBean.toString()}, 
-    // which means things like tables and persistance 
-    // might not behave properly.
     @Override
-    public String toString() {
+    public String toReportString() {
         String comment;
         switch (getOrientation()) {
             case ORIENTA:

--- a/java/src/jmri/jmris/simpleserver/SimpleReporterServer.java
+++ b/java/src/jmri/jmris/simpleserver/SimpleReporterServer.java
@@ -39,7 +39,11 @@ public class SimpleReporterServer extends AbstractReporterServer {
     public void sendReport(String reporterName, Object r) throws IOException {
         addReporterToList(reporterName);
         if (r != null) {
-            this.sendMessage("REPORTER " + reporterName + " " + r.toString() + "\n");
+            if (r instanceof jmri.Reportable ) {
+               this.sendMessage("REPORTER " + reporterName + " " + ((jmri.Reportable)r).toReportString() + "\n");
+            } else {
+               this.sendMessage("REPORTER " + reporterName + " " + r.toString() + "\n");
+            }
         } else {
             this.sendMessage("REPORTER " + reporterName + "\n");
         }

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -86,7 +86,7 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
                 }
                 value = r.getCurrentReport();
                 if(value == null) {
-                   return (String) null;
+                   return null;
                 } else if(value instanceof jmri.Reportable) {
                    return ((jmri.Reportable)value).toReportString();
                 } else {

--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -84,7 +84,14 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
                 if (r == null) {
                     return "";
                 }
-                return (value = r.getCurrentReport()) == null ? "" : value.toString();
+                value = r.getCurrentReport();
+                if(value == null) {
+                   return (String) null;
+                } else if(value instanceof jmri.Reportable) {
+                   return ((jmri.Reportable)value).toReportString();
+                } else {
+                   return value.toString();
+                }
             }
 
             /**

--- a/java/src/jmri/jmrit/display/ReporterIcon.java
+++ b/java/src/jmri/jmrit/display/ReporterIcon.java
@@ -117,11 +117,18 @@ public class ReporterIcon extends PositionableLabel implements java.beans.Proper
      * Drive the current state of the display from the state of the Reporter.
      */
     void displayState() {
-        if (reporter.getCurrentReport() != null) {
-            if (reporter.getCurrentReport().equals("")) {
+        Object currentReport = reporter.getCurrentReport();
+        if ( currentReport != null) {
+            String reportString = null;
+            if(currentReport instanceof jmri.Reportable) {
+              reportString = ((jmri.Reportable)currentReport).toReportString();
+            } else {
+              reportString = currentReport.toString();
+            }
+            if (currentReport.equals("")) {
                 setText(Bundle.getMessage("Blank"));
             } else {
-                setText(reporter.getCurrentReport().toString());
+                setText(reportString);
             }
         } else {
             setText(Bundle.getMessage("NoReport"));

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
@@ -707,9 +707,27 @@ public class VSDecoderManager implements PropertyChangeListener {
                         return;
                     }
                     if (blk.isReportingCurrent()) {
-                        repVal = (String) blk.getReporter().getCurrentReport();
+                        Object currentReport = blk.getReporter().getCurrentReport();
+                        if ( currentReport != null) {
+                           if(currentReport instanceof jmri.Reportable) {
+                              repVal = ((jmri.Reportable)currentReport).toReportString();
+                           } else {
+                              repVal = currentReport.toString();
+                           }
+                        } else {
+                           repVal = null;
+                        }
                     } else {
-                        repVal = (String) blk.getReporter().getLastReport();
+                        Object lastReport = blk.getReporter().getLastReport();
+                        if ( lastReport != null) {
+                           if(lastReport instanceof jmri.Reportable) {
+                              repVal = ((jmri.Reportable)lastReport).toReportString();
+                           } else {
+                              repVal = lastReport.toString();
+                           }
+                        } else {
+                           repVal = null;
+                        }
                     }
                 } else {
                     log.debug("Ignoring report. not an OCCUPIED event.");

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
@@ -714,8 +714,6 @@ public class VSDecoderManager implements PropertyChangeListener {
                            } else {
                               repVal = currentReport.toString();
                            }
-                        } else {
-                           repVal = null;
                         }
                     } else {
                         Object lastReport = blk.getReporter().getLastReport();
@@ -725,8 +723,6 @@ public class VSDecoderManager implements PropertyChangeListener {
                            } else {
                               repVal = lastReport.toString();
                            }
-                        } else {
-                           repVal = null;
                         }
                     }
                 } else {

--- a/java/test/jmri/IdTagTest.java
+++ b/java/test/jmri/IdTagTest.java
@@ -1,17 +1,15 @@
 package jmri;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.junit.Assert;
+import org.junit.*;
 
 /**
  * Tests for the IdTag class
  *
  * @author Matthew Harris Copyright (C) 2011
  */
-public class IdTagTest extends TestCase {
+public class IdTagTest {
 
+    @Test
     public void testStateConstants() {
 
         Assert.assertTrue("Seen and Unseen differ", (IdTag.SEEN != IdTag.UNSEEN));
@@ -25,29 +23,73 @@ public class IdTagTest extends TestCase {
 
     }
 
-    // from here down is testing infrastructure
-    public IdTagTest(String s) {
-        super(s);
+    @Test
+    public void testReportableIdTag() {
+       TestIdTag t = new TestIdTag("ID1234"); 
+       Assert.assertNotNull("default toReporterStringImplementation",t.toReportString());
+       Assert.assertEquals("default toReporterStringImplementation","ID1234",t.toReportString());
+
     }
 
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {IdTagTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
+    class TestIdTag extends jmri.implementation.AbstractNamedBean implements IdTag,Reportable {
+
+       public TestIdTag(String systemName){
+           super(systemName);
+       }
+
+       @Override
+       public String getBeanType(){
+           return "IDTAG";
+       }
+
+       @Override
+       public int getState(){
+          return IdTag.UNSEEN;
+       }
+
+       @Override
+       public void setState(int state){
+       }
+
+       @Override
+       public String getTagID(){
+          return "1234";
+       }
+
+       @Override
+       public void setWhereLastSeen(Reporter reporter){
+       }
+
+       @Override
+       public Reporter getWhereLastSeen(){
+          return null;
+       }
+
+       @Override
+       public java.util.Date getWhenLastSeen(){
+          return null;
+       }
+
+       @Override
+       public org.jdom2.Element store(boolean storeState){
+          return null;
+       }
+  
+       @Override
+       public void load(org.jdom2.Element e){
+       }
+
+       // don't override toReporterString so we can test the default
+       // implementation. 
+
     }
 
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(IdTagTest.class);
-        return suite;
-    }
-
-    @Override
+    @Before
     public void setUp() {
         jmri.util.JUnitUtil.setUp();
     }
 
-    @Override
+    @After
     public void tearDown() {
         jmri.util.JUnitUtil.tearDown();
     }

--- a/java/test/jmri/implementation/DefaultIdTagTest.java
+++ b/java/test/jmri/implementation/DefaultIdTagTest.java
@@ -4,6 +4,7 @@ import java.util.Calendar;
 import java.util.Date;
 import jmri.IdTag;
 import jmri.Reporter;
+import jmri.Reportable;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -38,10 +39,16 @@ public class DefaultIdTagTest {
     @Test
     public void testIdTagToString() {
         IdTag r = new DefaultIdTag("ID0413276BC1");
-        Assert.assertEquals("IdTag toString is 0413276BC1", "0413276BC1", r.toString());
+        Assert.assertEquals("IdTag toString is ID0413276BC1", "ID0413276BC1", r.toString());
+    }
+
+    @Test
+    public void testIdTagToReportString() {
+        DefaultIdTag r = new DefaultIdTag("ID0413276BC1");
+        Assert.assertEquals("IdTag toReportString is 0413276BC1", "0413276BC1", r.toReportString());
 
         r.setUserName("Test Tag");
-        Assert.assertEquals("IdTag toString is 'Test Tag'", "Test Tag", r.toString());
+        Assert.assertEquals("IdTag toReportString is 'Test Tag'", "Test Tag", r.toReportString());
     }
 
     @Test

--- a/java/test/jmri/implementation/DefaultRailComTest.java
+++ b/java/test/jmri/implementation/DefaultRailComTest.java
@@ -38,7 +38,13 @@ public class DefaultRailComTest {
     @Test
     public void testRailComToString() {
         RailCom r = new DefaultRailCom("ID1234");
-        Assert.assertEquals("RailCom toString ", "Unknown Orientation Address 1234(S) ", r.toString());
+        Assert.assertEquals("RailCom toString ", "ID1234", r.toString());
+    }
+
+    @Test
+    public void testRailComToReportString() {
+        DefaultRailCom r = new DefaultRailCom("ID1234");
+        Assert.assertEquals("RailCom toReportString ", "Unknown Orientation Address 1234(S) ", r.toReportString());
     }
 
     @Test

--- a/java/test/jmri/jmris/simpleserver/SimpleReporterServerTest.java
+++ b/java/test/jmri/jmris/simpleserver/SimpleReporterServerTest.java
@@ -159,6 +159,28 @@ public class SimpleReporterServerTest {
     }
 
     @Test
+    // test sending an ID tag as a Report message.
+    public void testSendIdTagReport() {
+        StringBuilder sb = new StringBuilder();
+        java.io.DataOutputStream output = new java.io.DataOutputStream(
+                new java.io.OutputStream() {
+                    @Override
+                    public void write(int b) throws java.io.IOException {
+                        sb.append((char)b);
+                    }
+                });
+        java.io.DataInputStream input = new java.io.DataInputStream(System.in);
+        SimpleReporterServer a = new SimpleReporterServer(input, output);
+        try {
+            a.initReporter("IR1");
+            a.sendReport("IR1",new jmri.implementation.DefaultIdTag("ID1234","Hello World"));
+            Assert.assertEquals("sendErrorStatus check","REPORTER IR1 Hello World\n",sb.toString());
+        } catch(java.io.IOException ioe){
+            Assert.fail("Exception sending Error Status");
+        }
+    }
+
+    @Test
     // test sending a null Report message.
     public void testSendNullReport() {
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
See #6463 for background.

This handles the required separation between the report and the toString method.

A follow-on PR will handle converting LocoNet Transponding reports from a string to an IdTag derived object.