### PR TITLE
Allow  skipDupIndexWrite with ESU decoders.

### DIFF
--- a/xml/decoders/ESU_Essential_Sound_Unit.xml
+++ b/xml/decoders/ESU_Essential_Sound_Unit.xml
@@ -124,7 +124,7 @@
                 <parameter name="PI">31</parameter>
                 <parameter name="SI">32</parameter>
                 <parameter name="cvFirst">false</parameter>
-                <parameter name="skipDupIndexWrite">false</parameter>
+                <parameter name="skipDupIndexWrite">true</parameter>
             </capability>
         </programming>
         <variables>

--- a/xml/decoders/ESU_LokPilot_StandardV1_0.xml
+++ b/xml/decoders/ESU_LokPilot_StandardV1_0.xml
@@ -140,6 +140,7 @@
                 <parameter name="PI">31</parameter>
                 <parameter name="SI">32</parameter>
                 <parameter name="cvFirst">false</parameter>
+                <parameter name="skipDupIndexWrite">true</parameter>
             </capability>
         </programming>
         <variables>

--- a/xml/decoders/ESU_LokSound5.xml
+++ b/xml/decoders/ESU_LokSound5.xml
@@ -82,7 +82,7 @@
                 <parameter name="PI">31</parameter>
                 <parameter name="SI">32</parameter>
                 <parameter name="cvFirst">false</parameter>
-                <parameter name="skipDupIndexWrite">false</parameter>
+                <parameter name="skipDupIndexWrite">true</parameter>
             </capability>
         </programming>
         <variables>

--- a/xml/decoders/ESU_LokSoundV4_0.xml
+++ b/xml/decoders/ESU_LokSoundV4_0.xml
@@ -138,7 +138,7 @@
                 <parameter name="PI">31</parameter>
                 <parameter name="SI">32</parameter>
                 <parameter name="cvFirst">false</parameter>
-                <parameter name="skipDupIndexWrite">false</parameter>
+                <parameter name="skipDupIndexWrite">true</parameter>
             </capability>
         </programming>
         <variables>

--- a/xml/decoders/ESU_LokSound_Select.xml
+++ b/xml/decoders/ESU_LokSound_Select.xml
@@ -184,6 +184,7 @@
                 <parameter name="PI">31</parameter>
                 <parameter name="SI">32</parameter>
                 <parameter name="cvFirst">false</parameter>
+                <parameter name="skipDupIndexWrite">true</parameter>
             </capability>
         </programming>
         <variables>

--- a/xml/decoders/ESU_LokSound_Select_Steam.xml
+++ b/xml/decoders/ESU_LokSound_Select_Steam.xml
@@ -211,6 +211,7 @@
                 <parameter name="PI">31</parameter>
                 <parameter name="SI">32</parameter>
                 <parameter name="cvFirst">false</parameter>
+                <parameter name="skipDupIndexWrite">true</parameter>
             </capability>
         </programming>
         <variables>

--- a/xml/decoders/ESU_Misc_LightingInterior.xml
+++ b/xml/decoders/ESU_Misc_LightingInterior.xml
@@ -88,6 +88,7 @@
                 <parameter name="PI">31</parameter>
                 <parameter name="SI">32</parameter>
                 <parameter name="cvFirst">false</parameter>
+                <parameter name="skipDupIndexWrite">true</parameter>
             </capability>
         </programming>
         <variables>


### PR DESCRIPTION
This wasn't enabled. Worth turning on in low-memory installations.