### PR TITLE
Fix setUp order for logging in test

### DIFF
--- a/java/test/jmri/util/zeroconf/ZeroConfServiceManagerTest.java
+++ b/java/test/jmri/util/zeroconf/ZeroConfServiceManagerTest.java
@@ -34,8 +34,8 @@ public class ZeroConfServiceManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        JUnitUtil.resetZeroConfServiceManager();
         JUnitUtil.setUp();
+        JUnitUtil.resetZeroConfServiceManager();
         JUnitUtil.resetProfileManager();
         // ensure the manager used for tests is also the default manager should
         // some other element involved invoke the default manager


### PR DESCRIPTION
JUnitUtil.setUp should be called first in a test class's @Before to make sure logging is initialized.