### PR TITLE
Web Signal Mast iconset

### DIFF
--- a/java/src/jmri/jmrit/signalling/SignallingBundle_cs.properties
+++ b/java/src/jmri/jmrit/signalling/SignallingBundle_cs.properties
@@ -18,7 +18,7 @@ PathSpeed = Rychlost cesty
 NoneSet = \u017d\u00e1dn\u00e9 nastaven\u00ed
 
 ErrorUnReachableDestination = C\u00edlov\u00e9 n\u00e1v\u011bstidlo nen\u00ed p\u0159\u00edmo dosa\u017eiteln\u00e9 od v\u00fdchoz\u00edho n\u00e1v\u011bstidla
-WarningUnabletoValidate = Nebylo mo\u017en\u00e9 ov\u011b\u0159it cestu meri dv\u011bma n\u00e1v\u011bstidly
+WarningUnabletoValidate = Nebylo mo\u017en\u00e9 ov\u011b\u0159it cestu mezi dv\u011bma n\u00e1v\u011bstidly
 
 EnableLayoutBlockRouting = Sm\u011brov\u00e1n\u00ed kolejov\u00fdch obvod\u016f ve schematu nen\u00ed dovoleno.\nChcete jej povolit?
 LayoutBlockRoutingEnabled = Sm\u011brov\u00e1n\u00ed kolejov\u00fdch obvod\u016f ve schematu bylo povoleno.\nZav\u0159ete toto okno a znovu ho otev\u0159ete aby se zm\u011bny projevily.

--- a/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
@@ -237,7 +237,7 @@ abstract class AbstractPanelServlet extends HttpServlet {
      *
      * @param name user/system name of the signalMast using the icons
      * @return an icons element containing icon URLs for SignalMast states
-     * @deprecated since 4.15.4 use {@ #getSignalMastIconsElement(String name, String imageset)} instead
+     * @deprecated since 4.15.4 use {@link #getSignalMastIconsElement(String, String)} instead
      */
     @Deprecated  
     protected Element getSignalMastIconsElement(String name) {

--- a/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
@@ -237,8 +237,9 @@ abstract class AbstractPanelServlet extends HttpServlet {
      *
      * @param name user/system name of the signalMast using the icons
      * @return an icons element containing icon URLs for SignalMast states
+     * @deprecated since 4.15.4 use {@ #getSignalMastIconsElement(String name, String imageset)} instead
      */
-    @Deprecated
+    @Deprecated  
     protected Element getSignalMastIconsElement(String name) {
         return getSignalMastIconsElement(name, "default") ;
     }
@@ -256,9 +257,15 @@ abstract class AbstractPanelServlet extends HttpServlet {
         Element icons = new Element("icons");
         SignalMast signalMast = InstanceManager.getDefault(SignalMastManager.class).getSignalMast(name);
         if (signalMast != null) {
+            final String imgset ;
+            if (imageset == null) {
+                imgset = "default" ;
+            } else {
+                imgset = imageset ;
+            }
             signalMast.getValidAspects().forEach((aspect) -> {
                 Element ea = new Element(aspect.replaceAll("[ ()]", "")); //create element for aspect after removing invalid chars
-                String url = signalMast.getAppearanceMap().getImageLink(aspect, imageset);  // use correct imageset
+                String url = signalMast.getAppearanceMap().getImageLink(aspect, imgset);  // use correct imageset
                 if (!url.contains("preference:")) {
                     url = "program:" + url.substring(url.indexOf("resources"));
                 }
@@ -266,7 +273,7 @@ abstract class AbstractPanelServlet extends HttpServlet {
                 ea.setAttribute("url", url);
                 icons.addContent(ea);
             });
-            String url = signalMast.getAppearanceMap().getImageLink("$held", imageset);  //add "Held" aspect if defined
+            String url = signalMast.getAppearanceMap().getImageLink("$held", imgset);  //add "Held" aspect if defined
             if (!url.isEmpty()) {
                 if (!url.contains("preference:")) {
                     url = "program:" + url.substring(url.indexOf("resources"));
@@ -276,7 +283,7 @@ abstract class AbstractPanelServlet extends HttpServlet {
                 ea.setAttribute("url", url);
                 icons.addContent(ea);
             }
-            url = signalMast.getAppearanceMap().getImageLink("$dark", imageset);  //add "Dark" aspect if defined
+            url = signalMast.getAppearanceMap().getImageLink("$dark", imgset);  //add "Dark" aspect if defined
             if (!url.isEmpty()) {
                 if (!url.contains("preference:")) {
                     url = "program:" + url.substring(url.indexOf("resources"));

--- a/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
@@ -238,13 +238,27 @@ abstract class AbstractPanelServlet extends HttpServlet {
      * @param name user/system name of the signalMast using the icons
      * @return an icons element containing icon URLs for SignalMast states
      */
+    @Deprecated
     protected Element getSignalMastIconsElement(String name) {
+        return getSignalMastIconsElement(name, "default") ;
+    }
+    
+    /**
+     * Build and return an "icons" element containing icon URLs for all
+     * SignalMast states. Element names are cleaned-up aspect names, aspect
+     * attribute is actual name of aspect.
+     *
+     * @param name user/system name of the signalMast using the icons
+     * @param imageset imageset name or "default"
+     * @return an icons element containing icon URLs for SignalMast states
+     */
+    protected Element getSignalMastIconsElement(String name, String imageset) {
         Element icons = new Element("icons");
         SignalMast signalMast = InstanceManager.getDefault(SignalMastManager.class).getSignalMast(name);
         if (signalMast != null) {
             signalMast.getValidAspects().forEach((aspect) -> {
                 Element ea = new Element(aspect.replaceAll("[ ()]", "")); //create element for aspect after removing invalid chars
-                String url = signalMast.getAppearanceMap().getImageLink(aspect, "default");  //TODO: use correct imageset
+                String url = signalMast.getAppearanceMap().getImageLink(aspect, imageset);  // use correct imageset
                 if (!url.contains("preference:")) {
                     url = "program:" + url.substring(url.indexOf("resources"));
                 }
@@ -252,7 +266,7 @@ abstract class AbstractPanelServlet extends HttpServlet {
                 ea.setAttribute("url", url);
                 icons.addContent(ea);
             });
-            String url = signalMast.getAppearanceMap().getImageLink("$held", "default");  //add "Held" aspect if defined
+            String url = signalMast.getAppearanceMap().getImageLink("$held", imageset);  //add "Held" aspect if defined
             if (!url.isEmpty()) {
                 if (!url.contains("preference:")) {
                     url = "program:" + url.substring(url.indexOf("resources"));
@@ -262,7 +276,7 @@ abstract class AbstractPanelServlet extends HttpServlet {
                 ea.setAttribute("url", url);
                 icons.addContent(ea);
             }
-            url = signalMast.getAppearanceMap().getImageLink("$dark", "default");  //add "Dark" aspect if defined
+            url = signalMast.getAppearanceMap().getImageLink("$dark", imageset);  //add "Dark" aspect if defined
             if (!url.isEmpty()) {
                 if (!url.contains("preference:")) {
                     url = "program:" + url.substring(url.indexOf("resources"));

--- a/java/src/jmri/web/servlet/panel/ControlPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/ControlPanelServlet.java
@@ -67,7 +67,11 @@ public class ControlPanelServlet extends AbstractPanelServlet {
                         Element e = ConfigXmlManager.elementFromObject(sub);
                         if (e != null) {
                             if ("signalmasticon".equals(e.getName())) {  //insert icon details into signalmast
-                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast")));
+                                String imageset = e.getAttributeValue("imageset") ;
+                                if (imageset == null) {
+                                    imageset = "default" ;
+                                }
+                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"), imageset));
                             }
                             try {
                                 e.setAttribute(JSON.ID, sub.getNamedBean().getSystemName());

--- a/java/src/jmri/web/servlet/panel/ControlPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/ControlPanelServlet.java
@@ -67,11 +67,7 @@ public class ControlPanelServlet extends AbstractPanelServlet {
                         Element e = ConfigXmlManager.elementFromObject(sub);
                         if (e != null) {
                             if ("signalmasticon".equals(e.getName())) {  //insert icon details into signalmast
-                                String imageset = e.getAttributeValue("imageset") ;
-                                if (imageset == null) {
-                                    imageset = "default" ;
-                                }
-                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"), imageset));
+                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"), e.getAttributeValue("imageset")));
                             }
                             try {
                                 e.setAttribute(JSON.ID, sub.getNamedBean().getSystemName());

--- a/java/src/jmri/web/servlet/panel/LayoutPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/LayoutPanelServlet.java
@@ -82,11 +82,7 @@ public class LayoutPanelServlet extends AbstractPanelServlet {
                         Element e = ConfigXmlManager.elementFromObject(sub);
                         if (e != null) {
                             if ("signalmasticon".equals(e.getName())) {  //insert icon details into signalmast
-                                String imageset = e.getAttributeValue("imageset") ;
-                                if (imageset == null) {
-                                    imageset = "default" ;
-                                }
-                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"), imageset));
+                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"), e.getAttributeValue("imageset")));
                             }
                             try {
                                 e.setAttribute(JSON.ID, sub.getNamedBean().getSystemName());

--- a/java/src/jmri/web/servlet/panel/LayoutPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/LayoutPanelServlet.java
@@ -82,7 +82,11 @@ public class LayoutPanelServlet extends AbstractPanelServlet {
                         Element e = ConfigXmlManager.elementFromObject(sub);
                         if (e != null) {
                             if ("signalmasticon".equals(e.getName())) {  //insert icon details into signalmast
-                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast")));
+                                String imageset = e.getAttributeValue("imageset") ;
+                                if (imageset == null) {
+                                    imageset = "default" ;
+                                }
+                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"), imageset));
                             }
                             try {
                                 e.setAttribute(JSON.ID, sub.getNamedBean().getSystemName());

--- a/java/src/jmri/web/servlet/panel/PanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/PanelServlet.java
@@ -75,11 +75,7 @@ public class PanelServlet extends AbstractPanelServlet {
                         Element e = ConfigXmlManager.elementFromObject(sub);
                         if (e != null) {
                             if ("signalmasticon".equals(e.getName())) {  //insert icon details into signalmast
-                                String imageset = e.getAttributeValue("imageset") ;
-                                if (imageset == null) {
-                                    imageset = "default" ;
-                                }
-                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"), imageset));
+                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"), e.getAttributeValue("imageset")));
                             }
                             try {
                                 e.setAttribute(JSON.ID, sub.getNamedBean().getSystemName());

--- a/java/src/jmri/web/servlet/panel/PanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/PanelServlet.java
@@ -75,7 +75,11 @@ public class PanelServlet extends AbstractPanelServlet {
                         Element e = ConfigXmlManager.elementFromObject(sub);
                         if (e != null) {
                             if ("signalmasticon".equals(e.getName())) {  //insert icon details into signalmast
-                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast")));
+                                String imageset = e.getAttributeValue("imageset") ;
+                                if (imageset == null) {
+                                    imageset = "default" ;
+                                }
+                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"), imageset));
                             }
                             try {
                                 e.setAttribute(JSON.ID, sub.getNamedBean().getSystemName());


### PR DESCRIPTION
Finished code for displaying correct imageset for signal mast in JMRI web panel.
I'm not sure, but the "null" test for e.getAttributeValue("imageset") may be redundant. 
The original getSignalMastIconsElement(String name) method is now unused and marked as deprecated.