### PR TITLE
VSDecoder: handle throttle direction change and emergency stop

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -465,7 +465,9 @@
    <h3>Virtual Sound Decoder</h3>
         <a id="VSD" name="VSD"/>
         <ul>
-            <li></li>
+            <li>Klaus Killinger added functionality to handle a throttle direction change at speed &gt; 0:
+                slow down to 0, change the direction, ramp-up to the old speed.</li>
+            <li>The engine sound will continue after an Emergency Stop.</li>
         </ul>
 
     <h3>Miscellaneous</h3>

--- a/java/src/jmri/jmrit/vsdecoder/SteamSound.java
+++ b/java/src/jmri/jmrit/vsdecoder/SteamSound.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * <P>
  *
  * @author Mark Underwood Copyright (C) 2011
- * @author Klaus Killinger Copyright (C) 2018
+ * @author Klaus Killinger Copyright (C) 2018, 2019
  */
 // Usage:
 // SteamSound() : constructor
@@ -80,13 +80,21 @@ class SteamSound extends EngineSound {
     // Engine Sounds
     ArrayList<RPMSound> rpm_sounds;
     int top_speed;
-    int driver_diameter;
-    int num_cylinders;
+    private int driver_diameter;
+    private int num_cylinders;
     RPMSound current_rpm_sound;
-    float exponent;
+    private float exponent;
 
     public SteamSound(String name) {
         super(name);
+    }
+
+    // Responds to throttle loco direction key (see EngineSound.java and EngineSoundEvent.java)
+    @Override
+    public void changeLocoDirection(int d) {
+        // If loco direction was changed we need to set topspeed of the loco to new value 
+        // (this is necessary, when topspeed-forward and topspeed-reverse differs)
+        log.debug("loco direction: {}", d);
     }
 
     @Override


### PR DESCRIPTION
A jmriuser reported on [groups.io](https://groups.io/g/jmriusers/topic/web_throttle_select_from/29598050):
1. Changing the the traveling direction at speed > 0 should slow down the loco, change the direction and ramp-up to the old speed. I added that functionality.
2. The engine sound is discontinued after an emergency stop. I moved the shutdown from the method which handles the stop to the shutdown methode. Further I set the negative throttle value (-1) to 0.
