### PR TITLE
Use display name for route turnout list

### DIFF
--- a/java/src/jmri/jmrit/beantable/RouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableAction.java
@@ -1005,7 +1005,7 @@ public class RouteTableAction extends AbstractTableAction<Route> {
     int setTurnoutInformation(Route g) {
         for (int i = 0; i < _includedTurnoutList.size(); i++) {
             RouteTurnout t = _includedTurnoutList.get(i);
-            g.addOutputTurnout(t.getSysName(), t.getState());
+            g.addOutputTurnout(t.getDisplayName(), t.getState());
         }
         return _includedTurnoutList.size();
     }


### PR DESCRIPTION
The turnout list currently uses the system name which results in user name renames being missed.