### PR TITLE
Openlcb test threading reduction

### DIFF
--- a/java/test/jmri/jmrix/openlcb/OlcbSensorManagerTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSensorManagerTest.java
@@ -3,7 +3,9 @@ package jmri.jmrix.openlcb;
 import jmri.Sensor;
 import jmri.util.JUnitUtil;
 import jmri.util.junit.annotations.*;
+import jmri.jmrix.can.TestTrafficController;
 import org.junit.*;
+import org.openlcb.*;
 
 /**
  * Tests for the jmri.jmrix.openlcb.OlcbSensorManager class.
@@ -12,7 +14,10 @@ import org.junit.*;
  */
 public class OlcbSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase {
 
-    private static OlcbSystemConnectionMemo m;
+    private static OlcbSystemConnectionMemo memo;
+    static Connection connection;
+    static NodeID nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
+    static java.util.ArrayList<Message> messages;
 
     @Override
     public String getSystemName(int i) {
@@ -77,13 +82,7 @@ public class OlcbSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
     @Override
     @Before
     public void setUp() {
-        l = new OlcbSensorManager(m);
-    }
-
-    @BeforeClass
-    public static void preClassInit(){
-        JUnitUtil.setUp();
-        m = OlcbTestInterface.createForLegacyTests();
+        l = new OlcbSensorManager(memo);
     }
 
     @After
@@ -91,11 +90,41 @@ public class OlcbSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         l.dispose();
     }
 
+    @BeforeClass
+    static public void preClassInit() {
+        JUnitUtil.setUp();
+        JUnitUtil.initInternalTurnoutManager();
+        nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
+
+        messages = new java.util.ArrayList<>();
+        connection = new AbstractConnection() {
+            @Override
+            public void put(Message msg, Connection sender) {
+                messages.add(msg);
+            }
+        };
+
+        memo = new OlcbSystemConnectionMemo(); // this self-registers as 'M'
+        memo.setProtocol(jmri.jmrix.can.ConfigurationManager.OPENLCB);
+        memo.setInterface(new OlcbInterface(nodeID, connection) {
+            public Connection getOutputConnection() {
+                return connection;
+            }
+        });
+        memo.setTrafficController(new TestTrafficController());
+        memo.configureManagers();
+    
+        jmri.util.JUnitUtil.waitFor(()->{return (messages.size()>0);},"Initialization Complete message");
+    }
+
     @AfterClass
-    public static void postClassTearDown(){
-        if(m != null && m.getInterface() !=null ) {
-           m.getInterface().dispose();
+    public static void postClassTearDown() throws Exception {
+        if(memo != null && memo.getInterface() !=null ) {
+           memo.getInterface().dispose();
         }
+        memo = null;
+        connection = null;
+        nodeID = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutManagerTest.java
@@ -2,12 +2,8 @@ package jmri.jmrix.openlcb;
 
 import jmri.Turnout;
 import jmri.util.JUnitUtil;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
+import org.openlcb.*;
 
 /**
  * Tests for the jmri.jmrix.openlcb.OlcbTurnoutManager class.
@@ -16,7 +12,10 @@ import org.junit.Test;
  */
 public class OlcbTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTestBase {
 
-    private static OlcbSystemConnectionMemo m; 
+    private static OlcbSystemConnectionMemo memo;
+    static Connection connection;
+    static NodeID nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
+    static java.util.ArrayList<Message> messages;
 
     @Override
     public String getSystemName(int i) {
@@ -59,25 +58,47 @@ public class OlcbTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
     @Override
     @Before
     public void setUp() {
-        l = new OlcbTurnoutManager(m);
+        l = new OlcbTurnoutManager(memo);
     }
  
-    @BeforeClass
-    public static void preClassInit() {
-        JUnitUtil.setUp();
-        m = OlcbTestInterface.createForLegacyTests();
-    }
-
     @After
     public void tearDown() {
         l.dispose();
     }
 
+    @BeforeClass
+    static public void preClassInit() {
+        JUnitUtil.setUp();
+        JUnitUtil.initInternalTurnoutManager();
+        nodeID = new NodeID(new byte[]{1, 0, 0, 0, 0, 0});
+
+        messages = new java.util.ArrayList<>();
+        connection = new AbstractConnection() {
+            @Override
+            public void put(Message msg, Connection sender) {
+                messages.add(msg);
+            }
+        };
+
+        memo = new OlcbSystemConnectionMemo(); // this self-registers as 'M'
+        memo.setProtocol(jmri.jmrix.can.ConfigurationManager.OPENLCB);
+        memo.setInterface(new OlcbInterface(nodeID, connection) {
+            public Connection getOutputConnection() {
+                return connection;
+            }
+        });
+    
+        jmri.util.JUnitUtil.waitFor(()->{return (messages.size()>0);},"Initialization Complete message");
+    }
+
     @AfterClass
-    public static void postClassTearDown() {
-        if(m != null && m.getInterface() !=null ) {
-           m.getInterface().dispose();
+    public static void postClassTearDown() throws Exception {
+        if(memo != null && memo.getInterface() !=null ) {
+           memo.getInterface().dispose();
         }
+        memo = null;
+        connection = null;
+        nodeID = null;
         JUnitUtil.tearDown();
-    } 
+    }
 }


### PR DESCRIPTION
Partially address #6827 by preventing some theads from being started during tests.

The initial commit reduces the maximum number of threads by approximately 200.