### PR TITLE
Change AnalogIO to use double instead of float

### DIFF
--- a/java/src/jmri/AnalogIO.java
+++ b/java/src/jmri/AnalogIO.java
@@ -51,7 +51,7 @@ public interface AnalogIO extends NamedBean {
      *                                  Float.NEGATIVE_INFINITY or
      *                                  Float.POSITIVE_INFINITY
      */
-    public void setCommandedAnalogValue(float value) throws JmriException;
+    public void setCommandedAnalogValue(double value) throws JmriException;
 
     /**
      * Query the commanded value. This is a bound parameter, so you can also
@@ -61,7 +61,7 @@ public interface AnalogIO extends NamedBean {
      *
      * @return the analog value
      */
-    public float getCommandedAnalogValue();
+    public double getCommandedAnalogValue();
     
     /**
      * Query the known analog value. This is a bound parameter, so you can also
@@ -73,24 +73,24 @@ public interface AnalogIO extends NamedBean {
      *
      * @return the known analog value
      */
-    default public float getKnownAnalogValue() {
+    default public double getKnownAnalogValue() {
         return getCommandedAnalogValue();
     }
     
     /**
      * Get the minimum value of this AnalogIO.
      */
-    public float getMin();
+    public double getMin();
     
     /**
      * Get the maximum value of this AnalogIO.
      */
-    public float getMax();
+    public double getMax();
     
     /**
      * Get the resloution of this AnalogIO.
      */
-    public float getResolution();
+    public double getResolution();
 
     /**
      * Is this AnalogIO absolute or relative?

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -132,7 +132,7 @@ public interface NamedBean extends Comparable<NamedBean>, PropertyChangeProvider
 
     /**
      * Get a fully formatted display that includes the SystemName and,
-     * if set, the UserName”.
+     * if set, the UserName.
      * <p>
      * This is the same as calling
      * {@link #getFullyFormattedDisplayName(boolean)} with the parameter true.

--- a/java/src/jmri/implementation/AbstractLight.java
+++ b/java/src/jmri/implementation/AbstractLight.java
@@ -271,7 +271,7 @@ public abstract class AbstractLight extends AbstractNamedBean
         mMaxIntensity = intensity;
 
         if (oldValue != intensity) {
-            firePropertyChange("MaxIntensity", Double.valueOf(oldValue), Double.valueOf(intensity));
+            firePropertyChange("MaxIntensity", oldValue, intensity);
         }
     }
 
@@ -439,7 +439,7 @@ public abstract class AbstractLight extends AbstractNamedBean
         double oldValue = mCurrentIntensity;
         mCurrentIntensity = intensity;
         if (oldValue != intensity) {
-            firePropertyChange("TargetIntensity", Double.valueOf(oldValue), Double.valueOf(intensity));
+            firePropertyChange("TargetIntensity", oldValue, intensity);
         }
     }
 
@@ -531,8 +531,8 @@ public abstract class AbstractLight extends AbstractNamedBean
     }
 
     @Override
-    public void setCommandedAnalogValue(float value) throws JmriException {
-        float middle = (getMax() - getMin()) / 2 + getMin();
+    public void setCommandedAnalogValue(double value) throws JmriException {
+        double middle = (getMax() - getMin()) / 2 + getMin();
         
         if (value > middle) {
             setCommandedState(ON);
@@ -542,24 +542,24 @@ public abstract class AbstractLight extends AbstractNamedBean
     }
 
     @Override
-    public float getCommandedAnalogValue() {
-        return (float) getCurrentIntensity();
+    public double getCommandedAnalogValue() {
+        return getCurrentIntensity();
     }
 
     @Override
-    public float getMin() {
-        return (float) getMinIntensity();
+    public double getMin() {
+        return getMinIntensity();
     }
 
     @Override
-    public float getMax() {
-        return (float) getMaxIntensity();
+    public double getMax() {
+        return getMaxIntensity();
     }
 
     @Override
-    public float getResolution() {
+    public double getResolution() {
         // AbstractLight is by default only ON or OFF
-        return (float) (getMaxIntensity() - getMinIntensity());
+        return (getMaxIntensity() - getMinIntensity());
     }
 
     @Override

--- a/java/src/jmri/implementation/AbstractVariableLight.java
+++ b/java/src/jmri/implementation/AbstractVariableLight.java
@@ -415,7 +415,7 @@ public abstract class AbstractVariableLight extends AbstractLight {
     }
 
     @Override
-    public void setCommandedAnalogValue(float value) throws JmriException {
+    public void setCommandedAnalogValue(double value) throws JmriException {
         int origState = mState;
         double origCurrent = mCurrentIntensity;
         
@@ -455,8 +455,8 @@ public abstract class AbstractVariableLight extends AbstractLight {
     }
 
     @Override
-    public float getResolution() {
-        return (float) 1.0 / getNumberOfSteps();
+    public double getResolution() {
+        return 1.0 / getNumberOfSteps();
     }
 
 }

--- a/java/test/jmri/AnalogIOTest.java
+++ b/java/test/jmri/AnalogIOTest.java
@@ -12,8 +12,8 @@ public class AnalogIOTest {
 
     @Test
     public void testAnalogIO() throws JmriException {
-        float min = (float) -1.0;
-        float max = (float) 1.0;
+        double min = -1.0;
+        double max = 1.0;
         AnalogIO analogIO = new MyAnalogIO("Analog");
         analogIO.setCommandedAnalogValue(min);
         Assert.assertTrue("AnalogIO has value -1.0", analogIO.getCommandedAnalogValue() == min);
@@ -43,7 +43,7 @@ public class AnalogIOTest {
     
     private class MyAnalogIO extends AbstractNamedBean implements AnalogIO {
 
-        float _value = (float) 0.0;
+        double _value = 0.0;
         
         public MyAnalogIO(String sys) {
             super(sys);
@@ -65,28 +65,28 @@ public class AnalogIOTest {
         }
 
         @Override
-        public void setCommandedAnalogValue(float value) throws JmriException {
+        public void setCommandedAnalogValue(double value) throws JmriException {
             _value = value;
         }
 
         @Override
-        public float getCommandedAnalogValue() {
+        public double getCommandedAnalogValue() {
             return _value;
         }
 
         @Override
-        public float getMin() {
+        public double getMin() {
             return Float.MIN_VALUE;
         }
 
         @Override
-        public float getMax() {
+        public double getMax() {
             return Float.MAX_VALUE;
         }
 
         @Override
-        public float getResolution() {
-            return (float) 0.1;
+        public double getResolution() {
+            return 0.1;
         }
 
         @Override


### PR DESCRIPTION
When I created the AnalogIO interface, I thought that float is enough. But I have later realized that it would be better if AnalogIO uses double instead of float.

This changes the public interface of AnalogIO, but since AnalogIO is added lately, it's probably nobody using it outside of JMRI yet.