### PR TITLE
Fix DCC++ accessory address calculation for 'a' command.

### DIFF
--- a/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppCommandStation.java
@@ -150,6 +150,7 @@ public class DCCppCommandStation implements jmri.CommandStation {
 
         int reg = 0;  // register 0, so this doesn't repeat
         DCCppMessage msg = DCCppMessage.makeWriteDCCPacketMainMsg(reg, packet.length, packet);
+        log.debug("sendPacket:'{}'", msg.toString());
 
         for (int i = 0; i < repeats; i++) {
             _tc.sendDCCppMessage(msg, null);

--- a/java/src/jmri/jmrix/dccpp/DCCppConstants.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppConstants.java
@@ -120,8 +120,8 @@ public final class DCCppConstants {
     public final static String READ_TRACK_CURRENT_REGEX = "\\s*c\\s*"; // <c>
     public final static String READ_CS_STATUS_REGEX = "\\s*s\\s*";// <s>
     public final static String QUERY_SENSOR_REGEX = "\\s*[Q,q]\\s*(\\d+)\\s*";
-    public final static String WRITE_DCC_PACKET_MAIN_REGEX = "M\\s+(\\d+)(\\s+[0-9a-fA-F]{1,2})(\\s+[0-9a-fA-F]{1,2})(\\s+[0-9a-fA-F]{1,2})(\\s+[0-9a-fA-F]{1,2})(\\s+[0-9a-fA-F]{1,2})\\s*"; // M REG pktbyte1 pktbyte2 pktbyte3 ?pktbyte4 ?pktbyte5
-    public final static String WRITE_DCC_PACKET_PROG_REGEX = "P\\s+(\\d+)(\\s+[0-9a-fA-F]{1,2})(\\s+[0-9a-fA-F]{1,2})(\\s+[0-9a-fA-F]{1,2})(\\s+[0-9a-fA-F]{1,2})(\\s+[0-9a-fA-F]{1,2})\\s*"; // P REG pktbyte1 pktbyte2 pktbyte3 ?pktbyte4 ?pktbyte5
+    public final static String WRITE_DCC_PACKET_MAIN_REGEX = "M\\s+(\\d+)((\\s+[0-9a-fA-F]{1,2}){2,5})\\s*"; // M REG pktbyte1 pktbyte2 pktbyte3 ?pktbyte4 ?pktbyte5
+    public final static String WRITE_DCC_PACKET_PROG_REGEX = "P\\s+(\\d+)((\\s+[0-9a-fA-F]{1,2}){2,5})\\s*"; // P REG pktbyte1 pktbyte2 pktbyte3 ?pktbyte4 ?pktbyte5
     public final static String GET_FREE_MEMORY_REGEX = "\\s*f\\s*";
     public final static String LIST_REGISTER_CONTENTS_REGEX = "\\s*L\\s*";
     public final static String ENTER_DIAG_MODE_REGEX = "\\s*D\\s*";

--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -1511,11 +1511,12 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
         // address = (address - 1) * 4 + subaddress + 1 for address>0;
         int addr, subaddr;
         if (address > 0) {
-            addr = (address - 1) / (DCCppConstants.MAX_ACC_DECODER_SUBADDR + 1);
+            addr = ((address - 1) / (DCCppConstants.MAX_ACC_DECODER_SUBADDR + 1)) + 1;
             subaddr = (address - 1) % (DCCppConstants.MAX_ACC_DECODER_SUBADDR + 1);
         } else {
             addr = subaddr = 0;
         }
+        log.debug("makeAccessoryDecoderMsg address {}, addr {}, subaddr {}, activate {}",address, addr, subaddr, activate);
         return(makeAccessoryDecoderMsg(addr, subaddr, activate));
     }
 

--- a/java/src/jmri/jmrix/dccpp/DCCppMessage.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppMessage.java
@@ -1406,7 +1406,7 @@ public class DCCppMessage extends jmri.jmrix.AbstractMRMessage implements Delaye
     public String getPacketString() {
        if ( this.isWriteDccPacketMessage() ) {
             StringBuffer b = new StringBuffer();
-            for(int i = 2;i<=getGroupCount();i++){
+            for(int i = 2;i<=getGroupCount()-1;i++){
                 b.append(this.getValueString(i));
             }
             return(b.toString());

--- a/java/test/jmri/jmrix/dccpp/DCCppLightTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppLightTest.java
@@ -22,14 +22,14 @@ public class DCCppLightTest extends jmri.implementation.AbstractLightTestBase {
 
     @Override
     public void checkOnMsgSent() {
-        Assert.assertEquals("ON message", "a 5 0 1",
+        Assert.assertEquals("ON message", "a 6 0 1",
                 xnis.outbound.elementAt(xnis.outbound.size() - 1).toString());
         Assert.assertEquals("ON state", jmri.Light.ON, t.getState());
     }
 
     @Override
     public void checkOffMsgSent() {
-        Assert.assertEquals("OFF message", "a 5 0 0",
+        Assert.assertEquals("OFF message", "a 6 0 0",
                 xnis.outbound.elementAt(xnis.outbound.size() - 1).toString());
         Assert.assertEquals("OFF state", jmri.Light.OFF, t.getState());
     }

--- a/java/test/jmri/jmrix/dccpp/DCCppMessageTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppMessageTest.java
@@ -43,6 +43,246 @@ public class DCCppMessageTest extends jmri.jmrix.AbstractMessageTestBase {
         Assert.assertEquals("5th byte", '1', msg.getElement(5) & 0xFF);
     }
 
+    @Test
+    public void testMakeAccessoryDecoderMsgAddr1ActivateTrue() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(1, true);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 7, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '1', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", ' ', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", '0', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", ' ', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", '1', msg.getElement(6) & 0xFF);
+    }
+
+    @Test
+    public void testMakeAccessoryDecoderMsgAddr1ActivateFalse() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(1, false);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 7, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '1', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", ' ', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", '0', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", ' ', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", '0', msg.getElement(6) & 0xFF);
+    }
+
+    @Test
+    public void testMakeAccessoryDecoderMsgAddr4ActivateTrue() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(4, true);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 7, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '1', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", ' ', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", '3', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", ' ', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", '1', msg.getElement(6) & 0xFF);
+    }
+
+    @Test
+    public void testMakeAccessoryDecoderMsgAddr4ActivateFalse() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(4, false);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 7, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '1', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", ' ', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", '3', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", ' ', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", '0', msg.getElement(6) & 0xFF);
+    }
+
+    @Test
+    public void testMakeAccessoryDecoderMsgAddr5ActivateTrue() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(5, true);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 7, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '2', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", ' ', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", '0', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", ' ', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", '1', msg.getElement(6) & 0xFF);
+    }
+
+    @Test
+    public void testMakeAccessoryDecoderMsgAddr5ActivateFalse() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(5, false);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 7, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '2', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", ' ', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", '0', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", ' ', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", '0', msg.getElement(6) & 0xFF);
+    }
+
+    @Test
+    public void testMakeAccessoryDecoderMsgAddr40ActivateTrue() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(40, true);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 8, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '1', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", '0', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", ' ', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", '3', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", ' ', msg.getElement(6) & 0xFF);
+        Assert.assertEquals("7th byte", '1', msg.getElement(7) & 0xFF);
+    }
+
+    @Test
+    public void testMakeAccessoryDecoderMsgAddr40ActivateFalse() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(40, false);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 8, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '1', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", '0', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", ' ', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", '3', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", ' ', msg.getElement(6) & 0xFF);
+        Assert.assertEquals("7th byte", '0', msg.getElement(7) & 0xFF);
+    }
+
+     @Test
+    public void testMakeAccessoryDecoderMsgAddr41ActivateTrue() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(41, true);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 8, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '1', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", '1', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", ' ', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", '0', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", ' ', msg.getElement(6) & 0xFF);
+        Assert.assertEquals("7th byte", '1', msg.getElement(7) & 0xFF);
+    }
+
+    @Test
+    public void testMakeAccessoryDecoderMsgAddr41ActivateFalse() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(41, false);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 8, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '1', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", '1', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", ' ', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", '0', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", ' ', msg.getElement(6) & 0xFF);
+        Assert.assertEquals("7th byte", '0', msg.getElement(7) & 0xFF);
+    }
+
+     @Test
+    public void testMakeAccessoryDecoderMsgAddr2040ActivateTrue() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(2040, true);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 9, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '5', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", '1', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", '0', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", ' ', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", '3', msg.getElement(6) & 0xFF);
+        Assert.assertEquals("7th byte", ' ', msg.getElement(7) & 0xFF);
+        Assert.assertEquals("8th byte", '1', msg.getElement(8) & 0xFF);
+    }
+
+    @Test
+    public void testMakeAccessoryDecoderMsgAddr2040ActivateFalse() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(2040, false);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 9, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '5', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", '1', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", '0', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", ' ', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", '3', msg.getElement(6) & 0xFF);
+        Assert.assertEquals("7th byte", ' ', msg.getElement(7) & 0xFF);
+        Assert.assertEquals("8th byte", '0', msg.getElement(8) & 0xFF);
+    }
+
+     @Test
+    public void testMakeAccessoryDecoderMsgAddr2041ActivateTrue() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(2041, true);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 9, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '5', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", '1', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", '1', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", ' ', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", '0', msg.getElement(6) & 0xFF);
+        Assert.assertEquals("7th byte", ' ', msg.getElement(7) & 0xFF);
+        Assert.assertEquals("8th byte", '1', msg.getElement(8) & 0xFF);
+    }
+
+    @Test
+    public void testMakeAccessoryDecoderMsgAddr2041ActivateFalse() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(2041, false);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 9, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '5', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", '1', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", '1', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", ' ', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", '0', msg.getElement(6) & 0xFF);
+        Assert.assertEquals("7th byte", ' ', msg.getElement(7) & 0xFF);
+        Assert.assertEquals("8th byte", '0', msg.getElement(8) & 0xFF);
+    }
+
+     @Test
+    public void testMakeAccessoryDecoderMsgAddr2044ActivateTrue() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(2044, true);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 9, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '5', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", '1', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", '1', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", ' ', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", '3', msg.getElement(6) & 0xFF);
+        Assert.assertEquals("7th byte", ' ', msg.getElement(7) & 0xFF);
+        Assert.assertEquals("8th byte", '1', msg.getElement(8) & 0xFF);
+    }
+
+    @Test
+    public void testMakeAccessoryDecoderMsgAddr2044ActivateFalse() {
+	msg = DCCppMessage.makeAccessoryDecoderMsg(2044, false);
+	log.debug("accessory decoder message = {}", msg.toString());
+        Assert.assertEquals("length", 9, msg.getNumDataElements());
+        Assert.assertEquals("0th byte", 'a', msg.getElement(0) & 0xFF);
+        Assert.assertEquals("1st byte", ' ', msg.getElement(1) & 0xFF);
+        Assert.assertEquals("2nd byte", '5', msg.getElement(2) & 0xFF);
+        Assert.assertEquals("3rd byte", '1', msg.getElement(3) & 0xFF);
+        Assert.assertEquals("4th byte", '1', msg.getElement(4) & 0xFF);
+        Assert.assertEquals("5th byte", ' ', msg.getElement(5) & 0xFF);
+        Assert.assertEquals("6th byte", '3', msg.getElement(6) & 0xFF);
+        Assert.assertEquals("7th byte", ' ', msg.getElement(7) & 0xFF);
+        Assert.assertEquals("8th byte", '0', msg.getElement(8) & 0xFF);
+    }
+
     // Test the canned messages.
     @Test
     public void testGetAccessoryDecoderMsgActivateTrue() {

--- a/java/test/jmri/jmrix/dccpp/DCCppTurnoutTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppTurnoutTest.java
@@ -26,13 +26,13 @@ public class DCCppTurnoutTest extends jmri.implementation.AbstractTurnoutTestBas
 
     @Override
     public void checkClosedMsgSent() {
-        Assert.assertEquals("closed message", "a 10 1 0",
+        Assert.assertEquals("closed message", "a 11 1 0",
                 dnis.outbound.elementAt(dnis.outbound.size() - 1).toString());
     }
 
     @Override
     public void checkThrownMsgSent() {
-        Assert.assertEquals("thrown message", "a 10 1 1",
+        Assert.assertEquals("thrown message", "a 11 1 1",
                 dnis.outbound.elementAt(dnis.outbound.size() - 1).toString());
     }
 


### PR DESCRIPTION
Addresses #6598 reported by @brookerg.

I don't have access to DCC++ hardware so would appreciate real-hardware testing. @brookerg has done some testing and reported success.