### PR TITLE
MR at start of system name for M Reporter ok

### DIFF
--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -170,6 +170,15 @@
       <h4>Default System Letters</h4>
       <p>Note that some of these are placeholders, and have no underlying
       implementation. (Links are to JMRI pages with more information)</p>
+      
+      <p>Also note that some older implementations used 
+      formats that don't meet the current standard, with 
+      system <u>letters</u> such as
+      "DX", "DCCPP", "DP", "MR", "MC", "PI", "TM".
+      These 
+      <a href="../../setup/MigrateSystemPrefixes.shtml">need to be migrated</a>,
+      and we have a have a 
+      <a href="../../setup/MigrateSystemPrefixes.shtml">process in place to do that</a>.
 
       <ul>
         <li>A CTI <a href=

--- a/help/en/html/setup/MigrateSystemPrefixes.shtml
+++ b/help/en/html/setup/MigrateSystemPrefixes.shtml
@@ -45,7 +45,9 @@
       <li>Open the Preferences, and look at each of the "Connection" panes.  If the connection prefix 
             has a letter or a single letter plus digits, this doesn't affect you.
             If it has more than a single letter, you should do this migration.
-            (With JMRI 4.13.4 or later, the background will be colored red 
+            (With 
+            <a href="/releasenotes/jmri4.13.4.shtml">JMRI 4.13.4</a>
+            or later, the background will be colored red 
             and the tooltip will say "This is a legacy prefix that should be migrated, ask on JMRIusers" 
             if the prefix needs to be migrated)
       <li>Check the system log after running and quiting the program to see if there's a 
@@ -59,11 +61,36 @@
       use new prefixes.
 
       <ul>
-      <li>First, you should be using JMRI 4.12 or later. If you're using an earlier
-            version, please update to at least JMRI 4.12 and fix any problems.
-      <li>Next, ask for help on the JMRIusers mailing list.  
+      <li>First, you should be using 
+            <a href="/releasenotes/jmri4.12.shtml">JMRI 4.12</a>
+            or later. If you're using an earlier
+            version, please update to at least 
+            <a href="/releasenotes/jmri4.12.shtml">JMRI 4.12</a>
+            and fix any problems.
+      <li>If your computer is connected to the Internet, please upload your configuration as 
+            debugging information as described on
+            <a href="../../package/jmri/jmrit/mailreport/Report.shtml">this page</a>.
+            This will make it easy for the people who help you in the next step 
+            to see exactly what's needed.
+      <li>Next, ask for help on the 
+            <a href="https://groups.io/g/jmriusers">JMRI users group</a>.  
             There are people there who will happily do the necessary file modifications.
+       </ul>
+      
+      <h2 id="not">What happens if I don't  make this change?</h2>
+      
+      If you don't make this change, your existing JMRI installation will keep working fine.
+      <p>
+      If/when you update to newer versions of JMRI:
+      <ul>
+      <li>When you update to JMRI 4.15.3 or later, you'll start getting prompts
+            about fixing this every time you start JMRI.
+      <li>If you update to JMRI 4.17.1 or later (summer 2019)
+            without fixing this, you won't be able to use your
+            existing configuration or panel files.
       </ul>
+      We're sorry for this inconvenience, but we really do have to fix this.
+      Giving people over 18 months lead time seems sufficient.
       
       
       <!--#include virtual="/Footer" -->

--- a/help/en/package/jmri/jmrit/mailreport/Report.shtml
+++ b/help/en/package/jmri/jmrit/mailreport/Report.shtml
@@ -32,7 +32,7 @@
       your private information. You can see previous problem
       reports on the <a href=
       "https://sourceforge.net/p/jmri/mailman/jmri-reports/">jmri-reports
-      SourceForge mailing list</a>.</p>
+      mailing list</a>.</p>
 
       <p>To make the information most useful, you should do the
       upload as soon as possible after encountering the problem, so

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -371,7 +371,9 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"/>
         <ul>
-            <li></li>
+            <li>Fixed an issue where Reporters with a system letter of M
+                were erroneously tagged as 
+                <a href="http://jmri.org/help/en/html/setup/MigrateSystemPrefixes.shtml">requiring migration</a>.</li>
         </ul>
 
     <h3>Scripting</h3>

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -440,6 +440,18 @@ public interface Manager<E extends NamedBean> {
                             public boolean execute() {
                                 if (legacyNameSet.size() == 0) return true;
                                 
+                                // as an extremely ugly hack, handle the special case of 
+                                // Reporters-with-an-M-system letter, e.g. from MERG
+                                //
+                                // We couldn't do this earlier because the name might be checked
+                                // before the bean is created
+                                ReporterManager rm = InstanceManager.getDefault(ReporterManager.class);
+                                for (String name : legacyNameSet) {
+                                    // The legacy MR name for MRC can't do Reporters
+                                    if (name.startsWith("MR") && rm.getReporter(name) != null) legacyNameSet.remove(name);
+                                }
+                                if (legacyNameSet.size() == 0) return true;
+                                
                                 org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Manager.class);
                                 log.warn("The following legacy names need to be migrated:");
                                 for (String name : legacyNameSet) log.warn("    {}", name);

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -446,7 +446,8 @@ public interface Manager<E extends NamedBean> {
                                 // We couldn't do this earlier because the name might be checked
                                 // before the bean is created
                                 ReporterManager rm = InstanceManager.getDefault(ReporterManager.class);
-                                for (String name : legacyNameSet) {
+                                 Set<String> tempSet = new HashSet<>(legacyNameSet); // to avoid concurrent mod
+                                for (String name : tempSet) {
                                     // The legacy MR name for MRC can't do Reporters
                                     if (name.startsWith("MR") && rm.getReporter(name) != null) legacyNameSet.remove(name);
                                 }

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -446,23 +446,27 @@ public interface Manager<E extends NamedBean> {
                                 // We couldn't do this earlier because the name might be checked
                                 // before the bean is created
                                 ReporterManager rm = InstanceManager.getDefault(ReporterManager.class);
-                                 Set<String> tempSet = new HashSet<>(legacyNameSet); // to avoid concurrent mod
-                                for (String name : tempSet) {
+                                java.util.SortedSet<String> tempSet = new java.util.TreeSet<>(); 
+                                for (String name : legacyNameSet) {
                                     // The legacy MR name for MRC can't do Reporters
-                                    if (name.startsWith("MR") && rm.getReporter(name) != null) legacyNameSet.remove(name);
+                                    if (name.startsWith("MR") && rm.getReporter(name) != null) continue;
+                                    tempSet.add(name);
                                 }
-                                if (legacyNameSet.size() == 0) return true;
+                                if (tempSet.size() == 0) return true;
                                 
                                 org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(Manager.class);
                                 log.warn("The following legacy names need to be migrated:");
-                                for (String name : legacyNameSet) log.warn("    {}", name);
+                                for (String name : tempSet) log.warn("    {}", name);
                                 
                                 // now create the legacy.csv file
                                 try (java.io.PrintWriter writer = new java.io.PrintWriter(jmri.util.FileUtil.getUserFilesPath()+java.io.File.separator+"legacy_bean_names.csv");) {
-                                    for (String name : legacyNameSet) writer.println(name);
+                                    for (String name : tempSet) writer.println(name);
                                 } catch (java.io.IOException e) {
                                     log.error("Failed to write legacy name file", e);
                                 }
+                                
+                                // clean up in case invoked twice
+                                legacyNameSet.clear();
                                 return true;
                             }
                 };

--- a/java/test/jmri/ManagerTest.java
+++ b/java/test/jmri/ManagerTest.java
@@ -3,6 +3,7 @@ package jmri;
 import java.util.*;
 
 import jmri.util.JUnitUtil;
+import jmri.util.JUnitAppender;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -70,6 +71,7 @@ public class ManagerTest {
         Assert.assertEquals("DCCPPT12", 5, Manager.getSystemPrefixLength("DCCPPT12"));
         Assert.assertEquals("MRT13", 2, Manager.getSystemPrefixLength("MRT13"));
         Assert.assertEquals("DXT512", 2, Manager.getSystemPrefixLength("DXT512"));
+
     }
 
     @Test
@@ -153,6 +155,61 @@ public class ManagerTest {
         for (String s : Manager.LEGACY_PREFIXES.toArray(new String[0])) {
             Assert.assertEquals("Length test of \""+s+"\"",s.length(), Manager.startsWithLegacySystemPrefix(s+"T12"));
         }
+    }
+
+    // test shutdown operation (without shutting down)
+    // doesn't check MR-is-OK-for-Reporter case
+    @Test
+    public void testLegacyReportTask() {
+
+        // load up
+        Manager.getSystemPrefixLength("DCCPPT1");
+        Manager.getSystemPrefixLength("MRT1");
+        Manager.getSystemPrefixLength("DXT1");
+        
+        // and try
+        Manager.legacyReportTask.execute();
+        
+        // check report (sorted order)
+        JUnitAppender.assertWarnMessage("The following legacy names need to be migrated:");
+        JUnitAppender.assertWarnMessage("    DCCPPT1");
+        JUnitAppender.assertWarnMessage("    DXT1");
+        JUnitAppender.assertWarnMessage("    MRT1");
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
+    }
+    
+    // test shutdown operation (without shutting down)
+    // checks MR-is-OK-for-Reporter case
+    @Test
+    public void testLegacyReportTaskWReporter() {
+        
+        // create reporter manager
+        JUnitUtil.resetInstanceManager();
+        JUnitUtil.initConfigureManager();
+        ReporterManager m = new jmri.jmrix.internal.InternalReporterManager(){
+            @Override
+            public String getSystemPrefix() {
+                return "M";
+            }
+        };
+        InstanceManager.getDefault(ConfigureManager.class).registerConfig(m, jmri.Manager.REPORTERS);
+        InstanceManager.setDefault(ReporterManager.class,m);
+
+        Assert.assertTrue(null != InstanceManager.getDefault(ReporterManager.class).provideReporter("MR2"));
+        Assert.assertTrue(null != InstanceManager.getDefault(ReporterManager.class).getReporter("MR2"));
+
+        // load up
+        Manager.getSystemPrefixLength("DCCPPT2");
+        Manager.getSystemPrefixLength("MR2");
+        Manager.getSystemPrefixLength("DXT2");
+        // and try
+        Manager.legacyReportTask.execute();
+        
+        // check report (sorted order)
+        JUnitAppender.assertWarnMessage("The following legacy names need to be migrated:");
+        JUnitAppender.assertWarnMessage("    DCCPPT2");
+        JUnitAppender.assertWarnMessage("    DXT2");
+        Assert.assertTrue(JUnitAppender.verifyNoBacklog());
     }
 
     // test proper coding of constants
@@ -281,6 +338,9 @@ public class ManagerTest {
 
     @After
     public void tearDown() {
+        // clear to avoid report at end of test
+        Manager.legacyNameSet.clear();
+
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/ManagerTest.java
+++ b/java/test/jmri/ManagerTest.java
@@ -143,6 +143,12 @@ public class ManagerTest {
         Assert.assertEquals(2, Manager.startsWithLegacySystemPrefix("DXS1"));
         Assert.assertEquals(5, Manager.startsWithLegacySystemPrefix("DCCPPT4"));
         Assert.assertEquals(2, Manager.startsWithLegacySystemPrefix("DPS12"));
+
+        Assert.assertEquals(5, Manager.startsWithLegacySystemPrefix("DCCPPT1"));
+        Assert.assertEquals(2, Manager.startsWithLegacySystemPrefix("DXT1"));
+        Assert.assertEquals(2, Manager.startsWithLegacySystemPrefix("MRT1"));
+        Assert.assertEquals(2, Manager.startsWithLegacySystemPrefix("TML1"));
+        Assert.assertEquals(2, Manager.startsWithLegacySystemPrefix("PIL1"));
         
         Assert.assertEquals(-1, Manager.startsWithLegacySystemPrefix("CT1"));
         Assert.assertEquals(-1, Manager.startsWithLegacySystemPrefix("C2T12"));
@@ -166,6 +172,7 @@ public class ManagerTest {
         Manager.getSystemPrefixLength("DCCPPT1");
         Manager.getSystemPrefixLength("MRT1");
         Manager.getSystemPrefixLength("DXT1");
+        Manager.getSystemPrefixLength("TML1");
         
         // and try
         Manager.legacyReportTask.execute();
@@ -175,6 +182,7 @@ public class ManagerTest {
         JUnitAppender.assertWarnMessage("    DCCPPT1");
         JUnitAppender.assertWarnMessage("    DXT1");
         JUnitAppender.assertWarnMessage("    MRT1");
+        JUnitAppender.assertWarnMessage("    TML1");
         Assert.assertTrue(JUnitAppender.verifyNoBacklog());
     }
     
@@ -202,6 +210,7 @@ public class ManagerTest {
         Manager.getSystemPrefixLength("DCCPPT2");
         Manager.getSystemPrefixLength("MR2");
         Manager.getSystemPrefixLength("DXT2");
+        Manager.getSystemPrefixLength("TML2");
         // and try
         Manager.legacyReportTask.execute();
         
@@ -209,6 +218,8 @@ public class ManagerTest {
         JUnitAppender.assertWarnMessage("The following legacy names need to be migrated:");
         JUnitAppender.assertWarnMessage("    DCCPPT2");
         JUnitAppender.assertWarnMessage("    DXT2");
+        // MR2 suppressed
+        JUnitAppender.assertWarnMessage("    TML2");
         Assert.assertTrue(JUnitAppender.verifyNoBacklog());
     }
 


### PR DESCRIPTION
Add special-case handling to determine whether a system name that starts with "MR" is a legacy prefix or a Reporter with an M system ID.

This is _not_ general code; it only catches the specific case in #6477 

Also includes some improvements to documentation.

See the plan for legacy migration in #4670 

@icklesteve Could you try this out?