### PR TITLE
Fix: SimpleClockFrame only updates changed properties

### DIFF
--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/java/.settings/Debug PanelPro.launch
+++ b/java/.settings/Debug PanelPro.launch
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/jmri/java/src/apps/PanelPro/PanelPro.java"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.ui.favoriteGroups">
-<listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="apps.PanelPro.PanelPro"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-Djava.security.policy=${project_path}/lib/security.policy -Dapple.laf.useScreenMenuBar=true -Dapple.awt.graphics.UseQuartz=true -Dapple.awt.graphics.EnableQ2DX=true -Dlog4j.ignoreTCL=true -Dfile.encoding=UTF-8 -Djinput.plugins=net.bobis.jinput.hidraw.HidRawEnvironmentPlugin -Dpurejavacomm.loglevel=0 PanelProConfig2.xml"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="jmri"/>
-<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms256m -Xmx640m"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/jmri/java/src/apps/PanelPro/PanelPro.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+        <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="apps.PanelPro.PanelPro"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-Djava.security.policy=${project_path}/lib/security.policy -Dapple.laf.useScreenMenuBar=true -Dapple.awt.graphics.UseQuartz=true -Dapple.awt.graphics.EnableQ2DX=true -Dlog4j.ignoreTCL=true -Dfile.encoding=UTF-8 -Djinput.plugins=net.bobis.jinput.hidraw.HidRawEnvironmentPlugin -Dpurejavacomm.loglevel=0 PanelProConfig2.xml"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="jmri"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms256m -Xmx640m"/>
 </launchConfiguration>

--- a/java/.settings/JMRI Tests.launch
+++ b/java/.settings/JMRI Tests.launch
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/jmri/java/test"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="2"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.ui.favoriteGroups">
-<listEntry value="org.eclipse.eclemma.ui.launchGroup.coverage"/>
-<listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
-</listAttribute>
-<listAttribute key="org.eclipse.eclemma.core.SCOPE_IDS">
-<listEntry value="=jmri/target\/generated-sources\/javacc"/>
-<listEntry value="=jmri/target\/generated-sources\/jjtree"/>
-<listEntry value="=jmri/java\/src"/>
-<listEntry value="=jmri/java\/maven-template"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=jmri/java\/test"/>
-<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
-<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
-<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
-<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="jmri"/>
-<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/jmri/java/test"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="2"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+        <listEntry value="org.eclipse.eclemma.ui.launchGroup.coverage"/>
+        <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.eclemma.core.SCOPE_IDS">
+        <listEntry value="=jmri/target\/generated-sources\/javacc"/>
+        <listEntry value="=jmri/target\/generated-sources\/jjtree"/>
+        <listEntry value="=jmri/java\/src"/>
+        <listEntry value="=jmri/java\/maven-template"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=jmri/java\/test"/>
+    <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="jmri"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
 </launchConfiguration>

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
@@ -5,6 +5,9 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
+import java.awt.event.WindowEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.text.DecimalFormat;
 import java.util.Date;
 
@@ -36,8 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dave Duchamp Copyright (C) 2004, 2007
  */
-public class SimpleClockFrame extends JmriJFrame
-        implements java.beans.PropertyChangeListener {
+public class SimpleClockFrame extends JmriJFrame implements PropertyChangeListener {
 
     private Timebase clock;
     private String hardwareName = null;
@@ -131,9 +133,9 @@ public class SimpleClockFrame extends JmriJFrame
             timeSourceBox.addItem(hardwareName);
         }
         timeSourceBox.setToolTipText(Bundle.getMessage("TipTimeSource"));
-        timeSourceBox.addActionListener(new java.awt.event.ActionListener() {
+        timeSourceBox.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 setTimeSourceChanged();
             }
         });
@@ -149,9 +151,9 @@ public class SimpleClockFrame extends JmriJFrame
                     + hardwareName);
             synchronizeCheckBox.setToolTipText(Bundle.getMessage("TipSynchronize"));
             synchronizeCheckBox.setSelected(clock.getSynchronize());
-            synchronizeCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            synchronizeCheckBox.addActionListener(new ActionListener() {
                 @Override
-                public void actionPerformed(java.awt.event.ActionEvent e) {
+                public void actionPerformed(ActionEvent e) {
                     synchronizeChanged();
                 }
             });
@@ -162,9 +164,9 @@ public class SimpleClockFrame extends JmriJFrame
                 correctCheckBox = new JCheckBox(Bundle.getMessage("Correct"));
                 correctCheckBox.setToolTipText(Bundle.getMessage("TipCorrect"));
                 correctCheckBox.setSelected(clock.getCorrectHardware());
-                correctCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                correctCheckBox.addActionListener(new ActionListener() {
                     @Override
-                    public void actionPerformed(java.awt.event.ActionEvent e) {
+                    public void actionPerformed(ActionEvent e) {
                         correctChanged();
                     }
                 });
@@ -176,9 +178,9 @@ public class SimpleClockFrame extends JmriJFrame
                 displayCheckBox = new JCheckBox(Bundle.getMessage("Display12Hour"));
                 displayCheckBox.setToolTipText(Bundle.getMessage("TipDisplay"));
                 displayCheckBox.setSelected(clock.use12HourDisplay());
-                displayCheckBox.addActionListener(new java.awt.event.ActionListener() {
+                displayCheckBox.addActionListener(new ActionListener() {
                     @Override
-                    public void actionPerformed(java.awt.event.ActionEvent e) {
+                    public void actionPerformed(ActionEvent e) {
                         displayChanged();
                     }
                 });
@@ -195,9 +197,9 @@ public class SimpleClockFrame extends JmriJFrame
         factorField.setToolTipText(Bundle.getMessage("TipFactorField"));
         panel12.add(new JLabel(":1 "));
         setRateButton.setToolTipText(Bundle.getMessage("TipSetRateButton"));
-        setRateButton.addActionListener(new java.awt.event.ActionListener() {
+        setRateButton.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 setRateButtonActionPerformed();
             }
         });
@@ -215,9 +217,9 @@ public class SimpleClockFrame extends JmriJFrame
         minutesField.setText("00");
         minutesField.setToolTipText(Bundle.getMessage("TipMinutesField"));
         setTimeButton.setToolTipText(Bundle.getMessage("TipSetTimeButton"));
-        setTimeButton.addActionListener(new java.awt.event.ActionListener() {
+        setTimeButton.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 setTimeButtonActionPerformed();
             }
         });
@@ -261,9 +263,9 @@ public class SimpleClockFrame extends JmriJFrame
         startSetTimeCheckBox = new JCheckBox(Bundle.getMessage("StartSetTime"));
         startSetTimeCheckBox.setToolTipText(Bundle.getMessage("TipStartSetTime"));
         startSetTimeCheckBox.setSelected(clock.getStartSetTime());
-        startSetTimeCheckBox.addActionListener(new java.awt.event.ActionListener() {
+        startSetTimeCheckBox.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 startSetTimeChanged();
             }
         });
@@ -277,9 +279,9 @@ public class SimpleClockFrame extends JmriJFrame
         startMinutesField.setToolTipText(Bundle.getMessage("TipStartMinutes"));
         panel62.add(startMinutesField);
         setStartTimeButton.setToolTipText(Bundle.getMessage("TipSetStartTimeButton"));
-        setStartTimeButton.addActionListener(new java.awt.event.ActionListener() {
+        setStartTimeButton.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 startSetTimeChanged();
             }
         });
@@ -290,9 +292,9 @@ public class SimpleClockFrame extends JmriJFrame
         startSetRateCheckBox = new JCheckBox(Bundle.getMessage("StartSetSpeedUpFactor") + " ");
         startSetRateCheckBox.setToolTipText(Bundle.getMessage("TipStartSetRate"));
         startSetRateCheckBox.setSelected(clock.getSetRateAtStart());
-        startSetRateCheckBox.addActionListener(new java.awt.event.ActionListener() {
+        startSetRateCheckBox.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 startSetRateChanged();
             }
         });
@@ -340,9 +342,9 @@ public class SimpleClockFrame extends JmriJFrame
             }
         }
         clockStartBox.setToolTipText(Bundle.getMessage("TipClockStartOption"));
-        clockStartBox.addActionListener(new java.awt.event.ActionListener() {
+        clockStartBox.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 setClockStartChanged();
             }
         });
@@ -350,9 +352,9 @@ public class SimpleClockFrame extends JmriJFrame
         JPanel panel64 = new JPanel();
         displayStartStopButton= new JCheckBox(Bundle.getMessage("DisplayOnOff"));
         displayStartStopButton.setSelected(clock.getShowStopButton());
-        displayStartStopButton.addActionListener(new java.awt.event.ActionListener() {
+        displayStartStopButton.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 showStopButtonChanged();
             }
         });
@@ -373,17 +375,17 @@ public class SimpleClockFrame extends JmriJFrame
         panel31.add(clockStatus);
         // Set up Start and Stop buttons
         startButton.setToolTipText(Bundle.getMessage("TipStartButton"));
-        startButton.addActionListener(new java.awt.event.ActionListener() {
+        startButton.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 startButtonActionPerformed();
             }
         });
         panel31.add(startButton);
         stopButton.setToolTipText(Bundle.getMessage("TipStopButton"));
-        stopButton.addActionListener(new java.awt.event.ActionListener() {
+        stopButton.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 stopButtonActionPerformed();
             }
         });
@@ -406,16 +408,16 @@ public class SimpleClockFrame extends JmriJFrame
         JPanel panel4 = new JPanel();
         panel4.setLayout(new BoxLayout(panel4, BoxLayout.X_AXIS));
         panel4.add(cancelButton);
-        cancelButton.addActionListener(new java.awt.event.ActionListener() {
+        cancelButton.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 cancelButtonActionPerformed();
             }
         });
         panel4.add(applyCloseButton);
-        applyCloseButton.addActionListener(new java.awt.event.ActionListener() {
+        applyCloseButton.addActionListener(new ActionListener() {
             @Override
-            public void actionPerformed(java.awt.event.ActionEvent e) {
+            public void actionPerformed(ActionEvent e) {
                 saveButtonActionPerformed();
             }
         });
@@ -439,14 +441,6 @@ public class SimpleClockFrame extends JmriJFrame
 
         // listen for changes to the timebase parameters
         clock.addPropertyChangeListener(this);
-
-        // request callback to update time
-        clock.addMinuteChangeListener(new java.beans.PropertyChangeListener() {
-            @Override
-            public void propertyChange(java.beans.PropertyChangeEvent e) {
-                updateTime();
-            }
-        });
 
         return;
     }
@@ -771,9 +765,20 @@ public class SimpleClockFrame extends JmriJFrame
      * Handle a change to clock properties
      */
     @Override
-    public void propertyChange(java.beans.PropertyChangeEvent e) {
-        updateRunningButton();
-        updateRate();
+    public void propertyChange(PropertyChangeEvent event) {
+        switch (event.getPropertyName()) {
+            case "run":
+                updateRunningButton();
+                break;
+            case "rate":
+                updateRate();
+                break;
+            case "time":
+                updateTime();
+                break;
+            default:
+                // ignore all other properties
+        }
     }
 
     @Override
@@ -826,7 +831,7 @@ public class SimpleClockFrame extends JmriJFrame
      * Handle window closing event.
      */
     @Override
-    public void windowClosing(java.awt.event.WindowEvent e) {
+    public void windowClosing(WindowEvent e) {
         if (changed) {
             // remind to save  
             javax.swing.JOptionPane.showMessageDialog(null,

--- a/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
@@ -9,6 +9,7 @@ import java.awt.event.WindowEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.text.DecimalFormat;
+import java.util.Calendar;
 import java.util.Date;
 
 import javax.annotation.CheckForNull;
@@ -101,7 +102,6 @@ public class SimpleClockFrame extends JmriJFrame implements PropertyChangeListen
     /**
      * Initialize the Clock config window.
      */
-    @SuppressWarnings("deprecation")
     @Override
     public void initComponents() {
         setTitle(Bundle.getMessage("SimpleClockWindowTitle"));
@@ -270,12 +270,13 @@ public class SimpleClockFrame extends JmriJFrame implements PropertyChangeListen
             }
         });
         panel62.add(startSetTimeCheckBox);
-        Date tem = clock.getStartTime();
-        startHoursField.setText("" + tem.getHours());
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(clock.getStartTime());
+        startHoursField.setText("" + cal.get(Calendar.HOUR_OF_DAY));
         startHoursField.setToolTipText(Bundle.getMessage("TipStartHours"));
         panel62.add(startHoursField);
         panel62.add(new JLabel(":"));
-        startMinutesField.setText("" + tem.getMinutes());
+        startMinutesField.setText("" + cal.get(Calendar.MINUTE));
         startMinutesField.setToolTipText(Bundle.getMessage("TipStartMinutes"));
         panel62.add(startMinutesField);
         setStartTimeButton.setToolTipText(Bundle.getMessage("TipSetStartTimeButton"));
@@ -587,7 +588,6 @@ public class SimpleClockFrame extends JmriJFrame implements PropertyChangeListen
     /**
      * Handle Set Time button
      */
-    @SuppressWarnings("deprecation")
     public void setTimeButtonActionPerformed() {
         int hours = 0;
         int minutes = 0;
@@ -622,9 +622,10 @@ public class SimpleClockFrame extends JmriJFrame implements PropertyChangeListen
         // set time of the fast clock
         long mSecPerHour = 3600000;
         long mSecPerMinute = 60000;
-        Date tem = clock.getTime();
-        int cHours = tem.getHours();
-        long cNumMSec = tem.getTime();
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(clock.getTime());
+        int cHours = cal.get(Calendar.HOUR_OF_DAY);
+        long cNumMSec = cal.getTime().getTime();
         long nNumMSec = ((cNumMSec / mSecPerHour) * mSecPerHour) - (cHours * mSecPerHour)
                 + (hours * mSecPerHour) + (minutes * mSecPerMinute);
         clock.userSetTime(new Date(nNumMSec));
@@ -697,9 +698,9 @@ public class SimpleClockFrame extends JmriJFrame implements PropertyChangeListen
         // set time of the fast clock
         long mSecPerHour = 3600000;
         long mSecPerMinute = 60000;
-        Date tem = clock.getTime();
-        int cHours = tem.getHours();
-        long cNumMSec = tem.getTime();
+        Calendar cal = Calendar.getInstance();
+        int cHours = cal.get(Calendar.HOUR_OF_DAY);
+        long cNumMSec = cal.getTime().getTime();
         long nNumMSec = ((cNumMSec / mSecPerHour) * mSecPerHour) - (cHours * mSecPerHour)
                 + (hours * mSecPerHour) + (minutes * mSecPerMinute);
         clock.setStartSetTime(startSetTimeCheckBox.isSelected(), new Date(nNumMSec));
@@ -750,12 +751,12 @@ public class SimpleClockFrame extends JmriJFrame implements PropertyChangeListen
     /**
      * Set the current Timebase time into timeLabel
      */
-    @SuppressWarnings("deprecation")
     void setTimeLabel() {
         // Get time
-        Date now = clock.getTime();
-        int hours = now.getHours();
-        int minutes = now.getMinutes();
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(clock.getTime());
+        int hours = cal.get(Calendar.HOUR_OF_DAY);
+        int minutes = cal.get(Calendar.MINUTE);
         // Format and display the time
         timeLabel.setText(" " + (hours / 10) + (hours - (hours / 10) * 10) + ":"
                 + (minutes / 10) + (minutes - (minutes / 10) * 10));

--- a/java/src/jmri/swing/EditableList.java
+++ b/java/src/jmri/swing/EditableList.java
@@ -1,6 +1,5 @@
 package jmri.swing;
 
-import java.applet.Applet;
 import java.awt.Component;
 import java.awt.KeyboardFocusManager;
 import java.awt.Point;
@@ -176,8 +175,7 @@ public class EditableList<E> extends JList<E> implements CellEditorListener {
                 if (c == EditableList.this) {
                     // focus remains inside the table
                     return;
-                } else if ((c instanceof Window)
-                        || (c instanceof Applet && c.getParent() == null)) {
+                } else if (c instanceof Window) {
                     if (c == SwingUtilities.getRoot(EditableList.this)) {
                         if (!getListCellEditor().stopCellEditing()) {
                             getListCellEditor().cancelCellEditing();

--- a/java/test/jmri/implementation/SignalSystemTestUtil.java
+++ b/java/test/jmri/implementation/SignalSystemTestUtil.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
 import jmri.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,14 +34,12 @@ public class SignalSystemTestUtil {
             {
                 Path inPath = new File(new File(FileUtil.getProgramPath(), "java/test/jmri/implementation"), "testAspects.xml").toPath();
                 Path outPath = new File(dummy, "aspects.xml").toPath();
-                new File(dummy, "aspects.xml").delete();  // in case left over
-                Files.copy(inPath, outPath);
+                Files.copy(inPath, outPath, StandardCopyOption.REPLACE_EXISTING);
             }
             {
                 Path inPath = new File(new File(FileUtil.getProgramPath(), "java/test/jmri/implementation"), "test-appearance-one-searchlight.xml").toPath();
                 Path outPath = new File(dummy, "appearance-one-searchlight.xml").toPath();
-                new File(dummy, "appearance-one-searchlight.xml").delete();  // in case left over
-                Files.copy(inPath, outPath);
+                Files.copy(inPath, outPath, StandardCopyOption.REPLACE_EXISTING);
             }
         } catch (IOException e) {
             log.error("Exception during createMockSystem", e);


### PR DESCRIPTION
Fix #6821 by ensuring the SimpleClockFrame only updates UI elements changed by a changed property when listening to changes in SimpleTimeBase.

Also removes use of some deprecated methods.