### PR TITLE
Active profile can be null

### DIFF
--- a/java/src/apps/Apps.java
+++ b/java/src/apps/Apps.java
@@ -192,7 +192,11 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
             configFilename = FileUtil.getProfilePath() + Profile.CONFIG_FILENAME;
             System.setProperty("org.jmri.Apps.configFilename", Profile.CONFIG_FILENAME);
             Profile profile = ProfileManager.getDefault().getActiveProfile();
-            log.info("Starting with profile {}", profile.getId());
+            if (profile != null) {
+                log.info("Starting with profile {}", profile.getId());
+            } else {
+                log.info("Starting without a profile");
+            }
             
             // rapid language set; must follow up later with full setting as part of preferences
             apps.gui.GuiLafPreferencesManager.setLocaleMinimally(profile);
@@ -838,8 +842,8 @@ public class Apps extends JPanel implements PropertyChangeListener, WindowListen
         pane2.add(new JLabel(line2()));
         pane2.add(new JLabel(line3()));
 
-        Profile profile = ProfileManager.getDefault().getActiveProfile();
-        pane2.add(new JLabel(Bundle.getMessage("ActiveProfile", profile.getName())));
+        String name = ProfileManager.getDefault().getActiveProfileName();
+        pane2.add(new JLabel(Bundle.getMessage("ActiveProfile", name)));
 
         // add listener for Com port updates
         ConnectionStatus.instance().addPropertyChangeListener(this);

--- a/java/src/apps/AppsBase.java
+++ b/java/src/apps/AppsBase.java
@@ -168,7 +168,11 @@ public abstract class AppsBase {
                 // Apps.setConfigFilename() does not reset the system property
                 System.setProperty("org.jmri.Apps.configFilename", Profile.CONFIG_FILENAME);
                 Profile profile = ProfileManager.getDefault().getActiveProfile();
-                log.info("Starting with profile {}", profile.getId());
+                if (profile != null) {
+                    log.info("Starting with profile {}", profile.getId());
+                } else {
+                    log.info("Starting without a profile");
+                }
             } else {
                 log.error("Specify profile to use as command line argument.");
                 log.error("If starting with saved profile configuration, ensure the autoStart property is set to \"true\"");
@@ -392,7 +396,6 @@ public abstract class AppsBase {
     }
 
     // We will use the value stored in the system property
-    // TODO: change to return profile-name/profile.xml
     static public String getConfigFileName() {
         if (System.getProperty("org.jmri.Apps.configFilename") != null) {
             return System.getProperty("org.jmri.Apps.configFilename");

--- a/java/src/apps/gui3/Apps3.java
+++ b/java/src/apps/gui3/Apps3.java
@@ -337,7 +337,11 @@ public abstract class Apps3 extends AppsBase {
             // Apps.setConfigFilename() does not reset the system property
             System.setProperty("org.jmri.Apps.configFilename", Profile.CONFIG_FILENAME);
             Profile profile = ProfileManager.getDefault().getActiveProfile();
-            log.info("Starting with profile {}", profile.getId());
+            if (profile != null) {
+                log.info("Starting with profile {}", profile.getId());
+            } else {
+                log.info("Starting without a profile");
+            }
 
             // rapid language set; must follow up later with full setting as part of preferences
             apps.gui.GuiLafPreferencesManager.setLocaleMinimally(profile);
@@ -360,10 +364,10 @@ public abstract class Apps3 extends AppsBase {
         super.setAndLoadPreferenceFile();
         if (sharedConfig == null && configOK == true && configDeferredLoadOK == true) {
             // this was logged in the super method
-            Profile profile = ProfileManager.getDefault().getActiveProfile();
+            String name = ProfileManager.getDefault().getActiveProfileName();
             if (!GraphicsEnvironment.isHeadless()) {
                 JOptionPane.showMessageDialog(sp,
-                        Bundle.getMessage("SingleConfigMigratedToSharedConfig", profile.getName()),
+                        Bundle.getMessage("SingleConfigMigratedToSharedConfig", name),
                         jmri.Application.getApplicationName(),
                         JOptionPane.INFORMATION_MESSAGE);
             }

--- a/java/src/jmri/implementation/JmriConfigurationManager.java
+++ b/java/src/jmri/implementation/JmriConfigurationManager.java
@@ -1,11 +1,5 @@
 package jmri.implementation;
 
-import apps.AppsBase;
-import apps.gui3.tabbedpreferences.EditConnectionPreferencesDialog;
-import apps.gui3.tabbedpreferences.TabbedPreferencesAction;
-import com.alexandriasoftware.swing.JSplitButton;
-import com.alexandriasoftware.swing.action.ButtonClickedActionListener;
-import com.alexandriasoftware.swing.action.SplitButtonClickedActionListener;
 import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -14,7 +8,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.io.File;
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -22,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import javax.swing.Action;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
@@ -32,6 +26,13 @@ import javax.swing.JPopupMenu;
 import javax.swing.KeyStroke;
 import javax.swing.TransferHandler;
 import javax.swing.event.ListSelectionEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import apps.AppsBase;
+import apps.gui3.tabbedpreferences.EditConnectionPreferencesDialog;
+import apps.gui3.tabbedpreferences.TabbedPreferencesAction;
 import jmri.Application;
 import jmri.ConfigureManager;
 import jmri.InstanceManager;
@@ -41,15 +42,12 @@ import jmri.configurexml.swing.DialogErrorHandler;
 import jmri.jmrit.XmlFile;
 import jmri.profile.Profile;
 import jmri.profile.ProfileManager;
-import jmri.profile.ProfileManagerDialog;
 import jmri.spi.PreferencesManager;
-import jmri.util.com.sun.TransferActionListener;
 import jmri.util.FileUtil;
 import jmri.util.SystemType;
+import jmri.util.com.sun.TransferActionListener;
 import jmri.util.prefs.HasConnectionButUnableToConnectException;
 import jmri.util.prefs.InitializationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *

--- a/java/src/jmri/jmrit/mailreport/ReportContext.java
+++ b/java/src/jmri/jmrit/mailreport/ReportContext.java
@@ -76,9 +76,13 @@ public class ReportContext {
         addCommunicationPortInfo();
 
         Profile profile = ProfileManager.getDefault().getActiveProfile();
-        addString("Active profile: " + profile.getName() + "   ");
-        addString("Profile location: " + profile.getPath().getPath() + "   ");
-        addString("Profile ID: " + profile.getId() + "   ");
+        if (profile != null) {
+            addString("Active profile: " + profile.getName() + "   ");
+            addString("Profile location: " + profile.getPath().getPath() + "   ");
+            addString("Profile ID: " + profile.getId() + "   ");
+        } else {
+            addString("No active profile");
+        }
         
         addString("JMRI Network ID: " + jmri.util.node.NodeIdentity.networkIdentity());
         addString("JMRI Storage ID: " + jmri.util.node.NodeIdentity.storageIdentity(profile));

--- a/java/src/jmri/jmrit/mailreport/ReportPanel.java
+++ b/java/src/jmri/jmrit/mailreport/ReportPanel.java
@@ -205,23 +205,25 @@ public class ReportPanel extends JPanel {
                 log.debug("prepare profile attachment");
                 // Check that a profile has been loaded
                 Profile profile = ProfileManager.getDefault().getActiveProfile();
-                File file = profile.getPath();
-                if (file != null) {
-                    log.debug("add profile: {}", file.getPath());
-                    // Now zip-up contents of profile
-                    // Create temp file that will be deleted when Java quits
-                    File temp = File.createTempFile("profile", ".zip");
-                    temp.deleteOnExit();
+                if (profile != null) {
+                    File file = profile.getPath();
+                    if (file != null) {
+                        log.debug("add profile: {}", file.getPath());
+                        // Now zip-up contents of profile
+                        // Create temp file that will be deleted when Java quits
+                        File temp = File.createTempFile("profile", ".zip");
+                        temp.deleteOnExit();
 
-                    FileOutputStream out = new FileOutputStream(temp);
-                    ZipOutputStream zip = new ZipOutputStream(out);
+                        FileOutputStream out = new FileOutputStream(temp);
+                        ZipOutputStream zip = new ZipOutputStream(out);
 
-                    addDirectory(zip, file);
+                        addDirectory(zip, file);
 
-                    zip.close();
-                    out.close();
+                        zip.close();
+                        out.close();
 
-                    msg.addFilePart("logfileupload[]", temp);
+                        msg.addFilePart("logfileupload[]", temp);
+                    }
                 } else {
                     // No profile loaded
                     log.warn("No profile loaded - not sending");

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderManager.java
@@ -493,9 +493,10 @@ public class VSDecoderManager implements PropertyChangeListener {
     }
 
     /**
-     * getProfilePath()
-     *
      * Retrieve the Path for a given Profile name.
+     * 
+     * @param profile the profile to get the path for
+     * @return the path for the profile
      */
     public String getProfilePath(String profile) {
         return profiletable.get(profile);

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderPane.java
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderPane.java
@@ -344,9 +344,10 @@ public class VSDecoderPane extends JmriPanel {
     }
 
     /**
-     * getDecoder(String)
-     *
      * Looks up a decoder profile by name and returns that decoder.
+     * 
+     * @param profile name of the profile to get
+     * @return the decoder for the profile
      */
     public VSDecoder getDecoder(String profile) {
         @SuppressWarnings("deprecation")

--- a/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
+++ b/java/src/jmri/jmrix/can/CanSystemConnectionMemo.java
@@ -1,19 +1,16 @@
 package jmri.jmrix.can;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import jmri.InstanceManager;
-import jmri.profile.Profile;
-import jmri.profile.ProfileManager;
 
 /**
  * Lightweight class to denote that a system is active, and provide general

--- a/java/src/jmri/jmrix/openlcb/OlcbConfigurationManager.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbConfigurationManager.java
@@ -448,8 +448,9 @@ public class OlcbConfigurationManager extends jmri.jmrix.can.ConfigurationManage
             l.add((byte)4); // version byte
             addStringPart("JMRI", l);
             addStringPart("PanelPro", l);
-            if (ProfileManager.getDefault().hasActiveProfile()) {
-                addStringPart("Profile " + ProfileManager.getDefault().getActiveProfileName(), l); // hardware version
+            String name = ProfileManager.getDefault().getActiveProfileName();
+            if (name != null) {
+                addStringPart("Profile " + name, l); // hardware version
             } else {
                 addStringPart("", l); // hardware version
             }

--- a/java/src/jmri/jmrix/sprog/SprogTrafficController.java
+++ b/java/src/jmri/jmrix/sprog/SprogTrafficController.java
@@ -1,20 +1,17 @@
 package jmri.jmrix.sprog;
 
-import java.awt.GraphicsEnvironment;
 import java.io.DataInputStream;
 import java.io.OutputStream;
 import java.util.Vector;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import javax.swing.JOptionPane;
-import jmri.InstanceManager;
-import jmri.JmriException;
-import jmri.PowerManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import jmri.jmrix.AbstractPortController;
 import jmri.jmrix.sprog.SprogConstants.SprogState;
 import jmri.jmrix.sprog.serialdriver.SerialDriverAdapter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import purejavacomm.SerialPort;
 import purejavacomm.SerialPortEvent;
 import purejavacomm.SerialPortEventListener;
@@ -357,6 +354,8 @@ public class SprogTrafficController implements SprogInterface, SerialPortEventLi
      * Break connection to existing SprogPortController object.
      * <p>
      * Once broken, attempts to send via "message" member will fail.
+     * 
+     * @param p the connection to break
      */
     public void disconnectPort(AbstractPortController p) {
         istream = null;

--- a/java/src/jmri/profile/ProfileManager.java
+++ b/java/src/jmri/profile/ProfileManager.java
@@ -9,6 +9,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -104,15 +106,6 @@ public class ProfileManager extends Bean {
     }
 
     /**
-     * Returns true if the manager has an active profile.
-     *
-     * @return true if the manager has an active profile
-     */
-    public boolean hasActiveProfile() {
-        return (activeProfile != null);
-    }
-
-    /**
      * Get the {@link Profile} that is currently in use.
      * <p>
      * Note that this returning null is not an error condition, and
@@ -122,6 +115,7 @@ public class ProfileManager extends Bean {
      *
      * @return the in use Profile or null if there is no Profile in use
      */
+    @CheckForNull
     public Profile getActiveProfile() {
         return activeProfile;
     }
@@ -136,25 +130,27 @@ public class ProfileManager extends Bean {
      * @return the name of the active profile or null if there is no active
      *         profile
      */
-    @Nonnull
+    @CheckForNull
     public String getActiveProfileName() {
-        if (activeProfile == null) {
-            throw new NullPointerException("activeProfile is null");
-        }
-        return activeProfile.getName();
+        return activeProfile != null ? activeProfile.getName() : null;
     }
 
     /**
      * Set the {@link Profile} to use. This method finds the Profile by path or
      * Id and calls {@link #setActiveProfile(jmri.profile.Profile)}.
      *
-     * @param identifier the profile path or id; must not be null
+     * @param identifier the profile path or id; can be null
      */
-    public void setActiveProfile(@Nonnull String identifier) {
+    public void setActiveProfile(@Nullable String identifier) {
         log.debug("setActiveProfile called with {}", identifier);
         // handle null profile
         if (identifier == null) {
-            throw new IllegalArgumentException("identifier is null");
+            Profile old = activeProfile;
+            activeProfile = null;
+            FileUtil.setProfilePath(null);
+            this.firePropertyChange(ProfileManager.ACTIVE_PROFILE, old, null);
+            log.debug("Setting active profile to null");
+            return;
         }
         // handle profile path
         File profileFile = new File(identifier);
@@ -197,10 +193,14 @@ public class ProfileManager extends Bean {
      *
      * @param profile the profile to activate
      */
-    public void setActiveProfile(@Nonnull Profile profile) {
+    public void setActiveProfile(@Nullable Profile profile) {
         Profile old = activeProfile;
         if (profile == null) {
-            throw new IllegalArgumentException("profile is null");
+            activeProfile = null;
+            FileUtil.setProfilePath(null);
+            this.firePropertyChange(ProfileManager.ACTIVE_PROFILE, old, null);
+            log.debug("Setting active profile to null");
+            return;
         }
         activeProfile = profile;
         FileUtil.setProfilePath(profile.getPath().toString());
@@ -235,7 +235,7 @@ public class ProfileManager extends Bean {
         this.saveActiveProfile(this.getActiveProfile(), this.autoStartActiveProfile);
     }
 
-    protected void saveActiveProfile(@Nonnull Profile profile, boolean autoStart) throws IOException {
+    protected void saveActiveProfile(@CheckForNull Profile profile, boolean autoStart) throws IOException {
         Properties p = new Properties();
         FileOutputStream os = null;
         File config = this.getConfigFile();
@@ -244,13 +244,11 @@ public class ProfileManager extends Bean {
             log.debug("No config file defined, not attempting to save active profile.");
             return;
         }
-        if (profile == null) {
-            throw new IllegalArgumentException("profile is null");
+        if (profile != null) {
+            p.setProperty(ACTIVE_PROFILE, profile.getId());
+            p.setProperty(AUTO_START, Boolean.toString(autoStart));
+            p.setProperty(AUTO_START_TIMEOUT, Integer.toString(this.getAutoStartActiveProfileTimeout()));
         }
-        
-        p.setProperty(ACTIVE_PROFILE, profile.getId());
-        p.setProperty(AUTO_START, Boolean.toString(autoStart));
-        p.setProperty(AUTO_START_TIMEOUT, Integer.toString(this.getAutoStartActiveProfileTimeout()));
         
         if (!config.exists() && !config.createNewFile()) {
             throw new IOException("Unable to create file at " + config.getAbsolutePath()); // NOI18N
@@ -329,7 +327,7 @@ public class ProfileManager extends Bean {
      * @return A list of all Profile objects
      */
     @Nonnull
-    public ArrayList<Profile> getAllProfiles() {
+    public List<Profile> getAllProfiles() {
         return new ArrayList<>(profiles);
     }
 
@@ -353,10 +351,7 @@ public class ProfileManager extends Bean {
      * @param profile the Profile to set
      * @param index   the index to set; any existing profile at index is removed
      */
-    public void setProfiles(@Nonnull Profile profile, int index) {
-        if (profile == null) {
-            throw new IllegalArgumentException("profile is null");
-        }
+    public void setProfiles(Profile profile, int index) {
         Profile oldProfile = profiles.get(index);
         if (!this.readingProfiles) {
             profiles.set(index, profile);
@@ -364,10 +359,7 @@ public class ProfileManager extends Bean {
         }
     }
 
-    protected void addProfile(@Nonnull Profile profile) {
-        if (profile == null) {
-            throw new IllegalArgumentException("profile is null");
-        }
+    protected void addProfile(Profile profile) {
         if (!profiles.contains(profile)) {
             profiles.add(profile);
             if (!this.readingProfiles) {
@@ -389,10 +381,7 @@ public class ProfileManager extends Bean {
         }
     }
 
-    protected void removeProfile(@Nonnull Profile profile) {
-        if (profile == null) {
-            throw new IllegalArgumentException("profile is null");
-        }
+    protected void removeProfile(Profile profile) {
         try {
             int index = profiles.indexOf(profile);
             if (index >= 0) {
@@ -400,7 +389,7 @@ public class ProfileManager extends Bean {
                     this.fireIndexedPropertyChange(PROFILES, index, profile, null);
                     this.writeProfiles();
                 }
-                if (profile.equals(this.getNextActiveProfile())) {
+                if (profile != null && profile.equals(this.getNextActiveProfile())) {
                     this.setNextActiveProfile(null);
                     this.saveActiveProfile(this.getActiveProfile(), this.autoStartActiveProfile);
                 }
@@ -470,9 +459,7 @@ public class ProfileManager extends Bean {
     }
 
     protected void setDefaultSearchPath(@Nonnull File defaultSearchPath) throws IOException {
-        if (defaultSearchPath == null) {
-            throw new NullPointerException();
-        }
+        Objects.requireNonNull(defaultSearchPath);
         if (!defaultSearchPath.equals(this.defaultSearchPath)) {
             File oldDefault = this.defaultSearchPath;
             this.defaultSearchPath = defaultSearchPath;
@@ -629,7 +616,7 @@ public class ProfileManager extends Bean {
      * @return true if the app should start without user interaction
      */
     public boolean isAutoStartActiveProfile() {
-        return (this.hasActiveProfile() && autoStartActiveProfile);
+        return (this.getActiveProfile() != null && autoStartActiveProfile);
     }
 
     /**
@@ -645,11 +632,11 @@ public class ProfileManager extends Bean {
     /**
      * Create a default profile if no profiles exist.
      *
-     * @return A new profile if profile does not already exist
-     * @throws java.io.IOException if unable to create a Profile
-     * @throws java.lang.RuntimeException if profile already exists
+     * @return A new profile or null if profiles already exist
+     * @throws java.io.IOException        if unable to create a Profile
+     * @throws IllegalArgumentException if profile already exists at default location
      */
-    @Nonnull
+    @CheckForNull
     public Profile createDefaultProfile() throws IllegalArgumentException, IOException {
         if (this.getAllProfiles().isEmpty()) {
             String pn = Bundle.getMessage("defaultProfileName");
@@ -661,9 +648,7 @@ public class ProfileManager extends Bean {
             log.info("Created default profile \"{}\"", pn);
             return profile;
         } else {
-            // createDefaultProfile() should never be called if there already
-            // exists a profile
-            throw new RuntimeException("profile already exists");
+            return null;
         }
     }
 
@@ -674,7 +659,8 @@ public class ProfileManager extends Bean {
      * @param config the configuration file
      * @param name   the name of the configuration
      * @return The profile with the migrated configuration
-     * @throws java.io.IOException if unable to create a Profile
+     * @throws java.io.IOException      if unable to create a Profile
+     * @throws IllegalArgumentException if profile already exists for config
      */
     @Nonnull
     public Profile migrateConfigToProfile(@Nonnull File config, @Nonnull String name) throws IllegalArgumentException, IOException {
@@ -700,33 +686,73 @@ public class ProfileManager extends Bean {
      * Profile-related states requiring preparation to use profiles:
      * <table>
      * <caption>Matrix of states determining if migration required.</caption>
-     * <tr><th>Profile Catalog</th><th>Profile Config</th><th>App
-     * Config</th><th>Action</th></tr>
-     * <tr><td>YES</td><td>YES</td><td>YES</td><td>No preparation required -
-     * migration from earlier JMRI complete</td></tr>
-     * <tr><td>YES</td><td>YES</td><td>NO</td><td>No preparation required - JMRI
-     * installed after profiles feature introduced</td></tr>
-     * <tr><td>YES</td><td>NO</td><td>YES</td><td>Migration required - other
-     * JMRI applications migrated to profiles by this user, but not this
-     * one</td></tr>
-     * <tr><td>YES</td><td>NO</td><td>NO</td><td>No preparation required -
-     * prompt user for desired profile if multiple profiles exist, use default
-     * otherwise</td></tr>
-     * <tr><td>NO</td><td>NO</td><td>NO</td><td>New user - create and use
-     * default profile</td></tr>
-     * <tr><td>NO</td><td>NO</td><td>YES</td><td>Migration required - need to
-     * create first profile</td></tr>
-     * <tr><td>NO</td><td>YES</td><td>YES</td><td>No preparation required -
-     * catalog will be automatically regenerated</td></tr>
-     * <tr><td>NO</td><td>YES</td><td>NO</td><td>No preparation required -
-     * catalog will be automatically regenerated</td></tr>
+     * <tr>
+     * <th>Profile Catalog</th>
+     * <th>Profile Config</th>
+     * <th>App Config</th>
+     * <th>Action</th>
+     * </tr>
+     * <tr>
+     * <td>YES</td>
+     * <td>YES</td>
+     * <td>YES</td>
+     * <td>No preparation required - migration from earlier JMRI complete</td>
+     * </tr>
+     * <tr>
+     * <td>YES</td>
+     * <td>YES</td>
+     * <td>NO</td>
+     * <td>No preparation required - JMRI installed after profiles feature
+     * introduced</td>
+     * </tr>
+     * <tr>
+     * <td>YES</td>
+     * <td>NO</td>
+     * <td>YES</td>
+     * <td>Migration required - other JMRI applications migrated to profiles by
+     * this user, but not this one</td>
+     * </tr>
+     * <tr>
+     * <td>YES</td>
+     * <td>NO</td>
+     * <td>NO</td>
+     * <td>No preparation required - prompt user for desired profile if multiple
+     * profiles exist, use default otherwise</td>
+     * </tr>
+     * <tr>
+     * <td>NO</td>
+     * <td>NO</td>
+     * <td>NO</td>
+     * <td>New user - create and use default profile</td>
+     * </tr>
+     * <tr>
+     * <td>NO</td>
+     * <td>NO</td>
+     * <td>YES</td>
+     * <td>Migration required - need to create first profile</td>
+     * </tr>
+     * <tr>
+     * <td>NO</td>
+     * <td>YES</td>
+     * <td>YES</td>
+     * <td>No preparation required - catalog will be automatically
+     * regenerated</td>
+     * </tr>
+     * <tr>
+     * <td>NO</td>
+     * <td>YES</td>
+     * <td>NO</td>
+     * <td>No preparation required - catalog will be automatically
+     * regenerated</td>
+     * </tr>
      * </table>
      * This method returns true if a migration occurred, and false in all other
      * circumstances.
      *
      * @param configFilename the name of the app config file
      * @return true if a user's existing config was migrated, false otherwise
-     * @throws java.io.IOException if unable to to create a Profile
+     * @throws java.io.IOException      if unable to to create a Profile
+     * @throws IllegalArgumentException if profile already exists for configFilename
      */
     public boolean migrateToProfiles(@Nonnull String configFilename) throws IllegalArgumentException, IOException {
         File appConfigFile = new File(configFilename);
@@ -780,9 +806,6 @@ public class ProfileManager extends Bean {
      *                                 Profile
      */
     public void export(@Nonnull Profile profile, @Nonnull File target, boolean exportExternalUserFiles, boolean exportExternalRoster) throws IOException, JDOMException {
-        if (profile == null) {
-            throw new IllegalArgumentException("profile is null");
-        }
         if (!target.exists() && !target.createNewFile()) {
             throw new IOException("Unable to create file " + target);
         }
@@ -880,16 +903,11 @@ public class ProfileManager extends Bean {
      */
     @CheckForNull
     public static Profile getStartingProfile() throws IOException {
-        if (!ProfileManager.getDefault().hasActiveProfile()) {
+        if (ProfileManager.getDefault().getActiveProfile() == null) {
             ProfileManager.getDefault().readActiveProfile();
             // Automatically start with only profile if only one profile
             if (ProfileManager.getDefault().getProfiles().length == 1) {
-                Profile profile = ProfileManager.getDefault().getProfiles(0);
-                if (profile != null) {
-                    ProfileManager.getDefault().setActiveProfile(profile);
-                } else {
-                    throw new RuntimeException("profile is null");
-                }
+                ProfileManager.getDefault().setActiveProfile(ProfileManager.getDefault().getProfiles(0));
                 // Display profile selector if user did not choose to auto start with last used profile
             } else if (!ProfileManager.getDefault().isAutoStartActiveProfile()) {
                 return null;

--- a/java/src/jmri/profile/ProfileManager.java
+++ b/java/src/jmri/profile/ProfileManager.java
@@ -805,7 +805,6 @@ public class ProfileManager extends Bean {
      *                                 Profile
      */
     public void export(@Nonnull Profile profile, @Nonnull File target, boolean exportExternalUserFiles, boolean exportExternalRoster) throws IOException, JDOMException {
-            boolean exportExternalRoster) throws IOException, JDOMException {
         if (!target.exists() && !target.createNewFile()) {
             throw new IOException("Unable to create file " + target);
         }

--- a/java/src/jmri/profile/ProfileManager.java
+++ b/java/src/jmri/profile/ProfileManager.java
@@ -108,10 +108,9 @@ public class ProfileManager extends Bean {
     /**
      * Get the {@link Profile} that is currently in use.
      * <p>
-     * Note that this returning null is not an error condition, and
-     * should not be treated as such, since there are times when the
-     * user interacts with a JMRI application that there should be no
-     * active profile.
+     * Note that this returning null is not an error condition, and should not
+     * be treated as such, since there are times when the user interacts with a
+     * JMRI application that there should be no active profile.
      *
      * @return the in use Profile or null if there is no Profile in use
      */
@@ -249,7 +248,7 @@ public class ProfileManager extends Bean {
             p.setProperty(AUTO_START, Boolean.toString(autoStart));
             p.setProperty(AUTO_START_TIMEOUT, Integer.toString(this.getAutoStartActiveProfileTimeout()));
         }
-        
+
         if (!config.exists() && !config.createNewFile()) {
             throw new IOException("Unable to create file at " + config.getAbsolutePath()); // NOI18N
         }
@@ -258,7 +257,7 @@ public class ProfileManager extends Bean {
             p.storeToXML(os, "Active profile configuration (saved at " + (new Date()).toString() + ")"); // NOI18N
             os.close();
         } catch (Throwable ex) { // IOException, but also misc errors in Java XML processing
-            log.error("While trying to save active profile {}", config,ex);
+            log.error("While trying to save active profile {}", config, ex);
             if (os != null) {
                 os.close();
             }
@@ -633,8 +632,8 @@ public class ProfileManager extends Bean {
      * Create a default profile if no profiles exist.
      *
      * @return A new profile or null if profiles already exist
-     * @throws java.io.IOException        if unable to create a Profile
      * @throws IllegalArgumentException if profile already exists at default location
+     * @throws java.io.IOException      if unable to create a Profile
      */
     @CheckForNull
     public Profile createDefaultProfile() throws IllegalArgumentException, IOException {
@@ -806,6 +805,7 @@ public class ProfileManager extends Bean {
      *                                 Profile
      */
     public void export(@Nonnull Profile profile, @Nonnull File target, boolean exportExternalUserFiles, boolean exportExternalRoster) throws IOException, JDOMException {
+            boolean exportExternalRoster) throws IOException, JDOMException {
         if (!target.exists() && !target.createNewFile()) {
             throw new IOException("Unable to create file " + target);
         }

--- a/java/src/jmri/profile/ProfileManagerDialog.java
+++ b/java/src/jmri/profile/ProfileManagerDialog.java
@@ -282,8 +282,13 @@ public class ProfileManagerDialog extends JDialog {
                 countDownLbl.setText(Integer.toString(countDown));
             } else {
                 setVisible(false);
-                ProfileManager.getDefault().setActiveProfile(profiles.getSelectedValue());
-                log.info("Automatically starting with profile " + ProfileManager.getDefault().getActiveProfile().getId() + " after timeout.");
+                Profile profile = profiles.getSelectedValue();
+                ProfileManager.getDefault().setActiveProfile(profile);
+                if (profile != null) {
+                    log.info("Automatically starting with profile " + profile.getId() + " after timeout.");
+                } else {
+                    log.info("Automatically starting without a profile");
+                }
                 timer.stop();
                 countDown = -1;
                 dispose();

--- a/java/src/jmri/spi/PreferencesManager.java
+++ b/java/src/jmri/spi/PreferencesManager.java
@@ -20,7 +20,7 @@ import jmri.util.prefs.InitializationException;
  * implementation that is ready to extend.
  *
  * @see jmri.util.prefs.AbstractPreferencesManager
- * @author Randall Wood 2015
+ * @author Randall Wood 2015, 2019
  */
 public interface PreferencesManager extends JmriServiceProviderInterface {
 
@@ -36,13 +36,16 @@ public interface PreferencesManager extends JmriServiceProviderInterface {
      * throwing an InitializationException to ensure that the provider is not
      * repeatedly initialized.
      *
-     * @param profile the configuration profile used for this initialization
+     * @param profile the configuration profile used for this initialization;
+     *                    may be null to initialize for this user regardless of
+     *                    profile
      * @throws jmri.util.prefs.InitializationException if the user needs to be
-     *                                                 notified of an issue that
-     *                                                 prevents regular use of
-     *                                                 the application
+     *                                                     notified of an issue
+     *                                                     that prevents regular
+     *                                                     use of the
+     *                                                     application
      */
-    public void initialize(@Nonnull Profile profile) throws InitializationException;
+    public void initialize(Profile profile) throws InitializationException;
 
     /**
      * Test if the PreferencesManager is initialized without errors for the
@@ -51,10 +54,12 @@ public interface PreferencesManager extends JmriServiceProviderInterface {
      * if isInitializedWithExceptions(Profile) returns true, this method must
      * return false.
      *
-     * @param profile the configuration profile to test against
+     * @param profile the configuration profile to test against; may be null to
+     *                    test for exceptions thrown when initializing for this
+     *                    user regardless of profile
      * @return true if the provider is initialized without exceptions
      */
-    public boolean isInitialized(@Nonnull Profile profile);
+    public boolean isInitialized(Profile profile);
 
     /**
      * Test if the PreferencesManager is initialized, but threw an
@@ -63,21 +68,25 @@ public interface PreferencesManager extends JmriServiceProviderInterface {
      * {@link #isInitialized(jmri.profile.Profile)} can be false, if
      * isInitialized(Profile) returns true, this method must return false.
      *
-     * @param profile the configuration profile to test against
+     * @param profile the configuration profile to test against; may be null to
+     *                    test for exceptions thrown when initializing for this
+     *                    user regardless of profile
      * @return true if the provide is initialized with exceptions
      */
-    public boolean isInitializedWithExceptions(@Nonnull Profile profile);
+    public boolean isInitializedWithExceptions(Profile profile);
 
     /**
      * Get the set of exceptions thrown during initialization for the provided
      * Profile.
      *
-     * @param profile the configuration profile to test against
+     * @param profile the configuration profile to test against; may be null to
+     *                    test for exceptions thrown when initializing for this
+     *                    user regardless of profile
      * @return A list of exceptions. If there are no exceptions, return an empty
      *         set instead of null.
      */
     @Nonnull
-    List<Exception> getInitializationExceptions(@Nonnull Profile profile);
+    List<Exception> getInitializationExceptions(Profile profile);
 
     /**
      * Get the set of PreferencesProviders that must be initialized prior to
@@ -107,8 +116,10 @@ public interface PreferencesManager extends JmriServiceProviderInterface {
     /**
      * Save the preferences that this provider manages for the provided Profile.
      *
-     * @param profile the profile associated with the preferences to save
+     * @param profile the profile associated with the preferences to save; may
+     *                    be null to save preferences that apply to the current
+     *                    user regardless of profile
      */
-    public void savePreferences(@Nonnull Profile profile);
+    public void savePreferences(Profile profile);
 
 }

--- a/java/src/jmri/util/node/NodeIdentity.java
+++ b/java/src/jmri/util/node/NodeIdentity.java
@@ -156,11 +156,10 @@ public class NodeIdentity {
      *         identity will change once that a configuration profile is loaded.
      */
     public static synchronized String networkIdentity() {
-        String uniqueId = "-";
-        try {
-            uniqueId += ProfileManager.getDefault().getActiveProfile().getUniqueId();
-        } catch (NullPointerException ex) {
-            uniqueId = "";
+        String uniqueId = "";
+        Profile profile = ProfileManager.getDefault().getActiveProfile();
+        if (profile != null) {
+            uniqueId = "-" + profile.getUniqueId();
         }
         if (instance == null) {
             instance = new NodeIdentity();

--- a/java/src/jmri/util/prefs/AbstractPreferencesManager.java
+++ b/java/src/jmri/util/prefs/AbstractPreferencesManager.java
@@ -24,20 +24,29 @@ public abstract class AbstractPreferencesManager extends Bean implements Prefere
     private final HashMap<Profile, Boolean> initializing = new HashMap<>();
     private final HashMap<Profile, List<Exception>> exceptions = new HashMap<>();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public boolean isInitialized(@Nonnull Profile profile) {
-        return this.initialized.getOrDefault(profile, false)
-                && this.exceptions.getOrDefault(profile, new ArrayList<>()).isEmpty();
+    public boolean isInitialized(Profile profile) {
+        return this.initialized.getOrDefault(profile, false) &&
+                this.exceptions.getOrDefault(profile, new ArrayList<>()).isEmpty();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public boolean isInitializedWithExceptions(@Nonnull Profile profile) {
-        return this.initialized.getOrDefault(profile, false)
-                && !this.exceptions.getOrDefault(profile, new ArrayList<>()).isEmpty();
+    public boolean isInitializedWithExceptions(Profile profile) {
+        return this.initialized.getOrDefault(profile, false) &&
+                !this.exceptions.getOrDefault(profile, new ArrayList<>()).isEmpty();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public List<Exception> getInitializationExceptions(@Nonnull Profile profile) {
+    public List<Exception> getInitializationExceptions(Profile profile) {
         return new ArrayList<>(this.exceptions.getOrDefault(profile, new ArrayList<>()));
     }
 
@@ -45,11 +54,12 @@ public abstract class AbstractPreferencesManager extends Bean implements Prefere
      * Test if the manager is being initialized.
      *
      * @param profile the profile against which the manager is being initialized
+     *                    or null if being initialized for this user regardless
+     *                    of profile
      * @return true if being initialized; false otherwise
      */
-    protected boolean isInitializing(@Nonnull Profile profile) {
-        return !this.initialized.getOrDefault(profile, false)
-                && this.initializing.getOrDefault(profile, false);
+    protected boolean isInitializing(Profile profile) {
+        return !this.initialized.getOrDefault(profile, false) && this.initializing.getOrDefault(profile, false);
     }
 
     /**
@@ -101,7 +111,7 @@ public abstract class AbstractPreferencesManager extends Bean implements Prefere
      * @param profile     the profile to set initialized against
      * @param initialized the initialized state to set
      */
-    protected void setInitialized(@Nonnull Profile profile, boolean initialized) {
+    protected void setInitialized(Profile profile, boolean initialized) {
         this.initialized.put(profile, initialized);
         if (initialized) {
             this.setInitializing(profile, false);
@@ -114,7 +124,7 @@ public abstract class AbstractPreferencesManager extends Bean implements Prefere
      * @param profile      the profile for which initializing is ongoing
      * @param initializing the initializing state to set
      */
-    protected void setInitializing(@Nonnull Profile profile, boolean initializing) {
+    protected void setInitializing(Profile profile, boolean initializing) {
         this.initializing.put(profile, initializing);
     }
 
@@ -122,10 +132,10 @@ public abstract class AbstractPreferencesManager extends Bean implements Prefere
      * Add an error to the list of exceptions.
      *
      * @param profile   the profile against which the manager is being
-     *                  initialized
+     *                      initialized
      * @param exception the exception to add
      */
-    protected void addInitializationException(@Nonnull Profile profile, @Nonnull Exception exception) {
+    protected void addInitializationException(Profile profile, @Nonnull Exception exception) {
         if (this.exceptions.get(profile) == null) {
             this.exceptions.put(profile, new ArrayList<>());
         }
@@ -142,19 +152,23 @@ public abstract class AbstractPreferencesManager extends Bean implements Prefere
      *
      * @param profile the profile against which the manager is being initialized
      * @param classes the manager classes for which all calling
-     *                {@link #isInitialized(jmri.profile.Profile)} must return
-     *                true against all instances of
+     *                    {@link #isInitialized(jmri.profile.Profile)} must
+     *                    return true against all instances of
      * @param message the localized message to display if an
-     *                InitializationExcpetion is thrown
+     *                    InitializationExcpetion is thrown
      * @throws InitializationException  if any instance of any class in classes
-     *                                  returns false on isIntialized(profile)
+     *                                      returns false on
+     *                                      isIntialized(profile)
      * @throws IllegalArgumentException if any member of classes is not also in
-     *                                  the set of classes returned by
-     *                                  {@link #getRequires()}
+     *                                      the set of classes returned by
+     *                                      {@link #getRequires()}
      */
-    protected void requiresNoInitializedWithExceptions(@Nonnull Profile profile, @Nonnull Set<Class<? extends PreferencesManager>> classes, @Nonnull String message) throws InitializationException {
+    protected void requiresNoInitializedWithExceptions(Profile profile,
+            @Nonnull Set<Class<? extends PreferencesManager>> classes, @Nonnull String message)
+            throws InitializationException {
         classes.stream().filter((clazz) -> (!this.getRequires().contains(clazz))).forEach((clazz) -> {
-            throw new IllegalArgumentException("Class " + clazz.getClass().getName() + " not marked as required by " + this.getClass().getName());
+            throw new IllegalArgumentException(
+                    "Class " + clazz.getClass().getName() + " not marked as required by " + this.getClass().getName());
         });
         for (Class<? extends PreferencesManager> clazz : classes) {
             for (PreferencesManager instance : InstanceManager.getList(clazz)) {
@@ -181,11 +195,13 @@ public abstract class AbstractPreferencesManager extends Bean implements Prefere
      *
      * @param profile the profile against which the manager is being initialized
      * @param message the localized message to display if an
-     *                InitializationExcpetion is thrown
+     *                    InitializationExcpetion is thrown
      * @throws InitializationException if any instance of any class in classes
-     *                                 returns false on isIntialized(profile)
+     *                                     returns false on
+     *                                     isIntialized(profile)
      */
-    protected void requiresNoInitializedWithExceptions(@Nonnull Profile profile, @Nonnull String message) throws InitializationException {
+    protected void requiresNoInitializedWithExceptions(Profile profile, @Nonnull String message)
+            throws InitializationException {
         this.requiresNoInitializedWithExceptions(profile, this.getRequires(), message);
     }
 }

--- a/java/src/jmri/web/servlet/about/AboutServlet.java
+++ b/java/src/jmri/web/servlet/about/AboutServlet.java
@@ -45,7 +45,7 @@ public class AboutServlet extends HttpServlet {
         response.setHeader("Connection", "Keep-Alive"); // NOI18N
         response.setContentType(UTF8_TEXT_HTML);
         Profile profile = ProfileManager.getDefault().getActiveProfile();
-        String profileName = profile.getName();
+        String profileName = profile != null ? profile.getName() : "";
         response.getWriter().print(String.format(request.getLocale(),
                 FileUtil.readURL(FileUtil.findURL(Bundle.getMessage(request.getLocale(), "About.html"))),
                 Bundle.getMessage(request.getLocale(), "AboutTitle"),                                   // page title is parm 1

--- a/java/test/apps/LaunchJmriAppBase.java
+++ b/java/test/apps/LaunchJmriAppBase.java
@@ -1,27 +1,23 @@
 package apps;
 
 import java.awt.GraphicsEnvironment;
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
 
-import org.apache.commons.io.*;
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.Rule;
-import org.junit.rules.Timeout;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
+
 import jmri.InstanceManager;
-import jmri.profile.ProfileManager;
 import jmri.managers.DefaultShutDownManager;
+import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
-import jmri.util.JUnitAppender;
 import jmri.util.junit.rules.RetryRule;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Base implementation for a test that launches and tests complete JMRI apps

--- a/java/test/jmri/managers/JmriUserPreferencesManagerTest.java
+++ b/java/test/jmri/managers/JmriUserPreferencesManagerTest.java
@@ -934,7 +934,9 @@ public class JmriUserPreferencesManagerTest {
         m1.setSimplePreferenceState(strClass, true);
         m1.setComboBoxLastSelection(strClass, "selection1");
         m1.setSaveAllowed(true);
-        File target = new File(new File(new File(ProfileManager.getDefault().getActiveProfile().getPath(), "profile"), NodeIdentity.storageIdentity()), "user-interface.xml");
+        Profile profile = ProfileManager.getDefault().getActiveProfile();
+        Assert.assertNotNull(profile); // test with profile
+        File target = new File(new File(new File(profile.getPath(), "profile"), NodeIdentity.storageIdentity()), "user-interface.xml");
         Assert.assertTrue(target.exists());
         Assert.assertTrue(target.isFile());
         if (log.isDebugEnabled()) {
@@ -974,7 +976,9 @@ public class JmriUserPreferencesManagerTest {
         m1.setSimplePreferenceState(strClass, true);
         m1.setComboBoxLastSelection(strClass, "selection1");
         m1.setSaveAllowed(true);
-        File target = new File(new File(new File(ProfileManager.getDefault().getActiveProfile().getPath(), "profile"), NodeIdentity.storageIdentity()), "user-interface.xml");
+        Profile profile = ProfileManager.getDefault().getActiveProfile();
+        Assert.assertNotNull(profile); // test with profile
+        File target = new File(new File(new File(profile.getPath(), "profile"), NodeIdentity.storageIdentity()), "user-interface.xml");
         Assert.assertTrue(target.exists());
         Assert.assertTrue(target.isFile());
         if (log.isDebugEnabled()) {

--- a/java/test/jmri/profile/ProfileListCellRendererTest.java
+++ b/java/test/jmri/profile/ProfileListCellRendererTest.java
@@ -34,6 +34,7 @@ public class ProfileListCellRendererTest {
         list.setToolTipText(null);
         ProfileListCellRenderer instance = new ProfileListCellRenderer();
         Profile activeProfile = ProfileManager.getDefault().getActiveProfile();
+        Assert.assertNotNull(activeProfile); // this tests a non-null active profile
         String noProfileMessage = Bundle.getMessage("ProfileManagerDialog.profiles.toolTipText");
         String activeProfileMessage = Bundle.getMessage("ProfileTableModel.toolTip", activeProfile.getName(), activeProfile.getPath(), activeProfile.getId(), "");
         // null profile, selected index

--- a/java/test/jmri/profile/ProfileManagerTest.java
+++ b/java/test/jmri/profile/ProfileManagerTest.java
@@ -72,12 +72,12 @@ public class ProfileManagerTest {
         
         // non-existant profile
         pm.setActiveProfile("NonExistantId");
-        Assert.assertFalse(pm.hasActiveProfile());
+        Assert.assertNull(pm.getActiveProfile());
         JUnitAppender.assertWarnMessage("Unable to set active profile.  No profile with id NonExistantId could be found.");
         // existant non-profile directory (real directory, but no profile)
         String folderName = folder.newFolder("non-profile").getAbsolutePath();
         pm.setActiveProfile(folderName);
-        Assert.assertFalse(pm.hasActiveProfile());
+        Assert.assertNull(pm.getActiveProfile());
         JUnitAppender.assertErrorMessage(folderName + " is not a profile folder.");
         JUnitAppender.assertWarnMessage("Unable to set active profile.  No profile with id " + folderName + " could be found.");
         // existant profile directory
@@ -86,7 +86,6 @@ public class ProfileManagerTest {
         FileUtil.copy(new File("java/test/jmri/profile/samples/ln-simulator"), profileFolder); // where is existing profile?
         pm.setActiveProfile(folderName);
         Profile p = new Profile(profileFolder);
-        Assert.assertTrue(pm.hasActiveProfile());
         Assert.assertEquals(p, pm.getActiveProfile());
     }
 

--- a/java/test/jmri/profile/ProfileManagerTest.java
+++ b/java/test/jmri/profile/ProfileManagerTest.java
@@ -31,20 +31,9 @@ public class ProfileManagerTest {
     @Test
     public void testSetActiveProfile_Profile() throws IOException {
         ProfileManager pm = new ProfileManager();
-        // expect this to throw exception because profile is null
-        boolean threw = false;
-        try {
-            // null profile
-            pm.setActiveProfile((Profile) null);
-        } catch (IllegalArgumentException ex) {
-            if (ex.getMessage().equals("profile is null")) {
-                threw = true;
-            } else {
-                Assert.fail("failed to set profile due to wrong reason: " + ex);
-            }
-        }
-        Assert.assertTrue("Expected exception IllegalArgumentException", threw);
-        
+        // null profile
+        pm.setActiveProfile((Profile) null);
+        Assert.assertNull(pm.getActiveProfile());
         // non-null profile
         File profileFolder = new File(folder.newFolder(Profile.PROFILE), "test");
         NullProfile p = new NullProfile("test", "test", profileFolder);
@@ -56,20 +45,9 @@ public class ProfileManagerTest {
     @Test
     public void testSetActiveProfile_String() throws IOException {
         ProfileManager pm = new ProfileManager();
-        // expect this to throw exception because identifier is null
-        boolean threw = false;
-        try {
-            // null profile
-            pm.setActiveProfile((String) null);
-        } catch (IllegalArgumentException ex) {
-            if (ex.getMessage().equals("identifier is null")) {
-                threw = true;
-            } else {
-                Assert.fail("failed to set profile due to wrong reason: " + ex);
-            }
-        }
-        Assert.assertTrue("Expected exception IllegalArgumentException", threw);
-        
+        // null profile
+        pm.setActiveProfile((String) null);
+        Assert.assertNull(pm.getActiveProfile());
         // non-existant profile
         pm.setActiveProfile("NonExistantId");
         Assert.assertNull(pm.getActiveProfile());
@@ -86,6 +64,7 @@ public class ProfileManagerTest {
         FileUtil.copy(new File("java/test/jmri/profile/samples/ln-simulator"), profileFolder); // where is existing profile?
         pm.setActiveProfile(folderName);
         Profile p = new Profile(profileFolder);
+        Assert.assertNotNull(pm.getActiveProfile());
         Assert.assertEquals(p, pm.getActiveProfile());
     }
 

--- a/java/test/jmri/swing/JmriJTablePersistenceManagerTest.java
+++ b/java/test/jmri/swing/JmriJTablePersistenceManagerTest.java
@@ -367,7 +367,7 @@ public class JmriJTablePersistenceManagerTest {
         String name1 = "Test1";
         String name2 = "Test2";
         Profile profile = ProfileManager.getDefault().getActiveProfile();
-        Assume.assumeNotNull(profile);
+        Assert.assertNotNull(profile); // test requires non-null profile
         // copy preferences into profile
         File source = new File(ClassLoader.getSystemResource("jmri/swing/JmriJTablePersistenceManagerTest-user-interface.xml").toURI());
         File target = new File(new File(new File(profile.getPath(), Profile.PROFILE), NodeIdentity.storageIdentity()), Profile.UI_CONFIG);


### PR DESCRIPTION
The Active profile can be null, and is, by design, null at certain points when a JMRI application is running. This completes the reversion of #5604 started in #6059.