### PR TITLE
Order seems to matter to profile startup tests

### DIFF
--- a/java/test/apps/PackageTest.java
+++ b/java/test/apps/PackageTest.java
@@ -5,20 +5,22 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-        BundleTest.class,
-        ConfigBundleTest.class,
-        ValidateConfigFilesTest.class,
-        apps.configurexml.PackageTest.class,
-        apps.startup.PackageTest.class,
-        apps.InstallTest.PackageTest.class,
-        apps.gui3.PackageTest.class,
-        apps.DecoderPro.PackageTest.class,
-        apps.DispatcherPro.PackageTest.class,
-        apps.PanelPro.PackageTest.class,
-        apps.SoundPro.PackageTest.class,
-        apps.TrainCrew.PackageTest.class,
-        JmriFacelessTest.class,
-        apps.systemconsole.PackageTest.class,
+    apps.DecoderPro.PackageTest.class,
+    apps.DispatcherPro.PackageTest.class,
+    apps.PanelPro.PackageTest.class,
+    apps.SoundPro.PackageTest.class,
+    apps.TrainCrew.PackageTest.class,
+
+    BundleTest.class,
+    ConfigBundleTest.class,
+    ValidateConfigFilesTest.class,
+    apps.configurexml.PackageTest.class,
+    apps.startup.PackageTest.class,
+    apps.InstallTest.PackageTest.class,
+    apps.gui3.PackageTest.class,
+    JmriFacelessTest.class,
+    apps.systemconsole.PackageTest.class,
+
 	AboutActionTest.class,
 	AppConfigBaseTest.class,
 	AppsTest.class,
@@ -39,10 +41,10 @@ import org.junit.runners.Suite;
 	StartupActionsManagerTest.class,
 	SystemConsoleActionTest.class,
 	SystemConsoleConfigPanelTest.class,
-        apps.gui.PackageTest.class,
-        SampleMinimalProgramTest.class,
-        SystemConsoleTest.class,
-        AppsLaunchFrameTest.class
+    apps.gui.PackageTest.class,
+    SampleMinimalProgramTest.class,
+    SystemConsoleTest.class,
+    AppsLaunchFrameTest.class
 })
 /**
  * Invoke complete set of tests for the apps package


### PR DESCRIPTION
Sometimes, the application startup tests give a message about the profile having been migrated and hang.  Other times, they go through without it.  It's not at all clear what causes it; rerunning the test (almost) never fails. Ant clean and ant realclean make it more likely, but not consistent.

This changes the order of the `apps` tests to move the application startup tests to the top.  This reduces the failure rate by about half, but of course doesn't address the underlying cause.