### PR TITLE
Drop thread in favour of the common ThreadingUtil actions

### DIFF
--- a/java/src/jmri/jmrix/dccpp/serial/SerialDCCppPacketizer.java
+++ b/java/src/jmri/jmrix/dccpp/serial/SerialDCCppPacketizer.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import jmri.jmrix.dccpp.DCCppListener;
 import jmri.jmrix.dccpp.DCCppMessage;
 import jmri.jmrix.dccpp.DCCppPacketizer;
+import jmri.util.ThreadingUtil;
 
 /**
  * This is an extension of the DCCppPacketizer to handle the device specific
@@ -60,40 +61,23 @@ public class SerialDCCppPacketizer extends DCCppPacketizer {
     }
 
     /**
-     * this is the background thread that periodically refreshes the last known
-     * function settings
+     * <code>true</code> when the self-rescheduling function refresh action was
+     * initially queued, to avoid duplicate actions
      */
-    private Thread backgroundRefresh = null;
+    private boolean backgroundRefreshStarted = false;
 
-    private final class RefreshThread extends Thread {
-        public RefreshThread() {
-            setDaemon(true);
-            setPriority(Thread.MIN_PRIORITY);
-            setName("SerialDCCppPacketizer.bkg_refresh");
-        }
-
+    final class RefreshAction implements ThreadingUtil.ThreadAction {
         @Override
         public void run() {
-            while (true) {
-                try {
-                    final DCCppMessage message = resendFunctions.take();
+            try {
+                final DCCppMessage message = resendFunctions.poll();
 
-                    if (message != null) {
-                        message.setRetries(0);
-                        sendDCCppMessage(message, null);
-
-                        // At 115200 baud only ~1k messages/s can be sent.
-                        // The limit is however how many messages DCC++ BaseStation can process.
-                        // At more than 25Hz random functions get activated and replies go missing.
-                        // Further on, reading CVs on the programming track is much slower.
-                        // The lowest common denominator between all modes is 4Hz, at this rate everything seems to work fine.
-                        sleep(250);
-                    }
-
-                    setName("SerialDCCppPacketizer.bkg_refresh (" + resendFunctions.size() + " msg)");
-                } catch (final InterruptedException e) {
-                    // should exit if interrupted
+                if (message != null) {
+                    message.setRetries(0);
+                    sendDCCppMessage(message, null);
                 }
+            } finally {
+                ThreadingUtil.runOnLayoutDelayed(this, 250);
             }
         }
     }
@@ -101,15 +85,15 @@ public class SerialDCCppPacketizer extends DCCppPacketizer {
     private void enqueueFunction(final DCCppMessage m) {
         /**
          * Set again the same group function value 250ms later (or more,
-         * depending on the queue depth; limited to 1kHz of calls)
+         * depending on the queue depth)
          */
         m.delayFor(250);
         resendFunctions.offer(m);
 
         synchronized (this) {
-            if (backgroundRefresh == null) {
-                backgroundRefresh = new RefreshThread();
-                backgroundRefresh.start();
+            if (!backgroundRefreshStarted) {
+                ThreadingUtil.runOnLayoutDelayed(new RefreshAction(), 250);
+                backgroundRefreshStarted = true;
             }
         }
     }


### PR DESCRIPTION
As discussed in #6529, the internal Thread refreshing the function values can be dropped. The new approach uses the ThreadingUtil to self reschedule the queue consumer task every 250ms.