### PR TITLE
Correct Hornby Elite programming sequence

### DIFF
--- a/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetProgrammer.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetProgrammer.java
@@ -27,7 +27,6 @@ import jmri.jmrix.lenz.XNetTrafficController;
  */
 public class EliteXNetProgrammer extends XNetProgrammer implements XNetListener {
 
-    static private final int RETURNSENT = 3;
     // Message timeout lengths.  These have been determined by
     // experimentation, and may need to be adjusted
     static private final int ELITEMESSAGETIMEOUT = 10000;
@@ -142,16 +141,6 @@ public class EliteXNetProgrammer extends XNetProgrammer implements XNetListener 
             throw e;
         }
 
-        // On the Elite, we're not getting a broadcast message
-        // saying we're in service mode, so go ahead and request
-        // the results.
-        progState = INQUIRESENT;
-        //start the error timer
-        restartTimer(EliteXNetProgrammerTimeout);
-        XNetMessage resultMsg = XNetMessage.getServiceModeResultsMsg();
-        resultMsg.setNeededMode(jmri.jmrix.AbstractMRTrafficController.NORMALMODE);
-        resultMsg.setTimeout(ELITEMESSAGETIMEOUT);
-        controller().sendXNetMessage(resultMsg, this);
     }
 
     /** 
@@ -208,16 +197,6 @@ public class EliteXNetProgrammer extends XNetProgrammer implements XNetListener 
                     notifyProgListenerEnd(_val, jmri.ProgListener.OK);
                     return;
                 }
-
-                // here ready to request the results
-                progState = INQUIRESENT;
-                //start the error timer
-                restartTimer(EliteXNetProgrammerTimeout);
-                XNetMessage resultMsg = XNetMessage.getServiceModeResultsMsg();
-
-                resultMsg.setNeededMode(jmri.jmrix.AbstractMRTrafficController.NORMALMODE);
-                resultMsg.setTimeout(ELITEMESSAGETIMEOUT);
-                controller().sendXNetMessage(resultMsg, this);
                 return;
             } else if (m.getElement(0) == XNetConstants.CS_INFO
                     && m.getElement(1) == XNetConstants.CS_NOT_SUPPORTED) {
@@ -227,11 +206,15 @@ public class EliteXNetProgrammer extends XNetProgrammer implements XNetListener 
                 return;
             } else if (m.getElement(0) == XNetConstants.CS_INFO
                     && m.getElement(1) == XNetConstants.BC_NORMAL_OPERATIONS) {
-                // We Exited Programming Mode early
-                log.error("Service mode exited before sequence complete.");
-                progState = NOTPROGRAMMING;
-                stopTimer();
-                notifyProgListenerEnd(_val, jmri.ProgListener.SequenceError);
+                    // On the Elite, the broadcast exit service mode message
+                    // needs to triger the request for results.
+                    progState = INQUIRESENT;
+                    //start the error timer
+                    restartTimer(EliteXNetProgrammerTimeout);
+                    XNetMessage resultMsg = XNetMessage.getServiceModeResultsMsg();
+                    resultMsg.setNeededMode(jmri.jmrix.AbstractMRTrafficController.NORMALMODE);
+                    resultMsg.setTimeout(ELITEMESSAGETIMEOUT);
+                    controller().sendXNetMessage(resultMsg, this);
             } else if (m.getElement(0) == XNetConstants.CS_INFO
                     && m.getElement(1) == XNetConstants.PROG_SHORT_CIRCUIT) {
                 // We experienced a short Circuit on the Programming Track
@@ -326,16 +309,6 @@ public class EliteXNetProgrammer extends XNetProgrammer implements XNetListener 
                 notifyProgListenerEnd(_val, jmri.ProgListener.CommError);
             } else {
                 // nothing important, ignore
-                return;
-            }
-
-        } else if (progState == RETURNSENT) {
-            log.debug("reply in RETURNSENT state");
-            if (m.getElement(0) == XNetConstants.CS_INFO
-                    && m.getElement(1) == XNetConstants.BC_NORMAL_OPERATIONS) {
-                progState = NOTPROGRAMMING;
-                stopTimer();
-                //notifyProgListenerEnd(_val, jmri.ProgListener.UnknownError);
                 return;
             }
         } else {

--- a/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetProgrammer.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetProgrammer.java
@@ -76,16 +76,6 @@ public class EliteXNetProgrammer extends XNetProgrammer implements XNetListener 
             throw e;
         }
 
-        // On the Elite, we're not getting a broadcast message
-        // saying we're in service mode, so go ahead and request
-        // the results.
-        progState = INQUIRESENT;
-        //start the error timer
-        restartTimer(EliteXNetProgrammerTimeout);
-        XNetMessage resultMsg = XNetMessage.getServiceModeResultsMsg();
-        resultMsg.setNeededMode(jmri.jmrix.AbstractMRTrafficController.NORMALMODE);
-        resultMsg.setTimeout(ELITEMESSAGETIMEOUT);
-        controller().sendXNetMessage(resultMsg, this);
     }
 
     /** 

--- a/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetProgrammerTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetProgrammerTest.java
@@ -78,20 +78,56 @@ public class EliteXNetProgrammerTest extends jmri.jmrix.lenz.XNetProgrammerTest 
     @Test
     public void testReadCvSequence() throws JmriException {
         // and do the read
-        p.readCV("10", l);
+        p.readCV("8", l);
         // check "prog mode" message sent
-        Assert.assertEquals("mode message sent", 2, t.outbound.size());
-        Assert.assertEquals("read message contents", "22 15 0A 3D", t.outbound.elementAt(0).toString());
+        Assert.assertEquals("mode message sent", 1, t.outbound.size());
+        Assert.assertEquals("read message contents", "22 15 08 3F", t.outbound.elementAt(0).toString());
 
-        // send reply
+        // The Elite send broadcast service mode entry twice
         XNetReply mr1 = new XNetReply();
         mr1.setElement(0, 0x61);
         mr1.setElement(1, 0x02);
         mr1.setElement(2, 0x63);
         t.sendTestMessage(mr1);
 
+        t.sendTestMessage(mr1);
+
+        // we should not send any additional messages here.
+        Assert.assertEquals("no new message", 1, t.outbound.size());
+
+        // and then send Normal Operations Resumed twice
+        XNetReply mr2 = new XNetReply();
+        mr2.setElement(0, 0x61);
+        mr2.setElement(1, 0x01);
+        mr2.setElement(2, 0x60);
+        t.sendTestMessage(mr2);
+
+        t.sendTestMessage(mr2);
+
+        // and now we should send the request for results.
+
         Assert.assertEquals("enquire message sent", 2, t.outbound.size());
         Assert.assertEquals("enquire message contents", "21 10 31", t.outbound.elementAt(1).toString());
+
+        // and then send the result to the programmer
+        XNetReply mr3 = new XNetReply();
+        mr3.setElement(0, 0x63);
+        mr3.setElement(1, 0x14);
+        mr3.setElement(2, 0x08);
+        mr3.setElement(3, 0x30);
+        mr3.setElement(4, 0x4F);
+        t.sendTestMessage(mr3);
+       
+        // At this point, the standard XpressNet programmer
+        // should send a result to the programmer listeners, and
+        // wait for either the next read/write request or for the
+        // traffic controller to exit from service mode.  We just
+        // need to wait a few seconds and see that the listener we
+        // registered earlier received the values we expected.
+
+        // failure in this test occurs with the next line.
+        JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;}, "Receive Called by Programmer");
+        Assert.assertEquals("Register mode received value", 48, l.getRcvdValue());
 
     }
 
@@ -103,17 +139,55 @@ public class EliteXNetProgrammerTest extends jmri.jmrix.lenz.XNetProgrammerTest 
         // and do the read
         p.readCV("29", l);
         // check "prog mode" message sent
-        Assert.assertEquals("mode message sent", 2, t.outbound.size());
+        Assert.assertEquals("mode message sent", 1, t.outbound.size());
         Assert.assertEquals("read message contents", "22 11 05 36", t.outbound.elementAt(0).toString());
-        // send reply
+
+        // The Elite send broadcast service mode entry twice
         XNetReply mr1 = new XNetReply();
         mr1.setElement(0, 0x61);
         mr1.setElement(1, 0x02);
         mr1.setElement(2, 0x63);
         t.sendTestMessage(mr1);
 
+        t.sendTestMessage(mr1);
+
+        // we should not send any additional messages here.
+        Assert.assertEquals("no new message", 1, t.outbound.size());
+
+        // and then send Normal Operations Resumed twice
+        XNetReply mr2 = new XNetReply();
+        mr2.setElement(0, 0x61);
+        mr2.setElement(1, 0x01);
+        mr2.setElement(2, 0x60);
+        t.sendTestMessage(mr2);
+
+        t.sendTestMessage(mr2);
+
+        // and now we should send the request for results.
+
         Assert.assertEquals("enquire message sent", 2, t.outbound.size());
         Assert.assertEquals("enquire message contents", "21 10 31", t.outbound.elementAt(1).toString());
+
+        // and then send the result to the programmer
+        XNetReply mr3 = new XNetReply();
+        mr3.setElement(0, 0x63);
+        mr3.setElement(1, 0x14);
+        mr3.setElement(2, 0x1D);
+        mr3.setElement(3, 0x22);
+        mr3.setElement(4, 0x48);
+        t.sendTestMessage(mr3);
+       
+        // At this point, the standard Elite XnetProgrammer
+        // should send a result to the programmer listeners, and
+        // wait for either the next read/write request or for the
+        // traffic controller to exit from service mode.  We just
+        // need to wait a few seconds and see that the listener we
+        // registered earlier received the values we expected.
+
+        // failure in this test occurs with the next line.
+        JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;}, "Receive Called by Programmer");
+        Assert.assertEquals("Register mode received value", 34, l.getRcvdValue());
+
     }
 
     // The minimal setup is for log4J

--- a/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetProgrammerTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetProgrammerTest.java
@@ -36,19 +36,52 @@ public class EliteXNetProgrammerTest extends jmri.jmrix.lenz.XNetProgrammerTest 
     @Override
     public void testWriteCvSequence() throws JmriException {
         // and do the write
-        p.writeCV("10", 20, l);
+        p.writeCV("08", 48, l);
         // check "prog mode" message sent
-        Assert.assertEquals("mode message sent", 2, t.outbound.size());
-        Assert.assertEquals("write message contents", "23 16 0A 14 2B", t.outbound.elementAt(0).toString());
-        // send reply
+        Assert.assertEquals("mode message sent", 1, t.outbound.size());
+        Assert.assertEquals("write message contents", "23 16 08 30 0D", t.outbound.elementAt(0).toString());
+
+        // The Elite send broadcast service mode entry twice
         XNetReply mr1 = new XNetReply();
         mr1.setElement(0, 0x61);
         mr1.setElement(1, 0x02);
         mr1.setElement(2, 0x63);
         t.sendTestMessage(mr1);
+        t.sendTestMessage(mr1);
+
+        // we should not send any additional messages here.
+        Assert.assertEquals("no new message", 1, t.outbound.size());
+
+        // and then send Normal Operations Resumed twice
+        XNetReply mr2 = new XNetReply();
+        mr2.setElement(0, 0x61);
+        mr2.setElement(1, 0x01);
+        mr2.setElement(2, 0x60);
+        t.sendTestMessage(mr2);
+
+        t.sendTestMessage(mr2);
 
         Assert.assertEquals("enquire message sent", 2, t.outbound.size());
         Assert.assertEquals("enquire message contents", "21 10 31", t.outbound.elementAt(1).toString());
+
+        // and then send the result to the programmer
+        XNetReply mr3 = new XNetReply();
+        mr3.setElement(0, 0x63);
+        mr3.setElement(1, 0x14);
+        mr3.setElement(2, 0x08);
+        mr3.setElement(3, 0x30);
+        mr3.setElement(4, 0x4F);
+        t.sendTestMessage(mr3);
+       
+        // At this point, the standard XpressNet programmer
+        // should send a result to the programmer listeners, and
+        // wait for either the next read/write request or for the
+        // traffic controller to exit from service mode.  We just
+        // need to wait a few seconds and see that the listener we
+        // registered earlier received the values we expected.
+
+        // failure in this test occurs with the next line.
+        JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;}, "Receive Called by Programmer");
 
     }
 
@@ -58,20 +91,53 @@ public class EliteXNetProgrammerTest extends jmri.jmrix.lenz.XNetProgrammerTest 
         p.setMode(ProgrammingMode.REGISTERMODE);
 
         // and do the write
-        p.writeCV("29", 12, l);
+        p.writeCV("29", 34, l);
         // check "prog mode" message sent
-        Assert.assertEquals("read message sent", 2, t.outbound.size());
-        Assert.assertEquals("write message contents", "23 12 05 0C 38", t.outbound.elementAt(0).toString());
+        Assert.assertEquals("read message sent", 1, t.outbound.size());
+        Assert.assertEquals("write message contents", "23 12 05 22 16", t.outbound.elementAt(0).toString());
 
-        // send reply
+        // The Elite send broadcast service mode entry twice
         XNetReply mr1 = new XNetReply();
         mr1.setElement(0, 0x61);
         mr1.setElement(1, 0x02);
         mr1.setElement(2, 0x63);
         t.sendTestMessage(mr1);
+        t.sendTestMessage(mr1);
+
+        // we should not send any additional messages here.
+        Assert.assertEquals("no new message", 1, t.outbound.size());
+
+        // and then send Normal Operations Resumed twice
+        XNetReply mr2 = new XNetReply();
+        mr2.setElement(0, 0x61);
+        mr2.setElement(1, 0x01);
+        mr2.setElement(2, 0x60);
+        t.sendTestMessage(mr2);
+
+        t.sendTestMessage(mr2);
 
         Assert.assertEquals("enquire message sent", 2, t.outbound.size());
         Assert.assertEquals("enquire message contents", "21 10 31", t.outbound.elementAt(1).toString());
+
+        // and then send the result to the programmer
+        XNetReply mr3 = new XNetReply();
+        mr3.setElement(0, 0x63);
+        mr3.setElement(1, 0x14);
+        mr3.setElement(2, 0x1D);
+        mr3.setElement(3, 0x22);
+        mr3.setElement(4, 0x48);
+        t.sendTestMessage(mr3);
+       
+        // At this point, the standard XpressNet programmer
+        // should send a result to the programmer listeners, and
+        // wait for either the next read/write request or for the
+        // traffic controller to exit from service mode.  We just
+        // need to wait a few seconds and see that the listener we
+        // registered earlier received the values we expected.
+
+        // failure in this test occurs with the next line.
+        JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;}, "Receive Called by Programmer");
+        Assert.assertEquals("Register mode received value", 34, l.getRcvdValue());
 
     }
 
@@ -127,7 +193,7 @@ public class EliteXNetProgrammerTest extends jmri.jmrix.lenz.XNetProgrammerTest 
 
         // failure in this test occurs with the next line.
         JUnitUtil.waitFor(()->{return l.getRcvdInvoked() != 0;}, "Receive Called by Programmer");
-        Assert.assertEquals("Register mode received value", 48, l.getRcvdValue());
+        Assert.assertEquals("Direct mode received value", 48, l.getRcvdValue());
 
     }
 


### PR DESCRIPTION
This changes when the feedback request is made for read operations, based on feedback from Elite users with the current Elite software version.

There are two open questions:

1. Did the old sequence ever work (i.e. did a change in software on the Elite change the required process)
2. Does the current (original) write process work as expected?

Waiting on Feedback for the second question before continuing.  The first question may only be answered if a user has an issue.