### PR TITLE
relax throttle message queue requirements for Z21 Throttle

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -100,7 +100,7 @@
 
         <h4>Roco z21/Z21</h4>
             <ul>
-                <li></li>
+                <li>Fixed Delay in throttle message processing</li>
             </ul>
 
         <h4>Secsi</h4>

--- a/java/src/jmri/jmrix/roco/z21/Z21HeartBeat.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21HeartBeat.java
@@ -67,8 +67,10 @@ public class Z21HeartBeat implements Z21Listener {
      */
     @Override
     public void message(Z21Message msg){
-       // if we see any outgoing message, restart the timer
-       keepAliveTimer.restart();
+       if(keepAliveTimer!=null) { 
+          // if we see any outgoing message, restart the timer
+          keepAliveTimer.restart();
+       }
     }
 
 }

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetMessage.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetMessage.java
@@ -126,8 +126,27 @@ public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage implements Seria
         }
         msg.setElement(4, functionbyte);
         msg.setParity();
+        msg.setBroadcastReply();
         return (msg);
     }
+
+    /**
+     * Generate a Z21 message to change the speed/direction of a locomotive.
+     *
+     * @param address the locomotive address
+     * @param speedStepMode the speedstep mode see @jmri.DccThrottle
+     *                       for possible values.
+     * @param speed a normalized speed value (a floating point number between 0
+     *              and 1).  A negative value indicates emergency stop.
+     * @param isForward true for forward, false for reverse.
+     */
+    public static XNetMessage getZ21LanXSetLocoDriveMsg(int address, int speedMode, float speed, boolean isForward) {
+        XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(address,
+                        speedMode,speed,isForward);
+        msg.setBroadcastReply();
+        return (msg);
+    }
+
 
     /**
      * Given a turnout address, generate a message to request the state.

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetMessage.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetMessage.java
@@ -134,7 +134,7 @@ public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage implements Seria
      * Generate a Z21 message to change the speed/direction of a locomotive.
      *
      * @param address the locomotive address
-     * @param speedStepMode the speedstep mode see @jmri.DccThrottle
+     * @param speedMode the speedstep mode see @jmri.DccThrottle
      *                       for possible values.
      * @param speed a normalized speed value (a floating point number between 0
      *              and 1).  A negative value indicates emergency stop.

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetThrottle.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetThrottle.java
@@ -34,6 +34,31 @@ public class Z21XNetThrottle extends jmri.jmrix.roco.RocoXNetThrottle {
      * {@inheritDoc}
      */
     @Override
+    synchronized public void setSpeedSetting(float speed) {
+        log.debug("set Speed to: {} Current step mode is: {}",speed,this.speedStepMode);
+        this.speedSetting = speed;
+        record(speed);
+        if (speed < 0) {
+            /* we're sending an emergency stop to this locomotive only */
+            sendEmergencyStop();
+        } else {
+            if (speed > 1) {
+                speed = (float) 1.0;
+            }
+            /* we're sending a speed to the locomotive */
+            XNetMessage msg = Z21XNetMessage.getZ21LanXSetLocoDriveMsg(getDccAddress(),
+                    this.speedStepMode,
+                    speed,
+                    this.isForward);
+            // now, queue the message for sending to the command station
+            queueMessage(msg, THROTTLEIDLE);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void setSpeedSetting(float speed, boolean allowDuplicates, boolean allowDuplicatesOnStop) {
         this.speedSetting = speed;
         record(speed);
@@ -64,19 +89,19 @@ public class Z21XNetThrottle extends jmri.jmrix.roco.RocoXNetThrottle {
         // send all the functions when there is a change in the group.
         XNetMessage msg = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),0,f0);
         // now, queue the message for sending to the command station
-        queueMessage(msg, THROTTLEFUNCSENT);
+        queueMessage(msg, THROTTLEIDLE);
         XNetMessage msg1 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),1,f1);
         // now, queue the message for sending to the command station
-        queueMessage(msg1, THROTTLEFUNCSENT);
+        queueMessage(msg1, THROTTLEIDLE);
         XNetMessage msg2 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),2,f2);
         // now, queue the message for sending to the command station
-        queueMessage(msg2, THROTTLEFUNCSENT);
+        queueMessage(msg2, THROTTLEIDLE);
         XNetMessage msg3 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),3,f3);
         // now, queue the message for sending to the command station
-        queueMessage(msg3, THROTTLEFUNCSENT);
+        queueMessage(msg3, THROTTLEIDLE);
         XNetMessage msg4 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),4,f4);
         // now, queue the message for sending to the command station
-        queueMessage(msg4, THROTTLEFUNCSENT);
+        queueMessage(msg4, THROTTLEIDLE);
     }
 
     /**
@@ -88,16 +113,16 @@ public class Z21XNetThrottle extends jmri.jmrix.roco.RocoXNetThrottle {
         // send all the functions when there is a change in the group.
         XNetMessage msg = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),5,f5);
         // now, queue the message for sending to the command station
-        queueMessage(msg, THROTTLEFUNCSENT);
+        queueMessage(msg, THROTTLEIDLE);
         XNetMessage msg1 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),6,f6);
         // now, queue the message for sending to the command station
-        queueMessage(msg1, THROTTLEFUNCSENT);
+        queueMessage(msg1, THROTTLEIDLE);
         XNetMessage msg2 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),7,f7);
         // now, queue the message for sending to the command station
-        queueMessage(msg2, THROTTLEFUNCSENT);
+        queueMessage(msg2, THROTTLEIDLE);
         XNetMessage msg3 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),8,f8);
         // now, queue the message for sending to the command station
-        queueMessage(msg3, THROTTLEFUNCSENT);
+        queueMessage(msg3, THROTTLEIDLE);
     }
 
     /**
@@ -110,16 +135,16 @@ public class Z21XNetThrottle extends jmri.jmrix.roco.RocoXNetThrottle {
         // send all the functions when there is a change in the group.
         XNetMessage msg = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),9,f9);
         // now, queue the message for sending to the command station
-        queueMessage(msg, THROTTLEFUNCSENT);
+        queueMessage(msg, THROTTLEIDLE);
         XNetMessage msg1 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),10,f10);
         // now, queue the message for sending to the command station
-        queueMessage(msg1, THROTTLEFUNCSENT);
+        queueMessage(msg1, THROTTLEIDLE);
         XNetMessage msg2 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),11,f11);
         // now, queue the message for sending to the command station
-        queueMessage(msg2, THROTTLEFUNCSENT);
+        queueMessage(msg2, THROTTLEIDLE);
         XNetMessage msg3 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),12,f12);
         // now, queue the message for sending to the command station
-        queueMessage(msg3, THROTTLEFUNCSENT);
+        queueMessage(msg3, THROTTLEIDLE);
     }
 
     /**
@@ -132,28 +157,28 @@ public class Z21XNetThrottle extends jmri.jmrix.roco.RocoXNetThrottle {
         // send all the functions when there is a change in the group.
         XNetMessage msg = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),13,f13);
         // now, queue the message for sending to the command station
-        queueMessage(msg, THROTTLEFUNCSENT);
+        queueMessage(msg, THROTTLEIDLE);
         XNetMessage msg1 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),14,f14);
         // now, queue the message for sending to the command station
-        queueMessage(msg1, THROTTLEFUNCSENT);
+        queueMessage(msg1, THROTTLEIDLE);
         XNetMessage msg2 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),15,f15);
         // now, queue the message for sending to the command station
-        queueMessage(msg2, THROTTLEFUNCSENT);
+        queueMessage(msg2, THROTTLEIDLE);
         XNetMessage msg3 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),16,f16);
         // now, queue the message for sending to the command station
-        queueMessage(msg3, THROTTLEFUNCSENT);
+        queueMessage(msg3, THROTTLEIDLE);
         XNetMessage msg4 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),17,f17);
         // now, queue the message for sending to the command station
-        queueMessage(msg4, THROTTLEFUNCSENT);
+        queueMessage(msg4, THROTTLEIDLE);
         XNetMessage msg5 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),18,f18);
         // now, queue the message for sending to the command station
-        queueMessage(msg5, THROTTLEFUNCSENT);
+        queueMessage(msg5, THROTTLEIDLE);
         XNetMessage msg6 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),19,f19);
         // now, queue the message for sending to the command station
-        queueMessage(msg6, THROTTLEFUNCSENT);
+        queueMessage(msg6, THROTTLEIDLE);
         XNetMessage msg7 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),20,f20);
         // now, queue the message for sending to the command station
-        queueMessage(msg7, THROTTLEFUNCSENT);
+        queueMessage(msg7, THROTTLEIDLE);
     }
     /**
      * Send the XpressNet message to set the state of functions F21, F22, F23,
@@ -165,28 +190,28 @@ public class Z21XNetThrottle extends jmri.jmrix.roco.RocoXNetThrottle {
         // send all the functions when there is a change in the group.
         XNetMessage msg = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),21,f21);
         // now, queue the message for sending to the command station
-        queueMessage(msg, THROTTLEFUNCSENT);
+        queueMessage(msg, THROTTLEIDLE);
         XNetMessage msg1 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),22,f22);
         // now, queue the message for sending to the command station
-        queueMessage(msg1, THROTTLEFUNCSENT);
+        queueMessage(msg1, THROTTLEIDLE);
         XNetMessage msg2 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),23,f23);
         // now, queue the message for sending to the command station
-        queueMessage(msg2, THROTTLEFUNCSENT);
+        queueMessage(msg2, THROTTLEIDLE);
         XNetMessage msg3 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),24,f24);
         // now, queue the message for sending to the command station
-        queueMessage(msg3, THROTTLEFUNCSENT);
+        queueMessage(msg3, THROTTLEIDLE);
         XNetMessage msg4 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),25,f25);
         // now, queue the message for sending to the command station
-        queueMessage(msg4, THROTTLEFUNCSENT);
+        queueMessage(msg4, THROTTLEIDLE);
         XNetMessage msg5 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),26,f26);
         // now, queue the message for sending to the command station
-        queueMessage(msg5, THROTTLEFUNCSENT);
+        queueMessage(msg5, THROTTLEIDLE);
         XNetMessage msg6 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),27,f27);
         // now, queue the message for sending to the command station
-        queueMessage(msg6, THROTTLEFUNCSENT);
+        queueMessage(msg6, THROTTLEIDLE);
         XNetMessage msg7 = Z21XNetMessage.getZ21LocomotiveFunctionOperationMsg(this.getDccAddress(),28,f28);
         // now, queue the message for sending to the command station
-        queueMessage(msg7, THROTTLEFUNCSENT);
+        queueMessage(msg7, THROTTLEIDLE);
     }
 
     // The Roco Doesn't support the XpressNet directed emergency stop
@@ -227,12 +252,10 @@ public class Z21XNetThrottle extends jmri.jmrix.roco.RocoXNetThrottle {
                // byte 6 and 7 contain function information for F13-F28
                parseFunctionHighInformation(b6,b7);
               
-               if(requestState != THROTTLEIDLE ) { 
-                  // set the request state to idle
-                  requestState = THROTTLEIDLE;
-                  // and send any queued messages.
-                  sendQueuedMessage();
-               }
+               // set the request state to idle
+               requestState = THROTTLEIDLE;
+               // and send any queued messages.
+               sendQueuedMessage();
            } 
         } else {
             // let the standard XpressNet Throttle have a chance to look


### PR DESCRIPTION
Standard XPressNet throttles queue outgoing messages to make sure there is never more than one outgoing request because the replies don't have addresses in them.  The Z21 replies include the address, so we can relax that requirement.

Fixes issue #6400