### PR TITLE
WIP MERG CBUS STL Validity

### DIFF
--- a/help/en/html/hardware/can/cbus/Names.shtml
+++ b/help/en/html/hardware/can/cbus/Names.shtml
@@ -295,17 +295,6 @@
           <td> </td>
         </tr>
         <tr>
-          <td>in</td>
-          <td>200018M07</td>
-          <td>listen to Events 18 .. 1F</td>
-          <td>MS200018M07</td>
-          <td>+ M + hex mask</td>
-          <td>N/A</td>
-          <td> </td>
-          <td> </td>
-          <td> </td>
-        </tr>
-        <tr>
           <td>both</td>
           <td>X90002D002E;X91FFFFFFFE</td>
           <td>hex CAN frame msg. Active;

--- a/java/src/jmri/jmrix/can/cbus/CbusAddress.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusAddress.java
@@ -7,8 +7,8 @@ import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.util.StringUtil;
 
-// import org.slf4j.Logger;
-// import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utilities for handling CBUS addresses.
@@ -265,30 +265,155 @@ public class CbusAddress {
      *
      */
     public static String getIncrement( @Nonnull String testAddr ) {
+        log.debug("testing address {}",testAddr);
         CbusAddress a = new CbusAddress(testAddr);
         CbusAddress[] v = a.split();
+        String newString="";
         switch (v.length) {
-            case 1:
-                // get last part and increment
-                int last =  StringUtil.getLastIntFromString(v[0].toString());
-                if ( last < 1 ) { // event numbers should be > 0
-                    return null;
-                }
-                return StringUtil.replaceLast(v[0].toString(), String.valueOf(last), String.valueOf(last+1));
             case 2:
                 int lasta =  StringUtil.getLastIntFromString(v[0].toString());
                 int lastb =  StringUtil.getLastIntFromString(v[1].toString());
-                if ( ( lasta < 1 ) || ( lastb < 1 ) ) { // event numbers should be > 0
-                    return null;
-                }
                 StringBuilder sb = new StringBuilder();
                 sb.append(StringUtil.replaceLast(v[0].toString(), String.valueOf(lasta), String.valueOf(lasta+1)));
                 sb.append(";");
                 sb.append(StringUtil.replaceLast(v[1].toString(), String.valueOf(lastb), String.valueOf(lastb+1)));
-                return sb.toString();
+                newString= sb.toString();
+                break;
             default:
-                return null;
+                // get last part and increment
+                int last =  StringUtil.getLastIntFromString(v[0].toString());
+                newString= StringUtil.replaceLast(v[0].toString(), String.valueOf(last), String.valueOf(last+1));
+                break;
         }
+        try {
+            return validateSysName(newString);
+        } catch (IllegalArgumentException e) {
+            log.error(e.toString());
+        }
+        return null;
+    }
+
+    /**
+     * Work out the details for Cbus hardware address validation
+     * Logging of handled cases no higher than WARN.
+     *
+     * @param address the hardware address to check
+     * @throws IllegalArgumentException when delimiter is not found
+     */
+    public static String validateSysName( String address ) throws IllegalArgumentException  {
+        
+        if ( address == null ) {
+            throw new IllegalArgumentException("No address Passed ");
+        }        
+        
+        if ( address.endsWith(";") ) {
+            throw new IllegalArgumentException("Should not end with ; " + address);
+        }
+        
+        // 1st set of switch cases enable strings to pass as a CbusAddress if unsigned
+        String[] addressArray = address.split(";");
+        switch (addressArray.length) {
+            case 1:
+                address = checkPartOfName(addressArray[0],"+");
+                break;
+            case 2:                    
+                address = checkPartOfName(addressArray[0],"+") + ";" + checkPartOfName(addressArray[1],"-");
+                break;
+            default:
+                throw new IllegalArgumentException("Wrong number of events in address: " + address);
+        }
+        
+        CbusAddress a = new CbusAddress(address);
+        CbusAddress[] v = a.split();
+        switch (v.length) {
+            case 0:
+                throw new IllegalArgumentException("Did not find usable hardware address: " + address + " for a valid Cbus sensor address");
+            case 1:
+                if ( address.startsWith("+") || address.startsWith("-") ) {
+                    break;
+                }
+                int unsigned = 0;
+                try {
+                    unsigned = Integer.parseInt(address); // accept unsigned integer, will add "+" upon creationz
+                    if ( unsigned > 100000 ) {
+                        break;
+                    }
+                } catch (NumberFormatException ex) {
+                    log.debug("Unable to convert {} into Cbus format +nn", address);
+                }
+                throw new IllegalArgumentException("can't make 2nd event from address " + address);
+            case 2:
+                break;
+            default:
+                throw new IllegalArgumentException("Wrong number of events in address: " + address);
+        }
+        return address;
+    }
+    
+    private static String checkPartOfName( String testpart, String plusOrMinus ){
+        int unsigned = 0;
+        String part = testpart;
+        try {
+            unsigned = Integer.parseInt(part); // accept unsigned single integer, will add "+" upon creationz
+            log.debug("part {} is integer {}",part,unsigned);
+            if ( unsigned == 0 ){
+                throw new IllegalArgumentException("Event cannot be 0 in address: " + part);
+            }
+            if ( (part.charAt(0) != '+') && ( (part.charAt(0) != '-') ) ) {
+                if ( unsigned > 0 && unsigned < 65536 ) {
+                    part = plusOrMinus + part;
+                }
+            }
+            if ( unsigned > 65535 && unsigned < 100000 ) {
+                throw new IllegalArgumentException("On Too big for an event, too low for node + event : " + part);
+            }
+            if ( unsigned < -65535 && unsigned > -100000 ) {
+                throw new IllegalArgumentException("Off Too big for an event, too low for node + event : " + part);
+            }
+            if (part == "+0") {
+                throw new IllegalArgumentException("Event cannot be 0 in address: " + part);
+            }
+            if (part == "-0") {
+                throw new IllegalArgumentException("Event cannot be 0 in address: " + part);
+            }            
+            
+        } catch (NumberFormatException ex) {
+            log.debug("Unable to convert {} into Cbus format +nn", part);
+        }
+        if ( unsigned == 0 ) {
+            // so it's a string.
+            // ignoring anything starting with x or X as it may be a HEX value
+            // which is checked by core CbusAddress
+            try {
+                if ( (part.charAt(0) != 'x') && (part.charAt(0) != 'X') ) {
+                    log.debug("not an int or hex {}",part);
+                    
+                    // it's got a string in somewhere, start by checking event number
+                    int lasta =  StringUtil.getLastIntFromString(part);
+                    log.debug("last string {}",lasta);
+                    if ( lasta == 0 ){
+                        throw new IllegalArgumentException("Event cannot be 0 in address: " + part);
+                    }
+                    if ( lasta > 65535 ){
+                        throw new IllegalArgumentException("Event Too Large in address: " + part);
+                    }
+                    int firsta =  StringUtil.getFirstIntFromString(part);
+                    log.debug("first string {}",firsta);
+                    if ( firsta == 0 ){
+                        throw new IllegalArgumentException("Node cannot be 0 in address: " + part);
+                    }
+                    if ( firsta > 65535 ){
+                        throw new IllegalArgumentException("Node Too Large in address: " + part);
+                    }
+                }
+            }
+            catch ( StringIndexOutOfBoundsException ex ) {
+                throw new IllegalArgumentException("Address Too Short? : " + part);
+            }
+            
+            
+        }
+        return part;
     }
 
     /**
@@ -329,5 +454,5 @@ public class CbusAddress {
         }
         return retval;
     }
-    // private final static Logger log = LoggerFactory.getLogger(CbusAddress.class);
+    private final static Logger log = LoggerFactory.getLogger(CbusAddress.class);
 }

--- a/java/src/jmri/jmrix/can/cbus/CbusSensor.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensor.java
@@ -189,8 +189,9 @@ public class CbusSensor extends AbstractSensor implements CanListener {
      * {@inheritDoc}
      *
      * When a reporter is attached to the sensor, the sensor will go
-     * active when an ID tag is present ( assuming Sensor not inverted )
-     * inactive when the same ID tag is announced by another reporter.
+     * active when > 0 ID tags are present ( assuming Sensor not inverted ),
+     * inactive when no ID tags are present, ie all previously announced
+     * ID tags have since been announced by other reporters.
      */
     @Override
     public void setReporter(Reporter er) {
@@ -198,13 +199,13 @@ public class CbusSensor extends AbstractSensor implements CanListener {
         if (reporter!=null) {
             log.debug("attached to reporter",reporter);
             reporter.addPropertyChangeListener((PropertyChangeEvent e) -> {
-                log.debug("Report {} new value {}",reporter, e.getNewValue());
-                if (e.getPropertyName().equals("currentReport")) {
+                log.debug("Report {} property {} new value {}",reporter, e.getPropertyName(), e.getNewValue());
+                if (e.getPropertyName().equals("state")) {
                     try {
-                        if (e.getNewValue()==null) {
-                            setKnownState(Sensor.INACTIVE); // setKnownState does any inversion
-                        } else {
+                        if ( (int) e.getNewValue()==jmri.IdTag.SEEN) {
                             setKnownState(Sensor.ACTIVE); // setKnownState does any inversion
+                        } else {
+                            setKnownState(Sensor.INACTIVE); // setKnownState does any inversion
                         }
                     } catch (jmri.JmriException ex) {
                         log.error("Reporter {} unable to change sensor status",reporter);

--- a/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableAction.java
+++ b/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableAction.java
@@ -113,7 +113,7 @@ public class CbusEventTableAction {
             _model.setValueAt("", i, CbusEventTableDataModel.STLR_ON_COLUMN);
             _model.setValueAt("", i, CbusEventTableDataModel.STLR_OFF_COLUMN);
         }
-        jmri.SensorManager sm = InstanceManager.sensorManagerInstance();
+        jmri.SensorManager sm = InstanceManager.getDefault(jmri.SensorManager.class);
         sm.getNamedBeanSet().forEach((nb) -> {
             if (nb instanceof CbusSensor) {
                 CbusSensor cs = (CbusSensor) sm.provideSensor(nb.toString());
@@ -123,7 +123,7 @@ public class CbusEventTableAction {
                 linkHwaddtoEvent( cs.getAddrInactive(), text, nb.getDisplayName() );
             }
         });
-        jmri.TurnoutManager tm = InstanceManager.turnoutManagerInstance();
+        jmri.TurnoutManager tm = InstanceManager.getDefault(jmri.TurnoutManager.class);
         tm.getNamedBeanSet().forEach((nb) -> {
             if (nb instanceof CbusTurnout) {
                 CbusTurnout ct = (CbusTurnout) tm.provideTurnout(nb.toString());
@@ -133,7 +133,7 @@ public class CbusEventTableAction {
                 linkHwaddtoEvent( ct.getAddrClosed(), text, nb.getDisplayName() );
             }
         });
-        jmri.LightManager lm = InstanceManager.lightManagerInstance();
+        jmri.LightManager lm = InstanceManager.getDefault(jmri.LightManager.class);
         lm.getNamedBeanSet().forEach((nb) -> {
             if (nb instanceof CbusLight) {
                 CbusLight cl = (CbusLight) lm.provideLight(nb.toString());

--- a/java/src/jmri/jmrix/can/cbus/swing/simulator/SimulatorPane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/simulator/SimulatorPane.java
@@ -20,9 +20,6 @@ import javax.swing.Timer;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.CbusCommandStation;
 import jmri.jmrix.can.cbus.simulator.CbusSimulator;
-import jmri.jmrix.can.cbus.swing.simulator.CsPane;
-import jmri.jmrix.can.cbus.swing.simulator.EvResponderPane;
-import jmri.jmrix.can.cbus.swing.simulator.NdPane;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,7 +87,7 @@ public class SimulatorPane extends jmri.jmrix.can.swing.CanPanel {
         super();
     }
     
-    public void init() {
+    private void init() {
         
         _disposeSimOnWindowClose=false;
         

--- a/java/src/jmri/util/StringUtil.java
+++ b/java/src/jmri/util/StringUtil.java
@@ -478,6 +478,34 @@ public class StringUtil {
     }
 
     /**
+     * Return the first int value within a string
+     * eg X X123XX456X will return 123
+     *
+     * @param str contents to process
+     * @return first value in int form , -1 if not found
+     */
+    @CheckReturnValue
+    static public int getFirstIntFromString(@Nonnull String str){
+        StringBuilder sb = new StringBuilder();
+        for (int i =0; i<str.length(); i ++) {
+            char c = str.charAt(i);
+            if(c != ' '){
+                if (Character.isDigit(c)) {
+                    sb.append(c);
+                } else {
+                    if (!sb.toString().equals("")) {
+                        break;
+                    }
+                }
+            }
+        }
+        if (!sb.toString().equals("")) {
+            return (Integer.parseInt(sb.toString()));  
+        }
+        return -1;
+    }
+
+    /**
      * Return the last int value within a string
      * eg XX123XX456X will return 456
      *

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.can.cbus;
 
+import jmri.Manager.NameValidity;
 import jmri.Sensor;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
@@ -7,8 +8,8 @@ import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import org.junit.*;
 
-// import org.slf4j.Logger;
-// import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tests for the jmri.jmrix.can.cbus.CbusSensorManager class.
@@ -158,7 +159,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MS;XABCDEF");
             Assert.fail("Single hex ; Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find usable ");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException:");
             Assert.assertTrue(true);
         }
 
@@ -166,7 +167,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MSXABCDEF;");
             Assert.fail("Single hex ; Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find usable ");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
         
@@ -174,7 +175,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MS;");
             Assert.fail("; no arg Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }        
         
@@ -182,7 +183,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MS;+N15E6");
             Assert.fail("MS Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
         
@@ -328,25 +329,148 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         Assert.assertNotNull("exists",t3);
 
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
     
     @Test
     public void testgetEntryToolTip() {
         String x = l.getEntryToolTip();
         Assert.assertTrue(x.contains("<html>"));
+        
+        Assert.assertTrue(l.allowMultipleAdditions("M77"));
+        
     }
+    
+    @Test
+    public void testvalidSystemNameFormat() {
+        
+        Assert.assertEquals("MS+123",NameValidity.VALID,l.validSystemNameFormat("MS+123"));
+        Assert.assertEquals("MS+N123E123",NameValidity.VALID,l.validSystemNameFormat("MS+N123E123"));
+        Assert.assertEquals("MS+123;456",NameValidity.VALID,l.validSystemNameFormat("MS+123;456"));
+        Assert.assertEquals("MS1",NameValidity.VALID,l.validSystemNameFormat("MS1"));
+        Assert.assertEquals("MS1;2",NameValidity.VALID,l.validSystemNameFormat("MS1;2"));
+        Assert.assertEquals("MS65535",NameValidity.VALID,l.validSystemNameFormat("MS65535"));
+        Assert.assertEquals("MS-65535",NameValidity.VALID,l.validSystemNameFormat("MS-65535"));
+        Assert.assertEquals("MS100001",NameValidity.VALID,l.validSystemNameFormat("MS100001"));
+        Assert.assertEquals("MS-100001",NameValidity.VALID,l.validSystemNameFormat("MS-100001"));
+        Assert.assertEquals("MS+N65535e65535",NameValidity.VALID,l.validSystemNameFormat("MS+N65535e65535"));
+        Assert.assertEquals("MS+N65535e65535;-N65535e65535",NameValidity.VALID,l.validSystemNameFormat("MS+N65535e65535;-N65535e65535"));
+        Assert.assertEquals("MS+N1E2;-N3E4",NameValidity.VALID,l.validSystemNameFormat("MS+N1E2;-N3E4"));
+        Assert.assertEquals("MS-N1E2;+N3E4",NameValidity.VALID,l.validSystemNameFormat("MS-N1E2;+N3E4"));
+
+        Assert.assertEquals("M",NameValidity.INVALID,l.validSystemNameFormat("M"));
+        Assert.assertEquals("MS",NameValidity.INVALID,l.validSystemNameFormat("MS"));
+        Assert.assertEquals("MS-65536",NameValidity.INVALID,l.validSystemNameFormat("MS-65536"));        
+        Assert.assertEquals("MS65536",NameValidity.INVALID,l.validSystemNameFormat("MS65536"));
+        Assert.assertEquals("MS+1;+0",NameValidity.INVALID,l.validSystemNameFormat("MS+1;+0"));
+        Assert.assertEquals("MS+1;-0",NameValidity.INVALID,l.validSystemNameFormat("MS+1;-0"));        
+        Assert.assertEquals("MS+0;+17",NameValidity.INVALID,l.validSystemNameFormat("MS+0;+17"));
+        Assert.assertEquals("MS+0;-17",NameValidity.INVALID,l.validSystemNameFormat("MS+0;-17"));
+        Assert.assertEquals("MS+0",NameValidity.INVALID,l.validSystemNameFormat("MS+0"));
+        Assert.assertEquals("MS-0",NameValidity.INVALID,l.validSystemNameFormat("MS-0"));
+        Assert.assertEquals("MS7;0",NameValidity.INVALID,l.validSystemNameFormat("MS7;0"));
+        Assert.assertEquals("MS0;7",NameValidity.INVALID,l.validSystemNameFormat("MS0;7"));
+        Assert.assertEquals("MS+N17E0",NameValidity.INVALID,l.validSystemNameFormat("MS+N17E0"));
+        Assert.assertEquals("MS+N17E00",NameValidity.INVALID,l.validSystemNameFormat("MS+N17E00"));
+        Assert.assertEquals("MS+N0E17",NameValidity.INVALID,l.validSystemNameFormat("MS+N0E17"));
+        Assert.assertEquals("MS+N00E17",NameValidity.INVALID,l.validSystemNameFormat("MS+N00E17"));
+        Assert.assertEquals("MS+0E17",NameValidity.INVALID,l.validSystemNameFormat("MS+0E17"));
+        Assert.assertEquals("MS0E17",NameValidity.INVALID,l.validSystemNameFormat("MS0E17"));
+        Assert.assertEquals("MS+N65535e65536",NameValidity.INVALID,l.validSystemNameFormat("MS+N65535e65536"));
+        Assert.assertEquals("MS+N65536e65535",NameValidity.INVALID,l.validSystemNameFormat("MS+N65536e65535"));
+        
+    }
+    
+    @Test
+    public void testgetNextValidAddress() {
+        
+        try {
+            Assert.assertEquals("+17","+17",l.getNextValidAddress("+17","M"));
+            Sensor t =  l.provideSensor("MS+17");
+            Assert.assertNotNull("exists",t);
+            Assert.assertEquals("+18","+18",l.getNextValidAddress("+17","M"));
+        
+            Assert.assertEquals("+N45E22","+N45E22",l.getNextValidAddress("+N45E22","M"));
+            Sensor ta =  l.provideSensor("MS+N45E22");
+            Assert.assertNotNull("exists",ta);
+            Assert.assertEquals("+N45E23","+N45E23",l.getNextValidAddress("+N45E22","M"));        
+        
+        
+            Assert.assertTrue(true);
+        } catch (Exception e) {
+            Assert.assertTrue(false);
+        }
+        
+        try {
+            Assert.assertEquals("null",null,l.getNextValidAddress(null,"M"));
+            
+        } catch (Exception e) {
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testgetNextValidAddressPt2() {
+        Sensor t =  l.provideSensor("MS+65535");
+        Assert.assertNotNull("exists",t);
+            
+        try {
+            Assert.assertEquals("+65535",null,l.getNextValidAddress("+65535","M"));
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(true);
+        } catch (Exception e) {
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(false);
+        }
+    }
+    
+    @Test
+    public void testgetNextValidAddressPt3() {
+        
+        Sensor t =  l.provideSensor("MS+10");
+        Assert.assertNotNull("exists",t);
+            
+        try {
+            Assert.assertEquals("+10","+11",l.getNextValidAddress("+10","M"));
+            Assert.assertTrue(true);
+        } catch (Exception e) {
+            Assert.assertTrue(false);
+        }
+    }
+
+    @Test
+    public void testcreateSystemName() {
+        
+        try {
+            Assert.assertEquals("MS+10","MS+10",l.createSystemName("+10","M"));
+            Assert.assertEquals("MS+N34E610","MS+N34E610",l.createSystemName("+N34E610","M"));
+            Assert.assertEquals("MS-N34E610","MS-N34E610",l.createSystemName("-N34E610","M"));
+            Assert.assertEquals("MS+N34E610;-N987E654","MS+N34E610;-N987E654",l.createSystemName("+N34E610;-N987E654","M"));
+            
+        } catch (Exception e) {
+            Assert.assertTrue(false);
+        }
+        
+        try {
+            Assert.assertEquals("M2S+10","MS+10",l.createSystemName("+10","M2"));
+        } catch (Exception e) {
+            Assert.assertTrue(false);
+        }
+
+        try {
+            Assert.assertEquals("M2S+10","MS+10",l.createSystemName("+10","ZZZZZZZZZ"));
+        } catch (Exception e) {
+            Assert.assertTrue(false);
+        }
+        
+        try {
+            Assert.assertEquals("MSS",null,l.createSystemName("S","M"));
+            Assert.assertTrue(false);
+        } catch (Exception e) {
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(true);
+        }
+    }
+    
     
     // The minimal setup for log4J
     @Override
@@ -365,5 +489,5 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         memo.dispose();
         JUnitUtil.tearDown();
     }
-    // private final static Logger log = LoggerFactory.getLogger(CbusSensorManagerTest.class);
+     private final static Logger log = LoggerFactory.getLogger(CbusSensorManagerTest.class);
 }

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.can.cbus;
 
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.Manager.NameValidity;
 import jmri.Turnout;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
@@ -33,7 +34,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
 
 
     public String getSystemName(int i){
-        return "MTX0A;+N123E9632" + i;
+        return "MTX0A;+N123E3" + i;
     }
     
     @Override
@@ -43,7 +44,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
     
     @Override
     protected int getNumToTest2() {
-        return 47269;
+        return 7269;
     }
     
     @Override
@@ -129,7 +130,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("MT;XABCDEF");
             Assert.fail("Single hex ; Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find usable ");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -137,7 +138,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("MTXABCDEF;");
             Assert.fail("Single hex ; Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find usable ");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
         
@@ -145,7 +146,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("MT;");
             Assert.fail("; no arg Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }        
         
@@ -153,7 +154,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("MT;+N15E6");
             Assert.fail("MS Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
         
@@ -167,7 +168,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             Assert.fail("; Should have thrown an exception");
             
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -270,6 +271,129 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
     public void testgetEntryToolTip() {
         String x = l.getEntryToolTip();
         Assert.assertTrue(x.contains("<html>"));
+        
+        Assert.assertTrue(l.allowMultipleAdditions("M77"));
+        
+    }
+
+    @Test
+    public void testvalidSystemNameFormat() {
+        
+        Assert.assertEquals("MT+123",NameValidity.VALID,l.validSystemNameFormat("MT+123"));
+        Assert.assertEquals("MT+N123E123",NameValidity.VALID,l.validSystemNameFormat("MT+N123E123"));
+        Assert.assertEquals("MT+123;456",NameValidity.VALID,l.validSystemNameFormat("MT+123;456"));
+        Assert.assertEquals("MT1",NameValidity.VALID,l.validSystemNameFormat("MT1"));
+        Assert.assertEquals("MT1;2",NameValidity.VALID,l.validSystemNameFormat("MT1;2"));
+        Assert.assertEquals("MT65535",NameValidity.VALID,l.validSystemNameFormat("MT65535"));
+        Assert.assertEquals("MT-65535",NameValidity.VALID,l.validSystemNameFormat("MT-65535"));
+        Assert.assertEquals("MT100001",NameValidity.VALID,l.validSystemNameFormat("MT100001"));
+        Assert.assertEquals("MT-100001",NameValidity.VALID,l.validSystemNameFormat("MT-100001"));
+
+        Assert.assertEquals("M",NameValidity.INVALID,l.validSystemNameFormat("M"));
+        Assert.assertEquals("MT",NameValidity.INVALID,l.validSystemNameFormat("MT"));
+        Assert.assertEquals("MT-65536",NameValidity.INVALID,l.validSystemNameFormat("MT-65536"));        
+        Assert.assertEquals("MT65536",NameValidity.INVALID,l.validSystemNameFormat("MT65536"));
+        Assert.assertEquals("MT+1;+0",NameValidity.INVALID,l.validSystemNameFormat("MT+1;+0"));
+        Assert.assertEquals("MT+1;-0",NameValidity.INVALID,l.validSystemNameFormat("MT+1;-0"));        
+        Assert.assertEquals("MT+0;+17",NameValidity.INVALID,l.validSystemNameFormat("MT+0;+17"));
+        Assert.assertEquals("MT+0;-17",NameValidity.INVALID,l.validSystemNameFormat("MT+0;-17"));
+        Assert.assertEquals("MT+0",NameValidity.INVALID,l.validSystemNameFormat("MT+0"));
+        Assert.assertEquals("MT-0",NameValidity.INVALID,l.validSystemNameFormat("MT-0"));
+        Assert.assertEquals("MT7;0",NameValidity.INVALID,l.validSystemNameFormat("MT7;0"));
+        Assert.assertEquals("MT0;7",NameValidity.INVALID,l.validSystemNameFormat("MT0;7"));
+        
+    }
+
+    @Test
+    public void testgetNextValidAddress() {
+        
+        try {
+            Assert.assertEquals("+17","+17",l.getNextValidAddress("+17","M"));
+            Turnout t =  l.provideTurnout("MT+17");
+            Assert.assertNotNull("exists",t);
+            Assert.assertEquals("+18","+18",l.getNextValidAddress("+17","M"));
+        
+            Assert.assertEquals("+N45E22","+N45E22",l.getNextValidAddress("+N45E22","M"));
+            Turnout ta =  l.provideTurnout("MT+N45E22");
+            Assert.assertNotNull("exists",ta);
+            Assert.assertEquals("+N45E23","+N45E23",l.getNextValidAddress("+N45E22","M"));        
+        
+        
+            Assert.assertTrue(true);
+        } catch (Exception e) {
+            Assert.assertTrue(false);
+        }
+        
+        try {
+            Assert.assertEquals("null",null,l.getNextValidAddress(null,"M"));
+            
+        } catch (Exception e) {
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            // Assert.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testgetNextValidAddressPt2() {
+        Turnout t =  l.provideTurnout("MT+65535");
+        Assert.assertNotNull("exists",t);
+            
+        try {
+            Assert.assertEquals("+65535",null,l.getNextValidAddress("+65535","M"));
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(true);
+        } catch (Exception e) {
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(false);
+        }
+    }
+    
+    @Test
+    public void testgetNextValidAddressPt3() {
+        
+        Turnout t =  l.provideTurnout("MT+10");
+        Assert.assertNotNull("exists",t);
+            
+        try {
+            Assert.assertEquals("+10","+11",l.getNextValidAddress("+10","M"));
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(true);
+        } catch (Exception e) {
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(false);
+        }
+    }
+
+    @Test
+    public void testcreateSystemName() {
+        
+        try {
+            Assert.assertEquals("MT+10","MT+10",l.createSystemName("10","M"));
+            Assert.assertEquals("MT+N34E610","MT+N34E610",l.createSystemName("+N34E610","M"));
+            Assert.assertEquals("MT5;6","MT+5;-6",l.createSystemName("5;6","M"));
+        } catch (Exception e) {
+            Assert.assertTrue(false);
+        }
+        
+        try {
+            Assert.assertEquals("M2T+10","MT+10",l.createSystemName("+10","M2"));
+        } catch (Exception e) {
+            Assert.assertTrue(false);
+        }
+
+        try {
+            Assert.assertEquals("M2T+10","MT+10",l.createSystemName("+10","ZZZZZZZZZ"));
+        } catch (Exception e) {
+            Assert.assertTrue(false);
+        }
+        
+        try {
+            Assert.assertEquals("MTT",null,l.createSystemName("S","M"));
+            Assert.assertTrue(false);
+        } catch (Exception e) {
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(true);
+        }
     }
     
     // The minimal setup for log4J

--- a/java/test/jmri/util/StringUtilTest.java
+++ b/java/test/jmri/util/StringUtilTest.java
@@ -277,6 +277,24 @@ public class StringUtilTest {
         int[] d = new int[]{1, 2, 3};
         Assert.assertEquals("Object", "[1],[2],[3]", StringUtil.arrayToString(d));
     }
+
+    @Test
+    public void testGetFirstIntFromString() {
+        Assert.assertEquals("F aABC123DEFb", 123, StringUtil.getFirstIntFromString("aABC123DEFb"));
+        Assert.assertEquals("F no val", -1, StringUtil.getFirstIntFromString(""));
+        Assert.assertEquals("F 0", 0, StringUtil.getFirstIntFromString("0"));
+        Assert.assertEquals("F +2", 2, StringUtil.getFirstIntFromString("+2"));
+        Assert.assertEquals("F -5", 5, StringUtil.getFirstIntFromString("-5"));
+        Assert.assertEquals("F ABC123DEF", 123,StringUtil.getFirstIntFromString("ABC123DEF"));
+        Assert.assertEquals("F ABC123", 123, StringUtil.getFirstIntFromString("ABC123"));
+        Assert.assertEquals("F 123", 123, StringUtil.getFirstIntFromString("123"));
+        Assert.assertEquals("F 123ABC", 123, StringUtil.getFirstIntFromString("123ABC"));
+        Assert.assertEquals("F 123 ABC ", 123, StringUtil.getFirstIntFromString("123 ABC"));
+        Assert.assertEquals("F 123ABC456", 123, StringUtil.getFirstIntFromString("123ABC456"));
+        Assert.assertEquals("F 123A654BC456", 123, StringUtil.getFirstIntFromString("123A654BC456"));
+        Assert.assertEquals("F XD+123ABC-456", 123, StringUtil.getFirstIntFromString("XD+123ABC-456"));
+        Assert.assertEquals("F A c456fg123ABC789jh", 456, StringUtil.getFirstIntFromString("A c456fg123ABC789jh"));
+    }
     
     @Test
     public void testGetLastIntFromString() {
@@ -289,11 +307,12 @@ public class StringUtilTest {
         Assert.assertEquals("ABC123", 123, StringUtil.getLastIntFromString("ABC123"));
         Assert.assertEquals("123", 123, StringUtil.getLastIntFromString("123"));
         Assert.assertEquals("123ABC", 123, StringUtil.getLastIntFromString("123ABC"));
+        Assert.assertEquals("123 ABC ", 123, StringUtil.getLastIntFromString("123 ABC "));
         Assert.assertEquals("123ABC456", 456, StringUtil.getLastIntFromString("123ABC456"));
         Assert.assertEquals("123A654BC456", 456, StringUtil.getLastIntFromString("123A654BC456"));
         Assert.assertEquals("XD+123ABC-456", 456, StringUtil.getLastIntFromString("XD+123ABC-456"));
         Assert.assertEquals("Ac456fg123ABC789jh", 789, StringUtil.getLastIntFromString("Ac456fg123ABC789jh"));
-    }        
+    }
     
     @Test
     public void testReplaceLast() {
@@ -304,6 +323,7 @@ public class StringUtilTest {
         Assert.assertEquals("77YYYzz", "77YYYzz", StringUtil.replaceLast("xxYYYzz","xx","77"));
         Assert.assertEquals("xxAA77YYYzz", "xxAA77YYYzz", StringUtil.replaceLast("xxAAxxYYYzz","xx","77"));
         Assert.assertEquals("122", "122", StringUtil.replaceLast("121","1","2"));
+        Assert.assertEquals("122 Z", "121", StringUtil.replaceLast("121","Z","2"));
     }
     
 }


### PR DESCRIPTION
Add getFirstIntFromString to StringUtil
Moved system Namevalidity stuff from STL Managers to CbusAddress
Improved validity checks,
1-9 will now pass
MS+N3E0 will now fail, event 0
MT+N3E65567 will now fail, too large
ML+N0E4 will now fail, node 0
MS+N65567E4 will now fail, node too large
MT+N3E4;+N0E5 will fail, node 0 in off address ( on address also checked )
ML+0 will now fail
MS+65566 will now fail, 100001 will pass