### PR TITLE
enable test of JmriHeadless in Cucumber Application Start tests.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1351,7 +1351,7 @@
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
-            <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags 'not @headed'"/>
+            <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags 'not @Headed'"/>
             <sysproperty key="jinput.plugins" path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
 
             <sysproperty key="java.awt.headless" value="true"/>
@@ -1377,6 +1377,7 @@
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
             <sysproperty key="jinput.plugins" path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
+            <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags 'not @Headed'"/>
 
             <sysproperty key="java.awt.headless" value="true"/>
 
@@ -1402,7 +1403,7 @@
             <sysproperty key="log4j.ignoreTCL" path="true/"/>
             <sysproperty key="java.library.path" path=".:${libdir}:${arch.lib.path}"/>
             <sysproperty key="jmri.prefsdir" path="${tempdir}"/>
-            <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags 'not @headed'"/>
+            <sysproperty key="cucumber.options" value="--tags 'not @Ignore' --tags 'not @Headed'"/>
             <sysproperty key="jinput.plugins" path="net.bobis.jinput.hidraw.HidRawEnvironmentPlugin"/>
 
             <sysproperty key="java.awt.headless" value="true"/>

--- a/build.xml
+++ b/build.xml
@@ -1642,6 +1642,9 @@
             <test name="jmri.RunCucumberTest">
                 <formatter usefile="no" type="brief"/>
             </test>
+            <test name="apps.RunCucumberTest">
+                <formatter usefile="no" type="brief"/>
+            </test>
         </junit>
         <fail>
             <condition>

--- a/java/acceptancetest/features/apps/HeadlessApplicationStart.feature
+++ b/java/acceptancetest/features/apps/HeadlessApplicationStart.feature
@@ -6,7 +6,7 @@ Scenario Outline: Application Start
    When starting application <application> with <name> 
    Then <infoline> is printed to the console
 
-   @JmriFacelessTest @Ignore
+   @JmriFacelessTest 
    Examples: Headless Tests
    | application | profile | name | infoline |
    | apps.JmriFaceless | java/test/apps/PanelPro/profiles/LocoNet_Simulator | JmriFaceless | JmriFaceless version |

--- a/java/acceptancetest/features/apps/HeadlessApplicationStart.feature
+++ b/java/acceptancetest/features/apps/HeadlessApplicationStart.feature
@@ -6,10 +6,14 @@ Scenario Outline: Application Start
    When starting application <application> with <name> 
    Then <infoline> is printed to the console
 
+   @FailingTests @Ignore
+   Examples: Tests that are failing
+   | application | profile | name | infoline |
+   | apps.JmriFaceless | java/test/apps/PanelPro/profiles/TMCC_Simulator | JmriFaceless | JmriFaceless version |
+
    @JmriFacelessTest 
    Examples: Headless Tests
    | application | profile | name | infoline |
    | apps.JmriFaceless | java/test/apps/PanelPro/profiles/LocoNet_Simulator | JmriFaceless | JmriFaceless version |
    | apps.JmriFaceless | java/test/apps/PanelPro/profiles/EasyDcc_Simulator | JmriFaceless | JmriFaceless version |
-   | apps.JmriFaceless | java/test/apps/PanelPro/profiles/TMCC_Simulator | JmriFaceless | JmriFaceless version |
    | apps.JmriFaceless | java/test/apps/PanelPro/profiles/Grapevine_Simulator | JmriFaceless | JmriFaceless version |

--- a/java/acceptancetest/features/apps/HeadlessApplicationStart.feature
+++ b/java/acceptancetest/features/apps/HeadlessApplicationStart.feature
@@ -10,10 +10,10 @@ Scenario Outline: Application Start
    Examples: Tests that are failing
    | application | profile | name | infoline |
    | apps.JmriFaceless | java/test/apps/PanelPro/profiles/TMCC_Simulator | JmriFaceless | JmriFaceless version |
+   | apps.JmriFaceless | java/test/apps/PanelPro/profiles/Grapevine_Simulator | JmriFaceless | JmriFaceless version |
 
    @JmriFacelessTest 
    Examples: Headless Tests
    | application | profile | name | infoline |
    | apps.JmriFaceless | java/test/apps/PanelPro/profiles/LocoNet_Simulator | JmriFaceless | JmriFaceless version |
    | apps.JmriFaceless | java/test/apps/PanelPro/profiles/EasyDcc_Simulator | JmriFaceless | JmriFaceless version |
-   | apps.JmriFaceless | java/test/apps/PanelPro/profiles/Grapevine_Simulator | JmriFaceless | JmriFaceless version |

--- a/java/acceptancetest/step_definitions/apps/ApplicationTestAcceptanceSteps.java
+++ b/java/acceptancetest/step_definitions/apps/ApplicationTestAcceptanceSteps.java
@@ -31,6 +31,7 @@ public class ApplicationTestAcceptanceSteps implements En {
       JUnitUtil.setUp();
       JUnitUtil.clearShutDownManager();
       JUnitUtil.resetApplication();
+      JUnitUtil.resetAppsBase();
    });
 
    Given("^I am using profile (.*)$", (String profile) -> {
@@ -82,6 +83,7 @@ public class ApplicationTestAcceptanceSteps implements En {
         System.clearProperty("jmri.prefsdir");
         System.clearProperty("org.jmri.profile");
         JUnitUtil.clearShutDownManager();
+        JUnitUtil.resetAppsBase();
         JUnitUtil.tearDown();
     });
 

--- a/java/acceptancetest/step_definitions/apps/ApplicationTestAcceptanceSteps.java
+++ b/java/acceptancetest/step_definitions/apps/ApplicationTestAcceptanceSteps.java
@@ -23,6 +23,7 @@ public class ApplicationTestAcceptanceSteps implements En {
      
    String[] tags = {"@apptest"};
    File tempFolder;
+   String initProperty;
    
    public ApplicationTestAcceptanceSteps(jmri.InstanceManager instance) {
 
@@ -40,6 +41,7 @@ public class ApplicationTestAcceptanceSteps implements En {
             tempFolder =Files.createTempDirectory("AppTest").toFile();
             File profileDir = new File(tempFolder.getAbsolutePath() + File.separator + "Name" );
             FileUtils.copyDirectory(new File(profile), profileDir );
+            initProperty=System.getProperty("jmri.prefsdir");
             System.setProperty("jmri.prefsdir",tempFolder.getAbsolutePath());
             System.setProperty("org.jmri.profile", profileDir.getAbsolutePath() );
        } catch(java.io.IOException ioe) {
@@ -80,7 +82,7 @@ public class ApplicationTestAcceptanceSteps implements En {
            jmri.util.JUnitUtil.releaseThread(this, 5000);
         }
         FileUtils.deleteDirectory(tempFolder);
-        System.clearProperty("jmri.prefsdir");
+        System.setProperty("jmri.prefsdir",initProperty);
         System.clearProperty("org.jmri.profile");
         JUnitUtil.clearShutDownManager();
         JUnitUtil.resetAppsBase();

--- a/java/acceptancetest/step_definitions/apps/ApplicationTestAcceptanceSteps.java
+++ b/java/acceptancetest/step_definitions/apps/ApplicationTestAcceptanceSteps.java
@@ -23,10 +23,8 @@ public class ApplicationTestAcceptanceSteps implements En {
      
    String[] tags = {"@apptest"};
    File tempFolder;
-   String initProperty;
    
    public ApplicationTestAcceptanceSteps(jmri.InstanceManager instance) {
-
 
    Before(tags,() -> {
       JUnitUtil.setUp();
@@ -41,7 +39,6 @@ public class ApplicationTestAcceptanceSteps implements En {
             tempFolder =Files.createTempDirectory("AppTest").toFile();
             File profileDir = new File(tempFolder.getAbsolutePath() + File.separator + "Name" );
             FileUtils.copyDirectory(new File(profile), profileDir );
-            initProperty=System.getProperty("jmri.prefsdir");
             System.setProperty("jmri.prefsdir",tempFolder.getAbsolutePath());
             System.setProperty("org.jmri.profile", profileDir.getAbsolutePath() );
        } catch(java.io.IOException ioe) {
@@ -82,7 +79,6 @@ public class ApplicationTestAcceptanceSteps implements En {
            jmri.util.JUnitUtil.releaseThread(this, 5000);
         }
         FileUtils.deleteDirectory(tempFolder);
-        System.setProperty("jmri.prefsdir",initProperty);
         System.clearProperty("org.jmri.profile");
         JUnitUtil.clearShutDownManager();
         JUnitUtil.resetAppsBase();

--- a/java/src/apps/JmriFaceless.java
+++ b/java/src/apps/JmriFaceless.java
@@ -34,8 +34,7 @@ public class JmriFaceless extends apps.AppsBase {
     public void start() {
         // Once the configServlet is usable, require the web server
         // WebServerManager.getWebServer().start();
-        //start LocoNetOverTcp server if configured to autostart
-        jmri.jmrix.loconet.loconetovertcp.LnTcpServer.getDefault();
+        super.start();
     }
 
     // Main entry point

--- a/java/test/apps/PackageTest.java
+++ b/java/test/apps/PackageTest.java
@@ -45,6 +45,7 @@ import org.junit.runners.Suite;
     SampleMinimalProgramTest.class,
     SystemConsoleTest.class,
     AppsLaunchFrameTest.class,
+    RunCucumberTest.class,
 })
 /**
  * Invoke complete set of tests for the apps package

--- a/java/test/apps/RunCucumberTest.java
+++ b/java/test/apps/RunCucumberTest.java
@@ -1,4 +1,4 @@
-package jmri;
+package apps;
 
 import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
@@ -24,20 +24,8 @@ import org.junit.BeforeClass;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(plugin = {"junit:cucumber-results.xml","progress","json:cucumber-results.json"},
-                 features="java/acceptancetest/features/web",
+                 features="java/acceptancetest/features/apps",
                  tags = {"not @webtest", "not @Ignore", "not @ignore"},
                  glue = {"apps","jmri"} )
 public class RunCucumberTest {
-   
-   @BeforeClass
-   public static void beforeTests(){
-     jmri.util.JUnitUtil.setUp();
-   }
-
-   @AfterClass
-   public static void afterTests(){
-      jmri.util.web.BrowserFactory.CloseAllDriver();
-      jmri.util.JUnitUtil.tearDown();
-   }
-
 }

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -196,6 +196,7 @@ public class JUnitUtil {
     static private StackTraceElement[] lastTearDownStackTrace = new StackTraceElement[0];
     
     static private boolean isLoggingInitialized = false;
+    static private String initPrefsDir = null;
     /**
      * JMRI standard setUp for tests. This should be the first line in the {@code @Before}
      * annotated method.
@@ -231,6 +232,13 @@ public class JUnitUtil {
         // do not set the UncaughtExceptionHandler while unit testing
         // individual tests can explicitly set it after calling this method
         Thread.setDefaultUncaughtExceptionHandler(null);
+
+        // make sure the jmri.prefsdir property match the property passed 
+        // to the tests.
+        if(initPrefsDir==null){
+           initPrefsDir = System.getProperty("jmri.prefsdir");
+        }
+        System.setProperty("jmri.prefsdir",initPrefsDir);
         
         // silence the Jemmy GUI unit testing framework
         JUnitUtil.silenceGUITestOutput();

--- a/java/test/jmri/util/JUnitUtil.java
+++ b/java/test/jmri/util/JUnitUtil.java
@@ -957,6 +957,20 @@ public class JUnitUtil {
     }
 
     /*
+     * Use reflection to reset the apps.AppsBase instance
+     */
+    public static void resetAppsBase() {
+        try {
+            Class<?> c = apps.AppsBase.class;
+            java.lang.reflect.Field f = c.getDeclaredField("preInit");
+            f.setAccessible(true);
+            f.set(null, false);
+        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException x) {
+            log.error("Failed to reset apps.AppsBase static preInit field", x);
+        }
+    }
+
+    /*
      * Use reflection to reset the jmri.util.node.NodeIdentity instance
      */
     public static void resetNodeIdentity() {


### PR DESCRIPTION
Resolves the LocoNet assumption noted in #7103, which otherwise causes these tests to fail.