### PR TITLE
MERG CBUS Revert Defs Update

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeConstants.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeConstants.java
@@ -337,7 +337,6 @@ public class CbusNodeConstants {
         result.put(58, "CANPiNODE"); // NOI18N
         result.put(59, "CANDISP"); // NOI18N
         result.put(60, "CANCOMPUTE"); // NOI18N
-        result.put(61, "CANCMDDC"); // NOI18N
         
         result.put(253, "CANUSB"); // NOI18N
         result.put(254, "EMPTY"); // NOI18N
@@ -468,7 +467,6 @@ public class CbusNodeConstants {
         result.put(58, "CBUS module based on Raspberry Pi");
         result.put(59, "25K80 version of CANLED64");
         result.put(60, "Event processing engine");
-        result.put(61, "8-Channel DC command station");
         
         result.put(253, "USB interface");
         result.put(254, "Empty module, bootloader only");
@@ -594,7 +592,6 @@ public class CbusNodeConstants {
         // result.put(58, "CANPiNODE"); // NOI18N
         result.put(59, "https://www.merg.org.uk/merg_wiki/doku.php?id=cbus:candisp"); // NOI18N
         result.put(60, "https://www.merg.org.uk/merg_wiki/doku.php?id=cbus:cancompute"); // NOI18N
-        result.put(61, "https://www.merg.org.uk/forum/viewtopic.php?f=45&t=6376"); // NOI18N
         
         // result.put(253, "CANUSB"); // NOI18N
         // result.put(254, "EMPTY"); // NOI18N


### PR DESCRIPTION
Please include in 4.15.8 , minor fix to prevent incorrect Node Identification

Node type 61 for manufacturer 165 has changed, removing until further info known.