### PR TITLE
Windows Installer looks for java11 windows registry

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -474,5 +474,7 @@
                 <a href="/help/en/html/doc/Technical/gitdeveloper.shtml">different way</a>
                 starting with this release.</li>
             <li>All the PackageList test files were updated to JUnit4 form, without a separate main()</li>
+            <li>The Windows "installer" and "launcher" have been updated to support 
+                Oracle's Java JDK 11 installation mechanisms on Windows platforms.</li>
         </ul>
 

--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -50,6 +50,9 @@
 ; -------------------------------------------------------------------------
 ; - Version History
 ; -------------------------------------------------------------------------
+; - Version 0.1.24.0
+; - Add support for Java 11 Registry Keys
+; -------------------------------------------------------------------------
 ; - Version 0.1.22.15
 ; - Backup and remove classes folder
 ; -------------------------------------------------------------------------
@@ -298,7 +301,7 @@
   ; -- usually, this will be determined by the build.xml ant script
   !define JRE_VER   "1.8"                       ; Required JRE version
 !endif
-!define INST_VER  "0.1.22.15"                   ; Installer version
+!define INST_VER  "0.1.24.0"                   ; Installer version
 !define PNAME     "${APP}.${JMRI_VER}"          ; Name of installer.exe
 !define SRCDIR    "."                           ; Path to head of sources
 InstallDir        "$PROGRAMFILES\JMRI"          ; Default install directory
@@ -1194,9 +1197,12 @@ Function CheckJRE
     ClearErrors
     ReadRegStr $1 HKLM "SOFTWARE\JavaSoft\JRE" "CurrentVersion"
     ReadRegStr $0 HKLM "SOFTWARE\JavaSoft\JRE\$1" "JavaHome"
-    IfErrors 0 +3
+    IfErrors 0 JRECheck
     ReadRegStr $1 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment" "CurrentVersion"
     ReadRegStr $0 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment\$1" "JavaHome"
+    IfErrors 0 JRECheck
+    ReadRegStr $R1 HKLM "SOFTWARE\JavaSoft\JDK" "CurrentVersion"
+    ReadRegStr $R0 HKLM "SOFTWARE\JavaSoft\JDK\$R1" "JavaHome"
 
     ; -- Not found
     IfErrors 0 JRECheck

--- a/scripts/WinInstallFiles/LaunchJMRI.nsi
+++ b/scripts/WinInstallFiles/LaunchJMRI.nsi
@@ -25,6 +25,9 @@
 ; -------------------------------------------------------------------------
 ; - Version History
 ; -------------------------------------------------------------------------
+; - Version 0.1.24.0
+; - Add support for Java 11 Registry Keys
+; -------------------------------------------------------------------------
 ; - Version 0.1.23.0
 ; - Add JVM option 'Djogamp.gluegen.UseTempJarCache=false'
 ; -------------------------------------------------------------------------
@@ -284,9 +287,13 @@ Section "Main"
     ClearErrors
     ReadRegStr $R1 HKLM "SOFTWARE\JavaSoft\JRE" "CurrentVersion"
     ReadRegStr $R0 HKLM "SOFTWARE\JavaSoft\JRE\$R1" "JavaHome"
-    IfErrors 0 +3
+    IfErrors 0 FoundJavaInstallPoint
     ReadRegStr $R1 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment" "CurrentVersion"
     ReadRegStr $R0 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment\$R1" "JavaHome"
+    IfErrors 0 FoundJavaInstallPoint
+    ReadRegStr $R1 HKLM "SOFTWARE\JavaSoft\JDK" "CurrentVersion"
+    ReadRegStr $R0 HKLM "SOFTWARE\JavaSoft\JDK\$R1" "JavaHome"
+  FoundJavaInstallPoint:
     StrCpy $R0 "$R0\bin\$JAVAEXE"
 
   ; -- Not found


### PR DESCRIPTION
Modifies Windows "installer" and "launcher" to look for JAVA 11-style Windows registry keys, in addition to previous JAVA registry key pairs.

Note that the both the "installer" and "launcher" _look for JAVA 11 keys after looking for previous-style registry keys_.  If multiple JAVA installs are present, ones other than JAVA 11 will be selected before the JAVA 11 JRE.  The order can be easily changed at a later date, if necessary.

These changes are based on reporting of JAVA 11-based Windows launching issue as reported by Felice Vittoria in post number 156194 on the jmriusers.groups.io list, and the Windows JAVA 11 registry keys later reported in post 156207.
