### PR TITLE
Infrastructure updates

### DIFF
--- a/help/en/html/doc/Technical/JUnit.shtml
+++ b/help/en/html/doc/Technical/JUnit.shtml
@@ -728,6 +728,19 @@ setenv JMRI_OPTIONS -Djmri.util.JUnitUtil.checkRemnantThreads=true
       is a bit time-intensive, so we don't leave it on 
       all the time.
 
+      <p>
+      Tools like heap dumps, thread dumps, and the jvisualvm
+      browser can help you see what's being left over by your tests.
+      But they must be used while the JVM is still running, and it
+      usually terminates right after the tests.
+      To prolong the JVM life, add an instance of 
+      <code>jmri.util.TestWaitsForever</code>
+      at the end of your <code>PackageList</code>
+      list of tests.  <code>TestWaitsForever</code>
+      does what it says on the tin: waits forever, allowing you
+      to look at the state of the JVM. When you're done,
+      you have to kill the test job manually.
+      
       <h3><a id="io" name="io"></a>Testing I/O</h3>
       Some test
       environments don't automatically flush I/O operations such as

--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -319,7 +319,7 @@
    <h3>Internationalization</h3>
         <a id="I18N" name="I18N"></a>
         <ul>
-            <li></li>
+            <li>Petr Šídlo improved the Czech translation</li>
         </ul>
 
     <h3>Layout Editor</h3>
@@ -460,6 +460,6 @@
     <h3>Miscellaneous</h3>
         <a id="Misc" name="Misc"></a>
         <ul>
-            <li></li>
+            <li>Add new <code>TestWaitsForever</class> test class to allow end-of-job debug.</li>
         </ul>
 

--- a/java/test/jmri/util/TestWaitsForever.java
+++ b/java/test/jmri/util/TestWaitsForever.java
@@ -1,0 +1,37 @@
+package jmri.util;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * A single test that waits forever.
+ * Put this at the end of a PackageTest file to 
+ * have execution wait so that you can e.g. get a 
+ * thread or heap dump at the end of execution.
+ * @author Bob Jacobsen 2019	
+ */
+public class TestWaitsForever {
+
+    @Test
+    public synchronized void deliberatelyWaitForever() throws InterruptedException {
+        Runtime.getRuntime().gc();
+        System.err.println("start permanent wait");
+        this.wait();
+    }
+
+    // The minimal setup for log4J
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+    // private final static Logger log = LoggerFactory.getLogger(TestWaitsForever.class);
+
+}

--- a/lib/README.md
+++ b/lib/README.md
@@ -13,7 +13,7 @@ macOS binaries are treated slightly differently, see the README file there.
 #### Updates
 
 If you make a change in this directory (add/change/remove a file), please make corresponding changes in the control files that are used for various JMRI development and release operations:
-- build.xml - used by Ant, and in turn by various IDEs
+- build.xml - used by Ant, and in turn by various IDEs. Note that in addition to changing the classpath entry or entries, you should also check to make sure that the three javadoc targets are linking to the proper sources.
 - .classpath - used by Eclipse
 - pom.xml - used by Maven (see notes below)
 - nbproject/ide-file-targets.xml, nbproject/project.xml - used by NetBeans
@@ -22,7 +22,7 @@ On macOS, most of these changes can be affected with:
 ```
 find . -type f -not -path './.git/*' -exec gsed -i 's/OLD_JAR_NAME/NEW_JAR_NAME/g' {} \;
 ```
-(you may need to install gsed using [Homebrew](http://brew.sh))
+(you may need to install gsed using [Homebrew](http://brew.sh)), although this probably doesn't fix the Javadoc links.
 
 On Linux, these same changes can be affected with:
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,8 @@
                         <exclude>jmri.util.SwingTestCase</exclude>
                         <exclude>jmri.jmrit.operations.OperationsTestCase</exclude>
                         <exclude>jmri.jmrit.operations.OperationsSwingTestCase</exclude>
+                        <!-- exclude since intentionally waits forever -->
+                        <exclude>jmri.util.TestWaitsForever</exclude>
                     </excludes>
                     <systemPropertyVariables>
                         <jmri.path.program>${basedir}</jmri.path.program>

--- a/tests_jacoco.lcf
+++ b/tests_jacoco.lcf
@@ -40,7 +40,7 @@ log4j.appender.A1.target=System.err
 # while still causing the debug code to run (isDebugEnabled will 
 # be true if log4j.rootCategory is set to DEBUG)
 # Note: comment on this line if you want DEBUG output from specific categories below
-log4j.appender.A1.Threshold=WARN
+log4j.appender.A1.Threshold=INFO
 
 # A1 uses PatternLayout to control the format of the log messages.
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
- tests_jacoco.lcf file needs to log info for some tests to pass in Jenkins
- mention that Javadoc links need to be updated with jars
- add a test class to help with end-of-job debug