### PR TITLE
WIP MERG CBUS CbusNameService

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusCommandStation.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusCommandStation.java
@@ -5,10 +5,7 @@ import jmri.jmrix.can.CanListener;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
-import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
-import jmri.jmrix.can.cbus.simulator.CbusSimulator;
 import jmri.jmrix.can.TrafficController;
-import jmri.util.ThreadingUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,16 +24,15 @@ public class CbusCommandStation implements CommandStation, CanListener {
     public CbusCommandStation(CanSystemConnectionMemo memo) {
         tc = memo.getTrafficController();
         adapterMemo = memo;
-        
         if ( ( tc != null ) && ( tc.getClass().getName().contains("Loopback")) ) {
-            _sim = getNetworkSim();
+            jmri.util.ThreadingUtil.runOnLayout( ()->{
+                new jmri.jmrix.can.cbus.simulator.CbusSimulator(adapterMemo);
+            });
         }
     }
 
     TrafficController tc;
     CanSystemConnectionMemo adapterMemo;
-    CbusSimulator _sim = null;
-    CbusEventTableDataModel _evTab = null;
 
     /**
      * Send a specific packet to the rails.
@@ -144,58 +140,6 @@ public class CbusCommandStation implements CommandStation, CanListener {
         msg.setElement(2, mode);
         tc.sendCanMessage(msg, this);
     }
-
-    public CbusSimulator getNetworkSim() {
-        if ( _sim == null ) {
-            ThreadingUtil.runOnLayout( ()->{
-                _sim = new CbusSimulator(adapterMemo);
-            });
-        }
-        return _sim;
-    }
-    
-    public void disposeNetworkSim() {
-        _sim.dispose();
-        _sim=null;
-    }
-    
-    public void setEventTable( CbusEventTableDataModel evTab ){
-        _evTab = evTab;
-    }
-    
-    public CbusEventTableDataModel getEventTable() {
-        return _evTab;
-    }
-    
-    public String getEventName( int nn, int en ){
-        if ( _evTab !=null ){
-            return _evTab.getEventName(nn,en);
-        }
-        return "";
-    }
-
-    public String getEventNodeString( int nn, int en ){
-        String _return="";
-        if ( _evTab !=null ){
-            _return =  _evTab.getEventString(nn,en);
-        }
-        if (_return.equals("")) {
-            StringBuilder addevbuf = new StringBuilder(50);
-            if (nn>0) {
-                addevbuf.append(Bundle.getMessage("OPC_NN"));
-                addevbuf.append(":");
-                addevbuf.append(nn);
-                addevbuf.append(" ");
-            }
-            addevbuf.append(Bundle.getMessage("OPC_EN"));
-            addevbuf.append(":");
-            addevbuf.append(en);
-            _return = addevbuf.toString();
-        }
-        return _return;
-    }
-    
-    
 
     @Override
     public void message(CanMessage m) {

--- a/java/src/jmri/jmrix/can/cbus/CbusEvent.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusEvent.java
@@ -45,6 +45,13 @@ public class CbusEvent {
         return _nn;
     }
     
+    public void setEn ( int en ) {
+        _en = en;
+    }
+
+    public void setNn ( int nn ) {
+        _nn = nn;
+    }
     
     public void setName( String name ) {
         _name = name;

--- a/java/src/jmri/jmrix/can/cbus/CbusNameService.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusNameService.java
@@ -1,0 +1,68 @@
+package jmri.jmrix.can.cbus;
+
+import javax.annotation.Nonnull;
+import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
+// import org.slf4j.Logger;
+// import org.slf4j.LoggerFactory;
+
+/**
+ * Class to lookup CBUS event names via the event table
+ * <P>
+ * @author Steve Young Copyright (C) 2019
+ */
+public class CbusNameService {
+    
+    private CbusEventTableDataModel eventModel;
+
+    public CbusNameService(){
+    }
+
+    /**
+     * Return a formatted String attempting to use the event toString method
+     * <P>
+     * eg no event table  (123,456) will return NN:123 EN:456 
+     * with event table instance would return   NN:123 Node Name EN:456 Event Name 
+     * No node present returns just event (0,56) EN:56 
+     * All with trailing space
+     * <P>
+     * @param nn Node Number
+     * @param en Event Number
+     * @return Event and node number with event and node name if available
+     */
+    @Nonnull
+    public String getEventNodeString( int nn, int en ){
+        // log.debug("looking up node {} event {}",nn,en);
+        try {
+            eventModel = jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel.class);
+            String addevbuf = eventModel.getEventString(nn,en);
+            if ( !addevbuf.equals("") ) {
+                return addevbuf;
+            }
+        } catch (NullPointerException e) {
+            // log.debug("event table not currently running");
+        }
+        return new CbusEvent(nn,en).toString();
+    }
+
+    /**
+     * Return a formatted String attempting locate the event name
+     * <P>
+     * get the event name, empty string if event not on event table, or if event name is empty
+     * <P>
+     * @param nn Node Number
+     * @param en Event Number
+     * @return Event name if available , else empty string
+     */
+    @Nonnull
+    public String getEventName( int nn, int en ){
+        try {
+            eventModel = jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel.class);
+            return eventModel.getEventName(nn,en);
+        } catch (NullPointerException e) {
+            // log.debug("event table not currently running");
+            return ("");
+        }
+    }
+
+    // private static final Logger log = LoggerFactory.getLogger(CbusNameService.class);
+}

--- a/java/src/jmri/jmrix/can/cbus/CbusOpCodes.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusOpCodes.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import jmri.jmrix.can.cbus.CbusCommandStation;
 import jmri.jmrix.AbstractMessage;
 
 // import org.slf4j.Logger;
@@ -56,11 +55,9 @@ public class CbusOpCodes {
                 fields[i] = locoFromBytes(msg.getElement(idx++), msg.getElement(idx++) );
             }
             else if (fields[i].startsWith("$4")) { // replace the 4 bytes with event / node name ( if possible )
-                CbusCommandStation cmndstat = (CbusCommandStation) jmri.InstanceManager.getDefault(jmri.CommandStation.class);
                 int nn = (256*msg.getElement(idx++))+(msg.getElement(idx++));
                 int en = (256*msg.getElement(idx++))+(msg.getElement(idx++));
-                // log.warn("fetching node {} event {}",nn,en);
-                fields[i] = cmndstat.getEventNodeString(nn,en);
+                fields[i] = new CbusNameService().getEventNodeString(nn,en);
             }
             // concatenat to the result
             buf.append(fields[i]);

--- a/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableDataModel.java
@@ -10,11 +10,8 @@ import jmri.jmrix.can.CanListener;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
-import jmri.jmrix.can.cbus.CbusCommandStation;
 import jmri.jmrix.can.cbus.CbusMessage;
 import jmri.jmrix.can.cbus.CbusOpCodes;
-import jmri.jmrix.can.cbus.eventtable.CbusEventTableAction;
-import jmri.jmrix.can.cbus.eventtable.CbusTableEvent;
 import jmri.jmrix.can.TrafficController;
 import jmri.util.swing.TextAreaFIFO;
 import jmri.util.ThreadingUtil;
@@ -73,12 +70,9 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
         log.info("Starting MERG CBUS Event Table");
         _mainArray = new ArrayList<CbusTableEvent>();
         tablefeedback = new TextAreaFIFO(MAX_LINES);
-       // _memo = memo;
-        // register instance with command station
-        CbusCommandStation cmndstat = (CbusCommandStation) memo.get(jmri.CommandStation.class);
-        if ( cmndstat != null ) {
-            cmndstat.setEventTable(this);
-        }
+
+        jmri.InstanceManager.store(this,jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel.class);
+        
         // connect to the CanInterface
         tc = memo.getTrafficController();
         if (tc != null ) {
@@ -597,7 +591,7 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
             }
         }
         return("");
-    }    
+    }
     
     /**
      * Register new event to table

--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeEvent.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeEvent.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.can.cbus.node;
 
+import javax.annotation.Nonnull;
 import jmri.jmrix.can.cbus.CbusEvent;
 
 /**
@@ -21,7 +22,16 @@ public class CbusNodeEvent extends CbusEvent {
         _evVarArr = new int[maxEvVar];
         java.util.Arrays.fill(_evVarArr,-1);
     }
-    
+ 
+    // copy one
+    public CbusNodeEvent(@Nonnull CbusNodeEvent m) {
+        super(m.getNn(),m.getEn());
+        _thisnode = m._thisnode;
+        _index = m._index;
+        _nodeConfigPanelID = m._nodeConfigPanelID;
+        _evVarArr = m._evVarArr;
+    }
+ 
     public void setEvVar(int index, int value) {
         _evVarArr[(index-1)]=value;
     }

--- a/java/src/jmri/jmrix/can/cbus/simulator/CbusSimulator.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/CbusSimulator.java
@@ -29,6 +29,7 @@ public class CbusSimulator {
 
     public CbusSimulator(CanSystemConnectionMemo sysmemo){
         memo = sysmemo;
+        jmri.InstanceManager.store(this,jmri.jmrix.can.cbus.simulator.CbusSimulator.class);
         init();
     }
     
@@ -110,6 +111,8 @@ public class CbusSimulator {
             _evResponseArr.set(i,null);
         } 
         _evResponseArr = null;
+        
+        jmri.InstanceManager.deregister(this, jmri.jmrix.can.cbus.simulator.CbusSimulator.class);
     }
 
     private static final Logger log = LoggerFactory.getLogger(CbusSimulator.class);

--- a/java/src/jmri/jmrix/can/cbus/swing/CbusEventHighlightFrame.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/CbusEventHighlightFrame.java
@@ -1,4 +1,4 @@
-package jmri.jmrix.can.cbus.swing.console;
+package jmri.jmrix.can.cbus.swing;
 
 import java.awt.Color;
 import javax.swing.BorderFactory;
@@ -7,6 +7,7 @@ import javax.swing.WindowConstants;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.cbus.CbusEventHighlighter;
+import jmri.jmrix.can.cbus.swing.console.CbusConsolePane;
 import jmri.jmrix.can.cbus.swing.configtool.ConfigToolPane;
 import jmri.util.JmriJFrame;
 

--- a/java/src/jmri/jmrix/can/cbus/swing/CbusEventHighlightPanel.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/CbusEventHighlightPanel.java
@@ -1,4 +1,4 @@
-package jmri.jmrix.can.cbus.swing.console;
+package jmri.jmrix.can.cbus.swing;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;

--- a/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolPane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolPane.java
@@ -22,7 +22,7 @@ import jmri.InstanceManager;
 import jmri.jmrix.can.CanListener;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.swing.console.CbusConsolePane;
-import jmri.jmrix.can.cbus.swing.console.CbusEventHighlightFrame;
+import jmri.jmrix.can.cbus.swing.CbusEventHighlightFrame;
 import jmri.jmrix.can.cbus.swing.CbusFilterFrame;
 import jmri.jmrix.can.TrafficController;
 import jmri.jmrix.can.cbus.CbusMessage;
@@ -55,7 +55,7 @@ public class ConfigToolPane extends jmri.jmrix.can.swing.CanPanel implements Can
     }
 
     public static int getConfigToolInstanceNum() {
-        log.warn("instance num {}",configtool_instance_num);
+        log.debug("instance num {}",configtool_instance_num);
         return configtool_instance_num;
     }
     

--- a/java/src/jmri/jmrix/can/cbus/swing/console/CbusConsolePane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/console/CbusConsolePane.java
@@ -38,6 +38,7 @@ import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.swing.configtool.ConfigToolPane;
 import jmri.jmrix.can.cbus.swing.CbusFilterFrame;
+import jmri.jmrix.can.cbus.swing.CbusEventHighlightFrame;
 import jmri.jmrix.can.TrafficController;
 import jmri.jmrix.can.cbus.CbusConstants;
 import jmri.jmrix.can.cbus.CbusMessage;

--- a/java/src/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestMonitorEvent.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestMonitorEvent.java
@@ -7,6 +7,7 @@ import javax.swing.Timer;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.CbusCommandStation;
 import jmri.jmrix.can.cbus.CbusEvent;
+import jmri.jmrix.can.cbus.CbusNameService;
 
 // import org.slf4j.Logger;
 // import org.slf4j.LoggerFactory;
@@ -118,8 +119,7 @@ public class CbusEventRequestMonitorEvent extends CbusEvent {
     // adds event + node name
     protected void getNameFromTable(){
         if (_name.equals("")) {
-            CbusCommandStation cmndstat = (CbusCommandStation) jmri.InstanceManager.getDefault(jmri.CommandStation.class);
-            _name = cmndstat.getEventName(getNn(),getEn());
+            _name = CbusNameService.getEventName(getNn(),getEn());
             if (!_name.equals("")) {
                 _model.setValueAt(_name, _model.eventRow(getNn(),getEn()), 
                     CbusEventRequestDataModel.NAME_COLUMN);

--- a/java/src/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestMonitorEvent.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestMonitorEvent.java
@@ -119,7 +119,7 @@ public class CbusEventRequestMonitorEvent extends CbusEvent {
     // adds event + node name
     protected void getNameFromTable(){
         if (_name.equals("")) {
-            _name = CbusNameService.getEventName(getNn(),getEn());
+            _name = new CbusNameService().getEventName(getNn(),getEn());
             if (!_name.equals("")) {
                 _model.setValueAt(_name, _model.eventRow(getNn(),getEn()), 
                     CbusEventRequestDataModel.NAME_COLUMN);

--- a/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventtable/CbusEventTablePane.java
@@ -66,7 +66,6 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultFormatter;
 import javax.swing.text.Element;
 import javax.swing.text.Highlighter;
-import jmri.jmrix.can.cbus.CbusCommandStation;
 import jmri.jmrix.can.cbus.eventtable.CbusTableEvent;
 import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
 import jmri.util.davidflanagan.HardcopyWriter;
@@ -126,12 +125,13 @@ public class CbusEventTablePane extends jmri.jmrix.can.swing.CanPanel implements
     @Override
     public void initComponents(CanSystemConnectionMemo memo) {
         super.initComponents(memo);
-        CbusCommandStation cmndstat = (CbusCommandStation) memo.get(jmri.CommandStation.class);
-        eventModel = cmndstat.getEventTable();
-        if (eventModel == null ) {
+        try {
+            eventModel = jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel.class);
+        } catch (NullPointerException e) {
             eventModel = new CbusEventTableDataModel(memo, 10,
                 CbusEventTableDataModel.MAX_COLUMN); // controller, row, column
         }
+        
         fcuxmlfilter = new javax.swing.filechooser.FileNameExtensionFilter( "FCU xml", "xml");
         fc = new JFileChooser(FileUtil.getUserFilesPath());
         init();

--- a/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/NodeEditEventFrame.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/NodeEditEventFrame.java
@@ -2,6 +2,7 @@ package jmri.jmrix.can.cbus.swing.nodeconfig;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -18,12 +19,15 @@ import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSeparator;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingConstants;
 import javax.swing.text.DefaultFormatter;
 import javax.swing.Timer;
 import jmri.jmrix.can.cbus.node.CbusNodeEvent;
-import jmri.jmrix.can.cbus.swing.nodeconfig.NodeConfigToolPane;
+import jmri.jmrix.can.cbus.CbusNameService;
 import jmri.util.JmriJFrame;
 
 import org.slf4j.Logger;
@@ -47,6 +51,8 @@ public class NodeEditEventFrame extends JmriJFrame {
     private Timer waitForLearnMode;
     private NodeConfigToolPane _tp;
     private CbusNodeEvent _ndEv;
+    private JLabel NdEvNameLabel;
+    private JPanel NdEvNamePanel;
     
     /**
      * Create a new instance of NodeEditEventFrame.
@@ -66,6 +72,10 @@ public class NodeEditEventFrame extends JmriJFrame {
         
         JPanel setevpanel = new JPanel();
         setevpanel.setLayout(new BoxLayout(setevpanel, BoxLayout.Y_AXIS));
+        JPanel setCoreNodeEventPanel = new JPanel();
+        setCoreNodeEventPanel.setLayout(new BoxLayout(setCoreNodeEventPanel, BoxLayout.Y_AXIS));
+        
+        JScrollPane scrollsetevpanel = new JScrollPane (setevpanel);
         
         JPanel inputpanel = new JPanel();
         frameeditevbutton = new JButton(Bundle.getMessage("EditEvent"));
@@ -89,7 +99,7 @@ public class NodeEditEventFrame extends JmriJFrame {
         JLabel newnvhexlabelEv = new JLabel(" ", JLabel.CENTER);
         evToHex.add(newnvhexlabelEv);
 
-        numberSpinnerEv = new JSpinner(new SpinnerNumberModel(Math.max(0,_ndEv.getEn()), 0, 65535, 1));
+        numberSpinnerEv = new JSpinner(new SpinnerNumberModel(Math.max(1,_ndEv.getEn()), 1, 65535, 1));
         evFields.add(numberSpinnerEv);                   
         numberSpinnerEv.setToolTipText(Bundle.getMessage("NdEvEditToolTip",_ndEv.getEn() ) );
         JComponent compEv = numberSpinnerEv.getEditor();
@@ -100,7 +110,7 @@ public class NodeEditEventFrame extends JmriJFrame {
         individeventEv.add(new JLabel(Bundle.getMessage("CbusEvent"), JLabel.RIGHT));
         individeventEv.add(numberSpinnerEv);
         individeventEv.add(newnvhexlabelEv);
-        setevpanel.add(individeventEv);
+        setCoreNodeEventPanel.add(individeventEv);
         
         JPanel individeventNd= new JPanel(); // row container
         individeventNd.setLayout(new GridLayout(1, 3));
@@ -121,8 +131,24 @@ public class NodeEditEventFrame extends JmriJFrame {
         individeventNd.add(new JLabel(Bundle.getMessage("CbusNode"), JLabel.RIGHT));
         individeventNd.add(numberSpinnernd);
         individeventNd.add(newnvhexlabelNd);
+      //  individeventNd.setVisible(true);
 
-        setevpanel.add(individeventNd);
+        setCoreNodeEventPanel.add(individeventNd);
+        
+        setCoreNodeEventPanel.add(new JSeparator(SwingConstants.HORIZONTAL));
+        
+        
+        
+        NdEvNamePanel= new JPanel(); // row container
+     //   NdEvNamePanel.setLayout(new GridLayout(1, 1));
+        NdEvNamePanel.setLayout(new BoxLayout(NdEvNamePanel, BoxLayout.X_AXIS));
+        // String NdEvName = new CbusNameService().getEventNodeString(_ndEv.getNn(), (Math.max(1,_ndEv.getEn())) );
+        
+        NdEvNameLabel = new JLabel("Fetching Name",SwingConstants.CENTER);
+        NdEvNameLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        updateSelectedEventNodeName();
+        
+        setCoreNodeEventPanel.add( NdEvNameLabel);
         
         evFields.get(0).addChangeListener(new ChangeListener() {
             @Override
@@ -137,6 +163,7 @@ public class NodeEditEventFrame extends JmriJFrame {
                 if (_ndEv.getEn()>0) {
                     enabledisableeditbutton();
                 }
+                updateSelectedEventNodeName();
             }
         });
         
@@ -153,6 +180,7 @@ public class NodeEditEventFrame extends JmriJFrame {
                 if (_ndEv.getEn()>0) {
                     enabledisableeditbutton();
                 }
+                updateSelectedEventNodeName();
             }
         });
         
@@ -207,8 +235,11 @@ public class NodeEditEventFrame extends JmriJFrame {
             setevpanel.add(individevent);
         }
         
-        setevpanel.validate();
-        add(setevpanel, BorderLayout.CENTER);
+        scrollsetevpanel.validate();
+        setCoreNodeEventPanel.validate();
+        
+        add(setCoreNodeEventPanel, BorderLayout.PAGE_START);
+        add(scrollsetevpanel, BorderLayout.CENTER);
         add(inputpanel, BorderLayout.PAGE_END);
         
         Dimension editevframeminimumSize = new Dimension(150, 200);
@@ -338,6 +369,14 @@ public class NodeEditEventFrame extends JmriJFrame {
         });           
         setTitle(title());
         setVisible(true);
+    }
+
+    private void updateSelectedEventNodeName(){
+        
+        NdEvNameLabel.setText("<html><div style='text-align: center;'>" + 
+        new CbusNameService().getEventNodeString(getNodeVal(), getEventVal() )
+        + "</div></html>");
+        
     }
 
 

--- a/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/NodeEditEventFrame.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/NodeEditEventFrame.java
@@ -51,8 +51,7 @@ public class NodeEditEventFrame extends JmriJFrame {
     private Timer waitForLearnMode;
     private NodeConfigToolPane _tp;
     private CbusNodeEvent _ndEv;
-    private JLabel NdEvNameLabel;
-    private JPanel NdEvNamePanel;
+    private JLabel ndEvNameLabel;
     
     /**
      * Create a new instance of NodeEditEventFrame.
@@ -134,21 +133,13 @@ public class NodeEditEventFrame extends JmriJFrame {
       //  individeventNd.setVisible(true);
 
         setCoreNodeEventPanel.add(individeventNd);
-        
         setCoreNodeEventPanel.add(new JSeparator(SwingConstants.HORIZONTAL));
         
-        
-        
-        NdEvNamePanel= new JPanel(); // row container
-     //   NdEvNamePanel.setLayout(new GridLayout(1, 1));
-        NdEvNamePanel.setLayout(new BoxLayout(NdEvNamePanel, BoxLayout.X_AXIS));
-        // String NdEvName = new CbusNameService().getEventNodeString(_ndEv.getNn(), (Math.max(1,_ndEv.getEn())) );
-        
-        NdEvNameLabel = new JLabel("Fetching Name",SwingConstants.CENTER);
-        NdEvNameLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        ndEvNameLabel = new JLabel("",SwingConstants.CENTER);
+        ndEvNameLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
         updateSelectedEventNodeName();
         
-        setCoreNodeEventPanel.add( NdEvNameLabel);
+        setCoreNodeEventPanel.add( ndEvNameLabel);
         
         evFields.get(0).addChangeListener(new ChangeListener() {
             @Override
@@ -373,7 +364,7 @@ public class NodeEditEventFrame extends JmriJFrame {
 
     private void updateSelectedEventNodeName(){
         
-        NdEvNameLabel.setText("<html><div style='text-align: center;'>" + 
+        ndEvNameLabel.setText("<html><div style='text-align: center;'>" + 
         new CbusNameService().getEventNodeString(getNodeVal(), getEventVal() )
         + "</div></html>");
         

--- a/java/src/jmri/jmrix/can/cbus/swing/simulator/SimulatorPane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/simulator/SimulatorPane.java
@@ -20,8 +20,8 @@ import javax.swing.Timer;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.cbus.simulator.CbusSimulator;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+// import org.slf4j.Logger;
+// import org.slf4j.LoggerFactory;
 
 /**
  * Pane for viewing and setting simulated network objects.
@@ -41,7 +41,6 @@ public class SimulatorPane extends jmri.jmrix.can.swing.CanPanel {
     private JPanel _csPanes;
     private JPanel _ndPanes;
     private JPanel _evPanes;
-    private Timer _initTimer;
     private Boolean _disposeSimOnWindowClose;
     private JScrollPane mainScroll;
 
@@ -229,5 +228,5 @@ public class SimulatorPane extends jmri.jmrix.can.swing.CanPanel {
                     jmri.InstanceManager.getDefault(CanSystemConnectionMemo.class));
         }
     }
-    private final static Logger log = LoggerFactory.getLogger(SimulatorPane.class);
+    // private final static Logger log = LoggerFactory.getLogger(SimulatorPane.class);
 }

--- a/java/src/jmri/util/StringUtil.java
+++ b/java/src/jmri/util/StringUtil.java
@@ -479,7 +479,8 @@ public class StringUtil {
 
     /**
      * Return the first int value within a string
-     * eg X X123XX456X will return 123
+     * eg :X X123XX456X: will return 123
+     * eg :X123 456: will return 123
      *
      * @param str contents to process
      * @return first value in int form , -1 if not found
@@ -489,17 +490,21 @@ public class StringUtil {
         StringBuilder sb = new StringBuilder();
         for (int i =0; i<str.length(); i ++) {
             char c = str.charAt(i);
-            if(c != ' '){
+            if (c != ' ' ){
                 if (Character.isDigit(c)) {
                     sb.append(c);
                 } else {
-                    if (!sb.toString().equals("")) {
+                    if ( sb.length() > 0 ) {
                         break;
                     }
                 }
+            } else {
+                if ( sb.length() > 0 ) {
+                    break;
+                }
             }
         }
-        if (!sb.toString().equals("")) {
+        if ( sb.length() > 0 ) {
             return (Integer.parseInt(sb.toString()));  
         }
         return -1;
@@ -507,7 +512,8 @@ public class StringUtil {
 
     /**
      * Return the last int value within a string
-     * eg XX123XX456X will return 456
+     * eg :XX123XX456X: will return 456
+     * eg :X123 456: will return 123
      *
      * @param str contents to process
      * @return last value in int form , -1 if not found
@@ -521,13 +527,17 @@ public class StringUtil {
                 if (Character.isDigit(c)) {
                     sb.insert(0, c);
                 } else {
-                    if (!sb.toString().equals("")) {
+                    if ( sb.length() > 0 ) {
                         break;
                     }
                 }
+            } else {
+                if ( sb.length() > 0 ) {
+                    break;
+                }
             }
         }
-        if (!sb.toString().equals("")) {
+        if ( sb.length() > 0 ) {
             return (Integer.parseInt(sb.toString()));  
         }
         return -1;

--- a/java/test/jmri/jmrix/can/cbus/CbusCommandStationTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusCommandStationTest.java
@@ -41,19 +41,11 @@ public class CbusCommandStationTest {
     }
     
     @Test
-    public void testgetSimNormaltc() {      
-        CbusSimulator sim = t.getNetworkSim();
-        Assert.assertNotNull("exists",sim);
-        sim.dispose();
-        sim = null;
-    }
-
-    @Test
     public void testgetSimLoopbacktc() {
         TrafficControllerScaffoldLoopback tc = new TrafficControllerScaffoldLoopback();
         memo.setTrafficController(tc); 
         CbusCommandStation tccs = new CbusCommandStation(memo);
-        CbusSimulator sim = tccs.getNetworkSim();
+        CbusSimulator sim = jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.simulator.CbusSimulator.class);
         Assert.assertNotNull("exists",sim);
         sim.dispose();
         sim = null;

--- a/java/test/jmri/jmrix/can/cbus/CbusCommandStationTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusCommandStationTest.java
@@ -44,16 +44,16 @@ public class CbusCommandStationTest {
     public void testgetSimLoopbacktc() {
         TrafficControllerScaffoldLoopback tc = new TrafficControllerScaffoldLoopback();
         memo.setTrafficController(tc);
-        CbusSimulator sim;
         CbusCommandStation ta = new CbusCommandStation(memo);
+        Assert.assertNotNull("exists",ta);
         try {
-            sim = jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.simulator.CbusSimulator.class);
+            CbusSimulator sim = jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.simulator.CbusSimulator.class);
             Assert.assertTrue(true);
+            Assert.assertNotNull("exists",sim);
         } catch (NullPointerException e) {
             Assert.assertTrue(false);
         }
         
-        sim = null;
         tc = null;
         ta = null;
     }

--- a/java/test/jmri/jmrix/can/cbus/CbusCommandStationTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusCommandStationTest.java
@@ -43,13 +43,19 @@ public class CbusCommandStationTest {
     @Test
     public void testgetSimLoopbacktc() {
         TrafficControllerScaffoldLoopback tc = new TrafficControllerScaffoldLoopback();
-        memo.setTrafficController(tc); 
-        CbusCommandStation tccs = new CbusCommandStation(memo);
-        CbusSimulator sim = jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.simulator.CbusSimulator.class);
-        Assert.assertNotNull("exists",sim);
-        sim.dispose();
+        memo.setTrafficController(tc);
+        CbusSimulator sim;
+        CbusCommandStation ta = new CbusCommandStation(memo);
+        try {
+            sim = jmri.InstanceManager.getDefault(jmri.jmrix.can.cbus.simulator.CbusSimulator.class);
+            Assert.assertTrue(true);
+        } catch (NullPointerException e) {
+            Assert.assertTrue(false);
+        }
+        
         sim = null;
-        tc=null;
+        tc = null;
+        ta = null;
     }
 
     // test originates from loconet

--- a/java/test/jmri/jmrix/can/cbus/CbusConfigurationManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusConfigurationManagerTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.can.cbus;
 
 import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -9,7 +10,8 @@ import org.junit.Test;
 
 /**
  *
- * @author Paul Bender Copyright (C) 2017	
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (c) 2019
  */
 public class CbusConfigurationManagerTest {
 
@@ -18,6 +20,136 @@ public class CbusConfigurationManagerTest {
         CbusConfigurationManager t = new CbusConfigurationManager(new CanSystemConnectionMemo());
         Assert.assertNotNull("exists",t);
     }
+    
+    @Test
+    public void testDisabled() {
+
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        memo.setDisabled(true);
+        
+        CbusConfigurationManager t = new CbusConfigurationManager(memo);
+        Assert.assertNotNull("exists",t);
+        
+        Assert.assertFalse( t.provides(jmri.PowerManager.class) );
+        
+        Assert.assertNull( t.get(jmri.PowerManager.class) );
+        
+        Assert.assertNull( t.getPowerManager() );
+        Assert.assertNull( t.getThrottleManager() );
+        Assert.assertNull( t.getTurnoutManager() );
+        Assert.assertNull( t.getSensorManager() );
+        Assert.assertNull( t.getReporterManager() );
+        Assert.assertNull( t.getLightManager() );
+        Assert.assertNull( t.getCommandStation() );
+        
+        t.dispose();
+        t = null;
+    }
+    
+    @Test
+    public void testProvides() {
+        
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        TrafficControllerScaffold tcis = new TrafficControllerScaffold();
+        memo.setTrafficController(tcis);
+        CbusConfigurationManager t = new CbusConfigurationManager(memo);
+        
+        Assert.assertTrue( t.provides(jmri.AddressedProgrammerManager.class) );
+        Assert.assertTrue( t.provides(jmri.GlobalProgrammerManager.class) );
+        Assert.assertTrue( t.provides(jmri.ThrottleManager.class) );
+        Assert.assertTrue( t.provides(jmri.PowerManager.class) );
+        Assert.assertTrue( t.provides(jmri.SensorManager.class) );
+        Assert.assertTrue( t.provides(jmri.TurnoutManager.class) );
+        Assert.assertTrue( t.provides(jmri.ReporterManager.class) );
+        Assert.assertTrue( t.provides(jmri.LightManager.class) );
+        Assert.assertTrue( t.provides(jmri.CommandStation.class) );
+        Assert.assertFalse( t.provides(jmri.jmrix.can.cbus.CbusSensor.class) );
+        
+        tcis = null;
+        memo = null;
+        t.dispose();
+        t = null;
+        
+    }    
+    
+    @Test
+    public void testGet() {
+        
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        TrafficControllerScaffold tcis = new TrafficControllerScaffold();
+        memo.setTrafficController(tcis);
+        CbusConfigurationManager t = new CbusConfigurationManager(memo);        
+        
+        Assert.assertNull( t.get(jmri.jmrix.can.cbus.CbusSensor.class) );
+
+        Assert.assertNotNull( t.get(jmri.AddressedProgrammerManager.class) );
+        Assert.assertNotNull( t.get(jmri.GlobalProgrammerManager.class) );
+        Assert.assertNotNull( t.get(jmri.ThrottleManager.class) );
+        Assert.assertNotNull( t.get(jmri.PowerManager.class) );
+        Assert.assertNotNull( t.get(jmri.SensorManager.class) );
+        Assert.assertNotNull( t.get(jmri.TurnoutManager.class) );
+        Assert.assertNotNull( t.get(jmri.ReporterManager.class) );
+        Assert.assertNotNull( t.get(jmri.LightManager.class) );
+        Assert.assertNotNull( t.get(jmri.CommandStation.class) );
+        
+        tcis = null;
+        memo = null;
+        t.dispose();
+        t = null;        
+        
+    }    
+    
+    @Test
+    public void testgetClasses() {
+        
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        TrafficControllerScaffold tcis = new TrafficControllerScaffold();
+        memo.setTrafficController(tcis);
+        CbusConfigurationManager t = new CbusConfigurationManager(memo); 
+        
+
+        CbusDccProgrammerManager prm = new CbusDccProgrammerManager( new CbusDccProgrammer(tcis), memo);
+        t.setProgrammerManager(prm);
+        Assert.assertTrue("programme manager",prm == t.get(jmri.GlobalProgrammerManager.class) );
+        
+        CbusPowerManager pm = t.getPowerManager();
+        Assert.assertTrue("powermanager",pm == t.get(jmri.PowerManager.class) );
+        
+        CbusThrottleManager tm = new CbusThrottleManager(memo);
+        t.setThrottleManager(tm);
+        Assert.assertTrue("throttlemanager",tm == t.get(jmri.ThrottleManager.class) );
+        
+        CbusTurnoutManager tom = t.getTurnoutManager();
+        Assert.assertTrue("turnoutmanager",tom == t.get(jmri.TurnoutManager.class) );
+        
+        CbusSensorManager sm = t.getSensorManager();
+        Assert.assertTrue("sensormanager",sm == t.get(jmri.SensorManager.class) );
+
+        CbusReporterManager rm = t.getReporterManager();
+        Assert.assertTrue("reportermanager",rm == t.get(jmri.ReporterManager.class) );        
+
+        CbusLightManager lm = t.getLightManager();
+        Assert.assertTrue("lightmanager",lm == t.get(jmri.LightManager.class) );
+
+        CbusCommandStation cs = t.getCommandStation();
+        Assert.assertTrue("lightmanager",cs == t.get(jmri.CommandStation.class) );        
+        
+        tcis = null;
+        memo = null;
+        t.dispose();
+        t = null;
+        
+        prm = null;
+        pm = null;
+        tm = null;
+        tom = null;
+        sm = null;
+        rm = null;
+        lm = null;
+        cs = null;
+
+    }
+    
 
     // The minimal setup for log4J
     @Before

--- a/java/test/jmri/jmrix/can/cbus/CbusNameServiceTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusNameServiceTest.java
@@ -1,0 +1,84 @@
+package jmri.jmrix.can.cbus;
+
+import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.jmrix.can.cbus.eventtable.CbusEventTableDataModel;
+import jmri.util.JUnitUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2019
+ */
+public class CbusNameServiceTest {
+
+    @Test
+    public void testCTor() {
+        CbusNameService t = new CbusNameService();
+        Assert.assertNotNull("exists",t);
+        t = null;
+    }
+    
+    @Test
+    public void testgetEventName() {
+        CbusNameService t = new CbusNameService();
+        Assert.assertEquals("no ev name no ev table","",t.getEventName(123,456));
+        
+        TrafficControllerScaffold tcis = new TrafficControllerScaffold();
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        memo.setTrafficController(tcis);
+        
+        CbusEventTableDataModel m = new CbusEventTableDataModel(memo, 2,CbusEventTableDataModel.MAX_COLUMN);
+        Assert.assertNotNull("exists",m);
+        m.addEvent(123,456, 0, null, "Event Name", "Node Name", "Comment", 0, 0, 0, 0);
+        Assert.assertEquals("Event and Node Name","Event Name",t.getEventName(123,456));
+        
+        memo = null;
+        tcis = null;
+        t = null;
+    }
+
+    @Test
+    public void testgetEventNodeString() {
+        CbusNameService t = new CbusNameService();
+        Assert.assertEquals("EventNodeStr","NN:123 EN:456 ",t.getEventNodeString(123,456));
+        Assert.assertEquals("EventNodeStr nd 0","EN:456 ",t.getEventNodeString(0,456));
+        
+        TrafficControllerScaffold tcis = new TrafficControllerScaffold();
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        memo.setTrafficController(tcis);
+        
+        CbusEventTableDataModel m = new CbusEventTableDataModel(memo, 3,CbusEventTableDataModel.MAX_COLUMN);
+        Assert.assertNotNull("exists",m);
+        m.addEvent(123,456, 0, null, "Event Name", "Node Name", "Comment", 0, 0, 0, 0);
+        m.addEvent(69,741, 0, null, "John Smith", "My Node", "My Comment", 0, 0, 0, 0);
+        m.addEvent(0,357, 0, null, "Alonso", "Other Node Name", "My Second Comment", 0, 0, 0, 0);
+        Assert.assertEquals("evstr Event and Node Name","NN:123 Node Name EN:456 Event Name ",t.getEventNodeString(123,456));
+        Assert.assertEquals("evstr Not on table","NN:98 EN:76 ",t.getEventNodeString(98,76));
+        Assert.assertEquals("js evstr Event and Node Name","NN:69 My Node EN:741 John Smith ",t.getEventNodeString(69,741));
+        Assert.assertEquals("alonso evstr Event Name","EN:357 Alonso ",t.getEventNodeString(0,357));
+        
+        memo = null;
+        tcis = null;
+        t = null;
+    }
+
+
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+    // private final static Logger log = LoggerFactory.getLogger(CbusNameServiceTest.class);
+
+}

--- a/java/test/jmri/jmrix/can/cbus/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/PackageTest.java
@@ -36,6 +36,7 @@ import org.junit.runners.Suite;
         BundleTest.class,
         CbusEventTest.class,
         CbusSendTest.class,
+        CbusNameServiceTest.class,
         jmri.jmrix.can.cbus.eventtable.PackageTest.class
 })
 

--- a/java/test/jmri/jmrix/can/cbus/swing/CbusEventHighlightFrameTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/CbusEventHighlightFrameTest.java
@@ -1,6 +1,7 @@
-package jmri.jmrix.can.cbus.swing.console;
+package jmri.jmrix.can.cbus.swing;
 
 import java.awt.GraphicsEnvironment;
+import jmri.jmrix.can.cbus.swing.console.CbusConsolePane;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;

--- a/java/test/jmri/jmrix/can/cbus/swing/CbusEventHighlightPanelTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/CbusEventHighlightPanelTest.java
@@ -1,4 +1,4 @@
-package jmri.jmrix.can.cbus.swing.console;
+package jmri.jmrix.can.cbus.swing;
 
 import java.awt.GraphicsEnvironment;
 import org.junit.After;

--- a/java/test/jmri/jmrix/can/cbus/swing/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/PackageTest.java
@@ -16,6 +16,8 @@ import org.junit.runners.Suite;
     jmri.jmrix.can.cbus.swing.CbusFilterFrameTest.class,
     jmri.jmrix.can.cbus.swing.CbusFilterPanelTest.class,
     jmri.jmrix.can.cbus.swing.eventrequestmonitor.PackageTest.class,
+    jmri.jmrix.can.cbus.swing.CbusEventHighlightFrameTest.class,
+    jmri.jmrix.can.cbus.swing.CbusEventHighlightPanelTest.class,
     BundleTest.class
 })
 

--- a/java/test/jmri/jmrix/can/cbus/swing/console/PackageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/console/PackageTest.java
@@ -6,8 +6,6 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
      CbusConsolePaneTest.class,
-     CbusEventHighlightFrameTest.class,
-     CbusEventHighlightPanelTest.class,
      BundleTest.class
 })
 

--- a/java/test/jmri/util/StringUtilTest.java
+++ b/java/test/jmri/util/StringUtilTest.java
@@ -289,6 +289,7 @@ public class StringUtilTest {
         Assert.assertEquals("F ABC123", 123, StringUtil.getFirstIntFromString("ABC123"));
         Assert.assertEquals("F 123", 123, StringUtil.getFirstIntFromString("123"));
         Assert.assertEquals("F 123ABC", 123, StringUtil.getFirstIntFromString("123ABC"));
+        Assert.assertEquals("F AB12 34ABC", 12, StringUtil.getFirstIntFromString("AB12 34ABC"));
         Assert.assertEquals("F 123 ABC ", 123, StringUtil.getFirstIntFromString("123 ABC"));
         Assert.assertEquals("F 123ABC456", 123, StringUtil.getFirstIntFromString("123ABC456"));
         Assert.assertEquals("F 123A654BC456", 123, StringUtil.getFirstIntFromString("123A654BC456"));
@@ -307,6 +308,7 @@ public class StringUtilTest {
         Assert.assertEquals("ABC123", 123, StringUtil.getLastIntFromString("ABC123"));
         Assert.assertEquals("123", 123, StringUtil.getLastIntFromString("123"));
         Assert.assertEquals("123ABC", 123, StringUtil.getLastIntFromString("123ABC"));
+        Assert.assertEquals("AB12 34ABC", 34, StringUtil.getLastIntFromString("AB12 34ABC"));
         Assert.assertEquals("123 ABC ", 123, StringUtil.getLastIntFromString("123 ABC "));
         Assert.assertEquals("123ABC456", 456, StringUtil.getLastIntFromString("123ABC456"));
         Assert.assertEquals("123A654BC456", 456, StringUtil.getLastIntFromString("123A654BC456"));


### PR DESCRIPTION
Provides Event Name Lookup for various CBUS components

Moves CbusSimulator and CbusEventTable to jmri.Instance lookups
General UI update to Cbus Node Config - Event variable list scrollable, Allows copying of events, Event name lookup
StringUtil getFirstLast as per comment #6511 
Moves Cbus Event highlighter from Console package as used by various
Adds tests for CbusConfigManager