### PR TITLE
MERG CBUS Protect extended frame

### DIFF
--- a/help/en/html/hardware/can/cbus/Names.shtml
+++ b/help/en/html/hardware/can/cbus/Names.shtml
@@ -576,8 +576,13 @@
       while future uses of this may also be for local media streaming ( eg. transferring 
       pictures of trains or sound files between modules. )
       <br>The extended frames do not interfere with the standard frames, 
-      hence modules can be targetted for boatloading by module number, without affecting Standard CAN event frames.
-      </p>
+      hence modules can be targetted for boatloading by module number, 
+      without affecting normal layout messaging.</p>
+      
+      <p>Extended CAN frames ( which are not CBUS messages ) can be monitored in the 
+      <a href="../../../../package/jmri/jmrix/can/cbus/swing/console/CbusConsoleFrame.shtml"
+        >CBUS console</a>,
+        and are filtered from all other JMRI objects ( Sensors, Turnouts etc. ).</p>
       
       <p>Although module firmware updates are not currently available within JMRI, 
       full support for this is available via 3rd party software ( FCU - FLiM Configuration Utility ), 

--- a/java/src/jmri/jmrix/can/cbus/CbusDccProgrammer.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusDccProgrammer.java
@@ -133,6 +133,9 @@ public class CbusDccProgrammer extends AbstractProgrammer implements CanListener
      */
     @Override
     synchronized public void reply(CanReply m) {
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         if (progState == NOTPROGRAMMING) {
             // we get the complete set of replies now, so ignore these
             return;

--- a/java/src/jmri/jmrix/can/cbus/CbusEvent.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusEvent.java
@@ -15,75 +15,187 @@ public class CbusEvent {
     private int _en;
     protected EvState _state;
     protected String _name;
-    protected String _nodeName; // this to be provided by a node table eventually
     
+    /**
+     * Enum of the event state.
+     * <p>
+     * Events generally have on, off or unknown status.
+     * <p>
+     * They can also be asked to request their current status via the network,
+     * or toggled to the opposite state that it is currently at.
+     *
+     */
     public enum EvState{
         ON, OFF, UNKNOWN, REQUEST, TOGGLE;
     }
     
+    /**
+     * Create a new event
+     * <p>
+     * New events have an unknown on or off status
+     *
+     * @param nn Node Number
+     * @param en Event Number
+     *
+     */
     public CbusEvent( int nn, int en){
         this._nn = nn;
         this._en = en;
         this._state = EvState.UNKNOWN;
         this._name = "";
-        this._nodeName = "";
     }
 
+    /**
+     * Get state of the event
+     *
+     * @return the enum event state, on off or unknown.
+     *
+     */
     public EvState getState() {
         return _state;
     }
     
+    /**
+     * Set current state of the event
+     * <p>
+     * Does NOT send update to layout
+     *
+     * @param newval the enum event state ie ON, OFF, UNKNOWN
+     *
+     */
     public void setState( EvState newval ) {
         _state = newval;
     }    
     
+    /**
+     * Get event event number
+     *
+     * @return event Number
+     *
+     */
     public int getEn() {
         return _en;
     }
 
+    /**
+     * Get event node number
+     *
+     * @return node Number
+     *
+     */
     public int getNn(){
         return _nn;
     }
     
+    /**
+     * Set event event number
+     *
+     * @param en Event Number, not restricted so can be -1 for unknown
+     *
+     */
     public void setEn ( int en ) {
         _en = en;
     }
 
+    /**
+     * Set event node number
+     *
+     * @param nn Node Number, not restricted so can be -1 for unknown
+     *
+     */
     public void setNn ( int nn ) {
         _nn = nn;
     }
     
+    /**
+     * Set event name
+     *
+     * @param name Event Name
+     *
+     */
     public void setName( String name ) {
         _name = name;
     }
     
+    /**
+     * Set event name
+     *
+     * @return the Event Name
+     *
+     */
     public String getName() {
         return _name;
     }
     
+    /**
+     * Get Node name
+     * <p>
+     * Helper method, node name not stored in event, retrieved via @CbusNameService
+     *
+     * @return Node Name
+     *
+     */
     public String getNodeName() {
         return new CbusNameService().getNodeName( getNn() );
     }
     
-    public Boolean matches(int nn, int en) {
+    /**
+     * Test if a node and event number combination matches this event
+     * 
+     * @param nn Node Number
+     * @param en Event Number
+     *
+     * @return true on match, else false
+     *
+     */
+    public boolean matches(int nn, int en) {
         if ( (nn == _nn) && (en == _en) ) {
             return true;
         }
         return false;
     }
     
+    /**
+     * Send ON event CAN frame
+     * <p>
+     * Long event if Node num > 0, else short
+     *
+     */
     public void sendOn(){
         sendEvent(EvState.ON);
     }
     
+    /**
+     * Send OFF event CAN frame
+     * <p>
+     * Long event if Node num > 0, else short
+     *
+     */
     public void sendOff(){
         sendEvent(EvState.OFF);
     }
-
+    
+    /**
+     * Send event status request CAN frame
+     * <p>
+     * Long request if Node num > 0, else short
+     *
+     */
     public void sendRequest(){
         sendEvent(EvState.REQUEST);
     }
 
+    /**
+     * Send event CAN frame via ENUM
+     * <p>
+     * Also updates the event status as per the enum value.
+     * <p>
+     * If current state unknown, toggle sends event off
+     * <p>
+     * Long event if Node num > 0, else short
+     * @param state The enum state requested to be sent, ie ON, OFF, REQUEST, TOGGLE
+     *
+     */
     public void sendEvent(EvState state) {
         CanSystemConnectionMemo memo = jmri.InstanceManager.getDefault(CanSystemConnectionMemo.class);
         TrafficController _tc = memo.getTrafficController();
@@ -125,6 +237,13 @@ public class CbusEvent {
         jmri.util.ThreadingUtil.runOnLayout( () -> { _tc.sendCanMessage(m, null); } );
     }
     
+    /**
+     * Get a String with event overview
+     * <p>
+     * 
+     * @return includes event name and node name if known
+     *
+     */
     @Override
     public String toString() {
         StringBuilder addevbuf = new StringBuilder(50);

--- a/java/src/jmri/jmrix/can/cbus/CbusEvent.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusEvent.java
@@ -158,7 +158,7 @@ public class CbusEvent {
     /**
      * Send ON event CAN frame
      * <p>
-     * Long event if Node num > 0, else short
+     * Long event if Node num greater than 0, else short
      *
      */
     public void sendOn(){
@@ -168,7 +168,7 @@ public class CbusEvent {
     /**
      * Send OFF event CAN frame
      * <p>
-     * Long event if Node num > 0, else short
+     * Long event if Node num greater than 0, else short
      *
      */
     public void sendOff(){
@@ -178,7 +178,7 @@ public class CbusEvent {
     /**
      * Send event status request CAN frame
      * <p>
-     * Long request if Node num > 0, else short
+     * Long request if Node num greater than 0, else short
      *
      */
     public void sendRequest(){
@@ -192,7 +192,7 @@ public class CbusEvent {
      * <p>
      * If current state unknown, toggle sends event off
      * <p>
-     * Long event if Node num > 0, else short
+     * Long event if Node num greater than 0, else short
      * @param state The enum state requested to be sent, ie ON, OFF, REQUEST, TOGGLE
      *
      */

--- a/java/src/jmri/jmrix/can/cbus/CbusLight.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusLight.java
@@ -106,6 +106,9 @@ public class CbusLight extends AbstractLight
     
     @Override
     public void message(CanMessage f) {
+        if ( f.isExtended() || f.isRtr() ) {
+            return;
+        }
         if (addrOn.match(f)) {
             setState(ON);
         } else if (addrOff.match(f)) {
@@ -115,6 +118,9 @@ public class CbusLight extends AbstractLight
 
     @Override
     public void reply(CanReply f) {
+        if ( f.isExtended() || f.isRtr() ) {
+            return;
+        }
         // convert response events to normal
         f = CbusMessage.opcRangeToStl(f);
         if (addrOn.match(f)) {

--- a/java/src/jmri/jmrix/can/cbus/CbusMultiMeter.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusMultiMeter.java
@@ -61,6 +61,9 @@ public class CbusMultiMeter extends jmri.implementation.AbstractMultiMeter imple
 
     @Override
     public void reply(CanReply r) {
+        if ( r.isExtended() || r.isRtr() ) {
+            return;
+        }
         if ( CbusMessage.getOpcode(r) != CbusConstants.CBUS_ACON2  ) {
             return;
         }

--- a/java/src/jmri/jmrix/can/cbus/CbusPowerManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusPowerManager.java
@@ -114,6 +114,9 @@ public class CbusPowerManager implements PowerManager, CanListener {
     // to listen for status changes from Cbus system
     @Override
     public void reply(CanReply m) {
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         if (CbusMessage.isTrackOff(m)) {
             power = OFF;
             firePropertyChange("Power", null, null);

--- a/java/src/jmri/jmrix/can/cbus/CbusReporter.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusReporter.java
@@ -55,6 +55,9 @@ public class CbusReporter extends AbstractReporter implements CanListener {
 
     @Override
     public void message(CanMessage m) {
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         log.debug("CbusReporter: message " + m.getOpCode());
         if (m.getOpCode() == CbusConstants.CBUS_DDES) {
             RFIDReport(m);
@@ -63,6 +66,9 @@ public class CbusReporter extends AbstractReporter implements CanListener {
 
     @Override
     public void reply(CanReply m) {
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         log.debug("CbusReporter: reply " + m.getOpCode());
         if (m.getOpCode() == CbusConstants.CBUS_DDES || m.getOpCode() == CbusConstants.CBUS_ACDAT) {
             int addr = (m.getElement(1) << 8) + m.getElement(2);

--- a/java/src/jmri/jmrix/can/cbus/CbusSensor.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensor.java
@@ -163,6 +163,9 @@ public class CbusSensor extends AbstractSensor implements CanListener {
      */
     @Override
     public void message(CanMessage f) {
+        if ( f.isExtended() || f.isRtr() ) {
+            return;
+        }
         if (addrActive.match(f)) {
             setOwnState(!getInverted() ? Sensor.ACTIVE : Sensor.INACTIVE);
         } else if (addrInactive.match(f)) {
@@ -176,6 +179,9 @@ public class CbusSensor extends AbstractSensor implements CanListener {
      */
     @Override
     public void reply(CanReply f) {
+        if ( f.isExtended() || f.isRtr() ) {
+            return;
+        }
         // convert response events to normal
         f = CbusMessage.opcRangeToStl(f);
         if (addrActive.match(f)) {

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnout.java
@@ -156,6 +156,9 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
      */
     @Override
     public void message(CanMessage f) {
+        if ( f.isExtended() || f.isRtr() ) {
+            return;
+        }
         if (addrThrown.match(f)) {
             int state = (!getInverted() ? THROWN : CLOSED);
             newCommandedState(state);
@@ -184,6 +187,9 @@ public class CbusTurnout extends jmri.implementation.AbstractTurnout
      */
     @Override
     public void reply(CanReply f) {
+        if ( f.isExtended() || f.isRtr() ) {
+            return;
+        }
         // convert response events to normal
         f = CbusMessage.opcRangeToStl(f);
         if (addrThrown.match(f)) {

--- a/java/src/jmri/jmrix/can/cbus/node/CbusAllocateNodeNumber.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusAllocateNodeNumber.java
@@ -190,6 +190,9 @@ public class CbusAllocateNodeNumber implements CanListener {
      */
     @Override
     public void message(CanMessage m) { // outgoing cbus message
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         if (CbusMessage.getOpcode(m) == CbusConstants.CBUS_QNN) {
             if (!NODE_NUM_DIALOGUE_OPEN) {
                 send.nodeRequestParamSetup();
@@ -203,6 +206,9 @@ public class CbusAllocateNodeNumber implements CanListener {
      */
     @Override
     public void reply(CanReply m) { // incoming cbus message
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         int opc = CbusMessage.getOpcode(m);
 
         if (opc==CbusConstants.CBUS_RQNN){ // node requesting a number, nn is existing number

--- a/java/src/jmri/jmrix/can/cbus/node/CbusNode.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNode.java
@@ -1408,7 +1408,9 @@ public class CbusNode implements CanListener {
     // so we monitor them the same
     @Override
     public void message(CanMessage m) {
-        
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         switch ( CbusMessage.getOpcode(m) ) {
             case CbusConstants.CBUS_NVSET:
             case CbusConstants.CBUS_NNREL:
@@ -1430,6 +1432,9 @@ public class CbusNode implements CanListener {
     // also parses outgoing messages
     @Override
     public void reply(CanReply m) {
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         int opc = CbusMessage.getOpcode(m);
         int nn = ( m.getElement(1) * 256 ) + m.getElement(2);
         

--- a/java/src/jmri/jmrix/can/cbus/simulator/CbusDummyCS.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/CbusDummyCS.java
@@ -45,8 +45,8 @@ public class CbusDummyCS implements CanListener {
     private Boolean _sendOut;
     protected CbusSend send;
 
-    public static ArrayList<String> csTypes = new ArrayList<String>();
-    public static ArrayList<String> csTypesTip = new ArrayList<String>();
+    public ArrayList<String> csTypes = new ArrayList<String>();
+    public ArrayList<String> csTypesTip = new ArrayList<String>();
     
     protected static int DEFAULT_CS_TIMEOUT = 60000; // ms
     protected static int DEFAULT_SESSION_START_SPDDIR = 128;  // default DCC speed direction on start session
@@ -337,6 +337,9 @@ public class CbusDummyCS implements CanListener {
 
     @Override
     public void message(CanMessage m) {
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         if ( _processOut ) {
             CanFrame test = m;
             passMessage(test);
@@ -345,6 +348,9 @@ public class CbusDummyCS implements CanListener {
 
     @Override
     public void reply(CanReply r) {
+        if ( r.isExtended() || r.isRtr() ) {
+            return;
+        }
         if ( _processIn ) {
             CanFrame test = r;
             passMessage(test);

--- a/java/src/jmri/jmrix/can/cbus/simulator/CbusDummyNode.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/CbusDummyNode.java
@@ -429,6 +429,9 @@ public class CbusDummyNode extends CbusNode implements CanListener {
     
     @Override
     public void message(CanMessage m) {
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         if ( _processOut ) {
             passMessage(m);
         }
@@ -436,6 +439,9 @@ public class CbusDummyNode extends CbusNode implements CanListener {
 
     @Override
     public void reply(CanReply r) {
+        if ( r.isExtended() || r.isRtr() ) {
+            return;
+        }
         if ( _processIn ) {
             CanMessage msg = new CanMessage(r);
             passMessage(msg);

--- a/java/src/jmri/jmrix/can/cbus/simulator/CbusEventResponder.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/CbusEventResponder.java
@@ -33,8 +33,8 @@ public class CbusEventResponder implements CanListener {
     private Boolean _sendOut;
     private CbusSend send;
     
-    public static ArrayList<String> evModes = new ArrayList<String>();
-    public static ArrayList<String> evModesTip = new ArrayList<String>();
+    public ArrayList<String> evModes = new ArrayList<String>();
+    public ArrayList<String> evModesTip = new ArrayList<String>();
     
     public CbusEventResponder( CanSystemConnectionMemo memod ){
         memo = memod;
@@ -195,6 +195,9 @@ public class CbusEventResponder implements CanListener {
     
     @Override
     public void message(CanMessage m) {
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         if ( _processOut ) {
             processEventforResponse(m);
         }
@@ -202,6 +205,9 @@ public class CbusEventResponder implements CanListener {
 
     @Override
     public void reply(CanReply r) {
+        if ( r.isExtended() || r.isRtr() ) {
+            return;
+        }
         if ( _processIn ) {
             CanMessage m = new CanMessage(r);
             processEventforResponse(m);

--- a/java/src/jmri/jmrix/can/cbus/swing/CbusEventHighlightPanel.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/CbusEventHighlightPanel.java
@@ -207,7 +207,7 @@ public class CbusEventHighlightPanel extends JPanel {
 
     }
         
-    public void setoptions(){    
+    private void setoptions(){    
         
         int nn = 0;
         int ev = 0;

--- a/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolPane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/configtool/ConfigToolPane.java
@@ -235,6 +235,9 @@ public class ConfigToolPane extends jmri.jmrix.can.swing.CanPanel implements Can
 
     @Override
     public void reply(jmri.jmrix.can.CanReply m) {
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         if ( ( _filterFrame!=null ) && ( _filterFrame.filter(m) ) ) {
             return;
         }
@@ -252,6 +255,9 @@ public class ConfigToolPane extends jmri.jmrix.can.swing.CanPanel implements Can
 
     @Override
     public void message(jmri.jmrix.can.CanMessage m) {
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         if ( ( _filterFrame!=null ) && ( _filterFrame.filter(m)) ) {
             return;
         }

--- a/java/src/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestDataModel.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestDataModel.java
@@ -327,7 +327,9 @@ public class CbusEventRequestDataModel extends javax.swing.table.AbstractTableMo
     // or incoming CanReply
     @Override
     public void message(CanMessage m) {
-        
+        if ( m.isExtended() || m.isRtr() ) {
+            return;
+        }
         int opc = CbusMessage.getOpcode(m);
         if (CbusOpCodes.isEventRequest(opc)) {
             processEvRequest( CbusMessage.getNodeNumber(m) , CbusMessage.getEvent(m) );
@@ -343,7 +345,10 @@ public class CbusEventRequestDataModel extends javax.swing.table.AbstractTableMo
     // incoming cbus message
     // handled the same as outgoing
     @Override
-    public void reply(CanReply r) { 
+    public void reply(CanReply r) {
+        if ( r.isExtended() || r.isRtr() ) {
+            return;
+        }
         CanMessage m = new CanMessage(r);
         message(m);
     }

--- a/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeNVTablePane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeNVTablePane.java
@@ -63,6 +63,10 @@ public class CbusNodeNVTablePane extends jmri.jmrix.can.swing.CanPanel {
         }
         pane1 = null;
         
+        if ( nodeNvTable == null ){
+            return;
+        }
+        
         TableColumnModel tableModel = nodeNvTable.getColumnModel();
         
 

--- a/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeRestoreFcuFrame.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeRestoreFcuFrame.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.util.ArrayList;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
+import javax.swing.event.ChangeEvent;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -218,6 +219,10 @@ public class CbusNodeRestoreFcuFrame extends JmriJFrame {
         tabbedPane.addTab(("Node Variables "), nodevarPane);
         tabbedPane.addTab(("Node Events"), nodeEventPane);
         
+        tabbedPane.addChangeListener((ChangeEvent e) -> {
+            updateTabs();
+        });
+        
         split = new JSplitPane(JSplitPane.VERTICAL_SPLIT, fcuPane, tabbedPane);
         split.setDividerLocation(0.5);
         split.setContinuousLayout(true);
@@ -339,9 +344,14 @@ public class CbusNodeRestoreFcuFrame extends JmriJFrame {
 
         if ( nodeTable.getSelectedRow() > -1 ) {
             
-            nodeinfoPane.initComponents( nodeFromSelectedRow() );
-            nodevarPane.setNode( nodeFromSelectedRow() );
-            nodeEventPane.setNode( nodeFromSelectedRow() );
+            if ( tabbedPane.getSelectedIndex() == 1 ){ // nv pane
+                nodevarPane.setNode( nodeFromSelectedRow() );
+            }
+            else if ( tabbedPane.getSelectedIndex() == 2 ) { // ev pane
+                nodeEventPane.setNode( nodeFromSelectedRow() );
+            } else {
+                nodeinfoPane.initComponents( nodeFromSelectedRow() );
+            }
         }
         else {
             nodeinfoPane.initComponents( null );

--- a/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeRestoreFcuFrame.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/nodeconfig/CbusNodeRestoreFcuFrame.java
@@ -538,7 +538,8 @@ public class CbusNodeRestoreFcuFrame extends JmriJFrame {
             if ( !evList.get(i).getName().isEmpty() ){
                 eventModel.provideEvent(evList.get(i).getNn(),evList.get(i).getEn()).setName(evList.get(i).getName());
             }
-        }        
+        }
+        eventModel.fireTableDataChanged();
     }
     
     private void showConfirmThenSave(){

--- a/java/src/jmri/jmrix/can/cbus/swing/simulator/CsPane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/simulator/CsPane.java
@@ -59,10 +59,10 @@ public class CsPane extends JPanel {
         tooltips = new ArrayList<String>();
         String getSelected="";
         
-        for (int i = 0; i < CbusDummyCS.csTypes.size(); i++) {
-            String option = CbusDummyCS.csTypes.get(i);
+        for (int i = 0; i < _cs.csTypes.size(); i++) {
+            String option = _cs.csTypes.get(i);
             _selectCs.addItem(option);
-            tooltips.add(CbusDummyCS.csTypesTip.get(i));
+            tooltips.add(_cs.csTypesTip.get(i));
             if ( i == _type ){
                 getSelected = option;
             }
@@ -74,8 +74,8 @@ public class CsPane extends JPanel {
             public void actionPerformed(ActionEvent e) {
                 String chosen = (String)_selectCs.getSelectedItem();
                 
-                for (int i = 0; i < CbusDummyCS.csTypes.size(); i++) {
-                    String option = CbusDummyCS.csTypes.get(i);
+                for (int i = 0; i < _cs.csTypes.size(); i++) {
+                    String option = _cs.csTypes.get(i);
                     if (option.equals(chosen)) {
                         log.debug("chosen {} {}",i,chosen);
                         _cs.setDummyType(i);

--- a/java/src/jmri/jmrix/can/cbus/swing/simulator/EvResponderPane.java
+++ b/java/src/jmri/jmrix/can/cbus/swing/simulator/EvResponderPane.java
@@ -65,10 +65,10 @@ public class EvResponderPane extends JPanel {
         tooltips = new ArrayList<String>();
         String getSelected="";
         
-        for (int i = 0; i < CbusEventResponder.evModes.size(); i++) {
-            String option = CbusEventResponder.evModes.get(i);
+        for (int i = 0; i < _evr.evModes.size(); i++) {
+            String option = _evr.evModes.get(i);
             _selectMode.addItem(option);
-            tooltips.add(CbusEventResponder.evModesTip.get(i));
+            tooltips.add(_evr.evModesTip.get(i));
             if ( i == _mode ){
                 getSelected = option;
             }
@@ -80,8 +80,8 @@ public class EvResponderPane extends JPanel {
             public void actionPerformed(ActionEvent e) {
                 String chosen = (String)_selectMode.getSelectedItem();
                 
-                for (int i = 0; i < CbusEventResponder.evModes.size(); i++) {
-                    String option = CbusEventResponder.evModes.get(i);
+                for (int i = 0; i < _evr.evModes.size(); i++) {
+                    String option = _evr.evModes.get(i);
                     if (option.equals(chosen)) {
                         log.debug("chosen {} {}",i,chosen);
                         _evr.setMode(i);

--- a/java/test/jmri/jmrix/can/cbus/CbusLightTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusLightTest.java
@@ -341,6 +341,70 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
         Assert.assertTrue(t.getState() == Light.OFF);
  
     }
+    
+    @Test
+    public void testCbusLightCanMessageExtendedRtR() throws jmri.JmriException {
+        CbusLight t = new CbusLight("ML","+N54321E12345",tcis);
+        Assert.assertTrue(t.getState() == Light.OFF); // Light.UNKNOWN ??
+        
+        CanMessage m = new CanMessage(tcis.getCanid());
+        m.setNumDataElements(5);
+        m.setElement(0, 0x90); // ACON OPC
+        m.setElement(1, 0xd4);
+        m.setElement(2, 0x31);
+        m.setElement(3, 0x30);
+        m.setElement(4, 0x39);
+        
+        m.setExtended(true);
+        
+        t.message(m);
+        Assert.assertTrue(t.getState() == Light.OFF ); 
+
+        m.setExtended(false);
+        m.setRtr(true);
+        t.message(m);
+        Assert.assertTrue(t.getState() == Light.OFF );
+        
+        m.setRtr(false);
+        t.message(m);
+        Assert.assertTrue(t.getState() == Light.ON);
+        
+        t = null;
+        m = null;
+ 
+    }
+    
+        @Test
+    public void testCbusLightCanReplyExtendedRtr() throws jmri.JmriException {
+        CbusLight t = new CbusLight("ML","+N54321E12345",tcis);
+        Assert.assertTrue(t.getState() == Light.OFF);  // Light.UNKNOWN ??
+        CanReply r = new CanReply(tcis.getCanid());
+        r.setNumDataElements(5);
+        r.setElement(0, 0x90); // ACON OPC
+        r.setElement(1, 0xd4);
+        r.setElement(2, 0x31);
+        r.setElement(3, 0x30);
+        r.setElement(4, 0x39);
+        r.setExtended(true);
+        
+        t.reply(r);
+        Assert.assertTrue(t.getState() == Light.OFF);   
+        
+        r.setExtended(false);
+        r.setRtr(true);
+        t.reply(r);
+        Assert.assertTrue(t.getState() == Light.OFF );
+
+        r.setRtr(false);
+        
+        t.reply(r);
+        Assert.assertTrue(t.getState() == Light.ON);
+        
+        t = null;
+        r = null;
+  
+    }
+    
 
     @Test
     public void testCbusLightCanReply() throws jmri.JmriException {
@@ -463,6 +527,15 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
         
          // t.setTargetIntensity(0.25); not currently defined for CBUS
     }
+    
+    @Test
+    public void testDoNewStateinvalid(){
+        
+        CbusLight t = new CbusLight("M","+12345",tcis);
+        t.doNewState(Light.OFF,999);
+        JUnitAppender.assertWarnMessage("illegal state requested for Light: ML+12345");
+        
+    }
 
     // The minimal setup for log4J
     @Before
@@ -474,9 +547,10 @@ public class CbusLightTest extends jmri.implementation.AbstractLightTestBase {
 
     @After
     public void tearDown() {
-        JUnitUtil.tearDown();
         t.dispose();
         tcis=null;
+        JUnitUtil.tearDown();
+        
     }
 
     // private final static Logger log = LoggerFactory.getLogger(CbusLightTest.class);

--- a/java/test/jmri/jmrix/can/cbus/CbusMultiMeterTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusMultiMeterTest.java
@@ -1,7 +1,12 @@
 package jmri.jmrix.can.cbus;
 
+import jmri.jmrix.can.CanMessage;
+import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.jmrix.can.cbus.node.CbusNode;
+import jmri.jmrix.can.cbus.node.CbusNodeTableDataModel;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -11,25 +16,181 @@ import org.junit.Test;
 /**
  *
  * @author Paul Bender Copyright (C) 2017
- * @author Paul Bender Copyright (C) 2019
+ * @author Steve Young Copyright (C) 2019
  */
 public class CbusMultiMeterTest extends jmri.implementation.AbstractMultiMeterTestBase {
+
+    private CanSystemConnectionMemo memo;
+    private TrafficControllerScaffold tcis;
 
     // The minimal setup for log4J
     @Before
     public void setUp() {
         JUnitUtil.setUp();
         
-        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
-        TrafficControllerScaffold tcis = new TrafficControllerScaffold();
+        memo = new CanSystemConnectionMemo();
+        tcis = new TrafficControllerScaffold();
         memo.setTrafficController(tcis);
         mm = new CbusMultiMeter(memo);
+    }
+    
+    @After
+    public void tearDown() {
+        
+        mm = null;
+        tcis=null;
+        memo = null;
+        JUnitUtil.tearDown();
+        
+    }
+    
+    @Test
+    public void testEnableDisable(){
+        
+        Assert.assertEquals("no listener to start",0,tcis.numListeners());
+        
+        mm.enable();
+        JUnitAppender.assertErrorMessageStartsWith("Unable to Locate Details for Master Command Station");
+        Assert.assertEquals("not listening",0,tcis.numListeners());
+        
+        CbusNodeTableDataModel nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
+        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
+        
+        mm.enable();
+        JUnitAppender.assertErrorMessageStartsWith("Unable to Locate Details for Master Command Station");
+        Assert.assertEquals("node table listening",1,tcis.numListeners());
+        
+        CbusNode testCs = nodeModel.provideNodeByNodeNum(777);
+        testCs.setCsNum(0);
+        Assert.assertEquals("node + node table listening",2,tcis.numListeners());
+        
+        mm.enable();
+        
+        Assert.assertEquals("multimeter listening",3,tcis.numListeners());
+        
+        mm.disable();
+        
+        Assert.assertEquals("mm not listening",2,tcis.numListeners());
+        
+        nodeModel.dispose();
+        testCs.dispose();
+        
+    }
+    
+    @Test
+    public void testMultiMCanReply(){
+        
+        CbusMultiMeter mm = new CbusMultiMeter(memo);
+        
+        CbusNodeTableDataModel nodeModel = new CbusNodeTableDataModel(memo, 3,CbusNodeTableDataModel.MAX_COLUMN);
+        jmri.InstanceManager.setDefault(CbusNodeTableDataModel.class,nodeModel );
+        
+        CbusNode testCs = nodeModel.provideNodeByNodeNum(54321);
+        testCs.setCsNum(0);
+        
+        mm.enable();
+        
+        CanReply r = new CanReply(tcis.getCanid());
+        r.setNumDataElements(7);
+        r.setElement(0, CbusConstants.CBUS_ACOF2);
+        r.setElement(1, 0xd4); // nn 54322
+        r.setElement(2, 0x32); // nn 54322
+        r.setElement(3, 0x00); // en 1
+        r.setElement(4, 0x01); // en 1
+        r.setElement(5, 0x00); // 8mA
+        r.setElement(6, 0x08); // 8mA
+        mm.reply(r);
+        
+        Assert.assertEquals(0,mm.getCurrent(),0.001 ); // wrong opc
+        
+        r.setElement(0, CbusConstants.CBUS_ACON2);
+        mm.reply(r);
+        
+        Assert.assertEquals(0,mm.getCurrent(),0.001 ); // wrong node
+        
+        r.setElement(2, 0x31); // nn 54321
+        mm.reply(r);
+        Assert.assertEquals(8,mm.getCurrent(),0.001 );
+        
+        r.setElement(5, 0x12); // 4807mA
+        r.setElement(6, 0xc7); // 4807mA
+        mm.reply(r);
+        Assert.assertEquals(4807,mm.getCurrent(),0.001 );
+        
+        CanMessage m = new CanMessage(tcis.getCanid());
+        m.setNumDataElements(7);
+        m.setElement(0, CbusConstants.CBUS_ACON2);
+        m.setElement(1, 0xd4); // nn 54321
+        m.setElement(2, 0x31); // nn 54321
+        m.setElement(3, 0x00); // en1
+        m.setElement(4, 0x01); // en1
+        m.setElement(5, 0x00); // 0mA
+        m.setElement(6, 0x00); // 0mA
+        
+        mm.message(m);
+        Assert.assertEquals(4807,mm.getCurrent(),0.001 ); // CanMessage Ignored
+        
+        r = new CanReply(tcis.getCanid());
+        r.setNumDataElements(7);
+        r.setElement(0, CbusConstants.CBUS_ACON2);
+        r.setElement(1, 0xd4); // nn 54321
+        r.setElement(2, 0x31); // nn 54321
+        r.setElement(3, 0x00); // en1
+        r.setElement(4, 0x01); // en1
+        r.setElement(5, 0x00); // 0mA
+        r.setElement(6, 0x00); // 0mA
+        
+        mm.reply(r);
+        Assert.assertEquals(0,mm.getCurrent(),0.001 );
+        
+        
+        r = new CanReply(tcis.getCanid());
+        r.setNumDataElements(7);
+        r.setElement(0, CbusConstants.CBUS_ACON2);
+        r.setElement(1, 0xd4); // nn 54321
+        r.setElement(2, 0x31); // nn 54321
+        r.setElement(3, 0x00); // en1
+        r.setElement(4, 0x01); // en1
+        r.setElement(5, 0x12); // 4807mA
+        r.setElement(6, 0xc7); // 4807mA
+        
+        r.setRtr(true);
+        
+        mm.reply(r);
+        Assert.assertEquals(0,mm.getCurrent(),0.001 );
+        
+        r.setExtended(true);
+        r.setRtr(false);
+        
+        mm.reply(r);
+        Assert.assertEquals(0,mm.getCurrent(),0.001 );
+        
+        r.setExtended(false);
+        mm.reply(r);
+        Assert.assertEquals(4807,mm.getCurrent(),0.001 );
+        
+        mm.disable();
+        
+        nodeModel.dispose();
+        testCs.dispose();
+        
     }
     
     @Test
     @Override
     public void testUpdateAndGetVoltage(){
         Assert.assertEquals("no voltage", false, mm.hasVoltage() );
+    }
+    
+    @Test
+    public void testSmallFuncs(){
+        
+        CbusMultiMeter mm = new CbusMultiMeter(memo);
+        
+        mm.requestUpdateFromLayout();
+        mm.initializeHardwareMeter();
+        Assert.assertEquals("name", "CBUS", mm.getHardwareMeterName() );
+        
     }
 
     // private final static Logger log = LoggerFactory.getLogger(CbusMultiMeterTest.class);

--- a/java/test/jmri/jmrix/can/cbus/CbusPowerManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusPowerManagerTest.java
@@ -4,6 +4,7 @@ import jmri.jmrix.AbstractPowerManagerTestBase;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.PowerManager;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -86,6 +87,31 @@ public class CbusPowerManagerTest extends AbstractPowerManagerTestBase {
         jmri.jmrix.can.CanMessage m = new jmri.jmrix.can.CanMessage(new int[]{CbusConstants.CBUS_TON},0x12);
         pwr.message(m);
         Assert.assertTrue(true);
+        
+    }
+    
+    
+    @Test
+    public void checkCanReplyExtendedRtr () throws jmri.JmriException {
+        
+        CanReply r = new CanReply( new int[]{CbusConstants.CBUS_TOF},0x12);
+        pwr.reply(r);
+        Assert.assertEquals("set off", PowerManager.OFF, p.getPower());
+        
+        r = new CanReply( new int[]{CbusConstants.CBUS_TON},0x12);
+        r.setExtended(true);
+        
+        pwr.reply(r);
+        Assert.assertEquals("still off", PowerManager.OFF, p.getPower());
+        
+        r.setExtended(false);
+        r.setRtr(true);
+        pwr.reply(r);
+        Assert.assertEquals("still off", PowerManager.OFF, p.getPower());
+        
+        r.setRtr(false);
+        pwr.reply(r);
+        Assert.assertEquals("on", PowerManager.ON, p.getPower());
         
     }
     

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorTest.java
@@ -398,6 +398,18 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
         r.setElement(0, 0x99); // ASOF OPC
         t.reply(r);
         Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
+        
+        
+        r.setElement(0, 0x98); // ASON OPC
+        r.setExtended(true);
+        t.reply(r);
+        Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
+        
+        r.setExtended(false);
+        r.setRtr(true);
+        t.reply(r);
+        Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
+        
     
     }
     
@@ -422,6 +434,16 @@ public class CbusSensorTest extends jmri.implementation.AbstractSensorTestBase {
         
         m.setElement(0, 0x99); // ASOF OPC
         t.message(m);
+        Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
+        
+        
+        m.setElement(0, 0x98); // ASON OPC
+        m.setExtended(true);
+        t.message(m);
+        Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
+        
+        m.setExtended(false);
+        m.setRtr(true);
         Assert.assertTrue(t.getKnownState() == Sensor.INACTIVE);
     
     }

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutTest.java
@@ -394,6 +394,19 @@ public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
         t.message(m);
         Assert.assertTrue(t.getCommandedState() == Turnout.CLOSED);
         
+        m.setElement(0, 0x98); // ASON OPC
+        m.setExtended(true);
+        t.message(m);
+        Assert.assertTrue(t.getCommandedState() == Turnout.CLOSED);
+        
+        m.setRtr(true);
+        t.message(m);
+        Assert.assertTrue(t.getCommandedState() == Turnout.CLOSED);
+        
+        m.setExtended(false);
+        t.message(m);
+        Assert.assertTrue(t.getCommandedState() == Turnout.CLOSED);
+        
         m = null;
         
     }
@@ -419,6 +432,18 @@ public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
         r.setElement(0, 0x99); // ASOF OPC
         t.reply(r);
         Assert.assertTrue(t.getCommandedState() == Turnout.CLOSED);
+        
+        
+        r.setElement(0, 0x98); // ASON OPC
+        r.setExtended(true);
+        t.reply(r);
+        Assert.assertTrue(t.getCommandedState() == Turnout.CLOSED);
+        
+        r.setExtended(false);
+        r.setRtr(true);
+        t.reply(r);
+        Assert.assertTrue(t.getCommandedState() == Turnout.CLOSED);
+        
         r = null;
         
     }

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutTest.java
@@ -459,7 +459,7 @@ public class CbusTurnoutTest extends jmri.implementation.AbstractTurnoutTestBase
         m.setElement(3, 0x30);
         m.setElement(4, 0x39);
         
-        CbusTurnout.DELAYED_FEEDBACK_INTERVAL=1;
+        CbusTurnout.DELAYED_FEEDBACK_INTERVAL=15;
         t.setFeedbackMode("DELAYED");
         t.message(m);
         Assert.assertTrue(t.getKnownState() == Turnout.INCONSISTENT); 

--- a/java/test/jmri/jmrix/can/cbus/node/CbusNodeTest.java
+++ b/java/test/jmri/jmrix/can/cbus/node/CbusNodeTest.java
@@ -70,7 +70,7 @@ public class CbusNodeTest {
     }
     
     @Test
-    public void testInOutLearnMode() {
+    public void testInOutLearnModeExtendedRtr() {
         CbusNode t = new CbusNode(memo,1234);
         
         Assert.assertEquals("default getNodeInLearnMode ",false,t.getNodeInLearnMode() );
@@ -116,8 +116,45 @@ public class CbusNodeTest {
         m.setNumDataElements(1);
         m.setElement(0, CbusConstants.CBUS_RTOF); // request track off
         t.message(m);
-        Assert.assertEquals("still in learn mode ",false,t.getNodeInLearnMode() );
-
+        Assert.assertEquals("not in learn mode ",false,t.getNodeInLearnMode() );
+        
+        
+        m = new CanMessage( tcis.getCanid() );
+        m.setElement(0, CbusConstants.CBUS_NNLRN); // enter learn mode
+        m.setElement(1, 0x04);
+        m.setElement(2, 0xd2);
+        
+        m.setExtended(true);
+        
+        t.message(m);
+        Assert.assertEquals("no change ext",false,t.getNodeInLearnMode() );
+        
+        m.setExtended(false);
+        m.setRtr(true);
+        t.message(m);
+        Assert.assertEquals("no change rtr",false,t.getNodeInLearnMode() );
+        
+        m.setRtr(false);
+        t.message(m);
+        Assert.assertEquals("message enter learn mode ",true,t.getNodeInLearnMode() );
+        
+        
+        r = new CanReply();
+        r.setHeader(tcis.getCanid());
+        r.setNumDataElements(3);
+        r.setElement(0, CbusConstants.CBUS_NNULN); 
+        r.setElement(1, 0x04);
+        r.setElement(2, 0xd2);
+        
+        r.setExtended(true);
+        t.reply(r);
+        Assert.assertEquals("no change ext",true,t.getNodeInLearnMode() );
+        
+        r.setExtended(false);
+        r.setRtr(true);
+        t.reply(r);
+        Assert.assertEquals("no change rtr",true,t.getNodeInLearnMode() );
+        
         m = null;
         r = null;
         
@@ -678,10 +715,10 @@ public class CbusNodeTest {
 
     @After
     public void tearDown() {
-        JUnitUtil.tearDown();
         
         tcis = null;
         memo = null;
+        JUnitUtil.tearDown();
         
     }
 

--- a/java/test/jmri/jmrix/can/cbus/simulator/CbusEventResponderTest.java
+++ b/java/test/jmri/jmrix/can/cbus/simulator/CbusEventResponderTest.java
@@ -29,9 +29,7 @@ public class CbusEventResponderTest {
         
     @Test
     public void testTCSetGet() {    
-        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
-        TrafficControllerScaffold tc = new TrafficControllerScaffold();
-        memo.setTrafficController(tc);
+        
         Assert.assertTrue("0 listeners to start",tc.numListeners()==0);
         CbusEventResponder t = new CbusEventResponder(memo);
         Assert.assertTrue("1 listener",tc.numListeners()==1);
@@ -45,14 +43,12 @@ public class CbusEventResponderTest {
         t.dispose();
         Assert.assertTrue("0 listeners",tc.numListeners()==0);
         t = null;
-        memo = null;
+
     }
     
     @Test
     public void testResponses() {
-        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
-        TrafficControllerScaffold tc = new TrafficControllerScaffold();
-        memo.setTrafficController(tc);
+
         CbusEventResponder t = new CbusEventResponder(memo);
         
         Assert.assertTrue(t.getDelay()>0);
@@ -73,7 +69,18 @@ public class CbusEventResponderTest {
         m.setElement(4, 0x00);
         
         CanReply r   = new CanReply(m);
+        
+        r.setExtended(true);
         t.reply(r);
+        
+        r.setExtended(false);
+        r.setRtr(true);
+        t.reply(r);
+        
+        r.setRtr(false);
+        t.reply(r);
+        
+        
         t.message(m);
         // as frames passed direct to responder, tc inbound / outbound will just be event responses
         
@@ -116,7 +123,6 @@ public class CbusEventResponderTest {
         
         m = null;
         t.dispose();
-        memo = null;
         
     }
         
@@ -124,9 +130,7 @@ public class CbusEventResponderTest {
         
     @Test
     public void testModes() {
-        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
-        final TrafficControllerScaffold tc = new TrafficControllerScaffold();
-        memo.setTrafficController(tc);
+
         CbusEventResponder t = new CbusEventResponder(memo);
         
         CanMessage m = new CanMessage(120);
@@ -139,6 +143,14 @@ public class CbusEventResponderTest {
     
         t.setMode(0); // off
         t.message(m); // no response should be generated
+        
+        m.setExtended(true);
+        t.message(m); // no response should be generated
+        
+        m.setExtended(false);
+        m.setRtr(true);
+        t.message(m); // no response should be generated
+        m.setRtr(false);
         
         t.setMode(2); // odd / even
         t.setNode(5777);
@@ -168,18 +180,27 @@ public class CbusEventResponderTest {
         
         m = null;
         t.dispose();
-        memo = null;
     
     }
+
+    private CanSystemConnectionMemo memo;
+    private TrafficControllerScaffold tc;
 
     // The minimal setup for log4J
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        
+        memo = new CanSystemConnectionMemo();
+        tc = new TrafficControllerScaffold();
+        memo.setTrafficController(tc);
     }
 
     @After
     public void tearDown() {
+        
+        tc = null;
+        memo = null;
         JUnitUtil.tearDown();
     }
 

--- a/java/test/jmri/jmrix/can/cbus/swing/configtool/ConfigToolPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/configtool/ConfigToolPaneTest.java
@@ -1,35 +1,126 @@
 package jmri.jmrix.can.cbus.swing.configtool;
 
 import java.awt.GraphicsEnvironment;
+import jmri.jmrix.can.CanMessage;
+import jmri.jmrix.can.CanReply;
+import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.util.JmriJFrame;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
-
+import org.netbeans.jemmy.operators.*;
 /**
  *
- * @author Paul Bender Copyright (C) 2017	
+ * @author Paul Bender Copyright (C) 2017
+ * @author Steve Young Copyright (C) 2019
  */
-public class ConfigToolPaneTest {
+public class ConfigToolPaneTest extends jmri.util.swing.JmriPanelTest {
 
-    @Test
-    public void testCTor() {
-        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
-        ConfigToolPane t = new ConfigToolPane();
-        Assert.assertNotNull("exists",t);
-    }
-
-    // The minimal setup for log4J
+    @Override
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        panel = new ConfigToolPane();
+        title = Bundle.getMessage("CapConfigTitle");
+        helpTarget = "package.jmri.jmrix.can.cbus.swing.configtool.ConfigToolFrame";
     }
 
+    @Override
     @After
     public void tearDown() {
         JUnitUtil.tearDown();
+    }
+    
+    @Test
+    public void testInitComp() {
+        
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        TrafficControllerScaffold tcis = new TrafficControllerScaffold();
+        memo.setTrafficController(tcis);
+        
+        ConfigToolPane panel = new ConfigToolPane();
+        
+        
+        Assert.assertEquals("no listener to start with",0,tcis.numListeners());
+        
+        panel.initComponents(memo);
+        
+        Assert.assertEquals("listening",1,tcis.numListeners());
+        
+        Assert.assertNotNull("exists", panel);
+        Assert.assertEquals("name with memo","CAN " + Bundle.getMessage("CapConfigTitle"),panel.getTitle());
+        
+        
+        // check pane has loaded something
+        JmriJFrame f = new JmriJFrame();
+        f.add(panel);
+        f.setTitle(panel.getTitle());
+        
+        f.pack();
+        f.setVisible(true);
+        
+        // Find new window by name
+        JFrameOperator jfo = new JFrameOperator( panel.getTitle() );
+        
+        Assert.assertTrue(getResetButtonEnabled(jfo));
+        
+        Assert.assertEquals("nothing in capture slot 1","",getStringCaptureOne(jfo) );
+        Assert.assertEquals("nothing in capture slot 2","",getStringCaptureTwo(jfo) );
+        
+        CanMessage m = new CanMessage(tcis.getCanid());
+        m.setNumDataElements(5);
+        m.setElement(0, 0x91); // ACOF OPC
+        m.setElement(1, 0xd4); // nn 
+        m.setElement(2, 0x31); // nn 
+        m.setElement(3, 0x30); // en 
+        m.setElement(4, 0x39); // en 
+        
+        panel.message(m);
+        Assert.assertEquals("event in capture slot 1","-n54321e12345",getStringCaptureOne(jfo) );
+        
+        CanReply r = new CanReply(tcis.getCanid());
+        r.setNumDataElements(5);
+        r.setElement(0, 0x98); // ASON OPC
+        r.setElement(1, 0x00); // nn 0
+        r.setElement(2, 0x00); // nn 0
+        r.setElement(3, 0xff); // en 
+        r.setElement(4, 0x39); // en 
+        
+        panel.reply(r);
+        Assert.assertEquals("event in capture slot 2","+65337",getStringCaptureTwo(jfo) );
+        
+        
+        
+        // Ask to close window
+        jfo.requestClose();
+        
+        panel.dispose();
+        
+        Assert.assertEquals("no listener after dispose",0,tcis.numListeners());
+        
+        panel = new ConfigToolPane();
+        
+        tcis = null;
+        memo = null;
+        
+    }
+    
+    private boolean getResetButtonEnabled( JFrameOperator jfo ){
+        return ( new JButtonOperator(jfo,Bundle.getMessage("ButtonResetCapture")).isEnabled() );
+    }
+    
+    private String getStringCaptureOne( JFrameOperator jfo ){
+        return ( new JTextFieldOperator(jfo,0).getText() );
+    }
+    
+    private String getStringCaptureTwo( JFrameOperator jfo ){
+        return ( new JTextFieldOperator(jfo,1).getText() );
     }
 
     // private final static Logger log = LoggerFactory.getLogger(ConfigToolPaneTest.class);

--- a/java/test/jmri/jmrix/can/cbus/swing/console/BundleTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/console/BundleTest.java
@@ -1,6 +1,6 @@
 package jmri.jmrix.can.cbus.swing.console;
 
-
+import java.util.Locale;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -11,13 +11,11 @@ import org.junit.Test;
  */
 public class BundleTest  {
 
-    @Test public void testGoodKeys() {
-        Assert.assertEquals("(none)", Bundle.getMessage("none"));
-        Assert.assertEquals("No locomotive detected (301);", Bundle.getMessage("NoLocoDetected"));
+    @Test public void testGoodKeyMessage() {
         Assert.assertEquals("Turnout", Bundle.getMessage("BeanNameTurnout"));
     }
 
-    @Test public void testBadKey() {
+    @Test public void testBadKeyMessage() {
         try {
             Bundle.getMessage("FFFFFTTTTTTT");
         } catch (java.util.MissingResourceException e) {
@@ -25,5 +23,29 @@ public class BundleTest  {
         } // OK
         Assert.fail("No exception thrown");
     }
+
+    @Test public void testGoodKeyMessageArg() {
+        Assert.assertEquals("Turnout", Bundle.getMessage("BeanNameTurnout", new Object[]{}));
+        Assert.assertEquals("About Test", Bundle.getMessage("TitleAbout", "Test"));
+    }
+
+    @Test public void testBadKeyMessageArg() {
+        try {
+            Bundle.getMessage("FFFFFTTTTTTT", new Object[]{});
+        } catch (java.util.MissingResourceException e) {
+            return;
+        } // OK
+        Assert.fail("No exception thrown");
+    }
+
+    @Test public void testLocaleMessage() {
+        Assert.assertEquals("Scambio", Bundle.getMessage(Locale.ITALY, "BeanNameTurnout"));
+    }
+
+    @Test public void testLocaleMessageArg() {
+        Assert.assertEquals("Scambio", Bundle.getMessage(Locale.ITALY, "BeanNameTurnout", new Object[]{}));
+        Assert.assertEquals("Informazioni su Test", Bundle.getMessage(Locale.ITALY, "TitleAbout", "Test"));
+    }
+
 
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestDataModelTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/eventrequestmonitor/CbusEventRequestDataModelTest.java
@@ -20,14 +20,10 @@ import org.junit.Test;
  */
 public class CbusEventRequestDataModelTest {
 
-    TrafficControllerScaffold tcis;
+    
 
     @Test
     public void testCtor() {
-
-        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
-        tcis = new TrafficControllerScaffold();
-        memo.setTrafficController(tcis);
         
         CbusEventRequestDataModel t = new CbusEventRequestDataModel(memo, 1,
                 CbusEventRequestDataModel.MAX_COLUMN); // controller, row, column
@@ -35,15 +31,11 @@ public class CbusEventRequestDataModelTest {
         
         t.dispose();
         t = null;
-        tcis = null;
-        memo = null;
+        
     }
     
     @Test
     public void testCanListenAndRemove() {
-        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
-        tcis = new TrafficControllerScaffold();
-        memo.setTrafficController(tcis);
         
         Assert.assertEquals("no listener to start with",0,tcis.numListeners());
         CbusEventRequestDataModel t = new CbusEventRequestDataModel(
@@ -54,15 +46,12 @@ public class CbusEventRequestDataModelTest {
         Assert.assertTrue("no listener to finish with",0 == tcis.numListeners());
         
         t = null;
-        memo = null;
         
     }
     
     @Test
     public void testColumns() {
-        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
-        TrafficControllerScaffold tcis = new TrafficControllerScaffold();
-        memo.setTrafficController(tcis);
+        
         CbusEventRequestDataModel t = new CbusEventRequestDataModel(
         memo,5,CbusEventRequestDataModel.MAX_COLUMN);
         
@@ -90,16 +79,12 @@ public class CbusEventRequestDataModelTest {
         
         t.dispose();
         t = null;
-        memo = null;
         
     }
     
     @Test
     public void testCreateRow() {
         
-        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
-        tcis = new TrafficControllerScaffold();
-        memo.setTrafficController(tcis);
         CbusEventRequestDataModel t = new CbusEventRequestDataModel(
         memo,5,CbusEventRequestDataModel.MAX_COLUMN);
         
@@ -174,19 +159,76 @@ public class CbusEventRequestDataModelTest {
         
         t.dispose();
         t = null;
-        memo = null;
         
     }
+    
+    @Test
+    public void testNotCreateRowExtendedRtr() {
+        
+        CbusEventRequestDataModel t = new CbusEventRequestDataModel(
+        memo,5,CbusEventRequestDataModel.MAX_COLUMN);
+        
+        Assert.assertTrue("no rows to start",0 == t.getRowCount() );
+        
+        CanReply r = new CanReply();
+        r.setHeader(tcis.getCanid());
+        r.setNumDataElements(5);
+        r.setElement(0, CbusConstants.CBUS_AREQ); // long event status request
+        r.setElement(1, 0x04); // node 1234
+        r.setElement(2, 0xd2); // node 1234
+        r.setElement(3, 0x00); // event 7
+        r.setElement(4, 0x07); // event 7
+        
+        r.setExtended(true);
+        t.reply(r);
+        Assert.assertTrue("no rows as extended",0 == t.getRowCount() );
+        
+        r.setExtended(false);
+        r.setRtr(true);
+        t.reply(r);
+        Assert.assertTrue("no rows as rtr",0 == t.getRowCount() );
+        
+        CanMessage m = new CanMessage(tcis.getCanid());
+        m.setNumDataElements(5);
+        m.setElement(0, CbusConstants.CBUS_AREQ); // long event status request
+        m.setElement(1, 0x04); // node 1234
+        m.setElement(2, 0xd2); // node 1234
+        m.setElement(3, 0x00); // event 7
+        m.setElement(4, 0x07); // event 7
+        
+        m.setExtended(true);
+        t.message(m);
+        Assert.assertTrue("no rows as rtr",0 == t.getRowCount() );
+        
+        m.setExtended(false);
+        m.setRtr(true);
+        t.message(m);
+        Assert.assertTrue("no rows as rtr",0 == t.getRowCount() );
+        
+        t.dispose();
+        t = null;
+        
+    }
+    
+    private TrafficControllerScaffold tcis;
+    private CanSystemConnectionMemo memo;
 
     @Before
     public void setUp() {
         JUnitUtil.setUp();
+        
+        memo = new CanSystemConnectionMemo();
+        tcis = new TrafficControllerScaffold();
+        memo.setTrafficController(tcis);
+        
     }
 
     @After
     public void tearDown() {        
-        JUnitUtil.tearDown();  
+        
         tcis = null;
+        memo = null;
+        JUnitUtil.tearDown();
     }
 
 }

--- a/java/test/jmri/jmrix/can/cbus/swing/simulator/SimulatorPaneTest.java
+++ b/java/test/jmri/jmrix/can/cbus/swing/simulator/SimulatorPaneTest.java
@@ -1,13 +1,25 @@
 package jmri.jmrix.can.cbus.swing.simulator;
 
+import java.awt.GraphicsEnvironment;
+import java.util.List;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import jmri.jmrix.can.CanSystemConnectionMemo;
+import jmri.jmrix.can.TrafficControllerScaffold;
+import jmri.util.JmriJFrame;
 import jmri.util.JUnitUtil;
 import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Test;
+import org.netbeans.jemmy.operators.*;
 
 /**
- * Test simple functioning of CbusSlotMonitorPane.
+ * Test simple functioning of CBUS SimulatorPane.
  *
  * @author Paul Bender Copyright (C) 2016
+ * @author Steve Young Copyright (C) 2019
  */
 public class SimulatorPaneTest extends jmri.util.swing.JmriPanelTest {
 
@@ -19,9 +31,62 @@ public class SimulatorPaneTest extends jmri.util.swing.JmriPanelTest {
         title = Bundle.getMessage("MenuItemNetworkSim");
         helpTarget = "package.jmri.jmrix.can.cbus.swing.simulator.SimulatorPane";
     }
-
+    
     @Override
     @After
     public void tearDown() {        JUnitUtil.tearDown();    }
+    
+    @Test
+    public void testInitComp() {
+        
+        Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+        
+        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
+        TrafficControllerScaffold tcis = new TrafficControllerScaffold();
+        memo.setTrafficController(tcis);
+        
+        SimulatorPane panel = new SimulatorPane();
+        panel.initComponents(memo);
+        
+        Assert.assertNotNull("exists", panel);
+        Assert.assertEquals("name with memo","CAN " + Bundle.getMessage("MenuItemNetworkSim"),panel.getTitle());
+        
+        
+        // check pane has loaded something
+        JmriJFrame f = new JmriJFrame();
+        f.add(panel);
+        f.setTitle(panel.getTitle());
+        
+        List<JMenu> list = panel.getMenus();
+        JMenuBar bar = f.getJMenuBar();
+        if (bar == null) {
+            bar = new JMenuBar();
+        }
+        for (JMenu menu : list) {
+            bar.add(menu);
+        }
+        f.setJMenuBar(bar);
+        
+        f.pack();
+        f.setVisible(true);
+        
+        // Find new window by name
+        JFrameOperator jfo = new JFrameOperator( panel.getTitle() );
+        
+        Assert.assertTrue(getResetCsButtonEnabled(jfo));
+        
+        
+        // Ask to close window
+        jfo.requestClose();
+        
+        
+        tcis = null;
+        memo = null;
+        
+    }
+    
+    private boolean getResetCsButtonEnabled( JFrameOperator jfo ){
+        return ( new JButtonOperator(jfo,Bundle.getMessage("Reset")).isEnabled() );
+    }
 
 }

--- a/jython/CanExample.py
+++ b/jython/CanExample.py
@@ -7,7 +7,6 @@
 # Part of the JMRI distribution
 
 import jmri
-
 import java
 
 # First, example of receiving. Put a listener in place.
@@ -16,30 +15,22 @@ class MyCanListener (jmri.jmrix.can.CanListener) :
         # this handles messages being sent by ignoring them
         return
     def reply(self, msg) :
-        print "received Frame"
-        print "ID: 0x"+java.lang.Integer.toHexString(msg.getHeader())
+        print "received incoming Frame"
+        print "Header ID: 0x"+java.lang.Integer.toHexString(msg.getHeader())
         print "content: ", msg.toString()
+        print "extended: ", msg.isExtended()
         return
     
 # Get the traffic controller
 tc = None
- 
-# Old way first...
 try:
-  tc = jmri.jmrix.can.TrafficController.instance()
+  tc = jmri.InstanceManager.getDefault(jmri.jmrix.can.CanSystemConnectionMemo).getTrafficController()
+  tc.addCanListener(MyCanListener())
 except:
-  # Then the new way...
-  try:
-    tc = jmri.InstanceManager.getDefault(jmri.jmrix.can.CanSystemConnectionMemo).getTrafficController()
-  except:
-    print "no traffic controller"
-    tc = None
- 
-tc.addCanListener(MyCanListener())
+  print "No Traffic Controller"
 
-
-# Send a frame
-frame = jmri.jmrix.can.CanMessage(0x123)
+# Send an outgoing CanMessage frame
+frame = jmri.jmrix.can.CanMessage(0x123)    # header ID value 0x123
 frame.setNumDataElements(2)   # will load 2 bytes
 frame.setElement(0, 0x45)
 frame.setElement(1, 0x67)


### PR DESCRIPTION
Protect various classes from Extended and RTR CAN frames which carry a risk of being interpreted as a normal CAN frame.

Included unit tests for this.