### PR TITLE
Fix broken Javadoc links and tags

### DIFF
--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -124,7 +124,7 @@ public interface Manager<E extends NamedBean> {
      * Note: this is not a live array; the contents don't stay up to date
      * @return (slow) copy of system names in array form
      * @deprecated 4.11.5 - use direct access via 
-     *                  {@link getNamedBeanSet} 
+     *                  {@link #getNamedBeanSet()} 
      */
     @Deprecated // 4.11.5
     @CheckReturnValue
@@ -139,12 +139,12 @@ public interface Manager<E extends NamedBean> {
      * Note: this is ordered by the underlying NamedBeans, not
      *       on the Strings themselves.
      * <p>
-     * Note: Access via {@link getNamedBeanSet} is faster.
+     * Note: Access via {@link #getNamedBeanSet()}  is faster.
      * <p>
      * Note: This is not a live list; the contents don't stay up to date
      * @return Unmodifiable access to a list of system names
      * @deprecated 4.11.5 - use direct access via 
-     *                  {@link getNamedBeanSet} 
+     *                  {@link #getNamedBeanSet()} 
      */
     @Deprecated // 4.11.5
     @CheckReturnValue
@@ -158,12 +158,12 @@ public interface Manager<E extends NamedBean> {
      * <p>
      * Note: this is ordered by the original add order, used for ConfigureXML
      * <p>
-     * Note: Access via {@link getNamedBeanSet} is faster.
+     * Note: Access via {@link #getNamedBeanSet()}  is faster.
      * <p>
      * Note: This is a live list, it will be updated as beans are added and removed.
      * @return Unmodifiable access to a list of system names
      * @deprecated 4.11.5 - use direct access via 
-     *                  {@link getNamedBeanSet} 
+     *                  {@link #getNamedBeanSet()} 
      */
     @Deprecated // 4.11.5
     @CheckReturnValue
@@ -175,12 +175,12 @@ public interface Manager<E extends NamedBean> {
      * {@linkplain java.util.Collections#unmodifiableList unmodifiable} List
      * of NamedBeans in system-name order.
      * <p>
-     * Note: Access via {@link getNamedBeanSet} is faster.
+     * Note: Access via {@link #getNamedBeanSet()} is faster.
      * <p>
      * Note: This is not a live list; the contents don't stay up to date
      * @return Unmodifiable access to a List of NamedBeans
      * @deprecated 4.11.5 - use direct access via 
-     *                  {@link getNamedBeanSet} 
+     *                  {@link #getNamedBeanSet()} 
      */
     @Deprecated // 4.11.5
     @CheckReturnValue

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -357,7 +357,7 @@ public interface NamedBean extends Comparable<NamedBean> {
      * the second argument's name, +1 if the first argument's name  orders after the second argument's name.
      * The comparison is alphanumeric on the system prefix, then alphabetic on the
      * type letter, then system-specific comparison on the two suffix parts
-     * via the {@link compareSystemNameSuffix} method.
+     * via the {@link #compareSystemNameSuffix} method.
      *
      * @param n2 The second NamedBean in the comparison ("this" is the first one)
      * @return -1,0,+1 for ordering if the names are well-formed; may not provide proper ordering if the names are not well-formed.

--- a/java/src/jmri/beans/UnboundArbitraryBean.java
+++ b/java/src/jmri/beans/UnboundArbitraryBean.java
@@ -44,7 +44,7 @@ public abstract class UnboundArbitraryBean extends UnboundBean {
      * want to use {@link Bean#hasProperty(java.lang.String)} to test that the
      * property exists.
      * <p>
-     * This implementation searches {@link ArbitraryPropertySupport#properties}
+     * This implementation searches the internal property collection
      * and uses introspection to get the property.
      *
      * @param key Property to retrieve.
@@ -60,7 +60,7 @@ public abstract class UnboundArbitraryBean extends UnboundBean {
      * Return a list of property names.
      * <p>
      * This implementation combines the keys in
-     * {@link ArbitraryPropertySupport#properties} with the results of
+     * the internal property collection with the results of
      * {@link Beans#getIntrospectedPropertyNames(java.lang.Object)}.
      *
      * @return a Set of names
@@ -74,7 +74,7 @@ public abstract class UnboundArbitraryBean extends UnboundBean {
     /**
      * Test if a property exists.
      * <p>
-     * This implementation searches {@link ArbitraryPropertySupport#properties}
+     * This implementation searches the internal property collection
      * and uses introspection to get the property.
      *
      * @param key Property to inspect.
@@ -115,7 +115,7 @@ public abstract class UnboundArbitraryBean extends UnboundBean {
      * <p>
      * This implementation checks that a write method is not available for the
      * property using JavaBeans introspection, and stores the property in
-     * {@link ArbitraryPropertySupport#properties} only if a write method does
+     * the internal property collection only if a write method does
      * not exist. This implementation also fires a PropertyChangeEvent for the
      * property.
      *

--- a/java/src/jmri/jmrit/MemoryContents.java
+++ b/java/src/jmri/jmrit/MemoryContents.java
@@ -69,13 +69,13 @@ import org.slf4j.LoggerFactory;
  * Similarly, when writing the contents of data storage to a file, the
  * instantiating method will create a {@link File} and an associated
  * {@link Writer} and pass the {@link Writer} object to
- * {@link writeHex}. The mechanisms implemented within this class do not
+ * {@link #writeHex}. The mechanisms implemented within this class do not
  * know about or care about the filename or its extension and do not use that
  * information as part of its file interpretation or file creation.
  * <p>
  * The class is implemented with a maximum of 24 bits of address space, with up
  * to 256 pages of up to 65536 bytes per page. A "sparse" implementation of
- * memory is modeled, where only occupied pages are allocated within the JAVA
+ * memory is modeled, where only occupied pages are allocated within the Java
  * system's memory.
  * <hr>
  * The Intel "Hexadecimal Object File Format File Format Specification"
@@ -275,7 +275,7 @@ public class MemoryContents {
      * information. Such Key/Value pair information is used within the .DMF
      * format to provide configuration information for firmware update
      * mechanism. This class also extracts key/value pair comments "I8HEX"
-     * format files. After successful completion of this {@link readHex},
+     * format files. After successful completion of the {@link #readHex} call,
      * then the {@link #extractValueOfKey(String keyName)} method may be used to inspect individual key values.
      * <p>
      * Key/Value pair definition comment lines are of the format:
@@ -781,7 +781,7 @@ public class MemoryContents {
      * any comment lines in its output.
      *
      * @param writer    Writer to which the character stream is sent
-     * @param blocksize is the maximum number of bytes defined in a data record
+     * @param blockSize is the maximum number of bytes defined in a data record
      * @throws IOException                         upon file access problem
      * @throws MemoryFileAddressingFormatException if unsupported addressing
      *                                             format

--- a/java/src/jmri/jmrit/XmlFile.java
+++ b/java/src/jmri/jmrit/XmlFile.java
@@ -132,10 +132,10 @@ public abstract class XmlFile {
      *
      * Exceptions are only thrown when local recovery is impossible.
      *
-     * @throws org.jdom2.JDOMException       only when all methods have failed
-     * @throws java.io.FileNotFoundException if file not found
      * @param file File to be parsed. A FileNotFoundException is thrown if it
      *             doesn't exist.
+     * @throws org.jdom2.JDOMException       only when all methods have failed
+     * @throws java.io.FileNotFoundException if file not found
      * @return root element from the file. This should never be null, as an
      *         exception should be thrown if anything goes wrong.
      */
@@ -154,9 +154,9 @@ public abstract class XmlFile {
      *
      * Exceptions are only thrown when local recovery is impossible.
      *
+     * @param stream InputStream to be parsed.
      * @throws org.jdom2.JDOMException       only when all methods have failed
      * @throws java.io.FileNotFoundException if file not found
-     * @param stream InputStream to be parsed.
      * @return root element from the file. This should never be null, as an
      *         exception should be thrown if anything goes wrong.
      */
@@ -169,9 +169,9 @@ public abstract class XmlFile {
      *
      * Exceptions are only thrown when local recovery is impossible.
      *
+     * @param url URL locating the data file
      * @throws org.jdom2.JDOMException only when all methods have failed
      * @throws FileNotFoundException   if file not found
-     * @param url URL locating the data file
      * @return root element from the file. This should never be null, as an
      *         exception should be thrown if anything goes wrong.
      */
@@ -262,9 +262,9 @@ public abstract class XmlFile {
     /**
      * Write a File as XML.
      *
-     * @throws FileNotFoundException if file not found
      * @param file File to be created.
      * @param doc  Document to be written out. This should never be null.
+     * @throws FileNotFoundException if file not found
      */
     public void writeXML(File file, Document doc) throws IOException, FileNotFoundException {
         // ensure parent directory exists

--- a/java/src/jmri/jmrix/loconet/bdl16/BDL16Panel.java
+++ b/java/src/jmri/jmrix/loconet/bdl16/BDL16Panel.java
@@ -415,7 +415,7 @@ public class BDL16Panel extends AbstractBoardProgPanel {
      * Create a JLabel for an OpSw.
      *
      * @param n   OpSw number
-     * @param jp  the JPanel into which the Label is placed
+     * @return the JPanel into which the Label is placed
      */
     private JLabel getLabel(int n) {
         String number = Integer.toString(n);
@@ -438,7 +438,7 @@ public class BDL16Panel extends AbstractBoardProgPanel {
      *
      * @param n first OpSw number
      * @param n2 second OpSw number
-     * @param jp the JPanel into which the Label is placed
+     * @return the JPanel into which the Label is placed
      */
     private JLabel getLabel(int n, int n2) {
         String number = Integer.toString(n);
@@ -468,7 +468,7 @@ public class BDL16Panel extends AbstractBoardProgPanel {
      * reported default value.
      * 
      * @param n   OpSw number
-     * @param jp  the JPanel into which the JComboBox is placed
+     * @return  the JPanel into which the JComboBox is placed
      */
     private JComboBox getComboBox(int n) {
         String number = Integer.toString(n);
@@ -498,7 +498,7 @@ public class BDL16Panel extends AbstractBoardProgPanel {
      * 
      * @param n first OpSw number
      * @param n2 second OpSw number
-     * @param jp the JPanel into which the JComboBox is placed
+     * @return the JPanel into which the JComboBox is placed
      */
     private JComboBox getComboBox(int n, int n2) {
         String number = Integer.toString(n);
@@ -531,8 +531,8 @@ public class BDL16Panel extends AbstractBoardProgPanel {
      * Determine the JComboBox index which corresponds to the default value 
      * for a given OpSw.
      * 
-     * @param   n OpSw number
-     * @return  JComboBox index of default choice
+     * @param  n OpSw number
+     * @return index of default choice
      */
     private int getIndexForDefault(int n) {
         switch (n) {

--- a/java/src/jmri/profile/NullProfile.java
+++ b/java/src/jmri/profile/NullProfile.java
@@ -14,7 +14,7 @@ import javax.annotation.Nonnull;
  * JMRI profile is not acceptable.
  * <p>
  * This class deliberately overrides all methods of {@link jmri.profile.Profile}
- * that access the {@link #name} and {@link #id} fields to remove protections
+ * that access the private Profile.name and Profile.id fields to remove protections
  * and restrictions on those fields.
  *
  * @author Randall Wood Copyright (C) 2014

--- a/java/src/jmri/util/MathUtil.java
+++ b/java/src/jmri/util/MathUtil.java
@@ -1144,7 +1144,7 @@ public final class MathUtil {
      * Draw a Bezier curve
      *
      * @param g2  the Graphics2D to draw to
-     * @param p[] control points
+     * @param p control points
      * @param displacement right/left to draw a line parallel to the Bezier
      * @return the length of the Bezier curve
      */
@@ -1168,7 +1168,7 @@ public final class MathUtil {
      * Draw a Bezier curve
      *
      * @param g2  the Graphics2D to draw to
-     * @param p[] control points
+     * @param p control points
      * @return the length of the Bezier curve
      */
     public static double drawBezier(Graphics2D g2, @Nonnull Point2D p[]) {


### PR DESCRIPTION
These were tagged by the new ECJ compiler in PR #6580, though this PR is independent of that.

No functional changes.