### PR TITLE
Check for attached objects before deleting layout track components.

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -2817,7 +2817,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         return layoutTrackDrawingOptions;
     }
 
-    /** 
+    /**
      * since 4.15.6 split variable defaultTrackColor and mainlineTrackColor/sidelineTrackColor
      * @param ltdo LayoutTrackDrawingOptions object
      */
@@ -7798,15 +7798,15 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             }
 
             //remove connections if any
-            TrackSegment t = o.getConnect1();
+            TrackSegment t1 = o.getConnect1();
+            TrackSegment t2 = o.getConnect2();
 
-            if (t != null) {
-                removeTrackSegment(t);
+            if (t1 != null) {
+                removeTrackSegment(t1);
             }
-            t = o.getConnect2();
 
-            if (t != null) {
-                removeTrackSegment(t);
+            if (t2 != null) {
+                removeTrackSegment(t2);
             }
 
             //delete from array
@@ -9125,7 +9125,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
     public String getTurnoutCircleThrownColor() {
         return ColorUtil.colorToColorName(turnoutCircleThrownColor);
     }
-    
+
     public boolean isTurnoutFillControlCircles() {
         return turnoutFillControlCircles;
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -851,5 +851,5 @@ TunnelFloorWidthMenuItemToolTip = Select this menu to change the tunnel floor wi
 TunnelEntranceWidthMenuItemTitle = Entrance Width
 TunnelEntranceWidthMenuItemToolTip = Select this menu to change the tunnel entrance width
 
-ProtectingBlock = Protecting Block :
+ProtectingBlock = Protecting Block : 
 EndOfBlock = End of Block

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -662,6 +662,8 @@ DeleteSmlReference = {0} "{1}" is linked to the following items.<br>Do you want 
 DeleteAtPoint1 = <br>Point of "{0}"
 DeleteAtPoint2 = &nbsp;and "{0}"
 DeleteAtOther = <br>{0}: "{1}"
+DeleteTrackItem = Unable to delete the {0}.\nThe following items will need to be removed first
+DeleteECisActive = Active edge connector link
 
 # Block/Sensor messages
 BlockSensorTitle = Block Entry/Exit Sensor Notification
@@ -849,5 +851,5 @@ TunnelFloorWidthMenuItemToolTip = Select this menu to change the tunnel floor wi
 TunnelEntranceWidthMenuItemTitle = Entrance Width
 TunnelEntranceWidthMenuItemToolTip = Select this menu to change the tunnel entrance width
 
-ProtectingBlock = Protecting Block : 
+ProtectingBlock = Protecting Block :
 EndOfBlock = End of Block

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorTools.java
@@ -3704,7 +3704,7 @@ public class LayoutEditorTools {
         if (setSignalsAtLevelXingFrame == null) {
             setSignalsAtLevelXingOpenFlag = false;
             setSignalsAtLevelXingFrame = new JmriJFrame(Bundle.getMessage("SignalsAtLevelXing"), false, true);
-            oneFrameToRuleThemAll(setSignalsAtXoverTurnoutFrame);
+            oneFrameToRuleThemAll(setSignalsAtLevelXingFrame);
             setSignalsAtLevelXingFrame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
             setSignalsAtLevelXingFrame.addHelpMenu("package.jmri.jmrit.display.SetSignalsAtLevelXing", true);
             setSignalsAtLevelXingFrame.setLocation(70, 30);

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
@@ -881,7 +881,7 @@ public class LayoutSlip extends LayoutTurnout {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (canDeleteTurnout() && layoutEditor.removeLayoutSlip(LayoutSlip.this)) {
+                    if (canRemoveTrackComponent() && layoutEditor.removeLayoutSlip(LayoutSlip.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
@@ -881,7 +881,7 @@ public class LayoutSlip extends LayoutTurnout {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (layoutEditor.removeLayoutSlip(LayoutSlip.this)) {
+                    if (canDeleteSlip() && layoutEditor.removeLayoutSlip(LayoutSlip.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();
@@ -996,6 +996,29 @@ public class LayoutSlip extends LayoutTurnout {
         }
         return popup;
     }   // showPopup
+
+    /**
+     * Check the connection points for object assignments.  Notify user if there
+     * are assigned objects.
+     * @return true if ok to delete
+     */
+    public boolean canDeleteSlip() {
+        ArrayList<String> beanReferences = getBeanReferences("All");
+        if (!beanReferences.isEmpty()) {
+            // The slip currently has sensors, heads, and/or masts assigned.
+            beanReferences.sort(null);
+            StringBuilder msg = new StringBuilder(Bundle.getMessage("MakeLabel",  // NOI18N
+                    Bundle.getMessage("DeleteTrackItem", Bundle.getMessage("SlipTurnout"))));  // NOI18N
+            for (String item : beanReferences) {
+                msg.append("\n    " + item);  // NOI18N
+            }
+            javax.swing.JOptionPane.showMessageDialog(null,
+                    msg.toString(),
+                    Bundle.getMessage("WarningTitle"),  // NOI18N
+                    javax.swing.JOptionPane.WARNING_MESSAGE);
+        }
+        return beanReferences.isEmpty();
+    }
 
     @Override
     public String[] getBlockBoundaries() {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
@@ -881,7 +881,7 @@ public class LayoutSlip extends LayoutTurnout {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (canRemoveObject() && layoutEditor.removeLayoutSlip(LayoutSlip.this)) {
+                    if (canRemove() && layoutEditor.removeLayoutSlip(LayoutSlip.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
@@ -881,7 +881,7 @@ public class LayoutSlip extends LayoutTurnout {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (canDeleteSlip() && layoutEditor.removeLayoutSlip(LayoutSlip.this)) {
+                    if (canDeleteTurnout() && layoutEditor.removeLayoutSlip(LayoutSlip.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();
@@ -996,29 +996,6 @@ public class LayoutSlip extends LayoutTurnout {
         }
         return popup;
     }   // showPopup
-
-    /**
-     * Check the connection points for object assignments.  Notify user if there
-     * are assigned objects.
-     * @return true if ok to delete
-     */
-    public boolean canDeleteSlip() {
-        ArrayList<String> beanReferences = getBeanReferences("All");
-        if (!beanReferences.isEmpty()) {
-            // The slip currently has sensors, heads, and/or masts assigned.
-            beanReferences.sort(null);
-            StringBuilder msg = new StringBuilder(Bundle.getMessage("MakeLabel",  // NOI18N
-                    Bundle.getMessage("DeleteTrackItem", Bundle.getMessage("SlipTurnout"))));  // NOI18N
-            for (String item : beanReferences) {
-                msg.append("\n    " + item);  // NOI18N
-            }
-            javax.swing.JOptionPane.showMessageDialog(null,
-                    msg.toString(),
-                    Bundle.getMessage("WarningTitle"),  // NOI18N
-                    javax.swing.JOptionPane.WARNING_MESSAGE);
-        }
-        return beanReferences.isEmpty();
-    }
 
     @Override
     public String[] getBlockBoundaries() {

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutSlip.java
@@ -881,7 +881,7 @@ public class LayoutSlip extends LayoutTurnout {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (canRemoveTrackComponent() && layoutEditor.removeLayoutSlip(LayoutSlip.this)) {
+                    if (canRemoveObject() && layoutEditor.removeLayoutSlip(LayoutSlip.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTrack.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTrack.java
@@ -294,6 +294,33 @@ public abstract class LayoutTrack {
     }
 
     /**
+     * Check for active block boundaries.
+     * <p>
+     * If any connection point of a track object has attached objects, such as signal
+     * masts, signal heads or NX sensors, the track component cannot be deleted.
+     * @return true if the track component can be deleted.
+     */
+    public abstract boolean canRemoveTrackComponent();
+
+    /**
+     * Display the attached items that prevent removing the component.
+     * @param itemList A list of the attached heads, masts and/or sensors.
+     * @param componentType The type such as Turnout, Level Crossing, etc.
+     */
+    public void displayRemoveTrackComponentDialog(List<String> itemList, String typeKey) {
+        itemList.sort(null);
+        StringBuilder msg = new StringBuilder(Bundle.getMessage("MakeLabel",  // NOI18N
+                Bundle.getMessage("DeleteTrackItem", Bundle.getMessage(typeKey))));  // NOI18N
+        for (String item : itemList) {
+            msg.append("\n    " + item);  // NOI18N
+        }
+        javax.swing.JOptionPane.showMessageDialog(null,
+                msg.toString(),
+                Bundle.getMessage("WarningTitle"),  // NOI18N
+                javax.swing.JOptionPane.WARNING_MESSAGE);
+    }
+
+    /**
      * Initialization method for LayoutTrack sub-classes. The following method
      * is called for each instance after the entire LayoutEditor is loaded to
      * set the specific objects for that instance

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTrack.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTrack.java
@@ -296,25 +296,25 @@ public abstract class LayoutTrack {
     /**
      * Check for active block boundaries.
      * <p>
-     * If any connection point of a track object has attached objects, such as signal
-     * masts, signal heads or NX sensors, the track component cannot be deleted.
-     * @return true if the track component can be deleted.
+     * If any connection point of a layout track object has attached objects, such as
+     * signal masts, signal heads or NX sensors, the layout track object cannot be deleted.
+     * @return true if the layout track item can be deleted.
      */
-    public abstract boolean canRemoveTrackComponent();
+    public abstract boolean canRemoveObject();
 
     /**
-     * Display the attached items that prevent removing the component.
+     * Display the attached items that prevent removing the layout track item.
      * @param itemList A list of the attached heads, masts and/or sensors.
-     * @param componentType The type such as Turnout, Level Crossing, etc.
+     * @param typeKey The object type such as Turnout, Level Crossing, etc.
      */
-    public void displayRemoveTrackComponentDialog(List<String> itemList, String typeKey) {
+    public void displayRemoveObjectDialog(List<String> itemList, String typeKey) {
         itemList.sort(null);
         StringBuilder msg = new StringBuilder(Bundle.getMessage("MakeLabel",  // NOI18N
                 Bundle.getMessage("DeleteTrackItem", Bundle.getMessage(typeKey))));  // NOI18N
         for (String item : itemList) {
             msg.append("\n    " + item);  // NOI18N
         }
-        javax.swing.JOptionPane.showMessageDialog(null,
+        javax.swing.JOptionPane.showMessageDialog(layoutEditor,
                 msg.toString(),
                 Bundle.getMessage("WarningTitle"),  // NOI18N
                 javax.swing.JOptionPane.WARNING_MESSAGE);

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTrack.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTrack.java
@@ -298,16 +298,16 @@ public abstract class LayoutTrack {
      * <p>
      * If any connection point of a layout track object has attached objects, such as
      * signal masts, signal heads or NX sensors, the layout track object cannot be deleted.
-     * @return true if the layout track item can be deleted.
+     * @return true if the layout track object can be deleted.
      */
-    public abstract boolean canRemoveObject();
+    public abstract boolean canRemove();
 
     /**
      * Display the attached items that prevent removing the layout track item.
      * @param itemList A list of the attached heads, masts and/or sensors.
      * @param typeKey The object type such as Turnout, Level Crossing, etc.
      */
-    public void displayRemoveObjectDialog(List<String> itemList, String typeKey) {
+    public void displayRemoveWarningDialog(List<String> itemList, String typeKey) {
         itemList.sort(null);
         StringBuilder msg = new StringBuilder(Bundle.getMessage("MakeLabel",  // NOI18N
                 Bundle.getMessage("DeleteTrackItem", Bundle.getMessage(typeKey))));  // NOI18N

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
@@ -735,10 +735,10 @@ public class LayoutTurnout extends LayoutTrack {
      * {@inheritDoc}
      */
     @Override
-    public boolean canRemoveObject() {
+    public boolean canRemove() {
         ArrayList<String> beanReferences = getBeanReferences("All");  // NOI18N
         if (!beanReferences.isEmpty()) {
-            displayRemoveObjectDialog(beanReferences, "BeanNameTurnout");  // NOI18N
+            displayRemoveWarningDialog(beanReferences, "BeanNameTurnout");  // NOI18N
         }
         return beanReferences.isEmpty();
     }
@@ -2748,7 +2748,7 @@ public class LayoutTurnout extends LayoutTrack {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (canRemoveObject() && layoutEditor.removeLayoutTurnout(LayoutTurnout.this)) {
+                    if (canRemove() && layoutEditor.removeLayoutTurnout(LayoutTurnout.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
@@ -732,24 +732,13 @@ public class LayoutTurnout extends LayoutTrack {
     }
 
     /**
-     * Check the connection points for object assignments.  Notify user if there
-     * are assigned objects.
-     * @return true if ok to delete
+     * {@inheritDoc}
      */
-    public boolean canDeleteTurnout() {
+    @Override
+    public boolean canRemoveTrackComponent() {
         ArrayList<String> beanReferences = getBeanReferences("All");  // NOI18N
         if (!beanReferences.isEmpty()) {
-            // The turnout currently has sensors, heads, and/or masts assigned.
-            beanReferences.sort(null);
-            StringBuilder msg = new StringBuilder(Bundle.getMessage("MakeLabel",  // NOI18N
-                    Bundle.getMessage("DeleteTrackItem", Bundle.getMessage("BeanNameTurnout"))));  // NOI18N
-            for (String item : beanReferences) {
-                msg.append("\n    " + item);  // NOI18N
-            }
-            javax.swing.JOptionPane.showMessageDialog(null,
-                    msg.toString(),
-                    Bundle.getMessage("WarningTitle"),  // NOI18N
-                    javax.swing.JOptionPane.WARNING_MESSAGE);
+            displayRemoveTrackComponentDialog(beanReferences, "BeanNameTurnout");  // NOI18N
         }
         return beanReferences.isEmpty();
     }
@@ -2759,7 +2748,7 @@ public class LayoutTurnout extends LayoutTrack {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (canDeleteTurnout() && layoutEditor.removeLayoutTurnout(LayoutTurnout.this)) {
+                    if (canRemoveTrackComponent() && layoutEditor.removeLayoutTurnout(LayoutTurnout.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
@@ -735,10 +735,10 @@ public class LayoutTurnout extends LayoutTrack {
      * {@inheritDoc}
      */
     @Override
-    public boolean canRemoveTrackComponent() {
+    public boolean canRemoveObject() {
         ArrayList<String> beanReferences = getBeanReferences("All");  // NOI18N
         if (!beanReferences.isEmpty()) {
-            displayRemoveTrackComponentDialog(beanReferences, "BeanNameTurnout");  // NOI18N
+            displayRemoveObjectDialog(beanReferences, "BeanNameTurnout");  // NOI18N
         }
         return beanReferences.isEmpty();
     }
@@ -2748,7 +2748,7 @@ public class LayoutTurnout extends LayoutTrack {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (canRemoveTrackComponent() && layoutEditor.removeLayoutTurnout(LayoutTurnout.this)) {
+                    if (canRemoveObject() && layoutEditor.removeLayoutTurnout(LayoutTurnout.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurnout.java
@@ -731,6 +731,64 @@ public class LayoutTurnout extends LayoutTrack {
         }
     }
 
+    /**
+     * Check the connection points for object assignments.  Notify user if there
+     * are assigned objects.
+     * @return true if ok to delete
+     */
+    public boolean canDeleteTurnout() {
+        ArrayList<String> beanReferences = getBeanReferences("All");  // NOI18N
+        if (!beanReferences.isEmpty()) {
+            // The turnout currently has sensors, heads, and/or masts assigned.
+            beanReferences.sort(null);
+            StringBuilder msg = new StringBuilder(Bundle.getMessage("MakeLabel",  // NOI18N
+                    Bundle.getMessage("DeleteTrackItem", Bundle.getMessage("BeanNameTurnout"))));  // NOI18N
+            for (String item : beanReferences) {
+                msg.append("\n    " + item);  // NOI18N
+            }
+            javax.swing.JOptionPane.showMessageDialog(null,
+                    msg.toString(),
+                    Bundle.getMessage("WarningTitle"),  // NOI18N
+                    javax.swing.JOptionPane.WARNING_MESSAGE);
+        }
+        return beanReferences.isEmpty();
+    }
+
+    /**
+     * Build a list of sensors, signal heads, and signal masts attached to a turnout point.
+     * @param pointName Specify the point (A-D) or all (All) points.
+     * @return a list of bean reference names.
+     */
+    public ArrayList<String> getBeanReferences(String pointName) {
+        ArrayList<String> references = new ArrayList<>();
+        if (pointName.equals("A") || pointName.equals("All")) {  // NOI18N
+            if (!getSignalAMastName().isEmpty()) references.add(getSignalAMastName());
+            if (!getSensorAName().isEmpty()) references.add(getSensorAName());
+            if (!getSignalA1Name().isEmpty()) references.add(getSignalA1Name());
+            if (!getSignalA2Name().isEmpty()) references.add(getSignalA2Name());
+            if (!getSignalA3Name().isEmpty()) references.add(getSignalA3Name());
+        }
+        if (pointName.equals("B") || pointName.equals("All")) {  // NOI18N
+            if (!getSignalBMastName().isEmpty()) references.add(getSignalBMastName());
+            if (!getSensorBName().isEmpty()) references.add(getSensorBName());
+            if (!getSignalB1Name().isEmpty()) references.add(getSignalB1Name());
+            if (!getSignalB2Name().isEmpty()) references.add(getSignalB2Name());
+        }
+        if (pointName.equals("C") || pointName.equals("All")) {  // NOI18N
+            if (!getSignalCMastName().isEmpty()) references.add(getSignalCMastName());
+            if (!getSensorCName().isEmpty()) references.add(getSensorCName());
+            if (!getSignalC1Name().isEmpty()) references.add(getSignalC1Name());
+            if (!getSignalC2Name().isEmpty()) references.add(getSignalC2Name());
+        }
+        if (pointName.equals("D") || pointName.equals("All")) {  // NOI18N
+            if (!getSignalDMastName().isEmpty()) references.add(getSignalDMastName());
+            if (!getSensorDName().isEmpty()) references.add(getSensorDName());
+            if (!getSignalD1Name().isEmpty()) references.add(getSignalD1Name());
+            if (!getSignalD2Name().isEmpty()) references.add(getSignalD2Name());
+        }
+        return references;
+    }
+
     @Nonnull
     public String getSignalAMastName() {
         if (signalAMastNamed != null) {
@@ -2701,7 +2759,7 @@ public class LayoutTurnout extends LayoutTrack {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (layoutEditor.removeLayoutTurnout(LayoutTurnout.this)) {
+                    if (canDeleteTurnout() && layoutEditor.removeLayoutTurnout(LayoutTurnout.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurntable.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurntable.java
@@ -81,7 +81,7 @@ public class LayoutTurntable extends LayoutTrack {
         radius = 25.0;
     }
 
-    // 
+    //
     /**
      * get a string that represents this object (this should only be used for
      * debugging...)
@@ -1380,6 +1380,14 @@ public class LayoutTurntable extends LayoutTrack {
     public void setAllLayoutBlocks(LayoutBlock layoutBlock) {
         // turntables don't have blocks...
         // nothing to see here, move along...
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean canRemoveTrackComponent() {
+        return true;
     }
 
     private final static Logger log

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurntable.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurntable.java
@@ -1386,7 +1386,7 @@ public class LayoutTurntable extends LayoutTrack {
      * {@inheritDoc}
      */
     @Override
-    public boolean canRemoveObject() {
+    public boolean canRemove() {
         return true;
     }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTurntable.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTurntable.java
@@ -1386,7 +1386,7 @@ public class LayoutTurntable extends LayoutTrack {
      * {@inheritDoc}
      */
     @Override
-    public boolean canRemoveTrackComponent() {
+    public boolean canRemoveObject() {
         return true;
     }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LevelXing.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LevelXing.java
@@ -1039,24 +1039,13 @@ public class LevelXing extends LayoutTrack {
     }
 
     /**
-     * Check the connection points for object assignments.  Notify user if there
-     * are assigned objects.
-     * @return true if ok to delete
+     * {@inheritDoc}
      */
-    public boolean canDeleteLevelCrossing() {
+    @Override
+    public boolean canRemoveTrackComponent() {
         ArrayList<String> beanReferences = getBeanReferences("All");  // NOI18N
         if (!beanReferences.isEmpty()) {
-            // The level crossing currently has sensors, heads, and/or masts assigned.
-            beanReferences.sort(null);
-            StringBuilder msg = new StringBuilder(Bundle.getMessage("MakeLabel",  // NOI18N
-                    Bundle.getMessage("DeleteTrackItem", Bundle.getMessage("LevelCrossing"))));  // NOI18N
-            for (String item : beanReferences) {
-                msg.append("\n    " + item);  // NOI18N
-            }
-            javax.swing.JOptionPane.showMessageDialog(null,
-                    msg.toString(),
-                    Bundle.getMessage("WarningTitle"),  // NOI18N
-                    javax.swing.JOptionPane.WARNING_MESSAGE);
+            displayRemoveTrackComponentDialog(beanReferences, "LevelCrossing");  // NOI18N
         }
         return beanReferences.isEmpty();
     }
@@ -1207,7 +1196,7 @@ public class LevelXing extends LayoutTrack {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (canDeleteLevelCrossing() && layoutEditor.removeLevelXing(LevelXing.this)) {
+                    if (canRemoveTrackComponent() && layoutEditor.removeLevelXing(LevelXing.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();

--- a/java/src/jmri/jmrit/display/layoutEditor/LevelXing.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LevelXing.java
@@ -1042,10 +1042,10 @@ public class LevelXing extends LayoutTrack {
      * {@inheritDoc}
      */
     @Override
-    public boolean canRemoveObject() {
+    public boolean canRemove() {
         ArrayList<String> beanReferences = getBeanReferences("All");  // NOI18N
         if (!beanReferences.isEmpty()) {
-            displayRemoveObjectDialog(beanReferences, "LevelCrossing");  // NOI18N
+            displayRemoveWarningDialog(beanReferences, "LevelCrossing");  // NOI18N
         }
         return beanReferences.isEmpty();
     }
@@ -1196,7 +1196,7 @@ public class LevelXing extends LayoutTrack {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (canRemoveObject() && layoutEditor.removeLevelXing(LevelXing.this)) {
+                    if (canRemove() && layoutEditor.removeLevelXing(LevelXing.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();

--- a/java/src/jmri/jmrit/display/layoutEditor/LevelXing.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LevelXing.java
@@ -1038,6 +1038,59 @@ public class LevelXing extends LayoutTrack {
         }
     }
 
+    /**
+     * Check the connection points for object assignments.  Notify user if there
+     * are assigned objects.
+     * @return true if ok to delete
+     */
+    public boolean canDeleteLevelCrossing() {
+        ArrayList<String> beanReferences = getBeanReferences("All");  // NOI18N
+        if (!beanReferences.isEmpty()) {
+            // The level crossing currently has sensors, heads, and/or masts assigned.
+            beanReferences.sort(null);
+            StringBuilder msg = new StringBuilder(Bundle.getMessage("MakeLabel",  // NOI18N
+                    Bundle.getMessage("DeleteTrackItem", Bundle.getMessage("LevelCrossing"))));  // NOI18N
+            for (String item : beanReferences) {
+                msg.append("\n    " + item);  // NOI18N
+            }
+            javax.swing.JOptionPane.showMessageDialog(null,
+                    msg.toString(),
+                    Bundle.getMessage("WarningTitle"),  // NOI18N
+                    javax.swing.JOptionPane.WARNING_MESSAGE);
+        }
+        return beanReferences.isEmpty();
+    }
+
+    /**
+     * Build a list of sensors, signal heads, and signal masts attached to a level crossing point.
+     * @param pointName Specify the point (A-D) or all (All) points.
+     * @return a list of bean reference names.
+     */
+    public ArrayList<String> getBeanReferences(String pointName) {
+        ArrayList<String> references = new ArrayList<>();
+        if (pointName.equals("A") || pointName.equals("All")) {  // NOI18N
+            if (!getSignalAMastName().isEmpty()) references.add(getSignalAMastName());
+            if (!getSensorAName().isEmpty()) references.add(getSensorAName());
+            if (!getSignalAName().isEmpty()) references.add(getSignalAName());
+        }
+        if (pointName.equals("B") || pointName.equals("All")) {  // NOI18N
+            if (!getSignalBMastName().isEmpty()) references.add(getSignalBMastName());
+            if (!getSensorBName().isEmpty()) references.add(getSensorBName());
+            if (!getSignalBName().isEmpty()) references.add(getSignalBName());
+        }
+        if (pointName.equals("C") || pointName.equals("All")) {  // NOI18N
+            if (!getSignalCMastName().isEmpty()) references.add(getSignalCMastName());
+            if (!getSensorCName().isEmpty()) references.add(getSensorCName());
+            if (!getSignalCName().isEmpty()) references.add(getSignalCName());
+        }
+        if (pointName.equals("D") || pointName.equals("All")) {  // NOI18N
+            if (!getSignalDMastName().isEmpty()) references.add(getSignalDMastName());
+            if (!getSensorDName().isEmpty()) references.add(getSensorDName());
+            if (!getSignalDName().isEmpty()) references.add(getSignalDName());
+        }
+        return references;
+    }
+
     JPopupMenu popup = null;
 
     /**
@@ -1154,7 +1207,7 @@ public class LevelXing extends LayoutTrack {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (layoutEditor.removeLevelXing(LevelXing.this)) {
+                    if (canDeleteLevelCrossing() && layoutEditor.removeLevelXing(LevelXing.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();

--- a/java/src/jmri/jmrit/display/layoutEditor/LevelXing.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LevelXing.java
@@ -1042,10 +1042,10 @@ public class LevelXing extends LayoutTrack {
      * {@inheritDoc}
      */
     @Override
-    public boolean canRemoveTrackComponent() {
+    public boolean canRemoveObject() {
         ArrayList<String> beanReferences = getBeanReferences("All");  // NOI18N
         if (!beanReferences.isEmpty()) {
-            displayRemoveTrackComponentDialog(beanReferences, "LevelCrossing");  // NOI18N
+            displayRemoveObjectDialog(beanReferences, "LevelCrossing");  // NOI18N
         }
         return beanReferences.isEmpty();
     }
@@ -1196,7 +1196,7 @@ public class LevelXing extends LayoutTrack {
             popup.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (canRemoveTrackComponent() && layoutEditor.removeLevelXing(LevelXing.this)) {
+                    if (canRemoveObject() && layoutEditor.removeLevelXing(LevelXing.this)) {
                         // Returned true if user did not cancel
                         remove();
                         dispose();

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -1281,7 +1281,7 @@ public class PositionablePoint extends LayoutTrack {
             @Override
             public void actionPerformed(ActionEvent e
             ) {
-                if (canDeletePoint() && layoutEditor.removePositionablePoint(PositionablePoint.this)) {
+                if (canRemoveTrackComponent() && layoutEditor.removePositionablePoint(PositionablePoint.this)) {
                     // user is serious about removing this point from the panel
                     remove();
                     dispose();
@@ -1426,11 +1426,10 @@ public class PositionablePoint extends LayoutTrack {
     }   // showPopup
 
     /**
-     * Check the connection point for object assignments.  Notify user if there
-     * are assigned objects.
-     * @return true if ok to delete
+     * {@inheritDoc}
      */
-    public boolean canDeletePoint() {
+    @Override
+    public boolean canRemoveTrackComponent() {
         List<String> itemList = new ArrayList<>();
         // A has two track segments, EB has one, EC has one plus optional link
 
@@ -1450,33 +1449,22 @@ public class PositionablePoint extends LayoutTrack {
         }
 
         if (!itemList.isEmpty()) {
-            itemList.sort(null);
-
             String typeName = "";
             switch (type) {
                 case ANCHOR:
-                    typeName = Bundle.getMessage("Anchor");
+                    typeName = "Anchor";  // NOI18N
                     break;
                 case END_BUMPER:
-                    typeName = Bundle.getMessage("EndBumper");
+                    typeName = "EndBumper";  // NOI18N
                     break;
                 case EDGE_CONNECTOR:
-                    typeName = Bundle.getMessage("EdgeConnector");
+                    typeName = "EdgeConnector";  // NOI18N
                     break;
                 default:
-                    typeName = "Unknown type (" + type + ")";
+                    typeName = "Unknown type (" + type + ")";  // NOI18N
                     break;
             }
-
-            StringBuilder msg = new StringBuilder(Bundle.getMessage("MakeLabel",
-                    Bundle.getMessage("DeleteTrackItem", typeName)));  // NOI18N
-            for (String item : itemList) {
-                msg.append("\n    " + item);  // NOI18N
-            }
-            javax.swing.JOptionPane.showMessageDialog(null,
-                    msg.toString(),
-                    Bundle.getMessage("WarningTitle"),  // NOI18N
-                    javax.swing.JOptionPane.WARNING_MESSAGE);
+            displayRemoveTrackComponentDialog(itemList, typeName);
         }
         return itemList.isEmpty();
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -1281,7 +1281,7 @@ public class PositionablePoint extends LayoutTrack {
             @Override
             public void actionPerformed(ActionEvent e
             ) {
-                if (canRemoveTrackComponent() && layoutEditor.removePositionablePoint(PositionablePoint.this)) {
+                if (canRemoveObject() && layoutEditor.removePositionablePoint(PositionablePoint.this)) {
                     // user is serious about removing this point from the panel
                     remove();
                     dispose();
@@ -1429,7 +1429,7 @@ public class PositionablePoint extends LayoutTrack {
      * {@inheritDoc}
      */
     @Override
-    public boolean canRemoveTrackComponent() {
+    public boolean canRemoveObject() {
         List<String> itemList = new ArrayList<>();
         // A has two track segments, EB has one, EC has one plus optional link
 
@@ -1464,7 +1464,7 @@ public class PositionablePoint extends LayoutTrack {
                     typeName = "Unknown type (" + type + ")";  // NOI18N
                     break;
             }
-            displayRemoveTrackComponentDialog(itemList, typeName);
+            displayRemoveObjectDialog(itemList, typeName);
         }
         return itemList.isEmpty();
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -1531,7 +1531,6 @@ public class PositionablePoint extends LayoutTrack {
      * Removes this object from display and persistence
      */
     private void remove() {
-        log.info("---- remove: {}", this);
         // remove from persistence by flagging inactive
         active = false;
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -1281,7 +1281,7 @@ public class PositionablePoint extends LayoutTrack {
             @Override
             public void actionPerformed(ActionEvent e
             ) {
-                if (canRemoveObject() && layoutEditor.removePositionablePoint(PositionablePoint.this)) {
+                if (canRemove() && layoutEditor.removePositionablePoint(PositionablePoint.this)) {
                     // user is serious about removing this point from the panel
                     remove();
                     dispose();
@@ -1429,7 +1429,7 @@ public class PositionablePoint extends LayoutTrack {
      * {@inheritDoc}
      */
     @Override
-    public boolean canRemoveObject() {
+    public boolean canRemove() {
         List<String> itemList = new ArrayList<>();
         // A has two track segments, EB has one, EC has one plus optional link
 
@@ -1464,7 +1464,7 @@ public class PositionablePoint extends LayoutTrack {
                     typeName = "Unknown type (" + type + ")";  // NOI18N
                     break;
             }
-            displayRemoveObjectDialog(itemList, typeName);
+            displayRemoveWarningDialog(itemList, typeName);
         }
         return itemList.isEmpty();
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -1586,7 +1586,7 @@ public class TrackSegment extends LayoutTrack {
         popupMenu.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
             @Override
             public void actionPerformed(ActionEvent e) {
-                if (canRemoveTrackComponent()) {
+                if (canRemoveObject()) {
                     layoutEditor.removeTrackSegment(TrackSegment.this);
                     remove();
                     dispose();
@@ -1669,7 +1669,7 @@ public class TrackSegment extends LayoutTrack {
      * {@inheritDoc}
      */
     @Override
-    public boolean canRemoveTrackComponent() {
+    public boolean canRemoveObject() {
         List<String> itemList = new ArrayList<>();
 
         int type1 = getType1();
@@ -1681,7 +1681,7 @@ public class TrackSegment extends LayoutTrack {
         itemList.addAll(getPointReferences(type2, conn2));
 
         if (!itemList.isEmpty()) {
-            displayRemoveTrackComponentDialog(itemList, "TrackSegment");  // NOI18N
+            displayRemoveObjectDialog(itemList, "TrackSegment");  // NOI18N
         }
         return itemList.isEmpty();
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -1702,7 +1702,7 @@ public class TrackSegment extends LayoutTrack {
     public ArrayList<String> getPointReferences(int type, LayoutTrack conn) {
         ArrayList<String> items = new ArrayList<>();
 
-        if (type == 1 && conn instanceof PositionablePoint) {
+        if (type == POS_POINT && conn instanceof PositionablePoint) {
             PositionablePoint pt = (PositionablePoint) conn;
             if (!pt.getEastBoundSignal().isEmpty()) items.add(pt.getEastBoundSignal());
             if (!pt.getWestBoundSignal().isEmpty()) items.add(pt.getWestBoundSignal());
@@ -1716,27 +1716,27 @@ public class TrackSegment extends LayoutTrack {
             return items;
         }
 
-        if (type > 1 && type < 6 && conn instanceof LayoutTurnout) {
+        if ((type == TURNOUT_A || type == TURNOUT_B || type == TURNOUT_C || type == TURNOUT_D) && conn instanceof LayoutTurnout) {
             LayoutTurnout lt = (LayoutTurnout) conn;
-            if (type == 2) return lt.getBeanReferences("A");  // NOI18N
-            if (type == 3) return lt.getBeanReferences("B");  // NOI18N
-            if (type == 4) return lt.getBeanReferences("C");  // NOI18N
+            if (type == TURNOUT_A) return lt.getBeanReferences("A");  // NOI18N
+            if (type == TURNOUT_B) return lt.getBeanReferences("B");  // NOI18N
+            if (type == TURNOUT_C) return lt.getBeanReferences("C");  // NOI18N
             return lt.getBeanReferences("D");  // NOI18N
         }
 
-        if (type > 5 && type < 10 && conn instanceof LevelXing) {
+        if ((type == LEVEL_XING_A || type == LEVEL_XING_B || type == LEVEL_XING_C || type == LEVEL_XING_D) && conn instanceof LevelXing) {
             LevelXing lx = (LevelXing) conn;
-            if (type == 6) return lx.getBeanReferences("A");  // NOI18N
-            if (type == 7) return lx.getBeanReferences("B");  // NOI18N
-            if (type == 8) return lx.getBeanReferences("C");  // NOI18N
+            if (type == LEVEL_XING_A) return lx.getBeanReferences("A");  // NOI18N
+            if (type == LEVEL_XING_B) return lx.getBeanReferences("B");  // NOI18N
+            if (type == LEVEL_XING_C) return lx.getBeanReferences("C");  // NOI18N
             return lx.getBeanReferences("D");  // NOI18N
         }
 
-        if (type > 20 && type < 25 && conn instanceof LayoutSlip) {
+        if ((type == SLIP_A || type == SLIP_B || type == SLIP_C || type == SLIP_D) && conn instanceof LayoutSlip) {
             LayoutSlip ls = (LayoutSlip) conn;
-            if (type == 21) return ls.getBeanReferences("A");  // NOI18N
-            if (type == 22) return ls.getBeanReferences("B");  // NOI18N
-            if (type == 23) return ls.getBeanReferences("C");  // NOI18N
+            if (type == SLIP_A) return ls.getBeanReferences("A");  // NOI18N
+            if (type == SLIP_B) return ls.getBeanReferences("B");  // NOI18N
+            if (type == SLIP_C) return ls.getBeanReferences("C");  // NOI18N
             return ls.getBeanReferences("D");  // NOI18N
         }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -1586,7 +1586,7 @@ public class TrackSegment extends LayoutTrack {
         popupMenu.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
             @Override
             public void actionPerformed(ActionEvent e) {
-                if (canRemoveTrackSegment(TrackSegment.this)) {
+                if (canRemoveTrackComponent()) {
                     layoutEditor.removeTrackSegment(TrackSegment.this);
                     remove();
                     dispose();
@@ -1666,35 +1666,22 @@ public class TrackSegment extends LayoutTrack {
     }   // showPopup
 
     /**
-     * Check for active block boundaries.
-     * <p>
-     * If either end of the track segment has attached objects, such as signal
-     * masts signal heads or NX sensors, the track segment cannot be deleted.
-     * @param ts The track segment that is going to be deleted if possible.
-     * @return true if the track segment can be deleted.
+     * {@inheritDoc}
      */
-    public boolean canRemoveTrackSegment(TrackSegment ts) {
+    @Override
+    public boolean canRemoveTrackComponent() {
         List<String> itemList = new ArrayList<>();
 
-        int type1 = ts.getType1();
-        LayoutTrack conn1 = ts.getConnect1();
+        int type1 = getType1();
+        LayoutTrack conn1 = getConnect1();
         itemList.addAll(getPointReferences(type1, conn1));
 
-        int type2 = ts.getType2();
-        LayoutTrack conn2 = ts.getConnect2();
+        int type2 = getType2();
+        LayoutTrack conn2 = getConnect2();
         itemList.addAll(getPointReferences(type2, conn2));
 
         if (!itemList.isEmpty()) {
-            itemList.sort(null);
-            StringBuilder msg = new StringBuilder(Bundle.getMessage("MakeLabel",
-                    Bundle.getMessage("DeleteTrackItem", Bundle.getMessage("TrackSegment"))));  // NOI18N
-            for (String item : itemList) {
-                msg.append("\n    " + item);  // NOI18N
-            }
-            javax.swing.JOptionPane.showMessageDialog(null,
-                    msg.toString(),
-                    Bundle.getMessage("WarningTitle"),  // NOI18N
-                    javax.swing.JOptionPane.WARNING_MESSAGE);
+            displayRemoveTrackComponentDialog(itemList, "TrackSegment");  // NOI18N
         }
         return itemList.isEmpty();
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -1586,7 +1586,7 @@ public class TrackSegment extends LayoutTrack {
         popupMenu.add(new AbstractAction(Bundle.getMessage("ButtonDelete")) {
             @Override
             public void actionPerformed(ActionEvent e) {
-                if (canRemoveObject()) {
+                if (canRemove()) {
                     layoutEditor.removeTrackSegment(TrackSegment.this);
                     remove();
                     dispose();
@@ -1669,7 +1669,7 @@ public class TrackSegment extends LayoutTrack {
      * {@inheritDoc}
      */
     @Override
-    public boolean canRemoveObject() {
+    public boolean canRemove() {
         List<String> itemList = new ArrayList<>();
 
         int type1 = getType1();
@@ -1681,7 +1681,7 @@ public class TrackSegment extends LayoutTrack {
         itemList.addAll(getPointReferences(type2, conn2));
 
         if (!itemList.isEmpty()) {
-            displayRemoveObjectDialog(itemList, "TrackSegment");  // NOI18N
+            displayRemoveWarningDialog(itemList, "TrackSegment");  // NOI18N
         }
         return itemList.isEmpty();
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -1721,7 +1721,7 @@ public class TrackSegment extends LayoutTrack {
             if (type == 2) return lt.getBeanReferences("A");  // NOI18N
             if (type == 3) return lt.getBeanReferences("B");  // NOI18N
             if (type == 4) return lt.getBeanReferences("C");  // NOI18N
-            if (type == 5) return lt.getBeanReferences("D");  // NOI18N
+            return lt.getBeanReferences("D");  // NOI18N
         }
 
         if (type > 5 && type < 10 && conn instanceof LevelXing) {
@@ -1729,7 +1729,7 @@ public class TrackSegment extends LayoutTrack {
             if (type == 6) return lx.getBeanReferences("A");  // NOI18N
             if (type == 7) return lx.getBeanReferences("B");  // NOI18N
             if (type == 8) return lx.getBeanReferences("C");  // NOI18N
-            if (type == 9) return lx.getBeanReferences("D");  // NOI18N
+            return lx.getBeanReferences("D");  // NOI18N
         }
 
         if (type > 20 && type < 25 && conn instanceof LayoutSlip) {
@@ -1737,7 +1737,7 @@ public class TrackSegment extends LayoutTrack {
             if (type == 21) return ls.getBeanReferences("A");  // NOI18N
             if (type == 22) return ls.getBeanReferences("B");  // NOI18N
             if (type == 23) return ls.getBeanReferences("C");  // NOI18N
-            if (type == 24) return ls.getBeanReferences("D");  // NOI18N
+            return ls.getBeanReferences("D");  // NOI18N
         }
 
         return items;

--- a/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/TrackSegment.java
@@ -1677,12 +1677,10 @@ public class TrackSegment extends LayoutTrack {
         List<String> itemList = new ArrayList<>();
 
         int type1 = ts.getType1();
-        log.info("type1 = {}", type1);
         LayoutTrack conn1 = ts.getConnect1();
         itemList.addAll(getPointReferences(type1, conn1));
 
         int type2 = ts.getType2();
-        log.info("type2 = {}", type2);
         LayoutTrack conn2 = ts.getConnect2();
         itemList.addAll(getPointReferences(type2, conn2));
 
@@ -1703,57 +1701,46 @@ public class TrackSegment extends LayoutTrack {
 
     public ArrayList<String> getPointReferences(int type, LayoutTrack conn) {
         ArrayList<String> items = new ArrayList<>();
-        switch (type) {
-            case 1:
-                if (conn instanceof PositionablePoint) {
-                    PositionablePoint pt = (PositionablePoint) conn;
-                    if (!pt.getEastBoundSignal().isEmpty()) items.add(pt.getEastBoundSignal());
-                    if (!pt.getWestBoundSignal().isEmpty()) items.add(pt.getWestBoundSignal());
-                    if (!pt.getEastBoundSignalMastName().isEmpty()) items.add(pt.getEastBoundSignalMastName());
-                    if (!pt.getWestBoundSignalMastName().isEmpty()) items.add(pt.getWestBoundSignalMastName());
-                    if (!pt.getEastBoundSensorName().isEmpty()) items.add(pt.getEastBoundSensorName());
-                    if (!pt.getWestBoundSensorName().isEmpty()) items.add(pt.getWestBoundSensorName());
-                    if (pt.getType() == EDGE_CONNECTOR && pt.getLinkedPoint() != null) {
-                        items.add(Bundle.getMessage("DeleteECisActive"));   // NOI18N
-                    }
-                    return items;
-                }
-            case 2:
-            case 3:
-            case 4:
-            case 5:
-                if (conn instanceof LayoutTurnout) {
-                    LayoutTurnout lt = (LayoutTurnout) conn;
-                    if (type == 2) return lt.getBeanReferences("A");  // NOI18N
-                    if (type == 3) return lt.getBeanReferences("B");  // NOI18N
-                    if (type == 4) return lt.getBeanReferences("C");  // NOI18N
-                    if (type == 5) return lt.getBeanReferences("D");  // NOI18N
-                }
-            case 6:
-            case 7:
-            case 8:
-            case 9:
-                if (conn instanceof LevelXing) {
-                    LevelXing lx = (LevelXing) conn;
-                    if (type == 6) return lx.getBeanReferences("A");  // NOI18N
-                    if (type == 7) return lx.getBeanReferences("B");  // NOI18N
-                    if (type == 8) return lx.getBeanReferences("C");  // NOI18N
-                    if (type == 9) return lx.getBeanReferences("D");  // NOI18N
-                }
-            case 21:
-            case 22:
-            case 23:
-            case 24:
-                if (conn instanceof LayoutSlip) {
-                    LayoutSlip ls = (LayoutSlip) conn;
-                    if (type == 21) return ls.getBeanReferences("A");  // NOI18N
-                    if (type == 22) return ls.getBeanReferences("B");  // NOI18N
-                    if (type == 23) return ls.getBeanReferences("C");  // NOI18N
-                    if (type == 24) return ls.getBeanReferences("D");  // NOI18N
-                }
-            default:
-                return items;
+
+        if (type == 1 && conn instanceof PositionablePoint) {
+            PositionablePoint pt = (PositionablePoint) conn;
+            if (!pt.getEastBoundSignal().isEmpty()) items.add(pt.getEastBoundSignal());
+            if (!pt.getWestBoundSignal().isEmpty()) items.add(pt.getWestBoundSignal());
+            if (!pt.getEastBoundSignalMastName().isEmpty()) items.add(pt.getEastBoundSignalMastName());
+            if (!pt.getWestBoundSignalMastName().isEmpty()) items.add(pt.getWestBoundSignalMastName());
+            if (!pt.getEastBoundSensorName().isEmpty()) items.add(pt.getEastBoundSensorName());
+            if (!pt.getWestBoundSensorName().isEmpty()) items.add(pt.getWestBoundSensorName());
+            if (pt.getType() == EDGE_CONNECTOR && pt.getLinkedPoint() != null) {
+                items.add(Bundle.getMessage("DeleteECisActive"));   // NOI18N
+            }
+            return items;
         }
+
+        if (type > 1 && type < 6 && conn instanceof LayoutTurnout) {
+            LayoutTurnout lt = (LayoutTurnout) conn;
+            if (type == 2) return lt.getBeanReferences("A");  // NOI18N
+            if (type == 3) return lt.getBeanReferences("B");  // NOI18N
+            if (type == 4) return lt.getBeanReferences("C");  // NOI18N
+            if (type == 5) return lt.getBeanReferences("D");  // NOI18N
+        }
+
+        if (type > 5 && type < 10 && conn instanceof LevelXing) {
+            LevelXing lx = (LevelXing) conn;
+            if (type == 6) return lx.getBeanReferences("A");  // NOI18N
+            if (type == 7) return lx.getBeanReferences("B");  // NOI18N
+            if (type == 8) return lx.getBeanReferences("C");  // NOI18N
+            if (type == 9) return lx.getBeanReferences("D");  // NOI18N
+        }
+
+        if (type > 20 && type < 25 && conn instanceof LayoutSlip) {
+            LayoutSlip ls = (LayoutSlip) conn;
+            if (type == 21) return ls.getBeanReferences("A");  // NOI18N
+            if (type == 22) return ls.getBeanReferences("B");  // NOI18N
+            if (type == 23) return ls.getBeanReferences("C");  // NOI18N
+            if (type == 24) return ls.getBeanReferences("D");  // NOI18N
+        }
+
+        return items;
     }
 
     /**


### PR DESCRIPTION
- Prevent track component deletes when signal heads, signal masts, or sensors are attached.  
- Fix a track segment delete problem where a positional point can be deleted but the track segment is void on one end.
- Fix an NPE that occurs when attaching signal heads to a level crossing.