### PR TITLE
Better logging of unexpected messages

### DIFF
--- a/java/test/jmri/util/JUnitAppender.java
+++ b/java/test/jmri/util/JUnitAppender.java
@@ -68,9 +68,13 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
 
     // package-level access for testing
     static boolean unexpectedFatalSeen = false;
+    static String  unexpectedFatalContent = null;  
     static boolean unexpectedErrorSeen = false;
+    static String  unexpectedErrorContent = null;  
     static boolean unexpectedWarnSeen = false;
+    static String  unexpectedWarnContent = null;  
     static boolean unexpectedInfoSeen = false;
+    static String  unexpectedInfoContent = null;  
 
     public static boolean unexpectedMessageSeen(Level l) {
         if (l == Level.FATAL) {
@@ -88,20 +92,46 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
         throw new java.lang.IllegalArgumentException("Did not expect " + l);
     }
 
+    public static String unexpectedMessageContent(Level l) {
+        if (l == Level.FATAL) {
+            return unexpectedFatalContent;
+        }
+        if (l == Level.ERROR) {
+            if (unexpectedFatalContent != null ) return unexpectedFatalContent;
+            return unexpectedErrorContent;
+        }
+        if (l == Level.WARN) {
+            if (unexpectedFatalContent != null ) return unexpectedFatalContent;
+            if (unexpectedErrorContent != null ) return unexpectedErrorContent;
+            return unexpectedWarnContent;
+        }
+        if (l == Level.INFO) {
+            if (unexpectedFatalContent != null ) return unexpectedFatalContent;
+            if (unexpectedErrorContent != null ) return unexpectedErrorContent;
+            if (unexpectedWarnContent != null ) return unexpectedWarnContent;
+            return unexpectedInfoContent;
+        }
+        throw new java.lang.IllegalArgumentException("Did not expect " + l);
+    }
+
     public static void resetUnexpectedMessageFlags(Level severity) {
         // cases statements are organized to flow 
         switch (severity.toInt()) {
             case Level.INFO_INT:
                 unexpectedInfoSeen = false;
+                unexpectedInfoContent = null;
                 //$FALL-THROUGH$
             case Level.WARN_INT:
                 unexpectedWarnSeen = false;
+                unexpectedWarnContent = null;
                 //$FALL-THROUGH$
             case Level.ERROR_INT:
                 unexpectedErrorSeen = false;
+                unexpectedErrorContent = null;
                 //$FALL-THROUGH$
             case Level.FATAL_INT:
                 unexpectedFatalSeen = false;
+                unexpectedFatalContent = null;
                 break;
             default:
                 Log.warn("Unhandled serverity code: {}", severity.toInt());
@@ -140,19 +170,23 @@ public class JUnitAppender extends org.apache.log4j.ConsoleAppender {
     void superappend(LoggingEvent l) {
         if (l.getLevel() == Level.FATAL) {
             unexpectedFatalSeen = true;
+            unexpectedFatalContent = l.getMessage().toString();
         }
         if (l.getLevel() == Level.ERROR) {
             if (compare(l, "Uncaught Exception caught by jmri.util.exceptionhandler.UncaughtExceptionHandler")) {
                 // still an error, just suppressed
             } else {
                 unexpectedErrorSeen = true;
+                unexpectedErrorContent = l.getMessage().toString();
             }
         }
         if (l.getLevel() == Level.WARN) {
             unexpectedWarnSeen = true;
+            unexpectedWarnContent = l.getMessage().toString();
         }
         if (l.getLevel() == Level.INFO) {
             unexpectedInfoSeen = true;
+            unexpectedInfoContent = l.getMessage().toString();
         }
 
         super.append(l);

--- a/java/test/jmri/util/JUnitAppenderTest.java
+++ b/java/test/jmri/util/JUnitAppenderTest.java
@@ -138,7 +138,8 @@ public class JUnitAppenderTest {
         log.warn(msg);
         JUnitAppender.assertWarnMessage(msg);
 
-        log.info("This INFO message was emitted to test the entire logging chain, please don't remove");
+        msg = "This INFO message was emitted to test the entire logging chain, please don't remove";
+        log.info(msg);
     }
 
     @Test
@@ -299,7 +300,8 @@ public class JUnitAppenderTest {
             Assert.assertFalse("post WARN",  JUnitAppender.unexpectedMessageSeen(Level.WARN));
 
             Assert.assertTrue("post INFO",  JUnitAppender.unexpectedMessageSeen(Level.INFO));
-
+            Assert.assertEquals("This INFO message was emitted to test the entire logging chain, please don't remove", JUnitAppender.unexpectedMessageContent(Level.INFO));
+            
             JUnitAppender.unexpectedFatalSeen = cacheFatal;
             JUnitAppender.unexpectedErrorSeen = cacheError;
             JUnitAppender.unexpectedWarnSeen  = cacheWarn; 

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -307,7 +307,7 @@ public class JUnitUtil {
         boolean unexpectedMessageSeen = JUnitAppender.unexpectedMessageSeen(severity);
         JUnitAppender.verifyNoBacklog();
         JUnitAppender.resetUnexpectedMessageFlags(severity);
-        Assert.assertFalse("Unexpected "+severity+" or higher messages emitted", unexpectedMessageSeen);
+        Assert.assertFalse("Unexpected "+severity+" or higher messages emitted: "+JUnitAppender.unexpectedMessageSeen(severity), unexpectedMessageSeen);
         
         // Optionally, check that no threads were left running (controlled by jmri.util.JUnitUtil.checkRemnantThreads environment var)
         if (checkRemnantThreads) {


### PR DESCRIPTION
Provide more context when a JUnit test is failed because it emitted unexpected log messages.
