### PR TITLE
Check for layout block references before proceeding with a block rename

### DIFF
--- a/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
+++ b/java/src/jmri/jmrit/beantable/BeanTableBundle.properties
@@ -327,6 +327,9 @@ BlockReporter = Reporter
 BlockSensor = Sensor
 BlockReporterCurrent = Use Current
 
+BlockRemoveUserNameWarning = The user name cannot be removed.\nLayout Editor track components are using block name "{0}".
+BlockChangeUserName = Layout Editor track components using block name "{0}" will now use "{1}"\nContinue with the change?
+
 LabelReport = Report
 LabelLastReport = Last Report
 

--- a/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
+++ b/java/src/jmri/jmrit/beantable/BeanTableDataModel.java
@@ -51,6 +51,8 @@ import jmri.NamedBean;
 import jmri.NamedBeanHandleManager;
 import jmri.NamedBeanPropertyDescriptor;
 import jmri.UserPreferencesManager;
+import jmri.jmrit.display.layoutEditor.LayoutBlock;
+import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
 import jmri.swing.JTablePersistenceManager;
 import jmri.util.davidflanagan.HardcopyWriter;
 import jmri.util.swing.XTableColumnModel;
@@ -750,6 +752,8 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
             }
         }
 
+        if (!allowBlockNameChange("Rename", nBean, value)) return;  // NOI18N
+
         nBean.setUserName(value);
         fireTableRowsUpdated(row, row);
         if (!value.equals("")) {
@@ -783,6 +787,7 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
 
     public void removeName(int row, int column) {
         T nBean = getBySystemName(sysNameList.get(row));
+        if (!allowBlockNameChange("Remove", nBean, "")) return;  // NOI18N
         String msg = Bundle.getMessage("UpdateToSystemName", new Object[]{getBeanType()});
         int optionPane = JOptionPane.showConfirmDialog(null,
                 msg, Bundle.getMessage("UpdateToSystemNameTitle"),
@@ -792,6 +797,45 @@ abstract public class BeanTableDataModel<T extends NamedBean> extends AbstractTa
         }
         nBean.setUserName(null);
         fireTableRowsUpdated(row, row);
+    }
+
+    /*
+     * Determine whether it is safe to rename/remove a Block user name.
+     * <p>The user name is used by the LayoutBlock to link to the block and
+     * by Layout Editor track components to link to the layout block.
+     * @oaram changeType This will be Remove or Rename.
+     * @param bean The affected bean.  Only the Block bean is of interest.
+     * @param newName For Remove this will be empty, for Rename it will be the new user name.
+     * @return true to continue with the user name change.
+     */
+    boolean allowBlockNameChange(String changeType, T bean, String newName) {
+        if (!bean.getBeanType().equals("Block")) return true;  // NOI18N
+
+        // If there is no layout block or the block name is empty, Block rename and remove are ok without notification.
+        String oldName = bean.getUserName();
+        if (oldName == null) return true;
+        LayoutBlock layoutBlock = jmri.InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(oldName);
+        if (layoutBlock == null) return true;
+
+        // Remove is not allowed if there is a layout block
+        if (changeType.equals("Remove")) {
+            log.warn("Cannot remove user name for block {}", oldName);  // NOI18N
+                JOptionPane.showMessageDialog(null,
+                        Bundle.getMessage("BlockRemoveUserNameWarning", oldName),  // NOI18N
+                        Bundle.getMessage("WarningTitle"),  // NOI18N
+                        JOptionPane.WARNING_MESSAGE);
+            return false;
+        }
+
+        // Confirmation dialog
+        int optionPane = JOptionPane.showConfirmDialog(null,
+                Bundle.getMessage("BlockChangeUserName", oldName, newName),  // NOI18N
+                Bundle.getMessage("QuestionTitle"),  // NOI18N
+                JOptionPane.YES_NO_OPTION);
+        if (optionPane == JOptionPane.YES_OPTION) {
+            return true;
+        }
+        return false;
     }
 
     @SuppressWarnings("deprecation") // needs careful unwinding for Set operations & generics

--- a/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
@@ -34,6 +34,8 @@ import javax.swing.JTextPane;
 import javax.swing.ListSelectionModel;
 import javax.swing.table.AbstractTableModel;
 import jmri.NamedBean;
+import jmri.jmrit.display.layoutEditor.LayoutBlock;
+import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
 import jmri.util.JmriJFrame;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -405,6 +407,7 @@ abstract class BeanEditAction extends AbstractAction {
      * @param _newName string to use as the new user name
      */
     public void renameBean(String _newName) {
+        if (!allowBlockNameChange("Rename", _newName)) return;  // NOI18N
         NamedBean nBean = bean;
         String oldName = nBean.getUserName();
 
@@ -461,6 +464,7 @@ abstract class BeanEditAction extends AbstractAction {
      * Generic method to remove the user name from a bean.
      */
     public void removeName() {
+        if (!allowBlockNameChange("Remove", "")) return;  // NOI18N
         String msg = java.text.MessageFormat.format(Bundle.getMessage("UpdateToSystemName"),
                 new Object[]{getBeanType()});
         int optionPane = JOptionPane.showConfirmDialog(null,
@@ -470,6 +474,44 @@ abstract class BeanEditAction extends AbstractAction {
             nbMan.updateBeanFromUserToSystem(bean);
         }
         bean.setUserName(null);
+    }
+
+    /*
+     * Determine whether it is safe to rename/remove a Block user name.
+     * <p>The user name is used by the LayoutBlock to link to the block and
+     * by Layout Editor track components to link to the layout block.
+     * @oaram changeType This will be Remove or Rename.
+     * @param newName For Remove this will be empty, for Rename it will be the new user name.
+     * @return true to continue with the user name change.
+     */
+    boolean allowBlockNameChange(String changeType, String newName) {
+        if (!bean.getBeanType().equals("Block")) return true;  // NOI18N
+
+        // If there is no layout block or the block has no user name, Block rename and remove are ok without notification.
+        String oldName = bean.getUserName();
+        if (oldName == null) return true;
+        LayoutBlock layoutBlock = jmri.InstanceManager.getDefault(LayoutBlockManager.class).getByUserName(oldName);
+        if (layoutBlock == null) return true;
+
+        // Remove is not allowed if there is a layout block
+        if (changeType.equals("Remove")) {
+            log.warn("Cannot remove user name for block {}", oldName);  // NOI18N
+                JOptionPane.showMessageDialog(null,
+                        Bundle.getMessage("BlockRemoveUserNameWarning", oldName),  // NOI18N
+                        Bundle.getMessage("WarningTitle"),  // NOI18N
+                        JOptionPane.WARNING_MESSAGE);
+            return false;
+        }
+
+        // Confirmation dialog
+        int optionPane = JOptionPane.showConfirmDialog(null,
+                Bundle.getMessage("BlockChangeUserName", oldName, newName),  // NOI18N
+                Bundle.getMessage("QuestionTitle"),  // NOI18N
+                JOptionPane.YES_NO_OPTION);
+        if (optionPane == JOptionPane.YES_OPTION) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/java/test/jmri/jmrit/beantable/BlockTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/BlockTableActionTest.java
@@ -5,15 +5,11 @@ import java.awt.GraphicsEnvironment;
 import javax.swing.JFrame;
 import jmri.Block;
 import jmri.InstanceManager;
+import jmri.jmrit.display.layoutEditor.LayoutBlock;
+import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
 import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
-import org.netbeans.jemmy.operators.JButtonOperator;
-import org.netbeans.jemmy.operators.JFrameOperator;
-import org.netbeans.jemmy.operators.JTextFieldOperator;
+import org.junit.*;
+import org.netbeans.jemmy.operators.*;
 
 /**
  * Tests for the jmri.jmrit.beantable.BlockTableAction class
@@ -117,18 +113,86 @@ public class BlockTableActionTest extends AbstractTableActionBase {
         JUnitUtil.dispose(f);
     }
 
+    @Test
+    public void testRenameBlock() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
+        // Create a Layout Block which will create the Block entry
+        LayoutBlockManager lbm = jmri.InstanceManager.getDefault(LayoutBlockManager.class);
+        LayoutBlock layoutBlock = lbm.createNewLayoutBlock("ILB999", "Block Name");  // NOI18N
+        layoutBlock.initializeLayoutBlock();
+        Assert.assertNotNull(layoutBlock);
+        Assert.assertEquals("Block Name", layoutBlock.getUserName());  // NOI18N
+
+        // Get the referenced block
+        jmri.Block block = jmri.InstanceManager.getDefault(jmri.BlockManager.class).getByUserName("Block Name");  // NOI18N
+        Assert.assertNotNull(block);
+
+        // Open the block table
+        a.actionPerformed(null); // show table
+        JFrameOperator jfo = new JFrameOperator(Bundle.getMessage("TitleBlockTable"));  // NOI18N
+        Assert.assertNotNull(jfo);
+
+        JTableOperator tbo = new JTableOperator(jfo);
+        Assert.assertNotNull(tbo);
+
+        // Click on the edit button, set the user name to empty for remove
+        tbo.clickOnCell(0, 5);
+        JFrameOperator jfoEdit = new JFrameOperator(Bundle.getMessage("TitleEditBlock"));  // NOI18N
+        JTextFieldOperator jtxt = new JTextFieldOperator(jfoEdit, 0);
+        jtxt.clickMouse();
+        jtxt.setText("");
+
+        // Preprare the dialog thread and click on OK
+        Thread remove = createModalDialogOperatorThread(Bundle.getMessage("WarningTitle"), Bundle.getMessage("ButtonOK"), "remove");  // NOI18N
+        new JButtonOperator(jfoEdit, "OK").doClick();  // NOI18N
+        JUnitUtil.waitFor(()->{return !(remove.isAlive());}, "remove finished");  // NOI18N
+        tbo.clickOnCell(0, 0);  // deselect the edit button
+
+        // Click on the edit button, set the user name to a new value
+        tbo.clickOnCell(0, 5);
+        jfoEdit = new JFrameOperator(Bundle.getMessage("TitleEditBlock"));  // NOI18N
+        jtxt = new JTextFieldOperator(jfoEdit, 0);
+        jtxt.clickMouse();
+        jtxt.setText("New Block Name");  // NOI18N
+
+        // Preprare the dialog thread and click on OK
+        Thread rename = createModalDialogOperatorThread(Bundle.getMessage("QuestionTitle"), Bundle.getMessage("ButtonYes"), "rename");  // NOI18N
+        new JButtonOperator(jfoEdit, "OK").doClick();  // NOI18N
+        JUnitUtil.waitFor(()->{return !(rename.isAlive());}, "rename finished");  // NOI18N
+        tbo.clickOnCell(0, 0);  // deselect the edit button
+
+        // Confirm the layout block user name change
+        Assert.assertEquals("New Block Name", layoutBlock.getUserName());
+
+        jmri.util.JUnitAppender.assertWarnMessage("Cannot remove user name for block Block Name");  // NOI18N
+    }
+
+    Thread createModalDialogOperatorThread(String dialogTitle, String buttonText, String threadName) {
+        Thread t = new Thread(() -> {
+            // constructor for jdo will wait until the dialog is visible
+            JDialogOperator jdo = new JDialogOperator(dialogTitle);
+            JButtonOperator jbo = new JButtonOperator(jdo, buttonText);
+            jbo.pushNoBlock();
+        });
+        t.setName(dialogTitle + " Close Dialog Thread: " + threadName);  // NOI18N
+        t.start();
+        return t;
+    }
+
     @Before
     @Override
     public void setUp() {
         JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
         JUnitUtil.initDefaultUserMessagePreferences();
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initInternalLightManager();
         JUnitUtil.initInternalSensorManager();
         JUnitUtil.initInternalSignalHeadManager();
-        helpTarget = "package.jmri.jmrit.beantable.BlockTable"; 
- 	a = new BlockTableAction();
+        helpTarget = "package.jmri.jmrit.beantable.BlockTable";
+        a = new BlockTableAction();
     }
 
     @After
@@ -139,5 +203,4 @@ public class BlockTableActionTest extends AbstractTableActionBase {
     }
 
     // private final static Logger log = LoggerFactory.getLogger(BlockTableActionTest.class);
-
 }


### PR DESCRIPTION
- Prevent removing a block name if there is a layout block reference.
- Notify users if a block rename will affect track block assignments.