### PR TITLE
Jython scripts Throttle release

### DIFF
--- a/help/en/html/doc/Technical/RP.shtml
+++ b/help/en/html/doc/Technical/RP.shtml
@@ -203,9 +203,7 @@
             with <code>ci-compile-deprecations</code> to check this, or look at the
             <a href="http://jmri.tagadab.com/jenkins/job/Development/job/Deprecations/lastBuild/warnings4Result/">Jenkins CI report</a>
             (click the Types tab) to check the JMRI/JMRI master branch.
-            Don't forget to also migrate the 
-            Jython sample scripts! 
-
+        <li><strong>Don't forget to migrate the Jython sample scripts!</strong>
         <li>Wait an appropriate length of time; the more visible the class or method,
             the longer to wait.  Things that were in scripts should wait at least two
             production releases.

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -378,7 +378,18 @@
     <h3>Scripting</h3>
         <a id="Scripting" name="Scripting"></a>
         <ul>
-            <li></li>
+            <li><strong>Custom scripts that release throttles may need to be modified.</strong><br>
+            <ul>
+                <li>AutoDispatcher2</li>
+                <li>RobotThrottle2</li>
+                <li>RobotThrottle3</li>
+                <li>RocoCrane</li>
+                <li>Zimo Programmers</li>
+            </ul>
+            <br>
+            Old syntax: <code>self.throttle.release()</code> <br>
+            New syntax assuming no throttle listeners in script: <code>self.throttle.release(None)</code>
+            </li>
         </ul>
 
     <h3>Signals</h3>

--- a/jython/AutoDispatcher2.py
+++ b/jython/AutoDispatcher2.py
@@ -4911,7 +4911,7 @@ class ADlocomotive :
     def setAddress(self, address) :
         # Change dcc address
         if self.throttle != None :
-            self.throttle.release()
+            self.throttle.release(None)
         if address <1 :
                 address = 1
         self.address = address
@@ -4970,11 +4970,11 @@ class ADlocomotive :
         if self.throttle != None :
             if ADsettings.lightMode != 0 :
                 self.setFunction(0, False)
-            self.throttle.release()
+            self.throttle.release(None)
             self.throttle = None
             self.throttleAssigned = False
             if self.leadLoco != 0 :
-                self.leadThrottle.release()
+                self.leadThrottle.release(None)
                 AutoDispatcher.message("Released throttles of consist "
                   + self.name + " (" + str(self.address) + ", " + 
                   str(self.leadLoco) + ")")

--- a/jython/LocoTest.py
+++ b/jython/LocoTest.py
@@ -108,7 +108,7 @@ class LocoTest(jmri.jmrit.automat.AbstractAutomaton) :
 
         # done!
         self.status.text = "Done"
-        self.throttle.release()
+        self.throttle.release(None)
         #re-enable button
         self.startButton.enabled = True
         # and stop

--- a/jython/RobotThrottle2.py
+++ b/jython/RobotThrottle2.py
@@ -270,7 +270,7 @@ class LocoThrot(jmri.jmrit.automat.AbstractAutomaton) :
             oldId = self.currentThrottle.getLocoAddress()
             self.msgText("stop and release the current loco: " + oldId.toString() + "\n")
             self.doStop();
-            self.currentThrottle.release()
+            self.currentThrottle.release(None)
             self.currentThrottle = None
             self.msgText("Throttle " + oldId.toString() + " released\n")
         self.msgText("Getting throttle - ") #add text to scroll field
@@ -566,7 +566,7 @@ class LocoThrot(jmri.jmrit.automat.AbstractAutomaton) :
         if (self.currentThrottle != None) :
             #print("RB2: releasing throttle\n")
             self.currentThrottle.setSpeedSetting(0)
-            self.currentThrottle.release()
+            self.currentThrottle.release(None)
         self.isAborting = True
         return
 

--- a/jython/RobotThrottle3.py
+++ b/jython/RobotThrottle3.py
@@ -285,7 +285,7 @@ class LocoThrot(jmri.jmrit.automat.AbstractAutomaton) :
             if (self.debugLevel >= LowDebug) :
                 self.msgText("stop and release the current loco: " + str(oldId))
             self.doStop();
-            self.currentThrottle.release()
+            self.currentThrottle.release(None)
             self.currentThrottle = None
             if (self.debugLevel >= LowDebug) :
                 self.msgText("Throttle " + str(oldId) + " released")
@@ -674,7 +674,7 @@ class LocoThrot(jmri.jmrit.automat.AbstractAutomaton) :
         if (self.currentThrottle != None) :
             #self.msgText("releasing throttle")
             self.currentThrottle.setSpeedSetting(0)
-            self.currentThrottle.release()
+            self.currentThrottle.release(None)
         self.isAborting = True
         return
 

--- a/jython/RocoCrane46800.py
+++ b/jython/RocoCrane46800.py
@@ -69,7 +69,7 @@ class RocoCrane(jmri.jmrit.automat.AbstractAutomaton) :
         return
 
     def whenReleaseButtonClicked(self,event) :
-    self.Throttle.release()
+    self.Throttle.release(None)
         self.status = javax.swing.JLabel("Enter address & click start")
         self.Address.enabled = True
         self.StartButton.enabled = True

--- a/jython/RocoCrane46902.py
+++ b/jython/RocoCrane46902.py
@@ -65,7 +65,7 @@ class RocoCrane(jmri.jmrit.automat.AbstractAutomaton) :
         return
     
     def whenReleaseButtonClicked(self,event) :
-    self.Throttle.release()
+    self.Throttle.release(None)
         self.status = javax.swing.JLabel("Enter address & click start")
         self.Address.enabled = True
         self.StartButton.enabled = True

--- a/jython/Zimo_function_programmer.py
+++ b/jython/Zimo_function_programmer.py
@@ -280,7 +280,7 @@ class LocoZimoProg(jmri.jmrit.automat.AbstractAutomaton) :
             statusText = "setting outputs for Function Key F" + str(self.dirCount) + " in Reverse Direction"
         else:
             # end of operations, release the throttle...
-            self.throttle.release()
+            self.throttle.release(None)
         self.status.text = statusText
         return
 

--- a/jython/Zimo_pseudo_programmer.py
+++ b/jython/Zimo_pseudo_programmer.py
@@ -95,7 +95,7 @@ class LocoZimoPseudoProg(jmri.jmrit.automat.AbstractAutomaton) :
         # we need to quit and clear down tidily...
         self.hideShowRadios(False)
         self.hideShowOpsButton(False)
-        self.throttle.release()
+        self.throttle.release(None)
         self.address.enabled = True
         self.startButton.enabled = True
         self.box.enabled = True


### PR DESCRIPTION
Looks like Throttle.release() was deprecated?

While rejigging Jython script LocoTest.py for another purpose, I gave it an initial test,
exception line 111 on throttle dispose.
https://github.com/JMRI/JMRI/blob/master/jython/LocoTest.py#L111

This fixes that, along with the other scripts.