### PR TITLE
ECJ warnings items:

### DIFF
--- a/java/ecj.warning.options
+++ b/java/ecj.warning.options
@@ -15,11 +15,11 @@
 -warn:-allJavadoc
 -warn:-javadoc
 
-# 36 on next
--warn:-invalidJavadoc
--warn:-invalidJavadocTag
--warn:-invalidJavadocTagDep
--warn:-invalidJavadocTagNotVisible
+# 57 warnings in source plus 9 in tests with next line on
+-warn:+invalidJavadoc
+-warn:+invalidJavadocTag
+-warn:+invalidJavadocTagDep
+-warn:+invalidJavadocTagNotVisible
 
 -warn:-missingJavadocTags
 -warn:-missingJavadocTagsMethod
@@ -65,6 +65,7 @@
 -warn:+deprecation
 -warn:+discouraged
 -warn:+enumIdentifier
+-warn:+enumSwitch
 -warn:+fallthrough
 -warn:+finalBound
 -warn:+finally 
@@ -88,13 +89,14 @@
 -warn:+semicolon
 -warn:+specialParamHiding
 -warn:+suppress
+-warn:+switchDefault
 -warn:+unavoidableGenericProblems
 -warn:+unchecked
 -warn:+uselessTypeCheck
 -warn:+varargsCast
 
 #
-# Checks we choose not to enforce as out common style
+# Checks we choose not to enforce as our common style
 #
 
   # no real cost to using implicit boxing/unboxing, and it's just easier
@@ -133,11 +135,10 @@
 #
 # Checks we're warning on, working to reduce, but not enforcing
 #
--warn:+enumSwitch
--warn:+switchDefault
+
 
 #
-# Checks we're working on putting in place
+# Checks we will eventually put in place, but would be burdensome now
 #
 
   # 14 outstanding items
@@ -157,7 +158,7 @@
 
 
 #
-# Checks not yet decided 
+# Checks still to be characterized
 #
 
 -warn:-all-static-method

--- a/java/ecj.warning.options
+++ b/java/ecj.warning.options
@@ -104,52 +104,55 @@
   # our inheritance tree doesn't insist on single-access to parent interfaces
 -warn:-intfRedundant
 
-  # non-nls string literals (mostly missing // $ NON-NLS)
+  # non-NLS string literals (mostly missing // $ NON-NLS)
 -warn:-nls
 
-# many of these in the code, and "final" for parameters is a matter of style
+  # many of these in the code, and "final" for parameters is a matter of style
 -warn:-paramAssign
 
-# JMRI doesn't anticipate use of Java serialization
+  # JMRI doesn't anticipate use of Java serialization
 -warn:-serial
 
-# maybe a good idea, but too expensive now
+  # maybe a good idea, but too expensive now
 -warn:-super
 
-# many of these aleady in the code, and the value is not clear
+  # many of these aleady in the code, and the value is not clear
 -warn:-syntheticAccess
 
-# we don't require "this." in every variable access
+  # we don't require "this." in every variable access to reduce verbosity
 -warn:-unqualifiedField
 -warn:-unqualified-field-access
 
-# our APIs routinely have "may need in future" parameters
+  # our APIs routinely have "may need in future" parameters
 -warn:-unusedArgument
+
+  # missing enum switch cases even when default case is present; `default` can be convenient
+-warn:-enumSwitchPedantic
 
 
 #
 # Checks we're warning on, working to reduce, but not enforcing
 #
--warn:-switchDefault
 -warn:+enumSwitch
+-warn:+switchDefault
 
 #
 # Checks we're working on putting in place
 #
 
-# 14 outstanding items
+  # 14 outstanding items
 -warn:-deadCode
 
-# missing synch in synchronized method override
-# 22 outstanding items
+  # missing synch in synchronized method override
+  # 22 outstanding items
 -warn:-syncOverride
 
-# raw type instead of parameterized type 
-# 159 outstanding items (some likely to be in APIs)
+  # raw type instead of parameterized type 
+  # 159 outstanding items (some likely to be in APIs)
 -warn:-raw
 
-# this tags some NetBeans and FindBugs tokens in @SuppressWarnings  
-# Until that's fixed, useful to run occasionally to find "Unnecessary" annotations
+  # this tags some NetBeans and FindBugs tokens in @SuppressWarnings  
+  # Until that's fixed, useful to run occasionally to find "Unnecessary" annotations
 -warn:-warningToken
 
 
@@ -159,11 +162,11 @@
 
 -warn:-all-static-method
 -warn:-emptyBlock
-  # missing enum switch cases even when default case is present
--warn:-enumSwitchPedantic
 
 -warn:-allDeadCode
-  # flags methods that can be made static because they don't access data members
+
+  # flags methods that can be made static because they don't access data member
+  # but that just seems distracting somehow
 -warn:-static-method
 
   # We often seem to _prefer_ the terminal else instead of bottom return

--- a/java/ecj.warning.options-ci
+++ b/java/ecj.warning.options-ci
@@ -11,11 +11,11 @@
 -warn:-allJavadoc
 -warn:-javadoc
 
-# 36 on next
--warn:-invalidJavadoc
--warn:-invalidJavadocTag
--warn:-invalidJavadocTagDep
--warn:-invalidJavadocTagNotVisible
+# 57 warnings in source plus 9 in tests with next line on
+-warn:+invalidJavadoc
+-err:+invalidJavadocTag
+-err:+invalidJavadocTagDep
+-err:+invalidJavadocTagNotVisible
 
 -warn:-missingJavadocTags
 -warn:-missingJavadocTagsMethod
@@ -58,6 +58,7 @@
 -err:+deprecation
 -err:+discouraged
 -err:+enumIdentifier
+-err:+enumSwitch
 -err:+fallthrough
 -err:+finalBound
 -err:+finally 
@@ -81,13 +82,14 @@
 -err:+semicolon
 -err:+specialParamHiding
 -err:+suppress
+-err:+switchDefault
 -err:+unavoidableGenericProblems
 -err:+unchecked
 -err:+uselessTypeCheck
 -err:+varargsCast
 
 
-# Checks we choose not to enforce as a matter of style
+# Checks we choose not to enforce as our common style
 -warn:-boxing
 -warn:-intfRedundant
 -warn:-nls
@@ -100,35 +102,41 @@
 -warn:-unusedArgument
 
 
+#
+# Checks we're warning on, working to reduce, but not enforcing
+#
 
-# Checks we're warning on, but not enforcing
--warn:-switchDefault
--warn:-enumSwitch
 
 
-# Checks we're working on
+# Checks we will eventually put in place, but would be burdensome now
 
-# 14 outstanding items
+    # 14 outstanding items
 -warn:-deadCode
 
-# 22 outstanding items
+    # 22 outstanding items
 -warn:-syncOverride
 
-# 159 outstanding items
+    # 159 outstanding items
 -warn:-raw
 
-# this tags some FindBugs labels?  But still useful to run occasionally
+    # this tags some FindBugs labels?  But still useful to run occasionally
 -warn:-warningToken
 
 
-# Checks not yet examined 
+# Checks still to be characterized
 
--warn:-allDeadCode
 -warn:-all-static-method
 -warn:-emptyBlock
--warn:-enumSwitchPedantic
+
+-warn:-allDeadCode
+
+  # flags methods that can be made static because they don't access data member
+  # but that just seems distracting somehow
 -warn:-static-method
-#-warn:-tasks(<task1>|...|<taskN>)
+
+  # We often seem to _prefer_ the terminal else instead of bottom return
 -warn:-unnecessaryElse
+
+#-warn:-tasks(<task1>|...|<taskN>)
 
 

--- a/java/src/apps/gui3/tabbedpreferences/package-info.java
+++ b/java/src/apps/gui3/tabbedpreferences/package-info.java
@@ -1,3 +1,5 @@
+package apps.gui3.tabbedpreferences;
+
 /**
  * Provides the tabbed preferences window and its contents.
  * <p>
@@ -43,4 +45,3 @@
  * @see jmri.swing.PreferencesPanel
  * @see apps.AppConfigBase
  */
-package apps.gui3.tabbedpreferences;

--- a/java/src/jmri/jmrit/beantable/SignalGroupSubTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalGroupSubTableAction.java
@@ -79,7 +79,8 @@ public class SignalGroupSubTableAction {
      * Set to OR when you at least one of the conditionals to be met for the
      * Signal Head to turn On when an included Aspect is shown.
      *
-     * @see operFromBox operFromBox()
+     * See {@link operFromBox operFromBox()}
+     * 
      * @param mode True for AND
      * @param box the comboBox object to set
      */
@@ -95,7 +96,8 @@ public class SignalGroupSubTableAction {
     /**
      * Get the user choice for conditional evaluation.
      *
-     * @see setoperBox setoperBox()
+     * See {@link setoperBox setoperBox()}
+     * 
      * @param box the comboBox object containing the user choice
      * @return True for AND, False for OR
      */
@@ -162,7 +164,8 @@ public class SignalGroupSubTableAction {
 
     /**
      * Get the user choice for a Sensor conditional's On state from the comboBox on the Edit Head sub pane.
-     * @see turnoutModeFromBox turnoutModeFromBox()
+     * See {@link turnoutModeFromBox turnoutModeFromBox()}
+     * 
      * @param box the comboBox object containing the user choice
      * @return Value for ACTIVE/INACTIVE
      */
@@ -181,7 +184,8 @@ public class SignalGroupSubTableAction {
      * Set selected item for a Sensor conditional's On state in the
      * comboBox on the Edit Head sub pane.
      *
-     * @see turnoutModeFromBox turnoutModeFromBox()
+     * See {@link turnoutModeFromBox turnoutModeFromBox()}
+     * 
      * @param mode Value for ACTIVE/INACTIVE
      * @param box the comboBox object to set
      */
@@ -194,7 +198,8 @@ public class SignalGroupSubTableAction {
      * Get the user choice for a Control Turnout conditional's On state
      * from the comboBox on the Edit Head sub pane.
      *
-     * @see sensorModeFromBox sensorModeFromBox()
+     * See {@link sensorModeFromBox sensorModeFromBox()}
+     * 
      * @param box the comboBox object containing the user choice
      * @return Value for CLOSED/THROWN
      */
@@ -213,7 +218,8 @@ public class SignalGroupSubTableAction {
      * Set selected item for a Control Turnout conditional's On state
      * in the comboBox on the Edit Head sub pane.
      *
-     * @see turnoutModeFromBox turnoutModeFromBox()
+     * See {@link turnoutModeFromBox turnoutModeFromBox()}
+     * 
      * @param mode Value for CLOSED/THROWN
      * @param box the comboBox object to set
      */

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -5173,7 +5173,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
      * selectedHitPointType is left referring to the results of the checking the
      * last track on the list.
      * <p>
-     * Refers to the current value of {@link #layoutTrackList) and {@link #dLoc}.
+     * Refers to the current value of {@link #layoutTrackList} and {@link #dLoc}.
      *
      * @param useRectangles set true to use rectangle; false for circles.
      */

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
@@ -417,10 +417,6 @@ public class LayoutShape {
 
     private JPopupMenu popup = null;
 
-    /**
-     * {@inheritDoc}
-     */
-    //@Override
     @Nonnull
     protected JPopupMenu showShapePopUp(@Nullable MouseEvent mouseEvent, int hitPointType) {
         if (popup != null) {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
@@ -526,6 +526,8 @@ public class LayoutShape {
                                 lsp.setType(LayoutShapePointType.eStraight);
                                 break;
                             }
+                            default:
+                              log.error("unexpected enum member!");
                         }
                         layoutEditor.repaint();
                     });
@@ -712,6 +714,9 @@ public class LayoutShape {
                     path.quadTo(p.getX(), p.getY(), midR.getX(), midR.getY());
                     break;
                 }
+                
+                default:
+                  log.error("unexpected enum member!");
             }
         }   // for (idx = 0; idx < cnt; idx++)
 

--- a/java/src/jmri/jmrit/roster/UpdateDecoderDefinitionAction.java
+++ b/java/src/jmri/jmrit/roster/UpdateDecoderDefinitionAction.java
@@ -57,14 +57,14 @@ public class UpdateDecoderDefinitionAction extends JmriAbstractAction {
 
     /**
      * The prefix string used to specify a query in decoder definition file
-     * {@link replacementFamily} and {@link replacementModel} elements.
+     * replacementFamily and replacementModel elements.
      */
     public static final String QRY_PREFIX = "query:";
 
     /**
      * The {@link java.util.regex regex} separator to
      * {@link java.lang.String#split(java.lang.String) split} items in
-     * {@link replacementFamily} and {@link replacementModel} elements.
+     * replacementFamily and replacementModel elements.
      */
     public static final String QRY_SEPARATOR = "\\|";
 
@@ -96,17 +96,17 @@ public class UpdateDecoderDefinitionAction extends JmriAbstractAction {
 
     /**
      * A {@link List} based on the combination of any
-     * {@link #replacementFamily replacementFamily} and
-     * {@link #replacementModel replacementModel} suggestions.
+     * replacementFamily and
+     * replacementModel suggestions.
      */
     transient volatile List<DecoderFile> replacementList;
 
     /**
-     * The subset of {@link #replacementList replacementList} that also matches
+     * The subset of the <code>replacementList</code> that also matches
      * both the
-     * {@link jmri.jmrit.decoderdefn.IdentifyDecoder#mfgID manufacturerID}
+     * {@link jmri.jmrit.decoderdefn.IdentifyDecoder} manufacturerID
      * stored in CV8 and the
-     * {@link jmri.jmrit.decoderdefn.IdentifyDecoder#modelID versionID} stored
+     * {@link jmri.jmrit.decoderdefn.IdentifyDecoder} versionID stored
      * in CV7.
      */
     transient volatile List<DecoderFile> versionMatchList;
@@ -685,9 +685,10 @@ public class UpdateDecoderDefinitionAction extends JmriAbstractAction {
      * <li>
      * A {@link #versionMatchList versionMatchList} that is the subset of
      * {@link #replacementList replacementList} that also matches both a
-     * {@link jmri.jmrit.decoderdefn.IdentifyDecoder#mfgID manufacturerID}
-     * stored in CV8 and a
-     * {@link jmri.jmrit.decoderdefn.IdentifyDecoder#modelID versionID} stored
+     * manufacturerID (from 
+     * {@link jmri.jmrit.decoderdefn.IdentifyDecoder} mfgID) 
+     * stored in CV8 and a versionID (from
+     * {@link jmri.jmrit.decoderdefn.IdentifyDecoder} modelID)  stored
      * in CV7.
      * </li>
      * </ul>

--- a/java/src/jmri/jmrix/lenz/XNetConsist.java
+++ b/java/src/jmri/jmrix/lenz/XNetConsist.java
@@ -74,7 +74,7 @@ public class XNetConsist extends jmri.implementation.DccConsist implements XNetL
     /**
      * Set the Consist Type.
      *
-     * @param consistType, an integer, should be either
+     * @param consistType An integer, should be either
      *                     jmri.Consist.ADVANCED_CONSIST or
      *                     jmri.Consist.CS_CONSIST.
      */

--- a/java/src/jmri/profile/ProfileManagerDialog.java
+++ b/java/src/jmri/profile/ProfileManagerDialog.java
@@ -63,8 +63,8 @@ public class ProfileManagerDialog extends JDialog {
     /**
      * Creates new form ProfileManagerDialog
      *
-     * @param parent {@inheritDoc}
-     * @param modal  {@inheritDoc}
+     * @param parent The frame containing this dialog
+     * @param modal The modal parameter for parent JDialog
      */
     public ProfileManagerDialog(Frame parent, boolean modal) {
         this(parent, modal, false);
@@ -73,8 +73,8 @@ public class ProfileManagerDialog extends JDialog {
     /**
      * Creates new form ProfileManagerDialog
      *
-     * @param parent {@inheritDoc}
-     * @param modal  {@inheritDoc}
+     * @param parent The frame containing this dialog
+     * @param modal The modal parameter for parent JDialog
      * @param disableTimer true if the timer should be disabled
      */
     public ProfileManagerDialog(Frame parent, boolean modal, boolean disableTimer) {

--- a/java/src/jmri/util/Log4JUtil.java
+++ b/java/src/jmri/util/Log4JUtil.java
@@ -71,7 +71,7 @@ public class Log4JUtil {
     static private boolean warnOnceHasWarned = false;
     
     /**
-     * Restart the "once" part of {@link warnOnce} so that the 
+     * Restart the "once" part of {@link #warnOnce} so that the 
      * nextInvocation will log, even if it already has.
      * <p>
      * Should only be used by test code. We denote this

--- a/java/src/jmri/util/MathUtil.java
+++ b/java/src/jmri/util/MathUtil.java
@@ -997,9 +997,9 @@ public final class MathUtil {
     /**
      * return rectangle at point
      *
-     * @param p,      the point
-     * @param width,  the width
-     * @param height, the height
+     * @param p      the point
+     * @param width  the width
+     * @param height the height
      * @return the rectangle
      */
     @CheckReturnValue
@@ -1156,7 +1156,7 @@ public final class MathUtil {
      * plot a Bezier curve
      *
      * @param g2           the Graphics2D to draw to
-     * @param p[]          control points
+     * @param p            control points
      * @param displacement right/left to draw a line parallel to the Bezier
      * @param fillFlag     false to draw / true to fill
      * @return the length of the Bezier curve
@@ -1184,7 +1184,7 @@ public final class MathUtil {
     /**
      * get the path for a Bezier curve
      *
-     * @param p[]          control points
+     * @param p             control points
      * @param displacement right/left to draw a line parallel to the Bezier
      * @return the length of the Bezier curve
      */
@@ -1203,7 +1203,7 @@ public final class MathUtil {
     /**
      * get the path for a Bezier curve
      *
-     * @param p[] control points
+     * @param p   control points
      * @return the length of the Bezier curve
      */
     public static GeneralPath getBezierPath(@Nonnull Point2D p[]) {
@@ -1214,7 +1214,7 @@ public final class MathUtil {
      * Draw a Bezier curve
      *
      * @param g2           the Graphics2D to draw to
-     * @param p[]          control points
+     * @param p            control points
      * @param displacement right/left to draw a line parallel to the Bezier
      * @return the length of the Bezier curve
      */
@@ -1229,7 +1229,7 @@ public final class MathUtil {
      * Fill a Bezier curve
      *
      * @param g2           the Graphics2D to draw to
-     * @param p[]          control points
+     * @param p            control points
      * @param displacement right/left to draw a line parallel to the Bezier
      * @return the length of the Bezier curve
      */
@@ -1255,7 +1255,7 @@ public final class MathUtil {
      * Fill a Bezier curve
      *
      * @param g2  the Graphics2D to draw to
-     * @param p[] control points
+     * @param p   control points
      * @return the length of the Bezier curve
      */
     public static double fillBezier(Graphics2D g2, @Nonnull Point2D p[]) {

--- a/java/src/jmri/util/ThreadingUtil.java
+++ b/java/src/jmri/util/ThreadingUtil.java
@@ -253,7 +253,7 @@ public class ThreadingUtil {
      * Check that a call is on the GUI thread. Warns (once) if not.
      * Intended to be the run-time check mechanism for {@code @InvokeOnGuiThread}
      * <p>
-     * In this implementation, this is the same as {@link requireLayoutThread}
+     * In this implementation, this is the same as {@link #requireLayoutThread(org.slf4j.Logger)}
      * @param logger The logger object from the calling class, usually "log"
      */
     static public void requireGuiThread(org.slf4j.Logger logger) {
@@ -267,7 +267,7 @@ public class ThreadingUtil {
      * Check that a call is on the Layout thread. Warns (once) if not.
      * Intended to be the run-time check mechanism for {@code @InvokeOnLayoutThread}
      * <p>
-     * In this implementation, this is the same as {@link requireGuiThread}
+     * In this implementation, this is the same as {@link #requireGuiThread(org.slf4j.Logger)}
      * @param logger The logger object from the calling class, usually "log"
      */
     static public void requireLayoutThread(org.slf4j.Logger logger) {

--- a/java/src/jmri/util/com/dictiography/collections/AbstractMap.java
+++ b/java/src/jmri/util/com/dictiography/collections/AbstractMap.java
@@ -465,7 +465,6 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
      * set, and adding up the results.
      *
      * @return the hash code value for this map
-     * @see Map.Entry#hashCode()
      * @see Object#equals(Object)
      * @see Set#equals(Object)
      */

--- a/java/src/jmri/util/com/dictiography/collections/package-info.java
+++ b/java/src/jmri/util/com/dictiography/collections/package-info.java
@@ -1,3 +1,4 @@
+package jmri.util.com.dictiography.collections;
 /**
  *  Provides sorted, yet directly accessible, {@link IndexedTreeSet} and {@link IndexedTreeMap} collection classes.
  
@@ -18,4 +19,3 @@
  * <!-- Put @see and @since tags down here. -->
  * @since JMRI 4.11.4
  */
-package jmri.util.com.dictiography.collections;

--- a/java/src/jmri/util/swing/ImagePanel.java
+++ b/java/src/jmri/util/swing/ImagePanel.java
@@ -20,8 +20,9 @@ public class ImagePanel extends JPanel {
 
     /**
      * Set background images for ImagePanel.
-     * @see jmri.jmrit.catalog.PreviewDialog#setupPanel()
-     * @see jmri.jmrit.catalog.CatalogPanel#makeButtonPanel()
+     * For specifics, 
+     * see the setupPanel() private method in {@link jmri.jmrit.catalog.PreviewDialog}
+     * and the makeButtonPanel() private method in {@link jmri.jmrit.catalog.CatalogPanel}
      *
      * @param img Image to load as background
      */

--- a/java/test/apps/LaunchJmriAppBase.java
+++ b/java/test/apps/LaunchJmriAppBase.java
@@ -44,9 +44,9 @@ abstract public class LaunchJmriAppBase {
 
     /**
      * Run one application
-     * @param Name of the Profile to copy from files in java/test/apps/PanelPro/profiles/
-     * @param Name application (frame) title 
-     * @param Start of the "we're up!" message
+     * @param profileName Name of the Profile to copy from files in java/test/apps/PanelPro/profiles/
+     * @param frameName Name application (frame) title 
+     * @param startMessageStart Start of the "we're up!" message
      */
     protected void runOne(String profileName, String frameName, String startMessageStart) throws IOException {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());


### PR DESCRIPTION
- `ant warnings` flags switch-over-enum blocks that don't have a `default` case even when there are `case` statements for every enum value.  This actually corresponds to a recommendation from the Java enum working group:  Although the enum's members are known in a single compilation unit, one can't assume that's the case for a library which might have code from different versions.  Left the warning in place, added defaults where needed that `log.error`

- Turned on warning for _erroneous_ (not missing) Javadoc.  Fixed about half of the ones tagged.  