### PR TITLE
Make Travis CI verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ sudo: required
 env:
   global:
   # false to silence most maven output; true to catch tests that do not complete
-  - PRINT_SUMMARY=false
+  - PRINT_SUMMARY=true
   - MAVEN_OPTS=-Xmx1536m
   # see http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder for valid values
   - RUN_ORDER=filesystem


### PR DESCRIPTION
Too many GUI builds on Travis CI are ending in timeouts without output. This change will cause Travis CI to log each test class as it is run so that whichever test class is causing these timeouts will be revealed so we can deal with it.