### PR TITLE
More flexible syntax for specifying outputs  in decoder definitions

### DIFF
--- a/java/src/jmri/jmrit/decoderdefn/DecoderIndexFile.java
+++ b/java/src/jmri/jmrit/decoderdefn/DecoderIndexFile.java
@@ -552,7 +552,7 @@ public class DecoderIndexFile extends XmlFile {
         // create root element and document
         Element root = new Element("decoderIndex-config");
         root.setAttribute("noNamespaceSchemaLocation",
-                "http://jmri.org/xml/schema/decoder.xsd",
+                "http://jmri.org/xml/schema/decoder-4-15-2.xsd",
                 org.jdom2.Namespace.getNamespace("xsi",
                         "http://www.w3.org/2001/XMLSchema-instance"));
 

--- a/java/src/jmri/jmrit/symbolicprog/FnMapPanel.java
+++ b/java/src/jmri/jmrit/symbolicprog/FnMapPanel.java
@@ -10,8 +10,9 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import jmri.jmrit.symbolicprog.tabbedframe.PaneProgPane;
 import jmri.util.jdom.LocaleSelector;
-import org.jdom2.Attribute;
-import org.jdom2.Element;
+
+import org.jdom2.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -307,7 +308,7 @@ public class FnMapPanel extends JPanel {
     }
 
     /**
-     * Use the "model" element from the decoder definition file to configure the
+     * Use the "family" and "model" element from the decoder definition file to configure the
      * number of outputs and set up any that are named instead of numbered.
      */
     protected void configOutputs(Element model) {
@@ -315,6 +316,15 @@ public class FnMapPanel extends JPanel {
             log.debug("configOutputs was given a null model");
             return;
         }
+        Element family = null;
+        Parent parent = model.getParent();
+        if (parent != null && parent instanceof Element) {
+            family = (Element) parent;
+        } else {
+            log.debug("configOutputs found an invalid parent family");
+            return;
+        }
+        
         // get numOuts, numFns or leave the defaults
         Attribute a = model.getAttribute("numOuts");
         try {
@@ -336,7 +346,10 @@ public class FnMapPanel extends JPanel {
             log.debug("numFns, numOuts " + numFn + "," + numOut);
         }
         // take all "output" children
-        List<Element> elemList = model.getChildren("output");
+        List<Element> elemList = new ArrayList<>();
+        elemList.addAll(family.getChildren("output"));
+        elemList.addAll(model.getChildren("output"));
+                
         if (log.isDebugEnabled()) {
             log.debug("output scan starting with " + elemList.size() + " elements");
         }

--- a/java/src/jmri/jmrit/symbolicprog/FnMapPanel.java
+++ b/java/src/jmri/jmrit/symbolicprog/FnMapPanel.java
@@ -345,17 +345,18 @@ public class FnMapPanel extends JPanel {
         if (log.isDebugEnabled()) {
             log.debug("numFns, numOuts " + numFn + "," + numOut);
         }
+        
         // take all "output" children
         List<Element> elemList = new ArrayList<>();
-        elemList.addAll(family.getChildren("output"));
-        elemList.addAll(model.getChildren("output"));
+        addOutputElements(family.getChildren(), elemList);
+        addOutputElements(model.getChildren(), elemList);
                 
-        if (log.isDebugEnabled()) {
-            log.debug("output scan starting with " + elemList.size() + " elements");
-        }
+        log.debug("output scan starting with {} elements", elemList.size());
+
         for (int i = 0; i < elemList.size(); i++) {
             Element e = elemList.get(i);
             String name = e.getAttribute("name").getValue();
+            log.debug("name: {} label: {}", e.getAttribute("name").getValue(), e.getAttribute("label").getValue());
             // if this a number, or a character name?
             try {
                 int outputNum = Integer.parseInt(name);
@@ -382,6 +383,18 @@ public class FnMapPanel extends JPanel {
         }
     }
 
+    void addOutputElements(List<Element> input, List<Element> accumulate) {
+      for (Element elem : input) {
+        if (elem.getName().equals("outputs")) {
+          log.debug(" found outputs element of size {}", elem.getChildren().size());
+          addOutputElements(elem.getChildren(), accumulate);
+        } else if (elem.getName().equals("output")) {
+          log.debug("adding output element {} {}", elem.getAttribute("name").getValue(), elem.getAttribute("label").getValue());
+          accumulate.add(elem);
+        }
+      }
+    }
+    
     // split and load two-line labels
     void loadSplitLabel(int iOut, String theLabel) {
         if (iOut < maxOut) {

--- a/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
+++ b/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
@@ -22,10 +22,9 @@ import jmri.jmrit.roster.RosterEntry;
 import jmri.jmrit.symbolicprog.tabbedframe.PaneProgPane;
 import jmri.util.FileUtil;
 import jmri.util.jdom.LocaleSelector;
-import org.jdom2.Attribute;
-import org.jdom2.DocType;
-import org.jdom2.Document;
-import org.jdom2.Element;
+
+import org.jdom2.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -748,6 +747,15 @@ public class FnMapPanelESU extends JPanel {
             log.debug("configOutputs was given a null model");
             return;
         }
+        Element family = null;
+        Parent parent = model.getParent();
+        if (parent != null && parent instanceof Element) {
+            family = (Element) parent;
+        } else {
+            log.debug("configOutputs found an invalid parent family");
+            return;
+        }
+
         // get numOuts, numFns or leave the defaults
         Attribute a = model.getAttribute("numOuts");
         try {
@@ -781,8 +789,11 @@ public class FnMapPanelESU extends JPanel {
         }
 
         // take all "output" children
-        List<Element> elemList = model.getChildren("output");
+        List<Element> elemList = new ArrayList<>();
+        elemList.addAll(family.getChildren("output"));
+        elemList.addAll(model.getChildren("output"));
         log.debug("output scan starting with {} elements", elemList.size());
+        
         for (int i = 0; i < elemList.size(); i++) {
             Element e = elemList.get(i);
             String name = e.getAttribute("name").getValue();

--- a/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
+++ b/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
@@ -790,8 +790,9 @@ public class FnMapPanelESU extends JPanel {
 
         // take all "output" children
         List<Element> elemList = new ArrayList<>();
-        elemList.addAll(family.getChildren("output"));
-        elemList.addAll(model.getChildren("output"));
+        addOutputElements(family.getChildren(), elemList);
+        addOutputElements(model.getChildren(), elemList);
+                
         log.debug("output scan starting with {} elements", elemList.size());
         
         for (int i = 0; i < elemList.size(); i++) {
@@ -819,6 +820,18 @@ public class FnMapPanelESU extends JPanel {
                 }
             }
         }
+    }
+
+    void addOutputElements(List<Element> input, List<Element> accumulate) {
+      for (Element elem : input) {
+        if (elem.getName().equals("outputs")) {
+          log.debug(" found outputs element of size {}", elem.getChildren().size());
+          addOutputElements(elem.getChildren(), accumulate);
+        } else if (elem.getName().equals("output")) {
+          log.debug("adding output element {} {}", elem.getAttribute("name").getValue(), elem.getAttribute("label").getValue());
+          accumulate.add(elem);
+        }
+      }
     }
 
     // split and load labels

--- a/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
+++ b/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
@@ -5,7 +5,7 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.util.List;
+import java.util.*;
 import java.util.MissingResourceException;
 import java.util.stream.IntStream;
 import javax.swing.ButtonGroup;

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
-<decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <!--Written by JMRI version 4.15.4ish+jake+20190221T1837Z+R68612e21e1 on Thu Feb 21 10:37:23 PST 2019-->
-  <decoderIndex version="928">
+<decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <!--Written by JMRI version 4.15.4ish+jake+20190308T1351Z+Ra117808886 on Fri Mar 08 05:51:09 PST 2019-->
+  <decoderIndex version="936">
     <mfgList nmraListDate="2015-03-06" updated="2015-03-25" lastadd="107,124,126,128,134">
       <manufacturer mfg="NMRA" mfgID="999" />
       <manufacturer mfg="A-Train Electronics" mfgID="137" />
@@ -159,6 +159,24 @@
     </mfgList>
     <familyList>
       <family name="NMRA standard CV definitions" mfg="NMRA" file="0NMRA.xml">
+        <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+        <!-- Copyright (C) JMRI 2001, 2005, 2007, 2009, 2010 All rights reserved -->
+        <!--                                                                        -->
+        <!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+        <!-- the terms of version 2 of the GNU General Public License as published  -->
+        <!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+        <!-- of this license.                                                       -->
+        <!--                                                                        -->
+        <!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+        <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+        <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+        <!-- for more details.  -->
+        <outputs xmlns:docbook="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+          <output name="1" label="White" connection="plug" />
+          <output name="2" label="Yellow" connection="plug" />
+          <output name="3" label="Green" connection="wire" />
+          <output name="4" label="Violet" connection="wire" />
+        </outputs>
         <model model="NMRA standard CV definitions" />
       </family>
       <family name="NMRA accessory decoders" mfg="NMRA" file="0NMRA_accessory.xml">
@@ -2228,22 +2246,30 @@
         </functionlabels>
       </family>
       <family name="Digitrax/Con-cor Sound" mfg="Digitrax" file="Digitrax_1SFX.xml">
-        <model model="Con-cor Aero-Train - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6004" comment="SDH164D Con-Cor #0001-006004">
+        <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+        <!-- Copyright (C) JMRI 2001, 2005, 2007, 2009, 2010 All rights reserved -->
+        <!--                                                                        -->
+        <!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+        <!-- the terms of version 2 of the GNU General Public License as published  -->
+        <!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+        <!-- of this license.                                                       -->
+        <!--                                                                        -->
+        <!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+        <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+        <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+        <!-- for more details.  -->
+        <outputs xmlns:docbook="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <output name="1" label="White" connection="plug" />
           <output name="2" label="Yellow" connection="plug" />
           <output name="3" label="Green" connection="wire" />
           <output name="4" label="Violet" connection="wire" />
+        </outputs>
+        <model model="Con-cor Aero-Train - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6004" comment="SDH164D Con-Cor #0001-006004">
           <output name="5" label="Brown" connection="wire" />
           <output name="6" label="White-Yellow" connection="wire" />
           <size length="1.273" width="0.67" height="0.25" units="inches" />
         </model>
         <model model="Con-cor ElectroLiner - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6005" comment="SDH164D Con-Cor #0001-006005">
-          <output name="1" label="White" connection="plug" />
-          <output name="2" label="Yellow" connection="plug" />
-          <output name="3" label="Green" connection="wire" />
-          <output name="4" label="Violet" connection="wire" />
-          <output name="5" label="Brown" connection="wire" />
-          <output name="6" label="White-Yellow" connection="wire" />
           <size length="1.273" width="0.67" height="0.25" units="inches" />
           <functionlabels>
             <functionlabel num="3" lockable="true">Open Door/Close - Track Squeals</functionlabel>
@@ -2258,12 +2284,6 @@
           </functionlabels>
         </model>
         <model model="Con-cor Galloping Goose - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6008" comment="SDH164D Con-Cor #0001-006008">
-          <output name="1" label="White" connection="plug" />
-          <output name="2" label="Yellow" connection="plug" />
-          <output name="3" label="Green" connection="wire" />
-          <output name="4" label="Violet" connection="wire" />
-          <output name="5" label="Brown" connection="wire" />
-          <output name="6" label="White-Yellow" connection="wire" />
           <size length="1.273" width="0.67" height="0.25" units="inches" />
           <functionlabels>
             <functionlabel num="5" lockable="true" />
@@ -2272,12 +2292,6 @@
           </functionlabels>
         </model>
         <model model="Con-cor MP54" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6009" comment="SDH164D Con-Cor #0001-006009">
-          <output name="1" label="White" connection="plug" />
-          <output name="2" label="Yellow" connection="plug" />
-          <output name="3" label="Green" connection="wire" />
-          <output name="4" label="Violet" connection="wire" />
-          <output name="5" label="Brown" connection="wire" />
-          <output name="6" label="White-Yellow" connection="wire" />
           <size length="1.273" width="0.67" height="0.25" units="inches" />
           <functionlabels>
             <functionlabel num="3" lockable="false">Track Squeals</functionlabel>
@@ -2292,12 +2306,6 @@
           </functionlabels>
         </model>
         <model model="Con-cor New Haven Comet - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6001" comment="SDH164D Con-Cor #0001-006001">
-          <output name="1" label="White" connection="plug" />
-          <output name="2" label="Yellow" connection="plug" />
-          <output name="3" label="Green" connection="wire" />
-          <output name="4" label="Violet" connection="wire" />
-          <output name="5" label="Brown" connection="wire" />
-          <output name="6" label="White-Yellow" connection="wire" />
           <size length="1.273" width="0.67" height="0.25" units="inches" />
           <functionlabels>
             <functionlabel num="3" lockable="true" />
@@ -2305,12 +2313,6 @@
           </functionlabels>
         </model>
         <model model="Con-cor UP M-10000 - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6003" comment="SDH164D Con-Cor #0001-006003">
-          <output name="1" label="White" connection="plug" />
-          <output name="2" label="Yellow" connection="plug" />
-          <output name="3" label="Green" connection="wire" />
-          <output name="4" label="Violet" connection="wire" />
-          <output name="5" label="Brown" connection="wire" />
-          <output name="6" label="White-Yellow" connection="wire" />
           <size length="1.273" width="0.67" height="0.25" units="inches" />
           <functionlabels>
             <functionlabel num="3" lockable="true" />
@@ -2318,36 +2320,18 @@
           </functionlabels>
         </model>
         <model model="Con-cor Zephyr - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6002" comment="SDH164D Con-Cor #0001-006002">
-          <output name="1" label="White" connection="plug" />
-          <output name="2" label="Yellow" connection="plug" />
-          <output name="3" label="Green" connection="wire" />
-          <output name="4" label="Violet" connection="wire" />
-          <output name="5" label="Brown" connection="wire" />
-          <output name="6" label="White-Yellow" connection="wire" />
           <size length="1.273" width="0.67" height="0.25" units="inches" />
           <functionlabels>
             <functionlabel num="3" lockable="true">Mars Light</functionlabel>
           </functionlabels>
         </model>
         <model model="Con-cor Aero-Train - N" numOuts="4" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="N" connector="NMRAmedium" productID="6019" comment="SDN144PS Con-Cor #0001-006019">
-          <output name="1" label="White" connection="plug" />
-          <output name="2" label="Yellow" connection="plug" />
-          <output name="3" label="Green" connection="wire" />
-          <output name="4" label="Violet" connection="wire" />
           <size length="1.22" width="0.4" height="0.164" units="inches" />
         </model>
         <model model="Con-cor UP M-10000 - N" numOuts="4" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="N" connector="NMRAmedium" productID="6011" comment="SDN144PS Con-Cor #0001-006011">
-          <output name="1" label="White" connection="plug" />
-          <output name="2" label="Yellow" connection="plug" />
-          <output name="3" label="Green" connection="wire" />
-          <output name="4" label="Violet" connection="wire" />
           <size length="1.22" width="0.4" height="0.164" units="inches" />
         </model>
         <model model="Con-cor Zephyr - N" numOuts="4" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="N" connector="NMRAmedium" productID="6014" comment="SDN144PS Con-Cor #0001-006014">
-          <output name="1" label="White" connection="plug" />
-          <output name="2" label="Yellow" connection="plug" />
-          <output name="3" label="Green" connection="wire" />
-          <output name="4" label="Violet" connection="wire" />
           <size length="1.22" width="0.4" height="0.164" units="inches" />
           <functionlabels>
             <functionlabel num="3" lockable="true">Mars Light</functionlabel>
@@ -2421,6 +2405,9 @@
       <family name="Command Stations" mfg="Digitrax" file="Digitrax_DCS240_DCS210.xml">
         <model model="DCS210" />
         <model model="DCS240" />
+      </family>
+      <family name="Command Stations" mfg="Digitrax" file="Digitrax_DCS52.xml">
+        <model model="DCS52" />
       </family>
       <family name="Command Stations" mfg="Digitrax" file="Digitrax_DCS5x.xml">
         <model model="DCS50" />
@@ -33324,6 +33311,97 @@
       <family name="Mini-Function Decoder" mfg="Uhlenbrock Elektronik" file="Uhlenbrock_73900.xml">
         <model model="73900" />
       </family>
+      <family name="IntelliDrive2" mfg="Uhlenbrock Elektronik" comment="Decoders not sorted (necessarily) in numerical order" file="Uhlenbrock_73xx5.xml">
+        <!-- to be checked by hardware owner -->
+        <model model="73105" numOuts="4" numFns="14" maxMotorCurrent="0.8A" formFactor="N" connector="Next18" productID="73105" comment="IntelliDrive2 Mini-Lokdecoder and RailCom(R) (Plus)">
+          <output name="1" label="F0(f)" connection="plug" maxcurrent="400 mA" />
+          <output name="2" label="F0(r)" connection="plug" maxcurrent="400 mA" />
+          <output name="3" label=". A1 ." connection="plug" maxcurrent="400 mA" />
+          <output name="4" label=". A2 ." connection="plug" maxcurrent="400 mA" />
+          <output name="Shunting" label="mode" />
+          <output name="Start/brake" label="inertia" />
+          <size length="14.7" width="8.6" height="2.9" units="mm" />
+        </model>
+        <model model="73115" numOuts="2" numFns="14" maxMotorCurrent="0.8A" formFactor="HO" connector="NEM651" productID="73115" comment="IntelliDrive2 Mini-Lokdecoder and RailCom(R) (Plus)">
+          <output name="1" label="F0(f)" connection="plug" maxcurrent="400 mA" />
+          <output name="2" label="F0(r)" connection="plug" maxcurrent="400 mA" />
+          <output name="Shunting" label="mode" />
+          <output name="Start/brake" label="inertia" />
+          <size length="9.5" width="7.8" height="2.4" units="mm" />
+        </model>
+        <model model="73145" numOuts="4" numFns="14" maxMotorCurrent="0.8A" formFactor="HO" connector="PluX12" productID="73145" comment="IntelliDrive2 Mini-Lokdecoder and RailCom(R) (Plus)">
+          <output name="1" label="F0(f)" connection="plug" maxcurrent="400 mA" />
+          <output name="2" label="F0(r)" connection="plug" maxcurrent="400 mA" />
+          <output name="3" label=". A1 ." connection="plug" maxcurrent="400 mA" />
+          <output name="4" label=". A2 ." connection="plug" maxcurrent="400 mA" />
+          <output name="Shunting" label="mode" />
+          <output name="Start/brake" label="inertia" />
+          <size length="15" width="8.6" height="3.2" units="mm" />
+        </model>
+        <model model="73235" numOuts="10" numFns="14" maxMotorCurrent="1.2A" formFactor="HO" connector="Next18" productID="73235" comment="IntelliDrive2 Lokdecoder and RailCom(R) (Plus)">
+          <output name="1" label="F0(f)" connection="plug" maxcurrent="400 mA" />
+          <output name="2" label="F0(r)" connection="plug" maxcurrent="400 mA" />
+          <output name="3" label=". A1 ." connection="plug" maxcurrent="400 mA" />
+          <output name="4" label=". A2 ." connection="plug" maxcurrent="400 mA" />
+          <output name="5" label=". A3 ." connection="plug" maxcurrent="400 mA" />
+          <output name="6" label=". A4 ." connection="plug" maxcurrent="400 mA" />
+          <output name="7" label=". A5 ." connection="plug" maxcurrent="400 mA" />
+          <output name="8" label=". A6 ." connection="plug" maxcurrent="400 mA" />
+          <output name="9" label=". A7 ." connection="plug" maxcurrent="400 mA" />
+          <output name="10" label=". A8 ." connection="plug" maxcurrent="400 mA" />
+          <output name="Shunting" label="mode" />
+          <output name="Start/brake" label="inertia" />
+          <size length="30.2" width="16" height="3.8" units="mm" />
+        </model>
+        <model model="73405" numOuts="4" numFns="14" maxMotorCurrent="0.7A" formFactor="N" connector="Wires" productID="73405" comment="IntelliDrive2 Mini-Lokdecoder and RailCom(R) (Plus)">
+          <output name="1" label="F0(f)" connection="plug" maxcurrent="400 mA" />
+          <output name="2" label="F0(r)" connection="plug" maxcurrent="400 mA" />
+          <output name="3" label=". A1 ." connection="plug" maxcurrent="400 mA" />
+          <output name="4" label=". A2 ." connection="plug" maxcurrent="400 mA" />
+          <output name="Shunting" label="mode" />
+          <output name="Start/brake" label="inertia" />
+          <size length="9.5" width="7.8" height="2.4" units="mm" />
+        </model>
+        <model model="73415" numOuts="4" numFns="14" maxMotorCurrent="0.7A" formFactor="N" connector="NEM651" productID="73415" comment="IntelliDrive2 Mini-Lokdecoder and RailCom(R) (Plus)">
+          <output name="1" label="F0(f)" connection="plug" maxcurrent="400 mA" />
+          <output name="2" label="F0(r)" connection="plug" maxcurrent="400 mA" />
+          <output name="3" label=". A1 ." connection="plug" maxcurrent="400 mA" />
+          <output name="4" label=". A2 ." connection="plug" maxcurrent="400 mA" />
+          <output name="Shunting" label="mode" />
+          <output name="Start/brake" label="inertia" />
+          <size length="9.5" width="7.8" height="2.4" units="mm" />
+        </model>
+        <model model="PIKO41RH2400" numOuts="10" numFns="14" maxMotorCurrent="1.2A" formFactor="N" connector="Next18" productID="PIKO41RH2400" comment="Piko SmartDecoder 4.1 Sound Diesel Loco Rh2400 Next18 plug and RailCom(R) (Plus)">
+          <output name="1" label="F0(f)" connection="plug" maxcurrent="400 mA" />
+          <output name="2" label="F0(r)" connection="plug" maxcurrent="400 mA" />
+          <output name="3" label=". A1 ." connection="plug" maxcurrent="400 mA" />
+          <output name="4" label=". A2 ." connection="plug" maxcurrent="400 mA" />
+          <output name="5" label=". A3 ." connection="plug" maxcurrent="400 mA" />
+          <output name="6" label=". A4 ." connection="plug" maxcurrent="400 mA" />
+          <output name="7" label=". A5 ." connection="plug" maxcurrent="400 mA" />
+          <output name="8" label=". A6 ." connection="plug" maxcurrent="400 mA" />
+          <output name="9" label=". A7 ." connection="plug" maxcurrent="400 mA" />
+          <output name="10" label=". A8 ." connection="plug" maxcurrent="400 mA" />
+          <output name="Shunting" label="mode" />
+          <output name="Start/brake" label="inertia" />
+          <size length="30.2" width="16" height="3.8" units="mm" />
+        </model>
+        <model model="PIKO41BR82" numOuts="10" numFns="14" maxMotorCurrent="1.2A" formFactor="N" connector="Next18" productID="PIKO41BR82" comment="Piko SmartDecoder 4.1 Sound Steam Loco BR82 Next18 plug and RailCom(R) (Plus)">
+          <output name="1" label="F0(f)" connection="plug" maxcurrent="400 mA" />
+          <output name="2" label="F0(r)" connection="plug" maxcurrent="400 mA" />
+          <output name="3" label=". A1 ." connection="plug" maxcurrent="400 mA" />
+          <output name="4" label=". A2 ." connection="plug" maxcurrent="400 mA" />
+          <output name="5" label=". A3 ." connection="plug" maxcurrent="400 mA" />
+          <output name="6" label=". A4 ." connection="plug" maxcurrent="400 mA" />
+          <output name="7" label=". A5 ." connection="plug" maxcurrent="400 mA" />
+          <output name="8" label=". A6 ." connection="plug" maxcurrent="400 mA" />
+          <output name="9" label=". A7 ." connection="plug" maxcurrent="400 mA" />
+          <output name="10" label=". A8 ." connection="plug" maxcurrent="400 mA" />
+          <output name="Shunting" label="mode" />
+          <output name="Start/brake" label="inertia" />
+          <size length="30.2" width="16" height="3.8" units="mm" />
+        </model>
+      </family>
       <family name="Standard Decoder" mfg="Uhlenbrock Elektronik" lowVersionID="1" highVersionID="20" file="Uhlenbrock_74400.xml">
         <model model="74400" />
         <model model="74420" />
@@ -33351,7 +33429,7 @@
           <output name="4" label=". A2 ." connection="plug" />
           <output name="Shunting" label="mode" />
           <output name="Start/brake" label="inertia" />
-          <size length="22" width="15" height="3,8" units="mm" />
+          <size length="22" width="15" height="3.8" units="mm" />
         </model>
         <model model="76320" numOuts="2" numFns="14" maxMotorCurrent="1.20" formFactor="HO" connector="NEM652" productID="76320" comment="HO-Scale, IntelliDrive Comfort with NEM652 plug (Piko #56122)">
           <output name="1" label="F0(F)" connection="plug" />

--- a/xml/decoderIndex.xml
+++ b/xml/decoderIndex.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="/xml/XSLT/DecoderID.xsl" type="text/xsl"?>
 <decoderIndex-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-  <!--Written by JMRI version 4.15.4ish+jake+20190308T1351Z+Ra117808886 on Fri Mar 08 05:51:09 PST 2019-->
-  <decoderIndex version="936">
+  <!--Written by JMRI version 4.15.4ish+jake+20190308T1702Z+R585f89d137 on Fri Mar 08 09:02:30 PST 2019-->
+  <decoderIndex version="944">
     <mfgList nmraListDate="2015-03-06" updated="2015-03-25" lastadd="107,124,126,128,134">
       <manufacturer mfg="NMRA" mfgID="999" />
       <manufacturer mfg="A-Train Electronics" mfgID="137" />
@@ -160,17 +160,6 @@
     <familyList>
       <family name="NMRA standard CV definitions" mfg="NMRA" file="0NMRA.xml">
         <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
-        <!-- Copyright (C) JMRI 2001, 2005, 2007, 2009, 2010 All rights reserved -->
-        <!--                                                                        -->
-        <!-- JMRI is free software; you can redistribute it and/or modify it under  -->
-        <!-- the terms of version 2 of the GNU General Public License as published  -->
-        <!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
-        <!-- of this license.                                                       -->
-        <!--                                                                        -->
-        <!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
-        <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
-        <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
-        <!-- for more details.  -->
         <outputs xmlns:docbook="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
           <output name="1" label="White" connection="plug" />
           <output name="2" label="Yellow" connection="plug" />
@@ -2246,24 +2235,6 @@
         </functionlabels>
       </family>
       <family name="Digitrax/Con-cor Sound" mfg="Digitrax" file="Digitrax_1SFX.xml">
-        <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
-        <!-- Copyright (C) JMRI 2001, 2005, 2007, 2009, 2010 All rights reserved -->
-        <!--                                                                        -->
-        <!-- JMRI is free software; you can redistribute it and/or modify it under  -->
-        <!-- the terms of version 2 of the GNU General Public License as published  -->
-        <!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
-        <!-- of this license.                                                       -->
-        <!--                                                                        -->
-        <!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
-        <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
-        <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
-        <!-- for more details.  -->
-        <outputs xmlns:docbook="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
-          <output name="1" label="White" connection="plug" />
-          <output name="2" label="Yellow" connection="plug" />
-          <output name="3" label="Green" connection="wire" />
-          <output name="4" label="Violet" connection="wire" />
-        </outputs>
         <model model="Con-cor Aero-Train - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6004" comment="SDH164D Con-Cor #0001-006004">
           <output name="5" label="Brown" connection="wire" />
           <output name="6" label="White-Yellow" connection="wire" />
@@ -2337,6 +2308,13 @@
             <functionlabel num="3" lockable="true">Mars Light</functionlabel>
           </functionlabels>
         </model>
+        <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+        <outputs xmlns:docbook="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+          <output name="1" label="White" connection="plug" />
+          <output name="2" label="Yellow" connection="plug" />
+          <output name="3" label="Green" connection="wire" />
+          <output name="4" label="Violet" connection="wire" />
+        </outputs>
         <functionlabels>
           <functionlabel num="0" lockable="true">Headlight</functionlabel>
           <functionlabel num="1" lockable="true">Bell</functionlabel>

--- a/xml/decoders/0NMRA.xml
+++ b/xml/decoders/0NMRA.xml
@@ -12,16 +12,52 @@
 <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
-<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
-  <version author="Alain Le Marchand" version="7" lastUpdated="20180102"/>
-  <version author="Bob Jacobsen" version="6" lastUpdated="20100312"/>
-  <version author="Bob Jacobsen" version="5" lastUpdated="20031205"/>
-  <!-- version 3 - add consist direction - jake -->
-  <!-- version 4 - Minor formatting changes - Jack Shall -->
-  <!-- version 6 - Start of I8N -->
-  <!-- version 7 - French trasnlation -->
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+  <copyright xmlns="http://docbook.org/ns/docbook">
+    <year>2000</year>
+    <year>2010</year>
+    <year>2019</year>
+    <holder>JMRI</holder>
+  </copyright>
+  <authorgroup xmlns="http://docbook.org/ns/docbook">
+    <author>
+      <personname><firstname>Jack</firstname><surname>Shall</surname></personname>
+    </author>
+    <author>
+      <personname><firstname>Alain</firstname><surname>Le Marchand</surname></personname>
+    </author>
+    <author>
+      <personname><firstname>Bob</firstname><surname>Jacobsen</surname></personname>
+    </author>
+  </authorgroup>
+  <revhistory xmlns="http://docbook.org/ns/docbook">
+    <revision>
+      <revnumber>3</revnumber><date>2002?</date><authorinitials>BJ</authorinitials>
+      <revremark>Add consist direction</revremark>
+    </revision>
+    <revision>
+      <revnumber>4</revnumber><date>2003?</date><authorinitials>JS</authorinitials>
+      <revremark>Minor formatting changes</revremark>
+    </revision>
+    <revision>
+      <revnumber>5</revnumber><date>2003-12-05</date><authorinitials>BJ</authorinitials>
+    </revision>
+    <revision>
+      <revnumber>6</revnumber><date>2010-03-12</date><authorinitials>BJ</authorinitials>
+      <revremark>Start of I8N </revremark>
+    </revision>
+    <revision>
+      <revnumber>7</revnumber><date>2018-01-02</date><authorinitials>ALM</authorinitials>
+      <revremark>French translation</revremark>
+    </revision>
+    <revision>
+      <revnumber>8</revnumber><date>2019-03-10</date><authorinitials>BJ</authorinitials>
+      <revremark>se included output definition</revremark>
+    </revision>
+  </revhistory>
   <decoder>
     <family name="NMRA standard CV definitions" mfg="NMRA">
+      <xi:include href="http://jmri.org/xml/decoders/nmra/outputs1-4.xml"/>
       <model model="NMRA standard CV definitions"/>
     </family>
     <programming direct="yes" paged="yes" register="yes" ops="yes"/>

--- a/xml/decoders/Digitrax_1SFX.xml
+++ b/xml/decoders/Digitrax_1SFX.xml
@@ -28,18 +28,13 @@
   <!--    Added several Con-cor models H0 and N                                   -->
   <decoder>
     <family name="Digitrax/Con-cor Sound" mfg="Digitrax">
-        <output name="1" label="White" connection="plug"/>
-        <output name="2" label="Yellow" connection="plug"/>
-        <output name="3" label="Green" connection="wire"/>
-        <output name="4" label="Violet" connection="wire"/>
-      <model model="Con-cor Aero-Train - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6004" comment="SDH164D Con-Cor #0001-006004">
+        <xi:include href="http://jmri.org/xml/decoders/nmra/outputs1-4.xml"/>
+        <model model="Con-cor Aero-Train - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6004" comment="SDH164D Con-Cor #0001-006004">
         <output name="5" label="Brown" connection="wire"/>
         <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
       </model>
       <model model="Con-cor ElectroLiner - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6005" comment="SDH164D Con-Cor #0001-006005">
-        <output name="5" label="Brown" connection="wire"/>
-        <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
         <functionlabels>
           <functionlabel num="3" lockable="true">Open Door/Close - Track Squeals</functionlabel>
@@ -54,8 +49,6 @@
         </functionlabels>
       </model>
       <model model="Con-cor Galloping Goose - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6008" comment="SDH164D Con-Cor #0001-006008">
-        <output name="5" label="Brown" connection="wire"/>
-        <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
         <functionlabels>
           <functionlabel num="5" lockable="true"/>
@@ -64,8 +57,6 @@
         </functionlabels>
       </model>
       <model model="Con-cor MP54" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6009" comment="SDH164D Con-Cor #0001-006009">
-        <output name="5" label="Brown" connection="wire"/>
-        <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
         <functionlabels>
           <functionlabel num="3" lockable="false">Track Squeals</functionlabel>
@@ -80,8 +71,6 @@
         </functionlabels>
       </model>
       <model model="Con-cor New Haven Comet - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6001" comment="SDH164D Con-Cor #0001-006001">
-        <output name="5" label="Brown" connection="wire"/>
-        <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
         <functionlabels>
           <functionlabel num="3" lockable="true"/>
@@ -89,8 +78,6 @@
         </functionlabels>
       </model>
       <model model="Con-cor UP M-10000 - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6003" comment="SDH164D Con-Cor #0001-006003">
-        <output name="5" label="Brown" connection="wire"/>
-        <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
         <functionlabels>
           <functionlabel num="3" lockable="true"/>
@@ -98,8 +85,6 @@
         </functionlabels>
       </model>
       <model model="Con-cor Zephyr - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6002" comment="SDH164D Con-Cor #0001-006002">
-        <output name="5" label="Brown" connection="wire"/>
-        <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
         <functionlabels>
           <functionlabel num="3" lockable="true">Mars Light</functionlabel>

--- a/xml/decoders/Digitrax_1SFX.xml
+++ b/xml/decoders/Digitrax_1SFX.xml
@@ -28,8 +28,7 @@
   <!--    Added several Con-cor models H0 and N                                   -->
   <decoder>
     <family name="Digitrax/Con-cor Sound" mfg="Digitrax">
-        <xi:include href="http://jmri.org/xml/decoders/nmra/outputs1-4.xml"/>
-        <model model="Con-cor Aero-Train - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6004" comment="SDH164D Con-Cor #0001-006004">
+      <model model="Con-cor Aero-Train - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6004" comment="SDH164D Con-Cor #0001-006004">
         <output name="5" label="Brown" connection="wire"/>
         <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
@@ -102,6 +101,7 @@
           <functionlabel num="3" lockable="true">Mars Light</functionlabel>
         </functionlabels>
       </model>
+      <xi:include href="http://jmri.org/xml/decoders/nmra/outputs1-4.xml"/>
       <functionlabels>
         <functionlabel num="0" lockable="true">Headlight</functionlabel>
         <functionlabel num="1" lockable="true">Bell</functionlabel>

--- a/xml/decoders/Digitrax_1SFX.xml
+++ b/xml/decoders/Digitrax_1SFX.xml
@@ -12,7 +12,7 @@
 <!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
-<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+<decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
   <version author="Alain Le Marchand" version="2" lastUpdated="20140427"/>
   <version author="Steve Lowens" version="1" lastUpdated="20120703"/>
   <!--    Added Con-cor Zephyr & MP54 decoders                                    -->
@@ -28,20 +28,16 @@
   <!--    Added several Con-cor models H0 and N                                   -->
   <decoder>
     <family name="Digitrax/Con-cor Sound" mfg="Digitrax">
-      <model model="Con-cor Aero-Train - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6004" comment="SDH164D Con-Cor #0001-006004">
         <output name="1" label="White" connection="plug"/>
         <output name="2" label="Yellow" connection="plug"/>
         <output name="3" label="Green" connection="wire"/>
         <output name="4" label="Violet" connection="wire"/>
+      <model model="Con-cor Aero-Train - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6004" comment="SDH164D Con-Cor #0001-006004">
         <output name="5" label="Brown" connection="wire"/>
         <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
       </model>
       <model model="Con-cor ElectroLiner - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6005" comment="SDH164D Con-Cor #0001-006005">
-        <output name="1" label="White" connection="plug"/>
-        <output name="2" label="Yellow" connection="plug"/>
-        <output name="3" label="Green" connection="wire"/>
-        <output name="4" label="Violet" connection="wire"/>
         <output name="5" label="Brown" connection="wire"/>
         <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
@@ -58,10 +54,6 @@
         </functionlabels>
       </model>
       <model model="Con-cor Galloping Goose - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6008" comment="SDH164D Con-Cor #0001-006008">
-        <output name="1" label="White" connection="plug"/>
-        <output name="2" label="Yellow" connection="plug"/>
-        <output name="3" label="Green" connection="wire"/>
-        <output name="4" label="Violet" connection="wire"/>
         <output name="5" label="Brown" connection="wire"/>
         <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
@@ -72,10 +64,6 @@
         </functionlabels>
       </model>
       <model model="Con-cor MP54" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6009" comment="SDH164D Con-Cor #0001-006009">
-        <output name="1" label="White" connection="plug"/>
-        <output name="2" label="Yellow" connection="plug"/>
-        <output name="3" label="Green" connection="wire"/>
-        <output name="4" label="Violet" connection="wire"/>
         <output name="5" label="Brown" connection="wire"/>
         <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
@@ -92,10 +80,6 @@
         </functionlabels>
       </model>
       <model model="Con-cor New Haven Comet - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6001" comment="SDH164D Con-Cor #0001-006001">
-        <output name="1" label="White" connection="plug"/>
-        <output name="2" label="Yellow" connection="plug"/>
-        <output name="3" label="Green" connection="wire"/>
-        <output name="4" label="Violet" connection="wire"/>
         <output name="5" label="Brown" connection="wire"/>
         <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
@@ -105,10 +89,6 @@
         </functionlabels>
       </model>
       <model model="Con-cor UP M-10000 - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6003" comment="SDH164D Con-Cor #0001-006003">
-        <output name="1" label="White" connection="plug"/>
-        <output name="2" label="Yellow" connection="plug"/>
-        <output name="3" label="Green" connection="wire"/>
-        <output name="4" label="Violet" connection="wire"/>
         <output name="5" label="Brown" connection="wire"/>
         <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
@@ -118,10 +98,6 @@
         </functionlabels>
       </model>
       <model model="Con-cor Zephyr - HO" numOuts="6" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="HO" connector="NMRAmedium" productID="6002" comment="SDH164D Con-Cor #0001-006002">
-        <output name="1" label="White" connection="plug"/>
-        <output name="2" label="Yellow" connection="plug"/>
-        <output name="3" label="Green" connection="wire"/>
-        <output name="4" label="Violet" connection="wire"/>
         <output name="5" label="Brown" connection="wire"/>
         <output name="6" label="White-Yellow" connection="wire"/>
         <size length="1.273" width="0.67" height="0.25" units="inches"/>
@@ -130,24 +106,12 @@
         </functionlabels>
       </model>
       <model model="Con-cor Aero-Train - N" numOuts="4" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="N" connector="NMRAmedium" productID="6019" comment="SDN144PS Con-Cor #0001-006019">
-        <output name="1" label="White" connection="plug"/>
-        <output name="2" label="Yellow" connection="plug"/>
-        <output name="3" label="Green" connection="wire"/>
-        <output name="4" label="Violet" connection="wire"/>
         <size length="1.22" width="0.4" height="0.164" units="inches"/>
       </model>
       <model model="Con-cor UP M-10000 - N" numOuts="4" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="N" connector="NMRAmedium" productID="6011" comment="SDN144PS Con-Cor #0001-006011">
-        <output name="1" label="White" connection="plug"/>
-        <output name="2" label="Yellow" connection="plug"/>
-        <output name="3" label="Green" connection="wire"/>
-        <output name="4" label="Violet" connection="wire"/>
         <size length="1.22" width="0.4" height="0.164" units="inches"/>
       </model>
       <model model="Con-cor Zephyr - N" numOuts="4" numFns="10" lowVersionID="16" highVersionID="16" maxMotorCurrent="1.0A (peak=2A)" formFactor="N" connector="NMRAmedium" productID="6014" comment="SDN144PS Con-Cor #0001-006014">
-        <output name="1" label="White" connection="plug"/>
-        <output name="2" label="Yellow" connection="plug"/>
-        <output name="3" label="Green" connection="wire"/>
-        <output name="4" label="Violet" connection="wire"/>
         <size length="1.22" width="0.4" height="0.164" units="inches"/>
         <functionlabels>
           <functionlabel num="3" lockable="true">Mars Light</functionlabel>

--- a/xml/decoders/nmra/outputs1-4.xml
+++ b/xml/decoders/nmra/outputs1-4.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
+<!-- Copyright (C) JMRI 2001, 2005, 2007, 2009, 2010 All rights reserved -->
+<!--                                                                        -->
+<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
+<!-- the terms of version 2 of the GNU General Public License as published  -->
+<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
+<!-- of this license.                                                       -->
+<!--                                                                        -->
+<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
+<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
+<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
+<!-- for more details.  -->
+
+<outputs xmlns:xi="http://www.w3.org/2001/XInclude" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xmlns:docbook="http://docbook.org/ns/docbook"
+         xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder-4-15-2.xsd">
+                 
+    <output name="1" label="White" connection="plug"/>
+    <output name="2" label="Yellow" connection="plug"/>
+    <output name="3" label="Green" connection="wire"/>
+    <output name="4" label="Violet" connection="wire"/>
+
+</outputs>

--- a/xml/decoders/nmra/outputs1-4.xml
+++ b/xml/decoders/nmra/outputs1-4.xml
@@ -1,16 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="../XSLT/decoder.xsl"?>
-<!-- Copyright (C) JMRI 2001, 2005, 2007, 2009, 2010 All rights reserved -->
-<!--                                                                        -->
-<!-- JMRI is free software; you can redistribute it and/or modify it under  -->
-<!-- the terms of version 2 of the GNU General Public License as published  -->
-<!-- by the Free Software Foundation. See the "COPYING" file for a copy     -->
-<!-- of this license.                                                       -->
-<!--                                                                        -->
-<!-- JMRI is distributed in the hope that it will be useful, but WITHOUT    -->
-<!-- ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or  -->
-<!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
-<!-- for more details.  -->
 
 <outputs xmlns:xi="http://www.w3.org/2001/XInclude" 
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -314,34 +314,34 @@
     </xs:annotation>
   </xs:element>
 
-    <xs:complexType  name="OutputsType">
-      <xs:sequence>
-        <!-- An outputs element can be the root of an include file, where version information may be useful -->
-        <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1" >
-          <xs:annotation><xs:documentation>
-              DocBook element(s) providing copyright information in standard form.
-          </xs:documentation></xs:annotation>
-        </xs:element>
-        <xs:element ref="docbook:authorgroup" minOccurs="0" maxOccurs="unbounded" >
-          <xs:annotation><xs:documentation>
-              DocBook element(s) describing the authors in standard form.
-          </xs:documentation></xs:annotation>
-        </xs:element>
-        <xs:element ref="docbook:revhistory" minOccurs="0" maxOccurs="unbounded" >
-          <xs:annotation><xs:documentation>
-              DocBook element(s) describing the revision history in standard form.
-          </xs:documentation></xs:annotation>
-        </xs:element>
-        <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
-          <xs:unique name="UniqueOutputLabel0">
-            <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
-            <xs:selector xpath="label"/>
-            <xs:field xpath="@xml:lang"/>
-          </xs:unique>
-        </xs:element>
-      </xs:sequence>
-    </xs:complexType>
-    
+  <xs:complexType  name="OutputsType">
+    <xs:sequence>
+      <!-- An outputs element can be the root of an include file, where version information may be useful -->
+      <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1" >
+        <xs:annotation><xs:documentation>
+            DocBook element(s) providing copyright information in standard form.
+        </xs:documentation></xs:annotation>
+      </xs:element>
+      <xs:element ref="docbook:authorgroup" minOccurs="0" maxOccurs="unbounded" >
+        <xs:annotation><xs:documentation>
+            DocBook element(s) describing the authors in standard form.
+        </xs:documentation></xs:annotation>
+      </xs:element>
+      <xs:element ref="docbook:revhistory" minOccurs="0" maxOccurs="unbounded" >
+        <xs:annotation><xs:documentation>
+            DocBook element(s) describing the revision history in standard form.
+        </xs:documentation></xs:annotation>
+      </xs:element>
+      <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
+        <xs:unique name="UniqueOutputLabel0">
+          <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
+          <xs:selector xpath="label"/>
+          <xs:field xpath="@xml:lang"/>
+        </xs:unique>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
   <xs:element name="outputs" type="OutputsType">
     <!-- element definition for include files -->
   </xs:element>

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -16,11 +16,11 @@
 <!-- for more details.                                                      -->
 
 
-    <!-- not yet in proper Venetian blind form -->
-    <!-- needs to share the pane type with programmer definition -->
+<!-- not yet in proper Venetian blind form -->
+<!-- needs to share the pane type with programmer definition -->
 
-    <!-- needs more attribute restrictions -->
-    <!-- needs attribute defaults -->
+<!-- needs more attribute restrictions -->
+<!-- needs attribute defaults -->
 
 <xs:schema xmlns:xi="http://www.w3.org/2001/XInclude"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -28,77 +28,77 @@
            xmlns:docbook="http://docbook.org/ns/docbook"
            xmlns:jmri="http://jmri.org/xml/schema/JMRIschema"
            xsi:schemaLocation="
-                http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
-                http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
-            "
-        >
+                               http://jmri.org/xml/schema/JMRIschema http://jmri.org/xml/schema/JMRIschema.xsd
+                               http://docbook.org/ns/docbook http://jmri.org/xml/schema/docbook/docbook.xsd
+                               "
+           >
 
-    <xs:include schemaLocation="http://jmri.org/xml/schema/types/general.xsd"/>
-    <xs:include schemaLocation="http://jmri.org/xml/schema/types/panetype.xsd"/>
-    <xs:import namespace='http://docbook.org/ns/docbook' schemaLocation='http://jmri.org/xml/schema/docbook/docbook.xsd'/>
-    <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd" />
-    <xs:import namespace="http://www.w3.org/2001/XInclude" schemaLocation="http://www.w3.org/2001/XInclude.xsd"/>
-
-    <xs:annotation>
-      <xs:documentation>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/general.xsd"/>
+  <xs:include schemaLocation="http://jmri.org/xml/schema/types/panetype.xsd"/>
+  <xs:import namespace='http://docbook.org/ns/docbook' schemaLocation='http://jmri.org/xml/schema/docbook/docbook.xsd'/>
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd" />
+  <xs:import namespace="http://www.w3.org/2001/XInclude" schemaLocation="http://www.w3.org/2001/XInclude.xsd"/>
+  
+  <xs:annotation>
+    <xs:documentation>
       Defines the JMRI decoder definition files.
-
+      
       This version is for use with JMRI 4.1.1 and later, in which
       support for the "ivariable" element and contained elements
       have been deprecated.  Those will not validate with this
       schema.
-
-      </xs:documentation>
-      <xs:appinfo>
-        <jmri:usingclass configurexml="false">jmri.jmrit.decoderdefn.DecoderFile</jmri:usingclass>
-        <jmri:usingclass configurexml="false">jmri.jmrit.symbolicprog.VariableTableModel</jmri:usingclass>
-      </xs:appinfo>
-    </xs:annotation>
-
+      
+    </xs:documentation>
+    <xs:appinfo>
+      <jmri:usingclass configurexml="false">jmri.jmrit.decoderdefn.DecoderFile</jmri:usingclass>
+      <jmri:usingclass configurexml="false">jmri.jmrit.symbolicprog.VariableTableModel</jmri:usingclass>
+    </xs:appinfo>
+  </xs:annotation>
+  
   <xs:complexType name="VersionType">
-      <xs:attribute name="author" type="xs:string" />
-      <xs:attribute name="version" type="xs:string" />
-      <xs:attribute name="lastUpdated" type="xs:string" />
+    <xs:attribute name="author" type="xs:string" />
+    <xs:attribute name="version" type="xs:string" />
+    <xs:attribute name="lastUpdated" type="xs:string" />
   </xs:complexType>
-
+  
   <xs:complexType name="DecoderType">
     <xs:sequence>
-
+      
       <xs:element name="family" type="FamilyType" minOccurs="1" maxOccurs="1" />
-
+      
       <xs:element name="programming" minOccurs="1" maxOccurs="1" >
         <xs:complexType>
           <xs:sequence>
             <xs:element name="capability" minOccurs="0" maxOccurs="unbounded">
               <xs:annotation><xs:documentation>
-              Indicate programmer facades to be added.
-              Later ones work through earlier ones.
+                  Indicate programmer facades to be added.
+                  Later ones work through earlier ones.
               </xs:documentation></xs:annotation>
               <xs:complexType>
                 <xs:sequence>
                   <xs:element name="name" minOccurs="1" maxOccurs="1">
                     <xs:annotation><xs:documentation>
-                    Required name of the particular facade to instantiate
+                        Required name of the particular facade to instantiate
                     </xs:documentation></xs:annotation>
                   </xs:element>
                   <xs:sequence>
                     <xs:element name="parameter" minOccurs="0" maxOccurs="unbounded">
                       <xs:annotation><xs:documentation>
-                      Parameter values for a specific facade.
+                          Parameter values for a specific facade.
                       </xs:documentation></xs:annotation>
                       <xs:complexType>
-                      <xs:simpleContent>
-                        <xs:extension base="xs:string">
-                          <xs:attribute name="name" type="xs:string" >
-                            <xs:annotation><xs:documentation>
-                            Name of the particular attribute being set.
-                            Whether this is required is defined by a
-                            particular facade; facades may take their
-                            parameters in a specified order instead of using names.
-                            </xs:documentation></xs:annotation>
-                          </xs:attribute>
-                        </xs:extension>
-                      </xs:simpleContent>
+                        <xs:simpleContent>
+                          <xs:extension base="xs:string">
+                            <xs:attribute name="name" type="xs:string" >
+                              <xs:annotation><xs:documentation>
+                                  Name of the particular attribute being set.
+                                  Whether this is required is defined by a
+                                  particular facade; facades may take their
+                                  parameters in a specified order instead of using names.
+                              </xs:documentation></xs:annotation>
+                            </xs:attribute>
+                          </xs:extension>
+                        </xs:simpleContent>
                       </xs:complexType>
                     </xs:element>
                   </xs:sequence>
@@ -107,19 +107,19 @@
             </xs:element>
             <xs:element name="mode" type="modeType" minOccurs="0" maxOccurs="unbounded">
               <xs:annotation><xs:documentation>
-              Content is the internal name of a supported programmer mode.
-              Having at least one of these (or the
-              historical direct, paged, et al attributes)
-              is required or programming is not possible.
+                  Content is the internal name of a supported programmer mode.
+                  Having at least one of these (or the
+                  historical direct, paged, et al attributes)
+                  is required or programming is not possible.
               </xs:documentation></xs:annotation>
             </xs:element>
           </xs:sequence>
           <xs:attribute name="direct" default="yes" >
             <xs:annotation><xs:documentation>
-            Yes indicates programmer supports one of the direct
-            programming modes,
-            specifically the DIRECTMODE, none, DIRECTBITMODE or DIRECTBYTEMODE
-            respectively.
+                Yes indicates programmer supports one of the direct
+                programming modes,
+                specifically the DIRECTMODE, none, DIRECTBITMODE or DIRECTBYTEMODE
+                respectively.
             </xs:documentation></xs:annotation>
             <xs:simpleType>
               <xs:restriction base="xs:token">
@@ -132,31 +132,31 @@
           </xs:attribute>
           <xs:attribute name="paged" type="yesNoType" default="yes">
             <xs:annotation><xs:documentation>
-            Yes indicates programmer supports Paged mode,
-            specifically the PAGEMODE type.
+                Yes indicates programmer supports Paged mode,
+                specifically the PAGEMODE type.
             </xs:documentation></xs:annotation>
           </xs:attribute>
           <xs:attribute name="register" type="yesNoType" default="yes">
             <xs:annotation><xs:documentation>
-            Yes indicates programmer supports Register mode,
-            specifically the REGISTERMODE type.
+                Yes indicates programmer supports Register mode,
+                specifically the REGISTERMODE type.
             </xs:documentation></xs:annotation>
           </xs:attribute>
           <xs:attribute name="ops" type="yesNoType" default="yes">
             <xs:annotation><xs:documentation>
-            Yes indicates programmer supports Ops mode for locomotive decoders,
-            specifically the OPSBITMODE type.
+                Yes indicates programmer supports Ops mode for locomotive decoders,
+                specifically the OPSBITMODE type.
             </xs:documentation></xs:annotation>
           </xs:attribute>
           <xs:attribute name="transpRead" type="yesNoType" default="no">
             <xs:annotation><xs:documentation>
-            Not a programming mode per say, this indicates that the
-            decoder is capable of replying to CV reads via Digitrax Transponding.
+                Not a programming mode per say, this indicates that the
+                decoder is capable of replying to CV reads via Digitrax Transponding.
             </xs:documentation></xs:annotation>
           </xs:attribute>
         </xs:complexType>
       </xs:element>
-
+      
       <xs:element name="variables" type="VariablesType" minOccurs="1" maxOccurs="1">
         <xs:unique name="UniqueVariableItemAttribute2">
           <xs:annotation><xs:documentation>Insist that the variable item attribute is unique</xs:documentation></xs:annotation>
@@ -166,35 +166,35 @@
           <xs:field xpath="@exclude"/>
         </xs:unique>
       </xs:element>
-
+      
       <xs:element name="resets" type="ResetsType" minOccurs="0" maxOccurs="1"/>
 
     </xs:sequence>
   </xs:complexType>
-
+  
   <xs:element name="decoder-config">
     <xs:complexType>
       <xs:sequence>
-          <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1" >
-              <xs:annotation><xs:documentation>
+        <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1" >
+          <xs:annotation><xs:documentation>
               DocBook element(s) providing copyright information in standard form.
-              </xs:documentation></xs:annotation>
-          </xs:element>
-          <xs:element ref="docbook:authorgroup" minOccurs="0" maxOccurs="unbounded" >
-              <xs:annotation><xs:documentation>
+          </xs:documentation></xs:annotation>
+        </xs:element>
+        <xs:element ref="docbook:authorgroup" minOccurs="0" maxOccurs="unbounded" >
+          <xs:annotation><xs:documentation>
               DocBook element(s) describing the authors in standard form.
-              </xs:documentation></xs:annotation>
-          </xs:element>
-          <xs:element ref="docbook:revhistory" minOccurs="0" maxOccurs="unbounded" >
-              <xs:annotation><xs:documentation>
+          </xs:documentation></xs:annotation>
+        </xs:element>
+        <xs:element ref="docbook:revhistory" minOccurs="0" maxOccurs="unbounded" >
+          <xs:annotation><xs:documentation>
               DocBook element(s) describing the revision history in standard form.
-              </xs:documentation></xs:annotation>
-          </xs:element>
+          </xs:documentation></xs:annotation>
+        </xs:element>
         <xs:element name="version" type="VersionType" minOccurs="0" maxOccurs="unbounded">
-              <xs:annotation><xs:documentation>
+          <xs:annotation><xs:documentation>
               Older form of version information. Not deprecated as such, but prefer
               the authorgroup/revhistory style to enable future automated processing.
-              </xs:documentation></xs:annotation>
+          </xs:documentation></xs:annotation>
         </xs:element>
         <xs:element name="decoder" type="DecoderType" minOccurs="1" maxOccurs="1"/>
         <xs:element name="pane"    type="PaneType" minOccurs="0" maxOccurs="unbounded"/>
@@ -202,7 +202,7 @@
       <xs:attribute name="showEmptyPanes" type="yesNoType"/>
     </xs:complexType>
   </xs:element>
-
+  
   <xs:element name="decoderIndex-config">
     <xs:annotation><xs:documentation>
         Defines the content of the JMRI decoderIndex.xml file.
@@ -265,8 +265,8 @@
   <xs:element name="variables" type="VariablesType">
     <xs:annotation>
       <xs:documentation>
-      Provides a base element that can be used in "variables" fragment files, those
-      little files that are XIncluded into primary decoder files.
+        Provides a base element that can be used in "variables" fragment files, those
+        little files that are XIncluded into primary decoder files.
       </xs:documentation>
     </xs:annotation>
     <xs:unique name="UniqueVariableItemAttribute3">
@@ -281,8 +281,8 @@
   <xs:element name="group" type="PaneGenericGroupType">
     <xs:annotation>
       <xs:documentation>
-      Provides a base element that can be used in "group" fragment files, those
-      little files that are XIncluded into primary decoder files.
+        Provides a base element that can be used in "group" fragment files, those
+        little files that are XIncluded into primary decoder files.
       </xs:documentation>
     </xs:annotation>
   </xs:element>
@@ -290,8 +290,8 @@
   <xs:element name="enumVal" type="EnumValType">
     <xs:annotation>
       <xs:documentation>
-      Provides a base element that can be used in "enumVal" fragment files, those
-      little files that are XIncluded into primary decoder files.
+        Provides a base element that can be used in "enumVal" fragment files, those
+        little files that are XIncluded into primary decoder files.
       </xs:documentation>
     </xs:annotation>
   </xs:element>
@@ -299,8 +299,8 @@
   <xs:element name="enumChoiceGroup" type="EnumChoiceGroupType">
     <xs:annotation>
       <xs:documentation>
-      Provides a base element that can be used in "enumChoiceGroup" fragment files, those
-      little files that are XIncluded into primary decoder files.
+        Provides a base element that can be used in "enumChoiceGroup" fragment files, those
+        little files that are XIncluded into primary decoder files.
       </xs:documentation>
     </xs:annotation>
   </xs:element>
@@ -308,8 +308,8 @@
   <xs:element name="resets" type="ResetsType" >
     <xs:annotation>
       <xs:documentation>
-      Provides a base element that can be used in "resets" fragment files, those
-      little files that are XIncluded into primary decoder files.
+        Provides a base element that can be used in "resets" fragment files, those
+        little files that are XIncluded into primary decoder files.
       </xs:documentation>
     </xs:annotation>
   </xs:element>
@@ -317,22 +317,22 @@
   <xs:element name="outputs" >
     <xs:complexType>
       <xs:sequence>
-          <!-- this info also needs to be handled two other places for it to be useful -->
-          <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1" >
-              <xs:annotation><xs:documentation>
+        <!-- this info also needs to be handled two other places for it to be useful -->
+        <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1" >
+          <xs:annotation><xs:documentation>
               DocBook element(s) providing copyright information in standard form.
-              </xs:documentation></xs:annotation>
-          </xs:element>
-          <xs:element ref="docbook:authorgroup" minOccurs="0" maxOccurs="unbounded" >
-              <xs:annotation><xs:documentation>
+          </xs:documentation></xs:annotation>
+        </xs:element>
+        <xs:element ref="docbook:authorgroup" minOccurs="0" maxOccurs="unbounded" >
+          <xs:annotation><xs:documentation>
               DocBook element(s) describing the authors in standard form.
-              </xs:documentation></xs:annotation>
-          </xs:element>
-          <xs:element ref="docbook:revhistory" minOccurs="0" maxOccurs="unbounded" >
-              <xs:annotation><xs:documentation>
+          </xs:documentation></xs:annotation>
+        </xs:element>
+        <xs:element ref="docbook:revhistory" minOccurs="0" maxOccurs="unbounded" >
+          <xs:annotation><xs:documentation>
               DocBook element(s) describing the revision history in standard form.
-              </xs:documentation></xs:annotation>
-          </xs:element>
+          </xs:documentation></xs:annotation>
+        </xs:element>
         <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
           <xs:unique name="UniqueOutputLabel0">
             <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
@@ -402,7 +402,7 @@
             <xs:element ref="xi:include" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="size" minOccurs="0" maxOccurs="1" >
               <xs:annotation><xs:documentation>
-                Describes the physical size of the package, for reference.
+                  Describes the physical size of the package, for reference.
               </xs:documentation></xs:annotation>
               <xs:complexType>
                 <xs:attribute name="length" type="xs:string" />
@@ -422,25 +422,25 @@
             </xs:element>
             <xs:element name="protocols" minOccurs="0" maxOccurs="1" >
               <xs:annotation><xs:documentation>
-                Lists communication protocols this decoder will respond to.
+                  Lists communication protocols this decoder will respond to.
               </xs:documentation></xs:annotation>
               <xs:complexType>
-              <xs:sequence>
-                <xs:element name="protocol" minOccurs="1" maxOccurs="unbounded">
-                  <xs:simpleType>
-                    <xs:restriction base="xs:token" >
-                      <xs:enumeration value="dcc"/>
-                      <xs:enumeration value="selectrix"/>
-                      <xs:enumeration value="motorola"/>
-                      <xs:enumeration value="mfx"/>
-                      <xs:enumeration value="m4"/>
-                      <xs:enumeration value="openlcb"/>
-                      <xs:enumeration value="other">
-                        <xs:annotation><xs:documentation>Intended only as a temporary for new protocols until schema can be updated.</xs:documentation></xs:annotation>
-                      </xs:enumeration>
-                    </xs:restriction>
-                  </xs:simpleType>
-                </xs:element>
+                <xs:sequence>
+                  <xs:element name="protocol" minOccurs="1" maxOccurs="unbounded">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:token" >
+                        <xs:enumeration value="dcc"/>
+                        <xs:enumeration value="selectrix"/>
+                        <xs:enumeration value="motorola"/>
+                        <xs:enumeration value="mfx"/>
+                        <xs:enumeration value="m4"/>
+                        <xs:enumeration value="openlcb"/>
+                        <xs:enumeration value="other">
+                          <xs:annotation><xs:documentation>Intended only as a temporary for new protocols until schema can be updated.</xs:documentation></xs:annotation>
+                        </xs:enumeration>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:element>
                 </xs:sequence>
               </xs:complexType>
             </xs:element>
@@ -454,20 +454,20 @@
           <xs:attribute name="options" type="xs:string" />
           <xs:attribute name="comment" type="xs:string" />
           <xs:attribute name="numFns" type="xs:int">
-              <xs:annotation><xs:documentation>
-              This is a legacy attribute that limits the total number of function mapping lines displayed. 
-              It is no longer required as there are many optional variations as well as
-              the original F0F, F0R &amp; F1-F28.
-              Hence the JMRI code now automatically suppresses unused lines.
-              </xs:documentation></xs:annotation>
+            <xs:annotation><xs:documentation>
+                This is a legacy attribute that limits the total number of function mapping lines displayed. 
+                It is no longer required as there are many optional variations as well as
+                the original F0F, F0R &amp; F1-F28.
+                Hence the JMRI code now automatically suppresses unused lines.
+            </xs:documentation></xs:annotation>
           </xs:attribute>
           <xs:attribute name="numOuts" type="xs:int" >
-              <xs:annotation><xs:documentation>
-              Number of physical outputs (wires) on the decoder.
-              For example, a decoder with three wires and two sounds would have this as 3.
-              It does not affect the number of columns displayed,
-              the JMRI code shows all used columns.
-              </xs:documentation></xs:annotation>
+            <xs:annotation><xs:documentation>
+                Number of physical outputs (wires) on the decoder.
+                For example, a decoder with three wires and two sounds would have this as 3.
+                It does not affect the number of columns displayed,
+                the JMRI code shows all used columns.
+            </xs:documentation></xs:annotation>
           </xs:attribute>
           <xs:attribute name="lowVersionID" type="xs:int" />
           <xs:attribute name="highVersionID" type="xs:int" />
@@ -570,36 +570,36 @@
   </xs:complexType>
 
   <xs:complexType name="OutputElementType">
-      <xs:annotation><xs:documentation>
+    <xs:annotation><xs:documentation>
         Can represent either an electrical output, i.e. a wire to a light,
         or some other kind of output, i.e. a sound,
         or even internal state operations, e.g. "Switch to alternating lights".
-      </xs:documentation></xs:annotation>
-        <xs:sequence>
-          <xs:element name="label" minOccurs="0" maxOccurs="unbounded">
-            <xs:annotation><xs:documentation>Multiple elements provide internationalized label text</xs:documentation></xs:annotation>
-            <xs:complexType mixed="true">
-                <xs:attribute ref="xml:lang" default=""/>
-            </xs:complexType>
-          </xs:element>
-        </xs:sequence>
-        <xs:attribute name="name" type="xs:string" use="required"/>
-        <xs:attribute name="label" type="xs:string" />
-        <xs:attribute name="comment" type="xs:string" />
-        <xs:attribute name="maxcurrent" type="xs:string" />
-        <xs:attribute name="connection" default="unspecified" >
-          <xs:simpleType>
-            <xs:restriction base="xs:token" >
-              <xs:enumeration value="unspecified"/>
-              <xs:enumeration value="plug"/>
-              <xs:enumeration value="wire"/>
-              <xs:enumeration value="solder"/>
-              <xs:enumeration value="LED"/>
-              <xs:enumeration value="bulb"/>
-              <xs:enumeration value="other"/>
-            </xs:restriction>
-          </xs:simpleType>
-        </xs:attribute>
+    </xs:documentation></xs:annotation>
+    <xs:sequence>
+      <xs:element name="label" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation><xs:documentation>Multiple elements provide internationalized label text</xs:documentation></xs:annotation>
+        <xs:complexType mixed="true">
+          <xs:attribute ref="xml:lang" default=""/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="label" type="xs:string" />
+    <xs:attribute name="comment" type="xs:string" />
+    <xs:attribute name="maxcurrent" type="xs:string" />
+    <xs:attribute name="connection" default="unspecified" >
+      <xs:simpleType>
+        <xs:restriction base="xs:token" >
+          <xs:enumeration value="unspecified"/>
+          <xs:enumeration value="plug"/>
+          <xs:enumeration value="wire"/>
+          <xs:enumeration value="solder"/>
+          <xs:enumeration value="LED"/>
+          <xs:enumeration value="bulb"/>
+          <xs:enumeration value="other"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="functionlabelsType">
@@ -643,265 +643,265 @@
 
   <xs:complexType name="VariablesType">
     <xs:sequence minOccurs="0" maxOccurs="1">
-        <xs:element name="qualifier" type="QualifierType" minOccurs="0" maxOccurs="unbounded" >
+      <xs:element name="qualifier" type="QualifierType" minOccurs="0" maxOccurs="unbounded" >
+        <xs:annotation><xs:documentation>
+            Qualifies whether the variables within this variables element will appear in the interface, depending
+            on the value in other pre-defined variables.
+        </xs:documentation></xs:annotation>
+      </xs:element>
+
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="variables" type="VariablesType" minOccurs="0" maxOccurs="unbounded" >
+          <xs:annotation><xs:documentation>Can be nested to make it possible to include groups</xs:documentation></xs:annotation>
+          <xs:unique name="UniqueVariableItemAttribute1">
+            <xs:annotation><xs:documentation>Insist that the variable item attribute is unique</xs:documentation></xs:annotation>
+            <xs:selector xpath=".//variable"/>
+            <xs:field xpath="@item"/>
+            <xs:field xpath="@include"/>
+            <xs:field xpath="@exclude"/>
+          </xs:unique>
+        </xs:element>
+
+        <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1" >
           <xs:annotation><xs:documentation>
-          Qualifies whether the variables within this variables element will appear in the interface, depending
-          on the value in other pre-defined variables.
+              DocBook element(s) providing copyright information in standard form.
+              For use in subfiles.
           </xs:documentation></xs:annotation>
         </xs:element>
 
-        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-          <xs:element name="variables" type="VariablesType" minOccurs="0" maxOccurs="unbounded" >
-            <xs:annotation><xs:documentation>Can be nested to make it possible to include groups</xs:documentation></xs:annotation>
-            <xs:unique name="UniqueVariableItemAttribute1">
-              <xs:annotation><xs:documentation>Insist that the variable item attribute is unique</xs:documentation></xs:annotation>
-              <xs:selector xpath=".//variable"/>
-              <xs:field xpath="@item"/>
-              <xs:field xpath="@include"/>
-              <xs:field xpath="@exclude"/>
-            </xs:unique>
-          </xs:element>
-
-          <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1" >
-              <xs:annotation><xs:documentation>
-              DocBook element(s) providing copyright information in standard form.
-              For use in subfiles.
-              </xs:documentation></xs:annotation>
-          </xs:element>
-
-          <xs:element ref="docbook:authorgroup" minOccurs="0" maxOccurs="unbounded" >
-              <xs:annotation><xs:documentation>
+        <xs:element ref="docbook:authorgroup" minOccurs="0" maxOccurs="unbounded" >
+          <xs:annotation><xs:documentation>
               DocBook element(s) describing the authors in standard form.
               For use in subfiles.
-              </xs:documentation></xs:annotation>
-          </xs:element>
+          </xs:documentation></xs:annotation>
+        </xs:element>
 
-          <xs:element ref="docbook:revhistory" minOccurs="0" maxOccurs="unbounded" >
-              <xs:annotation><xs:documentation>
+        <xs:element ref="docbook:revhistory" minOccurs="0" maxOccurs="unbounded" >
+          <xs:annotation><xs:documentation>
               DocBook element(s) describing the revision history in standard form.
               For use in subfiles.
-              </xs:documentation></xs:annotation>
-          </xs:element>
+          </xs:documentation></xs:annotation>
+        </xs:element>
 
-          <xs:element name="constant" minOccurs="0" maxOccurs="unbounded" >
-            <xs:complexType>
-              <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                  <xs:element name="label" minOccurs="0" maxOccurs="unbounded">
-                    <xs:annotation><xs:documentation>Multiple elements provide internationalized label text</xs:documentation></xs:annotation>
-                    <xs:complexType mixed="true">
-                        <xs:attribute ref="xml:lang" default=""/>
-                    </xs:complexType>
-                  </xs:element>
-              </xs:sequence>
-              <xs:attribute name="label" type="xs:string"/>
-              <xs:attribute name="default" type="xs:int"/>
-              <xs:attribute name="comment" type="xs:string"/>
-              <xs:attribute name="item" type="xs:string" use="required"/>
-              <xs:attribute name="minFn" type="xs:int"/>
-              <xs:attribute name="minOut" type="xs:int"/>
-              <xs:attribute name="inOptions" type="xs:string"/>
-              <xs:attribute name="include" type="xs:string" default=""/>
-              <xs:attribute name="exclude" type="xs:string" default=""/>
-            </xs:complexType>
-            <xs:unique name="UniqueConstantLabel1">
-              <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
-              <xs:selector xpath="label"/>
-              <xs:field xpath="@xml:lang"/>
-            </xs:unique>
-          </xs:element>
+        <xs:element name="constant" minOccurs="0" maxOccurs="unbounded" >
+          <xs:complexType>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+              <xs:element name="label" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation><xs:documentation>Multiple elements provide internationalized label text</xs:documentation></xs:annotation>
+                <xs:complexType mixed="true">
+                  <xs:attribute ref="xml:lang" default=""/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="label" type="xs:string"/>
+            <xs:attribute name="default" type="xs:int"/>
+            <xs:attribute name="comment" type="xs:string"/>
+            <xs:attribute name="item" type="xs:string" use="required"/>
+            <xs:attribute name="minFn" type="xs:int"/>
+            <xs:attribute name="minOut" type="xs:int"/>
+            <xs:attribute name="inOptions" type="xs:string"/>
+            <xs:attribute name="include" type="xs:string" default=""/>
+            <xs:attribute name="exclude" type="xs:string" default=""/>
+          </xs:complexType>
+          <xs:unique name="UniqueConstantLabel1">
+            <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
+            <xs:selector xpath="label"/>
+            <xs:field xpath="@xml:lang"/>
+          </xs:unique>
+        </xs:element>
 
-          <xs:element name="variable" minOccurs="0" maxOccurs="unbounded" >
-            <xs:complexType>
-              <xs:sequence minOccurs="1" maxOccurs="1">
-                  <xs:element name="defaultItem" minOccurs="0" maxOccurs="unbounded" >
-                    <xs:annotation><xs:documentation>
+        <xs:element name="variable" minOccurs="0" maxOccurs="unbounded" >
+          <xs:complexType>
+            <xs:sequence minOccurs="1" maxOccurs="1">
+              <xs:element name="defaultItem" minOccurs="0" maxOccurs="unbounded" >
+                <xs:annotation><xs:documentation>
                     Specifies the default value to use when the decoder family/model/productID has a specific value.
                     Either or both of "include" and "exclude" can be specified.
-                    </xs:documentation></xs:annotation>
-                    <xs:complexType>
-                      <xs:attribute name="default" type="xs:int" use="required"/>
-                      <xs:attribute name="include" type="xs:string" default=""/>
-                      <xs:attribute name="exclude" type="xs:string" default=""/>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="qualifier" type="QualifierType" minOccurs="0" maxOccurs="unbounded" >
-                    <xs:annotation><xs:documentation>
+                </xs:documentation></xs:annotation>
+                <xs:complexType>
+                  <xs:attribute name="default" type="xs:int" use="required"/>
+                  <xs:attribute name="include" type="xs:string" default=""/>
+                  <xs:attribute name="exclude" type="xs:string" default=""/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="qualifier" type="QualifierType" minOccurs="0" maxOccurs="unbounded" >
+                <xs:annotation><xs:documentation>
                     Qualifies whether this variable will appear in the interface, depending
                     on the value in other variables.
-                    </xs:documentation></xs:annotation>
-                  </xs:element>
-                <xs:choice minOccurs="1" maxOccurs="1">
-                  <xs:element name="enumVal" type="EnumValType">
-                    <xs:annotation><xs:documentation>
-                    A fixed set of choices is defined, each corresponding to a specific value
-                    </xs:documentation></xs:annotation>
-                  </xs:element>
-                  <xs:element name="decVal" >
-                    <xs:annotation><xs:documentation>
-                    A decimal value is used, subject to mask and limit requirements
-                    </xs:documentation></xs:annotation>
-                    <xs:complexType>
-                      <xs:attribute name="min" type="xs:int" default="0"/>
-                      <xs:attribute name="max" type="xs:int" default="255"/>
-                      <xs:attribute name="comment" type="xs:string"/>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="hexVal" >
-                    <xs:annotation><xs:documentation>
-                    A hexadecimal value is used, subject to mask and limit requirements
-                    </xs:documentation></xs:annotation>
-                    <xs:complexType>
-                      <xs:attribute name="min" type="xs:string" default="0"/>
-                      <xs:attribute name="max" type="xs:string" default="ff"/>
-                      <xs:attribute name="comment" type="xs:string"/>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="speedTableVal" >
-                    <xs:annotation><xs:documentation>
-                    NMRA speed table
-                    </xs:documentation></xs:annotation>
-                    <xs:complexType>
-                      <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:element name="speedTableEntry" >
-                          <xs:complexType>
-                            <xs:attribute name="step" type="xs:int" use="required" />
-                            <xs:attribute name="value" type="xs:int" use="required"  />
-                            <xs:attribute name="comment" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                      <xs:attribute name="entries" type="xs:int" default="28" />
-                      <xs:attribute name="min" type="xs:int" default="0">
-                        <xs:annotation><xs:documentation>
-                        Smallest allowable value for the CVs in the table
-                        </xs:documentation></xs:annotation>
-                      </xs:attribute>
-                      <xs:attribute name="max" type="xs:int" default="255">
-                        <xs:annotation><xs:documentation>
-                        Largest allowable value for the CVs in the table
-                        </xs:documentation></xs:annotation>
-                      </xs:attribute>
-                      <xs:attribute name="mfx" type="trueFalseType" default="false">
-                        <xs:annotation><xs:documentation>
-                        False, the default, is a NMRA speed table; true is a MFX speed table ala Markin, with fixed end points.
-                        </xs:documentation></xs:annotation>
-                      </xs:attribute>
-                      <xs:attribute name="comment" type="xs:string"/>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="longAddressVal" >
-                    <xs:annotation><xs:documentation>
-                    NMRA long address, including its unique behaviors
-                    </xs:documentation></xs:annotation>
-                    <xs:complexType>
-                      <xs:attribute name="comment" type="xs:string"/>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="shortAddressVal" >
-                    <xs:annotation><xs:documentation>
-                    NMRA short address, including its unique behaviors
-                    </xs:documentation></xs:annotation>
-                    <xs:complexType>
-                      <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:element name="shortAddressChanges" >
-                          <xs:complexType>
-                            <xs:attribute name="cv" type="cvNameType" use="required" />
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                      <xs:attribute name="comment" type="xs:string"/>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="splitVal" >
-                    <xs:annotation><xs:documentation>
-                    A decimal value, but stored across two CVs using some simple calculations
-                    </xs:documentation></xs:annotation>
-                    <xs:complexType>
-                      <xs:attribute name="highCV" type="cvNameType" use="required" />
-                      <xs:attribute name="min" type="xs:int" default="0"/>
-                      <xs:attribute name="max" type="xs:int" default="255"/>
-                      <xs:attribute name="default" type="xs:int"/>
-                      <xs:attribute name="factor" type="xs:int" default="1"/>
-                      <xs:attribute name="offset" type="xs:int" default="0"/>
-                      <xs:attribute name="comment" type="xs:string"/>
-                      <xs:attribute name="upperMask" type="maskType" default="VVVVVVVV" />
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="compositeVal" >
-                    <xs:annotation><xs:documentation>
-                    A value made up of references to others
-                    </xs:documentation></xs:annotation>
-                    <xs:complexType>
-                      <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                        <xs:element name="compositeChoice" >
-                          <xs:complexType>
-                            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                              <xs:element name="compositeSetting" >
-                                <xs:complexType>
-                                  <xs:attribute name="label" type="xs:string" use="required"/>
-                                  <xs:attribute name="value" type="xs:int" use="required" />
-                                </xs:complexType>
-                              </xs:element>
-                            </xs:sequence>
-                            <xs:attribute name="choice" type="xs:string" use="required"/>
-                            <xs:attribute name="comment" type="xs:string"/>
-                          </xs:complexType>
-                        </xs:element>
-                      </xs:sequence>
-                      <xs:attribute name="comment" type="xs:string"/>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element ref="xi:include" minOccurs="0" maxOccurs="1" />
-                </xs:choice>
-                <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                  <xs:element name="label" minOccurs="0" maxOccurs="unbounded">
-                    <xs:annotation><xs:documentation>Multiple elements provide internationalized label text</xs:documentation></xs:annotation>
-                    <xs:complexType mixed="true">
-                        <xs:attribute ref="xml:lang" default=""/>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="comment" minOccurs="0" maxOccurs="unbounded">
-                    <xs:annotation><xs:documentation>Multiple elements provide internationalized comment text</xs:documentation></xs:annotation>
-                  </xs:element>
-                  <xs:element name="tooltip" minOccurs="0" maxOccurs="unbounded">
-                    <xs:annotation><xs:documentation>Multiple elements provide internationalized tooltip text</xs:documentation></xs:annotation>
-                  </xs:element>
-                </xs:sequence>
+                </xs:documentation></xs:annotation>
+              </xs:element>
+              <xs:choice minOccurs="1" maxOccurs="1">
+                <xs:element name="enumVal" type="EnumValType">
+                  <xs:annotation><xs:documentation>
+                      A fixed set of choices is defined, each corresponding to a specific value
+                  </xs:documentation></xs:annotation>
+                </xs:element>
+                <xs:element name="decVal" >
+                  <xs:annotation><xs:documentation>
+                      A decimal value is used, subject to mask and limit requirements
+                  </xs:documentation></xs:annotation>
+                  <xs:complexType>
+                    <xs:attribute name="min" type="xs:int" default="0"/>
+                    <xs:attribute name="max" type="xs:int" default="255"/>
+                    <xs:attribute name="comment" type="xs:string"/>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="hexVal" >
+                  <xs:annotation><xs:documentation>
+                      A hexadecimal value is used, subject to mask and limit requirements
+                  </xs:documentation></xs:annotation>
+                  <xs:complexType>
+                    <xs:attribute name="min" type="xs:string" default="0"/>
+                    <xs:attribute name="max" type="xs:string" default="ff"/>
+                    <xs:attribute name="comment" type="xs:string"/>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="speedTableVal" >
+                  <xs:annotation><xs:documentation>
+                      NMRA speed table
+                  </xs:documentation></xs:annotation>
+                  <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                      <xs:element name="speedTableEntry" >
+                        <xs:complexType>
+                          <xs:attribute name="step" type="xs:int" use="required" />
+                          <xs:attribute name="value" type="xs:int" use="required"  />
+                          <xs:attribute name="comment" type="xs:string"/>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="entries" type="xs:int" default="28" />
+                    <xs:attribute name="min" type="xs:int" default="0">
+                      <xs:annotation><xs:documentation>
+                          Smallest allowable value for the CVs in the table
+                      </xs:documentation></xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="max" type="xs:int" default="255">
+                      <xs:annotation><xs:documentation>
+                          Largest allowable value for the CVs in the table
+                      </xs:documentation></xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="mfx" type="trueFalseType" default="false">
+                      <xs:annotation><xs:documentation>
+                          False, the default, is a NMRA speed table; true is a MFX speed table ala Markin, with fixed end points.
+                      </xs:documentation></xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="comment" type="xs:string"/>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="longAddressVal" >
+                  <xs:annotation><xs:documentation>
+                      NMRA long address, including its unique behaviors
+                  </xs:documentation></xs:annotation>
+                  <xs:complexType>
+                    <xs:attribute name="comment" type="xs:string"/>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="shortAddressVal" >
+                  <xs:annotation><xs:documentation>
+                      NMRA short address, including its unique behaviors
+                  </xs:documentation></xs:annotation>
+                  <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                      <xs:element name="shortAddressChanges" >
+                        <xs:complexType>
+                          <xs:attribute name="cv" type="cvNameType" use="required" />
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="comment" type="xs:string"/>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="splitVal" >
+                  <xs:annotation><xs:documentation>
+                      A decimal value, but stored across two CVs using some simple calculations
+                  </xs:documentation></xs:annotation>
+                  <xs:complexType>
+                    <xs:attribute name="highCV" type="cvNameType" use="required" />
+                    <xs:attribute name="min" type="xs:int" default="0"/>
+                    <xs:attribute name="max" type="xs:int" default="255"/>
+                    <xs:attribute name="default" type="xs:int"/>
+                    <xs:attribute name="factor" type="xs:int" default="1"/>
+                    <xs:attribute name="offset" type="xs:int" default="0"/>
+                    <xs:attribute name="comment" type="xs:string"/>
+                    <xs:attribute name="upperMask" type="maskType" default="VVVVVVVV" />
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="compositeVal" >
+                  <xs:annotation><xs:documentation>
+                      A value made up of references to others
+                  </xs:documentation></xs:annotation>
+                  <xs:complexType>
+                    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                      <xs:element name="compositeChoice" >
+                        <xs:complexType>
+                          <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="compositeSetting" >
+                              <xs:complexType>
+                                <xs:attribute name="label" type="xs:string" use="required"/>
+                                <xs:attribute name="value" type="xs:int" use="required" />
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                          <xs:attribute name="choice" type="xs:string" use="required"/>
+                          <xs:attribute name="comment" type="xs:string"/>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="comment" type="xs:string"/>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element ref="xi:include" minOccurs="0" maxOccurs="1" />
+              </xs:choice>
+              <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="label" minOccurs="0" maxOccurs="unbounded">
+                  <xs:annotation><xs:documentation>Multiple elements provide internationalized label text</xs:documentation></xs:annotation>
+                  <xs:complexType mixed="true">
+                    <xs:attribute ref="xml:lang" default=""/>
+                  </xs:complexType>
+                </xs:element>
+                <xs:element name="comment" minOccurs="0" maxOccurs="unbounded">
+                  <xs:annotation><xs:documentation>Multiple elements provide internationalized comment text</xs:documentation></xs:annotation>
+                </xs:element>
+                <xs:element name="tooltip" minOccurs="0" maxOccurs="unbounded">
+                  <xs:annotation><xs:documentation>Multiple elements provide internationalized tooltip text</xs:documentation></xs:annotation>
+                </xs:element>
               </xs:sequence>
-              <xs:attribute name="label" type="xs:string">
-                <xs:annotation><xs:documentation>Deprecated, use the label element instead.</xs:documentation></xs:annotation>
-              </xs:attribute>
-              <xs:attribute name="CV" type="cvNameType"/>
-              <xs:attribute name="mask" type="maskType" default="VVVVVVVV" />
-              <xs:attribute name="readOnly" type="yesNoType" default="no" />
-              <xs:attribute name="infoOnly" type="yesNoType" default="no" />
-              <xs:attribute name="opsOnly" type="yesNoType" default="no" />
-              <xs:attribute name="writeOnly" type="yesNoType" default="no" />
-              <xs:attribute name="default" type="xs:string"/>
-              <xs:attribute name="comment" type="xs:string"/>
-              <xs:attribute name="item" type="xs:string"/><!-- should be use="required" !!! -->
-              <xs:attribute name="minFn" type="xs:int">
-                  <xs:annotation><xs:documentation>Only present if the decoder has at least minFn functions defined in numFn</xs:documentation></xs:annotation>
-              </xs:attribute>
-              <xs:attribute name="minOut" type="xs:int">
-                  <xs:annotation><xs:documentation>Only present if the decoder has at least minOut functions defined in numOut</xs:documentation></xs:annotation>
-              </xs:attribute>
-              <xs:attribute name="inOptions" type="xs:string"/>
-              <xs:attribute name="tooltip" type="xs:string">
-                <xs:annotation><xs:documentation>Deprecated, use the tooltip element instead.</xs:documentation></xs:annotation>
-              </xs:attribute>
-              <xs:attribute name="include" type="xs:string" default=""/>
-              <xs:attribute name="exclude" type="xs:string" default=""/>
-            </xs:complexType>
-            <xs:unique name="UniqueVariableLabel1">
-              <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
-              <xs:selector xpath="label"/>
-              <xs:field xpath="@xml:lang"/>
-            </xs:unique>
-          </xs:element>
+            </xs:sequence>
+            <xs:attribute name="label" type="xs:string">
+              <xs:annotation><xs:documentation>Deprecated, use the label element instead.</xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="CV" type="cvNameType"/>
+            <xs:attribute name="mask" type="maskType" default="VVVVVVVV" />
+            <xs:attribute name="readOnly" type="yesNoType" default="no" />
+            <xs:attribute name="infoOnly" type="yesNoType" default="no" />
+            <xs:attribute name="opsOnly" type="yesNoType" default="no" />
+            <xs:attribute name="writeOnly" type="yesNoType" default="no" />
+            <xs:attribute name="default" type="xs:string"/>
+            <xs:attribute name="comment" type="xs:string"/>
+            <xs:attribute name="item" type="xs:string"/><!-- should be use="required" !!! -->
+            <xs:attribute name="minFn" type="xs:int">
+              <xs:annotation><xs:documentation>Only present if the decoder has at least minFn functions defined in numFn</xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="minOut" type="xs:int">
+              <xs:annotation><xs:documentation>Only present if the decoder has at least minOut functions defined in numOut</xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="inOptions" type="xs:string"/>
+            <xs:attribute name="tooltip" type="xs:string">
+              <xs:annotation><xs:documentation>Deprecated, use the tooltip element instead.</xs:documentation></xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="include" type="xs:string" default=""/>
+            <xs:attribute name="exclude" type="xs:string" default=""/>
+          </xs:complexType>
+          <xs:unique name="UniqueVariableLabel1">
+            <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
+            <xs:selector xpath="label"/>
+            <xs:field xpath="@xml:lang"/>
+          </xs:unique>
+        </xs:element>
 
-          <xs:element ref="xi:include" minOccurs="0" maxOccurs="unbounded" />
-        </xs:sequence>
+        <xs:element ref="xi:include" minOccurs="0" maxOccurs="unbounded" />
+      </xs:sequence>
     </xs:sequence>
     <xs:attribute ref="xml:base" />
     <xs:attribute name="include" type="xs:string"/>
@@ -912,7 +912,7 @@
     <xs:sequence>
       <xs:element name="mode" type="modeType" minOccurs="0" maxOccurs="unbounded">
         <xs:annotation><xs:documentation>
-          Specifies programmer mode(s) for use during reset
+            Specifies programmer mode(s) for use during reset
         </xs:documentation></xs:annotation>
       </xs:element>
       <xs:element name="factReset" minOccurs="0" maxOccurs="unbounded" >
@@ -920,7 +920,7 @@
           <xs:sequence minOccurs="0" maxOccurs="unbounded">
             <xs:element name="mode" type="modeType" minOccurs="0" maxOccurs="unbounded">
               <xs:annotation><xs:documentation>
-                Specifies programmer mode(s) for use during reset
+                  Specifies programmer mode(s) for use during reset
               </xs:documentation></xs:annotation>
             </xs:element>
             <xs:element name="label" minOccurs="0" maxOccurs="unbounded">
@@ -931,11 +931,11 @@
             </xs:element>
           </xs:sequence>
           <xs:attribute name="label" type="xs:string">
-              <xs:annotation><xs:documentation>Deprecated, use the label element instead.</xs:documentation></xs:annotation>
+            <xs:annotation><xs:documentation>Deprecated, use the label element instead.</xs:documentation></xs:annotation>
           </xs:attribute>
           <xs:attribute name="CV" type="cvNameType"/>
           <xs:attribute name="default" type="xs:string">
-              <xs:annotation><xs:documentation>Value to be written to CV to perform this reset.</xs:documentation></xs:annotation>
+            <xs:annotation><xs:documentation>Value to be written to CV to perform this reset.</xs:documentation></xs:annotation>
           </xs:attribute>
           <xs:attribute name="comment" type="xs:string"/>
           <xs:attribute name="item" type="xs:string"/>
@@ -954,25 +954,25 @@
 
   <xs:complexType name="EnumValType">
     <xs:annotation><xs:documentation>
-    A variable containing a fixed set of choices is defined, each choice corresponding to a specific value
+        A variable containing a fixed set of choices is defined, each choice corresponding to a specific value
     </xs:documentation></xs:annotation>
     <xs:sequence minOccurs="0" maxOccurs="unbounded">
       <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1">
-              <xs:annotation><xs:documentation>
-              DocBook element(s) providing copyright information in standard form.
-              For use in subfiles.
-              </xs:documentation></xs:annotation>
+        <xs:annotation><xs:documentation>
+            DocBook element(s) providing copyright information in standard form.
+            For use in subfiles.
+        </xs:documentation></xs:annotation>
       </xs:element>
       <xs:element ref="docbook:authorgroup" minOccurs="0" maxOccurs="unbounded" >
-          <xs:annotation><xs:documentation>
-          DocBook element(s) describing the authors in standard form.
-          For use in subfiles.
-          </xs:documentation></xs:annotation>
+        <xs:annotation><xs:documentation>
+            DocBook element(s) describing the authors in standard form.
+            For use in subfiles.
+        </xs:documentation></xs:annotation>
       </xs:element>
       <xs:element ref="docbook:revhistory" minOccurs="0" maxOccurs="unbounded" >
         <xs:annotation><xs:documentation>
-        DocBook element(s) describing the revision history in standard form.
-        For use in subfiles.
+            DocBook element(s) describing the revision history in standard form.
+            For use in subfiles.
         </xs:documentation></xs:annotation>
       </xs:element>
       <xs:element type="EnumChoiceType" name="enumChoice" minOccurs="0" maxOccurs="unbounded" />
@@ -985,55 +985,55 @@
 
   <xs:complexType name="EnumChoiceType">
     <xs:annotation><xs:documentation>
-    Defines one choice within an enumVal element (though may be grouped in one or more
-    intermediate enumChoiceGroup elements)
+        Defines one choice within an enumVal element (though may be grouped in one or more
+        intermediate enumChoiceGroup elements)
     </xs:documentation></xs:annotation>
-          <xs:sequence minOccurs="0" maxOccurs="unbounded">
-            <xs:annotation><xs:documentation>Multiple elements provide internationalized choice text</xs:documentation></xs:annotation>
-            <xs:element name="choice" minOccurs="1" maxOccurs="unbounded" />
-            <xs:element name="comment" minOccurs="0" maxOccurs="unbounded" />
-          </xs:sequence>
-          <xs:attribute name="choice" type="xs:string">
-            <xs:annotation><xs:documentation>Deprecated in favor of the choice sub-element</xs:documentation></xs:annotation>
-          </xs:attribute>
-          <xs:attribute name="value" type="xs:int" />
-          <xs:attribute name="include" type="xs:string"/>
-          <xs:attribute name="exclude" type="xs:string"/>
-          <xs:attribute name="comment" type="xs:string"/>
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:annotation><xs:documentation>Multiple elements provide internationalized choice text</xs:documentation></xs:annotation>
+      <xs:element name="choice" minOccurs="1" maxOccurs="unbounded" />
+      <xs:element name="comment" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute name="choice" type="xs:string">
+      <xs:annotation><xs:documentation>Deprecated in favor of the choice sub-element</xs:documentation></xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="value" type="xs:int" />
+    <xs:attribute name="include" type="xs:string"/>
+    <xs:attribute name="exclude" type="xs:string"/>
+    <xs:attribute name="comment" type="xs:string"/>
   </xs:complexType>
 
   <xs:complexType name="EnumChoiceGroupType">
     <xs:annotation><xs:documentation>
-    Allows grouping of enumChoice elements within an enumVal element.
-    This can be used for e.g. defining individual XML documents to be included.
-    The optional name element(s), if and only if present, is used in a tree display to
-    indicate the presence of intermediate tree nodes.
+        Allows grouping of enumChoice elements within an enumVal element.
+        This can be used for e.g. defining individual XML documents to be included.
+        The optional name element(s), if and only if present, is used in a tree display to
+        indicate the presence of intermediate tree nodes.
     </xs:documentation></xs:annotation>
-      <xs:sequence minOccurs="1" maxOccurs="1">
-        <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1">
-              <xs:annotation><xs:documentation>
-              DocBook element(s) providing copyright information in standard form.
-              For use in subfiles.
-              </xs:documentation></xs:annotation>
-        </xs:element>
-        <xs:element ref="docbook:authorgroup" minOccurs="0" maxOccurs="unbounded" >
-          <xs:annotation><xs:documentation>
-          DocBook element(s) describing the authors in standard form.
-          For use in subfiles.
-          </xs:documentation></xs:annotation>
-        </xs:element>
-        <xs:element ref="docbook:revhistory" minOccurs="0" maxOccurs="unbounded" >
-          <xs:annotation><xs:documentation>
-          DocBook element(s) describing the revision history in standard form.
-          For use in subfiles.
-          </xs:documentation></xs:annotation>
-        </xs:element>
-        <xs:element name="name" minOccurs="0" maxOccurs="unbounded">
-            <xs:annotation><xs:documentation>User-visible name for this group, can be repeated for I18N</xs:documentation></xs:annotation>
-        </xs:element>
-        <xs:sequence minOccurs="0" maxOccurs="unbounded">
-          <xs:element type="EnumChoiceType" name="enumChoice" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element type="EnumChoiceGroupType" name="enumChoiceGroup" minOccurs="0" maxOccurs="unbounded"/>
+    <xs:sequence minOccurs="1" maxOccurs="1">
+      <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1">
+        <xs:annotation><xs:documentation>
+            DocBook element(s) providing copyright information in standard form.
+            For use in subfiles.
+        </xs:documentation></xs:annotation>
+      </xs:element>
+      <xs:element ref="docbook:authorgroup" minOccurs="0" maxOccurs="unbounded" >
+        <xs:annotation><xs:documentation>
+            DocBook element(s) describing the authors in standard form.
+            For use in subfiles.
+        </xs:documentation></xs:annotation>
+      </xs:element>
+      <xs:element ref="docbook:revhistory" minOccurs="0" maxOccurs="unbounded" >
+        <xs:annotation><xs:documentation>
+            DocBook element(s) describing the revision history in standard form.
+            For use in subfiles.
+        </xs:documentation></xs:annotation>
+      </xs:element>
+      <xs:element name="name" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation><xs:documentation>User-visible name for this group, can be repeated for I18N</xs:documentation></xs:annotation>
+      </xs:element>
+      <xs:sequence minOccurs="0" maxOccurs="unbounded">
+        <xs:element type="EnumChoiceType" name="enumChoice" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element type="EnumChoiceGroupType" name="enumChoiceGroup" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:sequence>
     <xs:attribute ref="xml:base" />
@@ -1044,11 +1044,11 @@
 
   <xs:simpleType name="maskType">
     <xs:annotation>
-        <xs:documentation>
-          Type for CV mask values in one of two forms: 
-            8 or 16 characters of either V (valid bit) or X (ignore bit).
-            Decimal integer less than or equal to 128 which is the base. (in that case, max value is needed)
-        </xs:documentation>
+      <xs:documentation>
+        Type for CV mask values in one of two forms: 
+        8 or 16 characters of either V (valid bit) or X (ignore bit).
+        Decimal integer less than or equal to 128 which is the base. (in that case, max value is needed)
+      </xs:documentation>
     </xs:annotation>
     <xs:union>
       <xs:simpleType>

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -345,7 +345,7 @@
   </xs:element>
 
   <xs:complexType name="FamilyType">
-    <xs:sequence>
+    <xs:sequence minOccurs="1" maxOccurs="unbounded">
       <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
         <xs:unique name="UniqueOutputLabel1">
           <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -314,9 +314,38 @@
     </xs:annotation>
   </xs:element>
 
+  <xs:element name="outputs" >
+    <xs:complexType>
+      <xs:sequence>
+          <!-- this info also needs to be handled two other places for it to be useful -->
+          <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1" >
+              <xs:annotation><xs:documentation>
+              DocBook element(s) providing copyright information in standard form.
+              </xs:documentation></xs:annotation>
+          </xs:element>
+          <xs:element ref="docbook:authorgroup" minOccurs="0" maxOccurs="unbounded" >
+              <xs:annotation><xs:documentation>
+              DocBook element(s) describing the authors in standard form.
+              </xs:documentation></xs:annotation>
+          </xs:element>
+          <xs:element ref="docbook:revhistory" minOccurs="0" maxOccurs="unbounded" >
+              <xs:annotation><xs:documentation>
+              DocBook element(s) describing the revision history in standard form.
+              </xs:documentation></xs:annotation>
+          </xs:element>
+        <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
+          <xs:unique name="UniqueOutputLabel0">
+            <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
+            <xs:selector xpath="label"/>
+            <xs:field xpath="@xml:lang"/>
+          </xs:unique>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
   <xs:complexType name="FamilyType">
     <xs:sequence>
-
       <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
         <xs:unique name="UniqueOutputLabel1">
           <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
@@ -324,6 +353,21 @@
           <xs:field xpath="@xml:lang"/>
         </xs:unique>
       </xs:element>
+      <xs:element name="outputs" minOccurs="0" maxOccurs="unbounded" >
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
+              <!-- the following uniqueness item has to be at the "output" level, which prevents "outsput_s_" from being a complex type -->
+              <xs:unique name="UniqueOutputLabel2">
+                <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
+                <xs:selector xpath="label"/>
+                <xs:field xpath="@xml:lang"/>
+              </xs:unique>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element ref="xi:include" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="model" minOccurs="0" maxOccurs="unbounded" >
         <xs:complexType>
           <xs:sequence>
@@ -335,12 +379,27 @@
               </xs:complexType>
             </xs:element>
             <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
-              <xs:unique name="UniqueOutputLabel2">
+              <xs:unique name="UniqueOutputLabel3">
                 <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
                 <xs:selector xpath="label"/>
                 <xs:field xpath="@xml:lang"/>
               </xs:unique>
             </xs:element>
+            <xs:element name="outputs" minOccurs="0" maxOccurs="unbounded" >
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
+                    <!-- the following uniqueness item has to be at the "output" level, which prevents "outsput_s_" from being a complex type -->
+                    <xs:unique name="UniqueOutputLabel4">
+                      <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
+                      <xs:selector xpath="label"/>
+                      <xs:field xpath="@xml:lang"/>
+                    </xs:unique>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+            <xs:element ref="xi:include" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="size" minOccurs="0" maxOccurs="1" >
               <xs:annotation><xs:documentation>
                 Describes the physical size of the package, for reference.
@@ -516,7 +575,6 @@
         or some other kind of output, i.e. a sound,
         or even internal state operations, e.g. "Switch to alternating lights".
       </xs:documentation></xs:annotation>
-
         <xs:sequence>
           <xs:element name="label" minOccurs="0" maxOccurs="unbounded">
             <xs:annotation><xs:documentation>Multiple elements provide internationalized label text</xs:documentation></xs:annotation>
@@ -525,7 +583,6 @@
             </xs:complexType>
           </xs:element>
         </xs:sequence>
-
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="label" type="xs:string" />
         <xs:attribute name="comment" type="xs:string" />
@@ -543,8 +600,6 @@
             </xs:restriction>
           </xs:simpleType>
         </xs:attribute>
-
-
   </xs:complexType>
 
   <xs:complexType name="functionlabelsType">

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -314,10 +314,9 @@
     </xs:annotation>
   </xs:element>
 
-  <xs:element name="outputs" >
-    <xs:complexType>
+    <xs:complexType  name="OutputsType">
       <xs:sequence>
-        <!-- this info also needs to be handled two other places for it to be useful -->
+        <!-- An outputs element can be the root of an include file, where version information may be useful -->
         <xs:element ref="docbook:copyright" minOccurs="0" maxOccurs="1" >
           <xs:annotation><xs:documentation>
               DocBook element(s) providing copyright information in standard form.
@@ -342,6 +341,9 @@
         </xs:element>
       </xs:sequence>
     </xs:complexType>
+    
+  <xs:element name="outputs" type="OutputsType">
+    <!-- element definition for include files -->
   </xs:element>
 
   <xs:complexType name="FamilyType">
@@ -353,20 +355,7 @@
           <xs:field xpath="@xml:lang"/>
         </xs:unique>
       </xs:element>
-      <xs:element name="outputs" minOccurs="0" maxOccurs="unbounded" >
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
-              <!-- the following uniqueness item has to be at the "output" level, which prevents "outsput_s_" from being a complex type -->
-              <xs:unique name="UniqueOutputLabel2">
-                <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
-                <xs:selector xpath="label"/>
-                <xs:field xpath="@xml:lang"/>
-              </xs:unique>
-            </xs:element>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
+      <xs:element name="outputs" type="OutputsType" minOccurs="0" maxOccurs="unbounded" />
       <xs:element ref="xi:include" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="model" minOccurs="0" maxOccurs="unbounded" >
         <xs:complexType>
@@ -385,20 +374,7 @@
                 <xs:field xpath="@xml:lang"/>
               </xs:unique>
             </xs:element>
-            <xs:element name="outputs" minOccurs="0" maxOccurs="unbounded" >
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
-                    <!-- the following uniqueness item has to be at the "output" level, which prevents "outsput_s_" from being a complex type -->
-                    <xs:unique name="UniqueOutputLabel4">
-                      <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
-                      <xs:selector xpath="label"/>
-                      <xs:field xpath="@xml:lang"/>
-                    </xs:unique>
-                  </xs:element>
-                </xs:sequence>
-              </xs:complexType>
-            </xs:element>
+            <xs:element name="outputs" type="OutputsType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element ref="xi:include" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="size" minOccurs="0" maxOccurs="1" >
               <xs:annotation><xs:documentation>

--- a/xml/schema/decoder-4-15-2.xsd
+++ b/xml/schema/decoder-4-15-2.xsd
@@ -317,6 +317,13 @@
   <xs:complexType name="FamilyType">
     <xs:sequence>
 
+      <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
+        <xs:unique name="UniqueOutputLabel1">
+          <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
+          <xs:selector xpath="label"/>
+          <xs:field xpath="@xml:lang"/>
+        </xs:unique>
+      </xs:element>
       <xs:element name="model" minOccurs="0" maxOccurs="unbounded" >
         <xs:complexType>
           <xs:sequence>
@@ -327,40 +334,8 @@
                 <xs:attribute name="comment" type="xs:string" />
               </xs:complexType>
             </xs:element>
-            <xs:element name="output" minOccurs="0" maxOccurs="unbounded" >
-              <xs:annotation><xs:documentation>
-                Can represent either an electrical output, i.e. a wire to a light,
-                or some other kind of output, i.e. a sound,
-                or even internal state operations, e.g. "Switch to alternating lights".
-              </xs:documentation></xs:annotation>
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="label" minOccurs="0" maxOccurs="unbounded">
-                    <xs:annotation><xs:documentation>Multiple elements provide internationalized label text</xs:documentation></xs:annotation>
-                    <xs:complexType mixed="true">
-                        <xs:attribute ref="xml:lang" default=""/>
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-                <xs:attribute name="name" type="xs:string" use="required"/>
-                <xs:attribute name="label" type="xs:string" />
-                <xs:attribute name="comment" type="xs:string" />
-                <xs:attribute name="maxcurrent" type="xs:string" />
-                <xs:attribute name="connection" default="unspecified" >
-                  <xs:simpleType>
-                    <xs:restriction base="xs:token" >
-                      <xs:enumeration value="unspecified"/>
-                      <xs:enumeration value="plug"/>
-                      <xs:enumeration value="wire"/>
-                      <xs:enumeration value="solder"/>
-                      <xs:enumeration value="LED"/>
-                      <xs:enumeration value="bulb"/>
-                      <xs:enumeration value="other"/>
-                    </xs:restriction>
-                  </xs:simpleType>
-                </xs:attribute>
-              </xs:complexType>
-              <xs:unique name="UniqueOutputLabel1">
+            <xs:element name="output" type="OutputElementType"  minOccurs="0" maxOccurs="unbounded" >
+              <xs:unique name="UniqueOutputLabel2">
                 <xs:annotation><xs:documentation>Insist that there's only one label per language</xs:documentation></xs:annotation>
                 <xs:selector xpath="label"/>
                 <xs:field xpath="@xml:lang"/>
@@ -533,6 +508,43 @@
     <xs:attribute name="highVersionID" type="xs:int" />
     <xs:attribute name="type" type="xs:string" />
     <xs:attribute name="comment" type="xs:string" />
+  </xs:complexType>
+
+  <xs:complexType name="OutputElementType">
+      <xs:annotation><xs:documentation>
+        Can represent either an electrical output, i.e. a wire to a light,
+        or some other kind of output, i.e. a sound,
+        or even internal state operations, e.g. "Switch to alternating lights".
+      </xs:documentation></xs:annotation>
+
+        <xs:sequence>
+          <xs:element name="label" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation><xs:documentation>Multiple elements provide internationalized label text</xs:documentation></xs:annotation>
+            <xs:complexType mixed="true">
+                <xs:attribute ref="xml:lang" default=""/>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="label" type="xs:string" />
+        <xs:attribute name="comment" type="xs:string" />
+        <xs:attribute name="maxcurrent" type="xs:string" />
+        <xs:attribute name="connection" default="unspecified" >
+          <xs:simpleType>
+            <xs:restriction base="xs:token" >
+              <xs:enumeration value="unspecified"/>
+              <xs:enumeration value="plug"/>
+              <xs:enumeration value="wire"/>
+              <xs:enumeration value="solder"/>
+              <xs:enumeration value="LED"/>
+              <xs:enumeration value="bulb"/>
+              <xs:enumeration value="other"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+
+
   </xs:complexType>
 
   <xs:complexType name="functionlabelsType">


### PR DESCRIPTION
This PR allows more flexibility in positioning the `<output>` elements in a decoder definition
- They can be put at the `<family>` level, in addition to the `<model>` level.  Family definitions apply to all models unless countermanded.
- The `<output>` elements can optionally be grouped in an `<outputs>` element to help organization.
- A small file with an `<outputs>` containing `<output>` elements can be included in the usual way.

See the 0NMRA.xml and Digitrax_1SFX.xml files for examples.