### PR TITLE
Eliminate data files left behind by TimeTable tests.

### DIFF
--- a/java/src/jmri/jmrit/timetable/configurexml/TimeTableXml.java
+++ b/java/src/jmri/jmrit/timetable/configurexml/TimeTableXml.java
@@ -433,8 +433,7 @@ public class TimeTableXml {
     }
 
 
-
-    private static class TimeTableXmlFile extends XmlFile {
+    public static class TimeTableXmlFile extends XmlFile {
         private static String fileLocation = FileUtil.getUserFilesPath() + "timetable/";  // NOI18N
         private static String demoLocation = FileUtil.getProgramPath() + "xml/demoTimetable/";  // NOI18N
         private static String baseFileName = "TimeTableData.xml";  // NOI18N
@@ -477,6 +476,9 @@ public class TimeTableXml {
         }
 
         public static String getFileName() {
+            if(baseFileName == null) {
+               baseFileName = "TimeTableData.xml";  // NOI18N
+            }
             return baseFileName;
         }
 
@@ -486,6 +488,9 @@ public class TimeTableXml {
          * @return path to location
          */
         public static String getFileLocation() {
+            if(fileLocation==null){
+               fileLocation = FileUtil.getUserFilesPath() + "timetable/";  // NOI18N
+            }
             return fileLocation;
         }
     }

--- a/java/test/jmri/jmrit/timetable/StopTest.java
+++ b/java/test/jmri/jmrit/timetable/StopTest.java
@@ -11,6 +11,9 @@ import org.junit.*;
  */
 public class StopTest {
 
+    @Rule
+    public org.junit.rules.TemporaryFolder folder = new org.junit.rules.TemporaryFolder();
+
     @Test
     public void testCreate() {
         try {
@@ -85,11 +88,24 @@ public class StopTest {
         jmri.util.JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager();
+        try {
+            JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder.newFolder(jmri.profile.Profile.PROFILE)));
+        } catch(java.io.IOException ioe){
+          Assert.fail("failed to setup profile for test");
+        }
     }
 
     @After
     public void tearDown() {
+       // use reflection to reset the static file location.
+       try {
+            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
+            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
+            f.setAccessible(true);
+            f.set(new String(), null);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
+            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
+        }
         jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/timetable/TimeTableCsvExportTest.java
+++ b/java/test/jmri/jmrit/timetable/TimeTableCsvExportTest.java
@@ -14,6 +14,9 @@ import org.junit.*;
  */
 public class TimeTableCsvExportTest {
 
+    @Rule
+    public org.junit.rules.TemporaryFolder folder = new org.junit.rules.TemporaryFolder();
+
     @Test
     public void testExport() {
         TimeTableDataManager dm = new TimeTableDataManager(true);
@@ -74,11 +77,24 @@ public class TimeTableCsvExportTest {
         jmri.util.JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager();
+        try {
+            JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder.newFolder(jmri.profile.Profile.PROFILE)));
+        } catch(java.io.IOException ioe){
+          Assert.fail("failed to setup profile for test");
+        }
     }
 
     @After
     public void tearDown() {
+       // use reflection to reset the static file location.
+       try {
+            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
+            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
+            f.setAccessible(true);
+            f.set(new String(), null);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
+            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
+        }
         jmri.util.JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/timetable/TimeTableCsvImportTest.java
+++ b/java/test/jmri/jmrit/timetable/TimeTableCsvImportTest.java
@@ -18,6 +18,9 @@ import org.junit.*;
  */
 public class TimeTableCsvImportTest {
 
+    @Rule
+    public org.junit.rules.TemporaryFolder folder = new org.junit.rules.TemporaryFolder();
+
     @Test
     public void testImport() {
         TimeTableDataManager dm = new TimeTableDataManager(false);
@@ -161,11 +164,24 @@ public class TimeTableCsvImportTest {
         jmri.util.JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager();
+        try {
+            JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder.newFolder(jmri.profile.Profile.PROFILE)));
+        } catch(java.io.IOException ioe){
+          Assert.fail("failed to setup profile for test");
+        }
     }
 
     @After
     public void tearDown() {
+       // use reflection to reset the static file location.
+       try {
+            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
+            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
+            f.setAccessible(true);
+            f.set(new String(), null);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
+            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
+        }
         jmri.util.JUnitUtil.tearDown();
     }
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimeTableCsvImportTest.class);

--- a/java/test/jmri/jmrit/timetable/TimeTableDataManagerTest.java
+++ b/java/test/jmri/jmrit/timetable/TimeTableDataManagerTest.java
@@ -8,6 +8,9 @@ import org.junit.*;
  */
 public class TimeTableDataManagerTest {
 
+    @Rule
+    public org.junit.rules.TemporaryFolder folder = new org.junit.rules.TemporaryFolder();
+
     @Test
     public void testCreate() {
         TimeTableDataManager dx = new TimeTableDataManager(false);
@@ -82,10 +85,24 @@ public class TimeTableDataManagerTest {
     @Before
     public void setUp() {
         jmri.util.JUnitUtil.setUp();
+        try {
+            jmri.util.JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder.newFolder(jmri.profile.Profile.PROFILE)));
+        } catch(java.io.IOException ioe){
+          Assert.fail("failed to setup profile for test");
+        }
     }
 
     @After
     public void tearDown() {
+       // use reflection to reset the static file location.
+       try {
+            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
+            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
+            f.setAccessible(true);
+            f.set(new String(), null);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
+            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
+        }
         jmri.util.JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/timetable/TimeTableImportTest.java
+++ b/java/test/jmri/jmrit/timetable/TimeTableImportTest.java
@@ -12,6 +12,9 @@ import org.junit.*;
  */
 public class TimeTableImportTest {
 
+    @Rule
+    public org.junit.rules.TemporaryFolder folder = new org.junit.rules.TemporaryFolder();
+
     @Test
     public void testCreate() {
         new TimeTableImport();
@@ -53,10 +56,24 @@ public class TimeTableImportTest {
     @Before
     public void setUp() {
         jmri.util.JUnitUtil.setUp();
+        try {
+            jmri.util.JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder.newFolder(jmri.profile.Profile.PROFILE)));
+        } catch(java.io.IOException ioe){
+          Assert.fail("failed to setup profile for test");
+        }
     }
 
     @After
     public void tearDown() {
+       // use reflection to reset the static file location.
+       try {
+            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
+            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
+            f.setAccessible(true);
+            f.set(new String(), null);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
+            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
+        }
         jmri.util.JUnitUtil.tearDown();
     }
     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(TimeTableImportTest.class);

--- a/java/test/jmri/jmrit/timetable/TrainTest.java
+++ b/java/test/jmri/jmrit/timetable/TrainTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.timetable;
 
+import jmri.util.JUnitUtil;
 import org.junit.*;
 
 /**
@@ -7,6 +8,9 @@ import org.junit.*;
  * @author Dave Sand Copyright (C) 2018
  */
 public class TrainTest {
+
+    @Rule
+    public org.junit.rules.TemporaryFolder folder = new org.junit.rules.TemporaryFolder();
 
     @Test
     public void testCreate() {
@@ -70,10 +74,25 @@ public class TrainTest {
     @Before
     public void setUp() {
         jmri.util.JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        try {
+            JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder.newFolder(jmri.profile.Profile.PROFILE)));
+        } catch(java.io.IOException ioe){
+          Assert.fail("failed to setup profile for test");
+        }
     }
 
     @After
     public void tearDown() {
+       // use reflection to reset the static file location.
+       try {
+            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
+            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
+            f.setAccessible(true);
+            f.set(new String(), null);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
+            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
+        }
         jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/timetable/TrainTypeTest.java
+++ b/java/test/jmri/jmrit/timetable/TrainTypeTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrit.timetable;
 
+import jmri.util.JUnitUtil;
 import org.junit.*;
 
 /*
@@ -7,6 +8,9 @@ import org.junit.*;
  * @author Dave Sand Copyright (C) 2018
  */
 public class TrainTypeTest {
+
+    @Rule
+    public org.junit.rules.TemporaryFolder folder = new org.junit.rules.TemporaryFolder();
 
     @Test
     public void testCreate() {
@@ -32,10 +36,24 @@ public class TrainTypeTest {
     @Before
     public void setUp() {
         jmri.util.JUnitUtil.setUp();
+        try {
+            JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder.newFolder(jmri.profile.Profile.PROFILE)));
+        } catch(java.io.IOException ioe){
+          Assert.fail("failed to setup profile for test");
+        }
     }
 
     @After
     public void tearDown() {
+       // use reflection to reset the static file location.
+       try {
+            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
+            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
+            f.setAccessible(true);
+            f.set(new String(), null);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
+            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
+        }
         jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/timetable/configurexml/TimeTableXmlTest.java
+++ b/java/test/jmri/jmrit/timetable/configurexml/TimeTableXmlTest.java
@@ -12,6 +12,9 @@ import jmri.util.JUnitUtil;
  */
 public class TimeTableXmlTest {
 
+    @Rule
+    public org.junit.rules.TemporaryFolder folder = new org.junit.rules.TemporaryFolder();
+
     @Test
     public void testCreate() {
         new TimeTableXml();
@@ -33,11 +36,24 @@ public class TimeTableXmlTest {
         jmri.util.JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager();
+        try {
+            JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder.newFolder(jmri.profile.Profile.PROFILE)));
+        } catch(java.io.IOException ioe){
+          Assert.fail("failed to setup profile for test");
+        }
     }
 
     @After
     public void tearDown() {
+       // use reflection to reset the static file location.
+       try {
+            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
+            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
+            f.setAccessible(true);
+            f.set(new String(), null);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
+            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
+        }
         jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/timetable/swing/TimeTableActionTest.java
+++ b/java/test/jmri/jmrit/timetable/swing/TimeTableActionTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrit.timetable.swing;
 
 import java.awt.GraphicsEnvironment;
+import jmri.util.JUnitUtil;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 
@@ -9,6 +10,9 @@ import org.junit.rules.ExpectedException;
  * @author Dave Sand Copyright (C) 2018
  */
 public class TimeTableActionTest {
+
+    @Rule
+    public org.junit.rules.TemporaryFolder folder = new org.junit.rules.TemporaryFolder();
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
@@ -36,10 +40,25 @@ public class TimeTableActionTest {
     @Before
     public void setUp() {
         jmri.util.JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
+        try {
+            JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder.newFolder(jmri.profile.Profile.PROFILE)));
+        } catch(java.io.IOException ioe){
+          Assert.fail("failed to setup profile for test");
+        }
     }
 
     @After
     public void tearDown() {
+       // use reflection to reset the static file location.
+       try {
+            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
+            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
+            f.setAccessible(true);
+            f.set(new String(), null);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
+            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
+        }
         jmri.util.JUnitUtil.tearDown();
     }
 }

--- a/java/test/jmri/jmrit/timetable/swing/TimeTableFrameTest.java
+++ b/java/test/jmri/jmrit/timetable/swing/TimeTableFrameTest.java
@@ -14,6 +14,10 @@ import org.netbeans.jemmy.operators.*;
  * @author Dave Sand Copyright (C) 2018
  */
 public class TimeTableFrameTest {
+
+    @Rule
+    public org.junit.rules.TemporaryFolder folder = new org.junit.rules.TemporaryFolder();
+
     TimeTableFrame _ttf = null;
     JFrameOperator _jfo = null;
     JTreeOperator _jto = null;
@@ -481,11 +485,24 @@ public class TimeTableFrameTest {
         jmri.util.JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager();
+        try {
+            JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder.newFolder(jmri.profile.Profile.PROFILE)));
+        } catch(java.io.IOException ioe){
+          Assert.fail("failed to setup profile for test");
+        }
     }
 
     @After
     public  void tearDown() {
+       // use reflection to reset the static file location.
+       try {
+            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
+            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
+            f.setAccessible(true);
+            f.set(new String(), null);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
+            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
+        }
         jmri.util.JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/timetable/swing/TimeTableGraphTest.java
+++ b/java/test/jmri/jmrit/timetable/swing/TimeTableGraphTest.java
@@ -14,6 +14,9 @@ import org.junit.*;
  */
 public class TimeTableGraphTest {
 
+    @Rule
+    public org.junit.rules.TemporaryFolder folder = new org.junit.rules.TemporaryFolder();
+
     @Test
     public void testCreate() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
@@ -45,11 +48,24 @@ public class TimeTableGraphTest {
         jmri.util.JUnitUtil.setUp();
 
         JUnitUtil.resetInstanceManager();
-        JUnitUtil.resetProfileManager();
+        try {
+            JUnitUtil.resetProfileManager(new jmri.profile.NullProfile(folder.newFolder(jmri.profile.Profile.PROFILE)));
+        } catch(java.io.IOException ioe){
+          Assert.fail("failed to setup profile for test");
+        }
     }
 
     @After
     public void tearDown() {
+       // use reflection to reset the static file location.
+       try {
+            Class<?> c = jmri.jmrit.timetable.configurexml.TimeTableXml.TimeTableXmlFile.class;
+            java.lang.reflect.Field f = c.getDeclaredField("fileLocation");
+            f.setAccessible(true);
+            f.set(new String(), null);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
+            Assert.fail("Failed to reset TimeTableXml static fileLocation " + x);
+        }
         JUnitUtil.tearDown();
     }
 }


### PR DESCRIPTION
The timetable tests were leaving behind a number of data files in the source directories because it wasn't possible to completely reset the static file location in the static inner class TimeTableXmlFile contained inside of jmri.jmrit.timetable.configurexml.TimeTableXml.

This PR uses reflection to reset the static file location and makes a couple of minor changes to the class under test so the file can actually be reset (the inner class needed to be public and the method that accesses the private field needs to handle the case when that field is null).