### PR TITLE
Jacoco recursion

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1551,7 +1551,7 @@
 
     </target>
 
-    <target name="logalltest" depends="tests, runtime-library-selection" description="run headless test suite">
+    <target name="logalltest" depends="tests, runtime-library-selection" description="run headless test suite with jacaco output">
         <jacoco:coverage destfile="${jacocoexec}" excludes="org.slf4j.*">
 
         <junit haltonerror="false" haltonfailure="false" showoutput="yes" printsummary="withOutAndErr" fork="yes" dir="." timeout="3600000">
@@ -1580,7 +1580,17 @@
     </target>
 
 
-    <target name="alltest-coveragereport" depends="logalltest" description="Generate Test Coverage Report from logalltest">
+    <target name="alltest-coveragereport" depends="logalltest, coveragereport" description="Generate Test Coverage Report from logalltest" />
+
+    <target name="alltest-coveragecheck" depends="logalltest, coveragecheck" description="Test Coverage check from logalltest" />
+
+    <target name="ci-test-travis-coveragecheck" depends="ci-test-travis, coveragecheck" description="Test Coverage check from logalltest for Appveyor" />
+
+    <target name="ci-test-appveyor-coveragecheck" depends="ci-test-appveyor, coveragecheck" description="Test Coverage check from logalltest for Travis" />
+
+    <!-- end of test execution targets -->
+
+    <target name="coveragereport" description="Generate Test Coverage Report from existing jacoco.exe file">
     <!-- Generate Code Coverage report
     See: http://www.eclemma.org/jacoco/trunk/doc/ant.html -->
        <jacoco:report>
@@ -1600,7 +1610,7 @@
        </jacoco:report>
     </target>
 
-    <target name="alltest-coveragecheck" depends="logalltest" description="Test Coverage check from logalltest">
+    <target name="coveragecheck" description="Check test results in existing jacoco.exe file">
     <!-- Generate Code Coverage report
     See: http://www.eclemma.org/jacoco/trunk/doc/ant.html -->
        <jacoco:report>
@@ -1628,66 +1638,6 @@
           </check>
        </jacoco:report>
     </target>
-
-    <target name="ci-test-travis-coveragecheck" depends="ci-test-travis" description="Test Coverage check from logalltest">
-    <!-- Generate Code Coverage report
-    See: http://www.eclemma.org/jacoco/trunk/doc/ant.html -->
-       <jacoco:report>
-          <executiondata>
-              <file file="${jacocoexec}" />
-          </executiondata>
-
-          <structure name="AntTestReporting">
-              <classfiles>
-                 <fileset refid="jacocofileset"/>
-              </classfiles>
-          </structure>
-
-          <check>
-              <rule>
-                  <limit counter="LINE" value="COVEREDRATIO" minimum="0.50"/>
-                  <limit counter="CLASS" value="COVEREDRATIO" minimum="0.80"/>
-              </rule>
-              <rule element="PACKAGE">
-                 <limit counter="CLASS" value="COVEREDCOUNT" minimum="1"/>
-              </rule>
-              <rule element="SOURCEFILE">
-                 <limit counter="LINE" value="COVEREDCOUNT" minimum="1"/>
-              </rule>
-          </check>
-       </jacoco:report>
-    </target>
-
-    <target name="ci-test-appveyor-coveragecheck" depends="ci-test-appveyor" description="Test Coverage check from logalltest">
-    <!-- Generate Code Coverage report
-    See: http://www.eclemma.org/jacoco/trunk/doc/ant.html -->
-       <jacoco:report>
-          <executiondata>
-              <file file="${jacocoexec}" />
-          </executiondata>
-
-          <structure name="AntTestReporting">
-              <classfiles>
-                 <fileset refid="jacocofileset"/>
-              </classfiles>
-          </structure>
-
-          <check>
-              <rule>
-                  <limit counter="LINE" value="COVEREDRATIO" minimum="0.50"/>
-                  <limit counter="CLASS" value="COVEREDRATIO" minimum="0.80"/>
-              </rule>
-              <rule element="PACKAGE">
-                 <limit counter="CLASS" value="COVEREDCOUNT" minimum="1"/>
-              </rule>
-              <rule element="SOURCEFILE">
-                 <limit counter="LINE" value="COVEREDCOUNT" minimum="1"/>
-              </rule>
-          </check>
-       </jacoco:report>
-    </target>
-
-    <!-- end of test execution targets -->
 
     <!-- ============================================================================= -->
     <!-- Distribution build targets                                                    -->

--- a/java/src/jmri/util/JTextPaneAppender.java
+++ b/java/src/jmri/util/JTextPaneAppender.java
@@ -1,6 +1,7 @@
 package jmri.util;
 
 import java.awt.Color;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import javax.swing.JTextPane;
@@ -122,15 +123,24 @@ public class JTextPaneAppender extends AppenderSkeleton {
         }
         final String text = temp;
 
-        jmri.util.ThreadingUtil.runOnGUI( ()->{ 
-            try {
-                StyledDocument myDoc = myTextPane.getStyledDocument();
-                myDoc.insertString(myDoc.getLength(), text, myAttributeSet.get(event.getLevel().toString()));
-                myTextPane.setCaretPosition(myDoc.getLength());
-            } catch (BadLocationException badex) {
-                System.err.println(badex);  // can't log this, as it would be recursive error
-            }
-        } ); 
+        // The following can't be jmri.util.ThreadingUtil.runOnGUI(..) because
+        // that's a recursive logging loop
+        try {
+            javax.swing.SwingUtilities.invokeAndWait(() -> {
+                try {
+                    StyledDocument myDoc = myTextPane.getStyledDocument();
+                    myDoc.insertString(myDoc.getLength(), text, myAttributeSet.get(event.getLevel().toString()));
+                    myTextPane.setCaretPosition(myDoc.getLength());
+                } catch (BadLocationException badex) {
+                    System.err.println(badex);  // can't log this, as it would be recursive error
+                }
+            } ); 
+        } catch (InterruptedException e) {
+            System.err.println("JTextPaneAppender interrupted while doing logging on GUI thread"); // can't log this, as it would be recursive error
+            Thread.currentThread().interrupt();
+        } catch (InvocationTargetException e) {
+            System.err.println("JTextPaneAppender error while logging on GUI thread: "+e.getCause()); // can't log this, as it would be recursive error
+        }
     }
 
     /**

--- a/tests.lcf
+++ b/tests.lcf
@@ -23,7 +23,8 @@ log4j.rootCategory= WARN, R, J
 log4j.category.jmri=WARN
 
 # The R appender writes all logging output to the tests.log
-# file. This is where your debug output will appear.
+# file. This includes messages that the tests have intentionally
+# suppressed, so it's quite verbose.
 
 # The J appender is a JMRI-specific one, configured so that JMRI tests
 # can examine their output. Changing the levels or 


### PR DESCRIPTION
Fixes a deep recursion in logging that was surfaced by JaCoCo runs (which have different errors, hence different logging)

Also, cleans up duplication in build.xml for JaCoCo targets
