### PR TITLE
enable firefox tests on headless travis

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -29,7 +29,7 @@ if [[ "${HEADLESS}" == "true" ]] ; then
             -Dsurefire.runOrder=${RUN_ORDER} \
             -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" \
             -Djava.awt.headless=${HEADLESS} \
-            -Dcucumber.options="--tags 'not @Ignore' --tags 'not @firefox' --tags 'not @chrome'"
+            -Dcucumber.options="--tags 'not @Ignore' --tags 'not @chrome'"
     fi
 else
     # run full GUI test suite and fail on coverage issues


### PR DESCRIPTION
in PR #6630, we started using headless firefox, but we did not enable that during headless testing on travis.  This PR enables the firefox tests on travis.