### PR TITLE
End BlockBossLogic (SSL) cleanly in load/store tests

### DIFF
--- a/java/src/jmri/jmrit/blockboss/BlockBossLogic.java
+++ b/java/src/jmri/jmrit/blockboss/BlockBossLogic.java
@@ -1425,6 +1425,18 @@ public class BlockBossLogic extends Siglet implements java.beans.VetoableChangeL
         }
     }
 
+    /**
+     * Stop() all existing objects and clear the list.
+     * <p>
+     * Intended to be only used during testing.
+     */
+    public static void stopAllAndClear() {
+        for (BlockBossLogic b : bblList) {
+            b.stop();
+        }
+        bblList.clear();
+    }
+    
     private final static Logger log = LoggerFactory.getLogger(BlockBossLogic.class);
 
 }

--- a/java/test/jmri/configurexml/LoadAndStoreTestBase.java
+++ b/java/test/jmri/configurexml/LoadAndStoreTestBase.java
@@ -296,6 +296,7 @@ public class LoadAndStoreTestBase {
 
     @After
     public void tearDown() {
+        JUnitUtil.clearBlockBossLogic();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrit/blockboss/configurexml/BlockBossLogicXmlTest.java
+++ b/java/test/jmri/jmrit/blockboss/configurexml/BlockBossLogicXmlTest.java
@@ -156,6 +156,7 @@ public class BlockBossLogicXmlTest {
 
     @After
     public void tearDown() {
+        JUnitUtil.clearBlockBossLogic();
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.SortedSet;
@@ -864,6 +865,13 @@ public class JUnitUtil {
     }
 
     /**
+     * End any running BlockBossLogic (Simple Signal Logic) objects
+     */
+    public static void clearBlockBossLogic() {
+        jmri.jmrit.blockboss.BlockBossLogic.stopAllAndClear();
+    }
+    
+    /**
      * Leaves ShutDownManager, if any, in place,
      * but removes its contents.
      * @see #initShutDownManager()
@@ -1201,9 +1209,9 @@ public class JUnitUtil {
                         if (name.startsWith("Thread-")) {
                             Exception ex = new Exception("traceback of numbered thread");
                             ex.setStackTrace(Thread.getAllStackTraces().get(t));
-                            log.warn("Found remnant thread \"{}\" in group \"{}\" after {}", t.getName(), t.getThreadGroup().getName(), getTestClassName(), ex);
+                            log.warn("Found remnant thread \"{}\" in group \"{}\" after {}", t.getName(), (t.getThreadGroup() != null ? t.getThreadGroup().getName() : "<no group>"), getTestClassName(), ex);
                         } else {
-                            log.warn("Found remnant thread \"{}\" in group \"{}\" after {}", t.getName(), t.getThreadGroup().getName(), getTestClassName());
+                            log.warn("Found remnant thread \"{}\" in group \"{}\" after {}", t.getName(), (t.getThreadGroup() != null ? t.getThreadGroup().getName() : "<no group>"), getTestClassName());
                         }
                 }
             });


### PR DESCRIPTION
When doing load/store tests of XML files, sometimes SSL elements are started.  This shuts them down at the end of each test.