### PR TITLE
Retrofit LayoutEditor with validating inputs

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
@@ -37,7 +37,8 @@ import org.slf4j.LoggerFactory;
  * @author George Warner Copyright (c) 2017-2018
  */
 public class LayoutShape {
-
+    public static final int MAX_LINEWIDTH = 200;
+    
     // operational instance variables (not saved between sessions)
     private LayoutEditor layoutEditor = null;
     private String name;
@@ -540,7 +541,8 @@ public class LayoutShape {
                 int newValue = QuickPromptUtil.promptForInt(layoutEditor,
                         Bundle.getMessage("ShapeLevelMenuItemTitle"),
                         Bundle.getMessage("ShapeLevelMenuItemTitle"),
-                        level);
+                        level, QuickPromptUtil.checkIntRange(1, null, 
+                            Bundle.getMessage("ShapeLevelValueTitle")));
                 setLevel(newValue);
                 layoutEditor.repaint();
             });
@@ -580,7 +582,7 @@ public class LayoutShape {
                 int newValue = QuickPromptUtil.promptForInt(layoutEditor,
                         Bundle.getMessage("ShapeLineWidthMenuItemTitle"),
                         Bundle.getMessage("ShapeLineWidthMenuItemTitle"),
-                        lineWidth);
+                        lineWidth, QuickPromptUtil.checkIntRange(1, MAX_LINEWIDTH, null));
                 setLineWidth(newValue);
                 layoutEditor.repaint();
             });

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -19,7 +19,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.swing.AbstractAction;
@@ -776,7 +778,48 @@ public class TrackSegment extends LayoutTrack {
      * Maximum length of the bumper decoration.
      */
     private static final int MAX_BUMPER_LENGTH = 200;
+    private static final int MAX_ARROW_LINEWIDTH = 200;
+    private static final int MAX_ARROW_LENGTH = 200;
+    private static final int MAX_ARROW_GAP = 200;
+    private static final int MAX_BRIDGE_LINE_WIDTH = 200;
+    private static final int MAX_BRIDGE_APPROACH_WIDTH = 200;
+    private static final int MAX_BRIDGE_DECK_WIDTH = 200;
+    private static final int MAX_BUMPER_LINE_WIDTH = 200;
+    private static final int MAX_TUNNEL_FLOOR_WIDTH = 200;
+    private static final int MAX_TUNNEL_LINE_WIDTH = 200;
+    private static final int MAX_TUNNEL_ENTRANCE_WIDTH = 200;
 
+    /**
+     * Helper method, which adds "Set value" item to the menu. The value can be optionally
+     * range-checked. Item will be appended at the end of the menu.
+     * 
+     * @param menu the target menu.
+     * @param titleKey bundle key for the menu title/dialog title
+     * @param tooltipKey bundle key for the menu item tooltip
+     * @param val value getter
+     * @param set value setter
+     * @param predicate checking predicate, possibly null.
+     */
+    private void addNumericMenuItem(@Nonnull JMenu menu, 
+            @Nonnull String titleKey, @Nonnull String tooltipKey,
+            @Nonnull Supplier<Integer> val, 
+            @Nonnull Consumer<Integer> set, @Nullable Predicate<Integer> predicate) {
+        int oldVal = val.get();
+        JMenuItem jmi = menu.add(new JMenuItem(Bundle.getMessage("MakeLabel",
+                    Bundle.getMessage(titleKey)) + oldVal));
+            jmi.setToolTipText(Bundle.getMessage(tooltipKey));
+            jmi.addActionListener((java.awt.event.ActionEvent e3) -> {
+            //prompt for lineWidth
+            int newValue = QuickPromptUtil.promptForInt(layoutEditor,
+                    Bundle.getMessage(titleKey),
+                    Bundle.getMessage(titleKey),
+                    // getting again, maybe something changed from the menu construction ?
+                    val.get(), predicate);
+            set.accept(newValue);
+            layoutEditor.repaint();
+        });
+    }
+    
     /**
      * {@inheritDoc}
      */
@@ -1039,41 +1082,20 @@ public class TrackSegment extends LayoutTrack {
         jmi.setForeground(arrowColor);
         jmi.setBackground(ColorUtil.contrast(arrowColor));
 
-        jmi = arrowsMenu.add(new JMenuItem(Bundle.getMessage("MakeLabel",
-                Bundle.getMessage("DecorationLineWidthMenuItemTitle")) + arrowLineWidth));
-        jmi.setToolTipText(Bundle.getMessage("DecorationLineWidthMenuItemToolTip"));
-        jmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-            //prompt for arrow line width
-            int newValue = QuickPromptUtil.promptForInt(layoutEditor,
-                    Bundle.getMessage("DecorationLineWidthMenuItemTitle"),
-                    Bundle.getMessage("DecorationLineWidthMenuItemTitle"),
-                    arrowLineWidth);
-            setArrowLineWidth(newValue);
-        });
+        addNumericMenuItem(arrowsMenu, 
+                "DecorationLineWidthMenuItemTitle",  "DecorationLineWidthMenuItemToolTip", 
+                this::getArrowLineWidth, this::setArrowLineWidth,
+                QuickPromptUtil.checkIntRange(1, MAX_ARROW_LINEWIDTH, null));
 
-        jmi = arrowsMenu.add(new JMenuItem(Bundle.getMessage("MakeLabel",
-                Bundle.getMessage("DecorationLengthMenuItemTitle")) + arrowLength));
-        jmi.setToolTipText(Bundle.getMessage("DecorationLengthMenuItemToolTip"));
-        jmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-            //prompt for arrow length
-            int newValue = QuickPromptUtil.promptForInt(layoutEditor,
-                    Bundle.getMessage("DecorationLengthMenuItemTitle"),
-                    Bundle.getMessage("DecorationLengthMenuItemTitle"),
-                    arrowLength);
-            setArrowLength(newValue);
-        });
+        addNumericMenuItem(arrowsMenu, 
+                "DecorationLengthMenuItemTitle", "DecorationLengthMenuItemToolTip", 
+                this::getArrowLength, this::setArrowLength,
+                QuickPromptUtil.checkIntRange(1, MAX_ARROW_LENGTH, null));
 
-        jmi = arrowsMenu.add(new JMenuItem(Bundle.getMessage("MakeLabel",
-                Bundle.getMessage("DecorationGapMenuItemTitle")) + arrowGap));
-        jmi.setToolTipText(Bundle.getMessage("DecorationGapMenuItemToolTip"));
-        jmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-            //prompt for arrow gap
-            int newValue = QuickPromptUtil.promptForInt(layoutEditor,
-                    Bundle.getMessage("DecorationGapMenuItemTitle"),
-                    Bundle.getMessage("DecorationGapMenuItemTitle"),
-                    arrowGap);
-            setArrowGap(newValue);
-        });
+        addNumericMenuItem(arrowsMenu,  
+                "DecorationGapMenuItemTitle", "DecorationGapMenuItemToolTip", 
+                this::getArrowGap, this::setArrowGap,
+                QuickPromptUtil.checkIntRange(1, MAX_ARROW_GAP, null));
 
         //
         // bridge menus
@@ -1173,41 +1195,20 @@ public class TrackSegment extends LayoutTrack {
         jmi.setForeground(bridgeColor);
         jmi.setBackground(ColorUtil.contrast(bridgeColor));
 
-        jmi = bridgeMenu.add(new JMenuItem(Bundle.getMessage("MakeLabel",
-                Bundle.getMessage("DecorationLineWidthMenuItemTitle")) + bridgeLineWidth));
-        jmi.setToolTipText(Bundle.getMessage("DecorationLineWidthMenuItemToolTip"));
-        jmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-            //prompt for bridge line width
-            int newValue = QuickPromptUtil.promptForInt(layoutEditor,
-                    Bundle.getMessage("DecorationLineWidthMenuItemTitle"),
-                    Bundle.getMessage("DecorationLineWidthMenuItemTitle"),
-                    bridgeLineWidth);
-            setBridgeLineWidth(newValue);
-        });
+        addNumericMenuItem(bridgeMenu, 
+                "DecorationLineWidthMenuItemTitle", "DecorationLineWidthMenuItemToolTip", 
+                this::getBridgeLineWidth, this::setBridgeLineWidth,
+                QuickPromptUtil.checkIntRange(1, MAX_BRIDGE_LINE_WIDTH, null));
 
-        jmi = bridgeMenu.add(new JMenuItem(Bundle.getMessage("MakeLabel",
-                Bundle.getMessage("BridgeApproachWidthMenuItemTitle")) + bridgeApproachWidth));
-        jmi.setToolTipText(Bundle.getMessage("BridgeApproachWidthMenuItemToolTip"));
-        jmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-            //prompt for bridge approach width
-            int newValue = QuickPromptUtil.promptForInt(layoutEditor,
-                    Bundle.getMessage("BridgeApproachWidthMenuItemTitle"),
-                    Bundle.getMessage("BridgeApproachWidthMenuItemTitle"),
-                    bridgeApproachWidth);
-            setBridgeApproachWidth(newValue);
-        });
+        addNumericMenuItem(bridgeMenu, 
+                "BridgeApproachWidthMenuItemTitle", "BridgeApproachWidthMenuItemToolTip", 
+                this::getBridgeApproachWidth, this::setBridgeApproachWidth,
+                QuickPromptUtil.checkIntRange(1, MAX_BRIDGE_APPROACH_WIDTH, null));
 
-        jmi = bridgeMenu.add(new JMenuItem(Bundle.getMessage("MakeLabel",
-                Bundle.getMessage("BridgeDeckWidthMenuItemTitle")) + bridgeDeckWidth));
-        jmi.setToolTipText(Bundle.getMessage("BridgeDeckWidthMenuItemToolTip"));
-        jmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-            //prompt for bridge deck width
-            int newValue = QuickPromptUtil.promptForInt(layoutEditor,
-                    Bundle.getMessage("BridgeDeckWidthMenuItemTitle"),
-                    Bundle.getMessage("BridgeDeckWidthMenuItemTitle"),
-                    bridgeDeckWidth);
-            setBridgeDeckWidth(newValue);
-        });
+        addNumericMenuItem(bridgeMenu, 
+                "BridgeDeckWidthMenuItemTitle", "BridgeDeckWidthMenuItemToolTip", 
+                this::getBridgeDeckWidth, this::setBridgeDeckWidth,
+                QuickPromptUtil.checkIntRange(1, MAX_BRIDGE_DECK_WIDTH, null));
 
         //
         // end bumper menus
@@ -1258,40 +1259,14 @@ public class TrackSegment extends LayoutTrack {
         jmi.setForeground(bumperColor);
         jmi.setBackground(ColorUtil.contrast(bumperColor));
 
-        jmi = endBumperMenu.add(new JMenuItem(Bundle.getMessage("MakeLabel",
-                Bundle.getMessage("DecorationLineWidthMenuItemTitle")) + bumperLineWidth));
-        jmi.setToolTipText(Bundle.getMessage("DecorationLineWidthMenuItemToolTip"));
-        jmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-            //prompt for width
-            int newValue = QuickPromptUtil.promptForInt(layoutEditor,
-                    Bundle.getMessage("DecorationLineWidthMenuItemTitle"),
-                    Bundle.getMessage("DecorationLineWidthMenuItemTitle"),
-                    bumperLineWidth);
-            setBumperLineWidth(newValue);
-        });
-
-        jmi = endBumperMenu.add(new JMenuItem(Bundle.getMessage("MakeLabel",
-                Bundle.getMessage("DecorationLengthMenuItemTitle")) + bumperLength));
-        jmi.setToolTipText(Bundle.getMessage("DecorationLengthMenuItemToolTip"));
-        jmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-            //prompt for length
-            int newValue = QuickPromptUtil.promptForInt(layoutEditor,
-                    Bundle.getMessage("DecorationLengthMenuItemTitle"),
-                    Bundle.getMessage("DecorationLengthMenuItemTitle"),
-                    bumperLength, new Predicate<Integer>() {
-                        @Override
-                        public boolean test(Integer t) {
-                            if (t < 0 || t > MAX_BUMPER_LENGTH) {
-                                throw new IllegalArgumentException(
-                                        Bundle.getMessage("DecorationLengthMenuItemRange", MAX_BUMPER_LENGTH));
-                            }
-                            return true;
-                        }
-                    }
-            );
-            setBumperLength(newValue);
-        });
-
+        addNumericMenuItem(endBumperMenu, 
+                "DecorationLineWidthMenuItemTitle", "DecorationLineWidthMenuItemToolTip", 
+                this::getBumperLineWidth, this::setBumperLineWidth,
+                QuickPromptUtil.checkIntRange(1, MAX_BUMPER_LINE_WIDTH, null));
+        addNumericMenuItem(endBumperMenu, 
+                "DecorationLengthMenuItemTitle", "DecorationLengthMenuItemToolTip", 
+                this::getBumperLength, this::setBumperLength,
+                QuickPromptUtil.checkIntRange(1, MAX_BUMPER_LENGTH, null));
         //
         // tunnel menus
         //
@@ -1390,41 +1365,18 @@ public class TrackSegment extends LayoutTrack {
         jmi.setForeground(tunnelColor);
         jmi.setBackground(ColorUtil.contrast(tunnelColor));
 
-        jmi = tunnelMenu.add(new JMenuItem(Bundle.getMessage("MakeLabel",
-                Bundle.getMessage("TunnelFloorWidthMenuItemTitle")) + tunnelFloorWidth));
-        jmi.setToolTipText(Bundle.getMessage("TunnelFloorWidthMenuItemToolTip"));
-        jmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-            //prompt for tunnel floor width
-            int newValue = QuickPromptUtil.promptForInt(layoutEditor,
-                    Bundle.getMessage("TunnelFloorWidthMenuItemTitle"),
-                    Bundle.getMessage("TunnelFloorWidthMenuItemTitle"),
-                    tunnelFloorWidth);
-            setTunnelFloorWidth(newValue);
-        });
-
-        jmi = tunnelMenu.add(new JMenuItem(Bundle.getMessage("MakeLabel",
-                Bundle.getMessage("DecorationLineWidthMenuItemTitle")) + tunnelLineWidth));
-        jmi.setToolTipText(Bundle.getMessage("DecorationLineWidthMenuItemToolTip"));
-        jmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-            //prompt for tunnel line width
-            int newValue = QuickPromptUtil.promptForInt(layoutEditor,
-                    Bundle.getMessage("DecorationLineWidthMenuItemTitle"),
-                    Bundle.getMessage("DecorationLineWidthMenuItemTitle"),
-                    tunnelLineWidth);
-            setTunnelLineWidth(newValue);
-        });
-
-        jmi = tunnelMenu.add(new JMenuItem(Bundle.getMessage("MakeLabel",
-                Bundle.getMessage("TunnelEntranceWidthMenuItemTitle")) + tunnelEntranceWidth));
-        jmi.setToolTipText(Bundle.getMessage("TunnelEntranceWidthMenuItemToolTip"));
-        jmi.addActionListener((java.awt.event.ActionEvent e3) -> {
-            //prompt for tunnel entrance width
-            int newValue = QuickPromptUtil.promptForInt(layoutEditor,
-                    Bundle.getMessage("TunnelEntranceWidthMenuItemTitle"),
-                    Bundle.getMessage("TunnelEntranceWidthMenuItemTitle"),
-                    tunnelEntranceWidth);
-            setTunnelEntranceWidth(newValue);
-        });
+        addNumericMenuItem(tunnelMenu, 
+                "TunnelFloorWidthMenuItemTitle", "TunnelFloorWidthMenuItemToolTip", 
+                this::getTunnelFloorWidth, this::setTunnelFloorWidth,
+                QuickPromptUtil.checkIntRange(1, MAX_TUNNEL_FLOOR_WIDTH, null));
+        addNumericMenuItem(tunnelMenu, 
+                "DecorationLineWidthMenuItemTitle", "DecorationLineWidthMenuItemToolTip", 
+                this::getTunnelLineWidth, this::setTunnelLineWidth,
+                QuickPromptUtil.checkIntRange(1, MAX_TUNNEL_LINE_WIDTH, null));
+        addNumericMenuItem(tunnelMenu, 
+                "TunnelEntranceWidthMenuItemTitle", "TunnelEntranceWidthMenuItemToolTip", 
+                this::getTunnelEntranceWidth, this::setTunnelEntranceWidth,
+                QuickPromptUtil.checkIntRange(1, MAX_TUNNEL_ENTRANCE_WIDTH, null));
 
         popupMenu.add(decorationsMenu);
 

--- a/java/src/jmri/util/UtilBundle.properties
+++ b/java/src/jmri/util/UtilBundle.properties
@@ -23,3 +23,15 @@ InputDialogError=The value is invalid
 InputDialogOK=OK
 InputDialogCancel=Cancel
 InputDialogNotNumber=The value must be a number
+
+# {0} - label for the value/entry
+# {1} - minimum
+# {2} - maximum
+NumberCheckOutOfRangeBoth=The value ''{0}'' must be between {1} and {2}
+NumberCheckOutOfRangeMin=The value ''{0}'' must be at least {1}
+NumberCheckOutOfRangeMax=The value ''{0}'' must be at most {2}
+
+# The next messages should follow the NumberCheckOutOfRangeXXX, same meaning for parameters
+NumberCheckOutOfRangeBoth2=The value must be between {1} and {2}
+NumberCheckOutOfRangeMin2=The value must be at least {1}
+NumberCheckOutOfRangeMax2=The value must be at most {2}

--- a/java/src/jmri/util/ValidatingInputPane.java
+++ b/java/src/jmri/util/ValidatingInputPane.java
@@ -120,8 +120,8 @@ final class ValidatingInputPane<T> extends javax.swing.JPanel  {
      * @param val validator instance, {@code null} to disable.
      * @return this instance
      */
-    ValidatingInputPane<T> validator(Predicate<? extends T> val) {
-        this.validator = (Predicate<T>)val;
+    ValidatingInputPane<T> validator(Predicate<T> val) {
+        this.validator = val;
         return this;
     }
     

--- a/java/src/jmri/util/ValidatingInputPane.java
+++ b/java/src/jmri/util/ValidatingInputPane.java
@@ -120,8 +120,8 @@ final class ValidatingInputPane<T> extends javax.swing.JPanel  {
      * @param val validator instance, {@code null} to disable.
      * @return this instance
      */
-    ValidatingInputPane<T> validator(Predicate<T> val) {
-        this.validator = val;
+    ValidatingInputPane<T> validator(Predicate<? extends T> val) {
+        this.validator = (Predicate<T>)val;
         return this;
     }
     

--- a/java/test/jmri/util/QuickPromptUtilTest.java
+++ b/java/test/jmri/util/QuickPromptUtilTest.java
@@ -1,5 +1,10 @@
 package jmri.util;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.function.Predicate;
 import org.junit.*;
 
 /**
@@ -24,5 +29,74 @@ public class QuickPromptUtilTest {
     public void tearDown() {
         jmri.util.JUnitUtil.tearDown();
     }
+    
+    /**
+     * Checks that int predicate works well.
+     */
+    @Test
+    public void testIntRangePredicate() {
+        doTestIntRangePredicate("someValue");
+    }
+    
+    @Test
+    public void testIntRangePredicateWithLabel() {
+        doTestIntRangePredicate("someValue");
+    }
+    
+    private void doTestIntRangePredicate(String label) {
+        Predicate<Integer> pr = new QuickPromptUtil.IntRangePredicate(
+                null, 10, label);
+        assertTrue(pr.test(-1));
+        assertTrue(pr.test(5));
+        try {
+            assertTrue(pr.test(15));
+            fail("Exception expected");
+        } catch (IllegalArgumentException ex) {
+            if (label != null) {
+                assertTrue(ex.getLocalizedMessage().contains(label));
+            }
+            assertTrue(ex.getLocalizedMessage().contains("10"));
+            assertFalse(ex.getLocalizedMessage().contains("null"));
+        }
+        
+        pr = new QuickPromptUtil.IntRangePredicate(
+                10, null, label);
+        assertTrue(pr.test(15));
 
+        try {
+            assertTrue(pr.test(5));
+            fail("Exception expected");
+        } catch (IllegalArgumentException ex) {
+            if (label != null) {
+                assertTrue(ex.getLocalizedMessage().contains(label));
+            }
+            assertTrue(ex.getLocalizedMessage().contains("10"));
+            assertFalse(ex.getLocalizedMessage().contains("null"));
+        }
+        
+        pr = new QuickPromptUtil.IntRangePredicate(
+                10, 20, label);
+        assertTrue(pr.test(15));
+
+        try {
+            assertTrue(pr.test(5));
+            fail("Exception expected");
+        } catch (IllegalArgumentException ex) {
+            if (label != null) {
+                assertTrue(ex.getLocalizedMessage().contains(label));
+            }
+            assertTrue(ex.getLocalizedMessage().contains("10"));
+            assertFalse(ex.getLocalizedMessage().contains("null"));
+        }
+        try {
+            assertTrue(pr.test(25));
+            fail("Exception expected");
+        } catch (IllegalArgumentException ex) {
+            if (label != null) {
+                assertTrue(ex.getLocalizedMessage().contains(label));
+            }
+            assertTrue(ex.getLocalizedMessage().contains("20"));
+            assertFalse(ex.getLocalizedMessage().contains("null"));
+        }
+    }
 }


### PR DESCRIPTION
Following https://github.com/JMRI/JMRI/pull/6596, I went through users of `QuickPromptUtil` and did a retrofit. I made a standard range-checking predicate for `Integer`s as well.

I should have checked how many code actually uses the popup dialogs ;) because the improvement is not so broad as I imagined. Never mind. 
