### PR TITLE
EasyDCC update

### DIFF
--- a/java/src/jmri/jmrix/AbstractMRTrafficController.java
+++ b/java/src/jmri/jmrix/AbstractMRTrafficController.java
@@ -333,7 +333,7 @@ abstract public class AbstractMRTrafficController {
      * Permanent loop for the transmit thread.
      */
     protected void transmitLoop() {
-        log.debug("transmitLoop starts");
+        log.debug("transmitLoop starts in {}", this);
 
         // loop forever
         while (!connectionError && !threadStopRequest) {
@@ -864,7 +864,7 @@ abstract public class AbstractMRTrafficController {
      * Each turn of the loop is the receipt of a single message.
      */
     public void receiveLoop() {
-        log.debug("receiveLoop starts");
+        log.debug("receiveLoop starts in {}", this);
         int errorCount = 0;
         while (errorCount < maxRcvExceptionCount && !threadStopRequest) { // stream close will exit via exception
             try {

--- a/java/src/jmri/jmrix/easydcc/EasyDccTurnoutManager.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccTurnoutManager.java
@@ -117,21 +117,6 @@ public class EasyDccTurnoutManager extends jmri.managers.AbstractTurnoutManager 
         return entryToolTip;
     }
 
-    /**
-     * @deprecated JMRI Since 4.9.5 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated
-    static public EasyDccTurnoutManager instance() {
-        log.warn("deprecated instance() call for EasyDccTurnoutManager");
-        return null;
-    }
-
-    /**
-     * @deprecated JMRI Since 4.9.5 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated
-    static EasyDccTurnoutManager _instance = null;
-
     private final static Logger log = LoggerFactory.getLogger(EasyDccTurnoutManager.class);
 
 }

--- a/java/src/jmri/jmrix/easydcc/networkdriver/NetworkDriverAdapter.java
+++ b/java/src/jmri/jmrix/easydcc/networkdriver/NetworkDriverAdapter.java
@@ -45,15 +45,6 @@ public class NetworkDriverAdapter extends EasyDccNetworkPortController {
     // private control members
     private boolean opened = false;
 
-    /**
-     * @deprecated JMRI Since 4.9.5 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated
-    static public NetworkDriverAdapter instance() {
-        log.error("Unexpected call to instance()");
-        return null;
-    }
-
     Socket socket;
 
     public Vector<String> getPortNames() {

--- a/java/src/jmri/jmrix/easydcc/networkdriver/NetworkDriverAdapter.java
+++ b/java/src/jmri/jmrix/easydcc/networkdriver/NetworkDriverAdapter.java
@@ -28,13 +28,13 @@ public class NetworkDriverAdapter extends EasyDccNetworkPortController {
      */
     @Override
     public void configure() {
-        // connect to the traffic controller
+        // connect to the traffic controller, which is provided via the memo
         log.debug("set tc for memo {}", getSystemConnectionMemo().getUserName());
-        EasyDccTrafficController control = new EasyDccTrafficController(getSystemConnectionMemo());
-        control.connectPort(this);
-        this.getSystemConnectionMemo().setEasyDccTrafficController(control);
+
+        getSystemConnectionMemo().getTrafficController().connectPort(this);
+
         // do the common manager config
-        this.getSystemConnectionMemo().configureManagers();
+        getSystemConnectionMemo().configureManagers();
     }
 
     @Override

--- a/java/src/jmri/jmrix/easydcc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/easydcc/serialdriver/SerialDriverAdapter.java
@@ -99,13 +99,13 @@ public class SerialDriverAdapter extends EasyDccPortController implements jmri.j
      */
     @Override
     public void configure() {
-        // connect to the traffic controller
+        // connect to the traffic controller, which is provided via the memo
         log.debug("set tc for memo {}", getSystemConnectionMemo().getUserName());
-        EasyDccTrafficController control = new EasyDccTrafficController(getSystemConnectionMemo());
-        control.connectPort(this);
-        this.getSystemConnectionMemo().setEasyDccTrafficController(control);
+
+        getSystemConnectionMemo().getTrafficController().connectPort(this);
+
         // do the common manager config
-        this.getSystemConnectionMemo().configureManagers();
+        getSystemConnectionMemo().configureManagers();
     }
 
     // Base class methods for the EasyDccPortController interface

--- a/java/src/jmri/jmrix/easydcc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/easydcc/serialdriver/SerialDriverAdapter.java
@@ -158,14 +158,6 @@ public class SerialDriverAdapter extends EasyDccPortController implements jmri.j
     private boolean opened = false;
     InputStream serialStream = null;
 
-    /**
-     * @deprecated JMRI Since 4.9.5 instance() shouldn't be used, convert to JMRI multi-system support structure
-     */
-    @Deprecated
-    static public SerialDriverAdapter instance() {
-        return null;
-    }
-
     private final static Logger log = LoggerFactory.getLogger(SerialDriverAdapter.class);
 
 }

--- a/java/src/jmri/jmrix/easydcc/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/easydcc/simulator/SimulatorAdapter.java
@@ -102,12 +102,11 @@ public class SimulatorAdapter extends EasyDccPortController implements jmri.jmri
      */
     @Override
     public void configure() {
-        // connect to the traffic controller
+        // connect to the traffic controller, which is provided via the memo
         log.debug("set tc for memo {}", getSystemConnectionMemo().getUserName());
-        EasyDccTrafficController control = new EasyDccSimulatorTrafficController(getSystemConnectionMemo());
-        //compare with: XNetTrafficController packets = new XNetPacketizer(new LenzCommandStation());
-        control.connectPort(this);
-        this.getSystemConnectionMemo().setEasyDccTrafficController(control);
+
+        getSystemConnectionMemo().getTrafficController().connectPort(this);
+
         // do the common manager config
         this.getSystemConnectionMemo().configureManagers();
 


### PR DESCRIPTION
- Properly handle initialization of TrafficController, which should fix programmer problems in e.g. #6636 
- improve a debug message
- remove the `instance()` methods deprecated in JMRI 4.9.5 (three years ago)