### PR TITLE
Update schema to allow 1=2 indexed CV syntax

### DIFF
--- a/xml/schema/types/general.xsd
+++ b/xml/schema/types/general.xsd
@@ -379,6 +379,8 @@
           As a special case, when there's more than one group, the 1st can be alpha numeric to indicate the type
           of formatting, e.g. "T2CV.12.34" for TCS.
           
+          Each of the n groups in n.n et al can actually be n=n with a single equals sign.
+          
           Commas, hyphens, dollar signs and quotes (single or double) need to remain 
           reserved away from CV names to permit later grouping of CV names
           in other contexts.
@@ -386,7 +388,7 @@
         </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:normalizedString">
-      <xs:pattern value="([0-9]*)|(([0-9]*\.)*[0-9]*)|[a-zA-Z0-9]*\.(([0-9]*\.)*[0-9]*)"/>
+      <xs:pattern value="([0-9]*)|[a-zA-Z0-9]*\.(([0-9]*(=[0-9]*)?\.)*([0-9]*=)?[0-9]*)"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/xml/schema/types/general.xsd
+++ b/xml/schema/types/general.xsd
@@ -388,7 +388,7 @@
         </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:normalizedString">
-      <xs:pattern value="([0-9]*)|[a-zA-Z0-9]*\.(([0-9]*(=[0-9]*)?\.)*([0-9]*=)?[0-9]*)"/>
+      <xs:pattern value="([0-9]*)|[a-zA-Z0-9]*(=[0-9]*)?\.(([0-9]*(=[0-9]*)?\.)*([0-9]*=)?[0-9]*)"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
This updates the decoder schema (cvNameType) to allow the extended syntax implemented in #6616 