### PR TITLE
Disable invalid minVal/maxVal checking in splitVal.

### DIFF
--- a/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SplitVariableValue.java
@@ -325,15 +325,16 @@ public class SplitVariableValue extends VariableValue
         if (_textField != null && !oldContents.equals(_textField.getText())) {
             long newFieldVal = getValueFromText(_textField.getText());
             log.debug("_minVal = {},_maxVal = {},newFieldVal = {}", _minVal, _maxVal, newFieldVal);
-            if (newFieldVal < _minVal || newFieldVal > _maxVal) {
-                _textField.setText(oldContents);
-            } else {
+//            disable recently-added _minVal, _maxVal checking for now
+//            if (newFieldVal < _minVal || newFieldVal > _maxVal) {
+//                _textField.setText(oldContents);
+//            } else {
                 long newVal = (newFieldVal - mOffset) / mFactor;
                 long oldVal = (getValueFromText(oldContents) - mOffset) / mFactor;
 //            log.debug("Enter updatedTextField from exitField");
                 updatedTextField();
                 prop.firePropertyChange("Value", oldVal, newVal);
-            }
+//            }
         }
     }
 


### PR DESCRIPTION
Recently-added minVal/maxVal checking in splitVal caused chaos with many decoder definitions, as reported by Dick Bronson at [jmri-developers thread](https://jmri-developers.groups.io/g/jmri/topic/32102866#1503).

minVal/maxVal checking has not been previously been enabled in splitVal. Disabling for now (V4.16) as significant code changes would be required to make it workable.