### PR TITLE
Zimo decoder files update, adding "brake key"

### DIFF
--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <!--Written by JMRI version 4.15.3ish+jake+20190212T1417Z+R342025162a on Tue Feb 12 06:18:40 PST 2019-->
-  <decoderIndex version="926">
+  <!--Written by JMRI version 4.15.4ish+jake+20190221T1837Z+R68612e21e1 on Thu Feb 21 10:37:23 PST 2019-->
+  <decoderIndex version="928">
     <mfgList nmraListDate="2015-03-06" updated="2015-03-25" lastadd="107,124,126,128,134">
       <manufacturer mfg="NMRA" mfgID="999" />
       <manufacturer mfg="A-Train Electronics" mfgID="137" />
@@ -7862,6 +7862,77 @@
             <protocol>dcc</protocol>
             <protocol>motorola</protocol>
           </protocols>
+        </model>
+      </family>
+      <family name="Fl decoders RailCom" mfg="Fleischmann" file="Fl_decoders_RailCom.xml">
+        <model model="685303" maxInputVolts="20V" maxTotalCurrent="1.00 A" formFactor="N" connector="NEM651" numOuts="8" numFns="14" productID="685303">
+          <output name="1" label="Light forwards">
+            <label xml:lang="de">Licht vorwärts</label>
+            <label xml:lang="nl">Licht vooruit</label>
+          </output>
+          <output name="2" label="Light backwards">
+            <label xml:lang="de">Licht rückwärts</label>
+            <label xml:lang="nl">Licht achteruit</label>
+          </output>
+          <output name="3" label="Aux 1" />
+          <output name="4" label="Aux 2" />
+          <output name="5" label="Aux 3" />
+          <output name="6" label="Aux 4" />
+          <output name="7" label="Acceleration off">
+            <label xml:lang="de">Massen simulation aus</label>
+            <label xml:lang="nl">Massa simulatie uit</label>
+          </output>
+          <output name="8" label="Shunting-gear">
+            <label xml:lang="de">Rangier-gang</label>
+            <label xml:lang="nl">Rangeer-stand</label>
+          </output>
+          <size length="12.9" width="9" height="3.4" units="mm" />
+        </model>
+        <model model="685403" maxInputVolts="20V" maxTotalCurrent="1.00 A" formFactor="N" connector="NEM651" numOuts="8" numFns="14" productID="685403">
+          <output name="1" label="Light forwards">
+            <label xml:lang="de">Licht vorwärts</label>
+            <label xml:lang="nl">Licht vooruit</label>
+          </output>
+          <output name="2" label="Light backwards">
+            <label xml:lang="de">Licht rückwärts</label>
+            <label xml:lang="nl">Licht achteruit</label>
+          </output>
+          <output name="3" label="Aux 1" />
+          <output name="4" label="Aux 2" />
+          <output name="5" label="Aux 3" />
+          <output name="6" label="Aux 4" />
+          <output name="7" label="Acceleration off">
+            <label xml:lang="de">Massen simulation aus</label>
+            <label xml:lang="nl">Massa simulatie uit</label>
+          </output>
+          <output name="8" label="Shunting-gear">
+            <label xml:lang="de">Rangier-gang</label>
+            <label xml:lang="nl">Rangeer-stand</label>
+          </output>
+          <size length="12.9" width="9" height="3.4" units="mm" />
+        </model>
+        <model model="685503" maxInputVolts="20V" maxTotalCurrent="1.00 A" formFactor="N" connector="NEM651" numOuts="8" numFns="14" productID="685503">
+          <output name="1" label="Light forwards">
+            <label xml:lang="de">Licht vorwärts</label>
+            <label xml:lang="nl">Licht vooruit</label>
+          </output>
+          <output name="2" label="Light backwards">
+            <label xml:lang="de">Licht rückwärts</label>
+            <label xml:lang="nl">Licht achteruit</label>
+          </output>
+          <output name="3" label="Aux 1" />
+          <output name="4" label="Aux 2" />
+          <output name="5" label="Aux 3" />
+          <output name="6" label="Aux 4" />
+          <output name="7" label="Acceleration off">
+            <label xml:lang="de">Massen simulation aus</label>
+            <label xml:lang="nl">Massa simulatie uit</label>
+          </output>
+          <output name="8" label="Shunting-gear">
+            <label xml:lang="de">Rangier-gang</label>
+            <label xml:lang="nl">Rangeer-stand</label>
+          </output>
+          <size length="12.9" width="9" height="3.4" units="mm" />
         </model>
       </family>
       <family name="Fl decoders Train-Navigation" mfg="Fleischmann" file="Fl_decoders_Train-Navigation.xml">

--- a/xml/decoders/zimo/CV260-CV355sound_version30.xml
+++ b/xml/decoders/zimo/CV260-CV355sound_version30.xml
@@ -11,6 +11,7 @@
 <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
+<!-- version 1.5, added CV309 and CV349 for brake (function) key control, in decoders from zimo version 33.25.  Nigel Cliffe, 20 Sept 2018 -->
 <!-- version 1.4, corrected CV313 "inverted" output labels, which corrects bug in displayed file. Nigel Cliffe, 27Dec 2016 -->
 <!-- version 1.3, add german translation by Ronald Kuhn -->
 <!-- version 1.2, include statments for CV341 CV342 CV343 edited for new decoders and corrections by Mark Waters -->
@@ -677,6 +678,102 @@
     <label xml:lang="de">E-Motor: Steigung der Frequenz</label>
     <label xml:lang="cs">Trakční motor: závislost výšky tónu na rychlosti</label>
   </variable>
+  
+    <variable item="Brake Key" CV="309" default="0" tooltip="CV309, brake key">
+	<enumVal>
+      <enumChoice choice="No key assigned">
+        <choice>No key assigned</choice>
+        <choice xml:lang="it">Nessun Tasto</choice>
+        <choice xml:lang="de">keine Taste</choice>
+        <choice xml:lang="cs">Nepřiřazena žádná klávesa</choice>
+      </enumChoice>
+      <enumChoice choice="F1">
+        <choice>F1</choice>
+      </enumChoice>
+      <enumChoice choice="F2">
+        <choice>F2</choice>
+      </enumChoice>
+      <enumChoice choice="F3">
+        <choice>F3</choice>
+      </enumChoice>
+      <enumChoice choice="F4">
+        <choice>F4</choice>
+      </enumChoice>
+      <enumChoice choice="F5">
+        <choice>F5</choice>
+      </enumChoice>
+      <enumChoice choice="F6">
+        <choice>F6</choice>
+      </enumChoice>
+      <enumChoice choice="F7">
+        <choice>F7</choice>
+      </enumChoice>
+      <enumChoice choice="F8">
+        <choice>F8</choice>
+      </enumChoice>
+      <enumChoice choice="F9">
+        <choice>F9</choice>
+      </enumChoice>
+      <enumChoice choice="F10">
+        <choice>F10</choice>
+      </enumChoice>
+      <enumChoice choice="F11">
+        <choice>F11</choice>
+      </enumChoice>
+      <enumChoice choice="F12">
+        <choice>F12</choice>
+      </enumChoice>
+      <enumChoice choice="F13">
+        <choice>F13</choice>
+      </enumChoice>
+      <enumChoice choice="F14">
+        <choice>F14</choice>
+      </enumChoice>
+      <enumChoice choice="F15">
+        <choice>F15</choice>
+      </enumChoice>
+      <enumChoice choice="F16">
+        <choice>F16</choice>
+      </enumChoice>
+      <enumChoice choice="F17">
+        <choice>F17</choice>
+      </enumChoice>
+      <enumChoice choice="F18">
+        <choice>F18</choice>
+      </enumChoice>
+      <enumChoice choice="F19">
+        <choice>F19</choice>
+      </enumChoice>
+      <enumChoice choice="F20">
+        <choice>F20</choice>
+      </enumChoice>
+      <enumChoice choice="F21">
+        <choice>F21</choice>
+      </enumChoice>
+      <enumChoice choice="F22">
+        <choice>F22</choice>
+      </enumChoice>
+      <enumChoice choice="F23">
+        <choice>F23</choice>
+      </enumChoice>
+      <enumChoice choice="F24">
+        <choice>F24</choice>
+      </enumChoice>
+      <enumChoice choice="F25">
+        <choice>F25</choice>
+      </enumChoice>
+      <enumChoice choice="F26">
+        <choice>F26</choice>
+      </enumChoice>
+      <enumChoice choice="F27">
+        <choice>F27</choice>
+      </enumChoice>
+      <enumChoice choice="F28">
+        <choice>F28</choice>
+      </enumChoice>
+    </enumVal>
+  </variable>
+  
   <variable item="On/off key for engine and random sound" CV="310" default="8" tooltip="Defines the key that turns the engine and random sounds on or off">
     <enumVal>
       <enumChoice choice="No key assigned">
@@ -1485,6 +1582,12 @@
     <label xml:lang="cs">Strojová jízda volnoběh</label>
     <tooltip xml:lang="cs">Přehrávání zvuku volnoběhu při pomalé jízdě</tooltip>
   </variable>
+  
+   <variable item="Brake Key Deceleration Rate" CV="349" default="0" tooltip="CV349, brake key time">
+	<decVal min="0" max="255"/>
+  </variable>
+   
+  
 </variables>
   <variable item="Delay of Switchgear sound at startup" CV="350" default="0" tooltip="0 = no delay, 255 = 25sec">
     <decVal min="0" max="255"/>

--- a/xml/decoders/zimo/PaneAccelDecel.xml
+++ b/xml/decoders/zimo/PaneAccelDecel.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
 <!-- version 1 - for Unified Software -->
-<!-- version 1.1 - Ronald Kuhn - add german translation -->
 <pane xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <name>Accel/Decel</name>
-  <name xml:lang="cs">Zrychlení/Zpomalení</name>
-  <name xml:lang="de">Beschleunigungs-/Bremsverhalten</name>
   <column>
     <row>
       <column>
@@ -46,7 +42,7 @@
     <separator/>
     <row>
       <column>
-        <display item="Dither option"/>
+        <display item="BEMF Intensity"/>
       </column>
       <column>
         <label>
@@ -69,26 +65,18 @@
         <label>
             <text>A 'Hundreds' digit of 1 offsets the mid value for 'coreless' motors</text>
             <text xml:lang="it">Numero Centinaia =1 è valore intermedio per motori 'coreless'</text>
-            <text xml:lang="cs">Stovky jsou pro coreless motory, 1 je střední hodnota</text>
-            <text xml:lang="de">Der Hunderterwert modifiziert Einstellungen für Glockenanker-Motoren.</text>
           </label>
           <label>
             <text>Tens digit is the Proportional value, mid value = 5</text>
             <text xml:lang="it">Numero decine è valore proporzionale, valore medio=5</text>
-            <text xml:lang="cs">Desítky jsou proporcionální složka, 5 je střední hodnota</text>
-            <text xml:lang="de">Der Zehnerwert modifiziert den Proportional-Wert der PID-Regelung.</text>
           </label>
           <label>
             <text>Ones digit is the integral value, mid value = 5</text>
             <text xml:lang="it">Numero unità è valore integrale, valore medio =5</text>
-            <text xml:lang="cs">Jednotky jsou integrační složka, 5 je střední hodnota</text>
-            <text xml:lang="de">Der Einerwert modifiziert den Integral-Wert der PID-Regelung.</text>
           </label>
           <label>
             <text>With default setting of 0, proportional value auto adjusts and integral value is equivalent to 5</text>
             <text xml:lang="it">Con i valori di default = 0 il valore proporzionale si regola automaticamente e il valore integrale è = 5</text>
-            <text xml:lang="cs">S výchozím nastavením 0 se proporcionální složka upravuje automaticky a integrační složka odpovídá 5</text>
-            <text xml:lang="de">Mit dem Wert 0 wird der P-Wert automatisch und der I-Wert äquivalent dem Wert 5 eingestellt.</text>
           </label>
         <label>
           <text> </text>
@@ -110,38 +98,26 @@
         <label>
             <text>0 = 20/40KHz (set with CV112) and sample rate auto adjusts between 200Hz (low speed) and 50Hz</text>
             <text xml:lang="it">0 = 20/40KHz (con CV112) e campionamento si regola automaticamente tra 200Hz (bassa velocità) e 50Hz</text>
-            <text xml:lang="cs">0 = 20/40kHz (nastaveno s CV112) a vzorkovací frekvence se nastavuje automaticky mezi 200 Hz (nízká rychlost) a 50 Hz</text>
-            <text xml:lang="de">0 = 20 kHz, 1 = 40 kHz (gesetzt in CV112)</text>
           </label>
           <label>
             <text>Tens digit = Sampling rate (1-9) mid value = 5</text>
             <text xml:lang="it">Numero decine = campionamento (1-9) valore medio=5</text>
-            <text xml:lang="cs">Desítky = vzorkovací frekvence (1-9) střední hodnota = 5</text>
-            <text xml:lang="de">Zehnerstelle = Abtastrate (1-9)</text>
           </label>
           <label>
             <text>Ones digit = EMF sampling time (1-9) mid value = 5</text>
             <text xml:lang="it">Numero unità = tempo campionamento EMF(1-9), valore medio =5</text>
-            <text xml:lang="cs">Jednotky = EMF vzorkovací čas (1-9) střední hodnota = 5</text>
-            <text xml:lang="de">Einerstelle = EMK-Messlücke EMF (1-9)</text>
           </label>
           <label>
             <text>100 = 'Spread Spectrum' sampling rate for reduced noise, with medium sampling time</text>
             <text xml:lang="it">100 = Campionamento 'Ampio spettro' per rumore ridotto, con tempo campionamento medio</text>
-            <text xml:lang="cs">100 = 'Rozdělení spektra' vzorkovací frekvence pro omezení šumu, se středním vzorkovacím časem</text>
-            <text xml:lang="de">100 = ausgewogene Wiederholrate für vermindertes Geräusch mit mittlerer Wiederholzeit.</text>
           </label>
           <label>
             <text>255-176 = Low frequency according to formula;-</text>
             <text xml:lang="it">255-176 = Bassa frequenza secondo la formula;-</text>
-            <text xml:lang="cs">255-176 = Nízká frekvence podle vzorce</text>
-            <text xml:lang="de">255-176 = Niederfrequenz. Periode nach der Formel</text>
           </label>
           <label>
             <text>(131 + mantissa * 4) * 2 exp. Bits 0-4 = mantissa, Bits 5-7 = exp</text>
             <text xml:lang="it">(131 + mantissa * 4) * 2 exp. Bits 0-4 = mantissa, Bits 5-7 = exp-</text>
-            <text xml:lang="cs">(131 + mantisa * 4) * 2 ^ exponent. Bity 0-4 = mantisa, Bity 5-7 = exponent</text>
-            <text xml:lang="de">(131 + mantisse * 4) * 2 exp. Bit 0-4 ist mantisse, Bit 5-7 ist exp</text>
           </label>
         <label>
           <text> </text>
@@ -153,8 +129,6 @@
       <label>
         <text>Acceleration/Deceleration time (momentum) can be streched in the lower speed range</text>
         <text xml:lang="it">Il tempo di Accell./Decell. (inerzia) può essere allargato a velocità bassa</text>
-        <text xml:lang="cs">Doba zrychlení/zpomalení (hybnost) se může rozprostírat v rozmezí nížších rychlostí</text>
-        <text xml:lang="de">Beschleunigungs-/Bremsverhalten kann im Niedriggeschwindigkeitsbereich angepasst werden.</text>
       </label>
     </row>
     <row>
@@ -180,14 +154,10 @@
         <label>
             <text>Tens digit = percentage of speed range to be included (0-9)</text>
             <text xml:lang="it">Numero decine = percentuale velocità da includere (0-9)</text>
-            <text xml:lang="cs">Desítky = procentuální podíl rozsahu otáček, které mají být zahrnuty (0-9)</text>
-            <text xml:lang="de">Zehnerstelle: Prozentsatz (0 bis 90 %) des Geschwindigkeitsbereichs (0-9)</text>
           </label>
           <label>
             <text>Ones digit = Exponential curve (0-9)</text>
             <text xml:lang="it">Numero unità = curva esponenziale (0-9)</text>
-            <text xml:lang="cs">Jednotky = exponenciální křivka (0-9)</text>
-            <text xml:lang="de">Einerstelle: Parameter für die Krümmung der Exponentialfunktion. (0-9)</text>
           </label>
         <label>
           <text> </text>
@@ -200,14 +170,10 @@
         <label>
             <text>Raising or lowering the speed to the next internal step occurs only if the precedingstep is nearly reached.The tolerance</text>
             <text xml:lang="it">L'incremento o il decremento allo step vicino avviene solo se è raggiunto lo step precedente. La tolleranza</text>
-            <text xml:lang="cs">K zvyšování nebo snižování rychlosti na další interní krok dochází pouze pokud předchozí krok je téměř dosažen.</text>
-            <text xml:lang="de">Die Erhöhung bzw. Absenkung der Sollgeschwindigkeit soll erst nach einer definierten Annäherung</text>
           </label>
           <label>
             <text>for reaching the preceding step is defined by this CV (the smaller this value the smoother the acceleration/deceleration)</text>
             <text xml:lang="it">per raggiungere lo step precedente è definita da questa CV ( valori piccoli per accell./decell. più graduali)</text>
-            <text xml:lang="cs">Tolerance pro dosažení předchozího kroku je definována tímto CV (menší hodnota pro hladké zrychlení/zpomalení)</text>
-            <text xml:lang="de">der Ist-Geschwindigkeit an die bisher vorgegebene Sollgeschwindigkeit erfolgen.</text>
           </label>
       </column>
     </row>
@@ -233,20 +199,14 @@
         <label>
             <text>Tens digit = acceleration (1-9)</text>
             <text xml:lang="it">Numero decine = accellerazione (1-9)</text>
-            <text xml:lang="cs">Desítky = zrychlení (1-9)</text>
-            <text xml:lang="de">Zehnerstelle: für Beschleunigung (0-9)</text>
           </label>
           <label>
             <text>Ones digit = deceleration (1-9)</text>
             <text xml:lang="it">Numero unità = decellerazione (1-9)</text>
-            <text xml:lang="cs">Jednotky = zpomalení (1-9)</text>
-            <text xml:lang="de">Einerstelle: für die Bremsung (0-9)</text>
           </label>
           <label>
             <text>Value 0 = no adaptive acceleration/deceleration</text>
             <text xml:lang="it">Valore 0 = nessuna accell./decell. adattativa</text>
-            <text xml:lang="cs">Hodnota 0 = bez přizpůsobeného zrychlení/zpomalení</text>
-            <text xml:lang="de">0: kein adaptives Verfahren</text>
           </label>
         <label>
           <text> </text>
@@ -254,4 +214,5 @@
       </column>
     </row>
   </column>
+  <name>Accel/Decel</name>
 </pane>


### PR DESCRIPTION
From Nigel Cliffe via Issue #5836

Update to two files in the "zimo" subfolder within Decoders. This adds the "brake key" described in CV's 309 and 349 to the interface, supported in Zimo firmware 33.25 and later. Should automatically appear for decoder which uses those files.

