### PR TITLE
Fix #6617: fixing startup NPE and synchronization on mListenerMasks

### DIFF
--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -128,7 +128,7 @@ abstract public class AbstractMRTrafficController {
 
     // The methods to implement the abstract Interface
 
-    protected Vector<AbstractMRListener> cmdListeners = new Vector<AbstractMRListener>();
+    protected final Vector<AbstractMRListener> cmdListeners = new Vector<AbstractMRListener>();
 
     protected synchronized void addListener(AbstractMRListener l) {
         // add only if not already registered
@@ -158,6 +158,7 @@ abstract public class AbstractMRTrafficController {
         // make a copy of the listener vector to synchronized not needed for transmit
         Vector<AbstractMRListener> v;
         synchronized (this) {
+            // FIXME: unnecessary synchronized; the Vector IS already thread-safe.
             v = (Vector<AbstractMRListener>) cmdListeners.clone();
         }
         // forward to all listeners
@@ -271,6 +272,7 @@ abstract public class AbstractMRTrafficController {
         // make a copy of the listener vector to synchronized (not needed for transmit?)
         Vector<AbstractMRListener> v;
         synchronized (this) {
+            // FIXME: unnecessary synchronized; the Vector IS already thread-safe.
             v = (Vector<AbstractMRListener>) cmdListeners.clone();
         }
         // forward to all listeners

--- a/java/src/jmri/jmrix/lenz/XNetTrafficController.java
+++ b/java/src/jmri/jmrix/lenz/XNetTrafficController.java
@@ -20,7 +20,9 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class XNetTrafficController extends AbstractMRTrafficController implements XNetInterface {
 
-    protected HashMap<XNetListener, Integer> mListenerMasks;
+    // @GuardedBy(this)
+    // PENDING: the field should be probably made private w/ accessor to force proper synchronization for reading.
+    protected final HashMap<XNetListener, Integer> mListenerMasks;
 
     /**
      * Create a new XNetTrafficController.
@@ -90,50 +92,48 @@ public abstract class XNetTrafficController extends AbstractMRTrafficController 
         if (!((XNetReply) m).checkParity()) {
             log.warn("Ignore packet with bad checksum: {}", (m));
         } else {
-            try {
-                int mask = (mListenerMasks.get(client));
-                if (mask == XNetInterface.ALL) {
-                    ((XNetListener) client).message((XNetReply) m);
-                } else if ((mask & XNetInterface.COMMINFO)
-                        == XNetInterface.COMMINFO
-                        && (((XNetReply) m).getElement(0)
-                        == XNetConstants.LI_MESSAGE_RESPONSE_HEADER)) {
-                    ((XNetListener) client).message((XNetReply) m);
-                } else if ((mask & XNetInterface.CS_INFO)
-                        == XNetInterface.CS_INFO
-                        && (((XNetReply) m).getElement(0)
-                        == XNetConstants.CS_INFO
-                        || ((XNetReply) m).getElement(0)
-                        == XNetConstants.CS_SERVICE_MODE_RESPONSE
-                        || ((XNetReply) m).getElement(0)
-                        == XNetConstants.CS_REQUEST_RESPONSE
-                        || ((XNetReply) m).getElement(0)
-                        == XNetConstants.BC_EMERGENCY_STOP)) {
-                    ((XNetListener) client).message((XNetReply) m);
-                } else if ((mask & XNetInterface.FEEDBACK)
-                        == XNetInterface.FEEDBACK
-                        && (((XNetReply) m).isFeedbackMessage()
-                        || ((XNetReply) m).isFeedbackBroadcastMessage())) {
-                    ((XNetListener) client).message((XNetReply) m);
-                } else if ((mask & XNetInterface.THROTTLE)
-                        == XNetInterface.THROTTLE
-                        && ((XNetReply) m).isThrottleMessage()) {
-                    ((XNetListener) client).message((XNetReply) m);
-                } else if ((mask & XNetInterface.CONSIST)
-                        == XNetInterface.CONSIST
-                        && ((XNetReply) m).isConsistMessage()) {
-                    ((XNetListener) client).message((XNetReply) m);
-                } else if ((mask & XNetInterface.INTERFACE)
-                        == XNetInterface.INTERFACE
-                        && (((XNetReply) m).getElement(0)
-                        == XNetConstants.LI_VERSION_RESPONSE
-                        || ((XNetReply) m).getElement(0)
-                        == XNetConstants.LI101_REQUEST)) {
-                    ((XNetListener) client).message((XNetReply) m);
-                }
-            } catch (NullPointerException e) {
-                // catch null pointer exceptions, caused by a client
-                // that sent a message without being a registered listener
+            int mask;
+            synchronized (this) {
+                mask = mListenerMasks.getOrDefault(client, XNetInterface.ALL);
+            }
+            if (mask == XNetInterface.ALL) {
+                // Note: also executing this branch, if the client is not registered at all.
+                ((XNetListener) client).message((XNetReply) m);
+            } else if ((mask & XNetInterface.COMMINFO)
+                    == XNetInterface.COMMINFO
+                    && (((XNetReply) m).getElement(0)
+                    == XNetConstants.LI_MESSAGE_RESPONSE_HEADER)) {
+                ((XNetListener) client).message((XNetReply) m);
+            } else if ((mask & XNetInterface.CS_INFO)
+                    == XNetInterface.CS_INFO
+                    && (((XNetReply) m).getElement(0)
+                    == XNetConstants.CS_INFO
+                    || ((XNetReply) m).getElement(0)
+                    == XNetConstants.CS_SERVICE_MODE_RESPONSE
+                    || ((XNetReply) m).getElement(0)
+                    == XNetConstants.CS_REQUEST_RESPONSE
+                    || ((XNetReply) m).getElement(0)
+                    == XNetConstants.BC_EMERGENCY_STOP)) {
+                ((XNetListener) client).message((XNetReply) m);
+            } else if ((mask & XNetInterface.FEEDBACK)
+                    == XNetInterface.FEEDBACK
+                    && (((XNetReply) m).isFeedbackMessage()
+                    || ((XNetReply) m).isFeedbackBroadcastMessage())) {
+                ((XNetListener) client).message((XNetReply) m);
+            } else if ((mask & XNetInterface.THROTTLE)
+                    == XNetInterface.THROTTLE
+                    && ((XNetReply) m).isThrottleMessage()) {
+                ((XNetListener) client).message((XNetReply) m);
+            } else if ((mask & XNetInterface.CONSIST)
+                    == XNetInterface.CONSIST
+                    && ((XNetReply) m).isConsistMessage()) {
+                ((XNetListener) client).message((XNetReply) m);
+            } else if ((mask & XNetInterface.INTERFACE)
+                    == XNetInterface.INTERFACE
+                    && (((XNetReply) m).getElement(0)
+                    == XNetConstants.LI_VERSION_RESPONSE
+                    || ((XNetReply) m).getElement(0)
+                    == XNetConstants.LI101_REQUEST)) {
                 ((XNetListener) client).message((XNetReply) m);
             }
         }
@@ -141,16 +141,16 @@ public abstract class XNetTrafficController extends AbstractMRTrafficController 
 
     // We use the pollMessage routines for high priority messages.
     // This means responses to time critical messages (turnout off messages).
-    LinkedBlockingQueue<XNetMessage> highPriorityQueue = null;
-    LinkedBlockingQueue<XNetListener> highPriorityListeners = null;
+    // PENDING: these fields should be probably made private w/ accessor to force proper synchronization for reading.
+    final LinkedBlockingQueue<XNetMessage> highPriorityQueue;
+    final LinkedBlockingQueue<XNetListener> highPriorityListeners;
 
-    public void sendHighPriorityXNetMessage(XNetMessage m, XNetListener reply) {
-        try {
-            highPriorityQueue.put(m);
-            highPriorityListeners.put(reply);
-        } catch (java.lang.InterruptedException ie) {
-            log.error("Interrupted while adding High Priority Message to Queue");
-        }
+    public synchronized void sendHighPriorityXNetMessage(XNetMessage m, XNetListener reply) {
+        // using offer as the queue is unbounded and should never block on write.
+        // Note: the message should be inserted LAST, as the message is tested/acquired first
+        // by the reader; serves a a guard for next item processing.
+        highPriorityListeners.offer(reply);
+        highPriorityQueue.offer(m);
     }
 
     @Override
@@ -283,7 +283,7 @@ public abstract class XNetTrafficController extends AbstractMRTrafficController 
     /**
      * Reference to the command station in communication here.
      */
-    LenzCommandStation mCommandStation;
+    final LenzCommandStation mCommandStation;
 
     /**
      * Get access to communicating command station object.

--- a/java/src/jmri/jmrix/lenz/XNetTrafficController.java
+++ b/java/src/jmri/jmrix/lenz/XNetTrafficController.java
@@ -6,6 +6,7 @@ import jmri.jmrix.AbstractMRListener;
 import jmri.jmrix.AbstractMRMessage;
 import jmri.jmrix.AbstractMRReply;
 import jmri.jmrix.AbstractMRTrafficController;
+import net.jcip.annotations.GuardedBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,7 +21,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class XNetTrafficController extends AbstractMRTrafficController implements XNetInterface {
 
-    // @GuardedBy(this)
+    @GuardedBy("this")
     // PENDING: the field should be probably made private w/ accessor to force proper synchronization for reading.
     protected final HashMap<XNetListener, Integer> mListenerMasks;
 
@@ -149,8 +150,8 @@ public abstract class XNetTrafficController extends AbstractMRTrafficController 
         // using offer as the queue is unbounded and should never block on write.
         // Note: the message should be inserted LAST, as the message is tested/acquired first
         // by the reader; serves a a guard for next item processing.
-        highPriorityListeners.offer(reply);
-        highPriorityQueue.offer(m);
+        highPriorityListeners.add(reply);
+        highPriorityQueue.add(m);
     }
 
     @Override

--- a/java/src/jmri/jmrix/srcp/SRCPTrafficController.java
+++ b/java/src/jmri/jmrix/srcp/SRCPTrafficController.java
@@ -281,6 +281,7 @@ public class SRCPTrafficController extends AbstractMRTrafficController
         // make a copy of the listener vector to synchronized (not needed for transmit?)
         Vector<AbstractMRListener> v;
         synchronized (this) {
+            // FIXME: unnecessary synchronized; the Vector IS already thread-safe.
             v = (Vector<AbstractMRListener>) cmdListeners.clone();
         }
         // forward to all listeners

--- a/java/test/jmri/jmrix/openlcb/swing/monitor/MonitorFrameDemo.java
+++ b/java/test/jmri/jmrix/openlcb/swing/monitor/MonitorFrameDemo.java
@@ -27,12 +27,14 @@ public class MonitorFrameDemo {
          * Forward CanMessage to object under test
          */
         public void testMessage(CanMessage f) {
+            // FIXME: must clone, iterator is not threadsafe.
             for (jmri.jmrix.AbstractMRListener c : cmdListeners) {
                 ((CanListener) c).message(f);
             }
         }
 
         public void testReply(CanReply f) {
+            // FIXME: must clone, iterator is not threadsafe.
             for (jmri.jmrix.AbstractMRListener c : cmdListeners) {
                 ((CanListener) c).reply(f);
             }


### PR DESCRIPTION
See issue https://github.com/JMRI/JMRI/issues/6617

The simplest thing is to make the constructor-initialized fields `final` - according to JLS, this will make the values immediately visible **after** the object is initialized (last constructor finishes). 

The current code also does not access the `mListenerMasks` and other fields outside the object. Making it private would ensure that noone will bypass synchronization requirements.

Next, while `addXNetListener` is synchronized, the access to `mListenerMasks` in forwardReply is not: it may read even inconsistent state of the HashMap, if not all of the data flushed; there's no shared monitor/volatile guard that the writing + reading threads would be ordered by in the `happens-before` relation. Synchronizing on `this`.

I would advise against using a ConcurrentHashMap: unless the r/w contention is really high, the CHM has lower performance than a simple synchronized. Unless this need to be really exposed to clients or subclasses, Collections.synchronizedMap() would add an unnecessary level of indirection; again plain synchronized may be better.

Nitpick: the NPE resulting from unboxing `null` from the Map may be avoided at all - since NPE handler corresponds to the `XNetInterface.ALL` branch, `getOrDefault` can be used to unify the processing.

Removing the NPE handler since:
- real NPEs will surface soon
- expected null processing can be written without exception and `if`
- will uncover potential concurrency issues

The are constraints not only the individual collections, but across them as well: i.e. code calling `pollMessage` assumes that it will get the corresponding listener from `pollReplyHandler`. Imagine a thread But IF two threads some to `sendHighPriorityXNetMessage` at the same time, the concurrent execution `highPriorityListeners.put` and `highPriorityQueue.put` may mix message/reply pairs in the queue order. Even worse, blocking asusmption on the listener queue would fail, as there could be the "other" listener already. 

Now imagine the processor for the message and `sendHighPriorityXNetMessage` would run really concurrently; the reader may get the message, and then execute `highPriorityListeners.isEmpty` before it gets populated by the writer. Unlikely, but remember Murphy's laws.


Nitpick: reader reads the queues in the order: message, listener. In highly concurrent environment (not the case I think), this will be the total sequence of ops
1. thread A puts message
2. thread B reads message
3. thread B blocks (will not, it will just fail to deliver reply) at listener queue, which is empty
4. thread A puts listener
5. thread B ublock, gets the listener and processes message-reply

The block at (3) can be simply avoided by writing to the message queue **last**, so the reader's first operation will either recognize there are no messages and do nothing; or there will be a message AND the listener will be already prepared for the reader.

Only here I have discovered, that although the queues are BlockingQueues the blocking feature is completely killed by the surrounding implementation. Blocking behaviour of `highPriorityQueue` is killed - the queue is not size-bounded, so it won't ever block on `put`; `offer` can be used to avoid unnecessary `catch` block. Since the reader first checks for emptiness, the queue won't ever (intentionally) block on `take`. It can block (and cause a bug) when two concurrent threads processes the queue, but that's not the case, I believe. 
Note: instead `offer`, `add` can be conservatively used as it will throw exception on reached capacity - for the case someone will change the code in the future and applies size-limit.

It's really a question why the hevyweight, highly concurrent (and therefore slower) queue impls should be used instead of plain collections. Currently it just synchronizes sequence of `isEmpty` + `take` against `put`; more simpler `Collections.synchronizedXXX` would be sufficient or even more primitive sync as the collections themselves need not (?) to be exposed to clients as API.

The `null` value of `pollReplyHandler` is strictly useful just in tests, the production code would malfunction if the function ever returned `null` (not call the listener it was posted with the message).

Anyway, leaving BlockingQueues as they are, they're misused, but doe not actually break anything except performance.

Note: the two queues actually carry a pair which is to be processed as a logical item. Instead of 2 coordinated queues, one queue w/ typed lightweight pairs/tuples can be used to better encode the intent. I didn't want to change APIs just to fix a bug.

---
The other stuff are trivial things discovered as I swept the surrounding code. I did not change them - if it will be agreed on that the comments are valid / worth the change I'll extend the fix otherwise remove comemnts.

Note that similar patterns are found in `DCCppTrafficController` and possibly elsewhere. Once agreed on approach, will search & apply on other places.
