### PR TITLE
Depreciate CbusProgrammer

### DIFF
--- a/java/src/jmri/jmrix/can/cbus/CbusProgrammer.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusProgrammer.java
@@ -15,7 +15,9 @@ import jmri.jmrix.can.TrafficController;
  * Implements the jmri.Programmer interface via commands for CBUS.
  *
  * @author Bob Jacobsen Copyright (C) 2008
+ * @deprecated since 4.17.1; use {@link jmri.jmrix.can.cbus.node.CbusNode} instead
  */
+@Deprecated
 public class CbusProgrammer extends AbstractProgrammer implements CanListener, AddressedProgrammer {
 
     public CbusProgrammer(int nodenumber, TrafficController tc) {

--- a/java/src/jmri/jmrix/can/cbus/CbusProgrammerManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusProgrammerManager.java
@@ -9,7 +9,9 @@ import jmri.managers.DefaultProgrammerManager;
  *
  * @see jmri.managers.DefaultProgrammerManager
  * @author Bob Jacobsen Copyright (C) 2008
+ * @deprecated since 4.17.1; use {@link jmri.jmrix.can.cbus.node.CbusNode} instead
  */
+@Deprecated
 public class CbusProgrammerManager extends DefaultProgrammerManager {
 
     public CbusProgrammerManager(TrafficController tc) {


### PR DESCRIPTION
For after next production release.

Deprecates unused classes for CBUS Node programming, nothing to do with CV's.
Same capabilities available in jmrix.can.cbus.node.CbusNode