### PR TITLE
MERG CBUS Re-enable Node0 addresses

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusAddress.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusAddress.java
@@ -397,9 +397,6 @@ public class CbusAddress {
                     }
                     int firsta =  StringUtil.getFirstIntFromString(part);
                     log.debug("first string {}",firsta);
-                    if ( firsta == 0 ){
-                        throw new IllegalArgumentException("Node cannot be 0 in address: " + part);
-                    }
                     if ( firsta > 65535 ){
                         throw new IllegalArgumentException("Node Too Large in address: " + part);
                     }

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
@@ -370,9 +370,9 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         Assert.assertEquals("MS0;7",NameValidity.INVALID,l.validSystemNameFormat("MS0;7"));
         Assert.assertEquals("MS+N17E0",NameValidity.INVALID,l.validSystemNameFormat("MS+N17E0"));
         Assert.assertEquals("MS+N17E00",NameValidity.INVALID,l.validSystemNameFormat("MS+N17E00"));
-        Assert.assertEquals("MS+N0E17",NameValidity.INVALID,l.validSystemNameFormat("MS+N0E17"));
-        Assert.assertEquals("MS+N00E17",NameValidity.INVALID,l.validSystemNameFormat("MS+N00E17"));
-        Assert.assertEquals("MS+0E17",NameValidity.INVALID,l.validSystemNameFormat("MS+0E17"));
+        Assert.assertEquals("MS+N0E17",NameValidity.VALID,l.validSystemNameFormat("MS+N0E17"));
+        Assert.assertEquals("MS+N00E17",NameValidity.VALID,l.validSystemNameFormat("MS+N00E17"));
+        Assert.assertEquals("MS+0E17",NameValidity.VALID,l.validSystemNameFormat("MS+0E17"));
         Assert.assertEquals("MS0E17",NameValidity.INVALID,l.validSystemNameFormat("MS0E17"));
         Assert.assertEquals("MS+N65535e65536",NameValidity.INVALID,l.validSystemNameFormat("MS+N65535e65536"));
         Assert.assertEquals("MS+N65536e65535",NameValidity.INVALID,l.validSystemNameFormat("MS+N65536e65535"));


### PR DESCRIPTION
Re-enables CBUS addresses for short events in the long address format "+N0E1"

https://groups.io/g/jmriusers/message/158377