### PR TITLE
Handle error when creating menu after startup error

### DIFF
--- a/java/src/jmri/jmrix/ActiveSystemsMenu.java
+++ b/java/src/jmri/jmrix/ActiveSystemsMenu.java
@@ -38,9 +38,13 @@ public class ActiveSystemsMenu extends JMenu {
                 = jmri.InstanceManager.getList(ComponentFactory.class);
 
         for (ComponentFactory memo : list) {
-            JMenu menu = memo.getMenu();
-            if (menu != null) {
-                m.add(menu);
+            try {
+                JMenu menu = memo.getMenu();
+                if (menu != null) {
+                    m.add(menu);
+                }
+            } catch (RuntimeException ex) {
+                log.error("Proceeding after error while trying to create menu for {}", memo.getClass(), ex);
             }
         }
     }


### PR DESCRIPTION
Handle (i.e. bypass) an error when user presses "continue" when a comm port error happens in startup.  Still not going to be great, but hopefully DecoderPro won't freeze up (right away) with this.