### PR TITLE
Dbm win installer java11 fix

### DIFF
--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -50,6 +50,9 @@
 ; -------------------------------------------------------------------------
 ; - Version History
 ; -------------------------------------------------------------------------
+; - Version 0.1.24.1
+; - Correct the support for Java 11 Registry Keys
+; -------------------------------------------------------------------------
 ; - Version 0.1.24.0
 ; - Add support for Java 11 Registry Keys
 ; -------------------------------------------------------------------------
@@ -301,7 +304,7 @@
   ; -- usually, this will be determined by the build.xml ant script
   !define JRE_VER   "1.8"                       ; Required JRE version
 !endif
-!define INST_VER  "0.1.24.0"                   ; Installer version
+!define INST_VER  "0.1.24.1"                   ; Installer version
 !define PNAME     "${APP}.${JMRI_VER}"          ; Name of installer.exe
 !define SRCDIR    "."                           ; Path to head of sources
 InstallDir        "$PROGRAMFILES\JMRI"          ; Default install directory

--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -1201,8 +1201,8 @@ Function CheckJRE
     ReadRegStr $1 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment" "CurrentVersion"
     ReadRegStr $0 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment\$1" "JavaHome"
     IfErrors 0 JRECheck
-    ReadRegStr $R1 HKLM "SOFTWARE\JavaSoft\JDK" "CurrentVersion"
-    ReadRegStr $R0 HKLM "SOFTWARE\JavaSoft\JDK\$R1" "JavaHome"
+    ReadRegStr $1 HKLM "SOFTWARE\JavaSoft\JDK" "CurrentVersion"
+    ReadRegStr $0 HKLM "SOFTWARE\JavaSoft\JDK\$R1" "JavaHome"
 
     ; -- Not found
     IfErrors 0 JRECheck

--- a/scripts/WinInstallFiles/InstallJMRI.nsi
+++ b/scripts/WinInstallFiles/InstallJMRI.nsi
@@ -1205,7 +1205,7 @@ Function CheckJRE
     ReadRegStr $0 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment\$1" "JavaHome"
     IfErrors 0 JRECheck
     ReadRegStr $1 HKLM "SOFTWARE\JavaSoft\JDK" "CurrentVersion"
-    ReadRegStr $0 HKLM "SOFTWARE\JavaSoft\JDK\$R1" "JavaHome"
+    ReadRegStr $0 HKLM "SOFTWARE\JavaSoft\JDK\$1" "JavaHome"
 
     ; -- Not found
     IfErrors 0 JRECheck


### PR DESCRIPTION
Fixes incorrect variable names resulting from copy-and-paste from the corrected launcher config file.