### PR TITLE
Add timeout and retry to operations import tests

### DIFF
--- a/java/test/jmri/jmrit/operations/rollingstock/cars/tools/ImportCarsTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/cars/tools/ImportCarsTest.java
@@ -9,16 +9,23 @@ import jmri.jmrit.operations.OperationsXml;
 import jmri.jmrit.operations.rollingstock.cars.Car;
 import jmri.jmrit.operations.rollingstock.cars.CarManager;
 import jmri.util.JUnitOperationsUtil;
+import jmri.util.junit.rules.*;
 import jmri.util.swing.JemmyUtil;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+
+import org.junit.*;
+import org.junit.rules.*;
 
 /**
  *
  * @author Paul Bender Copyright (C) 2017
  */
 public class ImportCarsTest extends OperationsTestCase {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(60); // 60 second timeout for methods in this test class.
+
+    @Rule
+    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
 
     @Test
     public void testCTor() {

--- a/java/test/jmri/jmrit/operations/rollingstock/engines/tools/ImportEnginesTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/tools/ImportEnginesTest.java
@@ -11,16 +11,23 @@ import jmri.jmrit.operations.locations.Track;
 import jmri.jmrit.operations.rollingstock.engines.Engine;
 import jmri.jmrit.operations.rollingstock.engines.EngineManager;
 import jmri.util.JUnitOperationsUtil;
+import jmri.util.junit.rules.*;
 import jmri.util.swing.JemmyUtil;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+
+import org.junit.*;
+import org.junit.rules.*;
 
 /**
  *
  * @author Paul Bender Copyright (C) 2017
  */
 public class ImportEnginesTest extends OperationsTestCase {
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(60); // 60 second timeout for methods in this test class.
+
+    @Rule
+    public RetryRule retryRule = new RetryRule(2); // allow 2 retries
 
     @Test
     public void testCTor() {


### PR DESCRIPTION
Added timeout and retry rules to ImportCarsTest and ImportEnginesTest which occasionally hang.  The tests can take up to 60 seconds to run, and will be retried twice.