### PR TITLE
remove 'extra' LocoNet menu for standalone programmer mode

### DIFF
--- a/java/src/jmri/jmrix/loconet/pr2/LnPr2Packetizer.java
+++ b/java/src/jmri/jmrix/loconet/pr2/LnPr2Packetizer.java
@@ -18,6 +18,21 @@ public class LnPr2Packetizer extends LnPacketizer {
         super(new LocoNetSystemConnectionMemo());
         echo = true;
     }
+    
+    // 
+    /**
+     * Create a Packetizer against an existing LocoNetSystemConnectionMemo.
+     * <p>
+     * This allows for re-configuring an existing LocoNetSystemConnectionMemo, 
+     * which was created during PR3Adapter initialization, for use in the PR3's 
+     * "PR2 Mode" (i.e. "Standalone Programmer Mode".)
+     * <p>
+     * @param memo pre-existing LocoNetSystemConnectionMemo
+     */    
+    public LnPr2Packetizer(LocoNetSystemConnectionMemo memo) {
+        super(memo);
+        echo = true;
+    }
 
 //    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LnPr2Packetizer.class);
 

--- a/java/src/jmri/jmrix/loconet/pr3/PR3Adapter.java
+++ b/java/src/jmri/jmrix/loconet/pr3/PR3Adapter.java
@@ -72,7 +72,12 @@ public class PR3Adapter extends LocoBufferAdapter {
             // PR3 standalone case
             // connect to a packetizing traffic controller
             // that does echoing
-            jmri.jmrix.loconet.pr2.LnPr2Packetizer packets = new jmri.jmrix.loconet.pr2.LnPr2Packetizer();
+            //
+            // Note - already created a LocoNetSystemConnectionMemo, so re-use 
+            // it when creating a PR2 Packetizer.  (If create a new one, will
+            // end up with two "LocoNet" menus...)
+            jmri.jmrix.loconet.pr2.LnPr2Packetizer packets = 
+                    new jmri.jmrix.loconet.pr2.LnPr2Packetizer(this.getSystemConnectionMemo());
             packets.connectPort(this);
 
             // create memo


### PR DESCRIPTION
Attempts to address #6563 - two "LocoNet" menus appear if PR3 interface is used in "PR3 Standalone Programmer" mode.