### PR TITLE
Turnout system name handling

### DIFF
--- a/help/en/html/doc/Technical/Names.shtml
+++ b/help/en/html/doc/Technical/Names.shtml
@@ -368,8 +368,7 @@
         implemented as three different outputs, LT1, LT2 and LT3, the
         signal head object might be called IH3. 
         
-     <a name="special" id=
-                "special"></a></p>
+     <a name="special" id="special"></a></p>
       <p>Each different hardware system
       can specify the "suffix string" that follows the system and type
       letters. Generally, these are small numbers, but their exact
@@ -626,6 +625,19 @@
           <td>124/224/324/424</td>
         </tr>
         <tr>
+          <td>Internal</td>
+          <td>i/o</td>
+          <td>some string</td>
+          <td>whatever meaning the user wants to assign;<br>see 
+            <a href="#convention">below</a>
+            for special cases</td>
+          <td>ITsome string</td>
+          <td> </td>
+          <td> </td>
+          <td> </td>
+          <td> </td>
+        </tr>
+        <tr>
           <td>LocoNet</td>
           <td>i</td>
           <td>34</td>
@@ -851,7 +863,9 @@
       <!-- this table is maintained on the help/en/html/doc/Technical/Names.shtml based on information from the
       Hardware help pages by Egbert Broerse @silverailscolo July 2017 -->
     
-      <h2>Naming Conventions For Automated Use</h2>Some
+      <a id="convention" name="convention"></a>
+      <h2>Naming Conventions For Automated Use</h2>
+      Some
       higher-level constructs create their own items. For example,
       a "Sensor Group" is really just a collection of Routes that
       implements the sensor group logic; there is no specific
@@ -946,17 +960,33 @@ SENSOR GROUP:my group:LS2
 <pre style="font-family: monospace;">
           String userName = NamedBean.normalizeUserName(input);
 </pre><br>
+          Please use that, and only that, when creating a user name
+          from human input or other source. Do not explicitly
+          call <code>String#toUpper()</code>, <code>String#strip()</code>
+          or any other formatting operation; having those spread across the code is unmaintainable.
+          
+        <p>
           Because system names may vary from type to type 
-          and manager to manager, this is manager-specific for them:
-          <br>
-<pre style="font-family: monospace;">
-          String systemName = manager.normalizeSystemName(input);
-</pre><br>
+          and manager to manager, there are two manager-specific 
+          methods of interest: <code>manager.normalizeSystemName(input)</code>
+          and <code>manager.makeSystemName(input)</code>.
+          Since most NamedBeans are created by managers, and 
+          managers know about the complete set of NamedBeans, that's the right place to
+          put them.  But it means that an individual NameBean, i.e. 
+          <code>jmri.jmrix.internal.InternalTurnout</code>, constructor can't
+          access it.  If one of those constructors discovers it can't parse a 
+          provided system name argument because it's invalid, it should throw
+          a <code>NamedBean.BadSystemNameException</code>. The constructor should
+          not in any way transform the system name that it was given. It has to use
+          it as given or, if it can't, throw the exception.
+        <p>
           For more information, see the Javadoc for
-            <a href="http://jmri.org/JavaDoc/doc/jmri/NamedBean.html#normalizeUserName-java.lang.String-">normalizeUserName</a>
+            <a href="http://jmri.org/JavaDoc/doc/jmri/NamedBean.html#normalizeUserName-java.lang.String-">normalizeUserName</a>, 
+            <a href="http://jmri.org/JavaDoc/doc/jmri/Manager.html#normalizeSystemName-java.lang.String-">normalizeSystemName</a>,
+            <a href="http://jmri.org/JavaDoc/doc/jmri/Manager.html#makeSystemName-java.lang.String-">makeSystemName</a>,
+            <a href="http://jmri.org/JavaDoc/doc/jmri/NamedBean.BadUserNameException.html">BadUserNameException</a>,
             and
-            <a href="http://jmri.org/JavaDoc/doc/jmri/Manager.html#normalizeSystemName-java.lang.String-">normalizeSystemName</a>
-      
+            <a href="http://jmri.org/JavaDoc/doc/jmri/NamedBean.BadSystemNameException.html">BadSystemNameException</a>.         
         <p>
         In general, it's better to use an input method that already handles all this.  Two are available
         now:
@@ -1016,8 +1046,8 @@ SENSOR GROUP:my group:LS2
         in selection boxes and lists, etc.  We have two <code>java.util.Comparator&lt;&gt;</code>
         implementations to handle this:
         <ul>
-            <li><code>SystemNameComparator</code> - a comparison on Strings
             <li><code>NamedBeanComparator</code> - a comparison on the NamedBeans themselves
+            <li><code>SystemNameComparator</code> - a comparison on Strings (deprecated)
         </ul>
         Please use one of these whenever you need to compare or sort by system names to keep the complexity in one place.
         <p>
@@ -1025,17 +1055,17 @@ SENSOR GROUP:my group:LS2
         If there are objects of multiple types, the type letter is put in alphabetical order next.
         Finally, the system-specific suffix is sorted.
         <p>
-        Because it works with String values, <code>SystemNameComparator</code> can only
-        do a default ordering of the system-specific suffix; it can't do anything that
+        <code>NamedBeanComparator</code> is the standard method going forward as it can 
+        do type-specific sorting of the suffix part of the names: 
+        It knows what the C/MRI suffixes in 
+        "CT2003" and "C2B2" mean and can take that into account.
+        <p>
+        Because it works with String values, <code>SystemNameComparator</code> could only
+        do a default ordering of the system-specific suffix; it couldn't do anything that
         uses any information about the system-specific meaning of that string. It therefore
         uses an alphanumeric-by-chunks sort.
         Because it's comparing on the actual NamedBean objects, <code>NamedBeanComparator</code>
-        can do more specific comparisons:  It knows what the C/MRI suffixes in 
-        "CT2003" and "C2B2" mean and can take that into account.
-        <p>
-        Therefore, if you can, do the sort/comparison with <code>NamedBeanComparator</code> and
-        then convert to Strings, rather than converting NamedBeans to Strings and using 
-        <code>SystemNameComparator</code>.
+        can do more specific comparisons.
         <p>
         Also, if you've created a system that has complex information in the suffix,
         please have your <code>NamedBean</code> subclasses implement a system-specific

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -401,7 +401,20 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li></li>
+            <li>The handling of Turnout system names has been updated
+                to be (more, hopefully completely) consistent with the
+                <a href="../html/doc/Technical/Names.shtml">planned approach</a>.  
+                Specifically, case now (generally) matters in system names:
+                <ul>
+                    <li>You can now have an internal turnout named "ITsome lower case name".
+                    <li>But note you can no longer refer to "ITSOME LOWER CASE NAME" or
+                        "ITSome LoWeR cAse Name" and get the same one.
+                </ul>
+                This should not require any migration for stored configurations or 
+                panel files, as they have been automatically been being kept consistent 
+                since JMRI 4.8.  But you might have case errors in i.e. scripts which
+                will fixing inconsistent references in your scripts.
+                </li>
         </ul>
 
     <h3>Scripting</h3>

--- a/java/src/jmri/implementation/AbstractTurnout.java
+++ b/java/src/jmri/implementation/AbstractTurnout.java
@@ -42,11 +42,11 @@ public abstract class AbstractTurnout extends AbstractNamedBean implements
         Turnout, PropertyChangeListener {
 
     protected AbstractTurnout(String systemName) {
-        super(systemName.toUpperCase());
+        super(systemName);
     }
 
     protected AbstractTurnout(String systemName, String userName) {
-        super(systemName.toUpperCase(), userName);
+        super(systemName, userName);
     }
 
     @Override

--- a/java/src/jmri/jmris/simpleserver/SimpleTurnoutServer.java
+++ b/java/src/jmri/jmris/simpleserver/SimpleTurnoutServer.java
@@ -62,22 +62,22 @@ public class SimpleTurnoutServer extends AbstractTurnoutServer {
                 log.debug("Setting Turnout THROWN");
             }
             // create turnout if it does not exist since throwTurnout() no longer does so
-            this.initTurnout(statusString.substring(index, statusString.indexOf(" ", index + 1)).toUpperCase());
-            throwTurnout(statusString.substring(index, statusString.indexOf(" ", index + 1)).toUpperCase());
+            this.initTurnout(statusString.substring(index, statusString.indexOf(" ", index + 1)));
+            throwTurnout(statusString.substring(index, statusString.indexOf(" ", index + 1)));
         } else if (statusString.contains("CLOSED")) {
             if (log.isDebugEnabled()) {
                 log.debug("Setting Turnout CLOSED");
             }
             // create turnout if it does not exist since closeTurnout() no longer does so
-            this.initTurnout(statusString.substring(index, statusString.indexOf(" ", index + 1)).toUpperCase());
-            closeTurnout(statusString.substring(index, statusString.indexOf(" ", index + 1)).toUpperCase());
+            this.initTurnout(statusString.substring(index, statusString.indexOf(" ", index + 1)));
+            closeTurnout(statusString.substring(index, statusString.indexOf(" ", index + 1)));
         } else {
             // default case, return status for this turnout
             try {
                 sendStatus(statusString.substring(index),
-                    InstanceManager.turnoutManagerInstance().provideTurnout(statusString.substring(index).toUpperCase()).getKnownState());
+                    InstanceManager.turnoutManagerInstance().provideTurnout(statusString.substring(index)).getKnownState());
             } catch (IllegalArgumentException ex) {
-                log.warn("Failed to provide Turnout \"{}\" in parseStatus", statusString.substring(index).toUpperCase());
+                log.warn("Failed to provide Turnout \"{}\" in parseStatus", statusString.substring(index));
             }
         }
     }

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -1688,7 +1688,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
 
         String sName = null;
         String prefix = ConnectionNameFromSystemName.getPrefixFromName((String) prefixBox.getSelectedItem()); // Add "T" later
-        String curAddress = hardwareAddressTextField.getText().trim(); // N11N
+        String curAddress = hardwareAddressTextField.getText(); // N11N
         // initial check for empty entry
         if (curAddress.length() < 1) {
             statusBarLabel.setText(Bundle.getMessage("WarningEmptyHardwareAddress"));
@@ -2043,7 +2043,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
             if (fld == null) {
                 return false;
             }
-            value = getText().trim();
+            value = getText();
             if ((value.length() < 1) && (allow0Length == false)) {
                 return false;
             } else if ((allow0Length == true) && (value.length() == 0)) {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -7129,8 +7129,8 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             //turnout is valid and unique.
             o.setTurnout(turnoutName);
 
-            if (o.getTurnout().getSystemName().equals(turnoutName.toUpperCase())) {
-                turnoutNameComboBox.setText(turnoutName.toUpperCase());
+            if (o.getTurnout().getSystemName().equals(turnoutName)) {
+                turnoutNameComboBox.setText(turnoutName);
             }
         } else {
             o.setTurnout("");
@@ -7143,8 +7143,8 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             //turnout is valid and unique.
             o.setTurnoutB(turnoutName);
 
-            if (o.getTurnoutB().getSystemName().equals(turnoutName.toUpperCase())) {
-                extraTurnoutNameComboBox.setText(turnoutName.toUpperCase());
+            if (o.getTurnoutB().getSystemName().equals(turnoutName)) {
+                extraTurnoutNameComboBox.setText(turnoutName);
             }
         } else {
             o.setTurnoutB("");
@@ -7214,8 +7214,8 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             //turnout is valid and unique.
             o.setTurnout(turnoutName);
 
-            if (o.getTurnout().getSystemName().equals(turnoutName.toUpperCase())) {
-                turnoutNameComboBox.setText(turnoutName.toUpperCase());
+            if (o.getTurnout().getSystemName().equals(turnoutName)) {
+                turnoutNameComboBox.setText(turnoutName);
             }
         } else {
             o.setTurnout("");
@@ -7265,7 +7265,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 String sname = t.getSystemName();
                 String uname = t.getUserName();
                 log.debug("{}: Turnout tested '{}' and '{}'.", lt.getName(), sname, uname);
-                if ((sname.equals(inTurnoutName.toUpperCase()))
+                if ((sname.equals(inTurnoutName))
                         || ((uname != null) && (uname.equals(inTurnoutName)))) {
                     result = false;
                     break;
@@ -7281,7 +7281,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                     String sname = t.getSystemName();
                     String uname = t.getUserName();
                     log.debug("{}: 2nd Turnout tested '{}' and '{}'.", lt.getName(), sname, uname);
-                    if ((sname.equals(inTurnoutName.toUpperCase()))
+                    if ((sname.equals(inTurnoutName))
                             || ((uname != null) && (uname.equals(inTurnoutName)))) {
                         result = false;
                         break;
@@ -7298,7 +7298,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                     String sname = t.getSystemName();
                     String uname = t.getUserName();
                     log.debug("{}: slip Turnout tested '{}' and '{}'.", sl.getName(), sname, uname);
-                    if ((sname.equals(inTurnoutName.toUpperCase()))
+                    if ((sname.equals(inTurnoutName))
                             || ((uname != null) && (uname.equals(inTurnoutName)))) {
                         result = false;
                         break;
@@ -7310,7 +7310,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                     String sname = t.getSystemName();
                     String uname = t.getUserName();
                     log.debug("{}: slip Turnout B tested '{}' and '{}'.", sl.getName(), sname, uname);
-                    if ((sname.equals(inTurnoutName.toUpperCase()))
+                    if ((sname.equals(inTurnoutName))
                             || ((uname != null) && (uname.equals(inTurnoutName)))) {
                         result = false;
                         break;

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
@@ -4906,7 +4906,6 @@ public class LayoutEditorTools {
             String uname = turnout2.getUserName();
             if ((uname == null) || uname.isEmpty()
                     || !uname.equals(ttotTurnoutName2)) {
-                ttotTurnoutName2 = ttotTurnoutName2.toUpperCase();
                 turnout2ComboBox.setText(ttotTurnoutName2);
             }
             layoutTurnout2 = getLayoutTurnoutFromTurnout(turnout2, false, ttotTurnoutName2, setSignalsAtThroatToThroatTurnoutsFrame);
@@ -4957,7 +4956,6 @@ public class LayoutEditorTools {
             }
             String uname = turnout1.getUserName();
             if ((uname == null) || uname.isEmpty() || !uname.equals(ttotTurnoutName1)) {
-                ttotTurnoutName1 = ttotTurnoutName1.toUpperCase();
                 turnout1ComboBox.setText(ttotTurnoutName1);
             }
             // have turnout 1 - get corresponding layoutTurnout
@@ -5013,7 +5011,6 @@ public class LayoutEditorTools {
                 }
                 uname = turnout2.getUserName();
                 if ((uname == null) || uname.isEmpty() || !uname.equals(ttotTurnoutName2)) {
-                    ttotTurnoutName2 = ttotTurnoutName2.toUpperCase();
                     turnout2ComboBox.setText(ttotTurnoutName2);
                 }
                 layoutTurnout2 = getLayoutTurnoutFromTurnout(turnout2, false, ttotTurnoutName2, setSignalsAtThroatToThroatTurnoutsFrame);
@@ -13426,10 +13423,10 @@ public class LayoutEditorTools {
             if (to != null) {
                 String uname = to.getUserName();
                 String sname = to.getSystemName();
-                if (!inTurnoutNameA.isEmpty() && (sname.equals(inTurnoutNameA.toUpperCase()) || ((uname != null) && uname.equals(inTurnoutNameA)))) {
+                if (!inTurnoutNameA.isEmpty() && (sname.equals(inTurnoutNameA) || ((uname != null) && uname.equals(inTurnoutNameA)))) {
                     layoutTurnout = layoutTurnout1 = layoutTurnoutA = lt;
                 }
-                if (!inTurnoutNameB.isEmpty() && (sname.equals(inTurnoutNameB.toUpperCase()) || ((uname != null) && uname.equals(inTurnoutNameB)))) {
+                if (!inTurnoutNameB.isEmpty() && (sname.equals(inTurnoutNameB) || ((uname != null) && uname.equals(inTurnoutNameB)))) {
                     layoutTurnout2 = layoutTurnoutB = lt;
                 }
             }

--- a/java/src/jmri/jmrix/internal/InternalTurnoutManager.java
+++ b/java/src/jmri/jmrix/internal/InternalTurnoutManager.java
@@ -2,6 +2,11 @@ package jmri.jmrix.internal;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
+
+import jmri.NamedBean;
 import jmri.Turnout;
 import jmri.managers.AbstractTurnoutManager;
 import jmri.implementation.AbstractTurnout;
@@ -52,6 +57,22 @@ public class InternalTurnoutManager extends AbstractTurnoutManager {
         return prefix + typeLetter() + curAddress;
     }
 
+    /** 
+     * {@inheritDoc} 
+     * No changes to what was given; we can take it all
+     */
+    @CheckReturnValue
+    @Override
+    @Nonnull
+    public String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
+        return inputName;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return always 'VALID' because we can take anything
+     */
     @Override
     public NameValidity validSystemNameFormat(String systemName) {
         return NameValidity.VALID;

--- a/java/src/jmri/jmrix/jmriclient/JMRIClientTurnout.java
+++ b/java/src/jmri/jmrix/jmriclient/JMRIClientTurnout.java
@@ -30,7 +30,7 @@ public class JMRIClientTurnout extends AbstractTurnout implements JMRIClientList
      * JMRIClient turnouts use the turnout number on the remote host.
      */
     public JMRIClientTurnout(int number, JMRIClientSystemConnectionMemo memo) {
-        super(memo.getSystemPrefix() + "t" + number);
+        super(memo.getSystemPrefix() + "T" + number);
         _number = number;
         tc = memo.getJMRIClientTrafficController();
         prefix = memo.getSystemPrefix();

--- a/java/src/jmri/jmrix/pi/RaspberryPiTurnout.java
+++ b/java/src/jmri/jmrix/pi/RaspberryPiTurnout.java
@@ -36,15 +36,15 @@ public class RaspberryPiTurnout extends AbstractTurnout implements Turnout, java
    }
 
    public RaspberryPiTurnout(String systemName, GpioController _gpio) {
-        super(systemName.toUpperCase());
+        super(systemName);
         log.trace("Provisioning turnout '{}'",systemName);
-        init(systemName.toUpperCase(),_gpio);
+        init(systemName,_gpio);
    }
 
    public RaspberryPiTurnout(String systemName, String userName,GpioController _gpio) {
-        super(systemName.toUpperCase(), userName);
+        super(systemName, userName);
         log.trace("Provisioning turnout '{}' with username '{}'",systemName, userName);
-        init(systemName.toUpperCase(),_gpio);
+        init(systemName,_gpio);
    }
 
    /**

--- a/java/src/jmri/jmrix/pi/RaspberryPiTurnoutManager.java
+++ b/java/src/jmri/jmrix/pi/RaspberryPiTurnoutManager.java
@@ -17,7 +17,7 @@ public class RaspberryPiTurnoutManager extends jmri.managers.AbstractTurnoutMana
     // ctor has to register for RaspberryPi events
     public RaspberryPiTurnoutManager(String prefix) {
         super();
-        this.prefix=prefix.toUpperCase();
+        this.prefix = normalizeSystemName(prefix);
     }
 
     /**

--- a/java/src/jmri/managers/AbstractTurnoutManager.java
+++ b/java/src/jmri/managers/AbstractTurnoutManager.java
@@ -116,8 +116,7 @@ public abstract class AbstractTurnoutManager extends AbstractManager<Turnout>
         }
 
         // Some implementations of createNewTurnout() register the new bean,
-        // some don't. Also note that createNewTurnout() may change the system
-        // name. For example, AbstractTurnout does systemName.toUpperCase().
+        // some don't. 
         if (getBeanBySystemName(s.getSystemName()) == null) {
             // save in the maps if successful
             register(s);

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
@@ -256,7 +256,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
     public void testLowerUpper() {
         Turnout t = l.provideTurnout("mt+n1e77;-n1e45");
         Assert.assertNotNull("exists",t);
-        Assert.assertTrue("Retrievable lowercase",t == l.getTurnout(t.getSystemName().toUpperCase()));
+        Assert.assertTrue("Retrievable lowercase",t == l.getTurnout(t.getSystemName())); // case not changed
     }
 
     @Test

--- a/java/test/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManagerTest.java
@@ -46,7 +46,7 @@ public class XBeeTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         Turnout t = l.provide("ATNode 1:2");
         // check
         Assert.assertTrue("real object returned ", t != null);
-        Assert.assertEquals("correct object returned ", t ,l.getBySystemName("ATNODE 1:2"));
+        Assert.assertEquals("correct object returned ", t ,l.getBySystemName("ATNode 1:2"));
     }
 
     @Test

--- a/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/internal/InternalTurnoutManagerTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.internal;
 
 import jmri.JmriException;
+import jmri.NamedBean;
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
 import jmri.util.junit.annotations.ToDo;
@@ -32,6 +33,60 @@ public class InternalTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgr
 
     }
 
+    @Test
+    public void testCaseMatters() {
+        java.util.ArrayList<NamedBean> list = new  java.util.ArrayList<>();
+
+        NamedBean tn1a = l.provide("name1");
+        Assert.assertTrue(tn1a != null);
+        list.add(tn1a);
+
+        // a test with specific system prefix attached (could get from this.getSystemName(1))
+        NamedBean tn1b = l.provide("ITname1"); // meant to be same, note type-specific
+        Assert.assertTrue(tn1a != null);
+        list.add(tn1b);
+        Assert.assertEquals("tn1a and tn1b didn't match", tn1a, tn1b);
+
+        // case is checked
+        NamedBean tN1 = l.provide("NAME1");
+        Assert.assertTrue(tn1a != null);
+        list.add(tN1);
+        Assert.assertTrue("tn1a doesn't match tN1, case not handled right", tn1a != tN1);
+
+        // spaces fine, kept
+        NamedBean tSpaceM  = l.provide("NAME 1");
+        Assert.assertFalse("tSPaceM not unique", list.contains(tSpaceM));
+        Assert.assertTrue(tSpaceM != null);
+        list.add(tSpaceM);
+
+        NamedBean tSpaceMM = l.provide("NAME  1");
+        Assert.assertFalse("tSpaceMM not unique", list.contains(tSpaceMM));
+        Assert.assertTrue(tSpaceMM != null);
+        list.add(tSpaceMM);
+
+        NamedBean tSpaceE  = l.provide("NAME 1 ");
+        Assert.assertFalse("tSpaceE not unique", list.contains(tSpaceE));
+        Assert.assertTrue(tSpaceE != null);
+        list.add(tSpaceE);
+
+        NamedBean tSpaceEE  = l.provide("NAME 1  ");
+        Assert.assertFalse("tSpaceEE not unique", list.contains(tSpaceEE));
+        Assert.assertTrue(tSpaceEE != null);
+        list.add(tSpaceEE);
+
+        NamedBean tSpaceLEE  = l.provide(" NAME 1  ");
+        Assert.assertFalse("tSpaceLEE not unique", list.contains(tSpaceLEE));
+        Assert.assertTrue(tSpaceLEE != null);
+        list.add(tSpaceLEE);
+
+        NamedBean tSpaceLLEE  = l.provide("  NAME 1  ");
+        Assert.assertFalse("tSpaceLLEE not unique", list.contains(tSpaceLLEE));
+        Assert.assertTrue(tSpaceLLEE != null);
+        list.add(tSpaceLLEE);
+
+    }
+    
+    
     // from here down is testing infrastructure
     // The minimal setup for log4J
     @Override

--- a/java/test/jmri/jmrix/jmriclient/JMRIClientTurnoutTest.java
+++ b/java/test/jmri/jmrix/jmriclient/JMRIClientTurnoutTest.java
@@ -5,9 +5,7 @@ import jmri.Turnout;
 import jmri.util.JUnitUtil;
 
 /**
- * JMRIClientTurnoutTest.java
- *
- * Description:	tests for the jmri.jmrix.jmriclient.JMRIClientTurnout class
+ * Tests for the jmri.jmrix.jmriclient.JMRIClientTurnout class
  *
  * @author	Bob Jacobsen
  * @author  Paul Bender Copyright (C) 2017
@@ -38,7 +36,7 @@ public class JMRIClientTurnoutTest extends jmri.implementation.AbstractTurnoutTe
     public void testDispose() {
         t.setCommandedState(jmri.Turnout.CLOSED);    // in case registration with TrafficController
 
-        //is deferred to after first use
+        // is deferred to after first use
         t.dispose();
         Assert.assertEquals("controller listeners remaining", 1, numListeners());
     }

--- a/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 
 /**
  * <p>
- * Tests for RaspberryPiTurnoutManager
+ * Tests for RaspberryTurnoutManager
  * </P>
  * @author Paul Bender Copyright (C) 2016
  */
@@ -21,7 +21,7 @@ public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnout
 
     @Override
     public String getSystemName(int i){
-        return "PIT"+i;
+        return "PiT"+i;
     }
 
 
@@ -32,7 +32,7 @@ public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnout
 
    @Test
    public void checkPrefix(){
-       Assert.assertEquals("Prefix","PI",l.getSystemPrefix());
+       Assert.assertEquals("Prefix","Pi",l.getSystemPrefix());
    }
 
     @Override    
@@ -52,7 +52,7 @@ public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnout
         Turnout t = l.provide(getSystemName(20));
         // check
         Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(20)));
+        Assert.assertEquals("system name correct ", t, l.getBySystemName(getSystemName(20)));
     }
 
     @Override
@@ -62,7 +62,7 @@ public class RaspberryPiTurnoutManagerTest extends jmri.managers.AbstractTurnout
         Turnout t = l.provideTurnout(getSystemName(getNumToTest1()));
         // check
         Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
+        Assert.assertEquals("system name correct ", t, l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
     @Override

--- a/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/pi/RaspberryPiTurnoutManagerTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 
 /**
  * <p>
- * Tests for RaspberryTurnoutManager
+ * Tests for RaspberryPiTurnoutManager
  * </P>
  * @author Paul Bender Copyright (C) 2016
  */

--- a/java/test/jmri/util/NamedBeanComparatorTest.java
+++ b/java/test/jmri/util/NamedBeanComparatorTest.java
@@ -72,7 +72,7 @@ public class NamedBeanComparatorTest {
 
         // this just checks that the local sort is called
         Turnout it1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
-        Turnout it2 = new jmri.implementation.AbstractTurnout("it2") {
+        Turnout it2 = new jmri.implementation.AbstractTurnout("IT2") {
 
             @Override
             protected void forwardCommandChangeToLayout(int s) {

--- a/jython/test/BeanCaseHandlingTest.py
+++ b/jython/test/BeanCaseHandlingTest.py
@@ -1,0 +1,37 @@
+# Test script-level access to NamedBeans, specifically how Internal
+# objects can be named
+
+import jmri
+
+list = []
+
+tn1a = turnouts.provideTurnout("ITname1")
+list.append(tn1a)
+if (tn1a is None ) : raise AssertionError('tn1a None')
+tn1b = turnouts.provideTurnout("ITname1")
+list.append(tn1b)
+if (tn1b is None ) : raise AssertionError('tn1b None')
+if (tn1a != tn1b) : raise AssertionError("tn1a and tn1b didn't match")
+
+# case is checked
+tN1 = turnouts.provideTurnout("ITNAME1")
+list.append(tN1)
+if (tn1a == tN1) : raise AssertionError("tn1a matches tN1, case not handled right")
+
+# spaces fine, kept
+tSpaceM  = turnouts.provideTurnout("ITNAME 1")
+if (tSpaceM in list) : raise AssertionError("tSPaceM not unique")
+list.append(tSpaceM)
+
+tSpaceMM = turnouts.provideTurnout("ITNAME  1")
+if (tSpaceMM in list) : raise AssertionError("tSpaceMM not unique")
+list.append(tSpaceMM)
+
+tSpaceE  = turnouts.provideTurnout("ITNAME 1 ")
+if (tSpaceE in list) : raise AssertionError("tSpaceE not unique")
+list.append(tSpaceE)
+
+tSpaceEE  = turnouts.provideTurnout("ITNAME 1  ")
+if (tSpaceEE in list) : raise AssertionError("tSpaceEE not unique")
+list.append(tSpaceEE)
+


### PR DESCRIPTION
Update the handling of system names for Turnouts to the [agreed-upon implementation form](http://jmri.org/help/en/html/doc/Technical/Names.shtml).  Along the way, this means that some types (those that allow alpha characters in their names, as opposed to only numerals) will become case sensitive.  For more background, see the [jmri-developers "Normalizing names - time to accept reality?" thread](https://jmri-developers.groups.io/g/jmri/topic/29894921#1085) and prior ones.

This involved removing about 30 `String#toUpperCase()` calls that had been liberally sprinkled around the code, and centralizing them in appropriate normalization methods.  It is certainly possible that some of those were missed; it's sometimes hard to tell what kind of object and name a `toUpperCase()` is referring to.  It's also possible that there will be places where normalization or validation calls will need to be added. Testing in the wild will be helpful.

N.B.: Once this PR is merged and resulting issues resolved, the next steps are to do similar work on Sensor, Light and Reporter, followed by Memory (the original motivation for this), followed by the rest of the managed NamedBeans.  Getting the first five bean types unbroken is important for the [MQTT support](http://www.jmri.org/help/en/html/hardware/mqtt/index.shtml) and eventually others, so it would be good to get that done before JMRI 4.16.