### PR TITLE
chore: Use Ubuntu 16.04 LTS in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - openjdk8
+  - oraclejdk8
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     - libalut0
     - dbus-x11
     - tidy
-    - pulseaudio
+    - pulseaudio-module-x11
   firefox: latest
   chrome: beta
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
     - libalut0
     - dbus-x11
     - tidy
-    - pulseaudio
     - pulseaudio-module-x11
   firefox: latest
   chrome: beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ addons:
   firefox: latest
   chrome: beta
 
-services:
-  - xvfb
-
 before_install:
   # ensure no unwanted defaults are set
   # see https://github.com/travis-ci/travis-ci/issues/4613#issuecomment-181845546
@@ -28,8 +25,10 @@ install:
   - mvn verify -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 before_script:
+  # start audio services
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then start-pulseaudio-x11 ; fi
   # silence errors from firefox about dbus.
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$HEADLESS" == "false" ]]; then dbus-launch ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then dbus-launch ; fi
 
 script:
   - if [[ "$PRINT_SUMMARY" == "false" ]] ; then travis_wait 50 ./scripts/travis.sh ; else ./scripts/travis.sh ; fi
@@ -59,11 +58,18 @@ env:
   - HEADLESS=true STATIC=true
 
 matrix:
-  exclude:
-  - os: osx
+  include:
+  - os: linux
+    dist: xenial
     env: HEADLESS=true STATIC=true
-  - os: osx
+  - os: linux
+    dist: xenial
     env: HEADLESS=true STATIC=false
+  - os: linux
+    dist: xenial
+    services:
+      - xvfb
+    env: HEADLESS=false STATIC=false
 
 after_success:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$HEADLESS" == "false" ]] ; then mvn jacoco:report coveralls:report -U -P travis-coverage ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
     - libalut0
     - dbus-x11
     - tidy
+    - pulseaudio
     - pulseaudio-module-x11
   firefox: latest
   chrome: beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,12 @@ addons:
     - libalut0
     - dbus-x11
     - tidy
+    - pulseaudio
   firefox: latest
   chrome: beta
+
+services:
+  - xvfb
 
 before_install:
   # ensure no unwanted defaults are set
@@ -58,18 +62,11 @@ env:
   - HEADLESS=true STATIC=true
 
 matrix:
-  include:
-  - os: linux
-    dist: xenial
+  exclude:
+  - os: osx
     env: HEADLESS=true STATIC=true
-  - os: linux
-    dist: xenial
+  - os: osx
     env: HEADLESS=true STATIC=false
-  - os: linux
-    dist: xenial
-    services:
-      - xvfb
-    env: HEADLESS=false STATIC=false
 
 after_success:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$HEADLESS" == "false" ]] ; then mvn jacoco:report coveralls:report -U -P travis-coverage ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+jdk:
+  - openjdk8
+
 addons:
   apt:
     packages:
@@ -8,14 +11,15 @@ addons:
     - dbus-x11
     - tidy
   firefox: latest
-  chrome: beta 
+  chrome: beta
+
+services:
+  - xvfb
 
 before_install:
   # ensure no unwanted defaults are set
   # see https://github.com/travis-ci/travis-ci/issues/4613#issuecomment-181845546
   - export MAVEN_SKIP_RC="true"
-  # set Linux to use JDK 8, accept defaults on macOS
-  - if [ "$TRAVIS_OS_NAME" == "linux" ] ; then jdk_switcher use "oraclejdk8" ; fi
   # install graphviz on macOS
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install graphviz ; fi
@@ -24,8 +28,6 @@ install:
   - mvn verify -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 before_script:
-  # setup a display on linux ( the sleep gives xvfb some time to start )
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$HEADLESS" == "false" ]] ; then export DISPLAY=:99.0 ; sh -e /etc/init.d/xvfb start ; sleep 3 ; fi
   # silence errors from firefox about dbus.
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$HEADLESS" == "false" ]]; then dbus-launch ; fi
 
@@ -39,6 +41,8 @@ cache:
 os:
   - linux
 #  - osx # temporarilly disabled -- its more complex than originally anticipated to do conditional matrixes based on PR/push differentiation
+
+dist: xenial
 
 sudo: required
 

--- a/java/src/jmri/jmrit/Sound.java
+++ b/java/src/jmri/jmrit/Sound.java
@@ -97,7 +97,7 @@ public class Sound {
     private Clip openClip() {
         Clip newClip = null;
         try {
-            newClip = AudioSystem.getClip();
+            newClip = AudioSystem.getClip(null);
             newClip.addLineListener(event -> {
                 if (LineEvent.Type.STOP.equals(event.getType())) {
                     if (autoClose) {

--- a/java/test/jmri/jmrit/dispatcher/LoadAtStartUpTest.java
+++ b/java/test/jmri/jmrit/dispatcher/LoadAtStartUpTest.java
@@ -180,6 +180,7 @@ public class LoadAtStartUpTest {
         JUnitUtil.setUp();
         JUnitUtil.resetProfileManager();
         JUnitUtil.resetInstanceManager();
+        JUnitUtil.initShutDownManager();
         JUnitUtil.initDebugThrottleManager();
     }
 

--- a/java/test/jmri/jmrit/timetable/LayoutTest.java
+++ b/java/test/jmri/jmrit/timetable/LayoutTest.java
@@ -2,6 +2,8 @@ package jmri.jmrit.timetable;
 
 import org.junit.*;
 
+import jmri.util.JUnitUtil;
+
 /**
  * Tests for the Layout Class
  * @author Dave Sand Copyright (C) 2018
@@ -49,12 +51,13 @@ public class LayoutTest {
 
     @Before
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager();
     }
 
     @After
     public void tearDown() {
-        jmri.util.JUnitUtil.tearDown();
+        JUnitUtil.tearDown();
     }
 //     private final static org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(LayoutTest.class);
 }

--- a/java/test/jmri/jmrit/timetable/SegmentTest.java
+++ b/java/test/jmri/jmrit/timetable/SegmentTest.java
@@ -2,6 +2,8 @@ package jmri.jmrit.timetable;
 
 import org.junit.*;
 
+import jmri.util.JUnitUtil;
+
 /**
  * Tests for the Segment Class
  * @author Dave Sand Copyright (C) 2018
@@ -31,11 +33,12 @@ public class SegmentTest {
 
     @Before
     public void setUp() {
-        jmri.util.JUnitUtil.setUp();
+        JUnitUtil.setUp();
+        JUnitUtil.resetProfileManager();
     }
 
     @After
     public void tearDown() {
-        jmri.util.JUnitUtil.tearDown();
+        JUnitUtil.tearDown();
     }
 }


### PR DESCRIPTION
As of April 2019, Ubuntu 14.04 LTS is no longer supported by Canonical, and is no longer the default the Linux version for Travis CI. This is breaking new forks that use Travis CI since the JMRI project dis not explicitly define which Ubuntu distribution to use for Travis CI.

Instead of sticking with an unsupported version, this PR explicitly uses Ubuntu 16.04 LTS and takes advantage of some changes between 14.04 and 16.04 in Travis CI. As a result of this, OpenJDK is now used instead of the Oracle JDK.

The change to `jmri.jmrit.Sound` covers differences in how the Oracle JDK and OpenJDK determine the default audio device (Oracle appears to use a third party, non-open library that OpenJDK is unable to use).

The change to tests in `jmri.jmrit.timetable` corrects an issue where these tests merely passed previously through dumb luck, and need to ensure the current FileUtils point to a workable location, not a non-existent location.

Closes #6796