### PR TITLE
MERG CBUS Tests

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusAddress.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusAddress.java
@@ -326,8 +326,6 @@ public class CbusAddress {
         CbusAddress a = new CbusAddress(address);
         CbusAddress[] v = a.split();
         switch (v.length) {
-            case 0:
-                throw new IllegalArgumentException("Did not find usable hardware address: " + address + " for a valid Cbus sensor address");
             case 1:
                 if ( address.startsWith("+") || address.startsWith("-") ) {
                     break;
@@ -385,7 +383,7 @@ public class CbusAddress {
             // ignoring anything starting with x or X as it may be a HEX value
             // which is checked by core CbusAddress
             try {
-                if ( (part.charAt(0) != 'x') && (part.charAt(0) != 'X') ) {
+                if ( (part.toUpperCase().charAt(0) != 'X') ) {
                     log.debug("not an int or hex {}",part);
                     
                     // it's got a string in somewhere, start by checking event number

--- a/java/src/jmri/jmrix/can/cbus/CbusPowerManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusPowerManager.java
@@ -27,10 +27,7 @@ public class CbusPowerManager implements PowerManager, CanListener {
 
     @Override
     public String getUserName() {
-        if (memo != null) {
-            return memo.getUserName();
-        }
-        return "CBUS";
+        return memo.getUserName();
     }
 
     int power = ON;
@@ -42,19 +39,11 @@ public class CbusPowerManager implements PowerManager, CanListener {
         if (v == ON) {
             // send "Enable main track"
             tc.sendCanMessage(CbusMessage.getRequestTrackOn(tc.getCanid()), this);
-        } else if (v == OFF) {
+        }
+        if (v == OFF) {
             // send "Kill main track"
             tc.sendCanMessage(CbusMessage.getRequestTrackOff(tc.getCanid()), this);
         }
-    }
-
-    /*
-     * Used to update power state after service mode programming operation
-     * without sending a message to the SPROG
-     */
-    public void notePowerState(int v) {
-        power = v;
-        firePropertyChange("Power", null, null);
     }
 
     @Override
@@ -65,7 +54,9 @@ public class CbusPowerManager implements PowerManager, CanListener {
     // to free resources when no longer used
     @Override
     public void dispose() throws JmriException {
-        tc.removeCanListener(this);
+        if (tc !=null) {
+            tc.removeCanListener(this);
+        }
         tc = null;
     }
 

--- a/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
@@ -119,7 +119,7 @@ public class CbusSensorManager extends jmri.managers.AbstractSensorManager {
         }
         //If the new hardware address does not already exist then this can
         //be considered the next valid address.
-        Sensor snew = getBySystemName(prefix + newaddr);
+        Sensor snew = getBySystemName(prefix + typeLetter() + newaddr);
         if (snew == null) {
             return newaddr;
         }

--- a/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java
@@ -103,6 +103,9 @@ public class CbusThrottleManager extends AbstractThrottleManager implements Thro
 
     @Override
     public void message(CanMessage m) {
+        if ( m.isExtended() ) {
+            return;
+        }
         int opc = m.getElement(0);
         int handle;
         switch (opc) {
@@ -142,6 +145,9 @@ public class CbusThrottleManager extends AbstractThrottleManager implements Thro
 
     @Override
     synchronized public void reply(CanReply m) {
+        if ( m.isExtended() ) {
+            return;
+        }
         int opc = m.getElement(0);
         int rcvdIntAddr = (m.getElement(2) & 0x3f) * 256 + m.getElement(3);
         boolean rcvdIsLong = (m.getElement(2) & 0xc0) != 0;

--- a/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableAction.java
+++ b/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableAction.java
@@ -219,7 +219,7 @@ public class CbusEventTableAction {
                 //    log.warn(" 1173 eventnum is {} nodenum is {} ",eventnum, nodenum);
                 int row = _model.seeIfEventOnTable(nodenum,eventnum);
                 if ( row < 0 ) {
-                    _model.addEvent(nodenum,eventnum,0,CbusTableEvent.EvState.ON,eventName,nodeName,null,0,0,0,0);
+                    _model.addEvent(nodenum,eventnum,0,CbusTableEvent.EvState.UNKNOWN,eventName,nodeName,null,0,0,0,0);
                     addedtotable++;
                 } else {
                     

--- a/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/eventtable/CbusEventTableDataModel.java
@@ -537,7 +537,9 @@ public class CbusEventTableDataModel extends javax.swing.table.AbstractTableMode
             addEvent(node,event,canid,state,"","","",on,off,in,out); // on off in out
         } else {
             setValueAt(state, existingRow, STATE_COLUMN);
-            setValueAt(1, existingRow, LATEST_TIMESTAMP_COLUMN);
+             if ( (state==CbusTableEvent.EvState.ON) || (state==CbusTableEvent.EvState.OFF) ) {
+                setValueAt(1, existingRow, LATEST_TIMESTAMP_COLUMN);
+            }
             setValueAt(canid, existingRow, CANID_COLUMN);
             if (state==CbusTableEvent.EvState.ON) { setValueAt(1, existingRow, SESSION_ON_COLUMN); }
             if (state==CbusTableEvent.EvState.OFF) { setValueAt(1, existingRow, SESSION_OFF_COLUMN); }

--- a/java/src/jmri/jmrix/can/cbus/swing/console/CbusConsolePane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/console/CbusConsolePane.java
@@ -1361,7 +1361,7 @@ public class CbusConsolePane extends jmri.jmrix.can.swing.CanPanel implements Ca
         
         output.append(decode(r, r.isExtended(), r.getHeader()) + " ");
 
-        if (showOpcExtraCheckBox.isSelected()) {
+        if (showOpcExtraCheckBox.isSelected() && !r.isExtended() ) {
             String cbusopc = "CTIP_" + decodeopc(r, r.isExtended(), r.getHeader());
             output.append(Bundle.getMessage(cbusopc)+ " ");
         }

--- a/java/test/jmri/jmrix/can/cbus/CbusAddressTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusAddressTest.java
@@ -311,6 +311,38 @@ public class CbusAddressTest {
         Assert.assertTrue(new CbusAddress("+001").equals(v[0]));
         Assert.assertTrue(new CbusAddress("-2").equals(v[1]));
     }
+    
+    @Test
+    public void testgetIncrement() {
+        
+        Assert.assertEquals("+N34E17;-N34E17","+N34E18;-N34E18",CbusAddress.getIncrement("+N34E17;-N34E17"));
+        Assert.assertEquals("+N34E456;+N34E17","+N34E457;+N34E18",CbusAddress.getIncrement("+N34E456;+N34E17"));
+        Assert.assertEquals("-N34E456;-N34E17","-N34E457;-N34E18",CbusAddress.getIncrement("-N34E456;-N34E17"));
+        Assert.assertEquals("-N34E456;+N34E17","-N34E457;+N34E18",CbusAddress.getIncrement("-N34E456;+N34E17"));
+    }
+    
+    @Test
+    public void testvalidateSysName() {
+        try {
+            Assert.assertEquals("+0",null,CbusAddress.validateSysName("+0"));
+        } catch (Exception e) {
+            Assert.assertTrue(true);
+        }        
+
+        try {
+            Assert.assertEquals("-0",null,CbusAddress.validateSysName("-0"));
+        } catch (Exception e) {
+            Assert.assertTrue(true);
+        }   
+
+    }
+    
+    @Test
+    public void testhashcode() {
+        CbusAddress a = new CbusAddress("X9801D203A4");
+        Assert.assertEquals("a hashcode is present",530,a.hashCode());
+    }
+    
 
     // The minimal setup for log4J
     @Before

--- a/java/test/jmri/jmrix/can/cbus/CbusDccProgrammerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusDccProgrammerTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.can.cbus;
 
+import jmri.ProgListenerScaffold;
 import jmri.ProgrammingMode;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.util.JUnitUtil;
@@ -24,6 +25,58 @@ public class CbusDccProgrammerTest extends jmri.jmrix.AbstractProgrammerTest {
         Assert.assertEquals("Check Default", ProgrammingMode.PAGEMODE,
                 ((CbusDccProgrammer)programmer).getBestMode());        
     }
+
+
+/*
+
+    @Test(expected=java.lang.IllegalArgumentException.class)
+    public void testSetGetMode() {
+        programmer.setMode(ProgrammingMode.REGISTERMODE);
+        Assert.assertEquals("Check mode matches set", ProgrammingMode.REGISTERMODE,
+                programmer.getMode());        
+    }
+
+    @Test
+    public void testWriteSequence() throws jmri.ProgrammerException {
+        p.writeCV("4", 5, testListener);
+
+        Assert.assertEquals("listeners", 0, tc.numListeners());
+        Assert.assertEquals("sent count", 1, tc.outbound.size());
+        Assert.assertEquals("content 1", "[78] 96 00 03 04 05",
+                tc.outbound.get(0).toString());
+
+        // no reply from CAN and listener replies immediately,
+        // contrast read test below
+        Assert.assertTrue("listener invoked", testListener.getRcvdInvoked()>0);
+        Assert.assertEquals("status", 0, testListener.getRcvdStatus());
+    }
+
+    @Test
+    public void testReadSequence() throws jmri.ProgrammerException {
+        p.readCV("4", testListener);
+
+        Assert.assertEquals("listeners", 0, tc.numListeners());
+        Assert.assertEquals("sent count", 1, tc.outbound.size());
+        Assert.assertEquals("content 1", "[78] 71 00 03 04",
+                tc.outbound.get(0).toString());
+        Assert.assertTrue("listener not invoked", testListener.getRcvdInvoked()==0);
+
+        // pretend reply from CAN
+        int[] frame = new int[]{0x97, 0, 3, 5};
+        CanReply f = new CanReply(frame);
+        p.reply(f);
+
+        Assert.assertTrue("listener invoked", testListener.getRcvdInvoked()>0);
+        Assert.assertEquals("status", 0, testListener.getRcvdStatus());
+        Assert.assertEquals("value", 5, testListener.getRcvdValue());
+    }
+
+
+
+
+
+*/
+
 
     // The minimal setup for log4J
     @Override

--- a/java/test/jmri/jmrix/can/cbus/CbusEventHighlighterTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusEventHighlighterTest.java
@@ -90,9 +90,48 @@ public class CbusEventHighlighterTest {
 
         t.setType(CbusConstants.EVENT_ON);
         Assert.assertTrue("does highlight EVENT_ON ACON", (t.highlight(m)));
-        Assert.assertTrue("does highlight EVENT_ON ACON", (t.highlight(r))); 
+        Assert.assertTrue("does highlight EVENT_ON ACON", (t.highlight(r)));
+
+    }
+
+    @Test
+    public void testEventNodeNums() {
+        t.setNn(0);
+        t.setNnEnable(false);
+        t.setEv(0);
+        t.setEvEnable(false);
+        t.setType(CbusConstants.EVENT_EITHER);
+        t.setDir(CbusConstants.EVENT_DIR_EITHER);
         
-    }    
+        CanMessage m = new CanMessage( new int[]{CbusConstants.CBUS_ACON, 0x00, 0x00, 0x00, 0x01},0x12 );
+        CanReply r = new CanReply( new int[]{CbusConstants.CBUS_ACON, 0x00, 0x00, 0x00, 0x01},0x12 );
+        Assert.assertTrue("does highlight m CBUS_ACON", (t.highlight(m)));
+        Assert.assertTrue("does highlight r CBUS_ACON", (t.highlight(r)));
+        
+        t.setNnEnable(true);
+        Assert.assertTrue("node does highlight m nn0", (t.highlight(m)));
+        Assert.assertTrue("node does highlight r nn0", (t.highlight(r)));        
+        
+        m.setElement(2, 0xa4);
+        r.setElement(2, 0xa4);
+        
+        Assert.assertFalse("does not highlight node a4 EVENT_ON ACON", (t.highlight(m)));
+        Assert.assertFalse("does not highlight node a4 EVENT_ON ACON", (t.highlight(r)));        
+
+        t.setNn(0xa4);
+        Assert.assertTrue("does highlight node a4", (t.highlight(m)));
+        Assert.assertTrue("does highlight node a4", (t.highlight(r)));        
+        
+        
+        t.setNnEnable(false);
+        t.setEvEnable(true);
+        t.setEv(0xa4);
+        Assert.assertFalse("does not highlight event 1", (t.highlight(m)));
+        Assert.assertFalse("does not highlight event 1", (t.highlight(r)));          
+        t.setEv(1);
+        Assert.assertTrue("does highlight event 1", (t.highlight(m)));
+        Assert.assertTrue("does highlight event 1", (t.highlight(r)));         
+    }
     
     
 

--- a/java/test/jmri/jmrix/can/cbus/CbusEventTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusEventTest.java
@@ -33,6 +33,10 @@ public class CbusEventTest {
         Assert.assertEquals("getState off",CbusEvent.EvState.OFF,t.getState());
         t.setName("Jon Smith");
         Assert.assertEquals("getName","Jon Smith",t.getName());
+        t.setEn(4);
+        t.setNn(7);
+        Assert.assertEquals("get Node Number 7",7,t.getNn());
+        Assert.assertEquals("get Event Number 4",4,t.getEn());        
         t = null;
     }    
     

--- a/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
@@ -418,6 +418,8 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
         CbusLightManager l = new CbusLightManager(memo);
         Light t =  l.provideLight("ML+9");
         Light ta =  l.provideLight("ML+10");
+        Assert.assertNotNull("exists",t);
+        Assert.assertNotNull("exists",ta);
 
         try {
             Assert.assertEquals(" null +9 +10",null,l.getNextValidAddress("+9","M"));
@@ -427,7 +429,6 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
             // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(false);
         }
-        
     }
 
     
@@ -480,6 +481,7 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
         CbusLightManager l = new CbusLightManager(memo);
         try {
             Light t = l.createNewLight("", null);
+            Assert.assertNull("not exists",t);
             Assert.assertTrue(false);
         } catch (Exception e) {
             Assert.assertTrue(true);
@@ -496,7 +498,8 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
         }
 
         try {
-            Boolean test = l.validSystemNameConfig("");
+            Boolean testbool = l.validSystemNameConfig("");
+            Assert.assertNull("exists",testbool);
             Assert.assertTrue(false);
         } catch (Exception e) {
             Assert.assertTrue(true);

--- a/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
@@ -414,6 +414,34 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
     }
     
     @Test
+    public void testgetNextValidAddressPt4() {
+        CbusLightManager l = new CbusLightManager(memo);
+        Light t =  l.provideLight("ML+9");
+        Light ta =  l.provideLight("ML+10");
+
+        try {
+            Assert.assertEquals(" null +9 +10",null,l.getNextValidAddress("+9","M"));
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(true);
+        } catch (Exception e) {
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(false);
+        }
+        
+    }
+
+    
+    @Test
+    public void testProvideswhenNotNull() {
+        Light t = l.provideLight("+4");
+        Light ta = l.provideLight("+4");
+        Assert.assertTrue(t == ta);
+        t = null;
+        ta = null;
+    }
+    
+    
+    @Test
     public void testcreateSystemName() {
         
         CbusLightManager l = new CbusLightManager(memo);
@@ -443,6 +471,34 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
             Assert.assertTrue(true);
         } catch (Exception e) {
             // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testcreateNewLightException(){
+        CbusLightManager l = new CbusLightManager(memo);
+        try {
+            Light t = l.createNewLight("", null);
+            Assert.assertTrue(false);
+        } catch (Exception e) {
+            Assert.assertTrue(true);
+        }
+    }
+    
+    @Test
+    public void testvalidSystemNameConfig(){
+        CbusLightManager l = new CbusLightManager(memo);
+        try {
+            Assert.assertTrue(l.validSystemNameConfig("ML+123") );
+        } catch (Exception e) {
+            Assert.assertTrue(false);
+        }
+
+        try {
+            Boolean test = l.validSystemNameConfig("");
+            Assert.assertTrue(false);
+        } catch (Exception e) {
             Assert.assertTrue(true);
         }
     }

--- a/java/test/jmri/jmrix/can/cbus/CbusMessageTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusMessageTest.java
@@ -2,7 +2,7 @@ package jmri.jmrix.can.cbus;
 
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
-import jmri.jmrix.can.cbus.CbusConstants;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -380,7 +380,7 @@ public class CbusMessageTest {
         CbusMessage.setId(r,120);
         CbusMessage.setId(m,120);
         Assert.assertEquals("getId 120 r",120,CbusMessage.getId(r));
-        Assert.assertEquals("getId 120 m",120,CbusMessage.getId(m));        
+        Assert.assertEquals("getId 120 m",120,CbusMessage.getId(m));
         try {
             CbusMessage.setId(r,0xffffff);
             Assert.fail("r Should have thrown an exception");
@@ -405,9 +405,157 @@ public class CbusMessageTest {
         Assert.assertTrue(CbusMessage.isArst(r));
         r.setElement(0, 0x06);
         Assert.assertFalse(CbusMessage.isArst(r));
+        r = null;
     }
     
+    @Test
+    public void testgetReadCV() {
+        CanMessage m = CbusMessage.getReadCV(1,jmri.ProgrammingMode.PAGEMODE,0x12);
+        Assert.assertEquals("PAGEMODE","[592] 84 FF 00 01 02",m.toString());
+        m = CbusMessage.getReadCV(255,jmri.ProgrammingMode.DIRECTBITMODE,0x12);
+        Assert.assertEquals("DIRECTBITMODE","[592] 84 FF 00 FF 01",m.toString());
+        m = CbusMessage.getReadCV(214,jmri.ProgrammingMode.DIRECTBYTEMODE,0x12);
+        Assert.assertEquals("DIRECTBYTEMODE","[592] 84 FF 00 D6 00",m.toString());
+        m = CbusMessage.getReadCV(214,jmri.ProgrammingMode.REGISTERMODE,0x12);
+        Assert.assertEquals("REGISTERMODE","[592] 84 FF 00 D6 03",m.toString());
+        m = null;
+    }
+    
+    @Test
+    public void testgetgetWriteCV() {
+        CanMessage m = CbusMessage.getWriteCV(1,211,jmri.ProgrammingMode.PAGEMODE,0x12);
+        Assert.assertEquals("PAGEMODE","[592] A2 FF 00 01 02 D3",m.toString());
+        m = CbusMessage.getWriteCV(255,1,jmri.ProgrammingMode.DIRECTBITMODE,0x12);
+        Assert.assertEquals("DIRECTBITMODE","[592] A2 FF 00 FF 01 01",m.toString());
+        m = CbusMessage.getWriteCV(214,0,jmri.ProgrammingMode.DIRECTBYTEMODE,0x12);
+        Assert.assertEquals("DIRECTBYTEMODE","[592] A2 FF 00 D6 00 00",m.toString());
+        m = CbusMessage.getWriteCV(214,123,jmri.ProgrammingMode.REGISTERMODE,0x12);
+        Assert.assertEquals("REGISTERMODE","[592] A2 FF 00 D6 03 7B",m.toString());
+        m = null;
+    }    
+    
+    
+    @Test
+    public void testgetOpsModeWriteCV() {
+        CanMessage m = CbusMessage.getOpsModeWriteCV(22,false,211,255,0x12);
+        Assert.assertEquals("getOpsModeWriteCV","[592] C1 00 16 00 D3 05 FF",m.toString());
+    }        
+    
+    @Test
+    public void testgetBootEntry() {
+        CanMessage m = CbusMessage.getBootEntry(43215,0x12);
+        Assert.assertEquals("getBootEntry","[592] 5C A8 CF",m.toString());
+    }
 
+    @Test
+    public void testgetBootNop() {
+        CanMessage m = CbusMessage.getBootNop(0x3D,0x12);
+        Assert.assertEquals("getBootNop","[16000004] 00 00 3D 00 0D 00 00 00",m.toString());
+    }    
+
+    @Test
+    public void testgetBootReset() {
+        CanMessage m = CbusMessage.getBootReset(0x12);
+        Assert.assertEquals("getBootReset","[16000004] 00 00 00 00 0D 01 00 00",m.toString());
+    }
+
+    @Test
+    public void testgetBootInitialise() {
+        CanMessage m = CbusMessage.getBootInitialise(202,0x12);
+        Assert.assertEquals("getBootInitialise","[16000004] 00 00 CA 00 0D 02 00 00",m.toString());
+    }
+
+    @Test
+    public void testgetBootCheck() {
+        CanMessage m = CbusMessage.getBootCheck(123,0x12);
+        Assert.assertEquals("getBootCheck","[16000004] 00 00 00 00 0D 03 00 7B",m.toString());
+    }
+
+    @Test
+    public void testgetBootTest() {
+        CanMessage m = CbusMessage.getBootTest(0x12);
+        Assert.assertEquals("getBootTest","[16000004] 00 00 00 00 0D 04 00 00",m.toString());
+    }
+
+    @Test
+    public void testgetBootWriteData() {
+        CanMessage m = CbusMessage.getBootWriteData( new int[]{0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08},0x12);
+        Assert.assertEquals("getBootWriteData","[16000005] 01 02 03 04 05 06 07 08",m.toString());
+        
+        m = CbusMessage.getBootWriteData( new int[]{0x01,0x02},0x12);
+        JUnitAppender.assertErrorMessageStartsWith("Exception in bootloader data");
+        m = null;
+    }
+
+    @Test
+    public void testisBootError() {
+        CanReply r = new CanReply(0x14);
+        r.setExtended(false);
+        r.setElement(0,7);
+        Assert.assertEquals("isBootError fff",false,CbusMessage.isBootError(r)); // false false false
+        r.setElement(0,0);
+        Assert.assertEquals("isBootError ffp",false,CbusMessage.isBootError(r)); // ffp
+        r.setHeader(0x10000004);
+        Assert.assertEquals("isBootError fpp",false,CbusMessage.isBootError(r)); // fpp
+        r.setElement(0,7);
+        Assert.assertEquals("isBootError fpf",false,CbusMessage.isBootError(r)); // fpf
+        r.setExtended(true);
+        Assert.assertEquals("isBootError ppf",false,CbusMessage.isBootError(r)); // ppf
+        r.setHeader(0x14);
+        Assert.assertEquals("isBootError pff",false,CbusMessage.isBootError(r)); // pff
+        r.setHeader(0x10000004);
+        r.setElement(0,0);
+        Assert.assertEquals("isBootError ppp",true,CbusMessage.isBootError(r)); // ppp
+        r = null;
+    }
+
+    @Test
+    public void testisBootOK() {
+        CanReply r = new CanReply(0x14);
+        r.setExtended(false);
+        r.setElement(0,7);
+        Assert.assertEquals("isBootOK fff",false,CbusMessage.isBootOK(r)); // false false false
+        r.setElement(0,1);
+        Assert.assertEquals("isBootOK ffp",false,CbusMessage.isBootOK(r)); // ffp
+        r.setHeader(0x10000004);
+        Assert.assertEquals("isBootOK fpp",false,CbusMessage.isBootOK(r)); // fpp
+        r.setElement(0,7);
+        Assert.assertEquals("isBootOK fpf",false,CbusMessage.isBootOK(r)); // fpf
+        r.setExtended(true);
+        Assert.assertEquals("isBootOK ppf",false,CbusMessage.isBootOK(r)); // ppf
+        r.setHeader(0x14);
+        Assert.assertEquals("isBootOK pff",false,CbusMessage.isBootOK(r)); // pff
+        r.setHeader(0x10000004);
+        r.setElement(0,1);
+        Assert.assertEquals("isBootOK ppp",true,CbusMessage.isBootOK(r)); // ppp
+        r = null;
+    }
+
+
+
+    @Test
+    public void testisBootConfirm() {
+        CanReply r = new CanReply(0x14);
+        r.setExtended(false);
+        r.setElement(0,7);
+        Assert.assertEquals("isBootConfirm fff",false,CbusMessage.isBootConfirm(r)); // false false false
+        r.setElement(0,2);
+        Assert.assertEquals("isBootConfirm ffp",false,CbusMessage.isBootConfirm(r)); // ffp
+        r.setHeader(0x10000004);
+        Assert.assertEquals("isBootConfirm fpp",false,CbusMessage.isBootConfirm(r)); // fpp
+        r.setElement(0,7);
+        Assert.assertEquals("isBootConfirm fpf",false,CbusMessage.isBootConfirm(r)); // fpf
+        r.setExtended(true);
+        Assert.assertEquals("isBootConfirm ppf",false,CbusMessage.isBootConfirm(r)); // ppf
+        r.setHeader(0x14);
+        Assert.assertEquals("isBootConfirm pff",false,CbusMessage.isBootConfirm(r)); // pff
+        r.setHeader(0x10000004);
+        r.setElement(0,2);
+        Assert.assertEquals("isBootConfirm ppp",true,CbusMessage.isBootConfirm(r)); // ppp
+        r = null;
+    }
+    
+    
     // The minimal setup for log4J
     @Before
     public void setUp() {

--- a/java/test/jmri/jmrix/can/cbus/CbusOpCodesTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusOpCodesTest.java
@@ -25,8 +25,80 @@ public class CbusOpCodesTest {
         CanMessage m = new CanMessage( new int[]{CbusConstants.CBUS_RESTP },0x12 ); // request e stop
         Assert.assertTrue(CbusOpCodes.decode(m).contains("Request Emergency Stop All"));
         Assert.assertTrue(CbusOpCodes.decodeopc(m).contains("RESTP"));
+
+        m.setElement(0, 0x18);
+        Assert.assertEquals("0x18 no current opc definition","Reserved opcode",CbusOpCodes.decode(m));
+        m.setElement(0, CbusConstants.CBUS_DKEEP);
+        m.setElement(1, 0x04);
+        Assert.assertEquals("CBUS_DKEEP","Keep Alive Session: 4",CbusOpCodes.decode(m));
+
+        m.setElement(0, CbusConstants.CBUS_RLOC);
+        m.setElement(1, 0x00);
+        m.setElement(2, 0x2c);
+        Assert.assertEquals("CBUS_RLOC","Request Session Addr: 44 S",CbusOpCodes.decode(m));
+
+        m.setElement(0, CbusConstants.CBUS_ACON);
+        m.setElement(3, 0xd4);
+        m.setElement(4, 0xac);
+     //   Assert.assertEquals("CBUS_ACON","N: 44 E:5432",CbusOpCodes.decode(m));
+     
+        m.setElement(0, CbusConstants.CBUS_ERR);
+        m.setElement(1, 0xcc);
+        m.setElement(2, 0x8f);
+        m.setElement(3, 0x01);
+        Assert.assertEquals("CBUS_ERR 1","Command Station Error Loco stack full for address 3215 L",CbusOpCodes.decode(m));
+        m.setElement(3, 0x02);
+        Assert.assertEquals("CBUS_ERR 2","Command Station Error Loco address taken for address 3215 L",CbusOpCodes.decode(m));
+        m.setElement(3, 0x03);
+        Assert.assertEquals("CBUS_ERR 3","Command Station Error Session not present for session 204",CbusOpCodes.decode(m));
+        m.setElement(3, 0x04);
+        Assert.assertEquals("CBUS_ERR 4","Command Station Error Consist empty for consist 204",CbusOpCodes.decode(m));
+        m.setElement(3, 0x05);
+        Assert.assertEquals("CBUS_ERR 5","Command Station Error Loco not found for session 204",CbusOpCodes.decode(m));
+        m.setElement(3, 0x06);
+        Assert.assertEquals("CBUS_ERR 6","Command Station Error CAN bus error ",CbusOpCodes.decode(m));
+        m.setElement(3, 0x07);
+        Assert.assertEquals("CBUS_ERR 7","Command Station Error Invalid request for address 3215 L",CbusOpCodes.decode(m));
+        m.setElement(3, 0x08);
+        Assert.assertEquals("CBUS_ERR 8","Command Station Error Throttle cancelled for session 204",CbusOpCodes.decode(m));
+        m.setElement(3, 0x09);
+        Assert.assertEquals("CBUS_ERR 9","Command Station Error ",CbusOpCodes.decode(m));
+    }
+    
+    @Test
+    public void testDecodeCMDERR() {
+        CanMessage m = new CanMessage( new int[]{CbusConstants.CBUS_CMDERR,12,34,01 },0x12  );
+        Assert.assertEquals("CBUS_CMDERR 1","Node Config Error NN:3106 Command Not Supported.",CbusOpCodes.decode(m));
+        m.setElement(3, 0xaa);
+        Assert.assertEquals("CBUS_CMDERR aa","Node Config Error NN:3106 ",CbusOpCodes.decode(m));
+    }    
+
+    @Test
+    public void testDecodeextend() {
+        CanMessage m = new CanMessage( new int[]{CbusConstants.CBUS_CMDERR,12,34,01 },0x12  );
+        Assert.assertEquals("CBUS_CMDERR false1","Node Config Error NN:3106 Command Not Supported.",CbusOpCodes.decode(m,false,0x12));
+        Assert.assertEquals("CBUS_CMDERR true","Bootloader Message Type: 18",CbusOpCodes.decode(m,true,0x12));
     }
 
+    @Test
+    public void testdecodeopc() {
+        CanMessage m = new CanMessage( new int[]{0x18 },0x12  );
+        Assert.assertEquals("decodeopc 1","Reserved opcode",CbusOpCodes.decodeopc(m));
+        Assert.assertEquals("decodeopc 2","Reserved opcode",CbusOpCodes.decodeopc(m,false,0x12));
+        Assert.assertEquals("decodeopc 3","Bootloader Message Type: 18",CbusOpCodes.decodeopc(m,true,0x12));
+    }
+
+    @Test
+    public void testisEventNotRequest() {
+        Assert.assertEquals("EventNotRequest false",false,CbusOpCodes.isEventNotRequest(CbusConstants.CBUS_CMDERR));
+        Assert.assertEquals("EventNotRequest true",true,CbusOpCodes.isEventNotRequest(CbusConstants.CBUS_ACON));
+    }
+    
+    @Test
+    public void testisDCC() {
+        Assert.assertEquals("isDCC false",false,CbusOpCodes.isDcc(CbusConstants.CBUS_ACON));
+        Assert.assertEquals("isDCC true",true,CbusOpCodes.isDcc(CbusConstants.CBUS_DKEEP));
+    }    
 
     // The minimal setup for log4J
     @Before

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
@@ -111,7 +111,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MSX;+N15E6");
             Assert.fail("X Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -119,7 +119,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MSXA;+N15E6");
             Assert.fail("A Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -127,7 +127,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MSXABC;+N15E6");
             Assert.fail("AC Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -135,7 +135,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MSXABCDE;+N15E6");
             Assert.fail("ABCDE Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
         
@@ -143,7 +143,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MSXABCDEF0;+N15E6");
             Assert.fail("ABCDEF0 Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -212,7 +212,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MS++N156E77");
             Assert.fail("++ Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -220,7 +220,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MS--N156E77");
             Assert.fail("-- Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -228,7 +228,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MSN156E+77");
             Assert.fail("E+ Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -236,7 +236,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MSN156+E77");
             Assert.fail("+E Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -244,7 +244,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             l.provideSensor("MSXLKJK;XLKJK");
             Assert.fail("LKJK Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -436,6 +436,25 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
             Assert.assertTrue(false);
         }
     }
+    
+    @Test
+    public void testgetNextValidAddressPt4() {
+
+        Sensor t =  l.provideSensor("MS+9");
+        Sensor ta =  l.provideSensor("MS+10");
+        Assert.assertNotNull("exists",t);
+        Assert.assertNotNull("exists",ta);
+
+        try {
+            Assert.assertEquals(" null +9 +10",null,l.getNextValidAddress("+9","M"));
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(true);
+        } catch (Exception e) {
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(false);
+        }
+        
+    }    
 
     @Test
     public void testcreateSystemName() {

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
@@ -82,7 +82,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("MTX;+N15E6");
             Assert.fail("X Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -90,7 +90,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("MTXA;+N15E6");
             Assert.fail("A Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -98,7 +98,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("MTXABC;+N15E6");
             Assert.fail("AC Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -106,7 +106,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("MTXABCDE;+N15E6");
             Assert.fail("ABCDE Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
         
@@ -114,7 +114,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("MTXABCDEF0;+N15E6");
             Assert.fail("ABCDEF0 Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
 
@@ -176,7 +176,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("T+N156E77;+N123E456");
             Assert.fail("S Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
     }
@@ -187,7 +187,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             l.provideTurnout("M+N156E77;+N15E60");
             Assert.fail("M Should have thrown an exception");
         } catch (Exception e) {
-            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find usabl");
+            JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
     }
@@ -363,7 +363,24 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             Assert.assertTrue(false);
         }
     }
+    
+    @Test
+    public void testgetNextValidAddressPt4() {
 
+        Turnout t =  l.provideTurnout("MT+9");
+        Turnout ta =  l.provideTurnout("MT+10");
+
+        try {
+            Assert.assertEquals(" null +9 +10",null,l.getNextValidAddress("+9","M"));
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(true);
+        } catch (Exception e) {
+            // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
+            Assert.assertTrue(false);
+        }
+        
+    }
+    
     @Test
     public void testcreateSystemName() {
         
@@ -394,6 +411,16 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
             // JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
             Assert.assertTrue(true);
         }
+    }
+    
+    
+    @Test
+    public void testProvideswhenNotNull() {
+        Turnout t = l.provideTurnout("+4");
+        Turnout ta = l.provideTurnout("+4");
+        Assert.assertTrue(t == ta);
+        t = null;
+        ta = null;
     }
     
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
@@ -369,6 +369,8 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
 
         Turnout t =  l.provideTurnout("MT+9");
         Turnout ta =  l.provideTurnout("MT+10");
+        Assert.assertNotNull("exists",t);
+        Assert.assertNotNull("exists",ta);
 
         try {
             Assert.assertEquals(" null +9 +10",null,l.getNextValidAddress("+9","M"));

--- a/java/test/jmri/jmrix/can/cbus/simulator/CbusDummyNodeTest.java
+++ b/java/test/jmri/jmrix/can/cbus/simulator/CbusDummyNodeTest.java
@@ -14,7 +14,7 @@ public class CbusDummyNodeTest {
 
     @Test
     public void testCTor() {
-        CbusDummyNode t = new CbusDummyNode(null);
+        CbusDummyNode t = new CbusDummyNode(1,2,3,4,null);
         Assert.assertNotNull("exists",t);
         t.dispose();
     }

--- a/java/test/jmri/jmrix/can/cbus/simulator/CbusDummyNodeTest.java
+++ b/java/test/jmri/jmrix/can/cbus/simulator/CbusDummyNodeTest.java
@@ -14,7 +14,7 @@ public class CbusDummyNodeTest {
 
     @Test
     public void testCTor() {
-        CbusDummyNode t = new CbusDummyNode(1,2,3,4,null);
+        CbusDummyNode t = new CbusDummyNode(null);
         Assert.assertNotNull("exists",t);
         t.dispose();
     }


### PR DESCRIPTION
Enhance test coverage
CbusPowerManagerTest to use abstract
Shields a few classes from unexpected output from misinterpreting extended frames