### PR TITLE
fix: web manifest had null from some car attributes

### DIFF
--- a/java/src/jmri/jmrit/operations/rollingstock/Xml.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/Xml.java
@@ -16,7 +16,7 @@ public class Xml {
     static final String DIR = "dir"; // NOI18N
     static final String COMMENT = "comment"; // NOI18N
     static final String TRACK = "track"; // NOI18N
-    static final String TYPE = "type"; // NOI18N
+    public static final String TYPE = "type"; // NOI18N
     static final String LENGTH = "length"; // NOI18N
 
     static final String TRUE = "true"; // NOI18N

--- a/java/src/jmri/web/servlet/operations/HtmlManifest.java
+++ b/java/src/jmri/web/servlet/operations/HtmlManifest.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map.Entry;
 import jmri.InstanceManager;
+import jmri.jmrit.operations.rollingstock.Xml;
 import jmri.jmrit.operations.routes.RouteLocation;
 import jmri.jmrit.operations.setup.Setup;
 import jmri.jmrit.operations.trains.JsonManifest;
@@ -307,6 +308,8 @@ public class HtmlManifest extends HtmlTrainCommon {
                     builder.append(
                             this.getFormattedAttribute(attribute, this.getDropLocation(car.path(JsonOperations.LOCATION),
                                             ShowLocation.both))).append(" "); // NOI18N
+                } else if (attribute.equals(Xml.TYPE)) {
+                    builder.append(this.getTextAttribute(JsonOperations.CAR_TYPE, car)).append(" "); // NOI18N
                 } else {
                     builder.append(this.getTextAttribute(attribute, car)).append(" "); // NOI18N
                 }

--- a/java/src/jmri/web/servlet/operations/HtmlManifest.java
+++ b/java/src/jmri/web/servlet/operations/HtmlManifest.java
@@ -435,7 +435,7 @@ public class HtmlManifest extends HtmlTrainCommon {
             return this.getFormattedAttribute(JSON.FINAL_DESTINATION, this.getFormattedLocation(rollingStock
                     .path(JSON.FINAL_DESTINATION), ShowLocation.track, "FinalDestination")); // NOI18N
         }
-        return this.getFormattedAttribute(attribute, rollingStock.path(attribute).textValue());
+        return this.getFormattedAttribute(attribute, rollingStock.path(attribute).asText());
     }
 
     protected String getFormattedAttribute(String attribute, String value) {


### PR DESCRIPTION
This is the same as #7074, but against master for inclusion in 4.17.1 (unless there is some other process for ensuring #7074 also gets into master).