### PR TITLE
fix: Some fixes for NamedBean handling

### DIFF
--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -129,12 +129,33 @@ public interface NamedBean extends Comparable<NamedBean>, PropertyChangeProvider
     /**
      * Returns a fully formatted display that includes the SystemName and
      * UserName if set.
+     * <p>
+     * This is the same as calling
+     * {@link #getFullyFormattedDisplayName(boolean)} with the parameter true.
      *
-     * @return <code>UserName (SystemName)</code> or <code>SystemName</code>
+     * @return {@code UserName (SystemName)} or {@code SystemName} if the
+     *         UserName is null, empty, or matches the SystemName
      */
     @CheckReturnValue
     @Nonnull
-    public String getFullyFormattedDisplayName();
+    public default String getFullyFormattedDisplayName() {
+        return getFullyFormattedDisplayName(true);
+    }
+
+    /**
+     * Returns a fully formatted display that includes the SystemName and
+     * UserName if set.
+     *
+     * @param userNameFirst returns UserName followed by SystemName if true;
+     *                          otherwise returns SystemName followed by
+     *                          UserName
+     * @return {@code UserName (SystemName)} or {@code SystemName (UserName)}
+     *         based on value of userNameFirst, or {@code SystemName} if the
+     *         UserName is null, empty, or matches the SystemName
+     */
+    @CheckReturnValue
+    @Nonnull
+    public String getFullyFormattedDisplayName(boolean userNameFirst);
 
     /**
      * Request a call-back when a bound property changes. Bound properties are

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -79,6 +79,11 @@ public interface NamedBean extends Comparable<NamedBean>, PropertyChangeProvider
     public static final int INCONSISTENT = 0x08;
 
     /**
+     * Format used for {@link #getFullyFormattedDisplayName(boolean)}.
+     */
+    public static final String DISPLAY_NAME_FORMAT = "%s (%s)";
+
+    /**
      * User's identification for the item. Bound parameter so manager(s) can
      * listen to changes. Any given user name must be unique within the layout.
      * Must not match the system name.
@@ -144,7 +149,7 @@ public interface NamedBean extends Comparable<NamedBean>, PropertyChangeProvider
 
     /**
      * Returns a fully formatted display that includes the SystemName and
-     * UserName if set.
+     * UserName if set. This uses the format {@value #DISPLAY_NAME_FORMAT}
      *
      * @param userNameFirst returns UserName followed by SystemName if true;
      *                          otherwise returns SystemName followed by

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -106,9 +106,9 @@ public abstract class AbstractNamedBean implements NamedBean {
         String name = getUserName();
         if (name != null && !name.isEmpty() && !name.equals(getSystemName())) {
             if (userNameFirst) {
-                name = name + " (" + getSystemName() + ")";
+                name = String.format(NamedBean.DISPLAY_NAME_FORMAT, name, getSystemName());
             } else {
-                name = getSystemName() + " (" + name + ")";
+                name = String.format(NamedBean.DISPLAY_NAME_FORMAT, getSystemName(), name);
             }
         } else {
             name = getSystemName();

--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -102,10 +102,14 @@ public abstract class AbstractNamedBean implements NamedBean {
 
     /** {@inheritDoc} */
     @Override
-    final public String getFullyFormattedDisplayName() {
+    final public String getFullyFormattedDisplayName(boolean userNameFirst) {
         String name = getUserName();
         if (name != null && !name.isEmpty() && !name.equals(getSystemName())) {
-            name = getSystemName() + "(" + name + ")";
+            if (userNameFirst) {
+                name = name + " (" + getSystemName() + ")";
+            } else {
+                name = getSystemName() + " (" + name + ")";
+            }
         } else {
             name = getSystemName();
         }

--- a/java/src/jmri/implementation/DefaultConditional.java
+++ b/java/src/jmri/implementation/DefaultConditional.java
@@ -1283,7 +1283,7 @@ public class DefaultConditional extends AbstractNamedBean
             contentPanel.add(panel);
 
             panel = new JPanel();
-            panel.add(new JLabel(getUserName() + " (" + getSystemName() + ")"));
+            panel.add(new JLabel(getFullyFormattedDisplayName()));
             contentPanel.add(panel);
 
             panel = new JPanel();

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -1112,7 +1112,7 @@ public class LightTableAction extends AbstractTableAction<Light> {
             }
         }
         // provide feedback to user
-        String feedback = Bundle.getMessage("LightCreateFeedback") + " " + sName + " (" + uName + ")";
+        String feedback = Bundle.getMessage("LightCreateFeedback") + " " + g.getFullyFormattedDisplayName();
         // create additional lights if requested
         if (numberOfLights > 1) {
             String sxName = "";

--- a/java/src/jmri/jmrit/beantable/SectionTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SectionTableAction.java
@@ -1133,11 +1133,7 @@ public class SectionTableAction extends AbstractTableAction<Section> {
      */
     private void deleteSectionPressed(String sName) {
         final Section s = jmri.InstanceManager.getDefault(jmri.SectionManager.class).getBySystemName(sName);
-        String fullName = sName;
-        String uname = s.getUserName();
-        if (uname != null && uname.length() > 0) {
-            fullName = fullName + " (" + uname + ")";
-        }
+        String fullName = s.getFullyFormattedDisplayName();
         ArrayList<Transit> affectedTransits = jmri.InstanceManager.getDefault(jmri.TransitManager.class).getListUsingSection(s);
         final JDialog dialog = new JDialog();
         String msg = "";
@@ -1153,11 +1149,7 @@ public class SectionTableAction extends AbstractTableAction<Section> {
             dialog.add(p1);
             for (int i = 0; i < affectedTransits.size(); i++) {
                 Transit aTransit = affectedTransits.get(i);
-                String tFullName = aTransit.getSystemName();
-                uname = aTransit.getUserName();
-                if (uname != null && uname.length() > 0) {
-                    tFullName = tFullName + " (" + uname + ")";
-                }
+                String tFullName = aTransit.getFullyFormattedDisplayName();
                 p1 = new JPanel();
                 p1.setLayout(new FlowLayout());
                 iLabel = new JLabel("   " + tFullName);

--- a/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
+++ b/java/src/jmri/jmrit/beantable/beanedit/BeanEditAction.java
@@ -375,7 +375,7 @@ public abstract class BeanEditAction extends AbstractAction {
 
     public void save() {
         String feedback = Bundle.getMessage("ItemUpdateFeedback", Bundle.getMessage("BeanNameTurnout"))
-                + " " + bean.getSystemName() + " (" + bean.getUserName() + ")";
+                + " " + bean.getFullyFormattedDisplayName();
         // provide feedback to user, can be overwritten by save action error handler
         statusBar.setText(feedback);
         statusBar.setForeground(Color.gray);

--- a/java/src/jmri/jmrit/beantable/beanedit/BeanEditBundle.properties
+++ b/java/src/jmri/jmrit/beantable/beanedit/BeanEditBundle.properties
@@ -9,7 +9,7 @@ Basic = Basic
 Usage = Usage
 UsageText = Provides an indication as to where {0} is used within your Panel.
 
-NamedBeanPropertiesTableDescription = These are custom properties (delete Name to remove entry)\n- DO NOT CHANGE unless you know what you're doing!
+NamedBeanPropertiesTableDescription = These are custom properties (delete Name to remove entry)\n- DO NOT CHANGE unless you know what you are doing!
 NamedBeanPropertyName = Name
 NamedBeanPropertyValue = Value
 

--- a/java/src/jmri/jmrit/beantable/oblock/BlockPortalTableModel.java
+++ b/java/src/jmri/jmrit/beantable/oblock/BlockPortalTableModel.java
@@ -6,8 +6,9 @@ import java.util.Arrays;
 import java.util.List;
 import javax.swing.JTextField;
 import javax.swing.table.AbstractTableModel;
-import jmri.NamedBean;
 import jmri.jmrit.logix.OBlock;
+import jmri.util.NamedBeanComparator;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,9 +48,9 @@ public class BlockPortalTableModel extends AbstractTableModel implements Propert
     @Override
     public int getRowCount() {
         int count = 0;
-        List<NamedBean> list = _oBlockModel.getBeanList();
+        List<OBlock> list = _oBlockModel.getBeanList();
         for (int i = 0; i < list.size(); i++) {
-            count += ((OBlock) list.get(i)).getPortals().size();
+            count += list.get(i).getPortals().size();
         }
         return count;
     }
@@ -70,18 +71,18 @@ public class BlockPortalTableModel extends AbstractTableModel implements Propert
 
     @Override
     public Object getValueAt(int row, int col) {
-        List<NamedBean> list = _oBlockModel.getBeanList();
+        List<OBlock> list = _oBlockModel.getBeanList();
         if (list.size() > 0) {
             int count = 0;
             int idx = 0;  //accumulated row count
             OBlock block = null;
-            NamedBean[] array = new NamedBean[list.size()];
+            OBlock[] array = new OBlock[list.size()];
             array = list.toArray(array);
-            Arrays.sort(array, new jmri.util.NamedBeanComparator());
+            Arrays.sort(array, new NamedBeanComparator<>());
             while (count <= row) {
-                count += ((OBlock) array[idx++]).getPortals().size();
+                count += array[idx++].getPortals().size();
             }
-            block = (OBlock) array[--idx];
+            block = array[--idx];
             idx = row - (count - block.getPortals().size());
             if (col == BLOCK_NAME_COLUMN) {
                 if (idx == 0) {

--- a/java/src/jmri/jmrit/beantable/oblock/OBlockTableModel.java
+++ b/java/src/jmri/jmrit/beantable/oblock/OBlockTableModel.java
@@ -15,7 +15,6 @@ import javax.swing.JTextField;
 import jmri.Block;
 import jmri.InstanceManager;
 import jmri.Manager;
-import jmri.NamedBean;
 import jmri.Reporter;
 import jmri.Sensor;
 import jmri.jmrit.logix.OBlock;
@@ -123,18 +122,18 @@ public class OBlockTableModel extends jmri.jmrit.beantable.BeanTableDataModel<OB
         return OBlockTableModel.class.getName();
     }
 
-    protected List<NamedBean> getBeanList() {
-        TreeSet<NamedBean> ts = new TreeSet<>(new NamedBeanComparator());
+    protected List<OBlock> getBeanList() {
+        TreeSet<OBlock> ts = new TreeSet<>(new NamedBeanComparator<>());
 
         Iterator<String> iter = sysNameList.iterator();
         while (iter.hasNext()) {
             ts.add(getBySystemName(iter.next()));
         }
-        ArrayList<NamedBean> list = new ArrayList<>(sysNameList.size());
+        ArrayList<OBlock> list = new ArrayList<>(sysNameList.size());
 
-        Iterator<NamedBean> it = ts.iterator();
+        Iterator<OBlock> it = ts.iterator();
         while (it.hasNext()) {
-            NamedBean elt = it.next();
+            OBlock elt = it.next();
             list.add(elt);
         }
         return list;
@@ -680,7 +679,7 @@ public class OBlockTableModel extends jmri.jmrit.beantable.BeanTableDataModel<OB
         if (log.isDebugEnabled()) {
             log.debug("Delete with {} remaining listeners", count);
             //java.beans.PropertyChangeSupport pcs = new java.beans.PropertyChangeSupport(bean);
-            PropertyChangeListener[] listener = ((jmri.implementation.AbstractNamedBean) bean).getPropertyChangeListeners();
+            PropertyChangeListener[] listener = bean.getPropertyChangeListeners();
             for (int i = 0; i < listener.length; i++) {
                 log.debug("{}) {}", i, listener[i].getClass().getName());
             }

--- a/java/src/jmri/jmrit/catalog/AbstractCatalogTree.java
+++ b/java/src/jmri/jmrit/catalog/AbstractCatalogTree.java
@@ -125,9 +125,9 @@ public abstract class AbstractCatalogTree extends DefaultTreeModel implements Ca
         String name = getUserName();
         if (name != null && !name.isEmpty() && !name.equals(getSystemName())) {
             if (userNameFirst) {
-                name = name + " (" + getSystemName() + ")";
+                name = String.format(NamedBean.DISPLAY_NAME_FORMAT, name, getSystemName());
             } else {
-                name = getSystemName() + " (" + name + ")";
+                name = String.format(NamedBean.DISPLAY_NAME_FORMAT, getSystemName(), name);
             }
         } else {
             name = getSystemName();

--- a/java/src/jmri/jmrit/catalog/AbstractCatalogTree.java
+++ b/java/src/jmri/jmrit/catalog/AbstractCatalogTree.java
@@ -121,10 +121,14 @@ public abstract class AbstractCatalogTree extends DefaultTreeModel implements Ca
 
     @CheckReturnValue
     @Override
-    public String getFullyFormattedDisplayName() {
+    public String getFullyFormattedDisplayName(boolean userNameFirst) {
         String name = getUserName();
-        if (name != null && name.length() > 0) {
-            name = name + "(" + getSystemName() + ")";
+        if (name != null && !name.isEmpty() && !name.equals(getSystemName())) {
+            if (userNameFirst) {
+                name = name + " (" + getSystemName() + ")";
+            } else {
+                name = getSystemName() + " (" + name + ")";
+            }
         } else {
             name = getSystemName();
         }

--- a/java/src/jmri/jmrit/display/BlockContentsIcon.java
+++ b/java/src/jmri/jmrit/display/BlockContentsIcon.java
@@ -130,10 +130,8 @@ public class BlockContentsIcon extends MemoryIcon implements java.beans.Property
         String name;
         if (namedBlock == null) {
             name = Bundle.getMessage("NotConnected");
-        } else if (getBlock().getUserName() != null) {
-            name = getBlock().getUserName() + " (" + getBlock().getSystemName() + ")";
         } else {
-            name = getBlock().getSystemName();
+            name = getBlock().getFullyFormattedDisplayName();
         }
         return name;
     }

--- a/java/src/jmri/jmrit/display/LightIcon.java
+++ b/java/src/jmri/jmrit/display/LightIcon.java
@@ -176,10 +176,8 @@ public class LightIcon extends PositionableLabel implements java.beans.PropertyC
         String name;
         if (light == null) {
             name = Bundle.getMessage("NotConnected");
-        } else if (light.getUserName() != null) {
-            name = light.getUserName() + " (" + light.getSystemName() + ")";
         } else {
-            name = light.getSystemName();
+            name = light.getFullyFormattedDisplayName();
         }
         return name;
     }

--- a/java/src/jmri/jmrit/display/MemoryComboIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryComboIcon.java
@@ -183,10 +183,8 @@ public class MemoryComboIcon extends PositionableJPanel
         String name;
         if (namedMemory == null) {
             name = Bundle.getMessage("NotConnected");
-        } else if (getMemory().getUserName() != null) {
-            name = getMemory().getUserName() + " (" + getMemory().getSystemName() + ")";
         } else {
-            name = getMemory().getSystemName();
+            name = getMemory().getFullyFormattedDisplayName();
         }
         return name;
     }

--- a/java/src/jmri/jmrit/display/MemoryIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryIcon.java
@@ -192,10 +192,8 @@ public class MemoryIcon extends PositionableLabel implements java.beans.Property
         String name;
         if (namedMemory == null) {
             name = Bundle.getMessage("NotConnected");
-        } else if (getMemory().getUserName() != null) {
-            name = getMemory().getUserName() + " (" + getMemory().getSystemName() + ")";
         } else {
-            name = getMemory().getSystemName();
+            name = getMemory().getFullyFormattedDisplayName();
         }
         return name;
     }

--- a/java/src/jmri/jmrit/display/MemoryInputIcon.java
+++ b/java/src/jmri/jmrit/display/MemoryInputIcon.java
@@ -149,10 +149,8 @@ public class MemoryInputIcon extends PositionableJPanel implements java.beans.Pr
         String name;
         if (namedMemory == null) {
             name = Bundle.getMessage("NotConnected");
-        } else if (getMemory().getUserName() != null) {
-            name = getMemory().getUserName() + " (" + getMemory().getSystemName() + ")";
         } else {
-            name = getMemory().getSystemName();
+            name = getMemory().getFullyFormattedDisplayName();
         }
         return name;
     }

--- a/java/src/jmri/jmrit/display/MemorySpinnerIcon.java
+++ b/java/src/jmri/jmrit/display/MemorySpinnerIcon.java
@@ -142,10 +142,8 @@ public class MemorySpinnerIcon extends PositionableJPanel implements ChangeListe
         String name;
         if (namedMemory == null) {
             name = Bundle.getMessage("NotConnected");
-        } else if (getMemory().getUserName() != null) {
-            name = getMemory().getUserName() + " (" + getMemory().getSystemName() + ")";
         } else {
-            name = getMemory().getSystemName();
+            name = getMemory().getFullyFormattedDisplayName();
         }
         return name;
     }

--- a/java/src/jmri/jmrit/display/ReporterIcon.java
+++ b/java/src/jmri/jmrit/display/ReporterIcon.java
@@ -105,10 +105,8 @@ public class ReporterIcon extends PositionableLabel implements java.beans.Proper
         String name;
         if (reporter == null) {
             name = Bundle.getMessage("NotConnected");
-        } else if (reporter.getUserName() != null) {
-            name = reporter.getUserName() + " (" + reporter.getSystemName() + ")";
         } else {
-            name = reporter.getSystemName();
+            name = reporter.getFullyFormattedDisplayName();
         }
         return name;
     }

--- a/java/src/jmri/jmrit/display/SensorIcon.java
+++ b/java/src/jmri/jmrit/display/SensorIcon.java
@@ -300,10 +300,8 @@ public class SensorIcon extends PositionableIcon implements java.beans.PropertyC
         String name;
         if (namedSensor == null) {
             name = Bundle.getMessage("NotConnected");
-        } else if (getSensor().getUserName() == null) {
-            name = getSensor().getSystemName();
         } else {
-            name = getSensor().getUserName() + " (" + getSensor().getSystemName() + ")";
+            name = getSensor().getFullyFormattedDisplayName();
         }
         return name;
     }

--- a/java/src/jmri/jmrit/display/SignalMastIcon.java
+++ b/java/src/jmri/jmrit/display/SignalMastIcon.java
@@ -184,10 +184,8 @@ public class SignalMastIcon extends PositionableIcon implements java.beans.Prope
         String name;
         if (getSignalMast() == null) {
             name = Bundle.getMessage("NotConnected");
-        } else if (getSignalMast().getUserName() == null) {
-            name = getSignalMast().getSystemName();
         } else {
-            name = getSignalMast().getUserName() + " (" + getSignalMast().getSystemName() + ")";
+            name = getSignalMast().getFullyFormattedDisplayName();
         }
         return name;
     }

--- a/java/src/jmri/jmrit/display/TurnoutIcon.java
+++ b/java/src/jmri/jmrit/display/TurnoutIcon.java
@@ -221,10 +221,8 @@ public class TurnoutIcon extends PositionableIcon implements java.beans.Property
         String name;
         if (namedTurnout == null) {
             name = Bundle.getMessage("NotConnected");
-        } else if (getTurnout().getUserName() != null) {
-            name = getTurnout().getUserName() + " (" + getTurnout().getSystemName() + ")";
         } else {
-            name = getTurnout().getSystemName();
+            name = getTurnout().getFullyFormattedDisplayName();
         }
         return name;
     }

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutBlockManager.java
@@ -1881,7 +1881,7 @@ public class LayoutBlockManager extends AbstractManager<LayoutBlock> implements 
     }	//getProtectedBlockByNamedBean
 
     @CheckReturnValue
-    @Nullable
+    @Nonnull
     public List<LayoutBlock> getProtectingBlocksByNamedBean(
             @Nullable NamedBean nb,
             @Nullable LayoutEditor panel) {

--- a/java/src/jmri/jmrit/entryexit/EntryExitPairs.java
+++ b/java/src/jmri/jmrit/entryexit/EntryExitPairs.java
@@ -344,7 +344,7 @@ public class EntryExitPairs implements jmri.Manager<DestinationPoints>, jmri.Ins
      */
     @Override
     public SortedSet<DestinationPoints> getNamedBeanSet() {
-        TreeSet<DestinationPoints> beanList = new TreeSet<>(new jmri.util.NamedBeanComparator());
+        TreeSet<DestinationPoints> beanList = new TreeSet<>(new jmri.util.NamedBeanComparator<>());
         for (Source e : nxpair.values()) {
             List<String> uidList = e.getDestinationUniqueId();
             for (String uid : uidList) {
@@ -796,7 +796,10 @@ public class EntryExitPairs implements jmri.Manager<DestinationPoints>, jmri.Ins
                 for (int i = 0; i < lgx.getNumConditionals(); i++) {
                     String cdlName = lgx.getConditionalByNumberOrder(i);
                     jmri.implementation.DefaultConditional cdl = (jmri.implementation.DefaultConditional) lgx.getConditional(cdlName);
-                    String cdlUserName = (cdl.getUserName() == null) ? "" : cdl.getUserName();
+                    String cdlUserName = cdl.getUserName();
+                    if (cdlUserName == null) {
+                        cdlUserName = "";
+                    }
                     for (jmri.ConditionalVariable var : cdl.getStateVariableList()) {
                         if (var.getBean() == dPair.dp) {
                             String refName = (cdlUserName.equals("")) ? cdlName : cdlName + "  ( " + cdlUserName + " )";
@@ -1423,16 +1426,16 @@ public class EntryExitPairs implements jmri.Manager<DestinationPoints>, jmri.Ins
     }
 
     /** {@inheritDoc} */
-    public void addDataListener(ManagerDataListener e) {
+    public void addDataListener(ManagerDataListener<DestinationPoints> e) {
         if (e != null) listeners.add(e);
     }
 
     /** {@inheritDoc} */
-    public void removeDataListener(ManagerDataListener e) {
+    public void removeDataListener(ManagerDataListener<DestinationPoints> e) {
         if (e != null) listeners.remove(e);
     }
 
-    final List<ManagerDataListener> listeners = new ArrayList<>();
+    final List<ManagerDataListener<DestinationPoints>> listeners = new ArrayList<>();
     
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(EntryExitPairs.class);

--- a/java/src/jmri/jmrit/picker/PickListModel.java
+++ b/java/src/jmri/jmrit/picker/PickListModel.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
  * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
  * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
+ * @param <E> the supported type of NamedBean
  * @author Pete Cressman Copyright (C) 2009, 2010
  */
 public abstract class PickListModel<E extends NamedBean> extends BeanTableDataModel<E> implements PropertyChangeListener {
@@ -130,7 +131,7 @@ public abstract class PickListModel<E extends NamedBean> extends BeanTableDataMo
             }
         }
         List<String> systemNameList = getManager().getSystemNameList();
-        TreeSet<E> ts = new TreeSet<>(new NamedBeanComparator());
+        TreeSet<E> ts = new TreeSet<>(new NamedBeanComparator<>());
 
         Iterator<String> iter = systemNameList.iterator();
         while (iter.hasNext()) {
@@ -199,7 +200,7 @@ public abstract class PickListModel<E extends NamedBean> extends BeanTableDataMo
 
     /** {@inheritDoc} */
     @Override
-    public void clickOn(@Nonnull E t) {
+    public void clickOn(E t) {
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -95,7 +95,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
         _tuser.clear();
     }
 
-    protected TreeSet<E> _beans = new TreeSet<>(new jmri.util.NamedBeanComparator());
+    protected TreeSet<E> _beans = new TreeSet<>(new jmri.util.NamedBeanComparator<>());
     protected Hashtable<String, E> _tsys = new Hashtable<>();   // stores known E (NamedBean, i.e. Turnout) instances by system name
     protected Hashtable<String, E> _tuser = new Hashtable<>();   // stores known E (NamedBean, i.e. Turnout) instances by user name
     // Storage for getSystemNameOriginalList

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -25,13 +25,15 @@ import org.slf4j.LoggerFactory;
  * Automatically includes an Internal system, which need not be separately added
  * any more.
  * <p>
- * Encapsulates access to the "Primary" manager, used by default, which is the first one
- * provided.
+ * Encapsulates access to the "Primary" manager, used by default, which is the
+ * first one provided.
  * <p>
- * Internally, this is done by using an ordered list of all non-Internal managers, plus a
- * separate reference to the internal manager and default manager.
+ * Internally, this is done by using an ordered list of all non-Internal
+ * managers, plus a separate reference to the internal manager and default
+ * manager.
  *
- * @author	Bob Jacobsen Copyright (C) 2003, 2010, 2018
+ * @param <E> the supported type of NamedBean
+ * @author Bob Jacobsen Copyright (C) 2003, 2010, 2018
  */
 abstract public class AbstractProxyManager<E extends NamedBean> implements ProvidingManager<E>, Manager.ManagerDataListener<E> {
 
@@ -100,7 +102,10 @@ abstract public class AbstractProxyManager<E extends NamedBean> implements Provi
     }
 
     /**
-     * Returns the set default or, if not present, the internal manager as defacto default
+     * Returns the set default or, if not present, the internal manager as
+     * defacto default
+     * 
+     * @return the default manager or the internal manager if no default set
      */
     public Manager<E> getDefaultManager() {
         if (defaultManager != null) return defaultManager;
@@ -191,6 +196,7 @@ abstract public class AbstractProxyManager<E extends NamedBean> implements Provi
      *
      * @param name the user name or system name of the bean
      * @return an existing or new NamedBean
+     * @throws IllegalArgumentException if name is not usable in a bean
      */
     protected E provideNamedBean(String name) throws IllegalArgumentException {
         // make sure internal present
@@ -644,7 +650,7 @@ abstract public class AbstractProxyManager<E extends NamedBean> implements Provi
     @Nonnull
     public SortedSet<E> getNamedBeanSet() {
         if (namedBeanSet == null) {
-            namedBeanSet = new TreeSet<>(new NamedBeanComparator());
+            namedBeanSet = new TreeSet<>(new NamedBeanComparator<>());
             recomputeNamedBeanSet();
         }
         return Collections.unmodifiableSortedSet(namedBeanSet);
@@ -668,7 +674,7 @@ abstract public class AbstractProxyManager<E extends NamedBean> implements Provi
      * managers.
      */
     @Override
-    public void contentsChanged(Manager.ManagerDataEvent e) {
+    public void contentsChanged(Manager.ManagerDataEvent<E> e) {
     }
 
     /**

--- a/java/src/jmri/util/NamedBeanComparator.java
+++ b/java/src/jmri/util/NamedBeanComparator.java
@@ -7,24 +7,27 @@ import jmri.NamedBean;
  * <p>
  * Uses the built-in Comparable interface of the named beans.
  * <p>
- * A System Name is a system prefix followed by type letter then a suffix with a system-specific format. 
- * This class first compares on prefix, then if the prefixes are equal it 
- * compares the type letter, then if they're still equal it
- * does an {@link AlphanumComparator} compare on suffix.
+ * A System Name is a system prefix followed by type letter then a suffix with a
+ * system-specific format. This class first compares on prefix, then if the
+ * prefixes are equal it compares the type letter, then if they're still equal
+ * it does an {@link AlphanumComparator} compare on suffix.
  * <p>
- * This sorts on the information in the NamedBean itself, including using 
- * the actual type by deferring prefix comparison into the specific NamedBean subclass.
- * This is different from the (deprecated) SystemNameComparator, which only does a common
- * lexical sort.  
- * See the <a href="http://jmri.org/help/en/html/doc/Technical/Names.shtml">Names documentation page</a>.
+ * This sorts on the information in the NamedBean itself, including using the
+ * actual type by deferring prefix comparison into the specific NamedBean
+ * subclass. This is different from the (deprecated) SystemNameComparator, which
+ * only does a common lexical sort. See the
+ * <a href="http://jmri.org/help/en/html/doc/Technical/Names.shtml">Names
+ * documentation page</a>.
+ * 
+ * @param <B> supported type of NamedBean
  */
-public class NamedBeanComparator implements java.util.Comparator<NamedBean> {
+public class NamedBeanComparator <B extends NamedBean> implements java.util.Comparator<B> {
 
     public NamedBeanComparator() {
     }
 
     @Override
-    public int compare(NamedBean n1, NamedBean n2) {
+    public int compare(B n1, B n2) {
         return n1.compareTo(n2);
     }
 }

--- a/java/src/jmri/util/swing/JmriBeanComboBox.java
+++ b/java/src/jmri/util/swing/JmriBeanComboBox.java
@@ -179,7 +179,7 @@ public class JmriBeanComboBox extends JComboBox<String> implements java.beans.Pr
 
                         case USERNAMESYSTEMNAME:
                             if (uname != null && !uname.equals("")) {
-                                displayList[i] = nBean.getUserName() + " - " + name;
+                                displayList[i] = nBean.getFullyFormattedDisplayName();
                             } else {
                                 displayList[i] = name;
                             }
@@ -187,7 +187,7 @@ public class JmriBeanComboBox extends JComboBox<String> implements java.beans.Pr
 
                         case SYSTEMNAMEUSERNAME:
                             if (uname != null && !uname.equals("")) {
-                                displayList[i] = name + " - " + nBean.getUserName();
+                                displayList[i] = nBean.getFullyFormattedDisplayName(false);
                             } else {
                                 displayList[i] = name;
                             }
@@ -398,7 +398,7 @@ public class JmriBeanComboBox extends JComboBox<String> implements java.beans.Pr
 
                 case USERNAMESYSTEMNAME:
                     if (uname != null && !uname.equals("")) {
-                        selectedItem = uname + " - " + inNamedBean.getSystemName();
+                        selectedItem = inNamedBean.getFullyFormattedDisplayName();
                     } else {
                         selectedItem = inNamedBean.getSystemName();
                     }
@@ -406,7 +406,7 @@ public class JmriBeanComboBox extends JComboBox<String> implements java.beans.Pr
 
                 case SYSTEMNAMEUSERNAME:
                     if (uname != null && !uname.equals("")) {
-                        selectedItem = inNamedBean.getSystemName() + " - " + uname;
+                        selectedItem = inNamedBean.getFullyFormattedDisplayName(false);
                     } else {
                         selectedItem = inNamedBean.getSystemName();
                     }
@@ -528,13 +528,13 @@ public class JmriBeanComboBox extends JComboBox<String> implements java.beans.Pr
                     Set<NamedBean> namedBeanSet = uDaManager.getNamedBeanSet();
 
                     for (NamedBean namedBean : namedBeanSet) {
-                        //checking to see if it matches "<sname> - <uname>" or "<uname> - <sname>"
+                        //checking to see if it matches "<sname> (<uname>)" or "<uname> (<sname>)"
                         String uname = namedBean.getUserName();
                         String sname = namedBean.getSystemName();
 
                         if ((null != uname)) {
-                            String usname = uname + " - " + sname;
-                            String suname = sname + " - " + uname;
+                            String usname = namedBean.getFullyFormattedDisplayName();
+                            String suname = namedBean.getFullyFormattedDisplayName(false);
 
                             if (comboBoxText.equals(usname) || comboBoxText.equals(suname)) {
                                 result = namedBean;

--- a/java/src/jmri/util/swing/JmriBeanComboBox.java
+++ b/java/src/jmri/util/swing/JmriBeanComboBox.java
@@ -529,10 +529,7 @@ public class JmriBeanComboBox extends JComboBox<String> implements java.beans.Pr
 
                     for (NamedBean namedBean : namedBeanSet) {
                         //checking to see if it matches "<sname> (<uname>)" or "<uname> (<sname>)"
-                        String uname = namedBean.getUserName();
-                        String sname = namedBean.getSystemName();
-
-                        if ((null != uname)) {
+                        if ((namedBean.getUserName() != null)) {
                             String usname = namedBean.getFullyFormattedDisplayName();
                             String suname = namedBean.getFullyFormattedDisplayName(false);
 

--- a/java/test/jmri/ManagerTest.java
+++ b/java/test/jmri/ManagerTest.java
@@ -305,12 +305,14 @@ public class ManagerTest {
         
     /**
      * Service routine
+     * 
+     * @param iter set of entries
      * @return true when all entries are in correct order, false otherwise
      */
     boolean checkOrderNamedBeans(Iterator<NamedBean> iter) {
         NamedBean first = iter.next();
         NamedBean next;
-        jmri.util.NamedBeanComparator comp = new jmri.util.NamedBeanComparator();
+        jmri.util.NamedBeanComparator<NamedBean> comp = new jmri.util.NamedBeanComparator<>();
         while (iter.hasNext()) {
             next = iter.next();
             if (comp.compare(first, next) >= 0) return false;
@@ -321,6 +323,8 @@ public class ManagerTest {
     
     /**
      * Service routine
+     * 
+     * @param iter set of entries
      * @return true when all entries are in correct order, false otherwise
      */
     boolean checkOrderStrings(Iterator<String> iter) {

--- a/java/test/jmri/jmrix/cmri/serial/SerialLightTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialLightTest.java
@@ -1,12 +1,16 @@
 package jmri.jmrix.cmri.serial;
 
-import jmri.util.JUnitUtil;
-import jmri.*;
+import java.util.Iterator;
+import java.util.TreeSet;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import jmri.Light;
+import jmri.util.JUnitUtil;
+import jmri.util.NamedBeanComparator;
 
 /**
  *
@@ -31,7 +35,7 @@ public class SerialLightTest {
 
     @Test
     public void testSystemSpecificComparisonOfStandardNames() {
-        jmri.util.NamedBeanComparator t = new jmri.util.NamedBeanComparator();
+        NamedBeanComparator<Light> t = new NamedBeanComparator<>();
         
         Light t1 = new SerialLight("CL1", "to1", memo);
         Light t2 = new SerialLight("CL2", "to2", memo);
@@ -49,7 +53,7 @@ public class SerialLightTest {
     @Test
     public void testSystemSpecificComparisonOfSpecificFormats() {
         // test by putting into a tree set, then extracting and checking order
-        java.util.TreeSet<Light> set = new java.util.TreeSet<>(new jmri.util.NamedBeanComparator());
+        TreeSet<Light> set = new TreeSet<>(new NamedBeanComparator<>());
         
         set.add(new SerialLight("CL3B4",    "to3004", memo));
         set.add(new SerialLight("CL3003",    "to3003", memo));
@@ -69,7 +73,7 @@ public class SerialLightTest {
         set.add(new SerialLight("CL1",    "to1", memo));
         
         
-        java.util.Iterator<Light> it = set.iterator();
+        Iterator<Light> it = set.iterator();
         
         Assert.assertEquals("CL1", it.next().getSystemName());
         Assert.assertEquals("CL2", it.next().getSystemName());

--- a/java/test/jmri/jmrix/cmri/serial/SerialSensorTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialSensorTest.java
@@ -1,11 +1,16 @@
 package jmri.jmrix.cmri.serial;
 
-import jmri.util.JUnitUtil;
-import jmri.*;
+import java.util.Iterator;
+import java.util.TreeSet;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import jmri.Sensor;
+import jmri.util.JUnitUtil;
+import jmri.util.NamedBeanComparator;
 
 /**
  *
@@ -36,7 +41,7 @@ public class SerialSensorTest extends jmri.implementation.AbstractSensorTestBase
 
     @Test
     public void testSystemSpecificComparisonOfStandardNames() {
-        jmri.util.NamedBeanComparator c = new jmri.util.NamedBeanComparator();
+        NamedBeanComparator<Sensor> c = new NamedBeanComparator<>();
         
         Sensor t1 = new SerialSensor("CS1");
         Sensor t2 = new SerialSensor("CS2");
@@ -54,7 +59,7 @@ public class SerialSensorTest extends jmri.implementation.AbstractSensorTestBase
     @Test
     public void testSystemSpecificComparisonOfSpecificFormats() {
         // test by putting into a tree set, then extracting and checking order
-        java.util.TreeSet<Sensor> set = new java.util.TreeSet<>(new jmri.util.NamedBeanComparator());
+        TreeSet<Sensor> set = new TreeSet<>(new NamedBeanComparator<>());
         
         set.add(new SerialSensor("CS3B4"));
         set.add(new SerialSensor("CS3003"));
@@ -74,7 +79,7 @@ public class SerialSensorTest extends jmri.implementation.AbstractSensorTestBase
         set.add(new SerialSensor("CS1"));
         
         
-        java.util.Iterator<Sensor> it = set.iterator();
+        Iterator<Sensor> it = set.iterator();
         
         Assert.assertEquals("CS1", it.next().getSystemName());
         Assert.assertEquals("CS2", it.next().getSystemName());

--- a/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
+++ b/java/test/jmri/jmrix/cmri/serial/SerialTurnoutTest.java
@@ -1,9 +1,17 @@
 package jmri.jmrix.cmri.serial;
 
-import jmri.implementation.AbstractTurnoutTestBase;
-import jmri.*;
+import java.util.Iterator;
+import java.util.TreeSet;
 
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import jmri.Turnout;
+import jmri.implementation.AbstractTurnoutTestBase;
+import jmri.util.JUnitUtil;
+import jmri.util.NamedBeanComparator;
 
 /**
  * Tests for the jmri.jmrix.cmri.serial.SerialTurnout class
@@ -24,8 +32,8 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
     @Override
     @Before
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
-        jmri.util.JUnitUtil.resetInstanceManager();
+        JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
         
         // prepare an interface
         tcis = new SerialTrafficControlScaffold();
@@ -41,7 +49,7 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
 
     @After
     public void tearDown() {
-        jmri.util.JUnitUtil.tearDown();
+        JUnitUtil.tearDown();
         if (tcis != null) tcis.terminateThreads();
         tcis = null;
         memo = null;
@@ -71,7 +79,7 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
 
     @Test
     public void testSystemSpecificComparisonOfStandardNames() {
-        jmri.util.NamedBeanComparator t = new jmri.util.NamedBeanComparator();
+        NamedBeanComparator<Turnout> t = new NamedBeanComparator<>();
         
         Turnout t1 = new SerialTurnout("CT1", "to1", memo);
         Turnout t2 = new SerialTurnout("CT2", "to2", memo);
@@ -89,7 +97,7 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
     @Test
     public void testSystemSpecificComparisonOfSpecificFormats() {
         // test by putting into a tree set, then extracting and checking order
-        java.util.TreeSet<Turnout> set = new java.util.TreeSet<>(new jmri.util.NamedBeanComparator());
+        TreeSet<Turnout> set = new TreeSet<>(new NamedBeanComparator<>());
         
         set.add(new SerialTurnout("CT3B4",    "to3004", memo));
         set.add(new SerialTurnout("CT3003",    "to3003", memo));
@@ -109,7 +117,7 @@ public class SerialTurnoutTest extends AbstractTurnoutTestBase {
         set.add(new SerialTurnout("CT1",    "to1", memo));
         
         
-        java.util.Iterator<Turnout> it = set.iterator();
+        Iterator<Turnout> it = set.iterator();
         
         Assert.assertEquals("CT1", it.next().getSystemName());
         Assert.assertEquals("CT2", it.next().getSystemName());

--- a/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbSensorTest.java
@@ -1,24 +1,26 @@
 package jmri.jmrix.openlcb;
 
+import java.util.Iterator;
+import java.util.TreeSet;
 import java.util.regex.Pattern;
-
-import jmri.JmriException;
-import jmri.Sensor;
-import jmri.Turnout;
-import jmri.jmrix.can.CanMessage;
-import jmri.util.JUnitUtil;
-import jmri.util.PropertyChangeListenerScaffold;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
 import org.openlcb.EventID;
 import org.openlcb.implementations.EventTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jmri.JmriException;
+import jmri.Sensor;
+import jmri.jmrix.can.CanMessage;
+import jmri.util.JUnitUtil;
+import jmri.util.NamedBeanComparator;
+import jmri.util.PropertyChangeListenerScaffold;
+import jmri.util.junit.rules.RetryRule;
 
 /**
  * Tests for the jmri.jmrix.openlcb.OlcbSensor class.
@@ -28,7 +30,7 @@ import org.slf4j.LoggerFactory;
 public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
 
     @Rule
-    public jmri.util.junit.rules.RetryRule retryRule = new jmri.util.junit.rules.RetryRule(3);  // allow 3 retries of tests
+    public RetryRule retryRule = new RetryRule(3);  // allow 3 retries of tests
 
     private final static Logger log = LoggerFactory.getLogger(OlcbSensorTest.class);
     protected PropertyChangeListenerScaffold l; 
@@ -341,14 +343,14 @@ public class OlcbSensorTest extends jmri.implementation.AbstractSensorTestBase {
     public void testSystemSpecificComparisonOfSpecificFormats() {
 
         // test by putting into a tree set, then extracting and checking order
-        java.util.TreeSet<Sensor> set = new java.util.TreeSet<>(new jmri.util.NamedBeanComparator());
+        TreeSet<Sensor> set = new TreeSet<>(new NamedBeanComparator<>());
         
         set.add(new OlcbSensor("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", ti.iface));
         set.add(new OlcbSensor("M", "X0501010114FF2000;X0501010114FF2011", ti.iface));
         set.add(new OlcbSensor("M", "X0501010114FF2000;X0501010114FF2001", ti.iface));
         set.add(new OlcbSensor("M", "1.2.3.4.5.6.7.9;1.2.3.4.5.6.7.9", ti.iface));
         
-        java.util.Iterator<Sensor> it = set.iterator();
+        Iterator<Sensor> it = set.iterator();
         
         Assert.assertEquals("MS1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", it.next().getSystemName());
         Assert.assertEquals("MS1.2.3.4.5.6.7.9;1.2.3.4.5.6.7.9", it.next().getSystemName());

--- a/java/test/jmri/jmrix/openlcb/OlcbTurnoutTest.java
+++ b/java/test/jmri/jmrix/openlcb/OlcbTurnoutTest.java
@@ -1,20 +1,23 @@
 package jmri.jmrix.openlcb;
 
-import jmri.util.JUnitUtil;
+import java.util.Iterator;
+import java.util.TreeSet;
 import java.util.regex.Pattern;
-import jmri.Turnout;
-import jmri.jmrix.can.CanMessage;
-import jmri.util.PropertyChangeListenerScaffold;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.openlcb.EventID;
 import org.openlcb.implementations.EventTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jmri.Turnout;
+import jmri.jmrix.can.CanMessage;
+import jmri.util.JUnitUtil;
+import jmri.util.NamedBeanComparator;
+import jmri.util.PropertyChangeListenerScaffold;
 /**
  * Tests for the jmri.jmrix.openlcb.OlcbTurnout class.
  *
@@ -323,14 +326,14 @@ public class OlcbTurnoutTest {
     public void testSystemSpecificComparisonOfSpecificFormats() {
 
         // test by putting into a tree set, then extracting and checking order
-        java.util.TreeSet<Turnout> set = new java.util.TreeSet<>(new jmri.util.NamedBeanComparator());
+        TreeSet<Turnout> set = new TreeSet<>(new NamedBeanComparator<>());
         
         set.add(new OlcbTurnout("M", "1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", t.iface));
         set.add(new OlcbTurnout("M", "X0501010114FF2000;X0501010114FF2011", t.iface));
         set.add(new OlcbTurnout("M", "X0501010114FF2000;X0501010114FF2001", t.iface));
         set.add(new OlcbTurnout("M", "1.2.3.4.5.6.7.9;1.2.3.4.5.6.7.9", t.iface));
         
-        java.util.Iterator<Turnout> it = set.iterator();
+        Iterator<Turnout> it = set.iterator();
         
         Assert.assertEquals("MT1.2.3.4.5.6.7.8;1.2.3.4.5.6.7.9", it.next().getSystemName());
         Assert.assertEquals("MT1.2.3.4.5.6.7.9;1.2.3.4.5.6.7.9", it.next().getSystemName());

--- a/java/test/jmri/util/NamedBeanComparatorTest.java
+++ b/java/test/jmri/util/NamedBeanComparatorTest.java
@@ -15,7 +15,7 @@ public class NamedBeanComparatorTest {
 
     @Test
     public void testOneLetterCases() {
-        NamedBeanComparator t = new NamedBeanComparator();
+        NamedBeanComparator<Turnout> t = new NamedBeanComparator<>();
 
         Turnout it1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");
         Turnout it10 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT10");
@@ -32,7 +32,7 @@ public class NamedBeanComparatorTest {
 
     @Test
     public void testTwoLetterCases() {
-        NamedBeanComparator t = new NamedBeanComparator();
+        NamedBeanComparator<Turnout> t = new NamedBeanComparator<>();
 
         Turnout i2t1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I2T1");
         Turnout i2t10 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I2T10");
@@ -49,7 +49,7 @@ public class NamedBeanComparatorTest {
 
     @Test
     public void testThreeLetterCases() {
-        NamedBeanComparator t = new NamedBeanComparator();
+        NamedBeanComparator<Turnout> t = new NamedBeanComparator<>();
 
         Turnout i23t1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T1");
         Turnout i23t10 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("I23T10");
@@ -68,7 +68,7 @@ public class NamedBeanComparatorTest {
     
     @Test
     public void testSystemSpecificCase() {
-        NamedBeanComparator t = new NamedBeanComparator();
+        NamedBeanComparator<Turnout> t = new NamedBeanComparator<>();
 
         // this just checks that the local sort is called
         Turnout it1 = InstanceManager.getDefault(TurnoutManager.class).provideTurnout("IT1");


### PR DESCRIPTION
Three fixes:
- Use generics with NamedBeanComparator - the avoids some casting.
- Implementations of `NamedBean.getFullyFormattedDisplayName()` now match Javadocs for that method.
- JmriBeanComboBox now uses `NamedBean.getFullyFormattedDisplayName()` instead of its own formats for listing NamedBeans.