### PR TITLE
Set http.agent for Javadoc

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1806,6 +1806,7 @@
             <arg value="2300"/><!-- change from default 100 warnings -->
             <arg value="-quiet"/>
             <arg value="-splitindex"/>
+            <arg value="-J-Dhttp.agent=javadoc"/>
 
             <!-- disable output of custom @navassoc tag - used for UML image generation -->
             <tag name="navassoc" enabled="false"/>

--- a/pom.xml
+++ b/pom.xml
@@ -408,6 +408,7 @@
                     <failOnError>true</failOnError><!-- default -->
                     <quiet>true</quiet>
                     <splitindex>true</splitindex>
+                    <additionalJOption>-J-Dhttp.agent=maven-javadoc-plugin-${project.name}</additionalJOption>
                     <tags>
                         <tag>
                             <!-- disable output of custom @navassoc tag - used for UML image generation -->


### PR DESCRIPTION
This seems to be the solution for the bad links in #6608 

For more information, see the first answer from Chris Povirk here:
https://stackoverflow.com/questions/33866209/linking-to-javadoc-io-using-javadoc-link-option