### PR TITLE
ESC closes the edit turnout, edit track segment windows

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTrackEditors.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTrackEditors.java
@@ -12,8 +12,10 @@ import java.awt.Graphics2D;
 import java.awt.GridLayout;
 import java.awt.Label;
 import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
 import java.awt.event.WindowEvent;
 import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
@@ -27,12 +29,14 @@ import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRootPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
@@ -160,8 +164,6 @@ public class LayoutTrackEditors {
             InstanceManager.getDefault(BlockManager.class), null, JmriBeanComboBox.DisplayOptions.DISPLAYNAME);
     private JTextField editTrackSegmentArcTextField = new JTextField(5);
     private JButton editTrackSegmentSegmentEditBlockButton;
-    private JButton editTrackSegmentSegmentEditDoneButton;
-    private JButton editTrackSegmentSegmentEditCancelButton;
 
     private int editTrackSegmentMainlineTrackIndex;
     private int editTrackSegmentSideTrackIndex;
@@ -170,6 +172,24 @@ public class LayoutTrackEditors {
     private boolean editTrackSegmentOpen = false;
     private boolean editTrackSegmentNeedsRedraw = false;
 
+    private void addDoneCancelButtons(JPanel target, JRootPane rp, ActionListener doneCallback, ActionListener cancelCallback) {
+        // Done
+        JButton doneButton = new JButton(Bundle.getMessage("ButtonDone"));
+        target.add(doneButton);  // NOI18N
+        doneButton.addActionListener(doneCallback);
+        doneButton.setToolTipText(Bundle.getMessage("DoneHint", Bundle.getMessage("ButtonDone")));  // NOI18N
+
+        // Cancel
+        JButton cancelButton = new JButton(Bundle.getMessage("ButtonCancel")); // NOI18N
+        target.add(cancelButton); 
+        cancelButton.addActionListener(cancelCallback);
+        cancelButton.setToolTipText(Bundle.getMessage("CancelHint", Bundle.getMessage("ButtonCancel")));  // NOI18N
+
+        rp.setDefaultButton(doneButton);
+        // bind ESC to close window
+        rp.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
+                KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), "close"); // NOI18N
+    }
     /**
      * Edit a Track Segment.
      */
@@ -248,25 +268,9 @@ public class LayoutTrackEditors {
                 editTrackSegmentEditBlockPressed(e);
             });
             editTrackSegmentSegmentEditBlockButton.setToolTipText(Bundle.getMessage("EditBlockHint", "")); // empty value for block 1  // NOI18N
-            panel5.add(editTrackSegmentSegmentEditDoneButton = new JButton(Bundle.getMessage("ButtonDone")));  // NOI18N
-            editTrackSegmentSegmentEditDoneButton.addActionListener((ActionEvent e) -> {
-                editTracksegmentDonePressed(e);
-            });
-            editTrackSegmentSegmentEditDoneButton.setToolTipText(Bundle.getMessage("DoneHint", Bundle.getMessage("ButtonDone")));  // NOI18N
 
-            // make this button the default button (return or enter activates)
-            // Note: We have to invoke this later because we don't currently have a root pane
-            SwingUtilities.invokeLater(() -> {
-                JRootPane rootPane = SwingUtilities.getRootPane(editTrackSegmentSegmentEditDoneButton);
-                rootPane.setDefaultButton(editTrackSegmentSegmentEditDoneButton);
-            });
-
-            // Cancel
-            panel5.add(editTrackSegmentSegmentEditCancelButton = new JButton(Bundle.getMessage("ButtonCancel")));  // NOI18N
-            editTrackSegmentSegmentEditCancelButton.addActionListener((ActionEvent e) -> {
-                editTrackSegmentCancelPressed(e);
-            });
-            editTrackSegmentSegmentEditCancelButton.setToolTipText(Bundle.getMessage("CancelHint", Bundle.getMessage("ButtonCancel")));  // NOI18N
+            addDoneCancelButtons(panel5, editLayoutTurnoutFrame.getRootPane(), 
+                    this::editTracksegmentDonePressed, this::editTrackSegmentCancelPressed);
             contentPane.add(panel5);
         }
         // Set up for Edit
@@ -423,8 +427,6 @@ public class LayoutTrackEditors {
     private JComboBox<String> editLayoutTurnoutStateComboBox = new JComboBox<String>();
     private JCheckBox editLayoutTurnoutHiddenCheckBox = new JCheckBox(Bundle.getMessage("HideTurnout"));  // NOI18N
     private JButton editLayoutTurnoutBlockButton;
-    private JButton editLayoutTurnoutDoneButton;
-    private JButton editLayoutTurnoutCancelButton;
     private JButton editLayoutTurnoutBlockBButton;
     private JButton editLayoutTurnoutBlockCButton;
     private JButton editLayoutTurnoutBlockDButton;
@@ -626,26 +628,9 @@ public class LayoutTrackEditors {
             // Edit Block
 
             editLayoutTurnoutBlockButton.setToolTipText(Bundle.getMessage("EditBlockHint", "")); // empty value for block 1  // NOI18N
-            // Done
-            panel5.add(editLayoutTurnoutDoneButton = new JButton(Bundle.getMessage("ButtonDone")));  // NOI18N
-
-            // make this button the default button (return or enter activates)
-            // Note: We have to invoke this later because we don't currently have a root pane
-            SwingUtilities.invokeLater(() -> {
-                JRootPane rootPane = SwingUtilities.getRootPane(editLayoutTurnoutDoneButton);
-                rootPane.setDefaultButton(editLayoutTurnoutDoneButton);
-            });
-
-            editLayoutTurnoutDoneButton.addActionListener((ActionEvent e) -> {
-                editLayoutTurnoutDonePressed(e);
-            });
-            editLayoutTurnoutDoneButton.setToolTipText(Bundle.getMessage("DoneHint", Bundle.getMessage("ButtonDone")));  // NOI18N
-            // Cancel
-            panel5.add(editLayoutTurnoutCancelButton = new JButton(Bundle.getMessage("ButtonCancel")));  // NOI18N
-            editLayoutTurnoutCancelButton.addActionListener((ActionEvent e) -> {
-                editLayoutTurnoutCancelPressed(e);
-            });
-            editLayoutTurnoutCancelButton.setToolTipText(Bundle.getMessage("CancelHint", Bundle.getMessage("ButtonCancel")));  // NOI18N
+            
+            addDoneCancelButtons(panel5, editLayoutTurnoutFrame.getRootPane(), 
+                    this::editLayoutTurnoutDonePressed, this::editLayoutTurnoutCancelPressed);
             contentPane.add(panel5);
         }
 


### PR DESCRIPTION
Not sure whether this is actually needed - I didn't yet absorb the workflow in JMRI well. But those dialogs (although `JFrame`s) have standard `Done`, `Cancel` buttons, Done is the default one (ENTER), but ESC does not trigger cancel.

In case missing `ESC` is a bug rather than feature, please consider this PR. It just uses `InputMap` of the ancestor `RootPane` to bind the key to a standard window close action (implemented by LaF).

The other change was to just extract the standard buttons part from the two windows, as they should appear in the same order.