### PR TITLE
Test updates

### DIFF
--- a/java/test/jmri/implementation/DefaultCabSignalTest.java
+++ b/java/test/jmri/implementation/DefaultCabSignalTest.java
@@ -120,6 +120,7 @@ public class DefaultCabSignalTest {
                 sm.provideSensor("West1").setState(Sensor.INACTIVE);
                 sm.provideSensor("West2").setState(Sensor.INACTIVE);
              } catch (JmriException je) {
+                log.error("Expected error setting up test", je);
              }
         });
 
@@ -225,6 +226,6 @@ public class DefaultCabSignalTest {
         JUnitUtil.tearDown();
     }
 
-    //private final static Logger log = LoggerFactory.getLogger(DefaultCabSignalTest.class);
+    private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(DefaultCabSignalTest.class);
 
 }

--- a/java/test/jmri/jmrix/lenz/swing/lzv100/LZV100FrameTest.java
+++ b/java/test/jmri/jmrix/lenz/swing/lzv100/LZV100FrameTest.java
@@ -16,7 +16,7 @@ import org.junit.*;
  */
 public class LZV100FrameTest extends jmri.util.JmriJFrameTestBase {
         
-    private XNetInterfaceScaffold tc = new XNetInterfaceScaffold(new LenzCommandStation());
+    private XNetInterfaceScaffold tc;
 
     @Before
     @Override


### PR DESCRIPTION
- delay construction on an object until in setUp so that the proper logging is defined
- log an exception that was otherwise swallowed.