### PR TITLE
Fix: Use SystemNames for Sensors in MultiSensorIcon in web panel

### DIFF
--- a/java/src/jmri/jmrit/display/MultiSensorIcon.java
+++ b/java/src/jmri/jmrit/display/MultiSensorIcon.java
@@ -5,6 +5,8 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+
 import javax.swing.AbstractAction;
 import javax.swing.JPopupMenu;
 import jmri.InstanceManager;
@@ -97,6 +99,14 @@ public class MultiSensorIcon extends PositionableLabel implements java.beans.Pro
 
     public int getNumEntries() {
         return entries.size();
+    }
+
+    public List<Sensor> getSensors() {
+        ArrayList<Sensor> list = new ArrayList<>(getNumEntries());
+        for (Entry handle : entries) {
+            list.add(handle.namedSensor.getBean());
+        }
+        return list;
     }
 
     public String getSensorName(int i) {

--- a/java/src/jmri/jmrit/display/configurexml/PositionableLabelXml.java
+++ b/java/src/jmri/jmrit/display/configurexml/PositionableLabelXml.java
@@ -161,10 +161,12 @@ public class PositionableLabelXml extends AbstractXmlAdapter {
         element.setAttribute("showtooltip", p.showToolTip() ? "true" : "false");
         element.setAttribute("editable", p.isEditable() ? "true" : "false");
         ToolTip tip = p.getToolTip();
-        String txt = tip.getText();
-        if (txt != null) {
-            Element elem = new Element("tooltip").addContent(txt); // was written as "toolTip" 3.5.1 and before
-            element.addContent(elem);
+        if (tip != null) {
+            String txt = tip.getText();
+            if (txt != null) {
+                Element elem = new Element("tooltip").addContent(txt); // was written as "toolTip" 3.5.1 and before
+                element.addContent(elem);
+            }
         }
         if (p.getDegrees() != 0) {
             element.setAttribute("degrees", "" + p.getDegrees());

--- a/java/src/jmri/server/json/JsonNamedBeanSocketService.java
+++ b/java/src/jmri/server/json/JsonNamedBeanSocketService.java
@@ -16,6 +16,8 @@ import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.NamedBean;
 import jmri.ReporterManager;
+import jmri.Manager.NameValidity;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,13 +47,13 @@ public class JsonNamedBeanSocketService<T extends NamedBean, H extends JsonNamed
         setLocale(locale);
         String name = data.path(NAME).asText();
         // protect against a request made with a user name instead of a system name
-        if (method != PUT) {
+        if (method != PUT && service.getManager().validSystemNameFormat(name) != NameValidity.VALID) {
             T bean = service.getManager().getBeanBySystemName(name);
             if (bean == null) {
-                // set to warn so users can provide specific feedback to developers of JSON clients 
-                log.warn("{} request for {} made with user name \"{}\"; should use system name", method, type, name);
                 bean = service.getManager().getBeanByUserName(name);
                 if (bean != null) {
+                    // set to warn so users can provide specific feedback to developers of JSON clients
+                    log.warn("{} request for {} made with user name \"{}\"; should use system name", method, type, name);
                     name = bean.getSystemName();
                 } // service will throw appropriate error to client later if bean is still null
             }

--- a/java/src/jmri/server/json/JsonNamedBeanSocketService.java
+++ b/java/src/jmri/server/json/JsonNamedBeanSocketService.java
@@ -47,7 +47,7 @@ public class JsonNamedBeanSocketService<T extends NamedBean, H extends JsonNamed
         setLocale(locale);
         String name = data.path(NAME).asText();
         // protect against a request made with a user name instead of a system name
-        if (method != PUT && service.getManager().validSystemNameFormat(name) != NameValidity.VALID) {
+        if (!method.equals(PUT) && service.getManager().validSystemNameFormat(name) != NameValidity.VALID) {
             T bean = service.getManager().getBeanBySystemName(name);
             if (bean == null) {
                 bean = service.getManager().getBeanByUserName(name);

--- a/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/AbstractPanelServlet.java
@@ -14,7 +14,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.util.List;
+
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -22,9 +25,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.swing.JComponent;
 import jmri.InstanceManager;
+import jmri.Sensor;
 import jmri.SignalMast;
 import jmri.SignalMastManager;
+import jmri.configurexml.ConfigXmlManager;
 import jmri.jmrit.display.Editor;
+import jmri.jmrit.display.MultiSensorIcon;
+import jmri.jmrit.display.Positionable;
 import jmri.server.json.JSON;
 import jmri.server.json.util.JsonUtilHttpService;
 import jmri.util.FileUtil;
@@ -299,5 +306,45 @@ public abstract class AbstractPanelServlet extends HttpServlet {
             icons.addContent(ea);
         }
         return icons;
+    }
+
+    protected Element positionableElement(@Nonnull Positionable sub) {
+        Element e = ConfigXmlManager.elementFromObject(sub);
+        if (e != null) {
+            switch (e.getName()) {
+                case "signalmasticon":
+                    e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"),
+                            e.getAttributeValue("imageset")));
+                    break;
+                case "multisensoricon":
+                    if (sub instanceof MultiSensorIcon) {
+                        List<Sensor> sensors = ((MultiSensorIcon) sub).getSensors();
+                        for (Element a : e.getChildren()) {
+                            String s = a.getAttributeValue("sensor");
+                            if (s != null) {
+                                for (Sensor sensor : sensors) {
+                                    if (s.equals(sensor.getUserName())) {
+                                        a.setAttribute("sensor", sensor.getSystemName());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    break;
+                default:
+                    // nothing to do
+            }
+            try {
+                e.setAttribute(JSON.ID, sub.getNamedBean().getSystemName());
+            } catch (NullPointerException ex) {
+                if (sub.getNamedBean() == null) {
+                    log.debug("{} {} does not have an associated NamedBean", e.getName(), e.getAttribute(JSON.NAME));
+                } else {
+                    log.debug("{} {} does not have a SystemName", e.getName(), e.getAttribute(JSON.NAME));
+                }
+            }
+            parsePortableURIs(e);
+        }
+        return e;
     }
 }

--- a/java/src/jmri/web/servlet/panel/ControlPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/ControlPanelServlet.java
@@ -4,10 +4,9 @@ import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.swing.JFrame;
-import jmri.configurexml.ConfigXmlManager;
+
 import jmri.jmrit.display.Positionable;
 import jmri.jmrit.display.controlPanelEditor.ControlPanelEditor;
-import jmri.server.json.JSON;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.output.Format;
@@ -64,23 +63,7 @@ public class ControlPanelServlet extends AbstractPanelServlet {
             for (Positionable sub : contents) {
                 if (sub != null) {
                     try {
-                        Element e = ConfigXmlManager.elementFromObject(sub);
-                        if (e != null) {
-                            if ("signalmasticon".equals(e.getName())) {  //insert icon details into signalmast
-                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"), e.getAttributeValue("imageset")));
-                            }
-                            try {
-                                e.setAttribute(JSON.ID, sub.getNamedBean().getSystemName());
-                            } catch (NullPointerException ex) {
-                                if (sub.getNamedBean() == null) {
-                                    log.debug("{} {} does not have an associated NamedBean", e.getName(), e.getAttribute(JSON.NAME));
-                                } else {
-                                    log.debug("{} {} does not have a SystemName", e.getName(), e.getAttribute(JSON.NAME));
-                                }
-                            }
-                            parsePortableURIs(e);
-                            panel.addContent(e);
-                        }
+                        panel.addContent(positionableElement(sub));
                     } catch (Exception ex) {
                         log.error("Error storing panel element: " + ex, ex);
                     }

--- a/java/src/jmri/web/servlet/panel/LayoutPanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/LayoutPanelServlet.java
@@ -7,13 +7,11 @@ import javax.servlet.http.HttpServlet;
 import jmri.InstanceManager;
 import jmri.Sensor;
 import jmri.SensorManager;
-import jmri.configurexml.ConfigXmlManager;
 import jmri.jmrit.display.Positionable;
 import jmri.jmrit.display.layoutEditor.LayoutBlock;
 import jmri.jmrit.display.layoutEditor.LayoutBlockManager;
 import jmri.jmrit.display.layoutEditor.LayoutEditor;
 import jmri.jmrit.display.layoutEditor.LayoutTrack;
-import jmri.server.json.JSON;
 import jmri.util.ColorUtil;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -79,23 +77,7 @@ public class LayoutPanelServlet extends AbstractPanelServlet {
             for (Positionable sub : contents) {
                 if (sub != null) {
                     try {
-                        Element e = ConfigXmlManager.elementFromObject(sub);
-                        if (e != null) {
-                            if ("signalmasticon".equals(e.getName())) {  //insert icon details into signalmast
-                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"), e.getAttributeValue("imageset")));
-                            }
-                            try {
-                                e.setAttribute(JSON.ID, sub.getNamedBean().getSystemName());
-                            } catch (NullPointerException ex) {
-                                if (sub.getNamedBean() == null) {
-                                    log.debug("{} {} does not have an associated NamedBean", e.getName(), e.getAttribute(JSON.NAME));
-                                } else {
-                                    log.debug("{} {} does not have a SystemName", e.getName(), e.getAttribute(JSON.NAME));
-                                }
-                            }
-                            parsePortableURIs(e);
-                            panel.addContent(e);
-                        }
+                        panel.addContent(positionableElement(sub));
                     } catch (Exception ex) {
                         log.error("Error storing panel element: " + ex, ex);
                     }

--- a/java/src/jmri/web/servlet/panel/PanelServlet.java
+++ b/java/src/jmri/web/servlet/panel/PanelServlet.java
@@ -8,10 +8,8 @@ import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.swing.JFrame;
-import jmri.configurexml.ConfigXmlManager;
 import jmri.jmrit.display.Positionable;
 import jmri.jmrit.display.panelEditor.PanelEditor;
-import jmri.server.json.JSON;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.output.Format;
@@ -72,23 +70,7 @@ public class PanelServlet extends AbstractPanelServlet {
             for (Positionable sub : contents) {
                 if (sub != null) {
                     try {
-                        Element e = ConfigXmlManager.elementFromObject(sub);
-                        if (e != null) {
-                            if ("signalmasticon".equals(e.getName())) {  //insert icon details into signalmast
-                                e.addContent(getSignalMastIconsElement(e.getAttributeValue("signalmast"), e.getAttributeValue("imageset")));
-                            }
-                            try {
-                                e.setAttribute(JSON.ID, sub.getNamedBean().getSystemName());
-                            } catch (NullPointerException ex) {
-                                if (sub.getNamedBean() == null) {
-                                    log.debug("{} {} does not have an associated NamedBean", e.getName(), e.getAttribute(JSON.NAME));
-                                } else {
-                                    log.debug("{} {} does not have a SystemName", e.getName(), e.getAttribute(JSON.NAME));
-                                }
-                            }
-                            parsePortableURIs(e);
-                            panel.addContent(e);
-                        }
+                        panel.addContent(positionableElement(sub));
                     } catch (Exception ex) {
                         log.error("Error storing panel element: {}", ex.getMessage(), ex);
                     }

--- a/java/test/jmri/server/json/turnout/JsonTurnoutSocketServiceTest.java
+++ b/java/test/jmri/server/json/turnout/JsonTurnoutSocketServiceTest.java
@@ -1,6 +1,12 @@
 package jmri.server.json.turnout;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.beans.PropertyVetoException;
 import java.io.DataOutputStream;
@@ -14,9 +20,9 @@ import jmri.TurnoutManager;
 import jmri.server.json.JSON;
 import jmri.server.json.JsonException;
 import jmri.server.json.JsonMockConnection;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,131 +34,136 @@ import org.junit.Test;
 public class JsonTurnoutSocketServiceTest {
 
     @Test
-    public void testTurnoutChange() {
+    public void testTurnoutChange() throws IOException, JmriException, JsonException {
+        JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
+        JsonNode message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1");
+        JsonTurnoutSocketService service = new JsonTurnoutSocketService(connection);
+        TurnoutManager manager = InstanceManager.getDefault(TurnoutManager.class);
+        Turnout turnout1 = manager.provideTurnout("IT1");
+        turnout1.setCommandedState(Turnout.UNKNOWN);
+        service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.GET, Locale.ENGLISH);
+        // TODO: test that service is listener in TurnoutManager
+        message = connection.getMessage();
+        assertNotNull("message is not null", message);
+        assertEquals(JSON.UNKNOWN, message.path(JSON.DATA).path(JSON.STATE).asInt());
+        turnout1.setCommandedState(Turnout.CLOSED);
+        JUnitUtil.waitFor(() -> {
+            return turnout1.getKnownState() == Turnout.CLOSED;
+        }, "Turnout to close");
+        message = connection.getMessage();
+        assertNotNull("message is not null", message);
+        assertEquals(Turnout.CLOSED, turnout1.getKnownState());
+        assertEquals(JSON.CLOSED, message.path(JSON.DATA).path(JSON.STATE).asInt());
+        turnout1.setCommandedState(Turnout.THROWN);
+        JUnitUtil.waitFor(() -> {
+            return turnout1.getKnownState() == Turnout.THROWN;
+        }, "Turnout to throw");
+        message = connection.getMessage();
+        assertNotNull("message is not null", message);
+        assertEquals(JSON.THROWN, message.path(JSON.DATA).path(JSON.STATE).asInt());
+        service.onClose();
+        // TODO: test that service is no longer a listener in TurnoutManager
+    }
+
+    @Test
+    public void testOnMessageChange() throws IOException, JmriException, JsonException {
+        JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
+        JsonNode message;
+        JsonTurnoutSocketService service = new JsonTurnoutSocketService(connection);
+        TurnoutManager manager = InstanceManager.getDefault(TurnoutManager.class);
+        Turnout turnout1 = manager.provideTurnout("IT1");
+        turnout1.setCommandedState(Turnout.UNKNOWN);
+        // Turnout CLOSED
+        message =
+                connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1").put(JSON.STATE, JSON.CLOSED);
+        service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
+        assertEquals(Turnout.CLOSED, turnout1.getState());
+        // Turnout THROWN
+        message =
+                connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1").put(JSON.STATE, JSON.THROWN);
+        service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
+        assertEquals(Turnout.THROWN, turnout1.getState());
+        // Turnout UNKNOWN - remains THROWN
+        message =
+                connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1").put(JSON.STATE, JSON.UNKNOWN);
+        service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
+        assertEquals(Turnout.THROWN, turnout1.getState());
+        // Turnout Invalid State
+        message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1").put(JSON.STATE, 42); // invalid state
         try {
-            JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
-            JsonNode message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1");
-            JsonTurnoutSocketService service = new JsonTurnoutSocketService(connection);
-            TurnoutManager manager = InstanceManager.getDefault(TurnoutManager.class);
-            Turnout turnout1 = manager.provideTurnout("IT1");
-            turnout1.setCommandedState(Turnout.UNKNOWN);
+            service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
+            fail("Expected exception not thrown");
+        } catch (JsonException ex) {
+            assertEquals(Turnout.THROWN, turnout1.getState());
+            assertEquals(HttpServletResponse.SC_BAD_REQUEST, ex.getCode());
+        }
+    }
+
+    @Test
+    public void testOnList() throws IOException, JmriException, JsonException, PropertyVetoException {
+        JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
+        JsonNode message;
+        JsonTurnoutSocketService service = new JsonTurnoutSocketService(connection);
+        TurnoutManager manager = InstanceManager.getDefault(TurnoutManager.class);
+        // use register instead of provide in tests to avoid messages from the Turnouts themselves
+        Turnout turnout1 = manager.provide("IT1");
+        Turnout turnout2 = manager.provide("IT2");
+        manager.deregister(turnout1);
+        manager.deregister(turnout2);
+        service.onList(JsonTurnoutServiceFactory.TURNOUT, connection.getObjectMapper().createObjectNode(),
+                Locale.ENGLISH);
+        message = connection.getMessage();
+        assertNotNull("Message is not null", message);
+        assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
+        manager.register(turnout1);
+        JUnitUtil.waitFor(() -> {
+            return manager.getBeanBySystemName("IT1") != null;
+        });
+        message = connection.getMessage();
+        assertNotNull("Message is not null", message);
+        assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
+        manager.register(turnout2);
+        JUnitUtil.waitFor(() -> {
+            return manager.getBeanBySystemName("IT2") != null;
+        });
+        message = connection.getMessage();
+        assertNotNull("Message is not null", message);
+        assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
+        assertNotNull("Turnout 2 exists", turnout2);
+        manager.deleteBean(turnout2, "");
+        JUnitUtil.waitFor(() -> {
+            return manager.getBeanBySystemName("IT2") == null;
+        });
+        message = connection.getMessage();
+        assertNotNull("Message is not null", message);
+        assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
+    }
+
+    @Test
+    public void testWarningOnUserName() throws IOException, JmriException, JsonException {
+        String userName = "Internal Turnout 1";
+        JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
+        ObjectNode message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, userName);
+        JsonTurnoutSocketService service = new JsonTurnoutSocketService(connection);
+        TurnoutManager manager = InstanceManager.getDefault(TurnoutManager.class);
+        Turnout t1 = manager.provide("IT1");
+        t1.setUserName(userName);
+        // request with user name should log a warning
+        service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.GET, Locale.ENGLISH);
+        JUnitAppender.assertWarnMessage("get request for turnout made with user name \"" + userName + "\"; should use system name");
+        // request with system name should not log a warning
+        message.put(JSON.NAME, "IT1");
+        service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.GET, Locale.ENGLISH);
+        assertTrue(JUnitAppender.verifyNoBacklog());
+        // request with name of non-existant bean should not log a warning (but should throw exception)
+        try {
+            message.put(JSON.NAME, "IT2");
             service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.GET, Locale.ENGLISH);
-            // TODO: test that service is listener in TurnoutManager
-            message = connection.getMessage();
-            Assert.assertNotNull("message is not null", message);
-            Assert.assertEquals(JSON.UNKNOWN, message.path(JSON.DATA).path(JSON.STATE).asInt());
-            turnout1.setCommandedState(Turnout.CLOSED);
-            JUnitUtil.waitFor(() -> {
-                return turnout1.getKnownState() == Turnout.CLOSED;
-            }, "Turnout to close");
-            message = connection.getMessage();
-            Assert.assertNotNull("message is not null", message);
-            Assert.assertEquals(Turnout.CLOSED, turnout1.getKnownState());
-            Assert.assertEquals(JSON.CLOSED, message.path(JSON.DATA).path(JSON.STATE).asInt());
-            turnout1.setCommandedState(Turnout.THROWN);
-            JUnitUtil.waitFor(() -> {
-                return turnout1.getKnownState() == Turnout.THROWN;
-            }, "Turnout to throw");
-            message = connection.getMessage();
-            Assert.assertNotNull("message is not null", message);
-            Assert.assertEquals(JSON.THROWN, message.path(JSON.DATA).path(JSON.STATE).asInt());
-            service.onClose();
-            // TODO: test that service is no longer a listener in TurnoutManager
-        } catch (
-                IOException |
-                JmriException |
-                JsonException ex) {
-            Assert.fail(ex.getMessage());
+            fail("Expected exception not thrown");
+        } catch (JsonException ex) {
+            assertEquals(HttpServletResponse.SC_NOT_FOUND, ex.getCode());
         }
-    }
-
-    @Test
-    public void testOnMessageChange() {
-        try {
-            JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
-            JsonNode message;
-            JsonTurnoutSocketService service = new JsonTurnoutSocketService(connection);
-            TurnoutManager manager = InstanceManager.getDefault(TurnoutManager.class);
-            Turnout turnout1 = manager.provideTurnout("IT1");
-            turnout1.setCommandedState(Turnout.UNKNOWN);
-            // Turnout CLOSED
-            message =
-                    connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1").put(JSON.STATE, JSON.CLOSED);
-            service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
-            Assert.assertEquals(Turnout.CLOSED, turnout1.getState());
-            // Turnout THROWN
-            message =
-                    connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1").put(JSON.STATE, JSON.THROWN);
-            service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
-            Assert.assertEquals(Turnout.THROWN, turnout1.getState());
-            // Turnout UNKNOWN - remains THROWN
-            message =
-                    connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1").put(JSON.STATE, JSON.UNKNOWN);
-            service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
-            Assert.assertEquals(Turnout.THROWN, turnout1.getState());
-            // Turnout Invalid State
-            message = connection.getObjectMapper().createObjectNode().put(JSON.NAME, "IT1").put(JSON.STATE, 42); // invalid state
-            try {
-                service.onMessage(JsonTurnoutServiceFactory.TURNOUT, message, JSON.POST, Locale.ENGLISH);
-                Assert.fail("Expected exception not thrown");
-            } catch (JsonException ex) {
-                Assert.assertEquals(Turnout.THROWN, turnout1.getState());
-                Assert.assertEquals(HttpServletResponse.SC_BAD_REQUEST, ex.getCode());
-            }
-        } catch (
-                IOException |
-                JmriException |
-                JsonException ex) {
-            Assert.fail(ex.getMessage());
-        }
-    }
-
-    @Test
-    public void testOnList() {
-        try {
-            JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
-            JsonNode message;
-            JsonTurnoutSocketService service = new JsonTurnoutSocketService(connection);
-            TurnoutManager manager = InstanceManager.getDefault(TurnoutManager.class);
-            // use register instead of provide in tests to avoid messages from the Turnouts themselves
-            Turnout turnout1 = manager.provide("IT1");
-            Turnout turnout2 = manager.provide("IT2");
-            manager.deregister(turnout1);
-            manager.deregister(turnout2);
-            service.onList(JsonTurnoutServiceFactory.TURNOUT, connection.getObjectMapper().createObjectNode(),
-                    Locale.ENGLISH);
-            message = connection.getMessage();
-            Assert.assertNotNull("Message is not null", message);
-            Assert.assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
-            manager.register(turnout1);
-            JUnitUtil.waitFor(() -> {
-                return manager.getBeanBySystemName("IT1") != null;
-            });
-            message = connection.getMessage();
-            Assert.assertNotNull("Message is not null", message);
-            Assert.assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
-            manager.register(turnout2);
-            JUnitUtil.waitFor(() -> {
-                return manager.getBeanBySystemName("IT2") != null;
-            });
-            message = connection.getMessage();
-            Assert.assertNotNull("Message is not null", message);
-            Assert.assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
-            Assert.assertNotNull("Turnout 2 exists", turnout2);
-            manager.deleteBean(turnout2, "");
-            JUnitUtil.waitFor(() -> {
-                return manager.getBeanBySystemName("IT2") == null;
-            });
-            message = connection.getMessage();
-            Assert.assertNotNull("Message is not null", message);
-            Assert.assertEquals("Manager and message have same size", manager.getNamedBeanSet().size(), message.size());
-        } catch (
-                IOException |
-                JmriException |
-                JsonException |
-                PropertyVetoException ex) {
-            Assert.fail(ex.getMessage());
-        }
+        assertTrue(JUnitAppender.verifyNoBacklog());
     }
 
     @Before

--- a/java/test/jmri/web/servlet/panel/AbstractPanelServletTest.java
+++ b/java/test/jmri/web/servlet/panel/AbstractPanelServletTest.java
@@ -1,0 +1,64 @@
+package jmri.web.servlet.panel;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jdom2.Element;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import jmri.InstanceManager;
+import jmri.Sensor;
+import jmri.SensorManager;
+import jmri.configurexml.ConfigXmlManager;
+import jmri.jmrit.catalog.NamedIcon;
+import jmri.jmrit.display.MultiSensorIcon;
+import jmri.util.JUnitUtil;
+
+public class AbstractPanelServletTest {
+
+    @Test
+    public void testPositionableElement() {
+        String systemName = "IS1";
+        String userName = "Internal Sensor 1";
+        AbstractPanelServlet servlet = new NullPanelServlet();
+        Sensor s = InstanceManager.getDefault(SensorManager.class).provide(systemName);
+        s.setUserName(userName);
+        MultiSensorIcon p = new MultiSensorIcon(null);
+        p.addEntry(userName, new NamedIcon("program:resources/logo.gif", "logo"));
+        Element e = ConfigXmlManager.elementFromObject(p);
+        assertEquals(userName, e.getChild("active").getAttribute("sensor").getValue());
+        e = servlet.positionableElement(p);
+        assertEquals(systemName, e.getChild("active").getAttribute("sensor").getValue());
+    }
+
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+        JUnitUtil.initInternalSensorManager();
+    }
+
+    @After
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+    private class NullPanelServlet extends AbstractPanelServlet {
+
+        @Override
+        protected String getPanelType() {
+            return null;
+        }
+
+        @Override
+        protected String getJsonPanel(String name) {
+            return null;
+        }
+
+        @Override
+        protected String getXmlPanel(String name) {
+            return null;
+        }
+        
+    }
+}

--- a/java/test/jmri/web/servlet/panel/PackageTest.java
+++ b/java/test/jmri/web/servlet/panel/PackageTest.java
@@ -6,6 +6,7 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     BundleTest.class,
+    AbstractPanelServletTest.class,
     ControlPanelServletTest.class,
     LayoutPanelServletTest.class,
     SwitchboardServletTest.class,


### PR DESCRIPTION
Fixes #6826 by ensuring that Sensors in a MultiSensorIcon in a web panel are created with SystemNames instead of UserNames.

Also:
- for any passed in name for a named bean in the JSON Streaming API, the name is switched to a system name for further processing
- remove some duplication of code when creating XML for web panels