### PR TITLE
Remove excess Javadoc dashes

### DIFF
--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -325,7 +325,7 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
      *
      * Also listen for additions/removals or PowerManagers
      *
-     * @param e - the change event
+     * @param e the change event
      */
 
     @Override

--- a/java/src/jmri/ConditionalManager.java
+++ b/java/src/jmri/ConditionalManager.java
@@ -48,7 +48,7 @@ public interface ConditionalManager extends Manager<Conditional> {
      * Parses the Conditional system name to get the parent Logix system name,
      * then gets the parent Logix, and returns it.
      *
-     * @param name - system name of Conditional (must be trimmed and upper case)
+     * @param name system name of Conditional (must be trimmed and upper case)
      * @return the logix for the conditional
      */
     public Logix getParentLogix(String name);
@@ -59,8 +59,8 @@ public interface ConditionalManager extends Manager<Conditional> {
      * lookup. If this fails, or if x == null, looks up assuming that name is a
      * System Name. If both fail, returns null.
      *
-     * @param x    - parent Logix (may be null)
-     * @param name - name to look up
+     * @param x   parent Logix (may be null)
+     * @param name name to look up
      * @return null if no match found
      */
     public Conditional getConditional(Logix x, String name);

--- a/java/src/jmri/Logix.java
+++ b/java/src/jmri/Logix.java
@@ -81,7 +81,7 @@ public interface Logix extends NamedBean {
      * Add/Edit Logix dialog. If 'order' is greater than the number of
      * Conditionals for this Logix, and empty String is returned.
      *
-     * @param order - order in which the Conditional calculates
+     * @param order order in which the Conditional calculates
      * @return system name of conditional or an empty String
      */
     public String getConditionalByNumberOrder(int order);
@@ -90,7 +90,7 @@ public interface Logix extends NamedBean {
      * Add a Conditional name and sequence number to this Logix.
      *
      * @param systemName The Conditional system name
-     * @param order      - the order this conditional should calculate in if
+     * @param order      the order this conditional should calculate in if
      *                   order is negative, the conditional is added at the end
      *                   of current group of conditionals
      * @return true if the Conditional was added, false otherwise (most likely

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -198,7 +198,7 @@ public interface NamedBean extends Comparable<NamedBean> {
      * Get a list of all the property change listeners that are registered using
      * a specific name
      *
-     * @param name - The name (either system or user) that the listener has
+     * @param name The name (either system or user) that the listener has
      *             registered as referencing this namedBean
      * @return empty list if none
      */

--- a/java/src/jmri/SensorManager.java
+++ b/java/src/jmri/SensorManager.java
@@ -147,10 +147,10 @@ public interface SensorManager extends ProvidingManager<Sensor> {
      * return the next free valid address up to a maximum of 10 addresses away
      * from the initial address. Used when adding add a range of Sensors.
      *
-     * @param curAddress - The hardware address of the sensor we wish to add
-     * @param prefix     - The System Prefix used to make up the systemName
+     * @param curAddress The hardware address of the sensor we wish to add
+     * @param prefix     The System Prefix used to make up the systemName
      *                   check.
-     * @return - null if the system name made from prefix and curAddress is in
+     * @return null if the system name made from prefix and curAddress is in
      *         use
      * @throws jmri.JmriException if problem calculating next address
      */

--- a/java/src/jmri/ThrottleManager.java
+++ b/java/src/jmri/ThrottleManager.java
@@ -291,29 +291,29 @@ public interface ThrottleManager {
 
     /**
      * 
-     * @param la - Loco address to test
-     * @return - true, its still required, false its not.
+     * @param la Loco address to test
+     * @return true, its still required, false its not.
      */
     public boolean addressStillRequired(LocoAddress la);
 
     /**
      * 
-     * @param address - Loco number to test.
-     * @param addressIsLong - true if long address.
-     * @return - true, its still required, false its not.
+     * @param address Loco number to test.
+     * @param addressIsLong true if long address.
+     * @return true, its still required, false its not.
      */
     public boolean addressStillRequired(int address, boolean addressIsLong);
     /**
      * 
-     * @param address - Loco number to test
-     * @return - true, its still required, false its not.
+     * @param address Loco number to test
+     * @return true, its still required, false its not.
      */
     public boolean addressStillRequired(int address);
 
     /**
      * 
-     * @param re - roster entry to test
-     * @return - true, its still required, false its not.
+     * @param re roster entry to test
+     * @returntrue, its still required, false its not.
      */
     public boolean addressStillRequired(BasicRosterEntry re);
 
@@ -376,8 +376,8 @@ public interface ThrottleManager {
      * The PropertyChangeListener will be notified if it has been attached to a
      * loco address or not, via a PropertyChange notification.
      * <p>
-     * @param la - LocoAddress of the loco we wish to monitor
-     * @param p  - PropertyChangeListener to attach to the throttle
+     * @param la LocoAddress of the loco we wish to monitor
+     * @param p  PropertyChangeListener to attach to the throttle
      */
     public void attachListener(LocoAddress la, PropertyChangeListener p);
 
@@ -390,8 +390,8 @@ public interface ThrottleManager {
      * The PropertyChangeListener will be notified if it has been removed via a
      * PropertyChange notification.
      *
-     * @param la - LocoAddress of the loco we wish to monitor
-     * @param p  - PropertyChangeListener to remove from the throttle
+     * @param la LocoAddress of the loco we wish to monitor
+     * @param p  PropertyChangeListener to remove from the throttle
      */
     public void removeListener(LocoAddress la, PropertyChangeListener p);
 
@@ -405,7 +405,7 @@ public interface ThrottleManager {
     /**
      * Get the number of Throttles sharing the throttle for a ddcaddress.
      *
-     * @param la - LocoAddress of the loco you want the throttle usage count for.
+     * @param la LocoAddress of the loco you want the throttle usage count for.
      * @return number of throttles for this address, or 0 if throttle does not exist
      */
     public int getThrottleUsageCount(LocoAddress la);
@@ -413,8 +413,8 @@ public interface ThrottleManager {
     /**
      * Get the number of Throttles sharing the throttle for a ddcaddress.
      *
-     * @param address - number of the loco you want the throttle usage count for.
-     * @param isLongAddress - indicates whether the address is long or not.
+     * @param address number of the loco you want the throttle usage count for.
+     * @param isLongAddress indicates whether the address is long or not.
      * @return number of throttles for this address, or 0 if throttle does not exist
      */
      public int getThrottleUsageCount(int address, boolean isLongAddress);
@@ -422,7 +422,7 @@ public interface ThrottleManager {
     /**
      * Get the number of Throttles sharing the throttle for a ddcaddress.
      *
-     * @param address - number of the loco you want the throttle usage count for.
+     * @param address number of the loco you want the throttle usage count for.
      * @return number of throttles for this address, or 0 if throttle does not exist
      */
     public int getThrottleUsageCount(int address);
@@ -430,7 +430,7 @@ public interface ThrottleManager {
     /**
      * Get the number of Throttles sharing the throttle for a ddcaddress.
      *
-     * @param re - BasicRosterEntry of the loco you want the throttle usage count for.
+     * @param re BasicRosterEntry of the loco you want the throttle usage count for.
      * @return number of throttles for this address, or 0 if throttle does not exist
      */
     public int getThrottleUsageCount(BasicRosterEntry re);

--- a/java/src/jmri/ThrottleManager.java
+++ b/java/src/jmri/ThrottleManager.java
@@ -313,7 +313,7 @@ public interface ThrottleManager {
     /**
      * 
      * @param re roster entry to test
-     * @returntrue, its still required, false its not.
+     * @return true, its still required, false its not.
      */
     public boolean addressStillRequired(BasicRosterEntry re);
 

--- a/java/src/jmri/implementation/DefaultLogix.java
+++ b/java/src/jmri/implementation/DefaultLogix.java
@@ -93,7 +93,7 @@ public class DefaultLogix extends AbstractNamedBean
      * Add/Edit Logix dialog. If 'order' is greater than the number of
      * Conditionals for this Logix, and empty String is returned.
      *
-     * @param order - order in which the Conditional calculates.
+     * @param order  order in which the Conditional calculates.
      */
     @Override
     public String getConditionalByNumberOrder(int order) {
@@ -110,7 +110,7 @@ public class DefaultLogix extends AbstractNamedBean
      * has been exceeded.
      *
      * @param systemName The Conditional system name
-     * @param order      - the order this conditional should calculate in if
+     * @param order       the order this conditional should calculate in if
      *                   order is negative, the conditional is added at the end
      *                   of current group of conditionals
      */

--- a/java/src/jmri/implementation/DefaultSignalMastLogic.java
+++ b/java/src/jmri/implementation/DefaultSignalMastLogic.java
@@ -55,7 +55,7 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
     /**
      * Initialise a Signal Mast Logic for a given source Signal mast.
      *
-     * @param source - The Signal Mast we are configuring an SML for
+     * @param source  The Signal Mast we are configuring an SML for
      */
     public DefaultSignalMastLogic(@Nonnull SignalMast source) {
         super(source.toString()); // default system name

--- a/java/src/jmri/jmrit/dispatcher/ActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/ActiveTrain.java
@@ -530,7 +530,7 @@ public class ActiveTrain {
     /**
      * set train type using localized string name as stored
      *
-     * @param sType - name, such as "LOCAL_PASSENGER"
+     * @param sType  name, such as "LOCAL_PASSENGER"
      */
     public void setTrainType(String sType) {
         if (sType.equals(Bundle.getMessage("LOCAL_FREIGHT"))) {

--- a/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
+++ b/java/src/jmri/jmrit/dispatcher/AutoActiveTrain.java
@@ -1314,7 +1314,7 @@ public class AutoActiveTrain implements ThrottleListener {
 
     /**
      * Sets the throttle percent unless it is already less than the new setting
-     * @param throttleSetting - Max ThrottleSetting required.
+     * @param throttleSetting  Max ThrottleSetting required.
      */
     private synchronized void setToAMaximumThrottle(float throttleSetting) {
         if (throttleSetting < _targetSpeed) {
@@ -1324,7 +1324,7 @@ public class AutoActiveTrain implements ThrottleListener {
 
     /**
      * Calculates the throttle setting for a given speed.
-     * @param speed - the unadjusted speed.
+     * @param speed  the unadjusted speed.
      * @return - throttle setting (a percentage)
      */
     private synchronized float getThrottleSettingFromSpeed(float speed) {
@@ -1366,7 +1366,7 @@ public class AutoActiveTrain implements ThrottleListener {
 
     /**
      * sets the throttle based on an index number into _speedRatio array
-     * @param speedState - Index value
+     * @param speedState  Index value
      */
     private synchronized void setTargetSpeedState(int speedState) {
         _autoEngineer.slowToStop(false);
@@ -1946,7 +1946,7 @@ public class AutoActiveTrain implements ThrottleListener {
      * Convert ramp rate name, stored as a string into the constant value
      * assigned.
      *
-     * @param rampRate - name of ramp rate, such as "RAMP_FAST"
+     * @param rampRate  name of ramp rate, such as "RAMP_FAST"
      * @return integer representing a ramprate constant value
      */
     public static int getRampRateFromName(String rampRate) {

--- a/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
@@ -160,7 +160,7 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
      * Loads a train into the Dispatcher from a traininfo file
      *
      * @param traininfoFileName  the file name of a traininfo file.
-     * @return - 0 good. -1 create failure, -2 -3 file errors, -9 bother.
+     * @return 0 good, -1 create failure, -2 -3 file errors, -9 bother.
      */
     public int loadTrainFromTrainInfo(String traininfoFileName) {
         return loadTrainFromTrainInfo(traininfoFileName, "NONE", "");
@@ -174,7 +174,7 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
      * @param overRideType  "NONE", "USER", "ROSTER" or "OPERATIONS"
      * @param overRideValue  "" , dccAddress, RosterEntryName or Operations
      *            trainname.
-     * @return - 0 good. -1 create failure, -2 -3 file errors, -9 bother.
+     * @return 0 good, -1 create failure, -2 -3 file errors, -9 bother.
      */
     public int loadTrainFromTrainInfo(String traininfoFileName, String overRideType, String overRideValue) {
         //read xml data from selected filename and move it into trainfo
@@ -202,7 +202,7 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
      * Loads a train into the Dispatcher
      *
      * @param info  a completed TrainInfo class.
-     * @return - 0 good. -1 failure
+     * @return 0 good, -1 failure
      */
     public int loadTrainFromTrainInfo(TrainInfo info) {
         return loadTrainFromTrainInfo(info, "NONE", "");
@@ -215,7 +215,7 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
      * @param overRideType  "NONE", "USER", "ROSTER" or "OPERATIONS"
      * @param overRideValue  "" , dccAddress, RosterEntryName or Operations
      *            trainname.
-     * @return - 0 good. -1 failure
+     * @return 0 good, -1 failure
      */
     public int loadTrainFromTrainInfo(TrainInfo info, String overRideType, String overRideValue) {
 

--- a/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
+++ b/java/src/jmri/jmrit/dispatcher/DispatcherFrame.java
@@ -159,7 +159,7 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
     /**
      * Loads a train into the Dispatcher from a traininfo file
      *
-     * @param traininfoFileName - the file name of a traininfo file.
+     * @param traininfoFileName  the file name of a traininfo file.
      * @return - 0 good. -1 create failure, -2 -3 file errors, -9 bother.
      */
     public int loadTrainFromTrainInfo(String traininfoFileName) {
@@ -170,9 +170,9 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
      * Loads a train into the Dispatcher from a traininfo file, overriding
      * dccaddress
      *
-     * @param traininfoFileName - the file name of a traininfo file.
-     * @param overRideType - "NONE", "USER", "ROSTER" or "OPERATIONS"
-     * @param overRideValue - "" , dccAddress, RosterEntryName or Operations
+     * @param traininfoFileName  the file name of a traininfo file.
+     * @param overRideType  "NONE", "USER", "ROSTER" or "OPERATIONS"
+     * @param overRideValue  "" , dccAddress, RosterEntryName or Operations
      *            trainname.
      * @return - 0 good. -1 create failure, -2 -3 file errors, -9 bother.
      */
@@ -201,7 +201,7 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
     /**
      * Loads a train into the Dispatcher
      *
-     * @param info - a completed TrainInfo class.
+     * @param info  a completed TrainInfo class.
      * @return - 0 good. -1 failure
      */
     public int loadTrainFromTrainInfo(TrainInfo info) {
@@ -211,9 +211,9 @@ public class DispatcherFrame extends jmri.util.JmriJFrame implements InstanceMan
     /**
      * Loads a train into the Dispatcher
      *
-     * @param info - a completed TrainInfo class.
-     * @param overRideType - "NONE", "USER", "ROSTER" or "OPERATIONS"
-     * @param overRideValue - "" , dccAddress, RosterEntryName or Operations
+     * @param info  a completed TrainInfo class.
+     * @param overRideType  "NONE", "USER", "ROSTER" or "OPERATIONS"
+     * @param overRideValue  "" , dccAddress, RosterEntryName or Operations
      *            trainname.
      * @return - 0 good. -1 failure
      */

--- a/java/src/jmri/jmrit/display/IndicatorTurnoutIcon.java
+++ b/java/src/jmri/jmrit/display/IndicatorTurnoutIcon.java
@@ -248,9 +248,9 @@ public class IndicatorTurnoutIcon extends TurnoutIcon implements IndicatorTrack 
     /**
      * Place icon by its localized bean state name
      *
-     * @param status    - the track condition of the icon
-     * @param stateName - NamedBean name of turnout state
-     * @param icon      - icon corresponding to status and state
+     * @param status     the track condition of the icon
+     * @param stateName  NamedBean name of turnout state
+     * @param icon       icon corresponding to status and state
      */
     public void setIcon(String status, String stateName, NamedIcon icon) {
         if (log.isDebugEnabled()) {

--- a/java/src/jmri/jmrit/display/SlipTurnoutIcon.java
+++ b/java/src/jmri/jmrit/display/SlipTurnoutIcon.java
@@ -187,7 +187,7 @@ public class SlipTurnoutIcon extends PositionableLabel implements java.beans.Pro
     /**
      * Sets the type of turnout configuration which is being used
      *
-     * @param slip - valid values are
+     * @param slip  valid values are
      * <ul>
      * <li>0x00 - Double Slip
      * <li>0x02 - Single Slip

--- a/java/src/jmri/jmrit/display/controlPanelEditor/shape/DrawPolygon.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/shape/DrawPolygon.java
@@ -206,7 +206,7 @@ public class DrawPolygon extends DrawFrame {
 
     /**
      *  Add a vertex to polygon relative to selected vertex
-     * @param up - if true, add after selected vertex. otherwise before selected vertex
+     * @param up  if true, add after selected vertex. otherwise before selected vertex
      */
     protected void addVertex(boolean up) {
         if (_editing) {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlock.java
@@ -2934,8 +2934,8 @@ public class LayoutBlock extends AbstractNamedBean implements PropertyChangeList
     }
 
     /**
-     * @param destBlock - is the destination of the block we are following
-     * @param direction - is the direction of travel from the previous block
+     * @param destBlock  is the destination of the block we are following
+     * @param direction  is the direction of travel from the previous block
      * @return next block
      */
     public Block getNextBlock(Block destBlock, int direction) {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockConnectivityTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockConnectivityTools.java
@@ -132,16 +132,16 @@ public class LayoutBlockConnectivityTools {
      * protectingLayoutBlock or sourceLayoutBlock+1, a direction of travel can
      * then be determined, eg east to west, south to north etc.
      * <p>
-     * @param sourceBean   - The source bean (SignalHead, SignalMast or Sensor)
+     * @param sourceBean    The source bean (SignalHead, SignalMast or Sensor)
      *                     assigned to a block boundary that we are starting
      *                     from.
-     * @param destBean     - The destination bean.
-     * @param validateOnly - When set false, the system will not use layout
+     * @param destBean      The destination bean.
+     * @param validateOnly  When set false, the system will not use layout
      *                     blocks that are set as either reserved(useExtraColor
      *                     set) or occupied, if it finds any then it will try to
      *                     find an alternative path When set false, no block
      *                     state checking is performed.
-     * @param pathMethod   - Performs a check to see if any signal heads/masts
+     * @param pathMethod    Performs a check to see if any signal heads/masts
      *                     are in the path, if there are then the system will
      *                     try to find an alternative path. If set to NONE, then
      *                     no checking is performed.
@@ -415,20 +415,20 @@ public class LayoutBlockConnectivityTools {
      * protectingLayoutBlock or sourceLayoutBlock+1, a direction of travel can
      * then be determined, eg east to west, south to north etc.
      * <p>
-     * @param sourceLayoutBlock      - The layout block that we are starting
+     * @param sourceLayoutBlock       The layout block that we are starting
      *                               from, can also be considered as the block
      *                               facing a signal.
-     * @param destinationLayoutBlock - The layout block that we want to get to
-     * @param protectingLayoutBlock  - The next layout block connected to the
+     * @param destinationLayoutBlock  The layout block that we want to get to
+     * @param protectingLayoutBlock   The next layout block connected to the
      *                               source block, this can also be considered
      *                               as the block being protected by a signal
-     * @param validateOnly           - When set false, the system will not use
+     * @param validateOnly            When set false, the system will not use
      *                               layout blocks that are set as either
      *                               reserved(useExtraColor set) or occupied, if
      *                               it finds any then it will try to find an
      *                               alternative path When set true, no block
      *                               state checking is performed.
-     * @param pathMethod             - Performs a check to see if any signal
+     * @param pathMethod              Performs a check to see if any signal
      *                               heads/masts are in the path, if there are
      *                               then the system will try to find an
      *                               alternative path. If set to NONE, then no

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -1861,7 +1861,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
      * or SignalHead) is protecting.
      *
      * @param nb    NamedBean
-     * @param panel - panel that this bean is on
+     * @param panel  panel that this bean is on
      * @return The block that the bean object is facing
      */
     @CheckReturnValue
@@ -2128,7 +2128,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
      * or SignalHead).
      *
      * @param nb    NamedBean
-     * @param panel - panel that this bean is on
+     * @param panel  panel that this bean is on
      * @return The block that the bean object is facing
      */
     @CheckReturnValue

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutShape.java
@@ -309,8 +309,8 @@ public class LayoutShape {
     /**
      * find the hit (location) type for a point
      *
-     * @param hitPoint      - the point
-     * @param useRectangles - whether to use (larger) rectangles or (smaller)
+     * @param hitPoint       the point
+     * @param useRectangles  whether to use (larger) rectangles or (smaller)
      *                      circles for hit testing
      * @return the hit point type for the point (or NONE)
      */

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTrack.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTrack.java
@@ -331,10 +331,10 @@ public abstract class LayoutTrack {
     /**
      * find the hit (location) type for a point
      *
-     * @param hitPoint           - the point
-     * @param useRectangles      - whether to use (larger) rectangles or
+     * @param hitPoint            the point
+     * @param useRectangles       whether to use (larger) rectangles or
      *                           (smaller) circles for hit testing
-     * @param requireUnconnected - whether to only return hit types for free
+     * @param requireUnconnected  whether to only return hit types for free
      *                           connections
      * @return the location type for the point (or NONE)
      * @since 7.4.3
@@ -586,7 +586,7 @@ public abstract class LayoutTrack {
     /**
      * return true if this connection type is disconnected
      *
-     * @param connectionType - the connection type to test
+     * @param connectionType  the connection type to test
      * @return true if the connection for this connection type is free
      */
     public boolean isDisconnected(int connectionType) {

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -1404,7 +1404,7 @@ public class PositionablePoint extends LayoutTrack {
     /**
      * return true if this connection type is disconnected
      *
-     * @param connectionType - the connection type to test
+     * @param connectionType  the connection type to test
      * @return true if the connection for this connection type is free
      */
     @Override

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -187,8 +187,8 @@ public class TrackSegment extends LayoutTrack {
     /**
      * set a new connection 1
      *
-     * @param connectTrack   - the track we want to connect to
-     * @param connectionType - where on that track we want to be connected
+     * @param connectTrack    the track we want to connect to
+     * @param connectionType  where on that track we want to be connected
      */
     protected void setNewConnect1(@Nullable LayoutTrack connectTrack, int connectionType) {
         connect1 = connectTrack;
@@ -198,8 +198,8 @@ public class TrackSegment extends LayoutTrack {
     /**
      * set a new connection 2
      *
-     * @param connectTrack   - the track we want to connect to
-     * @param connectionType - where on that track we want to be connected
+     * @param connectTrack    the track we want to connect to
+     * @param connectionType  where on that track we want to be connected
      */
     protected void setNewConnect2(@Nullable LayoutTrack connectTrack, int connectionType) {
         connect2 = connectTrack;

--- a/java/src/jmri/jmrit/logix/BlockOrder.java
+++ b/java/src/jmri/jmrit/logix/BlockOrder.java
@@ -100,7 +100,7 @@ public class BlockOrder {
     /**
      * Set Path. Note that the Path's 'fromPortal' and 'toPortal' have no
      * bearing on the BlockOrder's entryPortal and exitPortal.
-     * @param path - Name of the OPath connecting the entry and exit Portals
+     * @param path  Name of the OPath connecting the entry and exit Portals
      */
     protected void setPathName(String path) {
         _pathName = path;

--- a/java/src/jmri/jmrit/logix/PortalManager.java
+++ b/java/src/jmri/jmrit/logix/PortalManager.java
@@ -107,7 +107,7 @@ public class PortalManager extends AbstractManager<Portal>
      * Method to get an existing Portal. First looks up assuming that name is a
      * User Name. If this fails looks up assuming that name is a System Name. If
      * both fail, returns null.
-     * @param name - either System name or user name
+     * @param name  either System name or user name
      * @return Portal, if found
      */
     public Portal getPortal(String name) {

--- a/java/src/jmri/jmrit/logix/SpeedUtil.java
+++ b/java/src/jmri/jmrit/logix/SpeedUtil.java
@@ -615,9 +615,9 @@ public class SpeedUtil {
 
     /**
      * Get the length of ramp for a speed change
-     * @param fSpeed - starting speed setting
-     * @param toSpeed - ending speed setting
-     * @param isForward - direction
+     * @param fSpeed  starting speed setting
+     * @param toSpeed  ending speed setting
+     * @param isForward  direction
      * @return distance in millimeters
      */
     protected float rampLengthForSpeedChange(float fSpeed, float toSpeed, boolean isForward) {

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -1326,9 +1326,9 @@ public class Warrant extends jmri.implementation.AbstractNamedBean implements Th
      * prevents total success. Note that warrants sharing their clearance
      * only allocate and set paths one block in advance.
      *
-     * @param show - value==1 will ignore _partialAllocate (to show route only)
+     * @param show  value==1 will ignore _partialAllocate (to show route only)
      *            parm name delay of turnout steting deprecated
-     * @param orders - BlockOrder list of route. If null, use permanent warrant
+     * @param orders  BlockOrder list of route. If null, use permanent warrant
      *            copy.
      * @return message if the first block fails allocation, otherwise null
      */

--- a/java/src/jmri/jmrit/roster/Roster.java
+++ b/java/src/jmri/jmrit/roster/Roster.java
@@ -1231,7 +1231,7 @@ public class Roster extends XmlFile implements RosterGroupSelector, PropertyChan
     /**
      * Get the identifier for all entries in the roster.
      *
-     * @param locale - The desired locale
+     * @param locale  The desired locale
      * @return "All Entries" in the specified locale
      */
     public static String allEntries(Locale locale) {

--- a/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
+++ b/java/src/jmri/jmrit/roster/RosterSpeedProfile.java
@@ -1005,8 +1005,8 @@ public class RosterSpeedProfile {
     /**
      * Get track speed in millimeters per second from throttle setting
      *
-     * @param speedStep - throttle setting
-     * @param isForward - direction
+     * @param speedStep  throttle setting
+     * @param isForward  direction
      * @return track speed
      */
     public float getSpeed(float speedStep, boolean isForward) {

--- a/java/src/jmri/jmrit/roster/swing/RosterGroupsPanel.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterGroupsPanel.java
@@ -189,7 +189,7 @@ public class RosterGroupsPanel extends JPanel implements RosterGroupSelector {
      * in the new window, otherwise it must accept a String defining the group
      * in JmriAbstractAction.setParameter(String, String).
      *
-     * @param action - An action that can work on the current selection
+     * @param action  An action that can work on the current selection
      */
     public void setNewWindowMenuAction(JmriAbstractAction action) {
         if (action != null) {

--- a/java/src/jmri/jmrit/throttle/SpeedPanel.java
+++ b/java/src/jmri/jmrit/throttle/SpeedPanel.java
@@ -54,7 +54,7 @@ public class SpeedPanel extends JInternalFrame implements java.beans.PropertyCha
      * Set the AddressPanel this throttle control is listening for new throttle
      * event
      *
-     * @param addressPanel - reference to the addresspanel
+     * @param addressPanel  reference to the addresspanel
      */
     public void setAddressPanel(AddressPanel addressPanel) {
         this.addressPanel = addressPanel;
@@ -112,9 +112,9 @@ public class SpeedPanel extends JInternalFrame implements java.beans.PropertyCha
 
     /**
      *
-     * @param useSpeedProfile - are we using speed profile
-     * @param throttleVolume  - throttle position (percent of 1)
-     * @param isForward       - true if going forward.
+     * @param useSpeedProfile  are we using speed profile
+     * @param throttleVolume   throttle position (percent of 1)
+     * @param isForward        true if going forward.
      * @return a string for displaying speed if available
      */
     private String updateSpeedLabel(boolean useSpeedProfile, float throttleVolume, boolean isForward) {

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -119,9 +119,9 @@ abstract public class AbstractThrottle implements DccThrottle {
      * to the system state (eg. the speed is the same, or effectivly the same, as the existing speed).
      * Then, the boolean options can affect this behaviour.
      *
-     * @param speed - the new speed
-     * @param allowDuplicates - don't suppress messages
-     * @param allowDuplicatesOnStop - don't suppress messages if the new speed is 'stop'
+     * @param speed  the new speed
+     * @param allowDuplicates  don't suppress messages
+     * @param allowDuplicatesOnStop  don't suppress messages if the new speed is 'stop'
      */
     @Override
     public void setSpeedSetting(float speed, boolean allowDuplicates, boolean allowDuplicatesOnStop) {
@@ -134,7 +134,7 @@ abstract public class AbstractThrottle implements DccThrottle {
     /**
      * setSpeedSettingAgain - set the speed and don't ever supress the sending of messages to the system
      *
-     * @param speed - the new speed
+     * @param speed  the new speed
      */
     @Override
     public void setSpeedSettingAgain(float speed) {

--- a/java/src/jmri/jmrix/AbstractThrottleManager.java
+++ b/java/src/jmri/jmrix/AbstractThrottleManager.java
@@ -168,7 +168,7 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
     /**
      * Does this DCC system allow a Throttle (e.g. an address) to be used by
      * only one user at a time?
-     * @return - true or false
+     * @return true or false
      */
     protected boolean singleUse() {
         return true;

--- a/java/src/jmri/jmrix/AbstractThrottleManager.java
+++ b/java/src/jmri/jmrix/AbstractThrottleManager.java
@@ -278,15 +278,15 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
     /**
      * Abstract member to actually do the work of configuring a new throttle,
      * usually via interaction with the DCC system
-     * @param a - address
-     * @param control - false  - read only.
+     * @param a  address
+     * @param control  false  - read only.
      */
     abstract public void requestThrottleSetup(LocoAddress a, boolean control);
 
     /**
      * Abstract member to actually do the work of configuring a new throttle,
      * usually via interaction with the DCC system
-     * @param a - address.
+     * @param a  address.
      */
     public void requestThrottleSetup(LocoAddress a) {
         requestThrottleSetup(a, true);
@@ -457,8 +457,8 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
      * <P>
      * This method creates a throttle for all ThrottleListeners of that address
      * and notifies them via the ThrottleListener.notifyThrottleFound method.
-     * @param throttle - throttle object
-     * @param addr - address.
+     * @param throttle  throttle object
+     * @param addr  address.
      */
     public void notifyThrottleKnown(DccThrottle throttle, LocoAddress addr) {
         log.debug("notifyThrottleKnown for " + addr);

--- a/java/src/jmri/jmrix/can/cbus/CbusNameService.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusNameService.java
@@ -67,7 +67,6 @@ public class CbusNameService {
 
     /**
      * Return a formatted String attempting locate the node name
-     * <P>
      * <p> 1st attempt - Node Username in node table ( eg. Control Panel West )
      * <p> 2nd attempt - Node Type Name ( eg. CANPAN )
      * <p> fallback empty string

--- a/java/src/jmri/jmrix/cmri/serial/SerialNode.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialNode.java
@@ -1193,8 +1193,8 @@ public class SerialNode extends AbstractNode {
     /**
      * The numbers here are 0 to MAXSENSORS, not 1 to MAXSENSORS.
      *
-     * @param s - Sensor object
-     * @param i - 0 to MAXSENSORS number of sensor's input bit on this node
+     * @param s  Sensor object
+     * @param i  0 to MAXSENSORS number of sensor's input bit on this node
      */
     public void registerSensor(Sensor s, int i) {
         // validate the sensor ordinal

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
@@ -197,7 +197,7 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
      * setSpeedStepMode - set the speed step value and the related
      *                    speedIncrement value.
      * <p>
-     * @param Mode - the current speed step mode - default should be 128
+     * @param Mode  the current speed step mode - default should be 128
      *              speed step mode in most cases
      *
      * NOTE: DCC++ only supports 128-step mode.  So we ignore the speed

--- a/java/src/jmri/jmrix/dccpp/DCCppTurnoutReplyCache.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppTurnoutReplyCache.java
@@ -41,7 +41,7 @@ public class DCCppTurnoutReplyCache implements DCCppListener {
     // requestCachedStateFromLayout
     // provide any cached state to the turnout.  Otherwise, call the turnout's 
     // requestUpdateFromLayout() method.
-    // @param turnout - the DCCppTurnout object we are requesting data for.
+    // @param turnout  the DCCppTurnout object we are requesting data for.
     synchronized public void requestCachedStateFromLayout(DCCppTurnout turnout) {
         int pNumber = turnout.getNumber();
         if (messagePending[pNumber]) {
@@ -68,7 +68,7 @@ public class DCCppTurnoutReplyCache implements DCCppListener {
     // requestCachedStateFromLayout
     // provide any cached state a sensor.  Otherwise, call the sensor's 
     // requestUpdateFromLayout() method.
-    // @param sensor - the DCCppSensor object we are requesting data for.
+    // @param sensor  the DCCppSensor object we are requesting data for.
     //
     // TODO: We don't have DCCppSensors yet. May never have them.
     /*

--- a/java/src/jmri/jmrix/easydcc/EasyDccMessage.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccMessage.java
@@ -60,8 +60,8 @@ public class EasyDccMessage extends jmri.jmrix.AbstractMRMessage {
      * Get a static message to add a locomotive to a Standard Consist
      * in the normal direction.
      *
-     * @param ConsistAddress - a consist address in the range 1-255
-     * @param LocoAddress - a jmri.DccLocoAddress object representing the 
+     * @param ConsistAddress  a consist address in the range 1-255
+     * @param LocoAddress  a jmri.DccLocoAddress object representing the 
      * locomotive to add
      * @return an EasyDccMessage of the form GN cc llll 
      */
@@ -81,8 +81,8 @@ public class EasyDccMessage extends jmri.jmrix.AbstractMRMessage {
      * Get a static message to add a locomotive to a Standard Consist in
      * the reverse direction.
      *
-     * @param ConsistAddress - a consist address in the range 1-255
-     * @param LocoAddress - a jmri.DccLocoAddress object representing the 
+     * @param ConsistAddress  a consist address in the range 1-255
+     * @param LocoAddress  a jmri.DccLocoAddress object representing the 
      * locomotive to add
      * @return an EasyDccMessage of the form GS cc llll 
      */
@@ -101,8 +101,8 @@ public class EasyDccMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Get a static message to subtract a locomotive from a Standard Consist.
      *
-     * @param ConsistAddress - a consist address in the range 1-255
-     * @param LocoAddress - a jmri.DccLocoAddress object representing the 
+     * @param ConsistAddress  a consist address in the range 1-255
+     * @param LocoAddress  a jmri.DccLocoAddress object representing the 
      * locomotive to remove
      * @return an EasyDccMessage of the form GS cc llll 
      */
@@ -121,7 +121,7 @@ public class EasyDccMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Get a static message to delete a Standard Consist.
      *
-     * @param ConsistAddress - a consist address in the range 1-255
+     * @param ConsistAddress  a consist address in the range 1-255
      * @return an EasyDccMessage of the form GK cc 
      */
     static public EasyDccMessage getKillConsist(int ConsistAddress) {
@@ -137,7 +137,7 @@ public class EasyDccMessage extends jmri.jmrix.AbstractMRMessage {
     /**
      * Get a static message to display a Standard Consist.
      *
-     * @param ConsistAddress - a consist address in the range 1-255
+     * @param ConsistAddress  a consist address in the range 1-255
      * @return an EasyDccMessage of the form GD cc 
      */
     static public EasyDccMessage getDisplayConsist(int ConsistAddress) {

--- a/java/src/jmri/jmrix/lenz/XNetFeedbackMessageCache.java
+++ b/java/src/jmri/jmrix/lenz/XNetFeedbackMessageCache.java
@@ -35,7 +35,7 @@ public class XNetFeedbackMessageCache implements XNetListener {
     // requestCachedStateFromLayout
     // provide any cached state to the turnout.  Otherwise, call the turnout's 
     // requestUpdateFromLayout() method.
-    // @param turnout - the XNetTurnout object we are requesting data for.
+    // @param turnout  the XNetTurnout object we are requesting data for.
     synchronized public void requestCachedStateFromLayout(XNetTurnout turnout) {
         int pNumber = turnout.getNumber();
         if (messagePending[(pNumber - 1) / 4][((pNumber - 1) % 4) < 2 ? 0 : 1]) {

--- a/java/src/jmri/jmrix/lenz/XNetThrottle.java
+++ b/java/src/jmri/jmrix/lenz/XNetThrottle.java
@@ -262,7 +262,7 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
     /**
      * Set the speed step value and the related speedIncrement value.
      *
-     * @param Mode - the current speed step mode - default should be 128
+     * @param Mode  the current speed step mode - default should be 128
      *              speed step mode in most cases
      */
     @Override

--- a/java/src/jmri/jmrix/lenz/XNetTurnout.java
+++ b/java/src/jmri/jmrix/lenz/XNetTurnout.java
@@ -614,8 +614,8 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
      * Parse the feedback message, and set the status of the turnout
      * accordingly.
      *
-     * @param l - feedback broadcast message
-     * @param startByte - first Byte of message to check
+     * @param l  feedback broadcast message
+     * @param startByte  first Byte of message to check
      *
      * @return 0 if address matches our turnout -1 otherwise
      */
@@ -685,8 +685,8 @@ public class XNetTurnout extends AbstractTurnout implements XNetListener {
      * it's motion or not.  Returns true for mostion complete, false
      * otherwise.
      *
-     * @param l - feedback broadcast message
-     * @param startByte - first Byte of message to check
+     * @param l  feedback broadcast message
+     * @param startByte  first Byte of message to check
      *
      * @return true if motion complete, false otherwise
      */

--- a/java/src/jmri/jmrix/loconet/AbstractAlmImplementation.java
+++ b/java/src/jmri/jmrix/loconet/AbstractAlmImplementation.java
@@ -205,28 +205,28 @@ public abstract class AbstractAlmImplementation implements LocoNetListener {
 
     /**
      * Notify possible subclass that a block has changed.
-     * @param block - something about a block
+     * @param block  something about a block
      */
     public void noteChanged(int block) {
     }
 
     /**
      * Notify possible subclass that a read cmd is being handled
-     * @param block - something about a block
+     * @param block  something about a block
      */
     public void noteReadCmd(int block) {
     }
 
     /**
      * Notify possible subclass that a read reply is being handled
-     * @param block - something about a block
+     * @param block  something about a block
      */
     public void noteReadReply(int block) {
     }
 
     /**
      * Notify possible subclass that a write operation is complete
-     * @param block - something about a block
+     * @param block  something about a block
      */
     public void noteWriteComplete(int block) {
     }

--- a/java/src/jmri/jmrix/loconet/AbstractBoardProgPanel.java
+++ b/java/src/jmri/jmrix/loconet/AbstractBoardProgPanel.java
@@ -107,7 +107,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
      * The board number defaults to 1, and the board will not
      * be automatically read.
      *
-     * @param boardTypeName - device type name, to be included in read and write GUI buttons
+     * @param boardTypeName  device type name, to be included in read and write GUI buttons
      */
     protected AbstractBoardProgPanel(String boardTypeName) {
         this(1, false, boardTypeName);
@@ -118,8 +118,8 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
      * to automatically read the board, plus a string defining
      * the "board type".  The board number defaults to 1.
      *
-     * @param readOnInit - true to read OpSw values of board 1 upon panel creation
-     * @param boardTypeName - device type name, to be included in read and write GUI buttons
+     * @param readOnInit  true to read OpSw values of board 1 upon panel creation
+     * @param boardTypeName  device type name, to be included in read and write GUI buttons
      */
     protected AbstractBoardProgPanel(boolean readOnInit, String boardTypeName) {
         this(1, readOnInit, boardTypeName);
@@ -129,9 +129,9 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
      * Constructor which accepts parameters for the initial board number, whether
      * to automatically read the board, and a "board type" string.
      *
-     * @param boardNum - default board ID number upon panel creation
-     * @param readOnInit - true to read OpSw values of board 1 upon panel creation
-     * @param boardTypeName - device type name, to be included in read and write GUI buttons
+     * @param boardNum  default board ID number upon panel creation
+     * @param readOnInit  true to read OpSw values of board 1 upon panel creation
+     * @param boardTypeName  device type name, to be included in read and write GUI buttons
      */
     protected AbstractBoardProgPanel(int boardNum, boolean readOnInit, String boardTypeName) {
         super();
@@ -150,8 +150,8 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
      * Constructor which allows the caller to pass in the board ID number
      * and board type name
      *
-     * @param boardNum - default board ID number upon panel creation
-     * @param boardTypeName - device type name, to be included in read and write GUI buttons
+     * @param boardNum  default board ID number upon panel creation
+     * @param boardTypeName  device type name, to be included in read and write GUI buttons
      */
     protected AbstractBoardProgPanel(int boardNum, String boardTypeName) {
         this(boardNum, false, boardTypeName);
@@ -197,7 +197,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
     /**
      * Set the Board ID number (also known as board address number)
      *
-     * @param boardId - board ID number to be accessed
+     * @param boardId  board ID number to be accessed
      */
     public void setBoardIdValue(Integer boardId) {
         /*
@@ -236,7 +236,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
      * read and write the device.  The "read" and "write" buttons have text which
      * uses the specified "board type name" from the method parameter.
      *
-     * @param boardTypeName - device type name, to be included in read and write GUI buttons
+     * @param boardTypeName  device type name, to be included in read and write GUI buttons
      * @return - a JPanel containing a JTextField and read and write JButtons
      */
     protected JPanel provideAddressing(String boardTypeName) {
@@ -289,7 +289,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
     /**
      * Update the status line.
      *
-     * @param msg - to be displayed on the status line
+     * @param msg  to be displayed on the status line
      */
     protected void setStatus(String msg) {
         status.setText(msg);
@@ -501,7 +501,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
      * to be written is taken from the appropriate entry in booleans[].
      *
      * @see jmri.jmrix.loconet.AbstractBoardProgPanel#writeAll()
-     * @param opswIndex - OpSw number
+     * @param opswIndex  OpSw number
      */
     public void writeOne(int opswIndex) {
         // check the address
@@ -534,7 +534,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
      * operation messages, and automatically advances to the next OpSw operation
      * as directed by {@link #nextState(int)}.
      *
-     *@param m - incoming LocoNet message
+     *@param m  incoming LocoNet message
      */
     @Override
     public void message(LocoNetMessage m) {

--- a/java/src/jmri/jmrix/loconet/AbstractBoardProgPanel.java
+++ b/java/src/jmri/jmrix/loconet/AbstractBoardProgPanel.java
@@ -237,7 +237,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
      * uses the specified "board type name" from the method parameter.
      *
      * @param boardTypeName  device type name, to be included in read and write GUI buttons
-     * @return - a JPanel containing a JTextField and read and write JButtons
+     * @return JPanel containing a JTextField and read and write JButtons
      */
     protected JPanel provideAddressing(String boardTypeName) {
         JPanel pane0 = new JPanel();
@@ -278,7 +278,7 @@ abstract public class AbstractBoardProgPanel extends jmri.jmrix.loconet.swing.Ln
     /**
      * Create the status line for the GUI.
      *
-     * @return - a JComponent which will display status updates
+     * @return JComponent which will display status updates
      */
     protected JComponent provideStatusLine() {
         status.setFont(status.getFont().deriveFont(0.9f * addrField.getFont().getSize())); // a bit smaller

--- a/java/src/jmri/jmrix/loconet/LnClockControl.java
+++ b/java/src/jmri/jmrix/loconet/LnClockControl.java
@@ -47,7 +47,7 @@ public class LnClockControl extends DefaultClockControl implements SlotListener 
 
     /**
      * Create a ClockControl object for a Loconet clock
-     * @param scm - the LocoNet System Connection Memo to associate with this
+     * @param scm  the LocoNet System Connection Memo to associate with this
      *              Clock Control object
      */
     public LnClockControl(LocoNetSystemConnectionMemo scm) {

--- a/java/src/jmri/jmrix/loconet/LnConstants.java
+++ b/java/src/jmri/jmrix/loconet/LnConstants.java
@@ -184,7 +184,7 @@ public final class LnConstants {
     /**
      * Encode consisting status as a string
      * <p>
-     * @param s - consist status bits
+     * @param s  consist status bits
      * @return string contaning a description of the consisting state
      */
     public final static String CONSIST_STAT(int s) {
@@ -211,7 +211,7 @@ public final class LnConstants {
     /**
      * Encode loco status as a string
      * <p>
-     * @param s - integer containing loco "status"
+     * @param s  integer containing loco "status"
      * @return string containing a description of the loco "status"
      */
     public final static String LOCO_STAT(int s) {
@@ -412,7 +412,7 @@ public final class LnConstants {
     /**
      * Encode LocoNet Opcode as a string
      * <p>
-     * @param opcode - a LocoNet opcode value
+     * @param opcode  a LocoNet opcode value
      * @return string containing the opcode "name"
      */
     public final static String OPC_NAME(int opcode) {

--- a/java/src/jmri/jmrix/loconet/LnLightManager.java
+++ b/java/src/jmri/jmrix/loconet/LnLightManager.java
@@ -117,7 +117,7 @@ public class LnLightManager extends AbstractLightManager {
      * Determine if it is possible to add a range of Lights in
      * numerical order eg. 11 thru 18, primarily used to show/not show the add
      * range box in the Add Light pane.
-     * @param systemName - an ignored parameter
+     * @param systemName  an ignored parameter
      * @return true, always
      */
     @Override

--- a/java/src/jmri/jmrix/loconet/LnMultiMeter.java
+++ b/java/src/jmri/jmrix/loconet/LnMultiMeter.java
@@ -15,7 +15,7 @@ public class LnMultiMeter extends jmri.implementation.AbstractMultiMeter impleme
     /**
      * Create a ClockControl object for a Loconet clock
      *
-     * @param scm - connection memo
+     * @param scm  connection memo
      */
     public LnMultiMeter(LocoNetSystemConnectionMemo scm) {
         super(LnConstants.METER_INTERVAL_MS);

--- a/java/src/jmri/jmrix/loconet/LnProgrammerManager.java
+++ b/java/src/jmri/jmrix/loconet/LnProgrammerManager.java
@@ -21,7 +21,7 @@ public class LnProgrammerManager extends DefaultProgrammerManager {
 
     /**
      * @deprecated 4.13.6 Use LnProgrammerManager(LocoNetSystemConnectionMemo memo) instead
-     * @param pSlotManager - an ignored parameter
+     * @param pSlotManager  an ignored parameter
      * @param memo the LocoNetSystemConnectionMemo to associate with this manager
      */
     @Deprecated // 4.13.6 Use LnProgrammerManager(LocoNetSystemConnectionMemo memo) instead

--- a/java/src/jmri/jmrix/loconet/LocoNetMessage.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetMessage.java
@@ -181,7 +181,7 @@ public class LocoNetMessage extends AbstractMessage implements Serializable {
      * Logs an error and aborts if the index is beyond the length of the message.
      * <p>
      * @param n  the byte index within the message
-     * @return  - the integer value of the byte at the index within the message
+     * @return integer value of the byte at the index within the message
      */
     @Override
     public int getElement(int n) {

--- a/java/src/jmri/jmrix/loconet/LocoNetMessage.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetMessage.java
@@ -180,7 +180,7 @@ public class LocoNetMessage extends AbstractMessage implements Serializable {
      * <p>
      * Logs an error and aborts if the index is beyond the length of the message.
      * <p>
-     * @param n - the byte index within the message
+     * @param n  the byte index within the message
      * @return  - the integer value of the byte at the index within the message
      */
     @Override
@@ -198,8 +198,8 @@ public class LocoNetMessage extends AbstractMessage implements Serializable {
      * <p>
      * Logs an error and aborts if the index is beyond the length of the message.
      * <p>
-     * @param n - the byte index within the message
-     * @param v - the value to be set
+     * @param n  the byte index within the message
+     * @param v  the value to be set
      */
     @Override
     public void setElement(int n, int v) {
@@ -445,7 +445,7 @@ public class LocoNetMessage extends AbstractMessage implements Serializable {
      * object does not have a user name assigned, then the method does not display 
      * a user name.
      * <p>
-     * @param prefix - the "System Name" prefix denoting the connection
+     * @param prefix  the "System Name" prefix denoting the connection
      * @return a human readable representation of the message.
      */
     public String toMonitorString(@Nonnull String prefix){
@@ -526,7 +526,7 @@ public class LocoNetMessage extends AbstractMessage implements Serializable {
      * Check if a high bit is set, usually used to store it in some other
      * location (LocoNet does not allow the high bit to be set in data bytes).
      * <p>
-     * @param val - value to be checked
+     * @param val  value to be checked
      * @return True if the argument has the high bit set
      */
     static protected boolean highBit(int val) {

--- a/java/src/jmri/jmrix/loconet/LocoNetSlot.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetSlot.java
@@ -37,7 +37,7 @@ public class LocoNetSlot {
      * Create a slot based solely on a slot number.  The remainder of the slot is
      * left un-initialized.
      * <p>
-     * @param slotNum - slot number to be assigned to the new LocoNetSlot object
+     * @param slotNum  slot number to be assigned to the new LocoNetSlot object
      */
     public LocoNetSlot(int slotNum) {
         slot = slotNum;
@@ -47,7 +47,7 @@ public class LocoNetSlot {
      * Creates a slot object based on the contents of a LocoNet message.
      * The slot number is assumed to be found in byte 2 of the message
      * <p>
-     * @param l - a LocoNet message
+     * @param l  a LocoNet message
      * @throws LocoNetException if the slot does not have an easily-found
      * slot number
      */
@@ -738,7 +738,7 @@ public class LocoNetSlot {
      * <p>Note that the object's "slot" field
      * is not updated by this method.
      * <p>
-     * @param l - a LocoNet message
+     * @param l  a LocoNet message
      * @throws LocoNetException if the message is not one which
      *      contains slot-related data
      */
@@ -933,7 +933,7 @@ public class LocoNetSlot {
     /**
      * Sets the object's ID value and returns a LocoNet message to inform the
      * command station that the throttle ID has been changed.
-     * @param newID - the new ID number to set into the slot object
+     * @param newID  the new ID number to set into the slot object
      * @return a LocoNet message containing a "Slot Write" message to inform the
      * command station that a specific throttle is controlling the slot.
      */
@@ -1038,7 +1038,7 @@ public class LocoNetSlot {
     /**
      * Registers a slot listener if it is not already registered.
      * <p>
-     * @param l - a slot listener
+     * @param l  a slot listener
      */
     public synchronized void addSlotListener(SlotListener l) {
         // add only if not already registered
@@ -1050,7 +1050,7 @@ public class LocoNetSlot {
     /**
      * Un-registers a slot listener.
      * <p>
-     * @param l - a slot listener
+     * @param l  a slot listener
      */
     public synchronized void removeSlotListener(SlotListener l) {
         if (slotListeners.contains(l)) {

--- a/java/src/jmri/jmrix/loconet/SlotManager.java
+++ b/java/src/jmri/jmrix/loconet/SlotManager.java
@@ -106,14 +106,14 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
      * messages are sent, resulting in lower throughput, but fewer
      * rejections by the command station on account of "buffer-overflow".
      *
-     * @param packet - the data bytes of the raw NMRA packet to be sent.  The
+     * @param packet  the data bytes of the raw NMRA packet to be sent.  The
      *          "error check" byte must be included, even though the LocoNet
      *          message will not include that byte; the command station
      *          will re-create the error byte from the bytes encoded in
      *          the LocoNet message.  LocoNet is unable to propagate packets
      *          longer than 6 bytes (including the error-check byte).
      *
-     * @param sendCount - the total number of times the packet is to be
+     * @param sendCount  the total number of times the packet is to be
      *          sent on the DCC track signal (not LocoNet!).  Valid range is
      *          between 1 and 8.  sendCount will be forced to this range if it
      *          is outside of this range.
@@ -389,7 +389,7 @@ public class SlotManager extends AbstractProgrammer implements LocoNetListener, 
     /**
      * Checks a LocoNet message to see if it encodes a DCC "direct function" packet.
      * <p>
-     * @param m - a LocoNet Message
+     * @param m  a LocoNet Message
      * @return the loco address if the LocoNet message encodes a "direct function" packet,
      * else returns -1
      */

--- a/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
@@ -512,7 +512,7 @@ public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
 
     /**
      * Add filter(s) for possible types to the input file chooser.
-     * @param chooser - a JFileChooser to which the filter is to be added
+     * @param chooser  a JFileChooser to which the filter is to be added
      */
     @Override
     protected void addChooserFilters(JFileChooser chooser) {

--- a/java/src/jmri/jmrix/loconet/ds64/Ds64TabbedPanel.java
+++ b/java/src/jmri/jmrix/loconet/ds64/Ds64TabbedPanel.java
@@ -1413,7 +1413,7 @@ public class Ds64TabbedPanel extends AbstractBoardProgPanel {
     /**
      * Set index into OpSw table
      *
-     * @param index - the indirect address
+     * @param index  the indirect address
      */
     protected void setOpSwIndex(int index) {
         opsw[25] = (index & 1) == 1;
@@ -1430,12 +1430,12 @@ public class Ds64TabbedPanel extends AbstractBoardProgPanel {
      * Updates data register to reflect address, state, and enable for two
      * turnouts.
      *
-     * @param address1  - first turnout address
-     * @param state1    - first turnout's state
-     * @param is1Unused - true if first turnout entry is to be "unused"
-     * @param address2  - second turnout address
-     * @param state2    - second turnout's state
-     * @param is2Unused - true if second turnout entry is to be "unused"
+     * @param address1   first turnout address
+     * @param state1     first turnout's state
+     * @param is1Unused  true if first turnout entry is to be "unused"
+     * @param address2   second turnout address
+     * @param state2     second turnout's state
+     * @param is2Unused  true if second turnout entry is to be "unused"
      */
     protected void updateOpSwsOutAddr(int address1, boolean state1, boolean is1Unused, int address2, boolean state2, boolean is2Unused) {
         int addr1 = address1 - 1;
@@ -1496,7 +1496,7 @@ public class Ds64TabbedPanel extends AbstractBoardProgPanel {
     /**
      * Updates OpSw values for a given index into the data array
      *
-     * @param index - indirect address
+     * @param index  indirect address
      */
     protected void updateOpswForWrite(int index) {
         Integer value1Address;

--- a/java/src/jmri/jmrix/loconet/ds64/SimpleTurnout.java
+++ b/java/src/jmri/jmrix/loconet/ds64/SimpleTurnout.java
@@ -73,7 +73,7 @@ public class SimpleTurnout {
     /**
      * Sets the turnout address of the simpleTurnout object.
      *
-     * @param addr - address value
+     * @param addr  address value
      */
     public void setAddress(Integer addr) {
         address = addr;
@@ -99,7 +99,7 @@ public class SimpleTurnout {
      * This position does not necessarily reflect the actual position of an associated
      * physical turnout.
      *
-     * @param isclosed - true if the object is to be marked as closed.
+     * @param isclosed  true if the object is to be marked as closed.
      */
     public void setIsClosed(boolean isclosed) {
         isClosed = isclosed;

--- a/java/src/jmri/jmrix/loconet/duplexgroup/swing/DuplexGroupScanPanel.java
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/swing/DuplexGroupScanPanel.java
@@ -238,7 +238,7 @@ public class DuplexGroupScanPanel extends jmri.jmrix.loconet.swing.LnPanel
      * Examines incoming LocoNet messages to see if the message is a Duplex
      * Group Channel Report. If so, captures the group number.
      *
-     * @param m - incoming LocoNetMessage
+     * @param m  incoming LocoNetMessage
      * @return true if message m is a Duplex Group Channel Report
      */
     private boolean handleMessageDuplexChannelReport(LocoNetMessage m) {
@@ -310,7 +310,7 @@ public class DuplexGroupScanPanel extends jmri.jmrix.loconet.swing.LnPanel
      * Creates a LocoNet message containing a channel-specific query for signal
      * information from UR92 device(s).
      *
-     * @param channelNum - integer between 11 and 26, inclusive
+     * @param channelNum  integer between 11 and 26, inclusive
      * @return LocoNetMessage - query for Dulpex Channel Scan information
      */
     private LocoNetMessage createDuplexScanQueryPacket(int channelNum) {
@@ -579,7 +579,7 @@ public class DuplexGroupScanPanel extends jmri.jmrix.loconet.swing.LnPanel
          * clear the channel highlight. After invoking this method, a call to
          * this class' repaint() method is required to cause the GUI update.
          * <p>
-         * @param channelNum - integer representing a Duplex Group channel
+         * @param channelNum  integer representing a Duplex Group channel
          *                   number.
          */
         public void setChannelBeingScanned(int channelNum) {

--- a/java/src/jmri/jmrix/loconet/duplexgroup/swing/LnDplxGrpInfoImpl.java
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/swing/LnDplxGrpInfoImpl.java
@@ -155,7 +155,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
      * A valid Duplex Group Name is an 8 character string. The calling method
      * should append spaces or truncate to give correct length if necessary.
      *
-     * @param sGroupName - string containing group name to be validated
+     * @param sGroupName  string containing group name to be validated
      * @return true if and only if groupName is a valid Duplex Group Name
      */
     public static final boolean validateGroupName(String sGroupName) {
@@ -172,7 +172,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
      * alphanumeric values are allowed. (See private field
      * limitPasswordToNumericCharacters.)
      * <p>
-     * @param sGroupPassword - Duplex Group Password to be validated
+     * @param sGroupPassword  Duplex Group Password to be validated
      * @return true if and only if sGroupPassword is a valid Duplex Group
      *         Password.
      */
@@ -190,7 +190,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
     /**
      * Validate a Duplex Group Channel Number.
      * <p>
-     * @param iGroupChannel - Duplex Group Channel number to be validated
+     * @param iGroupChannel  Duplex Group Channel number to be validated
      * @return true if and only if iGroupChannel is a valid Duplex Group
      *         Channel.
      */
@@ -206,7 +206,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
     /**
      * Validate the parameter as a Duplex Group ID number.
      * <p>
-     * @param iGroupId - Duplex Group ID number to be validated
+     * @param iGroupId  Duplex Group ID number to be validated
      * @return true if and only if iGroupId is a valid Duplex Group ID.
      */
     public static final boolean validateGroupID(Integer iGroupId) {
@@ -441,7 +441,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
      * message, including queries, reports, and writes, for Name, Channel,
      * Password, and ID.
      * <p>
-     * @param m - LocoNet message to check
+     * @param m  LocoNet message to check
      * @return true if message is query, report, or write of Duplex Group Name,
      *         Channel, Password or ID
      */
@@ -526,7 +526,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
      * <p>
      * If m does not contain a Duplex Group Name, returns null.
      * <p>
-     * @param m - LocoNet message from which a Duplex Group Name is to be extracted.
+     * @param m  LocoNet message from which a Duplex Group Name is to be extracted.
      * @return String containing Duplex Group Name as extracted from m
      */
     public static String extractDuplexGroupName(LocoNetMessage m) {
@@ -577,7 +577,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
      * <p>
      * Returns -1 if the m does not contain a Duplex Group Channel.
      * <p>
-     * @param m - LocoNet message from which a Duplex Group Channel number will
+     * @param m  LocoNet message from which a Duplex Group Channel number will
      *          be extracted
      * @return Integer containing Duplex Group Name as extracted from m
      */
@@ -601,7 +601,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
      * <p>
      * Returns -1 if the m does not contain a Duplex Group ID.
      * <p>
-     * @param m - LocoNet message from which a Duplex Group ID will be extracted
+     * @param m  LocoNet message from which a Duplex Group ID will be extracted
      * @return Integer containing Duplex Group Name as extracted from m
      */
     public static int extractDuplexGroupID(LocoNetMessage m) {
@@ -624,7 +624,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
      * <p>
      * Returns null if the m does not contain a Duplex Group Password.
      * <p>
-     * @param m - LocoNet message to be checked for a duplex group password message
+     * @param m  LocoNet message to be checked for a duplex group password message
      * @return String containing the Duplex Group Password as extracted from m
      */
     public static String extractDuplexGroupPassword(LocoNetMessage m) {
@@ -888,7 +888,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
     /**
      * Creates and sends a LocoNet message which sets the Duplex Group Name.
      *
-     * @param dgn - String containing the new Duplex Group Name
+     * @param dgn  String containing the new Duplex Group Name
      * @throws jmri.jmrix.loconet.LocoNetException if dgn is not a valid Duplex
      *                                             Group Name.
      */
@@ -901,7 +901,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
     /**
      * Creates and sends a LocoNet message which sets the Duplex Group Channel.
      *
-     * @param dgc - Integer containing the new Duplex Group Channel
+     * @param dgc  Integer containing the new Duplex Group Channel
      * @throws jmri.jmrix.loconet.LocoNetException if dgc is not a valid Duplex
      *                                             Group Channel number.
      */
@@ -913,7 +913,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
     /**
      * Creates and sends a LocoNet message which sets the Duplex Group Password.
      *
-     * @param dgp - String containing the new Duplex Group Password
+     * @param dgp  String containing the new Duplex Group Password
      * @throws jmri.jmrix.loconet.LocoNetException if dgp is not a valid Duplex
      *                                             Group Password.
      */
@@ -925,7 +925,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
     /**
      * Creates and sends a LocoNet message which sets the Duplex Group Id.
      *
-     * @param dgi - String containing the new Duplex Group Id
+     * @param dgi  String containing the new Duplex Group Id
      * @throws jmri.jmrix.loconet.LocoNetException if dgi is not a valid Duplex
      *                                             Group Id.
      */
@@ -1235,7 +1235,7 @@ public class LnDplxGrpInfoImpl extends javax.swing.JComponent implements jmri.jm
     /**
      * Connect this instance's LocoNetListener to the LocoNet Traffic Controller
      * <p>
-     * @param t - LocoNet traffic controller
+     * @param t  LocoNet traffic controller
      */
     public void connect(jmri.jmrix.loconet.LnTrafficController t) {
         if (t != null) {

--- a/java/src/jmri/jmrix/loconet/duplexgroup/swing/LnIPLImplementation.java
+++ b/java/src/jmri/jmrix/loconet/duplexgroup/swing/LnIPLImplementation.java
@@ -255,7 +255,7 @@ public class LnIPLImplementation extends javax.swing.JComponent implements jmri.
      * Checks message m to determine if it contains a IPL Identity Report
      * message.
      * <p>
-     * @param m - LocoNetMessage to be checked for an IPL Identity Query message
+     * @param m  LocoNetMessage to be checked for an IPL Identity Query message
      * @return true if message is report of IPL Identity
      */
     public static final boolean isIplIdentityQueryMessage(LocoNetMessage m) {
@@ -278,7 +278,7 @@ public class LnIPLImplementation extends javax.swing.JComponent implements jmri.
      * Checks message m to determine if it contains a IPL Identity Report
      * message.
      * <p>
-     * @param m - LocoNet message to check for an IPL Identity Report
+     * @param m  LocoNet message to check for an IPL Identity Report
      * @return true if message is report of IPL Identity
      */
     public static final boolean isIplIdentityReportMessage(LocoNetMessage m) {
@@ -733,10 +733,10 @@ public class LnIPLImplementation extends javax.swing.JComponent implements jmri.
      * return "Digitrax UT4(x)" in response to appropriate Host Manufacturer
      * number and appropriate Host Device number.
      * <p>
-     * @param hostMfr - host manufacturer number
-     * @param hostDevice - host device number
-     * @param slaveMfr - slave manufacturer number
-     * @param slaveDevice - slave device number
+     * @param hostMfr  host manufacturer number
+     * @param hostDevice  host device number
+     * @param slaveMfr  slave manufacturer number
+     * @param slaveDevice  slave device number
      * @return String containing Manufacturer name and Device model.
      */
     public static final String interpretHostManufacturerDevice(Integer hostMfr, Integer hostDevice,
@@ -869,8 +869,8 @@ public class LnIPLImplementation extends javax.swing.JComponent implements jmri.
      * return "Digitrax UT4(x)" in response to appropriate Host Manufacturer
      * number and appropriate Host Device number.
      * <p>
-     * @param hostMfr - host manufacturer number
-     * @param hostDevice - host device number
+     * @param hostMfr  host manufacturer number
+     * @param hostDevice  host device number
      * @return String containing Manufacturer name and Device model.
      */
     public static final String interpretHostManufacturerDevice(Integer hostMfr, Integer hostDevice) {
@@ -884,8 +884,8 @@ public class LnIPLImplementation extends javax.swing.JComponent implements jmri.
      * NOTE: Some IPL-capable devices may not be completely determined based
      * solely on Slave Manufacturer number and Slave Device number.
      * <p>
-     * @param slaveMfr - slave manufacturer number
-     * @param slaveDevice - slave device number
+     * @param slaveMfr  slave manufacturer number
+     * @param slaveDevice  slave device number
      * @return String containing Slave Manufacturer name and Device model.
      */
     public static final String interpretSlaveManufacturerDevice(Integer slaveMfr, Integer slaveDevice) {
@@ -920,7 +920,7 @@ public class LnIPLImplementation extends javax.swing.JComponent implements jmri.
     /**
      * Connect this instance's LocoNetListener to the LocoNet Traffic Controller.
      * <p>
-     * @param t - a LocoNet Traffic Controller
+     * @param t  a LocoNet Traffic Controller
      */
     public void connect(jmri.jmrix.loconet.LnTrafficController t) {
         if (t != null) {
@@ -946,7 +946,7 @@ public class LnIPLImplementation extends javax.swing.JComponent implements jmri.
      * Process all incoming LocoNet messages to look for IPL operations. Ignores
      * all other LocoNet messages.
      *
-     * @param m - incoming LocoNet message to be examined
+     * @param m  incoming LocoNet message to be examined
      */
     @Override
     public void message(LocoNetMessage m) {

--- a/java/src/jmri/jmrix/loconet/lnsvf2/LnSv2MessageContents.java
+++ b/java/src/jmri/jmrix/loconet/lnsvf2/LnSv2MessageContents.java
@@ -273,7 +273,7 @@ public class LnSv2MessageContents {
      * Interprets a LocoNet message to determine its SV Programming Format 2 &lt;SV_CMD&gt;.
      * If the message is not an SV Programming Format 2 message, returns null
      * @param m  LocoNet message containing SV Programming Format 2 message
-     * @return - Sv2Command found in the SV Programming Format 2 message
+     * @return Sv2Command found in the SV Programming Format 2 message
      */
     public static Sv2Command extractMessageType(LocoNetMessage m) {
         if (isSupportedSv2Message(m)) {
@@ -291,7 +291,7 @@ public class LnSv2MessageContents {
     /**
      * Interprets the SV Programming Format 2 message into a human-readable string.
      * 
-     * @return - a String containing a human-readable version of the SV Programming 
+     * @return String containing a human-readable version of the SV Programming 
      *      Format 2 message
      */
     @Override
@@ -304,7 +304,7 @@ public class LnSv2MessageContents {
      * Interprets the SV Programming Format 2 message into a human-readable string.
      * 
      * @param locale  locale to use for the human-readable string
-     * @return - a String containing a human-readable version of the SV Programming 
+     * @return String containing a human-readable version of the SV Programming 
      *      Format 2 message, in the language specified by the Locale, if the 
      *      properties have been translated to that Locale, else in the deafult 
      *      English language.
@@ -591,7 +591,7 @@ public class LnSv2MessageContents {
      * @param d2  SV Programming Format 2 second data value (for &lt;D2&gt;)
      * @param d3  SV Programming Format 2 third data value (for &lt;D3&gt;)
      * @param d4  SV Programming Format 2 fourth data value (for &lt;D4&gt;)
-     * @return - LocoNet message for the requested message
+     * @return LocoNet message for the requested message
      * @throws IllegalArgumentException of command is not a valid SV Programming Format 2 &lt;SV_CMD&gt; value
      */
     public static LocoNetMessage createSv2Message (int source, int command, 

--- a/java/src/jmri/jmrix/loconet/lnsvf2/LnSv2MessageContents.java
+++ b/java/src/jmri/jmrix/loconet/lnsvf2/LnSv2MessageContents.java
@@ -160,7 +160,7 @@ public class LnSv2MessageContents {
     /**
      * Check a LocoNet message to determine if it is a valid SV Programming Format 
      *      2 message.
-     * @param m - LocoNet message to check
+     * @param m  LocoNet message to check
      * @return true if Loconet message m is a supported SV Programming Format 2 
      *      message, else false.
      */
@@ -213,9 +213,9 @@ public class LnSv2MessageContents {
     
     /**
      *
-     * @param m - LocoNet message to be verified as an SV Programming Format 2 message
+     * @param m  LocoNet message to be verified as an SV Programming Format 2 message
      *      with the specified &lt;SV_CMD&gt; value
-     * @param svCmd - SV Programming Format 2 command to expect
+     * @param svCmd  SV Programming Format 2 command to expect
      * @return true if message is an SV Programming Format 2 message of the specified &lt;SV_CMD&gt;,
      *      else false.
      */
@@ -272,7 +272,7 @@ public class LnSv2MessageContents {
     /**
      * Interprets a LocoNet message to determine its SV Programming Format 2 &lt;SV_CMD&gt;.
      * If the message is not an SV Programming Format 2 message, returns null
-     * @param m - LocoNet message containing SV Programming Format 2 message
+     * @param m  LocoNet message containing SV Programming Format 2 message
      * @return - Sv2Command found in the SV Programming Format 2 message
      */
     public static Sv2Command extractMessageType(LocoNetMessage m) {
@@ -303,7 +303,7 @@ public class LnSv2MessageContents {
     /**
      * Interprets the SV Programming Format 2 message into a human-readable string.
      * 
-     * @param locale - locale to use for the human-readable string
+     * @param locale  locale to use for the human-readable string
      * @return - a String containing a human-readable version of the SV Programming 
      *      Format 2 message, in the language specified by the Locale, if the 
      *      properties have been translated to that Locale, else in the deafult 
@@ -504,7 +504,7 @@ public class LnSv2MessageContents {
 
     /**
      *
-     * @param possibleCmd - integer to be compared to the command list
+     * @param possibleCmd  integer to be compared to the command list
      * @return  true if the possibleCmd value is one of the supported SV 
      *      Programming Format 2 commands
      */
@@ -583,14 +583,14 @@ public class LnSv2MessageContents {
     }
     /**
      * Create a LocoNet message containing an SV Programming Format 2 message
-     * @param source - source device address (7 bit, for &lt;SRC&gt;)
-     * @param command - SV Programming Format 2 command number (for &lt;SV_CMD&gt;)
+     * @param source  source device address (7 bit, for &lt;SRC&gt;)
+     * @param command  SV Programming Format 2 command number (for &lt;SV_CMD&gt;)
      * @param destination = SV format 2 destination address (for &lt;DST_L&gt; and &lt;DST_H&gt;)
-     * @param svNum - SV Programming Format 2 16-bit SV number (for &lt;SVN_L&gt; and &lt;SVN_H&gt;)
-     * @param d1 - SV Programming Format 2 first data value (for &lt;D1&gt;)
-     * @param d2 - SV Programming Format 2 second data value (for &lt;D2&gt;)
-     * @param d3 - SV Programming Format 2 third data value (for &lt;D3&gt;)
-     * @param d4 - SV Programming Format 2 fourth data value (for &lt;D4&gt;)
+     * @param svNum  SV Programming Format 2 16-bit SV number (for &lt;SVN_L&gt; and &lt;SVN_H&gt;)
+     * @param d1  SV Programming Format 2 first data value (for &lt;D1&gt;)
+     * @param d2  SV Programming Format 2 second data value (for &lt;D2&gt;)
+     * @param d3  SV Programming Format 2 third data value (for &lt;D3&gt;)
+     * @param d4  SV Programming Format 2 fourth data value (for &lt;D4&gt;)
      * @return - LocoNet message for the requested message
      * @throws IllegalArgumentException of command is not a valid SV Programming Format 2 &lt;SV_CMD&gt; value
      */
@@ -701,12 +701,12 @@ public class LnSv2MessageContents {
     
     /** 
      * 
-     * @param ida - IDA number for "SRC" field of OPC_PEER_XFER
-     * @param currentDest - the destination address of the device
-     * @param mfg - the Manufacturer ID
-     * @param devel - the developer ID
-     * @param prodID - the product ID
-     * @param serial - the serial number
+     * @param ida  IDA number for "SRC" field of OPC_PEER_XFER
+     * @param currentDest  the destination address of the device
+     * @param mfg  the Manufacturer ID
+     * @param devel  the developer ID
+     * @param prodID  the product ID
+     * @param serial  the serial number
      * @return a LocoNet message containing the formatted reply
      */
     public static LocoNetMessage createSv2DeviceDiscoveryReply(int ida, int currentDest, 
@@ -726,8 +726,8 @@ public class LnSv2MessageContents {
      * Creates a LocoNet message for the reply for an SV2 "Change Address" 
      * message where the device requires a reconfigure.
      * 
-     * @param ida - IDA value, for the SRC field of the OPC_PEER_XFER
-     * @param destAddr - the "old" SV2 destination address
+     * @param ida  IDA value, for the SRC field of the OPC_PEER_XFER
+     * @param destAddr  the "old" SV2 destination address
      * @return a LocoNet message
      */
     public static LocoNetMessage createSv2ChangeAddressReply(int ida, int destAddr) {
@@ -741,12 +741,12 @@ public class LnSv2MessageContents {
      * Creates a LocoNet message for the reply for an SV2 "Change Address" 
      * message where the device requires a reconfigure.
      * 
-     * @param ida - IDA value, for the SRC field of the OPC_PEER_XFER
-     * @param newDestAddr - the "new" SV2 destination address
-     * @param mfg - manufacturer ID
-     * @param developer - device ID
-     * @param productId - product ID
-     * @param serialNum - serial Number
+     * @param ida  IDA value, for the SRC field of the OPC_PEER_XFER
+     * @param newDestAddr  the "new" SV2 destination address
+     * @param mfg  manufacturer ID
+     * @param developer  device ID
+     * @param productId  product ID
+     * @param serialNum  serial Number
      * @return a LocoNet message
      */
     public static LocoNetMessage createSv2ChangeAddressReply(int ida, int newDestAddr, 
@@ -761,12 +761,12 @@ public class LnSv2MessageContents {
     /**
      * Creates a LocoNet message for the reply for an SV2 "Reconfigure Reply"
      * 
-     * @param ida - IDA value, for the SRC field of the OPC_PEER_XFER
-     * @param newDestAddr - the "new" SV2 destination address
-     * @param mfg - manufacturer ID
-     * @param developer - device ID
-     * @param productId - product ID
-     * @param serialNum - serial Number
+     * @param ida  IDA value, for the SRC field of the OPC_PEER_XFER
+     * @param newDestAddr  the "new" SV2 destination address
+     * @param mfg  manufacturer ID
+     * @param developer  device ID
+     * @param productId  product ID
+     * @param serialNum  serial Number
      * @return a LocoNet message
      */
     public static LocoNetMessage createSv2ReconfigureReply(int ida, int newDestAddr, 
@@ -779,8 +779,8 @@ public class LnSv2MessageContents {
     }
     /**
      * 
-     * @param m - the preceeding LocoNet message
-     * @param svValues - array containing the SV values; only one value is used 
+     * @param m  the preceeding LocoNet message
+     * @param svValues  array containing the SV values; only one value is used 
      *          when m contains a SV_QUERY_ONE, else contains 4 values.
      * @return  LocoNet message containing the reply, or null if preceeding 
      *          message isn't a query.
@@ -823,8 +823,8 @@ public class LnSv2MessageContents {
 
     /**
      * 
-     * @param m - the preceeding LocoNet message
-     * @param svValue - value of one SV register
+     * @param m  the preceeding LocoNet message
+     * @param svValue  value of one SV register
      * @return  LocoNet message containing the reply, or null if preceeding 
      *          message isn't a query.
      */
@@ -886,8 +886,8 @@ public class LnSv2MessageContents {
     /**
      * Create LocoNet message for another query of an SV of this object
      * 
-     * @param deviceAddress - address of the device
-     * @param svNum - SV number
+     * @param deviceAddress  address of the device
+     * @param svNum  SV number
      * @return LocoNet message
      */
     public static LocoNetMessage createSvReadRequest(int deviceAddress, int svNum) {

--- a/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
@@ -291,7 +291,7 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
      * for a given readable choice return internal value
      * or the default
      * <p>
-     * @param s - string containing ?a packetizer name?
+     * @param s  string containing ?a packetizer name?
      * @return - internal value
      */
     protected String getPacketizerOption(String s) {

--- a/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
@@ -292,7 +292,7 @@ public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.Se
      * or the default
      * <p>
      * @param s  string containing ?a packetizer name?
-     * @return - internal value
+     * @return internal value
      */
     protected String getPacketizerOption(String s) {
         for (int i=0;i < packetizers.length; i++) {

--- a/java/src/jmri/jmrix/loconet/locogen/LocoGenPanel.java
+++ b/java/src/jmri/jmrix/loconet/locogen/LocoGenPanel.java
@@ -174,7 +174,7 @@ public class LocoGenPanel extends jmri.jmrix.loconet.swing.LnPanel
     /**
      * Run button pressed down, start the sequence operation
      *<p>
-     * @param e - a {@link java.awt.event.ActionEvent} to be triggered
+     * @param e  a {@link java.awt.event.ActionEvent} to be triggered
      */
     public void runButtonActionPerformed(java.awt.event.ActionEvent e) {
         if (!mRunButton.isSelected()) {
@@ -264,7 +264,7 @@ public class LocoGenPanel extends jmri.jmrix.loconet.swing.LnPanel
      * two characters each, as defined in
      * {@link jmri.util.StringUtil#bytesFromHexString(String s)} .
      * <p>
-     * @param s - a string containing raw hex data of good form
+     * @param s  a string containing raw hex data of good form
      * @return The packet, with contents filled-in
      */
     LocoNetMessage createPacket(String s) {

--- a/java/src/jmri/jmrix/loconet/locomon/Llnmon.java
+++ b/java/src/jmri/jmrix/loconet/locomon/Llnmon.java
@@ -147,7 +147,7 @@ public class Llnmon {
      * Create a LocoNet Message Formatter. The managers allow the user names of
      * managed devices to be included in messages with the system names.
      * <p>
-     * @param prefix - system connection prefix (i.e. "L")
+     * @param prefix  system connection prefix (i.e. "L")
      * <p>
      * @deprecated since 4.13.5; use the 
      * {@link LocoNetMessage#toMonitorString(String)} (preferred) or
@@ -360,8 +360,8 @@ public class Llnmon {
     /**
      * Return a string which is formatted by a bundle Resource Name.
      *
-     * @param hour   - fast-clock hour
-     * @param minute - fast-clock minute
+     * @param hour    fast-clock hour
+     * @param minute  fast-clock minute
      * @return a formatted string containing the time
      */
     private String fcTimeToString(int hour, int minute) {

--- a/java/src/jmri/jmrix/loconet/locostats/LocoStatsFunc.java
+++ b/java/src/jmri/jmrix/loconet/locostats/LocoStatsFunc.java
@@ -53,7 +53,7 @@ public class LocoStatsFunc implements LocoNetListener {
     /**
      * LocoNet message handler.
      * 
-     * @param msg - incoming LocoNet message to be interpreted
+     * @param msg  incoming LocoNet message to be interpreted
      */
     @Override
     public void message(LocoNetMessage msg) {
@@ -177,7 +177,7 @@ public class LocoStatsFunc implements LocoNetListener {
      * Add a listener to the list of listeners which will be notified upon receipt 
      * a LocoNet message containing interface statistics.
      * 
-     * @param l - LocoNetInterfaceStatsListener to be added
+     * @param l  LocoNetInterfaceStatsListener to be added
      */
     public synchronized void addLocoNetInterfaceStatsListener(@Nonnull LocoNetInterfaceStatsListener l) {
         java.util.Objects.requireNonNull(l);
@@ -191,7 +191,7 @@ public class LocoStatsFunc implements LocoNetListener {
      * Remove a listener (if present) from the list of listeners which will be 
      * notified upon receipt LocoNet message containing interface statistics.
      * 
-     * @param l - LocoNetInterfaceStatsListener to be removed
+     * @param l  LocoNetInterfaceStatsListener to be removed
      */
     public synchronized void removeLocoNetInterfaceStatsListener(@Nonnull LocoNetInterfaceStatsListener l) {
         java.util.Objects.requireNonNull(l);

--- a/java/src/jmri/jmrix/loconet/locostats/swing/LocoStatsPanel.java
+++ b/java/src/jmri/jmrix/loconet/locostats/swing/LocoStatsPanel.java
@@ -161,7 +161,7 @@ public class LocoStatsPanel extends LnPanel implements LocoNetInterfaceStatsList
     /**
      * Configure LocoNet connection
      * 
-     * @param memo - specifies which LocoNet connection is used by this tool
+     * @param memo  specifies which LocoNet connection is used by this tool
      */
     @Override
     public void initComponents(LocoNetSystemConnectionMemo memo) {

--- a/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
+++ b/java/src/jmri/jmrix/loconet/messageinterp/LocoNetMessageInterpret.java
@@ -4171,8 +4171,8 @@ public class LocoNetMessageInterpret {
     /**
      * Return a string which is formatted by a bundle Resource Name.
      *
-     * @param hour   - fast-clock hour
-     * @param minute - fast-clock minute
+     * @param hour    fast-clock hour
+     * @param minute  fast-clock minute
      * @return a formatted string containing the time
      */
     private static String fcTimeToString(int hour, int minute) {

--- a/java/src/jmri/jmrix/loconet/pr3/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/pr3/ConnectionConfig.java
@@ -14,7 +14,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
      * Ctor for an object being created during load process; Swing init is
      * deferred.
      * 
-     * @param p  - Serial port adapter for the connection
+     * @param p   Serial port adapter for the connection
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/loconet/pr3/PR3Adapter.java
+++ b/java/src/jmri/jmrix/loconet/pr3/PR3Adapter.java
@@ -31,7 +31,7 @@ public class PR3Adapter extends LocoBufferAdapter {
      * not considered a user-settable option.  Sets the PR3 for the appropriate
      * operating mode, based on the selected "command station type".
      *
-     * @param activeSerialPort - the port to be configured
+     * @param activeSerialPort  the port to be configured
      */
     @Override
     protected void setSerialPort(SerialPort activeSerialPort) throws UnsupportedCommOperationException {

--- a/java/src/jmri/jmrix/loconet/pr4/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/pr4/ConnectionConfig.java
@@ -18,7 +18,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
      * Ctor for an object being created during load process; Swing init is
      * deferred.
      * 
-     * @param p  - Serial port adapter for the connection
+     * @param p   Serial port adapter for the connection
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/loconet/pr4/PR4Adapter.java
+++ b/java/src/jmri/jmrix/loconet/pr4/PR4Adapter.java
@@ -34,7 +34,7 @@ public class PR4Adapter extends LocoBufferAdapter {
      * not considered a user-settable option.  Sets the PR4 for the appropriate
      * operating mode, based on the selected "command station type".
      *
-     * @param activeSerialPort - the port to be configured
+     * @param activeSerialPort  the port to be configured
      */
     @Override
     protected void setSerialPort(SerialPort activeSerialPort) throws UnsupportedCommOperationException {

--- a/java/src/jmri/jmrix/loconet/swing/LnPanelInterface.java
+++ b/java/src/jmri/jmrix/loconet/swing/LnPanelInterface.java
@@ -17,7 +17,7 @@ public interface LnPanelInterface {
      * This needs to be connected to the initContext() method in implementing
      * classes.
      * <p>
-     * @param memo - a {@link jmri.jmrix.loconet.LocoNetSystemConnectionMemo} object
+     * @param memo  a {@link jmri.jmrix.loconet.LocoNetSystemConnectionMemo} object
      */
     public void initComponents(LocoNetSystemConnectionMemo memo);
 

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/ConnectionConfig.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/ConnectionConfig.java
@@ -12,7 +12,7 @@ public class ConnectionConfig extends jmri.jmrix.AbstractSerialConnectionConfig 
      * Ctor for an object being created during load process; Swing init is
      * deferred.
      * <p>
-     * @param p - a @link jmri.jmrix.SerialPortAdapter} object
+     * @param p  a @link jmri.jmrix.SerialPortAdapter} object
      */
     public ConnectionConfig(jmri.jmrix.SerialPortAdapter p) {
         super(p);

--- a/java/src/jmri/jmrix/loconet/usb_dcs240/UsbDcs240Adapter.java
+++ b/java/src/jmri/jmrix/loconet/usb_dcs240/UsbDcs240Adapter.java
@@ -34,7 +34,7 @@ public class UsbDcs240Adapter extends LocoBufferAdapter {
      * not considered a user-settable option.  Sets the DCS240 USB interface for the appropriate
      * operating mode, based on the selected "command station type".
      *
-     * @param activeSerialPort - the port to be configured
+     * @param activeSerialPort  the port to be configured
      */
     @Override
     protected void setSerialPort(SerialPort activeSerialPort) throws UnsupportedCommOperationException {

--- a/java/src/jmri/jmrix/loconet/usb_dcs52/UsbDcs52Adapter.java
+++ b/java/src/jmri/jmrix/loconet/usb_dcs52/UsbDcs52Adapter.java
@@ -34,7 +34,7 @@ public class UsbDcs52Adapter extends LocoBufferAdapter {
      * not considered a user-settable option.  Sets the DCS52 USB interface for the appropriate
      * operating mode, based on the selected "command station type".
      *
-     * @param activeSerialPort - the port to be configured
+     * @param activeSerialPort  the port to be configured
      */
     @Override
     protected void setSerialPort(SerialPort activeSerialPort) throws UnsupportedCommOperationException {

--- a/java/src/jmri/jmrix/maple/InputBits.java
+++ b/java/src/jmri/jmrix/maple/InputBits.java
@@ -168,8 +168,8 @@ public class InputBits {
     /**
      * The numbers here are 0 to MAXSENSORS, not 1 to MAXSENSORS.
      *
-     * @param s - Sensor object
-     * @param i - 0 to MAXSENSORS number of sensor's input bit on this node
+     * @param s  Sensor object
+     * @param i  0 to MAXSENSORS number of sensor's input bit on this node
      */
     public void registerSensor(Sensor s, int i) {
         // validate the sensor ordinal

--- a/java/src/jmri/jmrix/nce/macro/NceMacroEditPanel.java
+++ b/java/src/jmri/jmrix/nce/macro/NceMacroEditPanel.java
@@ -1227,7 +1227,7 @@ public class NceMacroEditPanel extends jmri.jmrix.nce.swing.NcePanel implements 
     /**
      * Check for valid macro, return number if valid, -1 if not.
      *
-     * @param s - string of macro number
+     * @param s  string of macro number
      * @return mN - int of macro number or -1 if invalid
      */
     private int validMacro(String s) {
@@ -1453,7 +1453,7 @@ public class NceMacroEditPanel extends jmri.jmrix.nce.swing.NcePanel implements 
     /**
      * USB Write 1 byte of NCE memory
      *
-     * @param value - byte being written
+     * @param value  byte being written
      */
     private void writeUsbMemory1(int value) {
         replyLen = NceMessage.REPLY_1; // Expect 1 byte response

--- a/java/src/jmri/jmrix/ncemonitor/NcePacketMonitorPanel.java
+++ b/java/src/jmri/jmrix/ncemonitor/NcePacketMonitorPanel.java
@@ -433,7 +433,7 @@ public class NcePacketMonitorPanel extends jmri.jmrix.AbstractMonPane implements
     /**
      * Sends stream of bytes to the command station
      *
-     * @param bytes - array of bytes to send
+     * @param bytes  array of bytes to send
      */
     synchronized void sendBytes(byte[] bytes) {
         try {

--- a/java/src/jmri/jmrix/rfid/RfidProtocol.java
+++ b/java/src/jmri/jmrix/rfid/RfidProtocol.java
@@ -29,9 +29,9 @@ abstract public class RfidProtocol {
      * Constructor for an RFID Protocol. Supports the use of concentrators where
      * a character range is used to determine the specific reader port.
      *
-     * @param concentratorFirst - character representing first concentrator port
-     * @param concentratorLast  - character representing last concentrator port
-     * @param portPosition      - position of port character in reply string;
+     * @param concentratorFirst  character representing first concentrator port
+     * @param concentratorLast   character representing last concentrator port
+     * @param portPosition       position of port character in reply string;
      *                            1 for first character
      */
     public RfidProtocol(char concentratorFirst, char concentratorLast, int portPosition) {

--- a/java/src/jmri/jmrix/rfid/protocol/coreid/CoreIdRfidProtocol.java
+++ b/java/src/jmri/jmrix/rfid/protocol/coreid/CoreIdRfidProtocol.java
@@ -38,9 +38,9 @@ public class CoreIdRfidProtocol extends RfidProtocol {
      * Constructor for CORE-ID RFID Protocol. Supports the use of concentrators
      * where a character range is used to determine the specific reader port.
      *
-     * @param concentratorFirst - character representing first concentrator port
-     * @param concentratorLast  - character representing last concentrator port
-     * @param portPosition      - position of port character in reply string
+     * @param concentratorFirst  character representing first concentrator port
+     * @param concentratorLast   character representing last concentrator port
+     * @param portPosition       position of port character in reply string
      */
     public CoreIdRfidProtocol(char concentratorFirst, char concentratorLast, int portPosition) {
         super(concentratorFirst, concentratorLast, portPosition);

--- a/java/src/jmri/jmrix/rfid/protocol/em18/Em18RfidProtocol.java
+++ b/java/src/jmri/jmrix/rfid/protocol/em18/Em18RfidProtocol.java
@@ -40,9 +40,9 @@ public class Em18RfidProtocol extends RfidProtocol {
      * Constructor for EM-18 RFID Protocol. Supports the use of concentrators
      * where a character range is used to determine the specific reader port.
      *
-     * @param concentratorFirst - character representing first concentrator port
-     * @param concentratorLast  - character representing last concentrator port
-     * @param portPosition      - position of port character in reply string
+     * @param concentratorFirst  character representing first concentrator port
+     * @param concentratorLast   character representing last concentrator port
+     * @param portPosition       position of port character in reply string
      */
     public Em18RfidProtocol(char concentratorFirst, char concentratorLast, int portPosition) {
         super(concentratorFirst, concentratorLast, portPosition);

--- a/java/src/jmri/jmrix/rfid/protocol/seeedstudio/SeeedStudioRfidProtocol.java
+++ b/java/src/jmri/jmrix/rfid/protocol/seeedstudio/SeeedStudioRfidProtocol.java
@@ -39,9 +39,9 @@ public class SeeedStudioRfidProtocol extends RfidProtocol {
      * concentrators where a character range is used to determine the specific
      * reader port.
      *
-     * @param concentratorFirst - character representing first concentrator port
-     * @param concentratorLast  - character representing last concentrator port
-     * @param portPosition      - position of port character in reply string
+     * @param concentratorFirst  character representing first concentrator port
+     * @param concentratorLast   character representing last concentrator port
+     * @param portPosition       position of port character in reply string
      */
     public SeeedStudioRfidProtocol(char concentratorFirst, char concentratorLast, int portPosition) {
         super(concentratorFirst, concentratorLast, portPosition);

--- a/java/src/jmri/jmrix/sprog/SprogThrottle.java
+++ b/java/src/jmri/jmrix/sprog/SprogThrottle.java
@@ -125,7 +125,7 @@ public class SprogThrottle extends AbstractThrottle {
      * Set the speed step value and the related
      * speedIncrement value.
      *
-     * @param Mode - the current speed step mode - default should be 128 speed
+     * @param Mode  the current speed step mode - default should be 128 speed
      *             step mode in most cases
      */
     @Override

--- a/java/src/jmri/jmrix/srcp/SRCPMessage.java
+++ b/java/src/jmri/jmrix/srcp/SRCPMessage.java
@@ -70,7 +70,7 @@ public class SRCPMessage extends jmri.jmrix.AbstractMRMessage {
 
 
     /**
-     * @param bus - a bus number
+     * @param bus  a bus number
      * @return an SRCPMessage to initialize programming on the given bus.
      */
     static public SRCPMessage getProgMode(int bus) {
@@ -80,7 +80,7 @@ public class SRCPMessage extends jmri.jmrix.AbstractMRMessage {
     }
 
     /**
-     * @param bus - a bus number
+     * @param bus  a bus number
      * @return an SRCPMessage to terminate programming on the given bus.
      */
     static public SRCPMessage getExitProgMode(int bus) {
@@ -90,8 +90,8 @@ public class SRCPMessage extends jmri.jmrix.AbstractMRMessage {
     }
 
     /**
-     * @param bus - a bus number
-     * @param cv - the CV to read.
+     * @param bus  a bus number
+     * @param cv  the CV to read.
      * @return an SRCPMessage to read the given CV in direct mode the given bus.
      */
     static public SRCPMessage getReadDirectCV(int bus, int cv) {
@@ -102,9 +102,9 @@ public class SRCPMessage extends jmri.jmrix.AbstractMRMessage {
     }
 
     /**
-     * @param bus - a bus number
-     * @param cv - the CV to read.
-     * @param val - a value for the CV.
+     * @param bus  a bus number
+     * @param cv  the CV to read.
+     * @param val  a value for the CV.
      * @return an SRCPMessage to check the given cv has the given val using the given bus.
      */
     static public SRCPMessage getConfirmDirectCV(int bus, int cv, int val) {
@@ -116,9 +116,9 @@ public class SRCPMessage extends jmri.jmrix.AbstractMRMessage {
     }
 
     /**
-     * @param bus - a bus number
-     * @param cv - the CV to write.
-     * @param val - a value for the CV.
+     * @param bus  a bus number
+     * @param cv  the CV to write.
+     * @param val  a value for the CV.
      * @return an SRCPMessage to write the given value to the provided cv using the given bus.
      */
     static public SRCPMessage getWriteDirectCV(int bus, int cv, int val) {
@@ -129,9 +129,9 @@ public class SRCPMessage extends jmri.jmrix.AbstractMRMessage {
     }
 
     /**
-     * @param bus - a bus number
-     * @param cv - the CV to read.
-     * @param bit - the bit to read.
+     * @param bus  a bus number
+     * @param cv  the CV to read.
+     * @param bit  the bit to read.
      * @return an SRCPMessage to read the given bit of the given CV uisng the provided bus.
      */
     static public SRCPMessage getReadDirectBitCV(int bus, int cv, int bit) {
@@ -142,10 +142,10 @@ public class SRCPMessage extends jmri.jmrix.AbstractMRMessage {
     }
 
     /**
-     * @param bus - a bus number
-     * @param cv - the CV to read.
-     * @param bit - the bit to read.
-     * @param val - the value to check
+     * @param bus  a bus number
+     * @param cv  the CV to read.
+     * @param bit  the bit to read.
+     * @param val  the value to check
      * @return an SRCPMessage to verify the given bit of the given CV has the given val uisng the provided bus.
      */
     static public SRCPMessage getConfirmDirectBitCV(int bus, int cv, int bit, int val) {
@@ -157,10 +157,10 @@ public class SRCPMessage extends jmri.jmrix.AbstractMRMessage {
     }
 
     /**
-     * @param bus - a bus number
-     * @param cv - the CV to write.
-     * @param bit - the bit to write
-     * @param val - the value to write
+     * @param bus  a bus number
+     * @param cv  the CV to write.
+     * @param bit  the bit to write
+     * @param val  the value to write
      * @return an SRCPMessage to write the given value to the given bit of the given CV uisng the provided bus.
      */
     static public SRCPMessage getWriteDirectBitCV(int bus, int cv, int bit, int val) {
@@ -171,8 +171,8 @@ public class SRCPMessage extends jmri.jmrix.AbstractMRMessage {
     }
 
     /**
-     * @param bus - a bus number
-     * @param reg - a register to read.  Restricted to valuse less than 8.
+     * @param bus  a bus number
+     * @param reg  a register to read.  Restricted to valuse less than 8.
      * @return an SRCPMessage to read the provided register using the given bus.
      * @throws IllegalArgumentException if the register value is out of range.
      */
@@ -187,9 +187,9 @@ public class SRCPMessage extends jmri.jmrix.AbstractMRMessage {
     }
 
     /**
-     * @param bus - a bus number
-     * @param reg - a register to read.  Restricted to valuse less than 8.
-     * @param val - a value for the register
+     * @param bus  a bus number
+     * @param reg  a register to read.  Restricted to valuse less than 8.
+     * @param val  a value for the register
      * @return an SRCPMessage to verify the provided register has the expected val using the given bus.
      * @throws IllegalArgumentException if the register value is out of range.
      */
@@ -204,9 +204,9 @@ public class SRCPMessage extends jmri.jmrix.AbstractMRMessage {
     }
 
     /**
-     * @param bus - a bus number
-     * @param reg - a register to write.  Restricted to valuse less than 8.
-     * @param val - a value for the register
+     * @param bus  a bus number
+     * @param reg  a register to write.  Restricted to valuse less than 8.
+     * @param val  a value for the register
      * @return an SRCPMessage to write the given value to the provided register using the given bus.
      * @throws IllegalArgumentException if the register value is out of range.
      */

--- a/java/src/jmri/managers/DefaultConditionalManager.java
+++ b/java/src/jmri/managers/DefaultConditionalManager.java
@@ -144,7 +144,7 @@ public class DefaultConditionalManager extends AbstractManager<Conditional>
      * Logix name is 'SYS'.  LRoutes and exported Routes (RTX prefix) require
      * special logic
      *
-     * @param name - system name of Conditional (must be trimmed and upper case)
+     * @param name  system name of Conditional (must be trimmed and upper case)
      * @return the parent Logix or null
      */
     @Override
@@ -194,8 +194,8 @@ public class DefaultConditionalManager extends AbstractManager<Conditional>
      * lookup. If this fails, or if x == null, looks up assuming that name is a
      * System Name. If both fail, returns null.
      *
-     * @param x    - parent Logix (may be null)
-     * @param name - name to look up
+     * @param x     parent Logix (may be null)
+     * @param name  name to look up
      * @return null if no match found
      */
     @Override

--- a/java/src/jmri/profile/ProfileManagerDialog.java
+++ b/java/src/jmri/profile/ProfileManagerDialog.java
@@ -303,7 +303,7 @@ public class ProfileManagerDialog extends JDialog {
     /**
      * Get the active profile or display a dialog to prompt the user for it.
      *
-     * @param f - The {@link java.awt.Frame} to display the dialog over
+     * @param f  The {@link java.awt.Frame} to display the dialog over
      * @return the active or selected {@link Profile}
      * @throws java.io.IOException if unable to read or set the starting Profile
      * @see ProfileManager#getStartingProfile()

--- a/java/src/jmri/util/JmriJFrame.java
+++ b/java/src/jmri/util/JmriJFrame.java
@@ -76,8 +76,8 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      * Creates a JFrame with standard settings, optional save/restore of size
      * and position.
      *
-     * @param saveSize     - Set true to save the last known size
-     * @param savePosition - Set true to save the last known location
+     * @param saveSize      Set true to save the last known size
+     * @param savePosition  Set true to save the last known location
      */
     public JmriJFrame(boolean saveSize, boolean savePosition) {
         super();
@@ -128,7 +128,7 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      * Creates a JFrame with with given name plus standard settings, including
      * saving/restoring of size and position.
      *
-     * @param name - Title of the JFrame
+     * @param name  Title of the JFrame
      */
     public JmriJFrame(String name) {
         this(name, true, true);
@@ -138,9 +138,9 @@ public class JmriJFrame extends JFrame implements WindowListener, jmri.ModifiedF
      * Creates a JFrame with with given name plus standard settings, including
      * optional save/restore of size and position.
      *
-     * @param name         - Title of the JFrame
-     * @param saveSize     - Set true to save the last knowm size
-     * @param savePosition - Set true to save the last known location
+     * @param name          Title of the JFrame
+     * @param saveSize      Set true to save the last knowm size
+     * @param savePosition  Set true to save the last known location
      */
     public JmriJFrame(String name, boolean saveSize, boolean savePosition) {
         this(saveSize, savePosition);

--- a/java/src/jmri/util/datatransfer/RosterEntrySelection.java
+++ b/java/src/jmri/util/datatransfer/RosterEntrySelection.java
@@ -49,7 +49,7 @@ public class RosterEntrySelection implements Transferable, ClipboardOwner {
      * Takes as a parameter an ArrayList containing Strings representing
      * RosterEntry Ids.
      *
-     * @param rosterEntries - an ArrayList of RosterEntry Ids
+     * @param rosterEntries  an ArrayList of RosterEntry Ids
      */
     public RosterEntrySelection(ArrayList<String> rosterEntries) {
         this.Ids = rosterEntries;

--- a/java/src/jmri/util/swing/JmriBeanComboBox.java
+++ b/java/src/jmri/util/swing/JmriBeanComboBox.java
@@ -348,7 +348,7 @@ public class JmriBeanComboBox extends JComboBox<String> implements java.beans.Pr
     /**
      * Set the display order of the combobox.
      *
-     * @param inDisplayOrder - the desired display order for this combobox
+     * @param inDisplayOrder  the desired display order for this combobox
      */
     public void setDisplayOrder(DisplayOptions inDisplayOrder) {
         if (_displayOrder != inDisplayOrder) {


### PR DESCRIPTION
Javadoc `@return` and `@param` tags should not contain separator dashes.  This removed a bunch of them. c.f. Issue #6635