### PR TITLE
fix: Allow VS Code Java Tester to function

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,16 @@
 {
     "java.configuration.updateBuildConfiguration": "automatic",
-    "java.dependency.packagePresentation": "hierarchical"
+    "java.dependency.packagePresentation": "hierarchical",
+    "java.test.config": [
+        {
+            "name": "JMRI",
+            "workingDirectory": "${workspaceFolder}",
+            "env": {
+                "user.language": "en",
+                "user.region": "US",
+                "jmri.prefsdir": "${workspaceFolder}/temp"
+            }
+        }
+    ],
+    "java.test.defaultConfig": "JMRI"
 }


### PR DESCRIPTION
This fixes in-IDE unit testing in Visual Studio Code after #7105 broke it.