### PR TITLE
Update code where NetBeans 10 warns

### DIFF
--- a/java/src/apps/StartupActionsManager.java
+++ b/java/src/apps/StartupActionsManager.java
@@ -99,7 +99,7 @@ public class StartupActionsManager extends AbstractPreferencesManager {
                     log.debug("Read {} {} adapter {}", type, name, adapter);
                     try {
                         log.debug("Creating {} {} adapter {}...", type, name, adapter);
-                        ((XmlAdapter) Class.forName(adapter).newInstance()).load(action, null); // no perNode preferences
+                        ((XmlAdapter) Class.forName(adapter).getDeclaredConstructor().newInstance()).load(action, null); // no perNode preferences
                     } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
                         log.error("Unable to create {} for {}", adapter, action, ex);
                         this.addInitializationException(profile, new InitializationException(Bundle.getMessage(Locale.ENGLISH, "StartupActionsCreationError", adapter, name),

--- a/java/src/apps/startup/AbstractActionModel.java
+++ b/java/src/apps/startup/AbstractActionModel.java
@@ -110,7 +110,7 @@ public abstract class AbstractActionModel implements StartupModel {
     public void performAction() throws JmriException {
         log.debug("Invoke Action from {}", className);
         try {
-            Action action = (Action) Class.forName(className).newInstance();
+            Action action = (Action) Class.forName(className).getDeclaredConstructor().newInstance();
             if (SystemConnectionAction.class.isAssignableFrom(action.getClass())) {
                 SystemConnectionMemo memo = ConnectionNameFromSystemName.getSystemConnectionMemoFromSystemPrefix(this.getSystemPrefix());
                 if (memo != null) {
@@ -133,6 +133,12 @@ public abstract class AbstractActionModel implements StartupModel {
             throw new JmriException(ex);
         } catch (InstantiationException ex) {
             log.error("Could not instantiate specified class: {}", className, ex);
+            throw new JmriException(ex);
+        } catch (java.lang.reflect.InvocationTargetException ex) {
+            log.error("Error while invoking startup action for class: {}", className, ex);
+            throw new JmriException(ex);
+        } catch (NoSuchMethodException ex) {
+            log.error("Could not locate specified method: {}", className, ex);
             throw new JmriException(ex);
         } catch (Exception ex) {
             log.error("Error while performing startup action for class: {}", className, ex);

--- a/java/src/apps/startup/AbstractActionModelFactory.java
+++ b/java/src/apps/startup/AbstractActionModelFactory.java
@@ -2,6 +2,7 @@ package apps.startup;
 
 import apps.StartupActionsManager;
 import java.awt.Component;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import javax.swing.Action;
 import javax.swing.BoxLayout;
@@ -106,7 +107,7 @@ abstract public class AbstractActionModelFactory implements StartupModelFactory 
                     String className = StartupActionModelUtil.getDefault().getClassName(name);
                     if (className != null && StartupActionModelUtil.getDefault().isSystemConnectionAction(className)) {
                         try {
-                            Action action = (Action) Class.forName(className).newInstance();
+                            Action action = (Action) Class.forName(className).getDeclaredConstructor().newInstance();
                             if (SystemConnectionAction.class.isAssignableFrom(action.getClass())) {
                                 ((SystemConnectionAction) action).getSystemConnectionMemoClasses().stream().forEach((clazz) -> {
                                     InstanceManager.getList(SystemConnectionMemo.class).stream().forEach((memo) -> {
@@ -118,7 +119,7 @@ abstract public class AbstractActionModelFactory implements StartupModelFactory 
                                     });
                                 });
                             }
-                        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
+                        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException ex) {
                             log.error("Unable to create Action", ex);
                         }
                     }

--- a/java/src/jmri/TurnoutOperationManager.java
+++ b/java/src/jmri/TurnoutOperationManager.java
@@ -1,5 +1,6 @@
 package jmri;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -176,9 +177,9 @@ public class TurnoutOperationManager implements InstanceManagerAutoDefault {
                     // creating the instance invokes the TurnoutOperation ctor,
                     // which calls addOperation here, which adds it to the 
                     // turnoutOperations map.
-                    thisClass.newInstance();
+                    thisClass.getDeclaredConstructor().newInstance();
                     log.debug("loaded TurnoutOperation class {}", thisClassName);
-                } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e1) {
+                } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e1) {
                     log.error("during loadOperationTypes", e1);
                 }
             }

--- a/java/src/jmri/configurexml/ConfigXmlManager.java
+++ b/java/src/jmri/configurexml/ConfigXmlManager.java
@@ -508,8 +508,9 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
         log.debug("store using {}", aName);
         XmlAdapter adapter = null;
         try {
-            adapter = (XmlAdapter) Class.forName(adapterName(object)).newInstance();
-        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
+            adapter = (XmlAdapter) Class.forName(adapterName(object)).getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException 
+                    | NoSuchMethodException | java.lang.reflect.InvocationTargetException ex) {
             log.error("Cannot load configuration adapter for {}", object.getClass().getName(), ex);
         }
         if (adapter != null) {
@@ -648,7 +649,7 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
                     log.debug("attempt to get adapter {} for {}", adapterName, item);
                 }
                 adapterName = currentClassName(adapterName);
-                XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                 int order = adapter.loadOrder();
                 log.debug("add {} to load list with order id of {}", item, order);
                 loadlist.put(item, order);
@@ -666,7 +667,7 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
                 }
                 XmlAdapter adapter = null;
                 try {
-                    adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                    adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
 
                     // get version info
                     // loadVersion(root, adapter);
@@ -727,6 +728,14 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
             creationErrorEncountered(null, "loading from file " + url.getFile(),
                     "IllegalAccessException", null, null, e);
             result = false;
+        } catch (NoSuchMethodException e) {
+            creationErrorEncountered(null, "loading from file " + url.getFile(),
+                    "IllegalAccessException", null, null, e);
+            result = false;
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            creationErrorEncountered(null, "loading from file " + url.getFile(),
+                    "IllegalAccessException", null, null, e);
+            result = false;
         } finally {
             // no matter what, close error reporting
             handler.done();
@@ -767,7 +776,7 @@ public class ConfigXmlManager extends jmri.jmrit.XmlFile
                 log.debug("deferred load via " + adapterName);
                 XmlAdapter adapter = null;
                 try {
-                    adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                    adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                     boolean loadStatus = adapter.load(item, item);
                     log.debug("deferred load status for " + adapterName + " is " + loadStatus);
 

--- a/java/src/jmri/configurexml/turnoutoperations/TurnoutOperationXml.java
+++ b/java/src/jmri/configurexml/turnoutoperations/TurnoutOperationXml.java
@@ -37,12 +37,12 @@ public abstract class TurnoutOperationXml extends jmri.configurexml.AbstractXmlA
             log.debug("loadOperation for class {}", className);
             try {
                 Class<?> adapterClass = Class.forName(className);
-                TurnoutOperationXml adapter = (TurnoutOperationXml) adapterClass.newInstance();
+                TurnoutOperationXml adapter = (TurnoutOperationXml) adapterClass.getDeclaredConstructor().newInstance();
                 result = adapter.loadOne(e);
                 if (result.getName().charAt(0) == '*') {
                     result.setNonce(true);
                 }
-            } catch (ClassNotFoundException | InstantiationException e1) {
+            } catch (ClassNotFoundException | InstantiationException | NoSuchMethodException | java.lang.reflect.InvocationTargetException e1) {
                 log.error("while creating TurnoutOperation", e1);
                 return null;
             } catch (IllegalAccessException e2) {
@@ -95,8 +95,8 @@ public abstract class TurnoutOperationXml extends jmri.configurexml.AbstractXmlA
         log.debug("getAdapter looks for {}", fullConfigName);
         try {
             Class<?> configClass = Class.forName(fullConfigName);
-            adapter = (TurnoutOperationXml) configClass.newInstance();
-        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+            adapter = (TurnoutOperationXml) configClass.getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException | java.lang.reflect.InvocationTargetException e) {
             log.error("exception in getAdapter", e);
         }
         if (adapter == null) {

--- a/java/src/jmri/jmrit/automat/JythonAutomaton.java
+++ b/java/src/jmri/jmrit/automat/JythonAutomaton.java
@@ -46,7 +46,7 @@ public class JythonAutomaton extends AbstractAutomaton {
             initialize.invoke(null, (Object[]) null);
 
             // interp = new PythonInterpreter();
-            interp = Class.forName("org.python.util.PythonInterpreter").newInstance();
+            interp = Class.forName("org.python.util.PythonInterpreter").getDeclaredConstructor().newInstance();
 
             // load some general objects
             java.lang.reflect.Method set

--- a/java/src/jmri/jmrit/automat/JythonSiglet.java
+++ b/java/src/jmri/jmrit/automat/JythonSiglet.java
@@ -52,7 +52,7 @@ public class JythonSiglet extends Siglet {
             initialize.invoke(null, (Object[]) null);
 
             // interp = new PythonInterpreter();
-            interp = Class.forName("org.python.util.PythonInterpreter").newInstance();
+            interp = Class.forName("org.python.util.PythonInterpreter").getDeclaredConstructor().newInstance();
 
             // load some general objects
             java.lang.reflect.Method set

--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -28,6 +28,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
+import java.lang.reflect.InvocationTargetException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -1093,7 +1094,7 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
         JFrame frame = getTargetFrame();
 
         try {
-            Editor ed = (Editor) Class.forName(className).newInstance();
+            Editor ed = (Editor) Class.forName(className).getDeclaredConstructor().newInstance();
 
             ed.setName(getName());
             ed.init(getName());
@@ -1125,12 +1126,8 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
             InstanceManager.getDefault(PanelMenu.class).addEditorPanel(ed);
             dispose();
             return ed;
-        } catch (ClassNotFoundException cnfe) {
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException cnfe) {
             log.error("changeView exception {}", cnfe.toString());
-        } catch (InstantiationException ie) {
-            log.error("changeView exception {}", ie.toString());
-        } catch (IllegalAccessException iae) {
-            log.error("changeView exception {}", iae.toString());
         }
         return null;
     }

--- a/java/src/jmri/jmrit/display/controlPanelEditor/configurexml/ControlPanelEditorXml.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/configurexml/ControlPanelEditorXml.java
@@ -244,15 +244,15 @@ public class ControlPanelEditorXml extends AbstractXmlAdapter {
             String adapterName = item.getAttribute("class").getValue();
             log.debug("load via {}", adapterName);
             try {
-                XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                 // and do it
                 adapter.load(item, panel);
                 if (!panel.loadOK()) {
                     result = false;
                 }
             } catch (ClassNotFoundException | InstantiationException 
-                    | jmri.configurexml.JmriConfigureXmlException | IllegalAccessException
-                    | RuntimeException e) {
+                    | jmri.configurexml.JmriConfigureXmlException | IllegalAccessException 
+                    | NoSuchMethodException | java.lang.reflect.InvocationTargetException e) {
                 log.error("Exception while loading {}: {}", item.getName(), e.getMessage(), e);
                 result = false;
             }

--- a/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutEditorXml.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/configurexml/LayoutEditorXml.java
@@ -541,15 +541,15 @@ public class LayoutEditorXml extends AbstractXmlAdapter {
                 }
             }
             try {
-                XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                 // and do it
                 adapter.load(item, panel);
                 if (!panel.loadOK()) {
                     result = false;
                 }
-            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException
                     | jmri.configurexml.JmriConfigureXmlException
-                    | RuntimeException e) {
+                    | java.lang.reflect.InvocationTargetException e) {
                 log.error("Exception while loading {}", item.getName(), e);
                 result = false;
             }

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
@@ -15,6 +15,7 @@ import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1181,10 +1182,10 @@ public class PanelEditor extends Editor implements ItemListener {
                 className = ConfigXmlManager.adapterName(copied);
                 copied.setLocation(x, y);
                 try {
-                    adapter = (XmlAdapter) Class.forName(className).newInstance();
+                    adapter = (XmlAdapter) Class.forName(className).getDeclaredConstructor().newInstance();
                     Element el = adapter.store(copied);
                     adapter.load(el, this);
-                } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+                } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException
                     | jmri.configurexml.JmriConfigureXmlException
                     | RuntimeException ex) {
                         log.debug(ex.getLocalizedMessage(), ex);

--- a/java/src/jmri/jmrit/display/panelEditor/configurexml/PanelEditorXml.java
+++ b/java/src/jmri/jmrit/display/panelEditor/configurexml/PanelEditorXml.java
@@ -201,15 +201,15 @@ public class PanelEditorXml extends AbstractXmlAdapter {
             String adapterName = item.getAttribute("class").getValue();
             log.debug("load via " + adapterName);
             try {
-                XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                 // and do it
                 adapter.load(item, panel);
                 if (!panel.loadOK()) {
                     result = false;
                 }
-            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException
                     | jmri.configurexml.JmriConfigureXmlException
-                    | RuntimeException e) {
+                    | java.lang.reflect.InvocationTargetException e) {
                 log.error("Exception while loading {}", item.getName(), e);
                 result = false;
             }

--- a/java/src/jmri/jmrit/display/switchboardEditor/configurexml/SwitchboardEditorXml.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/configurexml/SwitchboardEditorXml.java
@@ -237,15 +237,15 @@ public class SwitchboardEditorXml extends AbstractXmlAdapter {
             String adapterName = item.getAttribute("class").getValue();
             log.debug("load via {}", adapterName);
             try {
-                XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                 // and do it
                 adapter.load(item, panel);
                 if (!panel.loadOK()) {
                     result = false;
                 }
-            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException
                     | jmri.configurexml.JmriConfigureXmlException
-                    | RuntimeException e) {
+                    | java.lang.reflect.InvocationTargetException e) {
                 log.error("Exception while loading {}", item.getName(), e);
                 result = false;
             }

--- a/java/src/jmri/jmrix/ActiveSystemsMenu.java
+++ b/java/src/jmri/jmrix/ActiveSystemsMenu.java
@@ -64,8 +64,8 @@ public class ActiveSystemsMenu extends JMenu {
 
     static JMenu getMenu(String className) {
         try {
-            return (JMenu) Class.forName(className).newInstance();
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            return (JMenu) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | java.lang.reflect.InvocationTargetException e) {
             log.error("Could not load class {}", className, e);
             return null;
         }

--- a/java/src/jmri/jmrix/ConnectionConfigManager.java
+++ b/java/src/jmri/jmrix/ConnectionConfigManager.java
@@ -100,7 +100,7 @@ public class ConnectionConfigManager extends AbstractPreferencesManager implemen
                     }
                     try {
                         log.debug("Creating connection {}:{} ({}) class {}", userName, systemName, manufacturer, className);
-                        XmlAdapter adapter = (XmlAdapter) Class.forName(className).newInstance();
+                        XmlAdapter adapter = (XmlAdapter) Class.forName(className).getDeclaredConstructor().newInstance();
                         ConnectionConfigManagerErrorHandler handler = new ConnectionConfigManagerErrorHandler();
                         adapter.setExceptionHandler(handler);
                         if (!adapter.load(shared, perNode)) {
@@ -112,7 +112,7 @@ public class ConnectionConfigManager extends AbstractPreferencesManager implemen
                         handler.exceptions.forEach((exception) -> {
                             this.addInitializationException(profile, exception);
                         });
-                    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
+                    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | java.lang.reflect.InvocationTargetException ex) {
                         log.error("Unable to create {} for {}", className, shared, ex);
                         String english = Bundle.getMessage(Locale.ENGLISH, "ErrorSingleConnection", userName, systemName); // NOI18N
                         String localized = Bundle.getMessage("ErrorSingleConnection", userName, systemName); // NOI18N

--- a/java/src/jmri/jmrix/JmrixConfigPane.java
+++ b/java/src/jmri/jmrix/JmrixConfigPane.java
@@ -2,6 +2,7 @@ package jmri.jmrix;
 
 import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.ResourceBundle;
 import javax.swing.BorderFactory;
@@ -188,20 +189,20 @@ public class JmrixConfigPane extends JPanel implements PreferencesPanel {
                         }
                     } else {
                         Class<?> cl = Class.forName(className);
-                        config = (ConnectionConfig) cl.newInstance();
-			if( !(config instanceof StreamConnectionConfig)) {
-			   // only include if the connection is not a 
-			   // StreamConnection.  Those connections require
-			   // additional context.
+                        config = (ConnectionConfig) cl.getDeclaredConstructor().newInstance();
+                        if( !(config instanceof StreamConnectionConfig)) {
+                           // only include if the connection is not a 
+                           // StreamConnection.  Those connections require
+                           // additional context.
                            modeBox.addItem(config.name());
-			} else {
-		           continue;
-			}
+                        } else {
+                               continue;
+                        }
                     }
                     classConnectionList[n++] = config;
                 } catch (NullPointerException e) {
                     log.error("Attempt to load {} failed.", className, e);
-                } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                } catch (InvocationTargetException | ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
                     log.debug("Attempt to load {} failed: {}.", className, e);
                 }
             }
@@ -256,20 +257,21 @@ public class JmrixConfigPane extends JPanel implements PreferencesPanel {
                 try {
                     jmri.jmrix.ConnectionConfig config;
                     Class<?> cl = Class.forName(classConnectionNameList1);
-                    config = (jmri.jmrix.ConnectionConfig) cl.newInstance();
-		    if( !(config instanceof StreamConnectionConfig)) {
-		        // only include if the connection is not a 
-			// StreamConnection.  Those connections require
-			// additional context.
+                    config = (jmri.jmrix.ConnectionConfig) cl.getDeclaredConstructor().newInstance();
+                    if( !(config instanceof StreamConnectionConfig)) {
+                        // only include if the connection is not a 
+                        // StreamConnection.  Those connections require
+                        // additional context.
                         modeBox.addItem(config.name());
-	            } else {
-		        continue;
-		    }
+                    } else {
+                        continue;
+                    }
                     classConnectionList[n++] = config;
                     if (classConnectionNameList.length == 1) {
                         modeBox.setSelectedIndex(1);
                     }
-                } catch (NullPointerException | ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                } catch (InvocationTargetException | NullPointerException | ClassNotFoundException 
+                                | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
                     log.warn("Attempt to load {} failed: {}", classConnectionNameList1, e);
                 }
             }

--- a/java/src/jmri/jmrix/configurexml/JmrixConfigPaneXml.java
+++ b/java/src/jmri/jmrix/configurexml/JmrixConfigPaneXml.java
@@ -38,9 +38,9 @@ public class JmrixConfigPaneXml extends AbstractXmlAdapter {
         String adapter = ConfigXmlManager.adapterName(oprime);
         log.debug("forward to " + adapter);
         try {
-            XmlAdapter x = (XmlAdapter) Class.forName(adapter).newInstance();
+            XmlAdapter x = (XmlAdapter) Class.forName(adapter).getDeclaredConstructor().newInstance();
             return x.store(oprime);
-        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException | java.lang.reflect.InvocationTargetException e) {
             log.error("Exception: ", e);
             return null;
         }

--- a/java/src/jmri/jmrix/ieee802154/xbee/configurexml/ConnectionConfigXml.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/configurexml/ConnectionConfigXml.java
@@ -87,9 +87,10 @@ public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
                     String adapter = ConfigXmlManager.adapterName(cf);
                     log.debug("forward to " + adapter);
                     try {
-                       XmlAdapter x = (XmlAdapter) Class.forName(adapter).newInstance();
+                       XmlAdapter x = (XmlAdapter) Class.forName(adapter).getDeclaredConstructor().newInstance();
                        n.addContent(x.store(cf));
-                    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
+                    } catch (ClassNotFoundException | IllegalAccessException | 
+                                InstantiationException | NoSuchMethodException | java.lang.reflect.InvocationTargetException  ex) {
                        log.error("Exception: ", ex);
                     }
                 }
@@ -206,10 +207,10 @@ public class ConnectionConfigXml extends AbstractSerialConnectionConfigXml {
 
                   try {
                         @SuppressWarnings("unchecked") // Class.forName cast is unchecked at this point
-                        XmlAdapter adapter = (XmlAdapter) Class.forName(className).newInstance();
+                        XmlAdapter adapter = (XmlAdapter) Class.forName(className).getDeclaredConstructor().newInstance();
                         adapter.load(connect,connectedConfig);
                     } catch (ClassNotFoundException | 
-		             InstantiationException | 
+		             InstantiationException | NoSuchMethodException | java.lang.reflect.InvocationTargetException |
 			     IllegalAccessException ex) {
                         log.error("Unable to create {} for {}", className, shared, ex);
                     } catch (RuntimeException | jmri.configurexml.JmriConfigureXmlException ex) {

--- a/java/src/jmri/jmrix/ieee802154/xbee/swing/nodeconfig/StreamConfigPane.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/swing/nodeconfig/StreamConfigPane.java
@@ -182,7 +182,7 @@ public class StreamConfigPane extends JmrixConfigPane {
                     } else {
                         Class<?> cl = Class.forName(className);
 			try {
-                           config = (StreamConnectionConfig) cl.newInstance();
+                           config = (StreamConnectionConfig) cl.getDeclaredConstructor().newInstance();
                            modeBox.addItem(config.name());
 			} catch (ClassCastException cce) {
 		           // the list may include non-StreamConnectinoConfig 
@@ -193,7 +193,7 @@ public class StreamConfigPane extends JmrixConfigPane {
                     classConnectionList[n++] = config;
                 } catch (NullPointerException e) {
                     log.error("Attempt to load {} failed.", className, e);
-                } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | java.lang.reflect.InvocationTargetException e) {
                     log.debug("Attempt to load {} failed: {}.", className, e);
                 }
             }
@@ -249,7 +249,7 @@ public class StreamConfigPane extends JmrixConfigPane {
                 try {
                     jmri.jmrix.StreamConnectionConfig config;
                     Class<?> cl = Class.forName(classConnectionNameList1);
-                    config = (jmri.jmrix.StreamConnectionConfig) cl.newInstance();
+                    config = (jmri.jmrix.StreamConnectionConfig) cl.getDeclaredConstructor().newInstance();
                     modeBox.addItem(config.name());
                     classConnectionList[n++] = config;
                     if (classConnectionNameList.length == 1) {
@@ -259,7 +259,8 @@ public class StreamConfigPane extends JmrixConfigPane {
 		    // the list may include non-StreamConnectinoConfig 
 		    // objects, so just ignore those.
 	            continue;
-                } catch (NullPointerException | ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                } catch (NullPointerException | ClassNotFoundException | InstantiationException | 
+                            IllegalAccessException | NoSuchMethodException | java.lang.reflect.InvocationTargetException e) {
                     log.warn("Attempt to load {} failed: {}", classConnectionNameList1, e);
                 }
             }

--- a/java/src/jmri/jmrix/rps/Engine.java
+++ b/java/src/jmri/jmrix/rps/Engine.java
@@ -49,7 +49,7 @@ public class Engine implements ReadingListener {
         double oldVal = vsound;
         vsound = v;
         log.info("change vsound from " + oldVal + " to " + v);
-        prop.firePropertyChange("vSound", new Double(oldVal), new Double(v));
+        prop.firePropertyChange("vSound", Double.valueOf(oldVal), Double.valueOf(v));
     }
 
     public double getVSound() {

--- a/java/src/jmri/jmrix/rps/aligntable/AlignTablePane.java
+++ b/java/src/jmri/jmrix/rps/aligntable/AlignTablePane.java
@@ -286,19 +286,19 @@ public class AlignTablePane extends javax.swing.JPanel {
                     if (rc == null) {
                         return null;
                     }
-                    return new Double(rc.getPosition().x);
+                    return Double.valueOf(rc.getPosition().x);
                 case YCOL:
                     rc = Engine.instance().getReceiver(r + 1);
                     if (rc == null) {
                         return null;
                     }
-                    return new Double(rc.getPosition().y);
+                    return Double.valueOf(rc.getPosition().y);
                 case ZCOL:
                     rc = Engine.instance().getReceiver(r + 1);
                     if (rc == null) {
                         return null;
                     }
-                    return new Double(rc.getPosition().z);
+                    return Double.valueOf(rc.getPosition().z);
                 case ACTIVECOL:
                     rc = Engine.instance().getReceiver(r + 1);
                     if (rc == null) {

--- a/java/src/jmri/jmrix/rps/swing/polling/PollDataModel.java
+++ b/java/src/jmri/jmrix/rps/swing/polling/PollDataModel.java
@@ -132,21 +132,21 @@ public class PollDataModel extends AbstractTableModel implements MeasurementList
                     return null;
                 }
                 val = m.getX();
-                return new Double(val);
+                return Double.valueOf(val);
             case LASTYCOL:
                 m = Engine.instance().getTransmitter(r).getLastMeasurement();
                 if (m == null) {
                     return null;
                 }
                 val = m.getY();
-                return new Double(val);
+                return Double.valueOf(val);
             case LASTZCOL:
                 m = Engine.instance().getTransmitter(r).getLastMeasurement();
                 if (m == null) {
                     return null;
                 }
                 val = m.getZ();
-                return new Double(val);
+                return Double.valueOf(val);
             case LASTTIME:
                 m = Engine.instance().getTransmitter(r).getLastMeasurement();
                 if (m == null) {

--- a/java/src/jmri/managers/JmriUserPreferencesManager.java
+++ b/java/src/jmri/managers/JmriUserPreferencesManager.java
@@ -616,8 +616,8 @@ public class JmriUserPreferencesManager extends Bean implements UserPreferencesM
             Class<?> cl = Class.forName(strClass);
             Object t;
             try {
-                t = cl.newInstance();
-            } catch (IllegalArgumentException | NullPointerException | ExceptionInInitializerError ex) {
+                t = cl.getDeclaredConstructor().newInstance();
+            } catch (IllegalArgumentException | NullPointerException | ExceptionInInitializerError | NoSuchMethodException | java.lang.reflect.InvocationTargetException ex) {
                 log.error("setClassDescription({}) failed in newInstance", strClass, ex);
                 return;
             }

--- a/java/src/jmri/managers/configurexml/AbstractSignalHeadManagerXml.java
+++ b/java/src/jmri/managers/configurexml/AbstractSignalHeadManagerXml.java
@@ -134,7 +134,7 @@ public class AbstractSignalHeadManagerXml extends AbstractNamedBeanManagerConfig
             String adapterName = item.getAttribute("class").getValue();
             log.debug("load via " + adapterName);
             try {
-                XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                 // and do it
                 adapter.load(item, null);
             } catch (Exception e) {

--- a/java/src/jmri/managers/configurexml/DefaultSignalMastManagerXml.java
+++ b/java/src/jmri/managers/configurexml/DefaultSignalMastManagerXml.java
@@ -110,7 +110,7 @@ public class DefaultSignalMastManagerXml
                 String adapterName = e.getAttribute("class").getValue();
                 log.debug("load via " + adapterName);
                 try {
-                    XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                    XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                     // and do it
                     adapter.load(e, null);
                 } catch (Exception ex) {
@@ -126,7 +126,7 @@ public class DefaultSignalMastManagerXml
                 String adapterName = e.getAttribute("class").getValue();
                 log.debug("load via " + adapterName);
                 try {
-                    XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                    XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                     // and do it
                     adapter.load(e, null);
                 } catch (Exception ex) {
@@ -142,7 +142,7 @@ public class DefaultSignalMastManagerXml
                 String adapterName = e.getAttribute("class").getValue();
                 log.debug("load via " + adapterName);
                 try {
-                    XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                    XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                     // and do it
                     adapter.load(e, null);
                 } catch (Exception ex) {
@@ -158,7 +158,7 @@ public class DefaultSignalMastManagerXml
                 String adapterName = e.getAttribute("class").getValue();
                 log.debug("load via " + adapterName);
                 try {
-                    XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                    XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                     // and do it
                     adapter.load(e, null);
                 } catch (Exception ex) {
@@ -174,7 +174,7 @@ public class DefaultSignalMastManagerXml
                 String adapterName = e.getAttribute("class").getValue();
                 log.debug("load via " + adapterName);
                 try {
-                    XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                    XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                     // and do it
                     adapter.load(e, null);
                 } catch (Exception ex) {
@@ -190,7 +190,7 @@ public class DefaultSignalMastManagerXml
                 String adapterName = e.getAttribute("class").getValue();
                 log.debug("load via " + adapterName);
                 try {
-                    XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).newInstance();
+                    XmlAdapter adapter = (XmlAdapter) Class.forName(adapterName).getDeclaredConstructor().newInstance();
                     // and do it
                     adapter.load(e, null);
                 } catch (Exception ex) {

--- a/java/src/jmri/util/AbstractFrameAction.java
+++ b/java/src/jmri/util/AbstractFrameAction.java
@@ -29,7 +29,7 @@ abstract public class AbstractFrameAction extends AbstractAction {
     @Override
     public void actionPerformed(ActionEvent e) {
         try {
-            JFrame f = (JFrame) Class.forName(className).newInstance();
+            JFrame f = (JFrame) Class.forName(className).getDeclaredConstructor().newInstance();
             f.setVisible(true);
         } catch (Exception ex) {
             log.error("Error starting JFrame " + className + ": " + ex);

--- a/java/src/jmri/util/JmriJFrameAction.java
+++ b/java/src/jmri/util/JmriJFrameAction.java
@@ -36,7 +36,7 @@ public class JmriJFrameAction extends AbstractAction {
 
         if (!name.equals("")) {
             try {
-                j = (JmriJFrame) Class.forName(name).newInstance();
+                j = (JmriJFrame) Class.forName(name).getDeclaredConstructor().newInstance();
                 j.initComponents();
                 j.setVisible(true);
             } catch (java.lang.ClassNotFoundException ex1) {

--- a/java/src/jmri/util/swing/JmriNamedPaneAction.java
+++ b/java/src/jmri/util/swing/JmriNamedPaneAction.java
@@ -74,13 +74,13 @@ public class JmriNamedPaneAction extends JmriAbstractAction {
     @Override
     public jmri.util.swing.JmriPanel makePanel() {
         try {
-            JmriPanel p = (JmriPanel) Class.forName(paneClass).newInstance();
+            JmriPanel p = (JmriPanel) Class.forName(paneClass).getDeclaredConstructor().newInstance();
             p.setWindowInterface(wi);
             p.initComponents();
             p.initContext(context);
 
             return p;
-        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException ex) {
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException | java.lang.reflect.InvocationTargetException ex ) {
             log.warn("could not load pane class: {}", paneClass, ex);
             return null;
         }


### PR DESCRIPTION
I'd like to use NetBeans 10 to help track down & fix the deadlocks reported in Issues #3678, #4675, and #6579. It generates a lot of compile warnings which make it hard to see what's going on.  This PR removes about 1/2 of those (the easy half)

- replace `new Double(double)` with `Double.valueOf(double)`

Reduces memory thrashing (in many cases, no new object).

- use `item.getDeclaredConstructor().newInstance()` instead of `item.newInstance()`

This makes sure that errors in creation are properly reported by exceptions.  It also requires that `NoSuchMethod` and `InvocationErrorException` be handled, so in some places that had to be added.

