### PR TITLE
load web panel in cucumber test.

### DIFF
--- a/java/acceptancetest/features/web/WebPanel.feature
+++ b/java/acceptancetest/features/web/WebPanel.feature
@@ -1,5 +1,5 @@
 #These tests load a panel window, so must run headed.
-@webtest @Headed
+@webtest @webpanel @Headed
 Feature: JMRI Web Panel 
 
 Scenario Outline: Web Panel requests
@@ -13,9 +13,11 @@ Scenario Outline: Web Panel requests
    Examples: Firefox Panel Tests
    | browser | panel | panelURL | PageTitle | 
    | firefox | java/test/jmri/jmrit/cabsignals/SimpleCabSignalTestPanel.xml | http://localhost:12080/panel/Layout/Cab%20Signal%20Test  | Layout/Cab%20Signal%20Test \| My JMRI Railroad | 
+   | firefox | java/test/jmri/jmrit/display/layoutEditor/load/LayoutEditorTest.xml | http://localhost:12080/panel/Layout/Layout%20Editor%20Test  | Layout/Layout%20Editor%20Test \| My JMRI Railroad | 
 
    @chrome
    Examples: Chrome Panel Tests
    | browser | panel | panelURL | PageTitle |
    | chrome | java/test/jmri/jmrit/cabsignals/SimpleCabSignalTestPanel.xml | http://localhost:12080/panel/Layout/Cab%20Signal%20Test  | Layout/Cab%20Signal%20Test \| My JMRI Railroad | 
+   | chrome| java/test/jmri/jmrit/display/layoutEditor/load/LayoutEditorTest.xml | http://localhost:12080/panel/Layout/Layout%20Editor%20Test  | Layout/Layout%20Editor%20Test \| My JMRI Railroad | 
 

--- a/java/acceptancetest/features/web/WebPanel.feature
+++ b/java/acceptancetest/features/web/WebPanel.feature
@@ -1,0 +1,19 @@
+@webtest
+Feature: JMRI Web Server 
+
+Scenario Outline: Web Panel requests
+   Given I am using <browser>
+   And panel <panel> is loaded
+   When I ask for the url <panelURL>
+   Then a page with title <PageTitle> is returned
+
+   @firefox
+   Examples: Firefox Panel Tests
+   | browser | panel | panelURL | PageTitle | 
+   | firefox | java/test/jmri/jmrit/cabsignals/SimpleCabSignalTestPanel.xml | http://localhost:12080/panel/Layout/Cab%20Signal%20Test  | Layout/Cab%20Signal%20Test \| My JMRI Railroad | 
+
+   @chrome
+   Examples: Chrome Panel Tests
+   | browser | panel | panelURL | PageTitle |
+   | chrome | java/test/jmri/jmrit/cabsignals/SimpleCabSignalTestPanel.xml | http://localhost:12080/panel/Layout/Cab%20Signal%20Test  | Layout/Cab%20Signal%20Test \| My JMRI Railroad | 
+

--- a/java/acceptancetest/features/web/WebPanel.feature
+++ b/java/acceptancetest/features/web/WebPanel.feature
@@ -8,7 +8,8 @@ Scenario Outline: Web Panel requests
    When I ask for the url <panelURL>
    Then a page with title <PageTitle> is returned
 
-   @firefox
+   # firefox version of the test appears to be hanging on travis
+   @firefox @Ignore
    Examples: Firefox Panel Tests
    | browser | panel | panelURL | PageTitle | 
    | firefox | java/test/jmri/jmrit/cabsignals/SimpleCabSignalTestPanel.xml | http://localhost:12080/panel/Layout/Cab%20Signal%20Test  | Layout/Cab%20Signal%20Test \| My JMRI Railroad | 

--- a/java/acceptancetest/features/web/WebPanel.feature
+++ b/java/acceptancetest/features/web/WebPanel.feature
@@ -1,5 +1,6 @@
-@webtest
-Feature: JMRI Web Server 
+#These tests load a panel window, so must run headed.
+@webtest @Headed
+Feature: JMRI Web Panel 
 
 Scenario Outline: Web Panel requests
    Given I am using <browser>

--- a/java/acceptancetest/step_definitions/jmri/web/WebServerAcceptanceSteps.java
+++ b/java/acceptancetest/step_definitions/jmri/web/WebServerAcceptanceSteps.java
@@ -1,9 +1,14 @@
 package jmri.web;
 
 import cucumber.api.java8.En;
+import java.io.File;
+import jmri.InstanceManager;
+import jmri.ConfigureManager;
 import org.junit.Assert;
+import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -35,6 +40,11 @@ public class WebServerAcceptanceSteps implements En {
             webDriver.get(url);
         });
 
+        Given("^panel (.*) is loaded$", (String path) -> {
+            InstanceManager.getDefault(ConfigureManager.class)
+                .load(new File(path));
+        });
+
         Then("^a page with title (.*) is returned$", (String pageTitle) -> {
             WebDriverWait wait = new WebDriverWait(webDriver, 10);
             wait.until(new ExpectedCondition<Boolean>() {
@@ -58,5 +68,13 @@ public class WebServerAcceptanceSteps implements En {
             });
             Assert.assertEquals("Page Title", pageTitle, webDriver.getTitle());
         });
+
+
+        After(tags, () -> {
+           // navigate back home to prevent the webpage from reloading.
+           webDriver.get("http://localhost:12080/");
+           jmri.util.JUnitUtil.closeAllPanels();
+        });
+
     }
 }

--- a/java/acceptancetest/step_definitions/jmri/web/WebServerAcceptanceSteps.java
+++ b/java/acceptancetest/step_definitions/jmri/web/WebServerAcceptanceSteps.java
@@ -25,6 +25,7 @@ public class WebServerAcceptanceSteps implements En {
     String[] firefoxtags = {"@webtest", "@firefox"};
     String[] chrometags = {"@webtest", "@chrome"};
     String[] tags = {"@webtest"};
+    String[] paneltags = {"@webpanel"};
 
     public WebServerAcceptanceSteps(jmri.InstanceManager instance) {
 
@@ -70,7 +71,7 @@ public class WebServerAcceptanceSteps implements En {
         });
 
 
-        After(tags, () -> {
+        After(paneltags, () -> {
            // navigate back home to prevent the webpage from reloading.
            webDriver.get("http://localhost:12080/");
            jmri.util.JUnitUtil.closeAllPanels();

--- a/java/acceptancetest/step_definitions/jmri/web/WebServerScaffold.java
+++ b/java/acceptancetest/step_definitions/jmri/web/WebServerScaffold.java
@@ -23,6 +23,11 @@ public class WebServerScaffold implements En {
 
         Before(tags, () -> {
             jmri.util.JUnitUtil.resetProfileManager();
+            jmri.util.JUnitUtil.initConfigureManager();
+            jmri.util.JUnitUtil.initInternalTurnoutManager();
+            jmri.util.JUnitUtil.initInternalLightManager();
+            jmri.util.JUnitUtil.initInternalSensorManager();
+            jmri.util.JUnitUtil.initMemoryManager();
             jmri.util.JUnitUtil.initShutDownManager();
             jmri.util.JUnitUtil.initConnectionConfigManager();
             jmri.util.JUnitUtil.initDebugPowerManager();

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -1217,6 +1217,19 @@ public class JUnitUtil {
             });
     }
 
+    /* Global Panel operations */
+    /**
+     * Close all panels associated with the jmri.jmrit.display.EditorManager instance.
+     */
+    public static void closeAllPanels(){
+        List<jmri.jmrit.display.Editor> l = (InstanceManager.getNullableDefault(jmri.jmrit.display.EditorManager.class)).getEditorsList();
+        for( jmri.jmrit.display.Editor e : l ){
+           jmri.jmrit.display.EditorFrameOperator efo = new jmri.jmrit.display.EditorFrameOperator(e);
+           efo.closeFrameWithConfirmations(); 
+        }
+    }
+
+
     /* GraphicsEnvironment utility methods */
 
     /**

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -29,7 +29,7 @@ if [[ "${HEADLESS}" == "true" ]] ; then
             -Dsurefire.runOrder=${RUN_ORDER} \
             -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" \
             -Djava.awt.headless=${HEADLESS} \
-            -Dcucumber.options="--tags 'not @Ignore'"
+            -Dcucumber.options="--tags 'not @Ignore' "--tags 'not @Headed'"
     fi
 else
     # run full GUI test suite and fail on coverage issues

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -29,7 +29,7 @@ if [[ "${HEADLESS}" == "true" ]] ; then
             -Dsurefire.runOrder=${RUN_ORDER} \
             -Dant.jvm.args="-Djava.awt.headless=${HEADLESS}" \
             -Djava.awt.headless=${HEADLESS} \
-            -Dcucumber.options="--tags 'not @Ignore' "--tags 'not @Headed'"
+            -Dcucumber.options="--tags 'not @Ignore' --tags 'not @Headed'"
     fi
 else
     # run full GUI test suite and fail on coverage issues


### PR DESCRIPTION
This started out as my reply to https://github.com/JMRI/JMRI/issues/6894#issuecomment-489116579

The OneOfEach panel that @mstevetodd mentioned doesn’t load a panel window, and that confused me before I looked at the file contents.

For now this just loads a single panel file and opens it on the web.  It doesn’t do anything with the panel yet.

It should be simple enough to add additional panels if there are panels we include in the tests we want to examine further.

The next step is to load OneOfEach and verify it adds items to the web accessible tables.
