### PR TITLE
Prevent NPE for EB and EC context menu

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/PositionablePoint.java
@@ -892,7 +892,7 @@ public class PositionablePoint extends LayoutTrack {
             popup.add(connectionsMenu);
         }
 
-        if ((type == EDGE_CONNECTOR) || (type == END_BUMPER)) {
+        if (connect1 != null && (type == EDGE_CONNECTOR || type == END_BUMPER)) {
             //
             // decorations menu
             //


### PR DESCRIPTION
When an edge connector or end bumper does not have an attached track segment, creating a context menu fails with a NPE.  This prevents deleting the EC or EB using the Delete option in the context menu.

The EB or EC can be deleted by adding a track segment and then the context menu works.