### PR TITLE
Update indexed CV capability to allow specifying PI, SI CV address

### DIFF
--- a/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
+++ b/help/en/html/apps/DecoderPro/CreateDecoderAdvanced.shtml
@@ -808,6 +808,11 @@ selects the different algorithm needed here.
       <p>If cvFirst is true, the format is CV.PI or CV.PI.SI as used
         by QSI. If it's false, the format is PI.CV or PI.SI.CV as used by
         ESU.
+        
+      <p>Alternately the PI and/or SI CV numbers can be set by using a "nn=nn" syntax when specifying
+        PI and/or SI.  For example, using a cvFirst false syntax, "101=12.80" sets CV101 to 12 before
+        accessing CV 80, regardless of the PI value configured into the capability.
+
       <p>If skipDupIndexWrite is true, certain writes to the PI and SI
         CVs can be skipped if the user selects skipping them. This speeds up access.
         Some decoders  require that the CVs be written for each operation, 

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -310,7 +310,10 @@
     <h3>DecoderPro</h3>
     <a id="DecoderPro" name="DecoderPro"></a>
         <ul>
-          <li></li>
+            <li>Decoder definitions for indexed-access CVs can now use a "81=23.40" syntax
+            to specify an alternate PI and/or SI CV. The previous syntax continues to
+            work unchanged.
+            </li>
         </ul>
 
    <h3>Dispatcher</h3>

--- a/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
+++ b/java/src/jmri/implementation/MultiIndexProgrammerFacade.java
@@ -38,6 +38,10 @@ import org.slf4j.LoggerFactory;
  * The specific CV numbers for PI and SI are provided when constructing the object.
  * They can be read from a decoder definition file by e.g. {@link jmri.implementation.ProgrammerFacadeSelector}.
  *<p>
+ * Alternately the PI and/or SI CV numbers can be set by using a "nn=nn" syntax when specifying
+ * PI and/or SI.  For example, using a cvFirst false syntax, "101=12.80" sets CV101 to 12 before
+ * accessing CV 80, regardless of the PI value configured into the facade.
+ *<p>
  * If skipDupIndexWrite is true, sequential operations with the same PI and SI values
  * (and only immediately sequential operations with both PI and SI unchanged) will
  * skip writing of the PI and SI CVs.  This might not work for some decoders, hence is
@@ -86,11 +90,14 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
      */
     public MultiIndexProgrammerFacade(Programmer prog, String indexPI, String indexSI, boolean cvFirst, boolean skipDupIndexWrite) {
         super(prog);
-        this.indexPI = indexPI;
-        this.indexSI = indexSI;
+        this.defaultIndexPI = indexPI;
+        this.defaultIndexSI = indexSI;
         this.cvFirst = cvFirst;
         this.skipDupIndexWrite = skipDupIndexWrite;
     }
+
+    String defaultIndexPI;
+    String defaultIndexSI;
 
     String indexPI;
     String indexSI;
@@ -110,6 +117,7 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
     int lastValueSI = -1;  // value written in last operation
     long lastOpTime = -1;  // time of last complete
 
+    // take the CV string and configure the actions to take
     void parseCV(String cv) {
         valuePI = -1;
         valueSI = -1;
@@ -118,16 +126,34 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
                 String[] splits = cv.split("\\.");
                 switch (splits.length) {
                     case 2:
-                        valuePI = Integer.parseInt(splits[1]);
+                        if (hasAlternateAddress(splits[1])) {
+                            valuePI = getAlternateValue(splits[1]);
+                            indexPI = getAlternateAddress(splits[1]);
+                        } else {
+                            valuePI = Integer.parseInt(splits[1]);
+                            indexPI = defaultIndexPI;
+                        }
                         _cv = splits[0];
                         break;
                     case 3:
-                        valuePI = Integer.parseInt(splits[1]);
-                        valueSI = Integer.parseInt(splits[2]);
+                        if (hasAlternateAddress(splits[1])) {
+                            valuePI = getAlternateValue(splits[1]);
+                            indexPI = getAlternateAddress(splits[1]);
+                        } else {
+                            valuePI = Integer.parseInt(splits[1]);
+                            indexPI = defaultIndexPI;
+                        }
+                        if (hasAlternateAddress(splits[2])) {
+                            valueSI = getAlternateValue(splits[2]);
+                            indexSI = getAlternateAddress(splits[2]);
+                        } else {
+                            valueSI = Integer.parseInt(splits[2]);
+                            indexSI = defaultIndexSI;
+                        }
                         _cv = splits[0];
                         break;
                     default:
-                        log.error("Too many parts in CV name " + cv);
+                        log.error("Too many parts in CV name; taking 1st two " + cv);
                         valuePI = Integer.parseInt(splits[1]);
                         valueSI = Integer.parseInt(splits[2]);
                         _cv = splits[0];
@@ -137,16 +163,34 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
                 String[] splits = cv.split("\\.");
                 switch (splits.length) {
                     case 2:
-                        valuePI = Integer.parseInt(splits[0]);
+                        if (hasAlternateAddress(splits[0])) {
+                            valuePI = getAlternateValue(splits[0]);
+                            indexPI = getAlternateAddress(splits[0]);
+                        } else {
+                            valuePI = Integer.parseInt(splits[0]);
+                            indexPI = defaultIndexPI;
+                        }
                         _cv = splits[1];
                         break;
                     case 3:
-                        valuePI = Integer.parseInt(splits[0]);
-                        valueSI = Integer.parseInt(splits[1]);
+                        if (hasAlternateAddress(splits[0])) {
+                            valuePI = getAlternateValue(splits[0]);
+                            indexPI = getAlternateAddress(splits[0]);
+                        } else {
+                            valuePI = Integer.parseInt(splits[0]);
+                            indexPI = defaultIndexPI;
+                        }
+                        if (hasAlternateAddress(splits[1])) {
+                            valueSI = getAlternateValue(splits[1]);
+                            indexSI = getAlternateAddress(splits[1]);
+                        } else {
+                            valueSI = Integer.parseInt(splits[1]);
+                            indexSI = defaultIndexSI;
+                        }
                         _cv = splits[2];
                         break;
                     default:
-                        log.error("Too many parts in CV name " + cv);
+                        log.error("Too many parts in CV name; taking 1st two " + cv);
                         valuePI = Integer.parseInt(splits[0]);
                         valueSI = Integer.parseInt(splits[1]);
                         _cv = splits[2];
@@ -158,6 +202,18 @@ public class MultiIndexProgrammerFacade extends AbstractProgrammerFacade impleme
         }
     }
 
+    boolean hasAlternateAddress(String cv) {
+        return cv.contains("=");
+    }
+    
+    String getAlternateAddress(String cv) {
+        return cv.split("=")[0];
+    }
+    
+    int getAlternateValue(String cv) {
+        return Integer.parseInt(cv.split("=")[1]);
+    }
+    
     /**
      * Check if the last-written PI and SI values can still be counted on.
      *

--- a/java/test/jmri/implementation/MultiIndexProgrammerFacadeTest.java
+++ b/java/test/jmri/implementation/MultiIndexProgrammerFacadeTest.java
@@ -302,6 +302,35 @@ public class MultiIndexProgrammerFacadeTest extends TestCase {
         Assert.assertEquals("index 2 written", 46, dp.getCvVal(82));
     }
 
+    public void testWriteReadDoubleIndexedAltPiSi() throws jmri.ProgrammerException, InterruptedException {
+
+        ProgDebugger dp = new ProgDebugger();
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", true, false);
+        ProgListener l = new ProgListener() {
+            @Override
+            public void programmingOpReply(int value, int status) {
+                log.debug("callback value=" + value + " status=" + status);
+                replied = true;
+                readValue = value;
+            }
+        };
+
+        p.writeCV("123.101=45.102=46", 12, l);
+        waitReply();
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(101));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(102));
+        Assert.assertEquals("value written", 12, dp.getCvVal(123));
+
+        dp.clearHasBeenWritten(101);
+        dp.clearHasBeenWritten(102);
+
+        p.readCV("123.101=45.102=46", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(101));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(102));
+    }
+
     public void testWriteReadDoubleIndexedSkip() throws jmri.ProgrammerException, InterruptedException {
 
         ProgDebugger dp = new ProgDebugger();
@@ -381,6 +410,54 @@ public class MultiIndexProgrammerFacadeTest extends TestCase {
 
     }
 
+    public void testWriteReadDoubleIndexedCvListAltPiSi() throws jmri.ProgrammerException, InterruptedException {
+
+        ProgDebugger dp = new ProgDebugger();
+        Programmer p = new MultiIndexProgrammerFacade(dp, "81", "82", false, false);
+        ProgListener l = new ProgListener() {
+            @Override
+            public void programmingOpReply(int value, int status) {
+                log.debug("callback value=" + value + " status=" + status);
+                replied = true;
+                readValue = value;
+            }
+        };
+
+        p.writeCV("101=45.102=46.123", 12, l);
+        waitReply();
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(101));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(102));
+        Assert.assertEquals("value written", 12, dp.getCvVal(123));
+
+        dp.clearHasBeenWritten(101);
+        dp.clearHasBeenWritten(102);
+
+        p.readCV("101=45.102=46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(101));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(102));
+
+        dp.clearHasBeenWritten(101);
+        dp.clearHasBeenWritten(102);
+
+        p.readCV("101=45.102=46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(101));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(102));
+
+        dp.clearHasBeenWritten(101);
+        dp.clearHasBeenWritten(102);
+
+        p.readCV("101=45.102=46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(101));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(102));
+
+    }
+
     public void testWriteReadDoubleIndexedCvListSkip() throws jmri.ProgrammerException, InterruptedException {
 
         ProgDebugger dp = new ProgDebugger();
@@ -438,6 +515,65 @@ public class MultiIndexProgrammerFacadeTest extends TestCase {
         Assert.assertEquals("read back", 12, readValue);
         Assert.assertEquals("index 1 written", 45, dp.getCvVal(81));
         Assert.assertEquals("index 2 written", 46, dp.getCvVal(82));
+    }
+
+    public void testWriteReadDoubleIndexedCvListSkipAltPiSi() throws jmri.ProgrammerException, InterruptedException {
+
+        ProgDebugger dp = new ProgDebugger();
+        MultiIndexProgrammerFacade p = new MultiIndexProgrammerFacade(dp, "81", "82", false, true);
+        ProgListener l = new ProgListener() {
+            @Override
+            public void programmingOpReply(int value, int status) {
+                log.debug("callback value=" + value + " status=" + status);
+                replied = true;
+                readValue = value;
+            }
+        };
+
+        p.writeCV("101=45.102=46.123", 12, l);
+        waitReply();
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(101));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(102));
+        Assert.assertEquals("value written", 12, dp.getCvVal(123));
+
+        dp.clearHasBeenWritten(101);
+        dp.clearHasBeenWritten(102);
+
+        p.readCV("101=45.102=46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertTrue("index 1 not written", !dp.hasBeenWritten(101));
+        Assert.assertTrue("index 2 not written", !dp.hasBeenWritten(102));
+
+        dp.clearHasBeenWritten(101);
+        dp.clearHasBeenWritten(102);
+
+        p.readCV("101=45.102=46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertTrue("index 1 not written", !dp.hasBeenWritten(101));
+        Assert.assertTrue("index 2 not written", !dp.hasBeenWritten(102));
+
+        dp.clearHasBeenWritten(101);
+        dp.clearHasBeenWritten(102);
+
+        p.readCV("101=45.102=46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertTrue("index 1 not written", !dp.hasBeenWritten(101));
+        Assert.assertTrue("index 2 not written", !dp.hasBeenWritten(102));
+
+        // add timeout
+        p.lastOpTime = p.lastOpTime - 2*p.maxDelay; 
+        
+        dp.clearHasBeenWritten(101);
+        dp.clearHasBeenWritten(102);
+
+        p.readCV("101=45.102=46.123", l);
+        waitReply();
+        Assert.assertEquals("read back", 12, readValue);
+        Assert.assertEquals("index 1 written", 45, dp.getCvVal(101));
+        Assert.assertEquals("index 2 written", 46, dp.getCvVal(102));
     }
 
     public void testWriteReadDoubleIndexedCvListDelayedSkip() throws jmri.ProgrammerException, InterruptedException {


### PR DESCRIPTION
Adds a new 80=23.40 syntax to the multi-index CV address format so that decoder definitions can access more than one set of indexed CVs.