### PR TITLE
MatrixMast comment

### DIFF
--- a/java/src/jmri/implementation/MatrixSignalMast.java
+++ b/java/src/jmri/implementation/MatrixSignalMast.java
@@ -74,11 +74,11 @@ public class MatrixSignalMast extends AbstractSignalMast {
         mast = mast.substring(0, mast.indexOf("("));
         setMastType(mast);
         
-        String tmp = parts[2].substring(parts[2].indexOf("($") + 2, parts[2].indexOf(")"));
+        String tmp = parts[2].substring(parts[2].indexOf("($") + 2, parts[2].indexOf(")")); // retrieve ordinal from name
         try {
             int autoNumber = Integer.parseInt(tmp);
-            if (autoNumber > lastRef) {
-                lastRef = autoNumber;
+            if (autoNumber > getLastRef()) {
+                setLastRef(autoNumber);
             }
         } catch (NumberFormatException e) {
             log.warn("Auto generated SystemName \"{}\" is not in the correct format", systemName);
@@ -488,7 +488,7 @@ public class MatrixSignalMast extends AbstractSignalMast {
 
     @Override
     public void vetoableChange(java.beans.PropertyChangeEvent evt) throws java.beans.PropertyVetoException {
-        if ("CanDelete".equals(evt.getPropertyName())) { //NOI18N
+        if ("CanDelete".equals(evt.getPropertyName())) { // NOI18N
             if (evt.getOldValue() instanceof Turnout) {
                 if (isTurnoutUsed((Turnout) evt.getOldValue())) {
                     java.beans.PropertyChangeEvent e = new java.beans.PropertyChangeEvent(this, "DoNotDelete", null, null);

--- a/java/src/jmri/implementation/MatrixSignalMast.java
+++ b/java/src/jmri/implementation/MatrixSignalMast.java
@@ -466,11 +466,25 @@ public class MatrixSignalMast extends AbstractSignalMast {
         return false;
     }
 
+    /**
+     * @return highest ordinal of all MatrixSignalMasts in use
+     */
     public static int getLastRef() {
         return lastRef;
     }
 
-    static int lastRef = 0;
+    /**
+     *
+     * @param newVal for ordinal of all MatrixSignalMasts in use
+     */
+    public static void setLastRef(int newVal) {
+        lastRef = newVal;
+    }
+
+    /**
+     * Ordinal of all MatrixSignalMasts to create unique system name.
+     */
+    private static int lastRef = 0;
 
     @Override
     public void vetoableChange(java.beans.PropertyChangeEvent evt) throws java.beans.PropertyVetoException {

--- a/java/src/jmri/jmrit/beantable/SignalMastTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalMastTableAction.java
@@ -35,7 +35,7 @@ public class SignalMastTableAction extends AbstractTableAction<SignalMast> {
 
     /**
      * Create the JTable DataModel, along with the changes for the specific case
-     * of Signal Masts
+     * of Signal Masts.
      */
     @Override
     protected void createModel() {
@@ -81,7 +81,7 @@ public class SignalMastTableAction extends AbstractTableAction<SignalMast> {
         JMenuBar menuBar = f.getJMenuBar();
         int pos = menuBar.getMenuCount() -1; // count the number of menus to insert the TableMenu before 'Window' and 'Help'
         int offset = 1;
-        log.debug("setMenuBar number of menu items = " + pos);
+        log.debug("setMenuBar number of menu items = {}", pos);
         for (int i = 0; i <= pos; i++) {
             if (menuBar.getComponent(i) instanceof JMenu) {
                 if (((JMenu) menuBar.getComponent(i)).getText().equals(Bundle.getMessage("MenuHelp"))) {

--- a/java/src/jmri/jmrit/beantable/signalmast/MatrixSignalMastAddPane.java
+++ b/java/src/jmri/jmrit/beantable/signalmast/MatrixSignalMastAddPane.java
@@ -23,7 +23,7 @@ import org.openide.util.lookup.ServiceProvider;
  *
  * @see jmri.jmrit.beantable.signalmast.SignalMastAddPane
  * @author Bob Jacobsen Copyright (C) 2018
- * @author Egbert Broerse Copyright (C) 2016
+ * @author Egbert Broerse Copyright (C) 2016, 2019
  * @since 4.11.2
  */
 public class MatrixSignalMastAddPane extends SignalMastAddPane {
@@ -54,7 +54,7 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
     
     String sigsysname;
     DefaultSignalAppearanceMap map;
-    MatrixSignalMast currentMast;
+    MatrixSignalMast currentMast; // mast being edited, null for new mast
     JCheckBox resetPreviousState = new JCheckBox(Bundle.getMessage("ResetPrevious"));
     jmri.UserPreferencesManager prefs = jmri.InstanceManager.getDefault(jmri.UserPreferencesManager.class);
     String matrixBitNumSelectionCombo = this.getClass().getName() + ".matrixBitNumSelected";
@@ -73,7 +73,8 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
     JComboBox<String> columnChoice = new JComboBox<>(choiceArray());
     JSpinner timeDelay = new JSpinner();
 
-    LinkedHashMap<String, MatrixAspectPanel> matrixAspect = new LinkedHashMap<>(NOTIONAL_ASPECT_COUNT); // LinkedHT type keeps things sorted // only used once, see updateMatrixAspectPanel()
+    LinkedHashMap<String, MatrixAspectPanel> matrixAspect = new LinkedHashMap<>(NOTIONAL_ASPECT_COUNT);
+    // LinkedHM type keeps things sorted // only used once, see updateMatrixAspectPanel()
 
     DecimalFormat paddedNumber = new DecimalFormat("0000");
 
@@ -142,7 +143,7 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
     public void setMast(SignalMast mast) { 
         log.debug("setMast({})", mast);
         if (mast == null) { 
-            currentMast = null; 
+            currentMast = null;
             return; 
         }
         
@@ -219,7 +220,7 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
         // repeat in order to set MAXMATRIXBITS > 6
         
         allowUnLit.setSelected(currentMast.allowUnLit());
-        // set up additional route specific Delay
+        // set up additional mast specific Delay
         timeDelay.setValue(currentMast.getMatrixMastCommandDelay());
 
         log.trace("setMast {} end", mast);
@@ -229,16 +230,17 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
     @Override
     public boolean createMast(@Nonnull String sigsysname, @Nonnull String mastname, @Nonnull String username) {
         log.debug("createMast({},{})", sigsysname, mastname);
+        String newMastName; // UserName for mast
 
-        // check all boxes are filled
-        if (       (              ( turnoutBox1.getDisplayName() == null || turnoutBox1.getDisplayName().isEmpty() ) )
-                || (bitNum > 1 && ( turnoutBox2.getDisplayName() == null || turnoutBox2.getDisplayName().isEmpty() ) )
-                || (bitNum > 2 && ( turnoutBox3.getDisplayName() == null || turnoutBox3.getDisplayName().isEmpty() ) )
-                || (bitNum > 3 && ( turnoutBox4.getDisplayName() == null || turnoutBox4.getDisplayName().isEmpty() ) )
-                || (bitNum > 4 && ( turnoutBox5.getDisplayName() == null || turnoutBox5.getDisplayName().isEmpty() ) )
-                || (bitNum > 5 && ( turnoutBox6.getDisplayName() == null || turnoutBox6.getDisplayName().isEmpty() ) )
+        // check all output boxes are filled (calling getDisplayName() would immediately create a new bean (with an empty comment)
+        if (       (              ( turnoutBox1.isEmpty() ) )
+                || (bitNum > 1 && ( turnoutBox2.isEmpty() ) )
+                || (bitNum > 2 && ( turnoutBox3.isEmpty() ) )
+                || (bitNum > 3 && ( turnoutBox4.isEmpty() ) )
+                || (bitNum > 4 && ( turnoutBox5.isEmpty() ) )
+                || (bitNum > 5 && ( turnoutBox6.isEmpty() ) )
         ) {
-            // add extra OR in order to set MAXMATRIXBITS > 6
+            // add an extra OR in list above in order to set MAXMATRIXBITS > 6
             // error dialog
             JOptionPane.showMessageDialog(null, Bundle.getMessage("MatrixOutputEmpty", mastname),
                     Bundle.getMessage("WarningTitle"),
@@ -247,7 +249,7 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
             return false;
         }
 
-        // check if bit sets are identical
+        // check/warn if bit sets are identical
         if (identicalBits()) {
             // error dialog
             JOptionPane.showMessageDialog(null, Bundle.getMessage("AspectMastBitsWarning", (int) Math.sqrt(numberOfActiveAspects), numberOfActiveAspects),
@@ -258,44 +260,49 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
         }
 
         if (currentMast == null) {
-            // Create was pressed for new mast:
-            // create new MatrixMast with props from panel
-            String name = "IF$xsm:"
+            // Create was pressed for new mast: create new MatrixMast with props from panel
+            newMastName = "IF$xsm:"
                     + sigsysname
                     + ":" + mastname.substring(11, mastname.length() - 4);
-            name += "($" + (paddedNumber.format(MatrixSignalMast.getLastRef() + 1));
-            name += ")" + "-" + bitNum + "t"; // for the number of t = "turnout-outputs", TODO: add d = option for direct packets
-            currentMast = new MatrixSignalMast(name); // timedDelay is stored later on
+            newMastName += "($" + (paddedNumber.format(MatrixSignalMast.getLastRef() + 1));
+            newMastName += ")" + "-" + bitNum + "t"; // for the number of t = "turnout-outputs"
+            // TODO: add d = option for direct packets
+            currentMast = new MatrixSignalMast(newMastName); // timedDelay is stored later on
             InstanceManager.getDefault(jmri.SignalMastManager.class).register(currentMast);
+        } else {
+            newMastName = currentMast.getSystemName();
         }
-        
-        String name = currentMast.getSystemName();
-        
+
         currentMast.setBitNum(bitNum); // store number of columns in aspect - outputs matrix in mast
 
-        //store outputs from turnoutBoxes; see method MatrixSignalMast#setOutput() line 356
-        currentMast.setOutput("output1", turnoutBox1.getDisplayName()); // store choice from turnoutBox1
-        setMatrixReference(turnoutBox1, name + ":output1"); // write mast name to output1 bean comment
-        if (bitNum > 1) {
-            currentMast.setOutput("output2", turnoutBox2.getDisplayName()); // store choice from turnoutBox2
-            setMatrixReference(turnoutBox2, name + ":output2"); // write mast name to output2 bean comment
-            if (bitNum > 2) {
-                currentMast.setOutput("output3", turnoutBox3.getDisplayName()); // store choice from turnoutBox3
-                setMatrixReference(turnoutBox3, name + ":output3"); // write mast name to output3 bean comment
-                if (bitNum > 3) {
-                    currentMast.setOutput("output4", turnoutBox4.getDisplayName()); // store choice from turnoutBox4
-                    setMatrixReference(turnoutBox4, name + ":output4"); // write mast name to output4 bean comment
-                    if (bitNum > 4) {
-                        currentMast.setOutput("output5", turnoutBox5.getDisplayName()); // store choice from turnoutBox5
-                        setMatrixReference(turnoutBox5, name + ":output5"); // write mast name to output5 bean comment
-                        if (bitNum > 5) {
-                            currentMast.setOutput("output6", turnoutBox6.getDisplayName()); // store choice from turnoutBox6
-                            setMatrixReference(turnoutBox6, name + ":output6"); // write mast name to output6 bean comment
-                            // repeat in order to set MAXMATRIXBITS > 6
+        // store outputs from turnoutBoxes; see method MatrixSignalMast#setOutput(colname, turnoutname) line 357
+        log.debug("newMastName = {}", newMastName);
+        currentMast.setOutput("output1", turnoutBox1.getDisplayName()); // store choice from turnoutBox1, creates bean if needed
+        try {
+            turnoutBox1.updateComment(turnoutBox1.getNamedBean(), newMastName + ":output1"); // write mast name to output1 bean comment
+            if (bitNum > 1) {
+                currentMast.setOutput("output2", turnoutBox2.getDisplayName()); // store choice from turnoutBox2
+                turnoutBox2.updateComment(turnoutBox2.getNamedBean(), newMastName + ":output2");
+                if (bitNum > 2) {
+                    currentMast.setOutput("output3", turnoutBox3.getDisplayName()); // store choice from turnoutBox3
+                    turnoutBox3.updateComment(turnoutBox3.getNamedBean(), newMastName + ":output3");
+                    if (bitNum > 3) {
+                        currentMast.setOutput("output4", turnoutBox4.getDisplayName()); // store choice from turnoutBox4
+                        turnoutBox4.updateComment(turnoutBox4.getNamedBean(), newMastName + ":output4");
+                        if (bitNum > 4) {
+                            currentMast.setOutput("output5", turnoutBox5.getDisplayName()); // store choice from turnoutBox5
+                            turnoutBox5.updateComment(turnoutBox5.getNamedBean(), newMastName + ":output5");
+                            if (bitNum > 5) {
+                                currentMast.setOutput("output6", turnoutBox6.getDisplayName()); // store choice from turnoutBox6
+                                turnoutBox6.updateComment(turnoutBox6.getNamedBean(), newMastName + ":output6");
+                                // repeat in order to set MAXMATRIXBITS > 6
+                            }
                         }
                     }
                 }
             }
+        } catch (JmriException e) {
+            log.warn("bean not found");
         }
 
         for (String aspect : matrixAspect.keySet()) {
@@ -330,7 +337,7 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
         // set MatrixMast specific Delay information, see jmri.implementation.MatrixSignalMast
         int addDelay = (Integer) timeDelay.getValue(); // from a JSpinner with 0 set as minimum
         currentMast.setMatrixMastCommandDelay(addDelay);
-
+        log.debug("mast create completed successfully");
         return true;
     }
 
@@ -383,7 +390,7 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
     void updateMatrixMastPanel() {
         matrixAspect = new LinkedHashMap<>(NOTIONAL_ASPECT_COUNT);
 
-        // nothing to if no map yet
+        // nothing to do if no map yet present
         if (map == null) return;
         
         Enumeration<String> aspects = map.getAspects();
@@ -492,17 +499,15 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
         delayPanel.add(timeDelay);
         timeDelay.setToolTipText(Bundle.getMessage("TooltipTurnoutDelay"));
         delayPanel.add(new JLabel(Bundle.getMessage("LabelMilliseconds")));
-        // set up additional route specific Delay?
-        // timeDelay.setValue(currentMast.getRouteCommandDelay());
         matrixMastPanel.add(delayPanel);
 
         matrixMastPanel.setLayout(new jmri.util.javaworld.GridLayout2(0, 1)); // 0 means enough
         matrixMastPanel.revalidate();
     }
     
-     /**
+    /**
      * When the user changes the number of columns in matrix from the drop down:
-     * store the new value.
+     * store the new value and redraw pane.
      *
      * @param newColNum int with the new value = the number of columns in the
      *                  Matrix Table
@@ -524,18 +529,6 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
     }
    
     
-    /**
-     * Write matrix mast name + output no. to output bean comment.
-     *
-     * @param bp           the bean panel containing the Turnout (output)
-     * @param functionName Description of turnout function on mast
-     */
-    void setMatrixReference(BeanSelectCreatePanel bp, String functionName) {
-        //System.out.println("box: " + bp.getDisplayName()); // debug
-        //System.out.println("name: " + functionName); // debug
-        bp.setReference(functionName);
-    }
-
     void copyFromAnotherMatrixMastAspect(String strMast) {
         MatrixSignalMast mast = (MatrixSignalMast) InstanceManager.getDefault(jmri.SignalMastManager.class).getNamedBean(strMast);
         if (mast == null) {
@@ -569,7 +562,7 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
      * Call for sub panel per aspect from hashmap matrixAspect with check boxes
      * to set properties.
      * <p>
-     * Invoked when updating MatrixMastPanel
+     * Invoked when updating MatrixMastPanel.
      *
      * @see #updateMatrixMastPanel()
      */
@@ -739,8 +732,8 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
     /**
      * JPanel to define properties of an Aspect for a Matrix Signal Mast.
      * <p>
-     * Invoked from the AddSignalMastPanel class when a Matrix Signal Mast is
-     * selected.
+     * Invoked from the AddSignalMastPanel class when Output Matrix Signal Mast is
+     * selected as mast type.
      *
      * @author Egbert Broerse
      */
@@ -761,8 +754,8 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
         char[] aspectBits = emptyBits;
 
         /**
-         * Build new aspect matrix panel called when Add Signal Mast Pane is
-         * built
+         * Build new aspect matrix panel.
+         * Called when Add Signal Mast Pane is built.
          *
          * @param aspect String like "Clear"
          */
@@ -771,9 +764,9 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
         }
 
         /**
-         * Rebuild an aspect matrix panel using char[] previously entered called
-         * from line 1870 when number of columns is changed (new mast creeation
-         * only)
+         * Rebuild an aspect matrix panel using char[] previously entered. Called
+         * from updateMatrixAspectPanel() (line 581) when number of outputs = columns
+         * is changed (possible during new mast creation only).
          *
          * @param aspect    String like "Clear"
          * @param panelBits char[] of up to 5 1's and 0's
@@ -936,7 +929,7 @@ public class MatrixSignalMastAddPane extends SignalMastAddPane {
                 matrixDetails.add(bitCheck5);
                 matrixDetails.add(bitCheck6);
                 // repeat in order to set MAXMATRIXBITS > 6
-                // ToDo refresh aspectSetting, can be in OKPressed() to store/warn for duplicates (with button 'Ignore')
+                // TODO refresh aspectSetting, can be in OKPressed() to store/warn for duplicates (with button 'Ignore')
                 // hide if id > bitNum (var in panel)
                 bitCheck2.setVisible(bitNum > 1);
                 bitCheck3.setVisible(bitNum > 2);

--- a/java/src/jmri/jmrit/beantable/signalmast/SignalMastAddPane.java
+++ b/java/src/jmri/jmrit/beantable/signalmast/SignalMastAddPane.java
@@ -13,13 +13,14 @@ import jmri.*;
 import jmri.spi.JmriServiceProviderInterface;
 
 /**
- * Definition of JPanel used to configure a specific SignalMast type
+ * Definition of JPanel used to configure a specific SignalMast type.
  *
  * Implementing classes <em>must</em> be registered as service providers of this
  * type to be recognized and usable.
  * <p>
  * General design documentation is available on the 
- * <a href="http://jmri.org/help/en/html/doc/Technical/SystemStructure.shtml">Structure of External System Connections page</a>.
+ * <a href="http://jmri.org/help/en/html/doc/Technical/SystemStructure.shtml">Structure of
+ * External System Connections page</a>.
  *
  * The general sequence is:
  * <ul>
@@ -39,13 +40,14 @@ public abstract class SignalMastAddPane extends JPanel implements JmriServicePro
     /**
      * Provide a new list of aspects in the signal system.
      * Must be done at startup before the pane is shown.
-     * May be done later, to update to a new system.
+     * May be done later, to update to a newly selected system.
      */
     abstract public void setAspectNames(@Nonnull SignalAppearanceMap map, 
                                @Nonnull SignalSystem sigSystem);
 
     /**
      * Can this pane edit a specific mast object, i.e. an object of its type?
+     *
      * @param mast the SignalMast to possibly display
      * @return true if this pane can handle that mast type; false if can't
      */
@@ -53,17 +55,18 @@ public abstract class SignalMastAddPane extends JPanel implements JmriServicePro
 
     /**
      * Load this pane with information from a mast.
-     * Do not invoke this is {@link #canHandleMast(SignalMast)} on that mast returns false.
+     * Do not invoke this if {@link #canHandleMast(SignalMast)} on that mast returns false.
      *
      * @param mast the SignalMast to display or null to reset a previous setting
      */
     abstract public void setMast(SignalMast mast);
     
     /**
-     * Called to either "create and register" or update an existing mast from the given information.
+     * Called to either "create and register" a new, or "update" an existing mast from the given information.
+     *
      * @param sigsysname the name of the signal system in use
-     * @param mastname the mast type name
-     * @param username user name value
+     * @param mastname   the mast type name
+     * @param username   user name value
      * @return false if the operation failed, in which case the user should have already been notified
      */
     abstract public boolean createMast(@Nonnull
@@ -72,7 +75,7 @@ public abstract class SignalMastAddPane extends JPanel implements JmriServicePro
                             String username);
     
     /**
-     * @return Human-prefered name for type of signal mast, in local language
+     * @return human-preferred name for type of signal mast, in local language
      */
     @Nonnull abstract public String getPaneName();
     

--- a/java/src/jmri/util/swing/BeanSelectCreatePanel.java
+++ b/java/src/jmri/util/swing/BeanSelectCreatePanel.java
@@ -4,6 +4,7 @@ import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
 import javax.swing.JComboBox;
@@ -40,7 +41,7 @@ public class BeanSelectCreatePanel<E extends NamedBean> extends JPanel {
     String systemSelectionCombo = this.getClass().getName() + ".SystemSelected";
 
     /**
-     * Create a JPanel, that provides the option to the user to either select an
+     * Create a JPanel that provides the option to the user to either select an
      * already created bean, or to create one on the fly. This only currently
      * works with Turnouts, Sensors, Memories and Blocks.
      *
@@ -147,7 +148,7 @@ public class BeanSelectCreatePanel<E extends NamedBean> extends JPanel {
 
     /**
      * Get the display name of the bean that has either been selected in the
-     * drop down list or has been created.
+     * drop down list or was asked to be created.
      *
      * @return the name of the bean
      */
@@ -166,7 +167,7 @@ public class BeanSelectCreatePanel<E extends NamedBean> extends JPanel {
 
     /**
      * Get the named bean that has either been selected in the drop down list or
-     * has been created.
+     * was asked to be created.
      *
      * @return the selected bean or a new bean
      * @throws JmriException if a bean needs to be created but can't be
@@ -234,18 +235,13 @@ public class BeanSelectCreatePanel<E extends NamedBean> extends JPanel {
         if (nBean == null) {
             throw new JmriException("Unable to create bean");
         }
-        // Update comment if there's content, and there's not already a comment
-        String comment = nBean.getComment();
-        if ((_reference != null && !_reference.isEmpty()) && (comment == null || comment.isEmpty())) {
-            nBean.setComment(_reference);
-        }
+        updateComment(nBean, _reference);
         setDefaultNamedBean(nBean);
         return nBean;
     }
 
     /**
-     * Set a reference that can be set against the comment for a bean, only if
-     * the bean has no previous comment.
+     * Set a reference that can be set against the comment for a bean.
      *
      * @param ref the default comment for a bean without a comment
      */
@@ -254,8 +250,8 @@ public class BeanSelectCreatePanel<E extends NamedBean> extends JPanel {
     }
 
     /**
-     * Sets the default selected item in the combo box, when this is set the
-     * combo box becomes active and the add hardware box details are then
+     * Set the default selected item in the combo box. After it has been set,
+     * the combo box becomes active and the Add Hardware box details are then
      * hidden.
      *
      * @param nBean the bean that is selected by default
@@ -267,10 +263,45 @@ public class BeanSelectCreatePanel<E extends NamedBean> extends JPanel {
         update();
     }
 
+    /**
+     * Check that the user selected something in this BeanSelectCreatePanel.
+     *
+     * @return true if not empty
+     */
+    public boolean isEmpty() {
+        if (existingItem.isSelected() && existingCombo.getSelectedBean() != null) { // use existing
+            log.debug("existingCombo.getSelectedBean() = {}", existingCombo.getSelectedBean().getDisplayName());
+            return false;
+        } else if (newItem.isSelected() && // create new
+                !hardwareAddress.getText().isEmpty() && hardwareAddress.getText() != null) {
+            log.debug("newBeanEntry = {}", hardwareAddress.getText());
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Update comment on bean if there's content AND there's not already a comment.
+     *
+     * @param nBean   the bean to edit
+     * @param content comment to add
+     */
+    public void updateComment(@Nonnull NamedBean nBean, String content) {
+        String comment = nBean.getComment();
+        log.debug((comment == null || comment.isEmpty()) ? "comment was empty" : "comment already filled");
+        if((content != null && !content.isEmpty()) && (comment ==null || comment.isEmpty())) {
+            log.debug("new comment added to bean {}", nBean.getDisplayName());
+            nBean.setComment(content);
+        } else {
+            log.debug("empty _reference received");
+        }
+    }
+
     public void dispose() {
         existingCombo.dispose();
     }
 
     //initialize logging
-    // private final static Logger log = LoggerFactory.getLogger(BeanSelectCreatePanel.class.getName());
+    private final static Logger log = LoggerFactory.getLogger(BeanSelectCreatePanel.class.getName());
+
 }


### PR DESCRIPTION
Store correct mast name in output comment.
Improve entry check without creating beans.
Fix set-get static var.