### PR TITLE
fix ReporterFormater.py

### DIFF
--- a/jython/ReporterFormatter.py
+++ b/jython/ReporterFormatter.py
@@ -21,7 +21,14 @@ class ReporterFormatter(java.beans.PropertyChangeListener):
     if (event.propertyName == "currentReport") :
       # new report, format and store
       self.report = event.newValue
-      self.value = self.format(self.report)
+      if (isinstance(self.report,jmri.Reportable)) :
+         # use the IdTag information from 4.15.3+
+         self.value = self.format(self.report.toReportString())
+      elif (self.report != None ) :
+         # use the text format from pre 4.15.3
+         self.value = self.format(self.report)
+      else :
+         self.value = ""
       self.memory.setValue(self.value)
     return 
 


### PR DESCRIPTION
This appears to be the only script we ship with JMRI that uses the entry/exit messages generated by a LocoNet Reporter.

This PR makes it use the Reportable interface introduced in the current development cycle.