### PR TITLE
Piko 4.1 non-sound

### DIFF
--- a/xml/decoders/Uhlenbrock_73xx5.xml
+++ b/xml/decoders/Uhlenbrock_73xx5.xml
@@ -105,6 +105,36 @@
                 <output name="Start/brake" label="inertia"/>
                 <size length="30.2" width="16" height="3.8" units="mm"/>
             </model>
+            <model model="Piko 56400" numOuts="10" numFns="14" maxMotorCurrent="1.2A" formFactor="HO" connector="PluX22" productID="PIKO56400" comment="Piko Smartdecoder 4.1 and RailCom(R) (Plus)">
+                <output name="1" label="F0(f)" connection="plug" maxcurrent="400 mA"/>
+                <output name="2" label="F0(r)" connection="plug" maxcurrent="400 mA"/>
+                <output name="3" label=". A1 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="4" label=". A2 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="5" label=". A3 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="6" label=". A4 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="7" label=". A5 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="8" label=". A6 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="9" label=". A7 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="10" label=". A8 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="Shunting" label="mode"/>
+                <output name="Start/brake" label="inertia"/>
+                <size length="38" width="22" height="15" units="mm"/>
+            </model>
+            <model model="Piko 56401" numOuts="10" numFns="14" maxMotorCurrent="1.2A" formFactor="HO" connector="PluX22" productID="PIKO56401" comment="Piko Smartdecoder 4.1, Mfx and RailCom(R) (Plus)">
+                <output name="1" label="F0(f)" connection="plug" maxcurrent="400 mA"/>
+                <output name="2" label="F0(r)" connection="plug" maxcurrent="400 mA"/>
+                <output name="3" label=". A1 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="4" label=". A2 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="5" label=". A3 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="6" label=". A4 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="7" label=". A5 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="8" label=". A6 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="9" label=". A7 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="10" label=". A8 ." connection="plug" maxcurrent="400 mA"/>
+                <output name="Shunting" label="mode"/>
+                <output name="Start/brake" label="inertia"/>
+                <size length="38" width="22" height="15" units="mm"/>
+            </model>
         </family>
         <programming direct="yes" paged="yes" register="yes" ops="yes">
             <capability>
@@ -125,7 +155,7 @@
                 <label xml:lang="de">Decoder Version: </label>
                 <label xml:lang="nl">Versie van decoder: </label>
             </variable>
-            <variable item="Manufacturer" CV="8" readOnly="yes" default="85" exclude="PIKO41RH2400,PIKO41BR82"><!-- Uhlenbrock -->
+            <variable item="Manufacturer" CV="8" readOnly="yes" default="85" exclude="PIKO41RH2400,PIKO41BR82,PIKO56400,PIKO56401"><!-- Uhlenbrock -->
                 <decVal/>
                 <!--<defaultItem default="162" include="PIKO41RH2400,PIKO41BR82"/> somehow not validating -->
                 <label>Manufacturer ID: </label>
@@ -134,7 +164,7 @@
                 <label xml:lang="de">Hersteller ID: </label>
                 <label xml:lang="nl">Fabrikant-ID: </label>
             </variable>
-            <variable item="Manufacturer" CV="8" readOnly="yes" default="162" include="PIKO41RH2400,PIKO41BR82"><!-- Piko -->
+            <variable item="Manufacturer" CV="8" readOnly="yes" default="162" include="PIKO41RH2400,PIKO41BR82,PIKO56400,PIKO56401"><!-- Piko -->
                 <decVal/>
                 <label>Manufacturer ID: </label>
                 <label xml:lang="it">ID Costruttore: </label>
@@ -149,7 +179,7 @@
                 <label xml:lang="de">Selectrix Datenformat</label>
                 <label xml:lang="nl">Selectrix modus</label>
             </variable>
-            <variable item="Mfx Operation" CV="12" default="1" mask="XXVXXXXX" include="PIKO41RH2400,PIKO41BR82">
+            <variable item="Mfx Operation" CV="12" default="1" mask="XXVXXXXX" include="PIKO41RH2400,PIKO41BR82,PIKO56400">
                 <xi:include href="http://jmri.org/xml/decoders/parts/enum-NoYes.xml"/>
                 <label>Mfx Mode</label>
                 <label xml:lang="de">Mfx Datenformat</label>
@@ -1290,10 +1320,11 @@
                 <tooltip>Maximum Period length in 100μs steps (min = CV53)</tooltip>
                 <tooltip xml:lang="de">maximale Periodendauer in 100μs Schritten (min = CV53)</tooltip>
             </variable>
-            <!--extended function mapping on IntelliDrive2 and Piko 4.1, includes cv 31-32 bank switches-->
+            <!--extended function mapping on IntelliDrive2 and Piko Smartdecoder (Sound) 4.1, includes cv 31-32 bank switches-->
             <xi:include href="http://jmri.org/xml/decoders/uhlenbrock/cv257.512extendedmap.xml"/>
 
-            <!--Sound, only basic -->
+<!--            <group exclude="PIKO56400,PIKO56401">-->
+            <!--Sound CVs -->
             <!-- Declaration of the "switch" CV, not for direct use but for checking value -->
             <variable item="Bank_Switch" CV="1021" default="0">
                 <enumVal>
@@ -1985,6 +2016,7 @@
                 </variable>
                 <!--end RH2400-->
             <!--</group>-->
+<!--            </group>-->
 
         </variables>
         <xi:include href="http://jmri.org/xml/decoders/uhlenbrock/factReset4.xml"/>

--- a/xml/decoders/Uhlenbrock_73xx5.xml
+++ b/xml/decoders/Uhlenbrock_73xx5.xml
@@ -1386,12 +1386,16 @@
                 <label>Minimum Random Period</label>
                 <label xml:lang="de">Minimale Zufallszeit</label>
                 <label xml:lang="nl">Min. toevalstijd</label>
+                <tooltip>From what time (minimum) should a random sound be played?</tooltip>
+                <tooltip xml:lang="de">ab welcher Mindestzeit soll ein Zufallsgeräusch abgespielt werden?</tooltip>
             </variable>
             <variable item="Bank C Sound Setting 3" CV="906.1021=2">
                 <decVal/>
                 <label>Maximum Random Period</label>
                 <label xml:lang="de">Maximale Zufallszeit</label>
                 <label xml:lang="nl">Max. toevalstijd</label>
+                <tooltip>Until what time (maximum) should a random sound be played? (how often = combination with Min. Rand.Per)</tooltip>
+                <tooltip xml:lang="de">bis zu welcher Zeit soll ein Zufallsgeräusch abgespielt werden? (wie häufig - Kombination mit Mind. Zufallszeit)</tooltip>
             </variable>
             <variable item="Bank C Sound Setting 4" CV="907.1021=2">
                 <decVal/>
@@ -1410,22 +1414,217 @@
                 <label>Soundfader Function</label>
                 <label xml:lang="de">Funktionstaste für Soundfader</label>
                 <label xml:lang="nl">Functieknop voor Soundfader</label>
+                <tooltip>Function mapping for Soundfader</tooltip>
             </variable>
             <variable item="Bank C Sound Setting 7" CV="911.1021=2">
                 <xi:include href="http://jmri.org/xml/decoders/uhlenbrock/enumFunctionChoiceOff255.xml"/>
                 <label>Volume Control Function</label>
                 <label xml:lang="de">Funktion für Soundfader</label>
                 <label xml:lang="nl">Functieknop voor Volumeregelaar</label>
+                <tooltip>Function mapping for Volume Control</tooltip>
             </variable>
-            <!--TODO CV 900.3-939.3-->
+            <!-- CV 900.3-939.3-->
+            <!-- Piko Info: Fahrstufenschwellen 0-255 für Schaltgeräusche, z.B. das Getriebeschalten eines -->
+            <!-- Schienenbusses o. die Schützschaltung für eine Altbau E-Lok/speed steps for sound effects in the model-->
             <variable item="Bank D Sound Setting 1" CV="900.1021=3">
                 <decVal/>
+                <tooltip>At which Speed Step should Switch Sound #1 be activated?</tooltip>
+                <tooltip xml:lang="de">Bei welchen Fahrstufe soll Schaltgeräusch #1 abgespielt werden?</tooltip>
             </variable>
-            <!--TODO CV 900.4-939.4-->
-            <variable item="Bank E Sound Setting 1" CV="900.1021=4">
+            <variable item="Bank D Sound Setting 2" CV="901.1021=3">
                 <decVal/>
             </variable>
-            <!--CVs 900.8-939.8-->
+            <variable item="Bank D Sound Setting 3" CV="902.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 4" CV="903.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 5" CV="904.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 6" CV="905.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 7" CV="906.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 8" CV="907.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 9" CV="908.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 10" CV="909.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 11" CV="910.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 12" CV="911.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 13" CV="912.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 14" CV="913.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 15" CV="914.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 16" CV="915.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 17" CV="916.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 18" CV="917.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 19" CV="918.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 20" CV="919.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 21" CV="920.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 22" CV="921.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 23" CV="922.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 24" CV="923.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 25" CV="924.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 26" CV="925.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 27" CV="926.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 28" CV="927.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 29" CV="928.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 30" CV="929.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 31" CV="930.1021=3">
+                <decVal/>
+            </variable>
+            <variable item="Bank D Sound Setting 32" CV="931.1021=3">
+                <decVal/>
+            </variable>
+            <!-- CV 900.4-931.4-->
+            <!-- Piko Info: Lautstärken 0-255 der Einzelgeräusche -->
+            <variable item="Bank E Sound Setting 1" CV="900.1021=4">
+                <decVal/>
+                <tooltip>Sound Slot #1 Volume</tooltip>
+                <tooltip xml:lang="de">Sound Slot #1 Lautstärke</tooltip>
+            </variable>
+            <variable item="Bank E Sound Setting 2" CV="901.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 3" CV="902.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 4" CV="903.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 5" CV="904.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 6" CV="905.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 7" CV="906.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 8" CV="907.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 9" CV="908.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 10" CV="909.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 11" CV="910.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 12" CV="911.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 13" CV="912.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 14" CV="913.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 15" CV="914.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 16" CV="915.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 17" CV="916.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 18" CV="917.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 19" CV="918.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 20" CV="919.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 21" CV="920.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 22" CV="921.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 23" CV="922.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 24" CV="923.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 25" CV="924.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 26" CV="925.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 27" CV="926.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 28" CV="927.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 29" CV="928.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 30" CV="929.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 31" CV="930.1021=4">
+                <decVal/>
+            </variable>
+            <variable item="Bank E Sound Setting 32" CV="931.1021=4">
+                <decVal/>
+            </variable>
+        <!--CVs 900.8-939.8-->
             <!--<group>-->
                 <!--<qualifier>-->
                     <!--<variableref>Bank_Switch</variableref>-->

--- a/xml/decoders/uhlenbrock/PaneExtendedFmap.xml
+++ b/xml/decoders/uhlenbrock/PaneExtendedFmap.xml
@@ -94,6 +94,8 @@
                   <griditem gridx="26" gridy="0" gridwidth="1" anchor="CENTER"><label><text>F26</text></label></griditem>
                   <griditem gridx="27" gridy="0" gridwidth="1" anchor="CENTER"><label><text>F27</text></label></griditem>
                   <griditem gridx="28" gridy="0" gridwidth="1" anchor="CENTER"><label><text>F28</text></label></griditem>
+                  <!-- TODO add F29 - F44 for Piko 56400/56401)-->
+
                   <!-- BEGIN - Row 2 (Slot 1)-->
                   <griditem gridx="0" gridy="1" anchor="LINE_END">
                       <display item="Z1 F0 Cond On" format="checkbox">
@@ -186,6 +188,7 @@
                   <griditem gridx="28" gridy="1" anchor="CENTER">
                       <display item="Z1 F28 Cond On" format="checkbox" label=""/>
                   </griditem>
+                  <!-- TODO add F29 - F44 for Piko 56400/56401)-->
                   <!-- BEGIN - Row 2 (Slot 1)-->
                   <griditem gridx="0" gridy="2" anchor="LINE_END">
                       <display item="Z1 F0 Cond Off" format="checkbox">
@@ -278,6 +281,7 @@
                   <griditem gridx="28" gridy="2" anchor="CENTER">
                       <display item="Z1 F28 Cond Off" format="checkbox" label=""/>
                   </griditem>
+                  <!-- TODO add F29 - F44 for Piko 56400/56401)-->
               </grid>
             <!--end Grid-->
         </row>
@@ -508,6 +512,8 @@
                   <griditem gridx="26" gridy="0" gridwidth="1" anchor="CENTER"><label><text>F26</text></label></griditem>
                   <griditem gridx="27" gridy="0" gridwidth="1" anchor="CENTER"><label><text>F27</text></label></griditem>
                   <griditem gridx="28" gridy="0" gridwidth="1" anchor="CENTER"><label><text>F28</text></label></griditem>
+                  <!-- TODO add F29 - F44 for Piko 56400/56401)-->
+
                   <!-- BEGIN - Row 2 (Slot 1)-->
                   <griditem gridx="0" gridy="1" anchor="LINE_END">
                       <display item="Z2 F0 Cond On" format="checkbox">
@@ -600,6 +606,8 @@
                   <griditem gridx="28" gridy="1" anchor="CENTER">
                       <display item="Z2 F28 Cond On" format="checkbox" label=""/>
                   </griditem>
+                  <!-- TODO add F29 - F44 for Piko 56400/56401)-->
+
                   <!-- BEGIN - Row 2 (Slot 1)-->
                   <griditem gridx="0" gridy="2" anchor="LINE_END">
                       <display item="Z2 F0 Cond Off" format="checkbox">
@@ -692,6 +700,7 @@
                   <griditem gridx="28" gridy="2" anchor="CENTER">
                       <display item="Z2 F28 Cond Off" format="checkbox" label=""/>
                   </griditem>
+                  <!-- TODO add F29 - F44 for Piko 56400/56401)-->
               </grid>
               <!--end Grid-->
           </row>

--- a/xml/decoders/uhlenbrock/PaneId2Advanced.xml
+++ b/xml/decoders/uhlenbrock/PaneId2Advanced.xml
@@ -19,7 +19,7 @@
             <authorinitials>EB</authorinitials>
             <revremark>Initial version, adapted from Uhlenbrock/soundPane7outputs.xml</revremark>
         </revision>
-        <!-- Valid only for certain Uhlenbrock decoders with IntelliDrive2, Piko Sound 4.1 (non exhaustive list) -->
+        <!-- Valid only for certain Uhlenbrock decoders with IntelliDrive2, Piko Smart 4.1/Sound 4.1 (non exhaustive list) -->
     </revhistory>
 
     <name>IntelliDrive2</name>

--- a/xml/decoders/uhlenbrock/SoundPaneId2.xml
+++ b/xml/decoders/uhlenbrock/SoundPaneId2.xml
@@ -100,9 +100,9 @@
       <column>
         <!--Bank 3-->
         <label>
-          <text>Speed Step for Switching Sound</text>
+          <text>Speed Step activating Switching Sound</text>
           <text xml:lang="de">Fahrstufe für Schaltgerausch</text>
-          <text xml:lang="nl">Snelheidsstap voor Rangeergeluid</text>
+          <text xml:lang="nl">Snelheidsstap bij Schakelgeluid</text>
         </label>
         <row>
           <display item="Bank D Sound Setting 1" layout="above" label=""/>
@@ -110,6 +110,235 @@
             <text> </text>
           </label>
           <display item="Bank D Sound Setting 1" layout="above" label="#1" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 2" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 2" layout="above" label="#2" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 3" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 3" layout="above" label="#3" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 4" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 4" layout="above" label="#4" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 5" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 5" layout="above" label="#5" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 6" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 6" layout="above" label="#6" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 7" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 7" layout="above" label="#7" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 8" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 8" layout="above" label="#8" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 9" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 9" layout="above" label="#9" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 10" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 10" layout="above" label="#10" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 11" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 11" layout="above" label="#11" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 12" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 12" layout="above" label="#12" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 13" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 13" layout="above" label="#13" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 14" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 14" layout="above" label="#14" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 15" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 15" layout="above" label="#15" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 16" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 16" layout="above" label="#16" format="hslider"/>
+        </row>
+      </column>
+
+      <column>
+        <label>
+          <text>     </text>
+        </label>
+      </column>
+
+      <column>
+        <label>
+          <text>     </text>
+        </label>
+        <row>
+          <display item="Bank D Sound Setting 17" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 17" layout="above" label="#17" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 18" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 18" layout="above" label="#18" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 19" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 19" layout="above" label="#19" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 20" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 20" layout="above" label="#20" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 21" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 21" layout="above" label="#21" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 22" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 22" layout="above" label="#22" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 23" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 23" layout="above" label="#23" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 24" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 24" layout="above" label="#24" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 25" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 25" layout="above" label="#25" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 26" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 26" layout="above" label="#26" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 27" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 27" layout="above" label="#27" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 28" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 28" layout="above" label="#28" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 29" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 29" layout="above" label="#29" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 30" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 30" layout="above" label="#30" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 31" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 31" layout="above" label="#31" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank D Sound Setting 32" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank D Sound Setting 32" layout="above" label="#32" format="hslider"/>
         </row>
       </column>
     </group>
@@ -123,8 +352,8 @@
       <column>
         <!--Bank 4-->
         <label>
-          <text>Volume for Soundslot</text>
-          <text xml:lang="de">Lautstärke für Soundslot</text>
+          <text>Volume for each Sound Slot</text>
+          <text xml:lang="de">Lautstärke für jedes Soundslot</text>
           <text xml:lang="nl">Volume per Soundslot</text>
         </label>
         <row>
@@ -133,6 +362,235 @@
             <text> </text>
           </label>
           <display item="Bank E Sound Setting 1" layout="above" label="#1" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 2" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 2" layout="above" label="#2" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 3" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 3" layout="above" label="#3" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 4" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 4" layout="above" label="#4" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 5" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 5" layout="above" label="#5" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 6" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 6" layout="above" label="#6" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 7" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 7" layout="above" label="#7" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 8" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 8" layout="above" label="#8" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 9" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 9" layout="above" label="#9" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 10" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 10" layout="above" label="#10" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 11" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 11" layout="above" label="#11" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 12" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 12" layout="above" label="#12" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 13" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 13" layout="above" label="#13" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 14" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 14" layout="above" label="#14" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 15" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 15" layout="above" label="#15" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 16" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 16" layout="above" label="#16" format="hslider"/>
+        </row>
+      </column>
+
+      <column>
+        <label>
+          <text>     </text>
+        </label>
+      </column>
+
+      <column>
+        <label>
+          <text>     </text>
+        </label>
+        <row>
+          <display item="Bank E Sound Setting 17" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 17" layout="above" label="#17" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 18" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 18" layout="above" label="#18" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 19" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 19" layout="above" label="#19" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 20" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 20" layout="above" label="#20" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 21" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 21" layout="above" label="#21" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 22" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 22" layout="above" label="#22" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 23" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 23" layout="above" label="#23" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 24" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 24" layout="above" label="#24" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 25" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 25" layout="above" label="#25" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 26" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 26" layout="above" label="#26" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 27" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 27" layout="above" label="#27" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 28" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 28" layout="above" label="#28" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 29" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 29" layout="above" label="#29" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 30" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 30" layout="above" label="#30" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 31" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 31" layout="above" label="#31" format="hslider"/>
+        </row>
+        <row>
+          <display item="Bank E Sound Setting 32" layout="above" label=""/>
+          <label>
+            <text> </text>
+          </label>
+          <display item="Bank E Sound Setting 32" layout="above" label="#32" format="hslider"/>
         </row>
       </column>
     </group>

--- a/xml/decoders/uhlenbrock/SoundPaneId2.xml
+++ b/xml/decoders/uhlenbrock/SoundPaneId2.xml
@@ -9,6 +9,13 @@
   <name xml:lang="it">Suoni</name>
   <name xml:lang="nl">Geluid</name>
 
+  <group include="PIKO56400,PIKO56401">
+    <label>
+      <text>Sound not available in this Piko SmartDecoder 4.1</text>
+    </label>
+  </group>
+
+  <group exclude="PIKO56400,PIKO56401">
   <column>
     <row>
       <display item="Bank_Switch"/>
@@ -636,5 +643,8 @@
         <display item="Bank F F28 activated sound"/>
       </column>
     </group>
+
+  <!--    end of SmartDecoder Sound vars group-->
+  </group>
 
 </pane>


### PR DESCRIPTION
Adds Piko 5640x non-sound decoders, otherwise identical to Uhlenbrock 73xxx
and expands Piko 4.1 sound CV900-931 based on Piko Support supplied information.