### PR TITLE
VSDecoder: improve buffer handling at steam1

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/AudioUtil.java
+++ b/java/src/jmri/jmrit/vsdecoder/AudioUtil.java
@@ -73,7 +73,7 @@ public class AudioUtil {
         try {
             ALut.alutLoadWAVFile(stream, format, data, size, freq, loop);
         } catch (ALException e) {
-            log.warn("Error loading JoalAudioBuffer: {}", e.getMessage());
+            log.warn("Error loading JoalAudioBuffer", e);
             return null;
         }
 
@@ -98,7 +98,6 @@ public class AudioUtil {
         return rlist;
     }
 
-    // steam1 helper 1
     static public ByteBuffer getWavData(InputStream stream) {
         int[] format = new int[1];
         int[] size = new int[1];
@@ -117,29 +116,32 @@ public class AudioUtil {
         return data[0];
     }
 
-    // steam1 helper 2
-    static public int getWavFormat(InputStream stream) {
+    static public int[] getWavFormats(InputStream stream) {
         int[] format = new int[1];
         int[] size = new int[1];
         ByteBuffer[] data = new ByteBuffer[1];
         int[] freq = new int[1];
         int[] loop = new int[1];
 
+        int[] formats = new int[3];
+
         // Pull the WAV data into the "data" buffer.
         try {
             ALut.alutLoadWAVFile(stream, format, data, size, freq, loop);
         } catch (ALException e) {
             log.warn("Error loading JoalAudioBuffer from stream", e);
-            return 0;
+            return formats;
         }
         // OK, for now, we're only going to support 8-bit and 16-bit Mono data.
         // I'll have to figure out later how to extend this to multiple data formats.
         if ((format[0] != AL.AL_FORMAT_MONO8) && (format[0] != AL.AL_FORMAT_MONO16)) {
             log.warn("Invalid Format! Failing out.{}", parseFormat(format[0]));
-            return 0;
+            return formats;
         }
-        log.debug("WAV format: {}", parseFormat(format[0]));
-        return format[0];
+        formats[0] = format[0];
+        formats[1] = freq[0];
+        formats[2] = frameSize(format[0]);
+        return formats;
     }
 
     /**
@@ -178,7 +180,7 @@ public class AudioUtil {
                 }
                 rlist.add(buf);
             } catch (AudioException | IllegalArgumentException e) {
-                log.warn("Error on provideAudio! {}", (Object) e);
+                log.warn("Error on provideAudio", e);
                 if (log.isDebugEnabled()) {
                     jmri.InstanceManager.getDefault(jmri.AudioManager.class).getSystemNameList(Audio.BUFFER).stream().forEach((s) -> {
                         log.debug("\tBuffer: {}", s);

--- a/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
@@ -483,7 +483,6 @@ class Steam1Sound extends EngineSound {
         private ByteBuffer coastfiller_data;
         private List<AudioBuffer> bufs_helper = new ArrayList<>();
         private List<ByteBuffer> chuff_bufs_data = new ArrayList<>();
-        private List<ByteBuffer> chufflight_bufs_data = new ArrayList<>();
         private List<ByteBuffer> coast_bufs_data = new ArrayList<>();
 
         private S1Notch(int notch) {
@@ -609,7 +608,6 @@ class Steam1Sound extends EngineSound {
         private boolean is_key_coasting;
         private boolean is_idling;
         private boolean is_braking;
-        private boolean waitForFiller;
         private boolean is_half_speed;
         private boolean is_in_rampup_mode;
         private int lastRpm;
@@ -630,8 +628,6 @@ class Steam1Sound extends EngineSound {
         private int count_pre_arrival;
         private int queue_limit;
         private int wait_loops;
-        private int sbl_fill;
-        private int wait_notch;
         public static final int SLEEP_INTERVAL = 50;
 
         public S1LoopThread(Steam1Sound d, String s, int ts, int tsr, float dd, 
@@ -650,7 +646,6 @@ class Steam1Sound extends EngineSound {
             is_key_coasting = false;
             is_idling = false;
             is_braking = false;
-            waitForFiller = false;
             is_in_rampup_mode = false;
             lastRpm = 0;
             rpm_dirfn = 0;
@@ -662,8 +657,6 @@ class Steam1Sound extends EngineSound {
             count_pre_arrival = 1;
             queue_limit = 2;
             wait_loops = 0;
-            sbl_fill = 0;
-            wait_notch = 1;
             if (r) {
                 this.start();
             }

--- a/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
+++ b/java/src/jmri/jmrit/vsdecoder/Steam1Sound.java
@@ -52,18 +52,18 @@ class Steam1Sound extends EngineSound {
     private int decel_rate;
     private int brake_time;
     private int decel_trigger_rpms;
+    private int wait_factor;
     private SoundBite idle_sound;
     private SoundBite boiling_sound;
     private SoundBite brake_sound;
     private SoundBite pre_arrival_sound;
-    float engine_rd;
-    float engine_gain;
+    private float engine_rd;
+    private float engine_gain;
 
-    // Common variables
     S1LoopThread _loopThread = null;
 
     private javax.swing.Timer rpmTimer;
-    int accdectime;
+    private int accdectime;
 
     // Constructor
     public Steam1Sound(String name) {
@@ -86,7 +86,6 @@ class Steam1Sound extends EngineSound {
         }
     }
 
-    // Responds to throttle loco direction key (see EngineSound.java and EngineSoundEvent.java)
     @Override
     public void changeLocoDirection(int dirfn) {
         log.debug("loco IsForward is {}", dirfn);
@@ -95,7 +94,6 @@ class Steam1Sound extends EngineSound {
         }
     }
 
-    // Responds to throttle function key (see EngineSound.java and EngineSoundEvent.java)
     @Override
     public void functionKey(String event, boolean value, String name) {
         log.debug("throttle function key {} pressed for {}: {}", event, name, value);
@@ -109,12 +107,10 @@ class Steam1Sound extends EngineSound {
         return Math.pow(t, exponent);
     }
 
-    // Called from thread
-    public S1Notch getNotch(int n) {
+    private S1Notch getNotch(int n) {
         return notch_sounds.get(n);
     }
 
-    // Called from thread
     private void initAccDecTimer() {
         rpmTimer = newTimer(1, true, new ActionListener() {
             @Override
@@ -128,7 +124,6 @@ class Steam1Sound extends EngineSound {
         log.debug("timer {} initialized, delay: {}", rpmTimer, accdectime);
     }
 
-    // Called from thread
     private void startAccDecTimer() {
         if (!rpmTimer.isRunning()) {
             rpmTimer.start();
@@ -136,7 +131,6 @@ class Steam1Sound extends EngineSound {
         }
     }
 
-    // Called from thread
     private void stopAccDecTimer() {
         if (rpmTimer.isRunning()) {
             rpmTimer.stop();
@@ -174,7 +168,7 @@ class Steam1Sound extends EngineSound {
 
         // Stop the loop thread, in case it's running
         if (_loopThread != null) {
-            _loopThread.setRunning(false); // Kill the thread
+            _loopThread.setRunning(false);
         }
     }
 
@@ -210,6 +204,7 @@ class Steam1Sound extends EngineSound {
 
     @Override
     public void setXml(Element e, VSDFile vf) {
+        boolean buffer_ok = true;
         Element el;
         String fn, n;
         S1Notch sb;
@@ -217,20 +212,18 @@ class Steam1Sound extends EngineSound {
         // Handle the common stuff
         super.setXml(e, vf);
 
-        _soundName = this.getName();
+        _soundName = this.getName() + ":LoopSound";
         log.debug("Steam1: name: {}, soundName: {}", this.getName(), _soundName);
 
-        // Required values
-        top_speed = Integer.parseInt(e.getChildText("top-speed"));
+        top_speed = Integer.parseInt(e.getChildText("top-speed")); // Required value
         log.debug("top speed forward: {} MPH", top_speed);
 
-        // Optional value
-        // Steam locos can have different top speed reverse.
-        n = e.getChildText("top-speed-reverse"); // Optional value.
-        if (n != null) {
+        // Steam locos can have different top speed reverse
+        n = e.getChildText("top-speed-reverse"); // Optional value
+        if ((n != null) && !(n.isEmpty())) {
             top_speed_reverse = Integer.parseInt(n);
         } else {
-            top_speed_reverse = top_speed;  // Default for top_speed_reverse!
+            top_speed_reverse = top_speed;  // Default for top_speed_reverse
         }
         log.debug("top speed reverse: {} MPH", top_speed_reverse);
 
@@ -239,20 +232,18 @@ class Steam1Sound extends EngineSound {
         num_cylinders = Integer.parseInt(e.getChildText("cylinders"));
         log.debug("Number of cylinders defined: {}", num_cylinders);
 
-        // Optional value
         // Allows to adjust speed
         n = e.getChildText("exponent"); // Optional value
-        if (n != null) {
+        if ((n != null) && !(n.isEmpty())) {
             exponent = Float.parseFloat(n);
         } else {
             exponent = 1.0f; // Default
         }
         log.debug("exponent: {}", exponent);
 
-        // Optional value
         // Acceleration and deceleration rate
         n = e.getChildText("accel-rate"); // Optional value
-        if (n != null) {
+        if ((n != null) && !(n.isEmpty())) {
             accel_rate = Integer.parseInt(n);
         } else {
             accel_rate = 35; // Default
@@ -260,7 +251,7 @@ class Steam1Sound extends EngineSound {
         log.debug("accel rate: {}", accel_rate);
 
         n = e.getChildText("decel-rate"); // Optional value
-        if (n != null) {
+        if ((n != null) && !(n.isEmpty())) {
             decel_rate = Integer.parseInt(n);
         } else {
             decel_rate = 18; // Default
@@ -268,28 +259,25 @@ class Steam1Sound extends EngineSound {
         log.debug("decel rate: {}", decel_rate);
 
         n = e.getChildText("brake-time"); // Optional value
-        if (n != null) {
+        if ((n != null) && !(n.isEmpty())) {
             brake_time = Integer.parseInt(n);
         } else {
             brake_time = 0;  // Default
         }
         log.debug("brake time: {}", brake_time);
 
-        // Optional value 
         // auto-start
-        is_auto_start = setXMLAutoStart(e);
+        is_auto_start = setXMLAutoStart(e); // Optional value
         log.debug("config auto-start: {}", is_auto_start);
 
-        // Optional value
         // Allows to adjust OpenAL attenuation
         // Sounds with distance to listener position lower than reference-distance will not have attenuation
-        engine_rd = setXMLReferenceDistance(e); // Handle reference distance
+        engine_rd = setXMLReferenceDistance(e); // Optional value
         log.debug("engine-sound referenceDistance: {}", engine_rd);
 
-        // Optional value
         // Allows to adjust the engine gain
-        n = e.getChildText("engine-gain");
-        if ((n != null) && (!n.isEmpty())) {
+        n = e.getChildText("engine-gain"); // Optional value
+        if ((n != null) && !(n.isEmpty())) {
             engine_gain = Float.parseFloat(n);
             // Make some restrictions, since engine_gain is used for calculations later
             if ((engine_gain < default_gain - 0.4f) || (engine_gain > default_gain + 0.2f)) {
@@ -301,10 +289,25 @@ class Steam1Sound extends EngineSound {
         }
         log.debug("engine gain: {}", engine_gain);
 
-        // Optional value
+        // Defines how many loops (50ms) to be subtracted from interval to calculate wait-time
+        // The lower the wait-factor, the more effect it has
+        // Better to take a higher value when running VSD on old/slow computers
+        n = e.getChildText("wait-factor"); // Optional value
+        if ((n != null) && !(n.isEmpty())) {
+            wait_factor = Integer.parseInt(n);
+            // Make some restrictions to protect the loop-player
+            if (wait_factor < 5 || wait_factor > 40) {
+                log.info("Invalid wait-factor {} was set to default 18", wait_factor);
+                wait_factor = 18;
+            }
+        } else {
+            wait_factor = 18; // Default
+        }
+        log.debug("number of loops to subtract from interval: {}", wait_factor);
+
         // Defines how many rpms in 0.5 seconds will trigger decel actions like braking
-        n = e.getChildText("decel-trigger-rpms");
-        if (n != null) {
+        n = e.getChildText("decel-trigger-rpms"); // Optional value
+        if ((n != null) && !(n.isEmpty())) {
             decel_trigger_rpms = Integer.parseInt(n);
         } else {
             decel_trigger_rpms = 999; // Default (need a value)
@@ -316,111 +319,86 @@ class Steam1Sound extends EngineSound {
         // Get the files and create a buffer and byteBuffer for each file
         // For each notch there must be <num_cylinders * 2> chuff files
         notch_sounds = new HashMap<>();
-        int i = 0; // notch number (index)
-        int j = 0; // chuff or coast number (index)
-        int fmt = 0; // Sound sample format
         int nn = 1; // notch number (visual)
 
-        // Get the notch-sounds.
+        // Get the notch-sounds
         Iterator<Element> itr = (e.getChildren("s1notch-sound")).iterator();
         while (itr.hasNext()) {
             el = itr.next();
-            sb = new S1Notch();
-            sb.setNotch(nn);
+            sb = new S1Notch(nn);
 
-            // Get the chuff sounds
+            // Get the medium/standard chuff sounds
             List<Element> elist = el.getChildren("notch-file");
-            j = 0;
             for (Element fe : elist) {
                 fn = fe.getText();
                 log.debug("notch: {}, file: {}", nn, fn);
-                AudioBuffer b = S1Notch.getBuffer(vf, fn, _soundName + 
-                        "_NOTCH_" + i + "_" + j, _soundName + "_NOTCH_" + i + "_" + j);
-                log.debug("buffer created: {}, name: {}, format: {}", b, 
-                        b.getSystemName(), b.getFormat());
-                sb.addChuffBuffer(b);
-                if (fmt == 0) {
-                    // Get the format of the (first) WAV file
-                    // Since all WAV files of the notches MUST have the same format,
-                    // I asume this format for all WAV files for now
-                    fmt = AudioUtil.getWavFormat(S1Notch.getWavStream(vf, fn)); 
-                    log.debug("fmt: {}", fmt);
-                }
-                ByteBuffer data = AudioUtil.getWavData(S1Notch.getWavStream(vf, fn));
-                sb.addChuffData(data);
-                j++;
+                sb.addChuffData(AudioUtil.getWavData(S1Notch.getWavStream(vf, fn)));
             }
-            log.debug("Number of chuff sounds for notch {} defined: {}", nn, j);
+            log.debug("Number of chuff medium/standard sounds for notch {} defined: {}", nn, elist.size());
 
-            // Create a filler Buffer for queueing and a ByteBuffer for length modification
-            fn = el.getChildText("notchfiller-file");
-            if (fn != null) {
-                log.debug("notch filler file: {}", fn);
-                AudioBuffer bnf = S1Notch.getBuffer(vf, 
-                        el.getChildText("notchfiller-file"), _soundName + 
-                        "_NOTCHFILLER_" + i, _soundName + "_NOTCHFILLER_" + i);
-                log.debug("buffer created: {}, name: {}, format: {}", bnf, bnf.getSystemName(), bnf.getFormat());
-                sb.setNotchFillerBuffer(bnf);
-                sb.setNotchFillerData(AudioUtil.getWavData(S1Notch.getWavStream(vf, fn)));
-            } else {
-                log.debug("no notchfiller available.");
-                sb.setNotchFillerBuffer(null);
-            }
-
-            // Coasting sound and helpers are bound to first notch only
+            // Filler sound, coasting sound and helpers are bound to the first notch only
             // VSDFile validation makes sure that there is at least one notch
             if (nn == 1) {
-                // Get the coasting sounds
-                j = 0;
+                // Take the first notch-file to determine the audio formats (format, frequence and framesize)
+                // All files of notch_sounds must have the same audio formats
+                fn = el.getChildText("notch-file");
+                int[] formats;
+                formats = AudioUtil.getWavFormats(S1Notch.getWavStream(vf, fn));
+                sb.setBufferFmt(formats[0]);
+                sb.setBufferFreq(formats[1]);
+                sb.setBufferFrameSize(formats[2]);
+
+                log.debug("WAV audio formats - format: {}, frequence: {}, frame size: {}",
+                        sb.getBufferFmt(), sb.getBufferFreq(), sb.getBufferFrameSize());
+
+                // Create a filler Buffer for queueing and a ByteBuffer for length modification
+                fn = el.getChildText("notchfiller-file");
+                if (fn != null) {
+                    log.debug("notch filler file: {}", fn);
+                    sb.setNotchFillerData(AudioUtil.getWavData(S1Notch.getWavStream(vf, fn)));
+                } else {
+                    log.debug("no notchfiller available.");
+                    sb.setNotchFillerData(null);
+                }
+
+                // Get the coasting sounds.
                 List<Element> elistc = el.getChildren("coast-file");
                 for (Element fe : elistc) {
                     fn = fe.getText();
                     log.debug("coasting file: {}", fn);
-                    AudioBuffer bc = S1Notch.getBuffer(vf, fn, _soundName + 
-                            "_COAST_" + j, _soundName + "_COAST_" + j);
-                    log.debug("buffer created: {}, name: {}, format: {}", 
-                            bc, bc.getSystemName(), bc.getFormat());
-                    sb.addCoastBuffer(bc); // WAV in Buffer for queueing
-                    ByteBuffer datac = AudioUtil.getWavData(S1Notch.getWavStream(vf, fn));
-                    sb.addCoastData(datac); // WAV data in ByteBuffer for length modification
-                    j++;
+                    sb.addCoastData(AudioUtil.getWavData(S1Notch.getWavStream(vf, fn)));
                 }
-                log.debug("Number of coasting sounds for notch {} defined: {}", nn, j);
+                log.debug("Number of coasting sounds for notch {} defined: {}", nn, elistc.size());
 
                 // Create a filler Buffer for queueing and a ByteBuffer for length modification
                 fn = el.getChildText("coastfiller-file");
                 if (fn != null) {
                     log.debug("coasting filler file: {}", fn);
-                    AudioBuffer bcf = S1Notch.getBuffer(vf, fn, _soundName +
-                            "_COASTFILLER", _soundName + "_COASTFILLER");
-                    log.debug("buffer created: {}, name: {}, format: {}", bcf, 
-                            bcf.getSystemName(), bcf.getFormat());
-                    sb.setCoastFillerBuffer(bcf);
                     sb.setCoastFillerData(AudioUtil.getWavData(S1Notch.getWavStream(vf, fn)));
                 } else {
                     log.debug("no coastfiller available.");
-                    sb.setCoastFillerBuffer(null);
+                    sb.setCoastFillerData(null);
                 }
 
                 // Add some helper Buffers. They are needed for creating
                 // variable sound clips in length. Ten helper buffers should
-                // serve well for that purpose. These buffers are bound to notch 1
-                for (int jk = 0; jk < 10; jk++) {
-                    AudioBuffer bh = S1Notch.getBufferHelper(_soundName + 
-                            "_BUFFERHELPER_" + jk, _soundName + "_BUFFERHELPER_" + jk);
-                    log.debug("buffer helper created: {}, name: {}", bh, bh.getSystemName());
-                    sb.addHelper(bh);
+                // serve well for that purpose.
+                for (int j = 0; j < 10; j++) {
+                    AudioBuffer bh = S1Notch.getBufferHelper(name + "_BUFFERHELPER_" + j, name + "_BUFFERHELPER_" + j);
+                    if (bh != null) {
+                        log.debug("buffer helper created: {}, name: {}", bh, bh.getSystemName());
+                        sb.addHelper(bh);
+                    } else {
+                        buffer_ok = false;
+                    }
                 }
             }
 
             sb.setMinLimit(Integer.parseInt(el.getChildText("min-rpm")));
             sb.setMaxLimit(Integer.parseInt(el.getChildText("max-rpm")));
-            sb.setBufferFmt(fmt);
-            log.debug("sample format for notch {}: {}", nn, fmt);
 
             // Store in the list
             notch_sounds.put(nn, sb);
-            i++;
             nn++;
         }
         log.debug("Number of notches defined: {}", notch_sounds.size());
@@ -449,210 +427,146 @@ class Steam1Sound extends EngineSound {
         el = e.getChild("boiling-sound");
         if (el != null) {
             fn = el.getChild("sound-file").getValue();
-            log.debug("boiling-sound: {}", fn);
             boiling_sound = new SoundBite(vf, fn, name + "_BOILING", name + "_Boiling");
             boiling_sound.setGain(setXMLGain(el)); // Handle gain
-            log.debug("boiling-sound gain: {}", boiling_sound.getGain());
             boiling_sound.setLooped(true);
             boiling_sound.setFadeTimes(500, 500);
             boiling_sound.setReferenceDistance(setXMLReferenceDistance(el));
-            log.debug("boiling-sound reference distance: {}", boiling_sound.getReferenceDistance());
             trigger_sounds.put("boiling", boiling_sound);
-            log.debug("trigger boiling sound: {}", trigger_sounds.get("boiling"));
         }
 
         // Get the brake sound
         el = e.getChild("brake-sound");
         if (el != null) {
             fn = el.getChild("sound-file").getValue();
-            log.debug("brake sound: {}", fn);
             brake_sound = new SoundBite(vf, fn, _soundName + "_BRAKE", _soundName + "_Brake");
             brake_sound.setGain(setXMLGain(el));
-            log.debug("brake sound gain: {}", brake_sound.getGain());
             brake_sound.setLooped(false);
             brake_sound.setFadeTimes(500, 500);
             brake_sound.setReferenceDistance(setXMLReferenceDistance(el));
-            log.debug("brake-sound reference distance: {}", brake_sound.getReferenceDistance());
             trigger_sounds.put("brake", brake_sound);
-            log.debug("trigger brake sound: {}", trigger_sounds.get("brake"));
         }
 
         // Get the pre-arrival sound
         el = e.getChild("pre-arrival-sound");
         if (el != null) {
             fn = el.getChild("sound-file").getValue();
-            log.debug("pre-arrival sound: {}", fn);
-            pre_arrival_sound = new SoundBite(vf, fn, _soundName + "_PRE-ARRIVAL", 
-                    _soundName + "_Pre-arrival");
+            pre_arrival_sound = new SoundBite(vf, fn, _soundName + "_PRE-ARRIVAL", _soundName + "_Pre-arrival");
             pre_arrival_sound.setGain(setXMLGain(el));
-            log.debug("pre-arrival sound gain: {}", pre_arrival_sound.getGain());
             pre_arrival_sound.setLooped(false);
             pre_arrival_sound.setFadeTimes(500, 500);
             pre_arrival_sound.setReferenceDistance(setXMLReferenceDistance(el));
-            log.debug("pre-arrival-sound reference distance: {}", pre_arrival_sound.getReferenceDistance());
             trigger_sounds.put("pre_arrival", pre_arrival_sound);
-            log.debug("trigger pre_arrival sound : {}", trigger_sounds.get("pre_arrival"));
         }
 
-        // Kick-start the loop thread
-        this.startThread();
+        if (buffer_ok) {
+            // Kick-start the loop thread
+            this.startThread();
 
-        // Check auto-start setting
-        autoStartCheck();
+            // Check auto-start setting
+            autoStartCheck();
+        } else {
+            log.warn("Engine cannot be started due to buffer exceeding");
+        }
     }
 
     private static final Logger log = LoggerFactory.getLogger(Steam1Sound.class);
 
     private static class S1Notch {
 
-        private AudioBuffer filler_bufn;
-        private AudioBuffer filler_bufc;
         private int my_notch;
         private int min_rpm, max_rpm;
         private int buffer_fmt;
+        private int buffer_freq;
+        private int buffer_frame_size;
         private ByteBuffer notchfiller_data;
         private ByteBuffer coastfiller_data;
-        private List<AudioBuffer> chuff_bufs = new ArrayList<>();
         private List<AudioBuffer> bufs_helper = new ArrayList<>();
         private List<ByteBuffer> chuff_bufs_data = new ArrayList<>();
-        private List<AudioBuffer> coast_bufs = new ArrayList<>();
+        private List<ByteBuffer> chufflight_bufs_data = new ArrayList<>();
         private List<ByteBuffer> coast_bufs_data = new ArrayList<>();
 
-        public S1Notch() {
-            this(1, null, null, null, null);
-        }
-
-        public S1Notch(int notch, AudioBuffer notchfiller, AudioBuffer coastfiller, 
-                List<AudioBuffer> chuff, List<AudioBuffer> coast) {
+        private S1Notch(int notch) {
             my_notch = notch;
-            filler_bufn = notchfiller;
-            filler_bufc = coastfiller;
-            if (chuff != null) {
-                chuff_bufs = chuff;
-            }
-            if (coast != null) {
-                coast_bufs = coast;
-            }
         }
 
-        public int getNotch() {
+        private int getNotch() {
             return my_notch;
         }
 
-        public int getMaxLimit() {
+        private int getMaxLimit() {
             return max_rpm;
         }
 
-        public int getMinLimit() {
+        private int getMinLimit() {
             return min_rpm;
         }
 
-        public void setNotch(int n) {
-            my_notch = n;
-        }
-
-        public void setMinLimit(int l) {
+        private void setMinLimit(int l) {
             min_rpm = l;
         }
 
-        public void setMaxLimit(int l) {
+        private void setMaxLimit(int l) {
             max_rpm = l;
         }
 
-        public Boolean isInLimits(int val) {
+        private Boolean isInLimits(int val) {
             return val >= min_rpm && val <= max_rpm;
         }
 
-        public void setBufferFmt(int fmt) {
+        private void setBufferFmt(int fmt) {
             buffer_fmt = fmt;
         }
 
-        public int getBufferFmt() {
+        private int getBufferFmt() {
             return buffer_fmt;
         }
 
-        public void setNotchFillerBuffer(AudioBuffer b) {
-            filler_bufn = b;
+        private void setBufferFreq(int freq) {
+            buffer_freq = freq;
         }
 
-        public AudioBuffer getNotchFillerBuffer() {
-            return filler_bufn;
+        private int getBufferFreq() {
+            return buffer_freq;
         }
 
-        public void setCoastFillerBuffer(AudioBuffer b) {
-            filler_bufc = b;
+        private void setBufferFrameSize(int framesize) {
+            buffer_frame_size = framesize;
         }
 
-        public AudioBuffer getCoastFillerBuffer() {
-            return filler_bufc;
+        private int getBufferFrameSize() {
+            return buffer_frame_size;
         }
 
-        public void setNotchFillerData(ByteBuffer dat) {
+        private void setNotchFillerData(ByteBuffer dat) {
             notchfiller_data = dat;
         }
 
-        public ByteBuffer getNotchFillerData() {
+        private ByteBuffer getNotchFillerData() {
             return notchfiller_data;
         }
 
-        public void setCoastFillerData(ByteBuffer dat) {
+        private void setCoastFillerData(ByteBuffer dat) {
             coastfiller_data = dat;
         }
 
-        public ByteBuffer getCoastFillerData() {
+        private ByteBuffer getCoastFillerData() {
             return coastfiller_data;
         }
 
-        public void addChuffBuffer(AudioBuffer b) {
-            chuff_bufs.add(b);
-        }
-
-        public void addChuffData(ByteBuffer dat) {
+        private void addChuffData(ByteBuffer dat) {
             chuff_bufs_data.add(dat);
         }
 
-        public void addCoastBuffer(AudioBuffer b) {
-            coast_bufs.add(b);
-        }
-
-        public void addCoastData(ByteBuffer dat) {
+        private void addCoastData(ByteBuffer dat) {
             coast_bufs_data.add(dat);
         }
 
-        public void addHelper(AudioBuffer b) {
+        private void addHelper(AudioBuffer b) {
             bufs_helper.add(b);
         }
 
-        static public AudioBuffer getBuffer(VSDFile vf, String filename, 
-                    String sname, String uname) {
-            AudioBuffer b = null;
-            AudioManager am = jmri.InstanceManager.getDefault(jmri.AudioManager.class);
-            try {
-                b = (AudioBuffer) am.provideAudio(VSDSound.BufSysNamePrefix + sname);
-                b.setUserName(VSDSound.BufUserNamePrefix + uname);
-                if (vf == null) {
-                    log.warn("No VSD File");
-                    return null;
-                } else {
-                    java.io.InputStream ins = vf.getInputStream(filename);
-                    if (ins != null) {
-                        b.setInputStream(ins);
-                    } else {
-                        log.warn("input Stream failed for {}", filename);
-                        return null;
-                    }
-                }
-            } catch (AudioException | IllegalArgumentException ex) {
-                log.warn("problem creating SoundBite", ex);
-                return null;
-            }
-
-            log.debug("buffer created: {}, name: {}, format: {}", 
-                    b, b.getSystemName(), b.getFormat());
-            return b;
-        }
-
-        static public AudioBuffer getBufferHelper(String sname, String uname) {
+        static private AudioBuffer getBufferHelper(String sname, String uname) {
             AudioBuffer bf = null;
             AudioManager am = jmri.InstanceManager.getDefault(jmri.AudioManager.class);
             try {
@@ -666,7 +580,7 @@ class Steam1Sound extends EngineSound {
             return bf;
         }
 
-        static public java.io.InputStream getWavStream(VSDFile vf, String filename) {
+        static private java.io.InputStream getWavStream(VSDFile vf, String filename) {
             java.io.InputStream ins = vf.getInputStream(filename);
             if (ins != null) {
                 return ins;
@@ -677,14 +591,14 @@ class Steam1Sound extends EngineSound {
         }
 
         private static final Logger log = LoggerFactory.getLogger(S1Notch.class);
+
     }
 
     private static class S1LoopThread extends Thread {
 
         Steam1Sound _parent;
         S1Notch _notch;
-        S1Notch coast_notch; // Needed for coasting sounds and buffers
-        S1Notch helper_notch; // Needed for helper buffers
+        S1Notch notch1;
         SoundBite _sound;
         float _throttle;
 
@@ -715,7 +629,7 @@ class Steam1Sound extends EngineSound {
         private int dec_time;
         private int count_pre_arrival;
         private int queue_limit;
-        private int waitFiller;
+        private int wait_loops;
         private int sbl_fill;
         private int wait_notch;
         public static final int SLEEP_INTERVAL = 50;
@@ -743,13 +657,11 @@ class Steam1Sound extends EngineSound {
             timeOfLastSpeedCheck = 0;
             _throttle = 0.0f;
             _notch = null;
-            coast_notch = null;
-            helper_notch = null;
             _sound = new SoundBite(s + "_QUEUE"); // Sound for queueing
             _sound.setGain(_parent.engine_gain); // All chuff sounds will have this gain
             count_pre_arrival = 1;
             queue_limit = 2;
-            waitFiller = 0;
+            wait_loops = 0;
             sbl_fill = 0;
             wait_notch = 1;
             if (r) {
@@ -757,7 +669,7 @@ class Steam1Sound extends EngineSound {
             }
         }
 
-        public void setRunning(boolean r) {
+        private void setRunning(boolean r) {
             is_running = r;
         }
 
@@ -809,7 +721,7 @@ class Steam1Sound extends EngineSound {
                                     is_braking = true;
                                     log.debug("braking activ!");
                                 }
-                            } else if (coast_notch.coast_bufs.size() > 0 && !is_key_coasting) {
+                            } else if (notch1.coast_bufs_data.size() > 0 && !is_key_coasting) {
                                 is_auto_coasting = true;
                                 log.debug("auto-coasting active");
                             }
@@ -900,10 +812,10 @@ class Steam1Sound extends EngineSound {
                 // Handle key-coasting on/off.
                 log.debug("COAST key pressed");
                 // Set coasting TRUE, if COAST key is pressed. Requires sufficient coasting sounds (chuff_index will rely on that).
-                if (coast_notch == null) {
-                    coast_notch = _parent.getNotch(1); // Because of initial send of throttle key, COAST function key could be "true"
+                if (notch1 == null) {
+                    notch1 = _parent.getNotch(1); // Because of initial send of throttle key, COAST function key could be "true"
                 }
-                if (is_true && coast_notch.coast_bufs.size() > 0) {
+                if (is_true && notch1.coast_bufs_data.size() > 0) {
                     is_key_coasting = true; // When idling is active, key-coasting will start after it.
                 } else {
                     is_key_coasting = false; // Stop the key-coasting sound
@@ -949,10 +861,11 @@ class Steam1Sound extends EngineSound {
         private void startEngine() {
             _sound.unqueueBuffers();
             log.debug("thread: start engine ...");
-            coast_notch  = _parent.getNotch(1); // Coast sounds are bound to notch 1
-            helper_notch = _parent.getNotch(1); // Helper buffers are bound to notch 1
             _notch = _parent.getNotch(1); // Initial value
-            _parent.engine_pane.setThrottle(1); // Set EnginePane (DieselPane) notch
+            notch1 = _parent.getNotch(1);
+            if (_parent.engine_pane != null) {
+                _parent.engine_pane.setThrottle(1); // Set EnginePane (DieselPane) notch
+            } 
             _sound.setReferenceDistance(_parent.engine_rd);
             setRpm(0);
             setRpmNominal(0);
@@ -1020,15 +933,7 @@ class Steam1Sound extends EngineSound {
                         }
                         log.debug("run loop. Buffers queued: {}", _sound.getSource().numQueuedBuffers());
                         if ((_sound.getSource().numQueuedBuffers() < queue_limit) && (getWait() == 0)) {
-                            AudioBuffer b;
-                            if (is_key_coasting || is_auto_coasting) {
-                                // Take the coasting sound. Yes, use same index as for chuffs
-                                b = coast_notch.coast_bufs.get(incChuffIndex());
-                            } else {
-                                // Take the standard chuff sound
-                                b = _notch.chuff_bufs.get(incChuffIndex());
-                            }
-                            setSound(b); // Queue the sound and, if necessary, a filler sound
+                            setSound(selectData()); // Select appropriate WAV data, handle sound and filler and queue the sound
                         }
                         if (_sound.getSource().getState() != Audio.STATE_PLAYING) {
                             _sound.play(); // Starts the Sound. Maybe also re-starts the sound
@@ -1060,10 +965,20 @@ class Steam1Sound extends EngineSound {
             }
         }
 
+        private ByteBuffer selectData() {
+            ByteBuffer data;
+            if (is_key_coasting || is_auto_coasting) {
+                data = notch1.coast_bufs_data.get(incChuffIndex()); // Take the coasting sound
+            } else {
+                data = _notch.chuff_bufs_data.get(incChuffIndex()); // Take the standard chuff sound
+            }
+            return data;
+        }
+
         private void changeNotch() {
             int new_notch = _notch.getNotch();
             log.debug("changing notch ... rpm: {}, notch: {}, chuff index: {}", 
-                    getRpm(), _notch.getNotch(), chuffIndex());
+                    getRpm(), _notch.getNotch(), chuff_index);
             if ((getRpm() > _notch.getMaxLimit()) && (new_notch < _parent.notch_sounds.size())) {
                 // Too fast. Need to go to next notch up
                 new_notch++;
@@ -1118,7 +1033,7 @@ class Steam1Sound extends EngineSound {
             checkState();
 
             // Are we in the right notch?
-            if ((getRpm() >= _parent.getNotch(1).getMinLimit()) && (!_notch.isInLimits(getRpm()))) {
+            if ((getRpm() >= notch1.getMinLimit()) && (!_notch.isInLimits(getRpm()))) {
                 log.debug("Notch change! Notch: {}, RPM nominal: {}, RPM actual: {}", _notch.getNotch(), getRpmNominal(), getRpm());
                 changeNotch();
             }
@@ -1126,7 +1041,7 @@ class Steam1Sound extends EngineSound {
 
         private void checkState() {
             if (is_looping) {
-                if (getRpm() < _parent.getNotch(1).getMinLimit()) {
+                if (getRpm() < notch1.getMinLimit()) {
                     is_looping = false; // Stop the loop player
                     setWait(0);
                     log.debug("change from chuff or coast to idle.");
@@ -1135,7 +1050,7 @@ class Steam1Sound extends EngineSound {
                     startIdling();
                 }
             } else {
-                if (_parent.engine_started && (getRpm() >= _parent.getNotch(1).getMinLimit())) {
+                if (_parent.engine_started && (getRpm() >= notch1.getMinLimit())) {
                     stopIdling();
                     // Now prepare to start the chuff sound (or coasting sound)
                     _notch = _parent.getNotch(1); // Initial notch value
@@ -1154,8 +1069,11 @@ class Steam1Sound extends EngineSound {
                 }
             }
 
-            if (getRpm() > 62) {
-                queue_limit = 3; // Allow more buffers to be queued at higher speed
+            // Allow more buffers to be queued at higher speed
+            if (getRpm() > 250) {
+                queue_limit = 5;
+            } else if ( getRpm() > 62) {
+                queue_limit = 3;
             } else {
                 queue_limit = 2;
             }
@@ -1168,17 +1086,11 @@ class Steam1Sound extends EngineSound {
         }
 
         private void setWait(int wait) {
-            waitFiller = wait;
+            wait_loops = wait;
         }
 
         private int getWait() {
-            return waitFiller;
-        }
-
-        // Place next two methods here (other than in Diesel3Sound)
-        // I want the chuffs in 1-2-3-4 series regardless the notch
-        private int chuffIndex() {
-            return chuff_index;
+            return wait_loops;
         }
 
         private int incChuffIndex() {
@@ -1187,14 +1099,14 @@ class Steam1Sound extends EngineSound {
             if (chuff_index >= (_num_cylinders * 2)) {
                 chuff_index = 0;
             }
-            log.debug("new chuff index: {}", chuffIndex());
+            log.debug("new chuff index: {}", chuff_index);
             return chuff_index;
         }
 
         private int incHelperIndex() {
             helper_index++;
             // Correct for wrap.
-            if (helper_index >= helper_notch.bufs_helper.size()) {
+            if (helper_index >= notch1.bufs_helper.size()) {
                 helper_index = 0;
             }
             return helper_index;
@@ -1214,123 +1126,90 @@ class Steam1Sound extends EngineSound {
             return (int) Math.round(60000.0 / revpm / _num_cylinders / 2.0);
         }
 
-        private void setSound(AudioBuffer b) {
-            int interval = calcChuffInterval(getRpm()); // Time in msec from chuff start up to begin of next chuff
-            int sbl = (int)SoundBite.calcLength(b); // Length of WAV file in msec
-            // Look if a filler is pending
-            if (waitForFiller) { 
-                // Filler waiting time is over. Go to queue the filler sound now
-                //  Only do this if we are in the same notch
-                if (wait_notch == _notch.getNotch()) {
-                    setFiller(sbl_fill);
-                    log.debug("wait filler set");
-                }
-                waitForFiller = false; // Done.
+        private void setSound(ByteBuffer data) {
+            AudioBuffer buf = notch1.bufs_helper.get(incHelperIndex()); // buffer for the queue
+            int sbl = 0;
+            if (notch1.getBufferFreq() > 0) {
+                sbl = (1000 * data.limit()/notch1.getBufferFrameSize()) / notch1.getBufferFreq(); // calculate the length of the clip in milliseconds
             }
+            log.debug("sbl: {}", sbl);
+            // Time in msec from chuff start up to begin of the next chuff, limited to a minimum
+            int interval = Math.max(calcChuffInterval(getRpm()), SLEEP_INTERVAL);
+            int bbufcount = notch1.getBufferFrameSize() * ((interval) * notch1.getBufferFreq() / 1000);
+            ByteBuffer bbuf = ByteBuffer.allocateDirect(bbufcount); // Target
 
-            if (interval >= sbl) {
+            if (interval > sbl) {
                 // Regular queueing. Whole sound clip goes to the queue. Low notches
-                _sound.queueBuffer(b);
-                log.debug("chuff or coast buffer queued. Interval: {}", interval);
-                setWait((sbl - SLEEP_INTERVAL * 4) / SLEEP_INTERVAL);
-                if (getWait() < 3) {
-                    setWait(0);
-                } else {
-                    sbl_fill = sbl; // Base for filler length calculation
-                    waitForFiller = true;
+                // Prepare the sound and transfer it to the target ByteBuffer bbuf
+                int bbufcount2 = notch1.getBufferFrameSize() * (sbl * notch1.getBufferFreq() / 1000);
+                byte[] bbytes2 = new byte[bbufcount2];
+                data.get(bbytes2); // Same as: data.get(bbytes2, 0, bbufcount2);
+                data.rewind();
+                bbuf.order(data.order()); // Set new buffer's byte order to match source buffer.
+                bbuf.put(bbytes2); // Same as: bbuf.put(bbytes2, 0, bbufcount2);
+
+                // Handle filler for the remaining part of the AudioBuffer
+                if (bbuf.hasRemaining()) {
+                    log.debug("remaining: {}", bbuf.remaining());
+                    ByteBuffer dataf;
+                    if (is_key_coasting || is_auto_coasting) {
+                        dataf = notch1.getCoastFillerData();
+                    } else {
+                        dataf = notch1.getNotchFillerData();
+                    }
+                    if (dataf == null) {
+                        log.debug("No filler sound found");
+                        // Nothing to do on 16-bit, because 0 is default for "silence"; 8-bit-mono needs 128, otherwise it's "noisy"
+                        if (notch1.getBufferFmt() == com.jogamp.openal.AL.AL_FORMAT_MONO8) {
+                            byte[] bbytesfiller = new byte[bbuf.remaining()];
+                            for (int i = 0; i < bbytesfiller.length; i++) {
+                                bbytesfiller[i] = (byte) 0x80; // fill array with "silence"
+                            }
+                            bbuf.put(bbytesfiller);
+                        }
+                    } else {
+                        // Filler sound found
+                        log.debug("data limit: {}, remaining: {}", dataf.limit(), bbuf.remaining());
+                        byte[] bbytesfiller2 = new byte[bbuf.remaining()];
+                        if (dataf.limit() >= bbuf.remaining()) {
+                            dataf.get(bbytesfiller2);
+                            dataf.rewind();
+                            bbuf.put(bbytesfiller2);
+                        } else {
+                            log.debug("not enough filler length");
+                            byte[] bbytesfillerpart = new byte[dataf.limit()];
+                            dataf.get(bbytesfillerpart);
+                            dataf.rewind();
+                            int k = 0;
+                            for (int i = 0; i < bbytesfiller2.length; i++) {
+                                bbytesfiller2[i] = bbytesfillerpart[k];
+                                k++;
+                                if (k == dataf.limit()) {
+                                    k = 0;
+                                }
+                            }
+                            bbuf.put(bbytesfiller2);
+                        }
+                    }
                 }
             } else {
                 // Need to cut the SoundBite to new length of interval
-                // To avoid queue underrun, interval should be a bit longer than SLEEP_INTERVAL
-                // SLEEP_INTERVAL + 10 should be lower than interval of max_rpm (e.g. max_rpm=214 -> interval=70)
-                if (interval > (SLEEP_INTERVAL + 10)) {
-                    log.debug("need to cut sound clip from {} to length {}", (int)SoundBite.calcLength(b), interval); 
-                    setWait((interval - SLEEP_INTERVAL * 8) / SLEEP_INTERVAL);
-                    if (getWait() < 4) {
-                        setWait(0);
-                    }
-                    // Take <interval> ms of the buffer. Regard sample size
-                    int bbufcount = b.getFrameSize() * (interval * b.getFrequency() / 1000);
-                    // Empty buffer (bound to the coast notch, notch = 1)
-                    AudioBuffer buf = helper_notch.bufs_helper.get(incHelperIndex());
-                    byte[] bbytes = new byte[bbufcount];
-                    ByteBuffer data;
-                    if (is_key_coasting || is_auto_coasting) {
-                        // Take coasting sound (WAV data)
-                        data = coast_notch.coast_bufs_data.get(chuffIndex());
-                    } else {
-                        // Take chuff sound (WAV data)
-                        data = _notch.chuff_bufs_data.get(chuffIndex());
-                    }
-                    data.get(bbytes); // Same as: data.get(bbytes, 0, bbufcount);
-                    data.rewind();
-                    ByteBuffer bbuf = ByteBuffer.allocateDirect(bbufcount); // Target
-                    bbuf.order(data.order()); // Set new buffer's byte order to match source buffer
-                    bbuf.put(bbytes); // Same as: bbuf.put(bbytes, 0, bbufcount);
-                    bbuf.rewind();
-                    buf.loadBuffer(bbuf, _notch.getBufferFmt(), b.getFrequency());
-                    _sound.queueBuffer(buf);
-                    log.debug("cut buffer queued. Length: {}", (int)SoundBite.calcLength(buf));
-                    // No filler needed here.
-                }
+                log.debug("need to cut sound clip from {} to length {}", sbl, interval); 
+                byte[] bbytes = new byte[bbufcount];
+                data.get(bbytes); // Same as: data.get(bbytes, 0, bbufcount);
+                data.rewind();
+                bbuf.order(data.order()); // Set new buffer's byte order to match source buffer
+                bbuf.put(bbytes); // Same as: bbuf.put(bbytes, 0, bbufcount);
             }
-        }
+            bbuf.rewind();
+            buf.loadBuffer(bbuf, notch1.getBufferFmt(), notch1.getBufferFreq());
+            _sound.queueBuffer(buf);
+            log.debug("buffer queued. Length: {}", (int)SoundBite.calcLength(buf));
 
-        private void setFiller(int lenx) {
-            // Fills time after a chuff up to the next chuff with a sound provided by the VSD file
-            // Since the filler can be a small amount of time, it might be queued several times
-            AudioBuffer fill_buf;
-            if (is_key_coasting || is_auto_coasting) {
-                fill_buf = coast_notch.getCoastFillerBuffer();
-            } else {
-                fill_buf = _notch.getNotchFillerBuffer();
-            }
-            if (fill_buf != null) {
-                int filler_length = (int)SoundBite.calcLength(fill_buf);
-                int interv_wo_chuff = calcChuffInterval(getRpm()) - lenx;
-                log.debug("filler length: {}, sound clip length: {}, interval: {}", filler_length, lenx, calcChuffInterval(getRpm()));
-                int im = interv_wo_chuff / filler_length; // How many fill_buf do we need?
-                int imrest = interv_wo_chuff - (im * filler_length); // Calculate rest
-                log.debug("interval without sound clip: {}, #buffers needed: {}, rest: {}", interv_wo_chuff, im, imrest);
-                int k = 0;
-                for (int i = 0; i < im; i++) {
-                    _sound.queueBuffer(fill_buf);
-                    k++;
-                }
-                log.debug("{} new buffers queued. Total buffers queued now: {}", 
-                        k, _sound.getSource().numQueuedBuffers());
-                // Create a buffer to queue rest of the filling time. Ignore small sound bites
-                if (imrest > (SLEEP_INTERVAL + 10)) {
-                    setWait((imrest - SLEEP_INTERVAL * 4) / SLEEP_INTERVAL);
-                    if (getWait() < 3) {
-                        setWait(0);
-                    }
-                    int bbufcount = fill_buf.getFrameSize() * (imrest * fill_buf.getFrequency() / 1000);
-                    log.debug("chuff_index: {}", chuffIndex());
-                    // Empty buffer (bound to notch = 1)
-                    AudioBuffer buf  = helper_notch.bufs_helper.get(incHelperIndex());
-                    byte[] bbytes = new byte[bbufcount];
-                    ByteBuffer dataf;
-                    if (is_key_coasting || is_auto_coasting) {
-                        dataf = coast_notch.getCoastFillerData();
-                    } else {
-                        dataf = _notch.getNotchFillerData();
-                    }
-                    dataf.get(bbytes); // Same as: data.get(bbytes, 0, bbufcount);
-                    dataf.rewind();
-                    ByteBuffer bbuf = ByteBuffer.allocate(bbufcount);
-                    bbuf.order(dataf.order()); // Set new buffer's byte order to match source buffer
-                    bbuf.put(bbytes); // Same as: bbuf.put(bbytes, 0, bbufcount);
-                    log.debug("bbuf after put: {}, order: {}", bbuf, bbuf.order());
-                    bbuf.rewind();
-                    buf.loadBuffer(bbuf, _notch.getBufferFmt(), fill_buf.getFrequency());
-                    _sound.queueBuffer(buf);
-                    log.debug("filler rest buffer queued. Length: {}", (int)SoundBite.calcLength(buf));
-                } else {
-                    log.debug("no filler rest buffer queued.");
-                }
-            } else {
-                log.warn("filler buffer missing.");
+            // wait some loops to get up-to-date speed value
+            setWait((interval - SLEEP_INTERVAL * _parent.wait_factor) / SLEEP_INTERVAL);
+            if (getWait() < 3) {
+                setWait(0);
             }
         }
 


### PR DESCRIPTION
I use a ByteBuffer now instead of a AudioBuffer plus a ByteBuffer to prepare the chuff sound for queueing.

The concept of buffering and queuing:
There are WAV files for every chuff in a VSD file. When the VSD file is loaded, a chuff sound is transferred into a ByteBuffer (before that PR, the chuff sound was transferred into a ByteBuffer plus an AudioBuffer).
At run-time, dependent on the speed, the chuffs must be extended or reduced. To reduce the chuff length I transfer less samples into the ByteBuffer. To extend the chuff length I fill up the ByteBuffer to the desired length. The ByteBuffer at its right length then is transferred into an AudioBuffer for queueing.
Queued sounds finally are played and processed by the loop-player.

The improved concept
- makes the audio buffer handling more robust and user friendly (regarding the length of the chuff sounds).
- needs less audio buffers (which are limited).

Did some code cleanup also.

Since this change is an internal change there is no release note provided.

