### PR TITLE
Fix for slow LokProgImporter.

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
+++ b/java/src/jmri/jmrit/symbolicprog/FnMapPanelESU.java
@@ -89,9 +89,10 @@ import org.slf4j.LoggerFactory;
  * <dl>
  * <dt>Variable definitions:</dt>
  * <dd>Are of the form "ESU Function Row xx Item yy" and are created "on the
- * fly" by this class. Many thousands of variables are needed to populate the function
- * map. It is more efficient to create these in code than to use XML in the
- * decoder file. <strong>DO NOT</strong> specify them in the decoder file.</dd>
+ * fly" by this class. Many thousands of variables are needed to populate the
+ * function map. It is more efficient to create these in code than to use XML in
+ * the decoder file. <strong>DO NOT</strong> specify them in the decoder
+ * file.</dd>
  * <dd><br>
  * The "tooltip" &amp; "label" attributes on a fnmapping variable are ignored.
  * Expanded internationalized tooltips are generated in the code.
@@ -497,11 +498,21 @@ public final class FnMapPanelESU extends JPanel {
                             }
                             if (cvObject != null) {
                                 cvObject.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
+                                    private int row;
+                                    private int block;
+
                                     @Override
                                     public void propertyChange(java.beans.PropertyChangeEvent e) {
-                                        updateAllSummaryLines();
+                                        log.debug("Updating Summary Line for row {} block {}", row, block);
+                                        updateSummaryLine(row, block);
                                     }
-                                });
+
+                                    private java.beans.PropertyChangeListener init(int i, int j) {
+                                        row = i;
+                                        block = j;
+                                        return this;
+                                    }
+                                }.init(iRow, outBlockNum));
                             } else {
                                 log.error("cvObject still null after attempt to allocate");
                             }
@@ -695,7 +706,7 @@ public final class FnMapPanelESU extends JPanel {
      * @param block the block to update
      */
     void updateSummaryLine(int row, int block) {
-        String retString = "";
+        StringBuilder retString = new StringBuilder("");
         int retState = AbstractValue.SAME;
 
         for (int item = outBlockStartCol[block]; item < (outBlockStartCol[block] + outBlockLength[block]); item++) {
@@ -708,37 +719,36 @@ public final class FnMapPanelESU extends JPanel {
                 if (value > 0) {
                     if (outBlockItemBits[block] == 1) {
                         if (itemLabel[item].equals("")) {
-                            retString = retString + "," + itemName[item][0];
+                            retString.append(",").append(itemName[item][0]);
                         } else {
-                            retString = retString + "," + itemLabel[item];
+                            retString.append(",").append(itemLabel[item]);
                         }
                     } else if (outBlockItemBits[block] == 2) {
                         if (value > 2) {
-                            retString = retString + "," + "reserved value " + value;
+                            retString.append(",").append("reserved value ").append(value);
                         } else if (itemName[item][value].equals("")) {
                             if (value == 1) {
-                                retString = retString + "," + itemName[item][0];
+                                retString.append(",").append(itemName[item][0]);
                             } else if (value == 2) {
-                                retString = retString + ",not " + itemName[item][0];
+                                retString.append(",not ").append(itemName[item][0]);
                             }
                         } else {
-                            retString = retString + "," + itemName[item][value];
+                            retString.append(",").append(itemName[item][value]);
                         }
                     }
                 }
             }
         }
 
-        if (retString.startsWith(",")) {
-            retString = retString.substring(1);
-        }
-        if (retString.equals("")) {
-            retString = "-";
+        if (retString.length() == 0) {
+            retString.append("-");
+        } else if (retString.charAt(0) == ',') {
+            retString.deleteCharAt(0);
         }
 
         summaryLine[row][block].setBackground(AbstractValue.stateColorFromValue(retState));
-        summaryLine[row][block].setText(retString);
-        summaryLine[row][block].setToolTipText(retString);
+        summaryLine[row][block].setText(retString.toString());
+        summaryLine[row][block].setToolTipText(retString.toString());
     }
 
     /**

--- a/java/src/jmri/jmrit/symbolicprog/LokProgImporter.java
+++ b/java/src/jmri/jmrit/symbolicprog/LokProgImporter.java
@@ -10,8 +10,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Import CV values from a LokProgrammer CV list file written by the ESU
  * LokProgrammer software.
- *
- *
  * <hr>
  * This file is part of JMRI.
  * <P>
@@ -38,22 +36,25 @@ public class LokProgImporter {
     private static final String CV_SEPARATOR = " = ";
 
     public LokProgImporter(File file, CvTableModel cvModel) throws IOException {
-        try (
-                FileReader fileReader = new FileReader(file);
-                BufferedReader bufferedReader = new BufferedReader(fileReader);
-            ){
+        FileReader fileReader = null;
+        BufferedReader bufferedReader = null;
+
+        try {
             CvValue cvObject;
-            String CVindex = "";
-            String line = null;
-            String name = null;
-            int value = 0;
+            String cvIndex = "";
+            String line;
+            String name;
+            int value;
+
+            fileReader = new FileReader(file);
+            bufferedReader = new BufferedReader(fileReader);
 
             while ((line = bufferedReader.readLine()) != null) {
                 if (line.startsWith(INDEX_PREFIX)) {
-                    CVindex = line.substring(line.indexOf(INDEX_1) + INDEX_1.length(), line.indexOf(INDEX_1_TERMINATOR)) + ".";
-                    CVindex = CVindex + line.substring(line.indexOf(INDEX_2) + INDEX_2.length(), line.indexOf(INDEX_2_TERMINATOR)) + ".";
+                    cvIndex = line.substring(line.indexOf(INDEX_1) + INDEX_1.length(), line.indexOf(INDEX_1_TERMINATOR)) + ".";
+                    cvIndex = cvIndex + line.substring(line.indexOf(INDEX_2) + INDEX_2.length(), line.indexOf(INDEX_2_TERMINATOR)) + ".";
                 } else if (line.startsWith(CV_PREFIX) && line.regionMatches(6, CV_SEPARATOR, 0, 3)) {
-                    name = CVindex + String.valueOf(Integer.parseInt(line.substring(3, 6)));
+                    name = cvIndex + String.valueOf(Integer.parseInt(line.substring(3, 6)));
                     value = Integer.parseInt(line.substring(9, 12));
                     cvObject = cvModel.allCvMap().get(name);
                     if (cvObject == null) {
@@ -61,13 +62,20 @@ public class LokProgImporter {
                         cvModel.addCV(name, false, false, false);
                         cvObject = cvModel.allCvMap().get(name);
                     }
+                    log.debug("Settting CV {} to {}", name, value);
                     cvObject.setValue(value);
                 }
             }
-            fileReader.close();
         } catch (IOException e) {
             log.error("Error reading file: " + e);
+        } finally {
+            if (bufferedReader != null) {
+                bufferedReader.close();
+            }
+            if (fileReader != null) {
+                fileReader.close();
+            }
         }
+        log.debug("LokProgImporter finished reading file");
     }
-
 }


### PR DESCRIPTION
Addresses #6921.

My tests showed a LokSound 5 CV list file being imported in around 15 seconds on an old iMac Core 2 Duo, and working similarly down to "-Xmx512m".

Change was to update only the JTextField affected by a CV change, not every JTextField on the pane.