### PR TITLE
remove unnecessary toUpperCase

### DIFF
--- a/java/src/jmri/managers/DefaultMemoryManager.java
+++ b/java/src/jmri/managers/DefaultMemoryManager.java
@@ -21,13 +21,13 @@ public class DefaultMemoryManager extends AbstractMemoryManager {
 
     @Override
     protected Memory createNewMemory(String systemName, String userName) {
-        if(systemName.equals("") || systemName.toUpperCase().equals("IM")){
+        if(systemName.equals("") || systemName.equals("IM")){
            log.error("Invalid system name for memory: \"{}\" but needed IM followed by a suffix",systemName);
            throw new IllegalArgumentException("Invalid system name for memory: \"" + systemName + "\" but needed IM followed by a suffix");
         }
         // we've decided to enforce that memory system
         // names start with IM by prepending if not present
-        if (!systemName.toUpperCase().startsWith("IM")) {
+        if (!systemName.startsWith("IM")) {
             systemName = "IM" + systemName;
         }
         return new DefaultMemory(systemName, userName);

--- a/java/test/jmri/managers/DefaultMemoryManagerTest.java
+++ b/java/test/jmri/managers/DefaultMemoryManagerTest.java
@@ -30,6 +30,13 @@ public class DefaultMemoryManagerTest extends AbstractProvidingManagerTestBase<j
         }
     }
 
+    @Test
+    public void testCreatesiM() {
+        jmri.Memory im = l.provideMemory("iM");
+        Assert.assertNotNull("iM created",im);
+        Assert.assertEquals("correct system name","IMIM",im.getSystemName());
+    }
+
     @Before
     public void setUp() {
         JUnitUtil.setUp();


### PR DESCRIPTION
eliminates a subtle bug created in #6911.  Thanks @rhwood for catching that.