### PR TITLE
temporarily disable chrome tests on travis while driver update issue is sorted out.

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -29,7 +29,7 @@ if [[ "${HEADLESS}" == "true" ]] ; then
             -Dsurefire.runOrder=${RUN_ORDER} \
             -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" \
             -Djava.awt.headless=${HEADLESS} \
-            -Dcucumber.options="--tags 'not @Ignore' --tags 'not @firefox'"
+            -Dcucumber.options="--tags 'not @Ignore' --tags 'not @firefox' --tags 'not @chrome'"
     fi
 else
     # run full GUI test suite and fail on coverage issues
@@ -38,5 +38,5 @@ else
         -Dsurefire.runOrder=${RUN_ORDER} \
         -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" \
         -Djava.awt.headless=${HEADLESS} \
-        -Dcucumber.options="--tags 'not @Ignore'"
+        -Dcucumber.options="--tags 'not @Ignore' --tags 'not @chrome'"
 fi


### PR DESCRIPTION
a new webdriver for chrome is causing issues because the version of chrome available on travis is older than expected.  this PR will temporarily disable those tests until we can resolve the issue.