### PR TITLE
Throw exception on duplicate systemName

### DIFF
--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -307,6 +307,8 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      * The non-system-specific SignalHeadManagers use this method extensively.
      *
      * @param n the bean
+     * @throws IllegalArgumentException if a different bean with the same
+     * system name is already registered in the manager
      */
     public void register(@Nonnull E n);
 

--- a/java/src/jmri/implementation/configurexml/DoubleTurnoutSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/DoubleTurnoutSignalHeadXml.java
@@ -84,7 +84,16 @@ public class DoubleTurnoutSignalHeadXml extends jmri.managers.configurexml.Abstr
 
         loadCommon(h, shared);
 
-        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        SignalHead existingBean =
+                InstanceManager.getDefault(jmri.SignalHeadManager.class)
+                        .getBeanBySystemName(sys);
+
+        if ((existingBean != null) && (existingBean != h)) {
+            log.error("systemName is already registered: " + sys);
+        } else {
+            InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        }
+
         return true;
     }
 

--- a/java/src/jmri/implementation/configurexml/LsDecSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/LsDecSignalHeadXml.java
@@ -103,7 +103,16 @@ public class LsDecSignalHeadXml extends jmri.managers.configurexml.AbstractNamed
 
         loadCommon(h, shared);
 
-        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        SignalHead existingBean =
+                InstanceManager.getDefault(jmri.SignalHeadManager.class)
+                        .getBeanBySystemName(sys);
+
+        if ((existingBean != null) && (existingBean != h)) {
+            log.error("systemName is already registered: " + sys);
+        } else {
+            InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        }
+
         return true;
     }
 

--- a/java/src/jmri/implementation/configurexml/MergSD2SignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/MergSD2SignalHeadXml.java
@@ -170,7 +170,16 @@ public class MergSD2SignalHeadXml extends jmri.managers.configurexml.AbstractNam
 
         loadCommon(h, shared);
 
-        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        SignalHead existingBean =
+                InstanceManager.getDefault(jmri.SignalHeadManager.class)
+                        .getBeanBySystemName(sys);
+
+        if ((existingBean != null) && (existingBean != h)) {
+            log.error("systemName is already registered: " + sys);
+        } else {
+            InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        }
+
         return true;
     }
 

--- a/java/src/jmri/implementation/configurexml/QuadOutputSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/QuadOutputSignalHeadXml.java
@@ -7,6 +7,8 @@ import jmri.SignalHead;
 import jmri.Turnout;
 import jmri.implementation.QuadOutputSignalHead;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handle XML configuration for QuadOutputSignalHead objects.
@@ -66,7 +68,18 @@ public class QuadOutputSignalHeadXml extends TripleTurnoutSignalHeadXml {
 
         loadCommon(h, shared);
 
-        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        SignalHead existingBean =
+                InstanceManager.getDefault(jmri.SignalHeadManager.class)
+                        .getBeanBySystemName(sys);
+
+        if ((existingBean != null) && (existingBean != h)) {
+            log.error("systemName is already registered: " + sys);
+        } else {
+            InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        }
+
         return true;
     }
+
+    private final static Logger log = LoggerFactory.getLogger(QuadOutputSignalHeadXml.class);
 }

--- a/java/src/jmri/implementation/configurexml/SE8cSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/SE8cSignalHeadXml.java
@@ -82,7 +82,16 @@ public class SE8cSignalHeadXml extends jmri.managers.configurexml.AbstractNamedB
 
         loadCommon(h, shared);
 
-        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        SignalHead existingBean =
+                InstanceManager.getDefault(jmri.SignalHeadManager.class)
+                        .getBeanBySystemName(sys);
+
+        if ((existingBean != null) && (existingBean != h)) {
+            log.error("systemName is already registered: " + sys);
+        } else {
+            InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        }
+
         return true;
     }
 

--- a/java/src/jmri/implementation/configurexml/SingleTurnoutSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/SingleTurnoutSignalHeadXml.java
@@ -110,7 +110,16 @@ public class SingleTurnoutSignalHeadXml extends jmri.managers.configurexml.Abstr
 
         loadCommon(h, shared);
 
-        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        SignalHead existingBean =
+                InstanceManager.getDefault(jmri.SignalHeadManager.class)
+                        .getBeanBySystemName(sys);
+
+        if ((existingBean != null) && (existingBean != h)) {
+            log.error("systemName is already registered: " + sys);
+        } else {
+            InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        }
+
         return true;
     }
 

--- a/java/src/jmri/implementation/configurexml/TripleOutputSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/TripleOutputSignalHeadXml.java
@@ -69,7 +69,16 @@ public class TripleOutputSignalHeadXml extends DoubleTurnoutSignalHeadXml {
 
         loadCommon(h, shared);
 
-        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        SignalHead existingBean =
+                InstanceManager.getDefault(jmri.SignalHeadManager.class)
+                        .getBeanBySystemName(sys);
+
+        if ((existingBean != null) && (existingBean != h)) {
+            log.error("systemName is already registered: " + sys);
+        } else {
+            InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        }
+
         return true;
     }
 

--- a/java/src/jmri/implementation/configurexml/TripleTurnoutSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/TripleTurnoutSignalHeadXml.java
@@ -68,7 +68,16 @@ public class TripleTurnoutSignalHeadXml extends DoubleTurnoutSignalHeadXml {
 
         loadCommon(h, shared);
 
-        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        SignalHead existingBean =
+                InstanceManager.getDefault(jmri.SignalHeadManager.class)
+                        .getBeanBySystemName(sys);
+
+        if ((existingBean != null) && (existingBean != h)) {
+            log.error("systemName is already registered: " + sys);
+        } else {
+            InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        }
+
         return true;
     }
 

--- a/java/src/jmri/implementation/configurexml/VirtualSignalHeadXml.java
+++ b/java/src/jmri/implementation/configurexml/VirtualSignalHeadXml.java
@@ -52,7 +52,16 @@ public class VirtualSignalHeadXml extends jmri.managers.configurexml.AbstractNam
 
         loadCommon(h, shared);
 
-        InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        SignalHead existingBean =
+                InstanceManager.getDefault(jmri.SignalHeadManager.class)
+                        .getBeanBySystemName(sys);
+
+        if ((existingBean != null) && (existingBean != h)) {
+            log.error("systemName is already registered: " + sys);
+        } else {
+            InstanceManager.getDefault(jmri.SignalHeadManager.class).register(h);
+        }
+
         return true;
     }
 

--- a/java/src/jmri/jmrit/logix/OBlockManager.java
+++ b/java/src/jmri/jmrit/logix/OBlockManager.java
@@ -122,7 +122,6 @@ public class OBlockManager extends AbstractManager<OBlock>
         if (ob == null) {
             ob = createNewOBlock(name, null);
             if (ob == null) throw new IllegalArgumentException("could not create OBlock \""+name+"\"");
-            register(ob);
         }
         return ob;
     }

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -180,6 +180,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
         String systemName = s.getSystemName();
 
         if (getBeanBySystemName(systemName) != null) {
+            log.error("systemName is already registered: " + systemName);
             throw new IllegalArgumentException("systemName is already registered: " + systemName);
         }
 

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -182,9 +182,9 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
         E existingBean = getBeanBySystemName(systemName);
         if (existingBean != null) {
             if (s == existingBean) {
-                log.warn("the named bean is registered twice: " + systemName);
+                log.warn("the named bean is registered twice: {}", systemName);
             } else {
-                log.error("systemName is already registered: " + systemName);
+                log.error("systemName is already registered: {}", systemName);
                 throw new IllegalArgumentException("systemName is already registered: " + systemName);
             }
         }

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -181,9 +181,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
 
         E existingBean = getBeanBySystemName(systemName);
         if (existingBean != null) {
-            if (s == existingBean) {
-                log.warn("the named bean is registered twice: " + systemName);
-            } else {
+            if (s != existingBean) {
                 log.error("systemName is already registered: " + systemName);
                 throw new IllegalArgumentException("systemName is already registered: " + systemName);
             }

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -182,7 +182,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
         E existingBean = getBeanBySystemName(systemName);
         if (existingBean != null) {
             if (s == existingBean) {
-                log.warn("the named bean is registered twice: {}", systemName);
+                log.debug("the named bean is registered twice: {}", systemName);
             } else {
                 log.error("systemName is already registered: {}", systemName);
                 throw new IllegalArgumentException("systemName is already registered: " + systemName);

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -179,9 +179,14 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
     public void register(E s) {
         String systemName = s.getSystemName();
 
-        if (getBeanBySystemName(systemName) != null) {
-            log.error("systemName is already registered: " + systemName);
-            throw new IllegalArgumentException("systemName is already registered: " + systemName);
+        E existingBean = getBeanBySystemName(systemName);
+        if (existingBean != null) {
+            if (s == existingBean) {
+                log.warn("the named bean is registered twice: " + systemName);
+            } else {
+                log.error("systemName is already registered: " + systemName);
+                throw new IllegalArgumentException("systemName is already registered: " + systemName);
+            }
         }
 
         // clear caches

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -181,7 +181,9 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
 
         E existingBean = getBeanBySystemName(systemName);
         if (existingBean != null) {
-            if (s != existingBean) {
+            if (s == existingBean) {
+                log.warn("the named bean is registered twice: " + systemName);
+            } else {
                 log.error("systemName is already registered: " + systemName);
                 throw new IllegalArgumentException("systemName is already registered: " + systemName);
             }

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -179,6 +179,10 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
     public void register(E s) {
         String systemName = s.getSystemName();
 
+        if (getBeanBySystemName(systemName) != null) {
+            throw new IllegalArgumentException("systemName is already registered: " + systemName);
+        }
+
         // clear caches
         cachedSystemNameArray = null;
         cachedSystemNameList = null;

--- a/java/src/jmri/managers/AbstractReporterManager.java
+++ b/java/src/jmri/managers/AbstractReporterManager.java
@@ -121,8 +121,13 @@ public abstract class AbstractReporterManager extends AbstractManager<Reporter>
         // doesn't exist, make a new one
         r = createNewReporter(systemName, userName);
 
-        // save in the maps
-        register(r);
+        // Some implementations of createNewReporter() registers the bean, some
+        // don't. Check if the bean is registered and register it if it isn't
+        // registered.
+        if (getBeanBySystemName(systemName) == null) {
+            // save in the maps
+            register(r);
+        }
 
         return r;
     }

--- a/java/src/jmri/managers/AbstractTurnoutManager.java
+++ b/java/src/jmri/managers/AbstractTurnoutManager.java
@@ -115,8 +115,14 @@ public abstract class AbstractTurnoutManager extends AbstractManager<Turnout>
             throw new IllegalArgumentException("Unable to create turnout from " + systemName);
         }
 
-        // save in the maps if successful
-        register(s);
+        // Some implementations of createNewTurnout() register the new bean,
+        // some don't. Also note that createNewTurnout() may change the system
+        // name. For example, AbstractTurnout does systemName.toUpperCase().
+        if (getBeanBySystemName(s.getSystemName()) == null) {
+            // save in the maps if successful
+            register(s);
+        }
+
         try {
             s.setStraightSpeed("Global");
         } catch (jmri.JmriException ex) {

--- a/java/test/jmri/configurexml/LoadAndStoreTestBase.java
+++ b/java/test/jmri/configurexml/LoadAndStoreTestBase.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import jmri.ConfigureManager;
 import jmri.InstanceManager;
 import jmri.util.FileUtil;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -278,6 +279,8 @@ public class LoadAndStoreTestBase {
 
         File outFile = storeFile(this.file, this.saveType);
         checkFile(compFile, outFile);
+        
+        JUnitAppender.suppressErrorMessage("systemName is already registered: ");
     }
 
     @Before

--- a/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
@@ -78,5 +78,4 @@ public class InternalLightManagerTest extends jmri.managers.AbstractLightMgrTest
     }
 
     private final static Logger log = LoggerFactory.getLogger(InternalLightManagerTest.class);
-
 }

--- a/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
@@ -62,13 +62,6 @@ public class InternalLightManagerTest extends jmri.managers.AbstractLightMgrTest
         Assert.assertTrue(lm.newLight("IL21", "my name").isIntensityVariable());
     }
 
-    @Override
-    @Test
-    @Ignore("Base class test cannot create a new bean since the bean is anonymous")
-    @ToDo("provide the base class with a new bean that is not registered in the manager")
-    public void testRegisterDuplicateSystemName() {
-    }
-
     // The minimal setup for log4J
     @Before
     @Override

--- a/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalLightManagerTest.java
@@ -3,9 +3,11 @@ package jmri.jmrix.internal;
 import jmri.Light;
 import jmri.LightManager;
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.ToDo;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +60,13 @@ public class InternalLightManagerTest extends jmri.managers.AbstractLightMgrTest
         LightManager lm = jmri.InstanceManager.lightManagerInstance();
 
         Assert.assertTrue(lm.newLight("IL21", "my name").isIntensityVariable());
+    }
+
+    @Override
+    @Test
+    @Ignore("Base class test cannot create a new bean since the bean is anonymous")
+    @ToDo("provide the base class with a new bean that is not registered in the manager")
+    public void testRegisterDuplicateSystemName() {
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
@@ -236,13 +236,6 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
 
     }
 
-    @Override
-    @Test
-    @Ignore("Base class test cannot create a new bean since the bean is anonymous")
-    @ToDo("provide the base class with a new bean that is not registered in the manager")
-    public void testRegisterDuplicateSystemName() {
-    }
-
     // from here down is testing infrastructure
 
     // Property listen & audit methods

--- a/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalSensorManagerTest.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import jmri.*;
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.ToDo;
 
 import org.junit.*;
 
@@ -233,6 +234,13 @@ public class InternalSensorManagerTest extends jmri.managers.AbstractSensorMgrTe
             Assert.fail("Should have thrown");
         } catch (UnsupportedOperationException e) { /* this is OK */}
 
+    }
+
+    @Override
+    @Test
+    @Ignore("Base class test cannot create a new bean since the bean is anonymous")
+    @ToDo("provide the base class with a new bean that is not registered in the manager")
+    public void testRegisterDuplicateSystemName() {
     }
 
     // from here down is testing infrastructure

--- a/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
@@ -1,7 +1,9 @@
 package jmri.jmrix.internal;
 
+import jmri.JmriException;
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.ToDo;
 import org.junit.*;
 
 /**
@@ -28,6 +30,13 @@ public class InternalTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgr
         Assert.assertTrue(null != l.getBySystemName("IT21"));
         Assert.assertTrue(null != l.getByUserName("my name"));
 
+    }
+
+    @Override
+    @Test
+    @Ignore("Base class test cannot create a new bean since the bean is anonymous")
+    @ToDo("provide the base class with a new bean that is not registered in the manager")
+    public void testRegisterDuplicateSystemName() {
     }
 
     // from here down is testing infrastructure

--- a/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
@@ -32,13 +32,6 @@ public class InternalTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgr
 
     }
 
-    @Override
-    @Test
-    @Ignore("Base class test cannot create a new bean since the bean is anonymous")
-    @ToDo("provide the base class with a new bean that is not registered in the manager")
-    public void testRegisterDuplicateSystemName() {
-    }
-
     // from here down is testing infrastructure
     // The minimal setup for log4J
     @Override

--- a/java/test/jmri/jmrix/pi/RaspberryPiSensorManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiSensorManagerTest.java
@@ -109,7 +109,14 @@ public class RaspberryPiSensorManagerTest extends jmri.managers.AbstractSensorMg
         Assert.assertTrue("real object returned ", t != null);
         Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(14)));
     }
-    
+
+    @Test
+    @Ignore
+    @Override
+    public void testRegisterDuplicateSystemName() {
+        // This test doesn't work for this class.
+    }
+
     @Override
     @Before
     public void setUp() {

--- a/java/test/jmri/jmrix/pi/RaspberryPiSensorManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiSensorManagerTest.java
@@ -4,6 +4,7 @@ import com.pi4j.io.gpio.GpioFactory;
 import com.pi4j.io.gpio.GpioProvider;
 import jmri.Sensor;
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.ToDo;
 import org.junit.*;
 
 
@@ -111,10 +112,10 @@ public class RaspberryPiSensorManagerTest extends jmri.managers.AbstractSensorMg
     }
 
     @Test
-    @Ignore
+    @Ignore("This test doesn't work for this class")
+    @ToDo("RaspberryPiSensorTest.setUp throws the error: java.lang.IllegalArgumentException: This GPIO pin already exists: GPIO 1")
     @Override
     public void testRegisterDuplicateSystemName() {
-        // This test doesn't work for this class.
     }
 
     @Override

--- a/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
@@ -4,6 +4,7 @@ import com.pi4j.io.gpio.GpioFactory;
 import com.pi4j.io.gpio.GpioProvider;
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
+import jmri.util.junit.annotations.ToDo;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -92,10 +93,10 @@ public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnout
     }
 
     @Test
-    @Ignore
+    @Ignore("This test doesn't work for this class")
+    @ToDo("RaspberryPiSensor.init throws the error: com.pi4j.io.gpio.exception.GpioPinExistsException: This GPIO pin already exists: GPIO 1")
     @Override
     public void testRegisterDuplicateSystemName() {
-        // This test doesn't work for this class.
     }
 
     @Override

--- a/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
@@ -7,6 +7,7 @@ import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -88,6 +89,13 @@ public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnout
         Turnout t2 = l.getByUserName("after");
         Assert.assertEquals("same object", t1, t2);
         Assert.assertEquals("no old object", null, l.getByUserName("before"));
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void testRegisterDuplicateSystemName() {
+        // This test doesn't work for this class.
     }
 
     @Override

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -157,6 +157,7 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
 
                 // If the test is unable to provide a named bean, abort this test.
                 JUnitAppender.clearBacklog(Level.WARN);
+                Assume.assumeTrue("We got no exception", ex == null);
                 return;
             }
 

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -109,11 +109,29 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
         Assert.assertEquals(base, l.getVetoableChangeListeners().length);
 
     }
+
     @Test
     public void testMakeSystemName() {
         String s = l.makeSystemName("1");
         Assert.assertTrue(s != null);
         Assert.assertTrue(! s.isEmpty());
+    }
+
+    @Test
+    public void testRegisterDuplicateSystemName() throws PropertyVetoException {
+        if (l instanceof ProvidingManager)  {
+            ProvidingManager<E> m = (ProvidingManager<E>) l;
+            String s = l.makeSystemName("1");
+            Assert.assertTrue(s != null);
+            Assert.assertTrue(! s.isEmpty());
+
+            E e = m.provide(s);
+
+            l.register(e);
+            l.register(e);
+            
+            l.deleteBean(e, "DoDelete");
+        }
     }
 
 }

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -158,6 +158,7 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
                 hasException = true;
                 Assert.assertTrue("exception message is correct",
                         expectedMessage.equals(ex.getMessage()));
+                JUnitAppender.assertErrorMessage(expectedMessage);
             }
             Assert.assertTrue("exception is thrown", hasException);
 

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -171,10 +171,8 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
             // Register the bean once. This should be OK.
             l.register(e1);
 
-            String expectedMessage = "the named bean is registered twice: " + e1.getSystemName();
             // Register bean twice. This should fail with an IllegalArgumentException.
             l.register(e1);
-            JUnitAppender.assertWarnMessage(expectedMessage);
 
             // Use reflection to change the systemName of e2
             // Try to find the field
@@ -182,7 +180,7 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
             f1.setAccessible(true);
             f1.set(e2, e1.getSystemName());
 
-            expectedMessage = "systemName is already registered: " + e1.getSystemName();
+            String expectedMessage = "systemName is already registered: " + e1.getSystemName();
             boolean hasException = false;
             try {
                 // Register different bean with existing systemName.

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -15,6 +15,8 @@ import org.apache.log4j.Level;
 import org.junit.Assume;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base for the various Abstract*MgrTestBase base classes for NamedBean Manager test classes
@@ -125,7 +127,7 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
 
     @SuppressWarnings("unchecked")  // The call Constructor.newInstance() generates an unchecked cast warning
     @Test
-    public void testRegisterDuplicateSystemName() throws PropertyVetoException, NoSuchFieldException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+    public void testRegisterDuplicateSystemName() throws PropertyVetoException, NoSuchFieldException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException, NoSuchMethodException, InstantiationException, InvocationTargetException {
         if (l instanceof ProvidingManager)  {
             ProvidingManager<E> m = (ProvidingManager<E>) l;
             String s1 = l.makeSystemName("1");
@@ -147,21 +149,13 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
 
                 // If the test is unable to provide a named bean, abort this test.
                 JUnitAppender.clearBacklog(Level.WARN);
+                log.debug("Cannot provide a named bean", ex);
                 Assume.assumeTrue("We got no exception", false);
                 return;
             }
 
-            try {
-                Constructor ctor = e1.getClass().getDeclaredConstructor(String.class, String.class);
-                e2 = (E) ctor.newInstance(s1, "My user name");
-            } catch (NoSuchMethodException | InstantiationException | InvocationTargetException ex) {
-                // jmri.jmrix.internal.InternalTurnoutManagerTest causes this exception
-                
-                // If the test is unable to create a named bean, abort this test.
-                JUnitAppender.clearBacklog(Level.WARN);
-                Assume.assumeTrue("We got no exception", false);
-                return;
-            }
+            Constructor ctor = e1.getClass().getDeclaredConstructor(String.class, String.class);
+            e2 = (E) ctor.newInstance(s1, "My user name");
 
             // Remove bean if it's already registered
             if (l.getBeanBySystemName(e1.getSystemName()) != null) {
@@ -199,4 +193,5 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
         }
     }
 
+    private final static Logger log = LoggerFactory.getLogger(AbstractManagerTestBase.class);
 }

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -141,10 +141,27 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
                 return;
             }
 
-            l.register(e);
+            // Remove bean if it's already registered
+            if (l.getBeanBySystemName(e.getSystemName()) != null) {
+                l.deregister(e);
+            }
+
+            // Register the bean once. This should be OK.
             l.register(e);
 
-            l.deleteBean(e, "DoDelete");
+            String expectedMessage = "systemName is already registered: " + e.getSystemName();
+            boolean hasException = false;
+            try {
+                // Register bean twice. This should fail with an IllegalArgumentException.
+                l.register(e);
+            } catch (IllegalArgumentException ex) {
+                hasException = true;
+                Assert.assertTrue("exception message is correct",
+                        expectedMessage.equals(ex.getMessage()));
+            }
+            Assert.assertTrue("exception is thrown", hasException);
+
+            l.deregister(e);
         }
     }
 

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -131,8 +131,9 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
 
             try {
                 e = m.provide(s);
-            } catch (IllegalArgumentException | NullPointerException ex) {
+            } catch (IllegalArgumentException | NullPointerException | ArrayIndexOutOfBoundsException ex) {
                 // jmri.jmrix.openlcb.OlcbLightManagerTest gives a NullPointerException here.
+                // jmri.jmrix.openlcb.OlcbSensorManagerTest gives a ArrayIndexOutOfBoundsException here.
                 // Some other tests give an IllegalArgumentException here.
 
                 // If the test is unable to provide a named bean, abort this test.

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Field;
 import jmri.util.JUnitAppender;
 import org.apache.log4j.Level;
 
+import org.junit.Assume;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -155,7 +156,7 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
                 // Some other tests give an IllegalArgumentException here.
 
                 // If the test is unable to provide a named bean, abort this test.
-                JUnitAppender.clearBacklog(Level.WARN);
+                Assume.assumeNoException(ex);
                 return;
             }
 

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -6,6 +6,8 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
+import jmri.util.JUnitAppender;
+import org.apache.log4j.Level;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -125,11 +127,19 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
             Assert.assertTrue(s != null);
             Assert.assertTrue(! s.isEmpty());
 
-            E e = m.provide(s);
+            E e;
+
+            try {
+                e = m.provide(s);
+            } catch (IllegalArgumentException ex) {
+                // If the test is unable to provide a named bean, abort this test.
+                JUnitAppender.clearBacklog(Level.WARN);
+                return;
+            }
 
             l.register(e);
             l.register(e);
-            
+
             l.deleteBean(e, "DoDelete");
         }
     }

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -184,13 +184,10 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
             // Register the bean once. This should be OK.
             l.register(e1);
 
-            String expectedMessage = "the named bean is registered twice: " + e1.getSystemName();
-
-            // Register bean twice. This should fail with a warning.
+            // Register bean twice. This gives only a debug message.
             l.register(e1);
-            JUnitAppender.assertWarnMessage(expectedMessage);
 
-            expectedMessage = "systemName is already registered: " + e1.getSystemName();
+            String expectedMessage = "systemName is already registered: " + e1.getSystemName();
             boolean hasException = false;
             try {
                 // Register different bean with existing systemName.

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -117,8 +117,8 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
     @Test
     public void testMakeSystemName() {
         String s = l.makeSystemName("1");
-        Assert.assertTrue(s != null);
-        Assert.assertTrue(! s.isEmpty());
+        Assert.assertNotNull(s);
+        Assert.assertFalse(s.isEmpty());
     }
 
     private Field getField(Class c, String fieldName) {
@@ -139,10 +139,10 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
             ProvidingManager<E> m = (ProvidingManager<E>) l;
             String s1 = l.makeSystemName("1");
             String s2 = l.makeSystemName("2");
-            Assert.assertTrue(s1 != null);
-            Assert.assertTrue(! s1.isEmpty());
-            Assert.assertTrue(s2 != null);
-            Assert.assertTrue(! s2.isEmpty());
+            Assert.assertNotNull(s1);
+            Assert.assertFalse(s1.isEmpty());
+            Assert.assertNotNull(s2);
+            Assert.assertFalse(s2.isEmpty());
 
             E e1;
             E e2;
@@ -172,8 +172,11 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
             // Register the bean once. This should be OK.
             l.register(e1);
 
-            // Register bean twice. This should fail with an IllegalArgumentException.
+            String expectedMessage = "the named bean is registered twice: " + e1.getSystemName();
+
+            // Register bean twice. This should fail with a warning.
             l.register(e1);
+            JUnitAppender.assertWarnMessage(expectedMessage);
 
             // Use reflection to change the systemName of e2
             // Try to find the field
@@ -181,7 +184,7 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
             f1.setAccessible(true);
             f1.set(e2, e1.getSystemName());
 
-            String expectedMessage = "systemName is already registered: " + e1.getSystemName();
+            expectedMessage = "systemName is already registered: " + e1.getSystemName();
             boolean hasException = false;
             try {
                 // Register different bean with existing systemName.

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -147,7 +147,7 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
 
                 // If the test is unable to provide a named bean, abort this test.
                 JUnitAppender.clearBacklog(Level.WARN);
-                Assume.assumeTrue("We got no exception", ex == null);
+                Assume.assumeTrue("We got no exception", false);
                 return;
             }
 
@@ -159,7 +159,7 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
                 
                 // If the test is unable to create a named bean, abort this test.
                 JUnitAppender.clearBacklog(Level.WARN);
-                Assume.assumeTrue("We got no exception", ex == null);
+                Assume.assumeTrue("We got no exception", false);
                 return;
             }
 

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -131,7 +131,10 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
 
             try {
                 e = m.provide(s);
-            } catch (IllegalArgumentException ex) {
+            } catch (IllegalArgumentException | NullPointerException ex) {
+                // jmri.jmrix.openlcb.OlcbLightManagerTest gives a NullPointerException here.
+                // Some other tests give an IllegalArgumentException here.
+
                 // If the test is unable to provide a named bean, abort this test.
                 JUnitAppender.clearBacklog(Level.WARN);
                 return;

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -156,7 +156,7 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
                 // Some other tests give an IllegalArgumentException here.
 
                 // If the test is unable to provide a named bean, abort this test.
-                Assume.assumeNoException(ex);
+                JUnitAppender.clearBacklog(Level.WARN);
                 return;
             }
 

--- a/java/test/jmri/managers/AbstractManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractManagerTestBase.java
@@ -6,7 +6,9 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import jmri.util.JUnitAppender;
 import org.apache.log4j.Level;
 
@@ -121,18 +123,7 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
         Assert.assertFalse(s.isEmpty());
     }
 
-    private Field getField(Class c, String fieldName) {
-        try {
-            return c.getDeclaredField(fieldName);
-        } catch (NoSuchFieldException ex) {
-            if (c.getSuperclass() != null)
-                return getField(c.getSuperclass(), fieldName);
-        }
-        
-        // Field not found
-        return null;
-    }
-    
+    @SuppressWarnings("unchecked")  // The call Constructor.newInstance() generates an unchecked cast warning
     @Test
     public void testRegisterDuplicateSystemName() throws PropertyVetoException, NoSuchFieldException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
         if (l instanceof ProvidingManager)  {
@@ -149,13 +140,24 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
 
             try {
                 e1 = m.provide(s1);
-                e2 = m.provide(s2);
             } catch (IllegalArgumentException | NullPointerException | ArrayIndexOutOfBoundsException ex) {
                 // jmri.jmrix.openlcb.OlcbLightManagerTest gives a NullPointerException here.
                 // jmri.jmrix.openlcb.OlcbSensorManagerTest gives a ArrayIndexOutOfBoundsException here.
                 // Some other tests give an IllegalArgumentException here.
 
                 // If the test is unable to provide a named bean, abort this test.
+                JUnitAppender.clearBacklog(Level.WARN);
+                Assume.assumeTrue("We got no exception", ex == null);
+                return;
+            }
+
+            try {
+                Constructor ctor = e1.getClass().getDeclaredConstructor(String.class, String.class);
+                e2 = (E) ctor.newInstance(s1, "My user name");
+            } catch (NoSuchMethodException | InstantiationException | InvocationTargetException ex) {
+                // jmri.jmrix.internal.InternalTurnoutManagerTest causes this exception
+                
+                // If the test is unable to create a named bean, abort this test.
                 JUnitAppender.clearBacklog(Level.WARN);
                 Assume.assumeTrue("We got no exception", ex == null);
                 return;
@@ -178,12 +180,6 @@ public abstract class AbstractManagerTestBase<T extends Manager<E>, E extends Na
             // Register bean twice. This should fail with a warning.
             l.register(e1);
             JUnitAppender.assertWarnMessage(expectedMessage);
-
-            // Use reflection to change the systemName of e2
-            // Try to find the field
-            Field f1 = getField(e2.getClass(), "mSystemName");
-            f1.setAccessible(true);
-            f1.set(e2, e1.getSystemName());
 
             expectedMessage = "systemName is already registered: " + e1.getSystemName();
             boolean hasException = false;

--- a/java/test/jmri/managers/DefaultSignalSystemManagerTest.java
+++ b/java/test/jmri/managers/DefaultSignalSystemManagerTest.java
@@ -1,5 +1,9 @@
 package jmri.managers;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.SortedSet;
+import jmri.SignalSystem;
 import jmri.implementation.SignalSystemTestUtil;
 import jmri.util.JUnitUtil;
 
@@ -48,6 +52,13 @@ public class DefaultSignalSystemManagerTest {
     @Test
     public void testLoad() {
         DefaultSignalSystemManager d = new DefaultSignalSystemManager();
+
+        // Remove all beans in the manager
+        Set<SignalSystem> set = new HashSet<>(d.getNamedBeanSet());
+        set.forEach((b) -> {
+            d.deregister(b);
+        });
+
         d.load();
         Assert.assertTrue(d.getSystemNameList().size() >= 2);
     }


### PR DESCRIPTION
AbstractManager.register() checks if a bean with the systemName is already registered and if so, throws an IllegalArgumentException.