### PR TITLE
Level Crossing Fixes

### DIFF
--- a/java/src/jmri/implementation/DefaultSignalMastLogic.java
+++ b/java/src/jmri/implementation/DefaultSignalMastLogic.java
@@ -2164,11 +2164,13 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
                         if ((levelXing.getLayoutBlockAC() != null)
                                 && (levelXing.getLayoutBlockBD() != null)
                                 && (levelXing.getLayoutBlockAC() != levelXing.getLayoutBlockBD())) {
-                            if (lblks.contains(levelXing.getLayoutBlockAC())) {
+                            if (lblks.contains(levelXing.getLayoutBlockAC()) &&
+                                    levelXing.getLayoutBlockAC() != facingBlock) {  // Don't include the facing xing blocks
                                 block.put(levelXing.getLayoutBlockBD().getBlock(), Block.UNOCCUPIED);
                                 xingAutoBlocks.add(levelXing.getLayoutBlockBD().getBlock());
                                 blockInXings.add(levelXing);
-                            } else if (lblks.contains(levelXing.getLayoutBlockBD())) {
+                            } else if (lblks.contains(levelXing.getLayoutBlockBD()) &&
+                                    levelXing.getLayoutBlockBD() != facingBlock) {  // Don't include the facing xing blocks
                                 block.put(levelXing.getLayoutBlockAC().getBlock(), Block.UNOCCUPIED);
                                 xingAutoBlocks.add(levelXing.getLayoutBlockAC().getBlock());
                                 blockInXings.add(levelXing);

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockConnectivityTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockConnectivityTools.java
@@ -735,9 +735,9 @@ public class LayoutBlockConnectivityTools {
                         && (lx.getLayoutBlockBD() != null)
                         && (lx.getLayoutBlockAC() != lx.getLayoutBlockBD())) {
                     if (lx.getLayoutBlockAC() == curBlock) {
-                        return canLBlockBeUsed(lx.getLayoutBlockBD());
+                        if (!canLBlockBeUsed(lx.getLayoutBlockBD())) return false;
                     } else if (lx.getLayoutBlockBD() == curBlock) {
-                        return canLBlockBeUsed(lx.getLayoutBlockAC());
+                        if (!canLBlockBeUsed(lx.getLayoutBlockAC())) return false;
                     }
                 }
             }


### PR DESCRIPTION
Fix Level Crossing Bugs:
- Check all level crossings in a block for conflicting NX allocations instead of just the first one.
- When the **facing block** contained a level crossing, the crossing block was being added to the automatic block list for signal mast logic.