### PR TITLE
fix: deliberately close listener to SimpleTimebase on exception

### DIFF
--- a/java/src/jmri/server/json/time/JsonTimeSocketService.java
+++ b/java/src/jmri/server/json/time/JsonTimeSocketService.java
@@ -70,8 +70,7 @@ public class JsonTimeSocketService extends JsonSocketService<JsonTimeHttpService
                 this.connection.sendMessage(ex.getJsonMessage());
             }
         } catch (IOException ex) {
-            // do nothing - the client has dropped off and a ping failure will
-            // clean up the connection if its not already being torn down
+            this.onClose();
         }
     }
 


### PR DESCRIPTION
The JsonTimeSocketService listener had been written under the assumption it was running within the context of a client handler, but within the unit tests that assumption was invalid. This change should allow the tests to clean up better.