### PR TITLE
Limi headlesstest memory to help Jenkins

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1375,6 +1375,9 @@
             <sysproperty key="user.language" value="en"/>
             <sysproperty key="user.country" value="US"/>
 
+            <jvmarg value="-Xmx1536m"/>
+            <jvmarg line="${jvm.args}"/>
+
             <classpath refid="test.class.path"/>
 
             <test name="jmri.HeadLessTest" outfile="junit-results">


### PR DESCRIPTION
Add -Xmx1536m in build.xml to headlesstest target (wasn't any explicit limit before)