### PR TITLE
Make some abstract classes public

### DIFF
--- a/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kevin Dickerson Copyright (C) 2011
  */
-abstract class BeanEditAction extends AbstractAction {
+public abstract class BeanEditAction extends AbstractAction {
 
     public BeanEditAction(String s) {
         super(s);

--- a/java/src/jmri/util/prefs/JmriConfiguration.java
+++ b/java/src/jmri/util/prefs/JmriConfiguration.java
@@ -23,7 +23,7 @@ import org.xml.sax.SAXException;
  *
  * @author Randall Wood
  */
-abstract class JmriConfiguration implements AuxiliaryConfiguration {
+public abstract class JmriConfiguration implements AuxiliaryConfiguration {
 
     private final static Logger log = LoggerFactory.getLogger(JmriConfiguration.class);
 

--- a/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Randall Wood
  */
-abstract class AbstractPanelServlet extends HttpServlet {
+public abstract class AbstractPanelServlet extends HttpServlet {
 
     protected ObjectMapper mapper;
     private final static Logger log = LoggerFactory.getLogger(AbstractPanelServlet.class);


### PR DESCRIPTION
Makes some `abstract` classes `public` so they generate Javadoc content. 