### PR TITLE
Documentation updates

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1832,8 +1832,7 @@
                         <IMG src="https://www.tagadab.com/sites/default/files/logo-tagadab-nostrap.png" height="28" width="103" border="0" alt="Tagadab Logo"> </A> 
                 ]]>
             </bottom>
-            <link href="http://docs.oracle.com/javase/8/docs/api/"/>
-            <link href="http://download.oracle.com/javase/8/docs/api/"/>
+            <link href="https://docs.oracle.com/javase/8/docs/api/"/>
             <link href="http://java.sun.com/products/javacomm/reference/api/"/>
             <link href="http://www.jdom.org/docs/apidocs/"/>
             <link href="http://javacsv.sourceforge.net/"/>
@@ -1903,8 +1902,7 @@
                         <IMG src="https://www.tagadab.com/sites/default/files/logo-tagadab-nostrap.png" height="28" width="103" border="0" alt="Tagadab Logo"> </A> 
                 ]]>
             </bottom>
-            <link href="http://docs.oracle.com/javase/8/docs/api/"/>
-            <link href="http://download.oracle.com/javase/8/docs/api/"/>
+            <link href="https://docs.oracle.com/javase/8/docs/api/"/>
             <link href="http://java.sun.com/products/javacomm/reference/api/"/>
             <link href="http://www.jdom.org/docs/apidocs/"/>
             <link href="http://javacsv.sourceforge.net/"/>
@@ -1988,8 +1986,7 @@
                         <IMG src="https://www.tagadab.com/sites/default/files/logo-tagadab-nostrap.png" height="28" width="103" border="0" alt="Tagadab Logo"> </A> 
                 ]]>
             </bottom>
-            <link href="http://docs.oracle.com/javase/8/docs/api/"/>
-            <link href="http://download.oracle.com/javase/8/docs/api/"/>
+            <link href="https://docs.oracle.com/javase/8/docs/api/"/>
             <link href="http://java.sun.com/products/javacomm/reference/api/"/>
             <link href="http://www.jdom.org/docs/apidocs/"/>
             <link href="http://javacsv.sourceforge.net/"/>

--- a/help/en/html/doc/Technical/Threads.shtml
+++ b/help/en/html/doc/Technical/Threads.shtml
@@ -190,7 +190,7 @@
     </ul>
     
    The <a href="http://jmri.org/JavaDoc/doc/jmri/util/TimerUtil.html">jmri.util.TimerUtil</a>
-   can help with the first of these.
+   can help with these issues.
     
 <h3>Other Items of Interest</h3>    
 


### PR DESCRIPTION
- Javdoc how requires https: to like to Java API
- Fix a comment that a user thought "ambiguous"