### PR TITLE
prevent ArrayIndexOutOfBoundsException when toggling signalmast

### DIFF
--- a/java/src/jmri/implementation/SignalHeadSignalMast.java
+++ b/java/src/jmri/implementation/SignalHeadSignalMast.java
@@ -199,15 +199,18 @@ public class SignalHeadSignalMast extends AbstractSignalMast implements java.bea
 
             if (!error) {
                 SignalHead head = heads.get(i).getBean();
-                int toSet = map.getAspectSettings(aspect)[i];
-                if (delay == 0) {
-                    head.setAppearance(toSet);
-                    if (log.isDebugEnabled()) {
-                        log.debug("Setting " + head.getSystemName() + " to "
-                                + head.getAppearanceName(toSet));
+                int[] dsam = map.getAspectSettings(aspect);
+                if (i < dsam.length) {
+                    int toSet = dsam[i];
+                    if (delay == 0) {
+                        head.setAppearance(toSet);
+                        log.debug("Setting {} to {}", head.getSystemName(), 
+                                head.getAppearanceName(toSet));
+                    } else {
+                        delayedSet.put(head, toSet);
                     }
                 } else {
-                    delayedSet.put(head, toSet);
+                    log.error("     head '{}' appearance not set for aspect '{}'", head.getSystemName(), aspect);                    
                 }
             } else {
                 log.error("     head appearance not set due to above error");

--- a/xml/signals/basic/appearance-two-low.xml
+++ b/xml/signals/basic/appearance-two-low.xml
@@ -73,6 +73,7 @@
     <appearance>
       <aspectname>Unlit</aspectname>
       <show>dark</show>
+      <show>dark</show>
       <imagelink>../../../resources/icons/smallschematics/searchlights/two-low-dark.gif</imagelink>
     </appearance>
   </appearances>


### PR DESCRIPTION
Error occurred using basic signals, following this existing warning:
WARN  - setAppearance to "Unlit" finds 2 heads but only 1 settings