### PR TITLE
Updates for running AllTest on Jenkins

### DIFF
--- a/help/en/html/doc/Technical/CI-status.shtml
+++ b/help/en/html/doc/Technical/CI-status.shtml
@@ -110,7 +110,6 @@
                 <a href="http://builds.jmri.org/jenkins/job/Development/job/Builds/lastBuild/testReport/">
                     <img src="http://builds.jmri.org/jenkins/job/Development/job/Builds/test/trend">
                 </a>
-http://builds.jmri.org/jenkins/job/Development/job/Builds/test/trend?failureOnly=true
             </td>
 
             <td>

--- a/java/src/jmri/jmrit/display/PositionableJPanel.java
+++ b/java/src/jmri/jmrit/display/PositionableJPanel.java
@@ -411,9 +411,9 @@ public class PositionableJPanel extends JPanel implements Positionable, MouseLis
     public void updateSize() {
         invalidate();
         setSize(maxWidth(), maxHeight());
-        if (log.isDebugEnabled()) {
-//            javax.swing.JTextField text = (javax.swing.JTextField)_popupUtil._textComponent;
-            log.debug("updateSize: {}, text: w={} h={}",
+        if (log.isTraceEnabled()) {
+            // the following fails when run on Jenkins under Xvfb with an NPE in non-JMRI code
+            log.trace("updateSize: {}, text: w={} h={}",
                     _popupUtil.toString(),
                     getFontMetrics(_popupUtil.getFont()).stringWidth(_popupUtil.getText()),
                     getFontMetrics(_popupUtil.getFont()).getHeight());

--- a/java/src/jmri/jmrit/display/controlPanelEditor/PortalIcon.java
+++ b/java/src/jmri/jmrit/display/controlPanelEditor/PortalIcon.java
@@ -220,6 +220,8 @@ public class PortalIcon extends PositionableIcon implements PropertyChangeListen
 
     @Override
     public String getNameString() {
+        Portal p = getPortal();
+        if (p == null) return "No Portal Defined";
         return getPortal().getDescription();
     }
 


### PR DESCRIPTION
The new [Jenkins AllTest job](http://builds.jmri.org/jenkins/job/Development/job/AllTest/) runs `ant logalltest`, which in turn runs the AllTest tests with logging set to DEBUG.

And that has turned up some bugs, a group of which are fixed here:
- `controlPanelEditor.PortalIcon` under DEBUG prints information from the Portal, but crashes if the Portal hasn't been set (is null)
- `display/PositionableJPanel` under DEBUG displays status information, but that info fails with an internal NPE (not in JMRI code) under Xvfb on Jenkins.  Bypassed by having the info only print at TRACE level.
- and fix a cut&paste error on the [CI status page](http://jmri.org/help/en/html/doc/Technical/CI-status.shtml).