### PR TITLE
MultiThrottle - isValidAddr causes Exception if argument too short

### DIFF
--- a/java/src/jmri/jmrit/withrottle/MultiThrottle.java
+++ b/java/src/jmri/jmrit/withrottle/MultiThrottle.java
@@ -130,6 +130,7 @@ public class MultiThrottle {
     private boolean isValidAddr(String key) {
         if (key.length() < 2) {
             String msg = Bundle.getMessage("ErrorAddressTooShort", key);
+            parentController.sendAlertMessage(msg);
             log.warn(msg);
             return false;
         }

--- a/java/src/jmri/jmrit/withrottle/MultiThrottle.java
+++ b/java/src/jmri/jmrit/withrottle/MultiThrottle.java
@@ -129,27 +129,43 @@ public class MultiThrottle {
      */
     private boolean isValidAddr(String key) {
         if (key.length() < 2) {
-            String msg = Bundle.getMessage("ErrorAddressTooShort", key);
+            String msg = Bundle.getMessage("ErrorInvalidAddressFormat", key);
+            log.warn(msg);
+            parentController.sendAlertMessage(msg);
+            return false;
+        }
+        try {
+            int addr = Integer.parseInt(key.substring(1));
+            if (key.charAt(0) == 'L') {
+                if (jmri.InstanceManager.throttleManagerInstance().canBeLongAddress(addr)) {
+                    return true;
+                } else {
+                    String msg = Bundle.getMessage("ErrorLongAddress", key);
+                    log.warn(msg);
+                    parentController.sendAlertMessage(msg);
+                    return false;
+                }
+            } else if (key.charAt(0) == 'S') {
+                if (jmri.InstanceManager.throttleManagerInstance().canBeShortAddress(addr)) {
+                    return true;
+                } else {
+                    String msg = Bundle.getMessage("ErrorShortAddress", key);
+                    log.warn(msg);
+                    parentController.sendAlertMessage(msg);
+                    return false;
+                }
+            }
+            String msg = Bundle.getMessage("ErrorInvalidAddressFormat", key);
+            parentController.sendAlertMessage(msg);
+            log.warn(msg);
+            return false;
+        } catch (NumberFormatException e) {
+            String msg = Bundle.getMessage("ErrorInvalidAddressFormat", key);
             parentController.sendAlertMessage(msg);
             log.warn(msg);
             return false;
         }
-        int addr = Integer.parseInt(key.substring(1));
-        if ((key.charAt(0) == 'L') && 
-                !jmri.InstanceManager.throttleManagerInstance().canBeLongAddress(addr)) {
-            String msg = Bundle.getMessage("ErrorLongAddress", key);
-            log.warn(msg);
-            parentController.sendAlertMessage(msg);
-            return false;
-        } else if ((key.charAt(0) == 'S') && 
-                !jmri.InstanceManager.throttleManagerInstance().canBeShortAddress(addr)) {
-            String msg = Bundle.getMessage("ErrorShortAddress", key);
-            log.warn(msg);
-            parentController.sendAlertMessage(msg);
-            return false;            
-        }
-        return true;
-}
+    }
 
     protected boolean removeThrottleController(String key, String action) {
 

--- a/java/src/jmri/jmrit/withrottle/MultiThrottle.java
+++ b/java/src/jmri/jmrit/withrottle/MultiThrottle.java
@@ -128,6 +128,11 @@ public class MultiThrottle {
      * @param key address to be validated, of form Lnnnn or Snnn
      */
     private boolean isValidAddr(String key) {
+        if (key.length() < 2) {
+            String msg = Bundle.getMessage("ErrorAddressTooShort", key);
+            log.warn(msg);
+            return false;
+        }
         int addr = Integer.parseInt(key.substring(1));
         if ((key.charAt(0) == 'L') && 
                 !jmri.InstanceManager.throttleManagerInstance().canBeLongAddress(addr)) {

--- a/java/src/jmri/jmrit/withrottle/WiThrottleBundle.properties
+++ b/java/src/jmri/jmrit/withrottle/WiThrottleBundle.properties
@@ -91,5 +91,5 @@ ErrorRouteBadMessage  =JMRI: Unsupported route message ''{0}''
 ErrorRouteOther       =Error setting route ''{0}'' in JMRI
 ErrorLongAddress      =JMRI: address ''{0}'' not allowed as Long
 ErrorShortAddress     =JMRI: address ''{0}'' not allowed as Short
-ErrorAddressTooShort  =JMRI: address ''{0}'' must have a letter S or L and then digit(s) 
+ErrorInvalidAddressFormat  =JMRI: address ''{0}'' must have a letter S or L and then digit(s) 
 

--- a/java/src/jmri/jmrit/withrottle/WiThrottleBundle.properties
+++ b/java/src/jmri/jmrit/withrottle/WiThrottleBundle.properties
@@ -91,4 +91,5 @@ ErrorRouteBadMessage  =JMRI: Unsupported route message ''{0}''
 ErrorRouteOther       =Error setting route ''{0}'' in JMRI
 ErrorLongAddress      =JMRI: address ''{0}'' not allowed as Long
 ErrorShortAddress     =JMRI: address ''{0}'' not allowed as Short
+ErrorAddressTooShort  =JMRI: address ''{0}'' must have a letter S or L and then digit(s) 
 

--- a/java/test/jmri/jmrit/withrottle/MultiThrottleTest.java
+++ b/java/test/jmri/jmrit/withrottle/MultiThrottleTest.java
@@ -155,6 +155,12 @@ public class MultiThrottleTest {
     public void testIsValidAddress() throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         Method m = throttle.getClass().getDeclaredMethod("isValidAddr", String.class);
         m.setAccessible(true);
+        Assert.assertFalse((Boolean)m.invoke(throttle, "hjs"));
+        JUnitAppender.assertWarnMessage("JMRI: address 'hjs' must have a letter S or L and then digit(s)");
+        Assert.assertFalse((Boolean)m.invoke(throttle, "s13"));
+        JUnitAppender.assertWarnMessage("JMRI: address 's13' must have a letter S or L and then digit(s)");
+        Assert.assertFalse((Boolean)m.invoke(throttle, "l13"));
+        JUnitAppender.assertWarnMessage("JMRI: address 'l13' must have a letter S or L and then digit(s)");
         Assert.assertFalse((Boolean)m.invoke(throttle, "S"));
         JUnitAppender.assertWarnMessage("JMRI: address 'S' must have a letter S or L and then digit(s)");
         Assert.assertFalse((Boolean)m.invoke(throttle, "L"));

--- a/java/test/jmri/jmrit/withrottle/MultiThrottleTest.java
+++ b/java/test/jmri/jmrit/withrottle/MultiThrottleTest.java
@@ -1,7 +1,10 @@
 package jmri.jmrit.withrottle;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import jmri.InstanceManager;
 import jmri.NamedBeanHandleManager;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import org.junit.*;
 
@@ -146,6 +149,23 @@ public class MultiThrottleTest {
        // function "on" from withrottle represents a button click event.
        throttle.handleMessage("AL1234<;>Q");
        Assert.assertEquals("outgoing message after quit", "MA-L1234<;>",cis.getLastPacket() );
+    }
+    
+    @Test
+    public void testIsValidAddress() throws NoSuchMethodException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        Method m = throttle.getClass().getDeclaredMethod("isValidAddr", String.class);
+        m.setAccessible(true);
+        Assert.assertFalse((Boolean)m.invoke(throttle, "S"));
+        JUnitAppender.assertWarnMessage("JMRI: address 'S' must have a letter S or L and then digit(s)");
+        Assert.assertFalse((Boolean)m.invoke(throttle, "L"));
+        JUnitAppender.assertWarnMessage("JMRI: address 'L' must have a letter S or L and then digit(s)");
+        Assert.assertFalse((Boolean)m.invoke(throttle, "7"));
+        JUnitAppender.assertWarnMessage("JMRI: address '7' must have a letter S or L and then digit(s)");
+        Assert.assertTrue((Boolean)m.invoke(throttle, "S32"));
+        Assert.assertFalse((Boolean)m.invoke(throttle, "S320"));
+        JUnitAppender.assertWarnMessage("JMRI: address 'S320' not allowed as Short");
+        Assert.assertTrue((Boolean)m.invoke(throttle, "L32"));
+        Assert.assertTrue((Boolean)m.invoke(throttle, "L320"));
     }
 
     @Before


### PR DESCRIPTION
PR from Heiko Rosemann.

Hi everyone,

In the course of fixing my wiThrottle-throttle, I came across a NullPointerException in MultiThrottle.java when the "key" (the part after "MT+") was too short.

Suggested fix (I haven't built that, still need to setup a JMRI build environment):

Best Regards,
Heiko