### PR TITLE
Fall back enum switch

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -252,7 +252,7 @@
 
         <h4>SoundTraxx</h4>
             <ul>
-                <li></li>
+                <li>Michael Mosher fixed a bug in GP35 SP CV54</li>
             </ul>
 
         <h4>TCS</h4>

--- a/java/ecj.warning.options
+++ b/java/ecj.warning.options
@@ -4,7 +4,9 @@
 
 # for compiling the test directory, the java/ecj.warning.options-test file overrides this
 
-# Group (macro) checks - these need to be sorted out
+#
+# Group (macro) checks - some still need to be sorted out
+#
 -warn:+hiding
 -warn:-fieldHiding
 -warn:-localHiding 
@@ -48,7 +50,10 @@
 -warn:-unusedTypeParameter
 
 
+#
 # Checks we choose to enforce
+#
+
 -warn:+allDeprecation
 -warn:+allOver-ann
 -warn:+assertIdentifier
@@ -94,12 +99,14 @@
 # Checks we choose not to enforce as out common style
 #
 
-# no real cost to using implicit boxing/unboxing, and it's just easier
+  # no real cost to using implicit boxing/unboxing, and it's just easier
 -warn:-boxing
 
-# our inheritance tree doesn't insist on single-access to parent interfaces
+  # redundant super-interfaces: this is a design-style issue
+  # our inheritance tree doesn't insist on single-access to parent interfaces
 -warn:-intfRedundant
 
+  # non-nls string literals (mostly missing // $ NON-NLS)
 -warn:-nls
 
 # many of these in the code, and "final" for parameters is a matter of style
@@ -134,26 +141,35 @@
 # 14 outstanding items
 -warn:-deadCode
 
+# missing synch in synchronized method override
 # 22 outstanding items
 -warn:-syncOverride
 
-# 159 outstanding items
+# raw type instead of parameterized type 
+# 159 outstanding items (some likely to be in APIs)
 -warn:-raw
 
 # this tags some NetBeans and FindBugs tokens in @SuppressWarnings  
 # Until that's fixed, useful to run occasionally to find "Unnecessary" annotations
 -warn:-warningToken
 
+
 #
-# Checks not yet examined 
+# Checks not yet decided 
 #
 
--warn:-allDeadCode
 -warn:-all-static-method
 -warn:-emptyBlock
+  # missing enum switch cases even when default case is present
 -warn:-enumSwitchPedantic
+
+-warn:-allDeadCode
+  # flags methods that can be made static because they don't access data members
 -warn:-static-method
-#-warn:-tasks(<task1>|...|<taskN>)
+
+  # We often seem to _prefer_ the terminal else instead of bottom return
 -warn:-unnecessaryElse
+
+#-warn:-tasks(<task1>|...|<taskN>)
 
 

--- a/java/ecj.warning.options
+++ b/java/ecj.warning.options
@@ -65,7 +65,6 @@
 -warn:+deprecation
 -warn:+discouraged
 -warn:+enumIdentifier
--warn:+enumSwitch
 -warn:+fallthrough
 -warn:+finalBound
 -warn:+finally 
@@ -89,7 +88,6 @@
 -warn:+semicolon
 -warn:+specialParamHiding
 -warn:+suppress
--warn:+switchDefault
 -warn:+unavoidableGenericProblems
 -warn:+unchecked
 -warn:+uselessTypeCheck
@@ -132,7 +130,8 @@
 #
 # Checks we're warning on, working to reduce, but not enforcing
 #
-
+-warn:-switchDefault
+-warn:+enumSwitch
 
 #
 # Checks we're working on putting in place

--- a/java/ecj.warning.options-ci
+++ b/java/ecj.warning.options-ci
@@ -58,7 +58,6 @@
 -err:+deprecation
 -err:+discouraged
 -err:+enumIdentifier
--err:+enumSwitch
 -err:+fallthrough
 -err:+finalBound
 -err:+finally 
@@ -82,7 +81,6 @@
 -err:+semicolon
 -err:+specialParamHiding
 -err:+suppress
--err:+switchDefault
 -err:+unavoidableGenericProblems
 -err:+unchecked
 -err:+uselessTypeCheck
@@ -104,7 +102,8 @@
 
 
 # Checks we're warning on, but not enforcing
-
+-warn:-switchDefault
+-warn:-enumSwitch
 
 
 # Checks we're working on

--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -573,6 +573,10 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         }
     }
 
+    /**
+     * Open Preferences action.
+     * Often done due to error
+     */
     public void doPreferences() {
         if (prefsAction == null) prefsAction = new TabbedPreferencesAction();
         prefsAction.actionPerformed(null);

--- a/java/src/apps/gui3/TabbedPreferencesAction.java
+++ b/java/src/apps/gui3/TabbedPreferencesAction.java
@@ -79,11 +79,11 @@ public class TabbedPreferencesAction extends jmri.util.swing.JmriAbstractAction 
         }
 
         if (f == null) {
+            setWait(true);
             f = new TabbedPreferencesFrame();
             Thread preferencesInitThread = new Thread(() -> {
                 final Object waiter = new Object();
                 try {
-                    setWait(true);
                     while (jmri.InstanceManager.getDefault(TabbedPreferences.class).init() != TabbedPreferences.INITIALISED) {
                         synchronized (waiter) {
                             waiter.wait(50);


### PR DESCRIPTION
Temporarily drop back on ECJ checks of enum switch statements.