### PR TITLE
Turnout Mast config errors handled better

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -482,7 +482,10 @@
 
         <h4>Signal Masts</h4>
             <ul>
-                <li></li>
+                <li>Better messages when a Turnout Signal Mast encounters errors
+                    due to part of its configuration not completed.</li>
+                <li>Better reporting of issues when Signal Mast Logic encounters
+                    a problem with a Signal Mast</li>
             </ul>
 
     	<h4>Signal Groups</h4>
@@ -518,7 +521,6 @@
 
     <h3>Timetable</h3>
         <a id="Timetable" name="Timetable"></a>
-        <span class="since">since 4.13.4</span>
         <ul>
             <li></li>
         </ul>

--- a/help/en/releasenotes/jmri4.15-master.shtml
+++ b/help/en/releasenotes/jmri4.15-master.shtml
@@ -424,7 +424,6 @@
 
     <h3>Timetable</h3>
         <a id="Timetable" name="Timetable"></a>
-        <span class="since">since 4.13.4</span>
         <ul>
             <li></li>
         </ul>

--- a/java/src/jmri/implementation/DefaultSignalMastLogic.java
+++ b/java/src/jmri/implementation/DefaultSignalMastLogic.java
@@ -972,7 +972,7 @@ public class DefaultSignalMastLogic extends AbstractNamedBean implements jmri.Si
                         getSourceMast().setAspect(aspectSet);
                     });
                 } catch (Exception ex) {
-                    log.error("Exception while setting Signal Logic {}", ex.getMessage());
+                    log.error("Exception while setting Signal Logic: {}", ex);
                 }
                 return;
             }

--- a/java/test/jmri/implementation/TurnoutSignalMastTest.java
+++ b/java/test/jmri/implementation/TurnoutSignalMastTest.java
@@ -25,6 +25,8 @@ public class TurnoutSignalMastTest {
         Turnout it1 = InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
         Turnout it2 = InstanceManager.turnoutManagerInstance().provideTurnout("IT2");
         TurnoutSignalMast t = new TurnoutSignalMast("IF$tsm:basic:one-searchlight($1)");
+        t.resetPreviousStates(false);
+        
         t.setTurnout("Stop", "IT1", Turnout.THROWN);
         t.setTurnout("Clear", "IT2", Turnout.CLOSED);
         
@@ -38,6 +40,10 @@ public class TurnoutSignalMastTest {
         Assert.assertEquals(Turnout.THROWN, it1.getCommandedState());
         Assert.assertEquals(Turnout.CLOSED, it2.getCommandedState()); // unchanged
         
+        // try an unconfigured one
+        t.setAspect("Approach");
+        jmri.util.JUnitAppender.assertErrorMessage("Trying to set \"Approach\" on signal mast \"IF$tsm:basic:one-searchlight($1)\" which has not been configured");
+
         try {
             t.setAspect("Marblesnarb");
         } catch (IllegalArgumentException ex) {
@@ -49,12 +55,46 @@ public class TurnoutSignalMastTest {
     }
 
     @Test
-    public void testUnLit() {
+    public void testSetAspectResetOthers() {
+        Turnout it1 = InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
+        Turnout it2 = InstanceManager.turnoutManagerInstance().provideTurnout("IT2");
+        TurnoutSignalMast t = new TurnoutSignalMast("IF$tsm:basic:one-searchlight($1)");
+        t.resetPreviousStates(true);
+
+        t.setTurnout("Stop", "IT1", Turnout.THROWN);
+        t.setTurnout("Clear", "IT2", Turnout.CLOSED);
+        
+        t.setAspect("Clear");
+        Assert.assertEquals("Clear", t.getAspect());
+        Assert.assertEquals(Turnout.CLOSED, it1.getCommandedState()); // reset
+        Assert.assertEquals(Turnout.CLOSED, it2.getCommandedState());
+        
+        t.setAspect("Stop");
+        Assert.assertEquals("Stop", t.getAspect());
+        Assert.assertEquals(Turnout.THROWN, it1.getCommandedState());
+        Assert.assertEquals(Turnout.THROWN, it2.getCommandedState()); // reset
+        
+        // try an unconfigured but valid one
+        t.setAspect("Approach");
+        jmri.util.JUnitAppender.assertErrorMessage("Trying to set \"Approach\" on signal mast \"IF$tsm:basic:one-searchlight($1)\" which has not been configured");
+        
+        try {
+            t.setAspect("Marblesnarb");
+        } catch (IllegalArgumentException ex) {
+            jmri.util.JUnitAppender.assertWarnMessage("attempting to set invalid aspect: Marblesnarb on mast: IF$tsm:basic:one-searchlight($1)");
+            return;
+        }
+        
+        Assert.fail("should have thrown");
+    }
+
+    @Test
+    public void testUnLitNoTurnout() {
         Turnout it1 = InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
         Turnout it2 = InstanceManager.turnoutManagerInstance().provideTurnout("IT2");
         TurnoutSignalMast t = new TurnoutSignalMast("IF$tsm:basic:one-searchlight($1)");
         t.setTurnout("Stop", "IT1", Turnout.THROWN);
-        t.setTurnout("Clear", "IT2", Turnout.CLOSED);
+        t.setTurnout("Clear", "IT2", Turnout.THROWN);
         
         t.setAspect("Clear");
         Assert.assertEquals(true, t.getLit());
@@ -63,7 +103,31 @@ public class TurnoutSignalMastTest {
         Assert.assertEquals(false, t.getLit());
         Assert.assertEquals("Clear", t.getAspect());
         Assert.assertEquals(Turnout.CLOSED, it1.getCommandedState());
+        Assert.assertEquals(Turnout.CLOSED, it2.getCommandedState());
+    }
+
+    @Test
+    public void testUnLitWithTurnout() {
+        Turnout it1 = InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
+        Turnout it2 = InstanceManager.turnoutManagerInstance().provideTurnout("IT2");
+        Turnout it3 = InstanceManager.turnoutManagerInstance().provideTurnout("IT3");
+        TurnoutSignalMast t = new TurnoutSignalMast("IF$tsm:basic:one-searchlight($1)");
+        t.setTurnout("Stop", "IT1", Turnout.THROWN);
+        t.setTurnout("Clear", "IT2", Turnout.THROWN);
+        t.setTurnout("Unlit", "IT3", Turnout.THROWN);
+        t.setUnLitTurnout("IT3",Turnout.THROWN );
+        
+        t.setAspect("Clear");
+        Assert.assertEquals(true, t.getLit());
+        Assert.assertEquals(Turnout.UNKNOWN, it1.getCommandedState());
         Assert.assertEquals(Turnout.THROWN, it2.getCommandedState());
+
+        t.setLit(false);
+        Assert.assertEquals(false, t.getLit());
+        Assert.assertEquals("Clear", t.getAspect());
+        Assert.assertEquals(Turnout.UNKNOWN, it1.getCommandedState());  // Unchanged
+        Assert.assertEquals(Turnout.THROWN, it2.getCommandedState());  // Unchanged
+        Assert.assertEquals(Turnout.THROWN, it3.getCommandedState());
     }
 
     // The minimal setup for log4J


### PR DESCRIPTION
Give better log messages if a Turnout Mast hits errors due to partial or inconsistent configuration.

Signal Mast Logic does a better job of logging issues that arise when operating Masts.

Includes tests.