### PR TITLE
update minimum coverage ratio to 50%

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1421,7 +1421,7 @@
 
           <check>
               <rule>
-                  <limit counter="LINE" value="COVEREDRATIO" minimum="0.45"/>
+                  <limit counter="LINE" value="COVEREDRATIO" minimum="0.50"/>
                   <limit counter="CLASS" value="COVEREDRATIO" minimum="0.80"/>
               </rule>
               <rule element="PACKAGE">
@@ -1616,7 +1616,7 @@
 
           <check>
               <rule>
-                  <limit counter="LINE" value="COVEREDRATIO" minimum="0.40"/>
+                  <limit counter="LINE" value="COVEREDRATIO" minimum="0.50"/>
                   <limit counter="CLASS" value="COVEREDRATIO" minimum="0.80"/>
               </rule>
               <rule element="PACKAGE">
@@ -1645,7 +1645,7 @@
 
           <check>
               <rule>
-                  <limit counter="LINE" value="COVEREDRATIO" minimum="0.40"/>
+                  <limit counter="LINE" value="COVEREDRATIO" minimum="0.50"/>
                   <limit counter="CLASS" value="COVEREDRATIO" minimum="0.80"/>
               </rule>
               <rule element="PACKAGE">
@@ -1674,7 +1674,7 @@
 
           <check>
               <rule>
-                  <limit counter="LINE" value="COVEREDRATIO" minimum="0.40"/>
+                  <limit counter="LINE" value="COVEREDRATIO" minimum="0.50"/>
                   <limit counter="CLASS" value="COVEREDRATIO" minimum="0.80"/>
               </rule>
               <rule element="PACKAGE">

--- a/pom.xml
+++ b/pom.xml
@@ -567,7 +567,7 @@
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.45</minimum>
+                                            <minimum>0.50</minimum>
                                         </limit>
                                         <limit>
                                             <counter>CLASS</counter>


### PR DESCRIPTION
This PR marks a milestone almost three years in the making.  We started tracking test coverage ratios back in issue #1333 which generated PRs #1335 and #1346.  Back at that time, our coverage was really poor, at somewhere around 20%.

With some PRs that were merged today, the coverage is now at 50.5%, which is enough cushion that this PR pushes the minimum line coverage up to 50%.  It has been our standard process to adjust this number in 5% increments, but this one is especially meaningful because it finally means we have more lines covered than uncovered.