### PR TITLE
OpenLCB Light fix

### DIFF
--- a/java/src/jmri/jmrix/openlcb/OlcbLight.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbLight.java
@@ -23,6 +23,7 @@ public class OlcbLight extends AbstractLight {
             (~BitProducerConsumer.LISTEN_INVALID_STATE);
     static final boolean DEFAULT_IS_AUTHORITATIVE = true;
     static final boolean DEFAULT_LISTEN = true;
+    private boolean _finishedLoad = false;
     
     OlcbAddress addrOn;    // go to On state
     OlcbAddress addrOff;  // go to Off state
@@ -87,12 +88,23 @@ public class OlcbLight extends AbstractLight {
         if (lightListener==null){
             return;
         }
+        _finishedLoad = true;
         lightControlList.stream().forEach((lc) -> {
             lc.activateLightControl();
         });
         mActive = true; // set flag for control listeners
     }
     
+    /** {@inheritDoc} */
+    @Override
+    public void setState(int newState) {
+        if (_finishedLoad){
+            super.setState(newState);
+        }
+        else {
+            log.debug("Light {} status being set while still Activating",this);
+        }
+    }
     
     /**
      * Set the current state of this Light This routine requests the hardware to
@@ -118,6 +130,7 @@ public class OlcbLight extends AbstractLight {
         }
     }
     
+    /** {@inheritDoc} */
     @Override
     public void setProperty(String key, Object value) {
         Object old = getProperty(key);
@@ -127,15 +140,13 @@ public class OlcbLight extends AbstractLight {
         finishLoad();
     }
     
+    /** {@inheritDoc} */
     @Override
     public void dispose() {
         if (lightListener != null) lightListener.release();
         if (pc != null) pc.release();
         super.dispose();
     }
-
-    
-    
     
     private final static Logger log = LoggerFactory.getLogger(OlcbLight.class);
 


### PR DESCRIPTION
For 4.17.1 , OP at https://groups.io/g/jmriusers/message/161004 will need to be on this branch for multiple Fast Clock Light Controllers.
Stops OpenLCB Light status being set before it has been completely initialised.
setStatus(int newStatus) requests when NOT initialised cause infinite OpenLCB network loops