### PR TITLE
Fix: Only update rate and running fields in SimpleClockFrame.java when receiving rate / running events

### DIFF
--- a/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
+++ b/java/src/jmri/jmrit/simpleclock/SimpleClockFrame.java
@@ -768,12 +768,17 @@ public class SimpleClockFrame extends JmriJFrame
     }
 
     /**
-     * Handle a change to clock properties
+     * Handle a change to clock properties "rate" and "run"
+     *
+     * Time changes are handled by the minuteChangeListener
      */
     @Override
     public void propertyChange(java.beans.PropertyChangeEvent e) {
-        updateRunningButton();
-        updateRate();
+	if (e.getPropertyName().contentEquals("rate")) {
+	    updateRate();
+	} else if (e.getPropertyName().contentEquals("run")) {
+	    updateRunningButton();
+	}
     }
 
     @Override


### PR DESCRIPTION
As descibed in #6821 I also tried my hands at a minimal-invasive patch to close #6821 