### PR TITLE
WIP Make location and size retention consistent for all 4 editors

### DIFF
--- a/help/en/package/jmri/jmrit/display/LayoutEditor.shtml
+++ b/help/en/package/jmri/jmrit/display/LayoutEditor.shtml
@@ -138,7 +138,10 @@
       panel changing during subsequent saves! The position and size
       of your panel will only change when you select <strong>Save
       Location and Size</strong>. So save your panel often to preserve
-      your work.</p>
+      your work.  There is an alternate option for saving the panel's location
+      and size.  The <strong>Always Save Location and Size</strong> option can
+      be set if you want to always have the panel positioned where it was
+      located when saved.</p>
 
       <p><strong>Layout Editor</strong> supports the construction and display
       of PanelPro panels. <strong>Layout Editor</strong> is similar to the
@@ -725,6 +728,11 @@
         and location saved when this item was selected, provided
         the computer operating system permits a window with that
         size and location.</li>
+
+        <li><strong>Always Save Location and Size</strong> - When this item is
+        selected, the <strong>current</strong> window size and location
+        will be saved each time the panel is saved.  This is the same behavior
+        as the other editors.</li>
 
         <li><strong>Add</strong>
           <ul>
@@ -1811,7 +1819,7 @@
       <p>The <strong>Block Line Dash Percentage</strong> has
       <strong><em>nothing</em></strong> to do with dashed track.  This is a
       special setting to create an on/off pattern to blocks.  The <strong>
-      British 70's</strong> or Czechoslovak <strong>&#268;SD A&#381;D-71</strong> 
+      British 70's</strong> or Czechoslovak <strong>&#268;SD A&#381;D-71</strong>
       preset uses this option.</p>
 
       <h3>Notes</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -447,20 +447,7 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li>The handling of Turnout system names has been updated
-                to be (more, hopefully completely) consistent with the
-                <a href="../html/doc/Technical/Names.shtml">planned approach</a>.
-                Specifically, case now (generally) matters in system names:
-                <ul>
-                    <li>You can now have an internal turnout named "ITsome lower case name".
-                    <li>But note you can no longer refer to "ITSOME LOWER CASE NAME" or
-                        "ITSome LoWeR cAse Name" and get the same one.
-                </ul>
-                This should not require any migration for stored configurations or
-                panel files, as they have been automatically been being kept consistent
-                since JMRI 4.8.  But you might have case errors in i.e. scripts which
-                will fixing inconsistent references in your scripts.
-                </li>
+            <li></li>
         </ul>
 
     <h3>Scripting</h3>

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -405,7 +405,7 @@
     <h3>Layout Editor</h3>
         <a id="LE" name="LE"></a>
         <ul>
-	        <li></li>
+	        <li>Add an option menu item to always save the current panel location and size.</li>
         </ul>
 
     <h3>Logix</h3>
@@ -449,15 +449,15 @@
         <ul>
             <li>The handling of Turnout system names has been updated
                 to be (more, hopefully completely) consistent with the
-                <a href="../html/doc/Technical/Names.shtml">planned approach</a>.  
+                <a href="../html/doc/Technical/Names.shtml">planned approach</a>.
                 Specifically, case now (generally) matters in system names:
                 <ul>
                     <li>You can now have an internal turnout named "ITsome lower case name".
                     <li>But note you can no longer refer to "ITSOME LOWER CASE NAME" or
                         "ITSome LoWeR cAse Name" and get the same one.
                 </ul>
-                This should not require any migration for stored configurations or 
-                panel files, as they have been automatically been being kept consistent 
+                This should not require any migration for stored configurations or
+                panel files, as they have been automatically been being kept consistent
                 since JMRI 4.8.  But you might have case errors in i.e. scripts which
                 will fixing inconsistent references in your scripts.
                 </li>

--- a/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/ControlPanelEditor.java
@@ -139,7 +139,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
     }
 
     public ControlPanelEditor(String name) {
-        super(name);
+        super(name, false, false);
         init(name);
     }
 
@@ -222,7 +222,7 @@ public class ControlPanelEditor extends Editor implements DropTargetListener, Cl
                 _itemPalette.setVisible(true);
             }
         }.init(this));
-        
+
         if (SystemType.isMacOSX()) {
             mi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, ActionEvent.META_MASK));
         } else {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -341,6 +341,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
     private transient JCheckBoxMenuItem turnoutDrawUnselectedLegCheckBoxMenuItem = null;
     private transient JCheckBoxMenuItem hideTrackSegmentConstructionLinesCheckBoxMenuItem = null;
     private transient JCheckBoxMenuItem useDirectTurnoutControlCheckBoxMenuItem = null;
+    private transient JCheckBoxMenuItem alwaysSaveLocAndSizeCheckBoxMenuItem = null;
     private transient ButtonGroup turnoutCircleSizeButtonGroup = null;
 
     private transient boolean turnoutDrawUnselectedLeg = true;
@@ -441,6 +442,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
 
     private transient boolean antialiasingOn = false;
     private transient boolean highlightSelectedBlockFlag = false;
+    private transient boolean alwaysSaveLocAndSize = false;
 
     private transient boolean turnoutCirclesWithoutEditMode = false;
     private transient boolean tooltipsWithoutEditMode = false;
@@ -518,7 +520,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
     }
 
     public LayoutEditor(@Nonnull String name) {
-        super(name);
+        super(name, false, false);
         layoutName = name;
 
         //initialise keycode map
@@ -997,7 +999,6 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         super.setTargetPanel(null, null);
         super.setTargetPanelSize(windowWidth, windowHeight);
         setSize(screenDim.width, screenDim.height);
-
         setupToolBar();
 
         //register the resulting panel for later configuration
@@ -1043,6 +1044,10 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 //log.debug("{}.antialiasingOn is {}", windowFrameRef, prefsAntialiasingOn);
                 setAntialiasingOn(prefsAntialiasingOn);
 
+                boolean prefsAlwaysSaveLocAndSize = prefsMgr.getSimplePreferenceState(windowFrameRef + ".alwaysSaveLocAndSize");
+                //log.debug("{}.alwaysSaveLocAndSize is {}", windowFrameRef, prefsAlwaysSaveLocAndSize);
+                setAlwaysSaveLocAndSize(prefsAlwaysSaveLocAndSize);
+
                 boolean prefsHighlightSelectedBlockFlag
                         = prefsMgr.getSimplePreferenceState(windowFrameRef + ".highlightSelectedBlock");
                 //log.debug("{}.highlightSelectedBlock is {}", windowFrameRef, prefsHighlightSelectedBlockFlag);
@@ -1055,34 +1060,6 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 //setupToolBarFontSizes(toolBarFontSize);
                 //}
                 updateAllComboBoxesDropDownListDisplayOrderFromPrefs();
-
-                //this doesn't work as expected (1st one called messes up 2nd?)
-                Point prefsWindowLocation = prefsMgr.getWindowLocation(windowFrameRef);
-                Dimension prefsWindowSize = prefsMgr.getWindowSize(windowFrameRef);
-                log.debug("prefsMgr.prefsWindowLocation({}) is {}", windowFrameRef, prefsWindowLocation);
-                log.debug("prefsMgr.prefsWindowSize is({}) {}", windowFrameRef, prefsWindowSize);
-
-                //Point prefsWindowLocation = null;
-                //Dimension prefsWindowSize = null;
-                //use this instead?
-                if (true) { //(Nope, it's not working ether: prefsProp always comes back null)
-                    prefsProp = prefsMgr.getProperty(windowFrameRef, "windowRectangle2D");
-                    log.debug("prefsMgr.getProperty({}, \"windowRectangle2D\") is {}", windowFrameRef, prefsProp);
-
-                    if (prefsProp != null) {
-                        Rectangle2D windowRectangle2D = (Rectangle2D) prefsProp;
-                        prefsWindowLocation.setLocation(windowRectangle2D.getX(), windowRectangle2D.getY());
-                        prefsWindowSize.setSize(windowRectangle2D.getWidth(), windowRectangle2D.getHeight());
-                    }
-                }
-
-                if ((prefsWindowLocation != null) && (prefsWindowSize != null)
-                        && (prefsWindowSize.width >= 640) && (prefsWindowSize.height >= 480)) {
-                    //note: panel width & height comes from the saved (xml) panel (file) on disk
-                    setLayoutDimensions(prefsWindowSize.width, prefsWindowSize.height,
-                            prefsWindowLocation.x, prefsWindowLocation.y,
-                            panelWidth, panelHeight, true);
-                }
             }); //InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent((prefsMgr)
 
             // make sure that the layoutEditorComponent is in the _targetPanel components
@@ -1097,6 +1074,20 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 }
             }
         });
+    }
+
+    @Override
+    public void componentMoved(java.awt.event.ComponentEvent e) {
+        if (isAlwaysSaveLocAndSize()) {
+            setCurrentPositionAndSize();
+        }
+    }
+
+    @Override
+    public void componentResized(java.awt.event.ComponentEvent e) {
+        if (isAlwaysSaveLocAndSize()) {
+            setCurrentPositionAndSize();
+        }
     }
 
     @Override
@@ -2521,6 +2512,16 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             setCurrentPositionAndSize();
             log.debug("Bounds:{}, {}, {}, {}, {}, {}", upperLeftX, upperLeftY, windowWidth, windowHeight, panelWidth, panelHeight);
         });
+
+        //
+        // always save location and size
+        //
+        alwaysSaveLocAndSizeCheckBoxMenuItem = new JCheckBoxMenuItem(Bundle.getMessage("SetLocationAlways"));
+        optionMenu.add(alwaysSaveLocAndSizeCheckBoxMenuItem);
+        alwaysSaveLocAndSizeCheckBoxMenuItem.addActionListener((ActionEvent event) -> {
+            setAlwaysSaveLocAndSize(alwaysSaveLocAndSizeCheckBoxMenuItem.isSelected());
+        });
+        alwaysSaveLocAndSizeCheckBoxMenuItem.setSelected(alwaysSaveLocAndSize);
 
         //
         // Add Options
@@ -4759,37 +4760,6 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         Point pt = getLocationOnScreen();
         upperLeftX = pt.x;
         upperLeftY = pt.y;
-
-        // TODO: figure out why this isn't working...
-        InstanceManager.getOptionalDefault(UserPreferencesManager.class).ifPresent((prefsMgr) -> {
-            String windowFrameRef = getWindowFrameRef();
-
-            //the restore code for this isn't working...
-            prefsMgr.setWindowLocation(windowFrameRef, new Point(upperLeftX, upperLeftY));
-            prefsMgr.setWindowSize(windowFrameRef, new Dimension(windowWidth, windowHeight));
-
-            if (true) {
-                Point prefsWindowLocation = prefsMgr.getWindowLocation(windowFrameRef);
-
-                if ((prefsWindowLocation.x != upperLeftX) || (prefsWindowLocation.y != upperLeftY)) {
-                    log.error("setWindowLocation failure.");
-                }
-                Dimension prefsWindowSize = prefsMgr.getWindowSize(windowFrameRef);
-
-                if ((prefsWindowSize.width != windowWidth) || (prefsWindowSize.height != windowHeight)) {
-                    log.error("setWindowSize failure.");
-                }
-            }
-
-            //we're going to use this instead
-            if (true) { //(Nope, it's not working ether)
-                //save it in the user preferences for the window
-                Rectangle2D windowRectangle2D = new Rectangle2D.Double(upperLeftX, upperLeftY, windowWidth, windowHeight);
-                prefsMgr.setProperty(windowFrameRef, "windowRectangle2D", windowRectangle2D);
-                Object prefsProp = prefsMgr.getProperty(windowFrameRef, "windowRectangle2D");
-                log.debug("testing prefsProp: {}", prefsProp);
-            }
-        });
 
         log.debug("setCurrentPositionAndSize Position - {},{} WindowSize - {},{} PanelSize - {},{}", upperLeftX, upperLeftY, windowWidth, windowHeight, panelWidth, panelHeight);
         setDirty();
@@ -9157,6 +9127,10 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         return antialiasingOn;
     }
 
+    public boolean isAlwaysSaveLocAndSize() {
+        return alwaysSaveLocAndSize;
+    }
+
     //TODO: @Deprecated // Java standard pattern for boolean getters is "isShowHelpBar()"
     public boolean getHighlightSelectedBlock() {
         return highlightSelectedBlockFlag;
@@ -9475,6 +9449,22 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             InstanceManager.getOptionalDefault(UserPreferencesManager.class
             ).ifPresent((prefsMgr) -> {
                 prefsMgr.setSimplePreferenceState(getWindowFrameRef() + ".antialiasingOn", antialiasingOn);
+            });
+        }
+    }
+
+    public void setAlwaysSaveLocAndSize(boolean state) {
+        if (alwaysSaveLocAndSize != state) {
+            alwaysSaveLocAndSize = state;
+
+            //this may not be set up yet...
+            if (alwaysSaveLocAndSizeCheckBoxMenuItem != null) {
+                alwaysSaveLocAndSizeCheckBoxMenuItem.setSelected(alwaysSaveLocAndSize);
+
+            }
+            InstanceManager.getOptionalDefault(UserPreferencesManager.class
+            ).ifPresent((prefsMgr) -> {
+                prefsMgr.setSimplePreferenceState(getWindowFrameRef() + ".alwaysSaveLocAndSize", alwaysSaveLocAndSize);
             });
         }
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -385,6 +385,7 @@ SetTrackDrawingOptions = Set Track Drawing Options
 SetTrackDrawingOptionsToolTip = Select this item to change your track drawing options
 SetTrackWidth = Set Track Line Width
 SetLocation = Save Location and Size
+SetLocationAlways = Always Save Location and Size
 TrackColorSubMenu = Default Track Colors
 DefaultTrackColor = Set Default Track Color
 DefaultOccupiedTrackColor = Set Default Occupied Track Color

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditor.java
@@ -116,8 +116,8 @@ public class PanelEditor extends Editor implements ItemListener {
     public PanelEditor() {
     }
 
-    public PanelEditor(String name) {
-        super(name, false, true);
+    public PanelEditor(String name, boolean saveSize, boolean savePosition) {
+        super(name, saveSize, savePosition);
         init(name);
     }
 
@@ -543,7 +543,7 @@ public class PanelEditor extends Editor implements ItemListener {
      *
      */
     public JmriJFrame makeFrame(String name) {
-        JmriJFrame targetFrame = new JmriJFrame(name);
+        JmriJFrame targetFrame = new JmriJFrame(name, false, false);
         targetFrame.setVisible(false);
 
         JMenuBar menuBar = new JMenuBar();

--- a/java/src/jmri/jmrit/display/panelEditor/PanelEditorAction.java
+++ b/java/src/jmri/jmrit/display/panelEditor/PanelEditorAction.java
@@ -29,7 +29,7 @@ public class PanelEditorAction extends AbstractAction {
                 name = Bundle.getMessage("PanelDefaultName", i);
             }
         }
-        PanelEditor frame = new PanelEditor(name);
+        PanelEditor frame = new PanelEditor(name, false, true);
         InstanceManager.getDefault(PanelMenu.class).addEditorPanel(frame);
         frame.setLocation(20, 20);
 

--- a/java/src/jmri/jmrit/display/panelEditor/configurexml/PanelEditorXml.java
+++ b/java/src/jmri/jmrit/display/panelEditor/configurexml/PanelEditorXml.java
@@ -123,7 +123,7 @@ public class PanelEditorXml extends AbstractXmlAdapter {
             log.warn("File contains a panel with the same name ({}) as an existing panel", name);
             result = false;
         }
-        PanelEditor panel = new PanelEditor(name);
+        PanelEditor panel = new PanelEditor(name, false, true);
         panel.setTitle();
         panel.getTargetFrame().setLocation(x, y);
         panel.getTargetFrame().setSize(width, height);

--- a/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
+++ b/java/src/jmri/jmrit/display/switchboardEditor/SwitchboardEditor.java
@@ -1272,7 +1272,7 @@ public class SwitchboardEditor extends Editor {
      * @param name title for the Switchboard
      */
     public JmriJFrame makeFrame(String name) {
-        JmriJFrame targetFrame = new JmriJFrame(name);
+        JmriJFrame targetFrame = new JmriJFrame(name, false, false);
         targetFrame.setVisible(true);
 
         JMenuBar menuBar = new JMenuBar();

--- a/java/test/jmri/jmrit/display/IconEditorWindowTest.java
+++ b/java/test/jmri/jmrit/display/IconEditorWindowTest.java
@@ -392,7 +392,7 @@ public class IconEditorWindowTest {
         JUnitUtil.initShutDownManager();
 
         if (!GraphicsEnvironment.isHeadless()) {
-            _editor = new PanelEditor("IconEditorTestPanel");
+            _editor = new PanelEditor("IconEditorTestPanel", false, true);
             Assert.assertNotNull(JFrameOperator.waitJFrame("IconEditorTestPanel", true, true));
             _panel = _editor.getTargetPanel();
             Assert.assertNotNull(_panel);
@@ -410,7 +410,7 @@ public class IconEditorWindowTest {
             _editor.dispose();
         }
         _editor = null;
-        
+
         JUnitUtil.resetWindows(false, false); // don't log existing windows here, should just be from this class
         JUnitUtil.tearDown();
     }

--- a/java/test/jmri/jmrit/display/IndicatorTurnoutIconTest.java
+++ b/java/test/jmri/jmrit/display/IndicatorTurnoutIconTest.java
@@ -37,7 +37,7 @@ public class IndicatorTurnoutIconTest extends PositionableIconTest {
         JFrame jf = new JFrame();
         jf.getContentPane().setLayout(new java.awt.FlowLayout());
 
-        IndicatorTurnoutIcon to = (IndicatorTurnoutIcon)p; 
+        IndicatorTurnoutIcon to = (IndicatorTurnoutIcon)p;
 
         IndicatorTurnoutIcon to2 = (IndicatorTurnoutIcon) to.deepClone();
 
@@ -52,7 +52,7 @@ public class IndicatorTurnoutIconTest extends PositionableIconTest {
     public void setUp() {
         super.setUp();
         if (!GraphicsEnvironment.isHeadless()) {
-            editor = new PanelEditor("Test IndicatorTurnoutIcon Panel");
+            editor = new PanelEditor("Test IndicatorTurnoutIcon Panel", false, true);
             IndicatorTurnoutIcon to = new IndicatorTurnoutIcon(editor);
             jmri.Turnout turnout = jmri.InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
             to.setTurnout(new jmri.NamedBeanHandle<>("IT1", turnout));

--- a/java/test/jmri/jmrit/display/LinkingLabelTest.java
+++ b/java/test/jmri/jmrit/display/LinkingLabelTest.java
@@ -72,7 +72,7 @@ public class LinkingLabelTest extends PositionableTestBase {
     public void setUp() {
         super.setUp();
         if (!GraphicsEnvironment.isHeadless()) {
-            editor = new jmri.jmrit.display.panelEditor.PanelEditor("LinkingLabel Test Panel");
+            editor = new jmri.jmrit.display.panelEditor.PanelEditor("LinkingLabel Test Panel", false, true);
             p = to = new LinkingLabel("JMRI Link", editor, "http://jmri.org");
             NamedIcon icon = new NamedIcon("resources/icons/redTransparentBox.gif", "box"); // 13x13
             to.setIcon(icon);

--- a/java/test/jmri/jmrit/display/MemoryIconTest.java
+++ b/java/test/jmri/jmrit/display/MemoryIconTest.java
@@ -57,8 +57,8 @@ public class MemoryIconTest extends PositionableTestBase {
         int g = ((colors[1] >> 8) & 0xFF) + ((colors[2] >> 8) & 0xFF) + ((colors[3] >> 8) & 0xFF) + ((colors[4] >> 8) & 0xFF);
         int b = ((colors[1]) & 0xFF) + ((colors[2]) & 0xFF) + ((colors[3]) & 0xFF) + ((colors[4]) & 0xFF);
         Assert.assertTrue("Expect gray/black text", r == g & g == b); // gray pixels
-        // the following assert fails on some Linux machines, but I am 
-        // uncertain what that implies, since the previous test verifies the 
+        // the following assert fails on some Linux machines, but I am
+        // uncertain what that implies, since the previous test verifies the
         // text is grey.
         //Assert.assertTrue("Expect blacker than grey", r < 4 * 0xee); // gray pixels
 
@@ -254,7 +254,7 @@ public class MemoryIconTest extends PositionableTestBase {
         super.setUp();
         jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
         if (!GraphicsEnvironment.isHeadless()) {
-            editor = new jmri.jmrit.display.panelEditor.PanelEditor("Test MemoryIcon Panel");
+            editor = new jmri.jmrit.display.panelEditor.PanelEditor("Test MemoryIcon Panel", false, true);
             p = to = new MemoryIcon("MemoryTest1", editor );
             to.setMemory("IM1");
         }

--- a/java/test/jmri/jmrit/display/MemorySpinnerIconTest.java
+++ b/java/test/jmri/jmrit/display/MemorySpinnerIconTest.java
@@ -89,7 +89,7 @@ public class MemorySpinnerIconTest extends PositionableJPanelTest {
         super.setUp();
         jmri.InstanceManager.store(new jmri.NamedBeanHandleManager(), jmri.NamedBeanHandleManager.class);
         if (!GraphicsEnvironment.isHeadless()) {
-            editor = new jmri.jmrit.display.panelEditor.PanelEditor("Test MemorySpinnerIcon Panel");
+            editor = new jmri.jmrit.display.panelEditor.PanelEditor("Test MemorySpinnerIcon Panel", false, true);
             p=tos1 = new MemorySpinnerIcon(editor);
             tos1.setMemory("IM1");
         }

--- a/java/test/jmri/jmrit/display/ReporterIconTest.java
+++ b/java/test/jmri/jmrit/display/ReporterIconTest.java
@@ -51,7 +51,7 @@ public class ReporterIconTest extends PositionableTestBase {
         super.setUp();
         JUnitUtil.initReporterManager();
         if (!GraphicsEnvironment.isHeadless()) {
-            editor = new PanelEditor("Test ReporterIcon Panel");
+            editor = new PanelEditor("Test ReporterIcon Panel", false, true);
             p = to = new ReporterIcon(editor);
 
             // create objects to test

--- a/java/test/jmri/jmrit/display/RpsPositionIconTest.java
+++ b/java/test/jmri/jmrit/display/RpsPositionIconTest.java
@@ -85,7 +85,7 @@ public class RpsPositionIconTest extends PositionableTestBase {
         super.setUp();
         JUnitUtil.initDefaultUserMessagePreferences();
         if (!GraphicsEnvironment.isHeadless()) {
-            editor = new jmri.jmrit.display.panelEditor.PanelEditor("Test RpsPositionIcon Panel");
+            editor = new jmri.jmrit.display.panelEditor.PanelEditor("Test RpsPositionIcon Panel", false, true);
             p = rpsIcon = new RpsPositionIcon(editor);
         }
     }

--- a/java/test/jmri/jmrit/display/SensorIconWindowTest.java
+++ b/java/test/jmri/jmrit/display/SensorIconWindowTest.java
@@ -25,7 +25,7 @@ public class SensorIconWindowTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
 
         jmri.jmrit.display.panelEditor.PanelEditor panel
-                = new jmri.jmrit.display.panelEditor.PanelEditor("SensorIconWindowTest.testPanelEditor");
+                = new jmri.jmrit.display.panelEditor.PanelEditor("SensorIconWindowTest.testPanelEditor", false, true);
 
         SensorIcon icon = new SensorIcon(panel);
         panel.putItem(icon);
@@ -46,7 +46,7 @@ public class SensorIconWindowTest {
         int yloc = icon.getLocation().y + icon.getSize().height / 2;
         co.clickMouse(xloc,yloc,1);
 
-        // this will wait for WAITFOR_MAX_DELAY (15 seconds) max 
+        // this will wait for WAITFOR_MAX_DELAY (15 seconds) max
         // checking the condition every WAITFOR_DELAY_STEP (5 mSecs)
         // if it's still false after max wait it throws an assert.
         JUnitUtil.waitFor(() -> {
@@ -101,14 +101,14 @@ public class SensorIconWindowTest {
         int yloc = icon.getLocation().y + icon.getSize().height / 2;
         co.clickMouse(xloc,yloc,1);
 
-        // this will wait for WAITFOR_MAX_DELAY (15 seconds) max 
+        // this will wait for WAITFOR_MAX_DELAY (15 seconds) max
         // checking the condition every WAITFOR_DELAY_STEP (5 mSecs)
         // if it's still false after max wait it throws an assert.
         JUnitUtil.waitFor(() -> {
             return sn.getState() != Sensor.UNKNOWN;
         }, "state not still unknown after one click");
 
-        // this will wait for WAITFOR_MAX_DELAY (15 seconds) max 
+        // this will wait for WAITFOR_MAX_DELAY (15 seconds) max
         // checking the condition every WAITFOR_DELAY_STEP (5 mSecs)
         // if it's still false after max wait it throws an assert.
         JUnitUtil.waitFor(() -> {

--- a/java/test/jmri/jmrit/display/SignalMastIconTest.java
+++ b/java/test/jmri/jmrit/display/SignalMastIconTest.java
@@ -79,7 +79,7 @@ public class SignalMastIconTest extends PositionableIconTest {
     public void setUp() {
         super.setUp();
         if (!GraphicsEnvironment.isHeadless()) {
-            editor = new PanelEditor("Test SignalMastIcon Panel");
+            editor = new PanelEditor("Test SignalMastIcon Panel", false, true);
             p = new SignalMastIcon(editor);
             to = new SignalMastIcon(editor);
             to.setShowAutoText(true);

--- a/java/test/jmri/jmrit/display/TurnoutIconTest.java
+++ b/java/test/jmri/jmrit/display/TurnoutIconTest.java
@@ -131,7 +131,7 @@ public class TurnoutIconTest extends PositionableIconTest {
     public void setUp() {
         super.setUp();
         if (!GraphicsEnvironment.isHeadless()) {
-           editor = new jmri.jmrit.display.panelEditor.PanelEditor("Test TurnoutIcon Panel");
+           editor = new jmri.jmrit.display.panelEditor.PanelEditor("Test TurnoutIcon Panel", false, true);
            Editor e = new EditorScaffold();
            TurnoutIcon to = new TurnoutIcon(e);
            jmri.Turnout t = jmri.InstanceManager.turnoutManagerInstance().provideTurnout("IT1");

--- a/java/test/jmri/jmrit/display/TurnoutIconWindowTest.java
+++ b/java/test/jmri/jmrit/display/TurnoutIconWindowTest.java
@@ -20,21 +20,21 @@ import org.netbeans.jemmy.operators.JFrameOperator;
  * @author	Bob Jacobsen Copyright 2009, 2010
  */
 public class TurnoutIconWindowTest {
-    
+
     @Test
     public void testPanelEditor() throws Exception {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         jmri.jmrit.display.panelEditor.PanelEditor panel
-                = new jmri.jmrit.display.panelEditor.PanelEditor("TurnoutIconWindowTest.testPanelEditor");
-        
+                = new jmri.jmrit.display.panelEditor.PanelEditor("TurnoutIconWindowTest.testPanelEditor", false, true);
+
         panel.getTargetPanel();
-        
+
         TurnoutIcon icon = new TurnoutIcon(panel);
         Turnout sn = jmri.InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
         icon.setTurnout(new NamedBeanHandle<Turnout>("IT1", sn));
-        
+
         icon.setDisplayLevel(Editor.TURNOUTS);
-        
+
         icon.setIcon("TurnoutStateClosed",
                 new NamedIcon("resources/icons/smallschematics/tracksegments/os-lefthand-east-closed.gif",
                         "resources/icons/smallschematics/tracksegments/os-lefthand-east-closed.gif"));
@@ -47,10 +47,10 @@ public class TurnoutIconWindowTest {
         icon.setIcon("BeanStateUnknown",
                 new NamedIcon("resources/icons/smallschematics/tracksegments/os-lefthand-east-unknown.gif",
                         "resources/icons/smallschematics/tracksegments/os-lefthand-east-unknown.gif"));
-        
+
         panel.putItem(icon);
         panel.setVisible(true);
-        
+
         Assert.assertEquals("initial state", Turnout.UNKNOWN, sn.getState());
 
         // Click icon change state to Active
@@ -81,20 +81,20 @@ public class TurnoutIconWindowTest {
         to.closeFrameWithConfirmations();
     }
 
-    @Test    
+    @Test
     public void testLayoutEditor() throws Exception {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         jmri.jmrit.display.layoutEditor.LayoutEditor panel
                 = new jmri.jmrit.display.layoutEditor.LayoutEditor("TurnoutIconWindowTest.testLayoutEditor");
-        
+
         panel.getTargetPanel();
-        
+
         TurnoutIcon icon = new TurnoutIcon(panel);
         icon.setDisplayLevel(Editor.TURNOUTS);
-        
+
         Turnout sn = jmri.InstanceManager.turnoutManagerInstance().provideTurnout("IT1");
         icon.setTurnout("IT1");
-        
+
         icon.setIcon("TurnoutStateClosed",
                 new NamedIcon("resources/icons/smallschematics/tracksegments/os-lefthand-east-closed.gif",
                         "resources/icons/smallschematics/tracksegments/os-lefthand-east-closed.gif"));
@@ -107,10 +107,10 @@ public class TurnoutIconWindowTest {
         icon.setIcon("BeanStateUnknown",
                 new NamedIcon("resources/icons/smallschematics/tracksegments/os-lefthand-east-unknown.gif",
                         "resources/icons/smallschematics/tracksegments/os-lefthand-east-unknown.gif"));
-        
+
         panel.putItem(icon);
         panel.setVisible(true);
-        
+
         Assert.assertEquals("initial state", Turnout.UNKNOWN, sn.getState());
 
         // Click icon change state to Active
@@ -118,18 +118,18 @@ public class TurnoutIconWindowTest {
         int xloc = icon.getLocation().x + icon.getSize().width / 2;
         int yloc = icon.getLocation().y + icon.getSize().height / 2;
         co.clickMouse(xloc,yloc,1);
-        
+
         JUnitUtil.waitFor(() -> {
             return sn.getState() != Turnout.UNKNOWN;
         }, "Not initial state");
-        
+
         JUnitUtil.waitFor(() -> {
             return sn.getState() == Turnout.CLOSED;
         }, "state after one click");
 
         // Click icon change state to inactive
         co.clickMouse(xloc,yloc,1);
-        
+
         JUnitUtil.waitFor(() -> {
             return sn.getState() == Turnout.THROWN;
         }, "state after two clicks");
@@ -148,7 +148,7 @@ public class TurnoutIconWindowTest {
         JUnitUtil.initInternalTurnoutManager();
         JUnitUtil.initInternalSensorManager();
     }
-    
+
     @After
     public void tearDown() throws Exception {
         JUnitUtil.tearDown();

--- a/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
+++ b/java/test/jmri/jmrit/display/layoutEditor/LayoutEditorTest.java
@@ -762,7 +762,7 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
         EditorFrameOperator jfo = new EditorFrameOperator(e);
         JMenuOperator jmo = new JMenuOperator(jfo,Bundle.getMessage("MenuOptions"));
         Assert.assertNotNull("Options Menu Exists",jmo);
-        Assert.assertEquals("Menu Item Count",18,jmo.getItemCount());
+        Assert.assertEquals("Menu Item Count",19,jmo.getItemCount());
     }
 
     @Test
@@ -838,6 +838,23 @@ public class LayoutEditorTest extends AbstractEditorTestBase<LayoutEditor> {
         jmo.pushMenuNoBlock(Bundle.getMessage("MenuOptions") + "/"
                              + Bundle.getMessage("ToolBar") + "/"
                              + Bundle.getMessage("ToolBarSideFloat"), "/");
+    }
+
+    @Test
+    public void testPanelLocation() {
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        e.setVisible(true);
+        EditorFrameOperator jfo = new EditorFrameOperator(e);
+        JMenuOperator jmo = new JMenuOperator(jfo,Bundle.getMessage("MenuOptions"));
+
+        jmo.pushMenuNoBlock(Bundle.getMessage("MenuOptions") + "/"
+                             + Bundle.getMessage("SetLocation"), "/");
+
+        jmo.pushMenuNoBlock(Bundle.getMessage("MenuOptions") + "/"
+                             + Bundle.getMessage("SetLocationAlways"), "/");
+
+        e.componentMoved(null);
+        e.componentResized(null);
     }
 
     @Test

--- a/java/test/jmri/jmrit/display/panelEditor/PanelEditorTest.java
+++ b/java/test/jmri/jmrit/display/panelEditor/PanelEditorTest.java
@@ -36,7 +36,7 @@ public class PanelEditorTest extends AbstractEditorTestBase<PanelEditor> {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
         if (!GraphicsEnvironment.isHeadless()) {
-            e = new PanelEditor("Panel Editor Test");
+            e = new PanelEditor("Panel Editor Test", false, true);
         }
     }
 

--- a/java/test/jmri/jmrit/operations/trains/TrainIconAnimationTest.java
+++ b/java/test/jmri/jmrit/operations/trains/TrainIconAnimationTest.java
@@ -57,7 +57,7 @@ public class TrainIconAnimationTest extends OperationsTestCase {
 
         // create and register a panel
         jmri.jmrit.display.panelEditor.PanelEditor editor = new jmri.jmrit.display.panelEditor.PanelEditor(
-                "Train Test Panel");
+                "Train Test Panel", false, true);
         InstanceManager.getDefault(PanelMenu.class).addEditorPanel(editor);
 
         // confirm panel creation

--- a/java/test/jmri/server/json/util/JsonUtilSocketServiceTest.java
+++ b/java/test/jmri/server/json/util/JsonUtilSocketServiceTest.java
@@ -52,7 +52,7 @@ public class JsonUtilSocketServiceTest {
 
     /**
      * Test of onMessage method, of class JsonUtilSocketService. Tests only
-     * responses that are expected to be consistent between a 
+     * responses that are expected to be consistent between a
      *
      * @throws java.lang.Exception if an exception unexpected in the context of
      *                             these tests occurs
@@ -135,7 +135,7 @@ public class JsonUtilSocketServiceTest {
         JUnitUtil.dispose(editor.getTargetFrame());
         JUnitUtil.dispose(editor);
     }
-    
+
     /**
      * Test of onList method, of class JsonUtilSocketService. Does not test CONFIG_PROFILE
      * JSON type, see {@link #testOnListConfigProfile()} for that. Does not test PANEL
@@ -194,8 +194,8 @@ public class JsonUtilSocketServiceTest {
         Editor switchboard = new SwitchboardEditor("json test switchboard");
         Editor controlPanel = new ControlPanelEditor("json test control panel");
         Editor layoutPanel = new LayoutEditor("json test layout panel");
-        Editor panel = new PanelEditor("json test panel");
-        Editor disabled = new PanelEditor("disabled json test panel");
+        Editor panel = new PanelEditor("json test panel", false, true);
+        Editor disabled = new PanelEditor("disabled json test panel", false, true);
         disabled.setAllowInFrameServlet(false);
         // 5 editors should return array of 4 since one is barred
         JsonMockConnection connection = new JsonMockConnection((DataOutputStream) null);
@@ -279,12 +279,12 @@ public class JsonUtilSocketServiceTest {
             }
             return super.doGet(type, name, locale);
         }
-        
+
         public void setThrowException(boolean throwException) {
             this.throwException = throwException;
         }
-        
+
     }
-    
+
     private static final Logger log = LoggerFactory.getLogger(JsonUtilSocketServiceTest.class);
 }


### PR DESCRIPTION
- The location and size for a panel are stored only in the panel XML file.  The panel location and size are no longer saved in the user-interface.xml file.
- The location of the separate editor windows for PanelEditor and SwitchboardEditor continue to use the user-interface.xml file as does the LayoutEditor floating tool box for its location and size.
- The **Always Save Location and Size** item has been added to the Layout Editor Options menu.  When this is active, the **current** location and size of the Layout Editor panel will always be saved during the panel xml file store process.  This is consistent with the other editors.