### PR TITLE
Provide an escape mechanism to change how MQTT Turnouts payloads are coded

### DIFF
--- a/help/en/html/hardware/mqtt/index.shtml
+++ b/help/en/html/hardware/mqtt/index.shtml
@@ -43,6 +43,36 @@
       hardware via the Connections pane in the Preferences window.
       Select "MQTT" as the manufacturer name.
 
+      <a id="payload" name="payload"></a>
+      <h2>Message Content</h2>
+        <h3>Turnouts</h3>
+            By default, the message content for turnouts is
+            "CLOSED" and "THROWN".
+        <h3>Changing the Coding</h3>
+            You can use
+            <a href="../../tools/scripting/index.shtml">scripting</a>
+            to install a new 
+            <a href="http://jmri.org/JavaDoc/doc/jmri/jmrix/mqtt/MqttContentParser.html">jmri.jmrix.mqtt.MqttContentParser</a>
+            object to code and decode the content of messages.
+            See the 
+            <a href="/jython/SetMqttParser.py">jython/SetMqttParser.py</a>
+            sample script for how to do that.
+            <p>
+            Note that you can call
+            <code>setParser(...)</code>
+            on the
+            <a href="http://jmri.org/JavaDoc/doc/jmri/jmrix/mqtt/MqttTurnoutManager.html">jmri.jmrix.mqtt.MqttTurnoutManager</a>
+            or on an individual
+            <a href="http://jmri.org/JavaDoc/doc/jmri/jmrix/mqtt/MqttTurnout.html">jmri.jmrix.mqtt.MqttTurnout</a>
+            object.  If you call it on an individual 
+            MqttTurnout, that's the only one that's affected.
+            If you call it on the MqttTurnoutManager
+            all <u>later created</u> 
+            MqttTurnout objects will use the new parser; earlier-created ones
+            will not be changed.  This means you should 
+            call a script to change this before loading any panel files
+            if you want all MqttTurnouts to be modified.
+            
       
       <!--#include virtual="/Footer" -->
     </div><!-- closes #mainContent-->

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -66,7 +66,13 @@
 
         <h4>MQTT</h4>
             <ul>
-                <li></li>
+                <li>This release has an experimental method for changing the payload
+                    of MqttTurnouts, i.e. to use JSON instead of fixed strings.
+                    See the description at the bottom of the 
+                    <a href="http://jmri.org/help/en/hardware/mqtt/index.shtml#payload">bottom of the MQTT page</a>.
+                    More work is needed on this before it actually sends and receives
+                    JSON.
+                    </li>
             </ul>
 
         <h4>MRC</h4>

--- a/java/src/jmri/jmrix/mqtt/MqttContentParser.java
+++ b/java/src/jmri/jmrix/mqtt/MqttContentParser.java
@@ -1,0 +1,30 @@
+package jmri.jmrix.mqtt;
+
+import javax.annotation.Nonnull;
+import jmri.NamedBean;
+
+/**
+ * Interface defining a content parser, which translates to and from the MQTT payload
+ * content.
+ * 
+ * @author Bob Jacobsen
+ */
+public interface MqttContentParser<T extends NamedBean> {
+    /**
+     * Load a bean's state from a received MQTT payload.
+     * @param bean The particular item receiving the payload
+     * @param payload The entire string received via MQTT
+     * @throws IllegalArgumentException if the payload is unparsable.
+     */
+    public void beanFromPayload(@Nonnull T bean, @Nonnull String payload, @Nonnull String topic);
+    
+    /**
+     * Create the payload for a particular state transformation on 
+     * a particular bean.
+     * @param bean The particular item sending the payload
+     * @param newState The value to be sent to the layout; this is not yet present in the bean
+     * @return String payload to transfer via MQTT.
+     */
+    public @Nonnull String payloadFromBean(@Nonnull T bean, int newState);
+     
+}

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -22,8 +22,8 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
     }
     
     MqttContentParser<Turnout> parser = new MqttContentParser<Turnout>() {
-        private final String closedText = "CLOSED";
-        private final String thrownText = "THROWN";
+        private final static String closedText = "CLOSED";
+        private final static String thrownText = "THROWN";
         @Override
         public void beanFromPayload(@Nonnull Turnout bean, @Nonnull String payload, @Nonnull String topic) {
             switch (payload) {

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -38,6 +38,7 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
                     break;
             }
         }
+        
         @Override
         public @Nonnull String payloadFromBean(@Nonnull Turnout bean, int newState){
             // sort out states

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.mqtt;
 
+import javax.annotation.Nonnull;
 import jmri.Turnout;
 import jmri.implementation.AbstractTurnout;
 import org.slf4j.Logger;
@@ -16,9 +17,44 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
     private final String mysubTopic;
     private final int _number;   // turnout number
 
-    private final String closedText = "CLOSED";
-    private final String thrownText = "THROWN";
-
+    MqttContentParser<Turnout> parser = new MqttContentParser<Turnout>() {
+        private final String closedText = "CLOSED";
+        private final String thrownText = "THROWN";
+        @Override
+        public void beanFromPayload(@Nonnull Turnout bean, @Nonnull String payload, @Nonnull String topic) {
+            switch (payload) {
+                case closedText:                
+                    newKnownState(CLOSED);
+                    break;
+                case thrownText:
+                    newKnownState(THROWN);
+                    break;
+                default:
+                    log.warn("Unknown state : {}", payload);
+                    break;
+            }
+        }
+        @Override
+        public @Nonnull String payloadFromBean(@Nonnull Turnout bean, int newState){
+            // sort out states
+            if ((newState & Turnout.CLOSED) != 0) {
+                // first look for the double case, which we can't handle
+                if ((newState & Turnout.THROWN) != 0) {
+                    // this is the disaster case!
+                    log.error("Cannot command both CLOSED and THROWN: {}", newState);
+                    throw new IllegalArgumentException("Cannot command both CLOSED and THROWN: "+newState);
+                } else {
+                    // send a CLOSED command
+                    return closedText;
+                }
+            } else {
+                // send a THROWN command
+                return thrownText;
+            }
+        }
+    };
+    
+    
     MqttTurnout(MqttAdapter ma, int number) {
         super("MT" + number);
         _number = number;
@@ -41,20 +77,10 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
     @Override
     protected void forwardCommandChangeToLayout(int s) {
         // sort out states
-        if ((s & Turnout.CLOSED) != 0) {
-            // first look for the double case, which we can't handle
-            if ((s & Turnout.THROWN) != 0) {
-                // this is the disaster case!
-                log.error("Cannot command both CLOSED and THROWN {}", s);
-                return;
-            } else {
-                // send a CLOSED command
-                sendMessage(closedText);
-            }
-        } else {
-            // send a THROWN command
-            sendMessage(thrownText);
-        }
+        String payload = parser.payloadFromBean(this, s);
+
+        // send appropriate command
+        sendMessage(thrownText);
     }
 
     @Override
@@ -72,17 +98,8 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
             log.error("Got a message whose topic ({}) wasn't for me ({})", topic, mysubTopic);
             return;
         }
-        switch (message) {
-            case closedText:                
-                newKnownState(CLOSED);
-                break;
-            case thrownText:
-                newKnownState(THROWN);
-                break;
-            default:
-                log.warn("Unknow state : {} (topic : {})", message, topic);
-                break;
-        }
+        
+        parser.beanFromPayload(this, message, topic);
     }
 
     private final static Logger log = LoggerFactory.getLogger(MqttTurnout.class);

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -80,7 +80,7 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
         String payload = parser.payloadFromBean(this, s);
 
         // send appropriate command
-        sendMessage(thrownText);
+        sendMessage(payload);
     }
 
     @Override

--- a/java/src/jmri/jmrix/mqtt/MqttTurnout.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnout.java
@@ -17,6 +17,10 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
     private final String mysubTopic;
     private final int _number;   // turnout number
 
+    public void setParser(MqttContentParser<Turnout> parser) {
+        this.parser = parser;
+    }
+    
     MqttContentParser<Turnout> parser = new MqttContentParser<Turnout>() {
         private final String closedText = "CLOSED";
         private final String thrownText = "THROWN";
@@ -37,9 +41,9 @@ public class MqttTurnout extends AbstractTurnout implements MqttEventListener {
         @Override
         public @Nonnull String payloadFromBean(@Nonnull Turnout bean, int newState){
             // sort out states
-            if ((newState & Turnout.CLOSED) != 0) {
+            if ((newState & Turnout.CLOSED) != 0 ^ getInverted()) {
                 // first look for the double case, which we can't handle
-                if ((newState & Turnout.THROWN) != 0) {
+                if ((newState & Turnout.THROWN ) != 0 ^ getInverted()) {
                     // this is the disaster case!
                     log.error("Cannot command both CLOSED and THROWN: {}", newState);
                     throw new IllegalArgumentException("Cannot command both CLOSED and THROWN: "+newState);

--- a/java/src/jmri/jmrix/mqtt/MqttTurnoutManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnoutManager.java
@@ -32,9 +32,16 @@ public class MqttTurnoutManager extends jmri.managers.AbstractTurnoutManager {
         t = new MqttTurnout(mqttAdapter, addr);
         t.setUserName(userName);
 
+        if (parser != null) t.setParser(parser);
+        
         return t;
     }
 
+    public void setParser(MqttContentParser<Turnout> parser) {
+        this.parser = parser;
+    }
+    MqttContentParser<Turnout> parser = null;
+    
     static volatile MqttTurnoutManager _instance = null;
 
 }

--- a/java/src/jmri/jmrix/mqtt/MqttTurnoutManager.java
+++ b/java/src/jmri/jmrix/mqtt/MqttTurnoutManager.java
@@ -14,7 +14,7 @@ public class MqttTurnoutManager extends jmri.managers.AbstractTurnoutManager {
     private final MqttAdapter mqttAdapter;
     private final String systemPrefix;
 
-    MqttTurnoutManager(MqttAdapter ma, String p) {
+    public MqttTurnoutManager(MqttAdapter ma, String p) {
         super();
         mqttAdapter = ma;
         systemPrefix = p;        
@@ -27,7 +27,7 @@ public class MqttTurnoutManager extends jmri.managers.AbstractTurnoutManager {
 
     @Override
     public Turnout createNewTurnout(String systemName, String userName) {
-        Turnout t;
+        MqttTurnout t;
         int addr = Integer.parseInt(systemName.substring(systemPrefix.length() + 1));
         t = new MqttTurnout(mqttAdapter, addr);
         t.setUserName(userName);

--- a/java/test/jmri/jmrix/mqtt/MqttTurnoutTest.java
+++ b/java/test/jmri/jmrix/mqtt/MqttTurnoutTest.java
@@ -1,6 +1,11 @@
 package jmri.jmrix.mqtt;
 
+import javax.annotation.Nonnull;
+
+import jmri.Turnout;
+import jmri.implementation.AbstractTurnoutTestBase;
 import jmri.util.*;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -12,23 +17,103 @@ import org.junit.Test;
  * @author Bob Jacobsen Copyright (C) 2018
  * @since 4.11.5
  */
-public class MqttTurnoutTest {
+public class MqttTurnoutTest extends AbstractTurnoutTestBase {
 
-    @Test
-    public void ConstructorTest() {
-        MqttAdapter a = new MqttAdapter();
-        Assert.assertNotNull("constructor", new MqttTurnout(a, 2));
+    MqttAdapter a;
+    String saveTopic;
+    byte[] savePayload;
+    
+    @Before
+    @Override
+    public void setUp() {
+        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.initDefaultUserMessagePreferences();
+        // prepare an interface
+        saveTopic = null;
+        savePayload = null;
+        a = new MqttAdapter(){
+                @Override
+                public void publish(String topic, byte[] payload) {
+                    saveTopic = topic;
+                    savePayload = payload;
+                }
+            };
+
+        t = new MqttTurnout(a, 2);
         JUnitAppender.assertWarnMessage("Trying to subscribe before connect/configure is done");
     }
 
-    @Before
-    public void setUp() {
-        JUnitUtil.setUp();
-        JUnitUtil.initDefaultUserMessagePreferences();
+    @Override
+    public int numListeners() {
+        // return tcis.numListeners();
+        return 0;
     }
 
-    @After
-    public void tearDown() {
-        JUnitUtil.tearDown();
+    @Test
+    public void testParserUpdate() {
+        MqttContentParser<Turnout> parser = new MqttContentParser<Turnout>() {
+            private final String closedText = "BAR";
+            private final String thrownText = "FOO";
+            @Override
+            public void beanFromPayload(@Nonnull Turnout bean, @Nonnull String payload, @Nonnull String topic) {
+                switch (payload) {
+                    case closedText:                
+                        ((MqttTurnout)t).newKnownState(Turnout.CLOSED);
+                        break;
+                    case thrownText:
+                        ((MqttTurnout)t).newKnownState(Turnout.THROWN);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        
+            @Override
+            public @Nonnull String payloadFromBean(@Nonnull Turnout bean, int newState){
+                // sort out states
+                if ((newState & Turnout.CLOSED) != 0) {
+                    // first look for the double case, which we can't handle
+                    if ((newState & Turnout.THROWN ) != 0) {
+                        // this is the disaster case!
+                        throw new IllegalArgumentException("Cannot command both CLOSED and THROWN: "+newState);
+                    } else {
+                        // send a CLOSED command
+                        return closedText;
+                    }
+                } else {
+                    // send a THROWN command
+                    return thrownText;
+                }
+            }
+        };
+        ((MqttTurnout)t).setParser(parser);
+        
+        t.setCommandedState(Turnout.THROWN);
+        
+        Assert.assertEquals("topic", "track/turnout/2", saveTopic);
+        Assert.assertEquals("topic", "FOO", new String(savePayload));
+        
+        t.setCommandedState(Turnout.CLOSED);
+        
+        Assert.assertEquals("topic", "track/turnout/2", saveTopic);
+        Assert.assertEquals("topic", "BAR", new String(savePayload));
+        
     }
+    
+    
+    @Override
+    public void checkThrownMsgSent() {
+        Assert.assertEquals("topic", "track/turnout/2", saveTopic);
+        Assert.assertEquals("topic", "THROWN", new String(savePayload));
+    }
+
+    @Override
+    public void checkClosedMsgSent() {
+        Assert.assertEquals("topic", "track/turnout/2", saveTopic);
+        Assert.assertEquals("topic", "CLOSED", new String(savePayload));
+    }
+
+
+
+
 }

--- a/jython/SetMqttParser.py
+++ b/jython/SetMqttParser.py
@@ -1,0 +1,27 @@
+# Example of how to install a new parser for the MQTT Turnouts
+#
+# Ideally, this would be a sample JSON coder/decoder
+# but right now it's not
+#
+
+import jmri;
+import java;
+
+
+# First, create the parser class
+
+class ParserReplacement (jmri.jmrix.mqtt.MqttContentParser) :
+    def beanFromPayload(bean, payload, topic) :
+        # this needs code
+        return
+    def payloadFromBean(bean, newState) :
+        # sort out states
+        if ((newState & jmri.Turnout.CLOSED) != 0 ^ bean.getInverted()) :
+            return "Really Thrown";
+        else :
+            return "Really Closed";
+
+# now find the MqttTurnoutManager and install one
+
+m = jmri.InstanceManager.getNullableDefault(jmri.jmrix.mqtt.MqttTurnoutManager)
+if (m is not None) : m.setParser(ParserReplacement())

--- a/jython/test/SetMqttParserTest.py
+++ b/jython/test/SetMqttParserTest.py
@@ -1,0 +1,8 @@
+# Test the SetMqttParser.py script
+import jmri
+
+m = jmri.jmrix.mqtt.MqttTurnoutManager(None, "M");
+jmri.InstanceManager.setDefault(jmri.jmrix.mqtt.MqttTurnoutManager, m)
+
+execfile("jython/SetMqttParser.py")
+


### PR DESCRIPTION
The allows a user to, via script, change how the payloads of MQTT Turnouts are implemented. A sample script is provided, but is incomplete.  The next step is to find a user to complete that script to demonstrate JSON coding of the payload.