### PR TITLE
feat: Remove, with immediate effect, system name normalization

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -382,7 +382,12 @@
     <h3>Turnouts, Lights, Sensors and other elements</h3>
         <a id="TLae" name="TLae"></a>
         <ul>
-            <li></li>
+            <li>JMRI no longer modifies "system names" as provided by the user.
+                There may be cases where a script or panel file is creating an
+                object with a system name that is slightly different than a system
+                name used elsewhere, and JMRI used to change these to be the same.
+                Users may have to modify scripts and panel files to ensure system
+                names match in all places.</li>
         </ul>
 
     <h3>Scripting</h3>

--- a/help/en/releasenotes/current-draft-warnings.shtml
+++ b/help/en/releasenotes/current-draft-warnings.shtml
@@ -1,4 +1,8 @@
 
     <!-- contains new warnings for the release under development -->
 
-    <li>None yet</li>
+    <li>JMRI no longer modifies "system names" as provided by the user. There may
+        be cases where a script or panel file is creating an object with a system
+        name that is slightly different than a system name used elsewhere, and
+        JMRI used to change these to be the same. Users may have to modify scripts
+        and panel files to ensure system names match in all places.</li>

--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -221,22 +221,6 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * Forces upper case and trims leading and trailing whitespace.
-     * The IB prefix is added if necessary.
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        if (inputName.length() < 3 || !inputName.startsWith("IB")) {
-            inputName = "IB" + inputName;
-        }
-        return inputName.toUpperCase().trim();
-    }
-
-    /**
      * @return the default BlockManager instance
      * @deprecated since 4.9.1; use
      * {@link InstanceManager#getDefault(Class)} instead

--- a/java/src/jmri/LightManager.java
+++ b/java/src/jmri/LightManager.java
@@ -1,6 +1,5 @@
 package jmri;
 
-import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -129,25 +128,6 @@ public interface LightManager extends ProvidingManager<Light> {
      */
     @CheckReturnValue
     public boolean validSystemNameConfig(@Nonnull String systemName);
-
-    /**
-     * Normalize the system name.
-     * <p>
-     * This routine is used to ensure that each system name is uniquely linked
-     * to one C/MRI bit, by removing extra zeros inserted by the user.
-     * <p>
-     * This routine is implemented in AbstractLightManager to return the same
-     * name. If a system implementation has names that could be normalized, the
-     * system-specific Light Manager should override this routine and supply a
-     * normalized system name.
-     *
-     * @param systemName the system name to normalize
-     * @return the normalized system name
-     */
-    @CheckReturnValue
-    @Nonnull
-    @Override
-    public String normalizeSystemName(@Nonnull String systemName);
 
     /**
      * Convert the system name to a normalized alternate name.

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -75,6 +75,9 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
     }
 
     /**
+     * Create a SystemName by prepending the system name prefix to the name if
+     * not already present.
+     * 
      * @param name the item to make the system name for
      * @return A system name from a user input, typically a number.
      * @throws IllegalArgumentException if a valid name can't be created

--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -407,19 +407,6 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
     public String getBeanTypeHandled();
 
     /**
-     * Enforces, and as a user convenience converts to, the standard form for a
-     * system name for the NamedBeans handled by this manager.
-     *
-     * @param inputName System name to be normalized
-     * @throws NamedBean.BadSystemNameException If the inputName can't be
-     *                                          converted to normalized form
-     * @return A system name in standard normalized form
-     */
-    @CheckReturnValue
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException;
-
-    /**
      * Provides length of the system prefix of the given system name.
      * <p>
      * This is a common operation across JMRI, as the system prefix can be

--- a/java/src/jmri/SectionManager.java
+++ b/java/src/jmri/SectionManager.java
@@ -10,10 +10,6 @@ import jmri.managers.AbstractManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-
 /**
  * Basic Implementation of a SectionManager.
  * <p>
@@ -162,20 +158,6 @@ public class SectionManager extends AbstractManager<Section> implements Property
 
     public Section getByUserName(String key) {
         return _tuser.get(key);
-    }
-
-    /**
-     * {@inheritDoc}
-     * 
-     * Forces upper case and trims leading and trailing whitespace.
-     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
-        return inputName.toUpperCase().trim();
     }
 
     /**

--- a/java/src/jmri/TransitManager.java
+++ b/java/src/jmri/TransitManager.java
@@ -3,12 +3,7 @@ package jmri;
 import java.beans.PropertyChangeListener;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
-import java.util.List;
 import jmri.managers.AbstractManager;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 
 /**
  * Implementation of a Transit Manager
@@ -153,20 +148,6 @@ public class TransitManager extends AbstractManager<Transit> implements Property
 
     public Transit getByUserName(String key) {
         return _tuser.get(key);
-    }
-
-    /**
-     * {@inheritDoc}
-     * 
-     * Forces upper case and trims leading and trailing whitespace.
-     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
-        return inputName.toUpperCase().trim();
     }
 
     /**

--- a/java/src/jmri/implementation/AbstractSensor.java
+++ b/java/src/jmri/implementation/AbstractSensor.java
@@ -19,11 +19,11 @@ public abstract class AbstractSensor extends AbstractNamedBean implements Sensor
 
     // ctor takes a system-name string for initialization
     public AbstractSensor(String systemName) {
-        super(systemName.toUpperCase());
+        super(systemName);
     }
 
     public AbstractSensor(String systemName, String userName) {
-        super(systemName.toUpperCase(), userName);
+        super(systemName, userName);
     }
 
     @Override

--- a/java/src/jmri/jmrit/beantable/BlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/BlockTableAction.java
@@ -1029,7 +1029,6 @@ public class BlockTableAction extends AbstractTableAction<Block> {
 
         String system = sysName.getText();
         String sName = system; // keep result separate to prevent recursive manipulation
-        sName = InstanceManager.getDefault(BlockManager.class).normalizeSystemName(sName);
         // initial check for empty entry using the raw name
         if (sName.length() < 3 && !_autoSystemNameCheckBox.isSelected()) {  // Using 3 to catch a plain IB
             statusBar.setText(Bundle.getMessage("WarningSysNameEmpty"));

--- a/java/src/jmri/jmrit/beantable/BlockTableAction.java
+++ b/java/src/jmri/jmrit/beantable/BlockTableAction.java
@@ -1027,7 +1027,7 @@ public class BlockTableAction extends AbstractTableAction<Block> {
         }
         String uName = user; // keep result separate to prevent recursive manipulation
 
-        String system = sysName.getText();
+        String system = InstanceManager.getDefault(jmri.BlockManager.class).makeSystemName(sysName.getText());
         String sName = system; // keep result separate to prevent recursive manipulation
         // initial check for empty entry using the raw name
         if (sName.length() < 3 && !_autoSystemNameCheckBox.isSelected()) {  // Using 3 to catch a plain IB

--- a/java/src/jmri/jmrit/beantable/LightTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LightTableAction.java
@@ -953,8 +953,7 @@ public class LightTableAction extends AbstractTableAction<Light> {
         } else {
             hardwareAddressTextField.setBackground(Color.white);
         }
-        // Format is valid, normalize it
-        String sName = InstanceManager.getDefault(LightManager.class).normalizeSystemName(suName);
+        String sName = suName;
         // check if a Light with this name already exists
         Light g = InstanceManager.getDefault(LightManager.class).getBySystemName(sName);
         if (g != null) {
@@ -1008,8 +1007,6 @@ public class LightTableAction extends AbstractTableAction<Light> {
         }
         // check if requested Light uses the same address as a Turnout
         String testSN = turnoutPrefix + curAddress;
-        // normalize name before test to compare the string used as Light system name, normalized above
-        testSN = InstanceManager.turnoutManagerInstance().normalizeSystemName(testSN);
         Turnout testT = InstanceManager.turnoutManagerInstance().
                 getBySystemName(testSN);
         if (testT != null) {
@@ -1153,7 +1150,7 @@ public class LightTableAction extends AbstractTableAction<Light> {
     void editPressed() {
         // check if a Light with this name already exists
         String suName = fixedSystemName.getText();
-        String sName = InstanceManager.getDefault(LightManager.class).normalizeSystemName(suName);
+        String sName = suName;
         if (sName.isEmpty()) {
             // Entered system name has invalid format
             status1.setText(Bundle.getMessage("LightError3"));
@@ -1873,9 +1870,7 @@ public class LightTableAction extends AbstractTableAction<Light> {
                     if (t == null) {
                         // not user name, try system name
                         t = InstanceManager.turnoutManagerInstance().
-                                getBySystemName(
-                                    InstanceManager.getDefault(jmri.TurnoutManager.class).normalizeSystemName(turnoutName)
-                                );
+                                getBySystemName(turnoutName);
                         if (t != null) {
                             // update turnout system name in case it changed
                             turnoutName = t.getSystemName();

--- a/java/src/jmri/jmrit/beantable/LogixTableAction.java
+++ b/java/src/jmri/jmrit/beantable/LogixTableAction.java
@@ -1088,7 +1088,7 @@ public class LogixTableAction extends AbstractTableAction<Logix> {
      * @return false if name has length &lt; 1 after displaying a dialog
      */
     boolean checkLogixSysName() {
-        String sName = InstanceManager.getDefault(LogixManager.class).normalizeSystemName(_systemName.getText());
+        String sName = _systemName.getText();
         if ((sName.length() < 1)) {
             // Entered system name is blank or too short
             JOptionPane.showMessageDialog(addLogixFrame,

--- a/java/src/jmri/jmrit/beantable/MemoryTableAction.java
+++ b/java/src/jmri/jmrit/beantable/MemoryTableAction.java
@@ -228,7 +228,7 @@ public class MemoryTableAction extends AbstractTableAction<Memory> {
         if (uName == null || uName.isEmpty()) {
             uName = null;
         }
-        String sName = jmri.InstanceManager.memoryManagerInstance().normalizeSystemName(sysNameField.getText());
+        String sName = sysNameField.getText();
         // initial check for empty entry
         if (sName.isEmpty() && !autoSystemNameBox.isSelected()) {
             statusBarLabel.setText(Bundle.getMessage("WarningSysNameEmpty"));

--- a/java/src/jmri/jmrit/beantable/RouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableAction.java
@@ -950,7 +950,6 @@ public class RouteTableAction extends AbstractTableAction<Route> {
             }
         }
         // check if a Route with this system name already exists
-        sName = InstanceManager.getDefault(jmri.RouteManager.class).normalizeSystemName(sName);
         g = InstanceManager.getDefault(jmri.RouteManager.class).getBySystemName(sName);
         if (g != null) {
             // Route already exists
@@ -982,7 +981,6 @@ public class RouteTableAction extends AbstractTableAction<Route> {
                 return null;
             }
             try {
-                sName = InstanceManager.getDefault(jmri.RouteManager.class).normalizeSystemName(sName);
                 g = InstanceManager.getDefault(jmri.RouteManager.class).provideRoute(sName, uName);
             } catch (IllegalArgumentException ex) {
                 g = null; // for later check

--- a/java/src/jmri/jmrit/beantable/RouteTableAction.java
+++ b/java/src/jmri/jmrit/beantable/RouteTableAction.java
@@ -950,6 +950,7 @@ public class RouteTableAction extends AbstractTableAction<Route> {
             }
         }
         // check if a Route with this system name already exists
+        sName = InstanceManager.getDefault(jmri.RouteManager.class).makeSystemName(sName);
         g = InstanceManager.getDefault(jmri.RouteManager.class).getBySystemName(sName);
         if (g != null) {
             // Route already exists
@@ -981,6 +982,7 @@ public class RouteTableAction extends AbstractTableAction<Route> {
                 return null;
             }
             try {
+                sName = InstanceManager.getDefault(jmri.RouteManager.class).makeSystemName(sName);
                 g = InstanceManager.getDefault(jmri.RouteManager.class).provideRoute(sName, uName);
             } catch (IllegalArgumentException ex) {
                 g = null; // for later check

--- a/java/src/jmri/jmrit/beantable/SectionTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SectionTableAction.java
@@ -717,7 +717,7 @@ public class SectionTableAction extends AbstractTableAction<Section> {
         }
 
         // attempt to create the new Section
-        String sName = InstanceManager.getDefault(jmri.SectionManager.class).normalizeSystemName(sysName.getText()); // N11N
+        String sName = sysName.getText();
         try {
             if (_autoSystemName.isSelected()) {
                 curSection = sectionManager.createNewSection(uName);

--- a/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
@@ -865,6 +865,7 @@ public class SignalGroupTableAction extends AbstractTableAction<SignalGroup> imp
             }
         }
         // check if a SignalGroup with this system name already exists
+        sName = InstanceManager.getDefault(SignalGroupManager.class).makeSystemName(sName);
         g = InstanceManager.getDefault(SignalGroupManager.class).getBySystemName(sName);
         if (g != null) {
             // SignalGroup already exists
@@ -915,6 +916,7 @@ public class SignalGroupTableAction extends AbstractTableAction<SignalGroup> imp
                 return null;
             }
             try {
+                sName = InstanceManager.getDefault(SignalGroupManager.class).makeSystemName(sName);
                 g = InstanceManager.getDefault(SignalGroupManager.class).provideSignalGroup(sName, uName);
             } catch (IllegalArgumentException ex) {
                 log.error("checkNamesOK; Unknown failure to create Signal Group with System Name: {}", sName); // NOI18N
@@ -1033,7 +1035,7 @@ public class SignalGroupTableAction extends AbstractTableAction<SignalGroup> imp
      */
     void editPressed(ActionEvent e) {
         // identify the Signal Group with this name if it already exists
-        String sName = _systemName.getText();
+        String sName = InstanceManager.getDefault(SignalGroupManager.class).makeSystemName(_systemName.getText());
         // sName is already filled in from the Signal Group table by addPressed()
         SignalGroup g = InstanceManager.getDefault(SignalGroupManager.class).getBySystemName(sName);
         if (g == null) {

--- a/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalGroupTableAction.java
@@ -865,7 +865,6 @@ public class SignalGroupTableAction extends AbstractTableAction<SignalGroup> imp
             }
         }
         // check if a SignalGroup with this system name already exists
-        sName = InstanceManager.getDefault(SignalGroupManager.class).normalizeSystemName(sName);
         g = InstanceManager.getDefault(SignalGroupManager.class).getBySystemName(sName);
         if (g != null) {
             // SignalGroup already exists
@@ -916,7 +915,6 @@ public class SignalGroupTableAction extends AbstractTableAction<SignalGroup> imp
                 return null;
             }
             try {
-                sName = InstanceManager.getDefault(SignalGroupManager.class).normalizeSystemName(sName);
                 g = InstanceManager.getDefault(SignalGroupManager.class).provideSignalGroup(sName, uName);
             } catch (IllegalArgumentException ex) {
                 log.error("checkNamesOK; Unknown failure to create Signal Group with System Name: {}", sName); // NOI18N
@@ -1035,7 +1033,7 @@ public class SignalGroupTableAction extends AbstractTableAction<SignalGroup> imp
      */
     void editPressed(ActionEvent e) {
         // identify the Signal Group with this name if it already exists
-        String sName = InstanceManager.getDefault(SignalGroupManager.class).normalizeSystemName(_systemName.getText());
+        String sName = _systemName.getText();
         // sName is already filled in from the Signal Group table by addPressed()
         SignalGroup g = InstanceManager.getDefault(SignalGroupManager.class).getBySystemName(sName);
         if (g == null) {

--- a/java/src/jmri/jmrit/beantable/SignalHeadTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalHeadTableAction.java
@@ -1172,12 +1172,10 @@ public class SignalHeadTableAction extends AbstractTableAction<SignalHead> {
     }
 
     private boolean checkBeforeCreating(String sysName) {
-        String sName;
         if (dccSignalDecoder.equals(typeBox.getSelectedItem())) {
-            sName = sysName;
             try {
                 Integer.parseInt(sysName.substring(sysName.indexOf("$") + 1, sysName.length()));
-            } catch (Exception ex) {
+            } catch (NumberFormatException ex) {
                 String msg = Bundle.getMessage("ShouldBeNumber", new Object[]{"Hardware Address"});
                 JOptionPane.showMessageDialog(addFrame, msg,
                         Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
@@ -1186,35 +1184,34 @@ public class SignalHeadTableAction extends AbstractTableAction<SignalHead> {
             }
 
         } else {
-            sName = InstanceManager.getDefault(SignalHeadManager.class).normalizeSystemName(sysName);
 
             boolean ok = true;
             try {
-                int i = jmri.Manager.getSystemPrefixLength(sName);
-                if (sName.length() < i+2) {
+                int i = jmri.Manager.getSystemPrefixLength(sysName);
+                if (sysName.length() < i+2) {
                     ok = false;
                 } else {
-                    if (!sName.substring(i, i+1).equals("H")) ok = false;
+                    if (!sysName.substring(i, i+1).equals("H")) ok = false;
                 }
             } catch (NamedBean.BadSystemNameException e) {
                 ok = false;
             }
             if (!ok) {
-                String msg = Bundle.getMessage("InvalidSignalSystemName", new Object[]{sName});
+                String msg = Bundle.getMessage("InvalidSignalSystemName", new Object[]{sysName});
                 JOptionPane.showMessageDialog(addFrame, msg,
                         Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
                 return false;
             }
         }
         // check for pre-existing signal head with same system name
-        SignalHead s = InstanceManager.getDefault(jmri.SignalHeadManager.class).getBySystemName(sName);
+        SignalHead s = InstanceManager.getDefault(jmri.SignalHeadManager.class).getBySystemName(sysName);
         // return true if signal head does not exist
         if (s == null) {
             //Need to check that the Systemname doesn't already exists as a UserName
-            SignalHead nB = InstanceManager.getDefault(jmri.SignalHeadManager.class).getByUserName(sName);
+            SignalHead nB = InstanceManager.getDefault(jmri.SignalHeadManager.class).getByUserName(sysName);
             if (nB != null) {
-                log.error("System name is not unique " + sName + " It already exists as a User name");
-                String msg = Bundle.getMessage("WarningSystemNameAsUser", new Object[]{("" + sName)});
+                log.error("System name is not unique " + sysName + " It already exists as a User name");
+                String msg = Bundle.getMessage("WarningSystemNameAsUser", new Object[]{("" + sysName)});
                 JOptionPane.showMessageDialog(editFrame, msg,
                         Bundle.getMessage("WarningTitle"),
                         JOptionPane.ERROR_MESSAGE);
@@ -1223,8 +1220,8 @@ public class SignalHeadTableAction extends AbstractTableAction<SignalHead> {
             return true;
         }
         // inform the user if signal head already exists, and return false so creation can be bypassed
-        log.warn("Attempt to create signal with duplicate system name " + sName);
-        String msg = Bundle.getMessage("DuplicateSignalSystemName", new Object[]{sName});
+        log.warn("Attempt to create signal with duplicate system name " + sysName);
+        String msg = Bundle.getMessage("DuplicateSignalSystemName", new Object[]{sysName});
         JOptionPane.showMessageDialog(addFrame, msg,
                 Bundle.getMessage("WarningTitle"), JOptionPane.ERROR_MESSAGE);
         return false;
@@ -1281,7 +1278,7 @@ public class SignalHeadTableAction extends AbstractTableAction<SignalHead> {
                 handleSE8cOkPressed();
             } else if (acelaAspect.equals(typeBox.getSelectedItem())) {
                 String inputusername = userNameTextField.getText();
-                String inputsysname = InstanceManager.getDefault(SignalHeadManager.class).normalizeSystemName(ato1TextField.getText());
+                String inputsysname = ato1TextField.getText();
                 int headnumber;
                 //int aspecttype;
 
@@ -1349,7 +1346,7 @@ public class SignalHeadTableAction extends AbstractTableAction<SignalHead> {
                     log.warn("must supply a signalhead number (i.e. GH23)");
                     return;
                 }
-                String inputsysname = InstanceManager.getDefault(SignalHeadManager.class).normalizeSystemName(systemNameTextField.getText());
+                String inputsysname = systemNameTextField.getText();
                 int offset = jmri.Manager.getSystemPrefixLength(inputsysname);
                 if (!inputsysname.substring(0, 1).equals("G") || !inputsysname.substring(offset, offset + 1).equals("H")) { // TODO add real check for G123H
                     log.warn("skipping creation of signal head, '{}' does not start with GxH", inputsysname);

--- a/java/src/jmri/jmrit/beantable/TransitTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TransitTableAction.java
@@ -1296,7 +1296,7 @@ public class TransitTableAction extends AbstractTableAction<Transit> {
         if (_autoSystemName.isSelected()) {
             curTransit = transitManager.createNewTransit(uName);
         } else {
-            String sName = InstanceManager.getDefault(jmri.TransitManager.class).normalizeSystemName(sysName.getText());
+            String sName = sysName.getText();
             curTransit = transitManager.createNewTransit(sName, uName);
         }
         if (curTransit == null) {

--- a/java/src/jmri/jmrit/entryexit/EntryExitPairs.java
+++ b/java/src/jmri/jmrit/entryexit/EntryExitPairs.java
@@ -272,20 +272,6 @@ public class EntryExitPairs implements jmri.Manager<DestinationPoints>, jmri.Ins
         return NameValidity.VALID;
     }
 
-    /**
-     * Enforces, and as a user convenience converts to, the standard form for a system name
-     * for the NamedBeans handled by this manager.
-     *
-     * @param inputName System name to be normalized
-     * @throws NamedBean.BadSystemNameException If the inputName can't be converted to normalized form
-     * @return A system name in standard normalized form
-     */
-    @Override
-    @CheckReturnValue
-    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
-        return inputName;
-    }
-
     /** {@inheritDoc} */
     @Override
     @CheckReturnValue

--- a/java/src/jmri/jmrit/picker/PickSinglePanel.java
+++ b/java/src/jmri/jmrit/picker/PickSinglePanel.java
@@ -120,7 +120,7 @@ public class PickSinglePanel<T extends NamedBean> extends JPanel {
     }
 
     void addToTable() {
-        String sysname = _model.getManager().normalizeSystemName(_sysNametext.getText());
+        String sysname = _sysNametext.getText();
         if (sysname.length() > 1) {
             String uname = NamedBean.normalizeUserName(_userNametext.getText());
             if (uname != null && uname.trim().length() == 0) {

--- a/java/src/jmri/jmrix/acela/AcelaLightManager.java
+++ b/java/src/jmri/jmrix/acela/AcelaLightManager.java
@@ -90,17 +90,6 @@ public class AcelaLightManager extends AbstractLightManager {
     }
 
     /**
-     * Public method to normalize a system name.
-     *
-     * @return a normalized system name if system name has a valid format,
-     * else return ""
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        return (AcelaAddress.normalizeSystemName(systemName, getSystemPrefix()));
-    }
-
-    /**
      * Public method to convert system name to its alternate format.
      *
      * @return a normalized system name if system name is valid and has a valid

--- a/java/src/jmri/jmrix/acela/AcelaSensorManager.java
+++ b/java/src/jmri/jmrix/acela/AcelaSensorManager.java
@@ -46,8 +46,8 @@ public class AcelaSensorManager extends jmri.managers.AbstractSensorManager
     @Override
     public Sensor createNewSensor(String systemName, String userName) {
         Sensor s;
-        // validate the system name, and normalize it
-        String sName = normalizeSystemName(systemName);
+        // TODO: validate the system name
+        String sName = systemName;
         if (sName.equals("")) {
             // system name is not valid
             log.error("Invalid Acela Sensor system name: {}", systemName);
@@ -104,17 +104,6 @@ public class AcelaSensorManager extends jmri.managers.AbstractSensorManager
     @Override
     public NameValidity validSystemNameFormat(String systemName) {
         return (AcelaAddress.validSystemNameFormat(systemName, 'S', getSystemPrefix()));
-    }
-
-    /**
-     * Public method to normalize a system name.
-     *
-     * @return a normalized system name if system name has a valid format,
-     * else return ""
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        return (AcelaAddress.normalizeSystemName(systemName, getSystemPrefix()));
     }
 
     /**

--- a/java/src/jmri/jmrix/acela/AcelaTurnoutManager.java
+++ b/java/src/jmri/jmrix/acela/AcelaTurnoutManager.java
@@ -97,17 +97,6 @@ public class AcelaTurnoutManager extends AbstractTurnoutManager {
     }
 
     /**
-     * Public method to normalize a system name.
-     *
-     * @return a normalized system name if system name has a valid format, else
-     * return "" (empty string)
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        return (AcelaAddress.normalizeSystemName(systemName, getSystemPrefix()));
-    }
-
-    /**
      * Public method to convert system name to its alternate format
      * <p>
      * Returns a normalized system name if system name is valid and has a valid

--- a/java/src/jmri/jmrix/anyma/UsbLightManager.java
+++ b/java/src/jmri/jmrix/anyma/UsbLightManager.java
@@ -98,19 +98,6 @@ public class UsbLightManager extends AbstractLightManager {
     }
 
     /**
-     * Public method to normalize a system name.
-     *
-     * @param systemName the system name to normalize
-     * @return a normalized system name if system name has a valid format, else
-     *         returns ""
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        log.debug("*    UsbLightManager.normalizeSystemName() called");
-        return _memo.normalizeSystemName(systemName);
-    }
-
-    /**
      * Public method to convert system name to its alternate format
      *
      * @param systemName the system name to convert

--- a/java/src/jmri/jmrix/can/cbus/CbusLightManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusLightManager.java
@@ -46,8 +46,7 @@ public class CbusLightManager extends AbstractLightManager {
      */
     @Override
     @Nonnull
-    public Light provideLight(@Nonnull String key) {
-        String name = normalizeSystemName(key);
+    public Light provideLight(@Nonnull String name) {
         //log.debug("passed name {}", name);
         Light result = getLight(name);
         if (result == null) {
@@ -146,34 +145,7 @@ public class CbusLightManager extends AbstractLightManager {
     @Override
     @CheckForNull
     public Light getBySystemName(@Nonnull String key ) {
-        String name = normalizeSystemName(key);
-        return _tsys.get(name);
-    }
-
-    /**
-     * {@inheritDoc}
-     * 
-     * Forces upper case and trims leading and trailing whitespace, adding +/- if not present.
-     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        String address = inputName.toUpperCase().trim();
-        // check Cbus hardware address parts
-        if ((!address.startsWith(prefix + typeLetter()) || (address.length() < prefix.length() + 2))) {
-            return address;
-        }
-        try {
-            log.debug("Normalize address = {}", address);
-            address = CbusAddress.validateSysName(address.substring(prefix.length() + 1));
-        } catch (IllegalArgumentException e){
-            return address;
-        } catch (StringIndexOutOfBoundsException e){
-            return address;
-        }
-        return prefix + typeLetter() + address;
+        return _tsys.get(key);
     }
 
     /**

--- a/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusSensorManager.java
@@ -162,31 +162,6 @@ public class CbusSensorManager extends jmri.managers.AbstractSensorManager {
 
     /**
      * {@inheritDoc}
-     *
-     * Forces upper case and trims leading and trailing whitespace, adding +/- if not present.
-     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        String address = inputName.toUpperCase().trim();
-        // check Cbus hardware address parts
-        if ((!address.startsWith(prefix + typeLetter()) || (address.length() < prefix.length() + 2))) {
-            return address;
-        }
-        try {
-            address = CbusAddress.validateSysName(address.substring(prefix.length() + 1));
-        } catch (IllegalArgumentException e) {
-            return address;
-        } catch (StringIndexOutOfBoundsException e) {
-            return address;
-        }
-        return prefix + typeLetter() + address;
-    }
-
-    /**
-     * {@inheritDoc}
      */
     @Override
     public String getEntryToolTip() {

--- a/java/src/jmri/jmrix/can/cbus/CbusTurnoutManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusTurnoutManager.java
@@ -44,8 +44,7 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
      */
     @Override
     @Nonnull
-    public Turnout provideTurnout(@Nonnull String key) {
-        String name = normalizeSystemName(key);
+    public Turnout provideTurnout(@Nonnull String name) {
         Turnout result = getTurnout(name);
         if (result == null) {
             if (name.startsWith(prefix + typeLetter())) {
@@ -172,33 +171,7 @@ public class CbusTurnoutManager extends AbstractTurnoutManager {
     /** {@inheritDoc} */
     @Override
     public Turnout getBySystemName(@Nonnull String key) {
-        String name = normalizeSystemName(key);
-        return _tsys.get(name);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * Forces upper case and trims leading and trailing whitespace, adding +/- if not present.
-     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        String address = inputName.toUpperCase().trim();
-        // check Cbus hardware address parts
-        if ((!address.startsWith(prefix + typeLetter()) || (address.length() < prefix.length() + 2))) {
-            return address;
-        }
-        try {
-            address = CbusAddress.validateSysName(address.substring(prefix.length() + 1));
-        } catch (IllegalArgumentException e){
-            return address;
-        } catch (StringIndexOutOfBoundsException e){
-            return address;
-        }
-        return prefix + typeLetter() + address;
+        return _tsys.get(key);
     }
 
     /**

--- a/java/src/jmri/jmrix/cmri/serial/SerialLightManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialLightManager.java
@@ -104,16 +104,6 @@ public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Public method to normalize a system name.
-     *
-     * @return a normalized system name if system name has a valid format, else returns ""
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        return _memo.normalizeSystemName(systemName);
-    }
-
-    /**
      * Public method to convert system name to its alternate format
      *
      * @return a normalized system name if system name is valid and has a valid

--- a/java/src/jmri/jmrix/cmri/serial/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialSensorManager.java
@@ -263,14 +263,6 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
      * {@inheritDoc}
      */
     @Override
-    public String normalizeSystemName(String systemName) {
-        return _memo.normalizeSystemName(systemName);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public String getEntryToolTip() {
         return Bundle.getMessage("AddInputEntryToolTip");
     }

--- a/java/src/jmri/jmrix/cmri/serial/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/cmri/serial/SerialTurnoutManager.java
@@ -365,14 +365,6 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
      * {@inheritDoc}
      */
     @Override
-    public String normalizeSystemName(String systemName) {
-        return _memo.normalizeSystemName(systemName);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public String getEntryToolTip() {
         return Bundle.getMessage("AddOutputEntryToolTip");
     }

--- a/java/src/jmri/jmrix/ecos/EcosLocoAddressManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosLocoAddressManager.java
@@ -75,9 +75,15 @@ public class EcosLocoAddressManager extends jmri.managers.AbstractManager<NamedB
     private RosterEntry _re;
     private boolean addLocoToRoster = false;
 
+    /**
+     * EcosLocoAddresses have no system prefix, so return input unchanged.
+     * 
+     * @param s the input to make a system name
+     * @return the resultant system name
+     */
     @Override
     public String makeSystemName(String s) {
-        return "";
+        return s;
     }
 
     @Override

--- a/java/src/jmri/jmrix/grapevine/SerialLightManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialLightManager.java
@@ -82,17 +82,6 @@ public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Public method to normalize a system name.
-     *
-     * @return a normalized system name if system name has a valid format, else
-     * returns ""
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        return (SerialAddress.normalizeSystemName(systemName, getSystemPrefix()));
-    }
-
-    /**
      * Public method to convert system name to its alternate format.
      *
      * @return a normalized system name if system name is valid and has a valid

--- a/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialSensorManager.java
@@ -49,20 +49,6 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
     }
 
     /**
-     * Enforces, and as a user convenience converts to, the standard form for a system name
-     * for the NamedBeans handled by this manager.
-     *
-     * @param inputName System name to be normalized
-     * @throws NamedBean.BadSystemNameException if the inputName can't be converted to normalized form
-     * @return A system name in standard normalized form
-     */
-    @Override
-    @CheckReturnValue
-    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
-        return SerialAddress.normalizeSystemName(inputName, getSystemPrefix());
-    }
-
-    /**
      * Create a new sensor if all checks are passed.
      * System name is normalized to ensure uniqueness.
      *

--- a/java/src/jmri/jmrix/grapevine/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/grapevine/SerialTurnoutManager.java
@@ -168,17 +168,6 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
     }
 
     /**
-     * Public method to normalize a system name.
-     *
-     * @return a normalized system name if system name has a valid format, else
-     * returns ""
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        return (SerialAddress.normalizeSystemName(systemName, getSystemPrefix()));
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeLightManager.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeLightManager.java
@@ -185,17 +185,6 @@ public class XBeeLightManager extends AbstractLightManager {
         return Bundle.getMessage("AddOutputEntryToolTip");
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        return inputName; // toUpperCase and trim don't behave well with 
-                          // the XBee Node Identifier based addresses.
-    }
-
     private final static Logger log = LoggerFactory.getLogger(XBeeLightManager.class);
 
 }

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeSensorManager.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeSensorManager.java
@@ -284,17 +284,6 @@ public class XBeeSensorManager extends jmri.managers.AbstractSensorManager imple
         return Bundle.getMessage("AddInputEntryToolTip");
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        return inputName; // toUpperCase and trim don't behave well with 
-                          // the XBee Node Identifier based addresses.
-    }
-
     private final static Logger log = LoggerFactory.getLogger(XBeeSensorManager.class);
 
 }

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManager.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeTurnoutManager.java
@@ -218,17 +218,6 @@ public class XBeeTurnoutManager extends AbstractTurnoutManager {
         return Bundle.getMessage("AddOutputEntryToolTip");
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        return inputName; // toUpperCase and trim don't behave well with 
-                          // the XBee Node Identifier based addresses.
-    }
-
     private final static Logger log = LoggerFactory.getLogger(XBeeTurnoutManager.class);
 
 }

--- a/java/src/jmri/jmrix/internal/InternalTurnoutManager.java
+++ b/java/src/jmri/jmrix/internal/InternalTurnoutManager.java
@@ -57,17 +57,6 @@ public class InternalTurnoutManager extends AbstractTurnoutManager {
         return prefix + typeLetter() + curAddress;
     }
 
-    /** 
-     * {@inheritDoc} 
-     * No changes to what was given; we can take it all
-     */
-    @CheckReturnValue
-    @Override
-    @Nonnull
-    public String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
-        return inputName;
-    }
-
     /**
      * {@inheritDoc}
      *

--- a/java/src/jmri/jmrix/maple/SerialLightManager.java
+++ b/java/src/jmri/jmrix/maple/SerialLightManager.java
@@ -106,14 +106,6 @@ public class SerialLightManager extends AbstractLightManager {
      * {@inheritDoc}
      */
     @Override
-    public String normalizeSystemName(String systemName) {
-        return (SerialAddress.normalizeSystemName(systemName, getSystemPrefix()));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public String getEntryToolTip() {
         return Bundle.getMessage("AddOutputEntryToolTip");
     }

--- a/java/src/jmri/jmrix/maple/SerialSensorManager.java
+++ b/java/src/jmri/jmrix/maple/SerialSensorManager.java
@@ -105,17 +105,6 @@ public class SerialSensorManager extends jmri.managers.AbstractSensorManager
     }
 
     /**
-     * Normalize a system name.
-     *
-     * @return a normalized system name if system name has a valid format, else
-     * return ""
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        return (SerialAddress.normalizeSystemName(systemName, getSystemPrefix()));
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/src/jmri/jmrix/maple/SerialTurnoutManager.java
+++ b/java/src/jmri/jmrix/maple/SerialTurnoutManager.java
@@ -102,16 +102,6 @@ public class SerialTurnoutManager extends AbstractTurnoutManager {
     }
 
     /**
-     * Public method to normalize a system name.
-     * @return a normalized system name if system name has a valid format, else
-     * return "".
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        return (SerialAddress.normalizeSystemName(systemName, getSystemPrefix()));
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/src/jmri/jmrix/oaktree/SerialLightManager.java
+++ b/java/src/jmri/jmrix/oaktree/SerialLightManager.java
@@ -79,17 +79,6 @@ public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Normalize a system name.
-     *
-     * @return a normalized system name if system name has a valid format,
-     * else return ""
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        return (SerialAddress.normalizeSystemName(systemName, prefix));
-    }
-
-    /**
      * Convert system name to its alternate format.
      *
      * @return a normalized system name if system name is valid and has a valid

--- a/java/src/jmri/jmrix/powerline/SerialLightManager.java
+++ b/java/src/jmri/jmrix/powerline/SerialLightManager.java
@@ -88,17 +88,6 @@ abstract public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Public method to normalize a system name
-     *
-     * @return a normalized system name if system name has a valid format, else
-     * return ""
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        return (tc.getAdapterMemo().getSerialAddress().normalizeSystemName(systemName));
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/src/jmri/jmrix/secsi/SerialLightManager.java
+++ b/java/src/jmri/jmrix/secsi/SerialLightManager.java
@@ -77,17 +77,6 @@ public class SerialLightManager extends AbstractLightManager {
     }
 
     /**
-     * Normalize a system name.
-     *
-     * @return a normalized system name if system name has a valid format, else
-     * returns ""
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        return (SerialAddress.normalizeSystemName(systemName, getSystemPrefix()));
-    }
-
-    /**
      * Public method to convert system name to its alternate format
      *
      * @return a normalized system name if system name is valid and has a valid

--- a/java/src/jmri/jmrix/srcp/SRCPSensor.java
+++ b/java/src/jmri/jmrix/srcp/SRCPSensor.java
@@ -25,7 +25,7 @@ public class SRCPSensor extends AbstractSensor implements SRCPListener {
      * @param memo   associated connection memo
      */
     public SRCPSensor(int number, SRCPBusConnectionMemo memo) {
-        super(memo.getSystemPrefix() + "s" + number);
+        super(memo.getSystemPrefix() + "S" + number);
         _number = number;
         _bus = memo.getBus();
         tc = memo.getTrafficController();

--- a/java/src/jmri/managers/AbstractLightManager.java
+++ b/java/src/jmri/managers/AbstractLightManager.java
@@ -173,15 +173,6 @@ public abstract class AbstractLightManager extends AbstractManager<Light>
      */
     @Override
     @Nonnull
-    public String normalizeSystemName(@Nonnull String systemName) {
-        return systemName;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @Nonnull
     public String convertSystemNameToAlternate(@Nonnull String systemName) {
         return "";
     }

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -575,17 +575,6 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
         }
     }
 
-    /** {@inheritDoc} */
-    @CheckReturnValue
-    @Override
-    @Nonnull
-    public String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
-        if (validSystemNameFormat(inputName) != NameValidity.VALID) {
-            throw new NamedBean.BadSystemNameException();
-        }
-        return inputName;
-    }
-
     /**
      * {@inheritDoc}
      *

--- a/java/src/jmri/managers/AbstractProxyManager.java
+++ b/java/src/jmri/managers/AbstractProxyManager.java
@@ -175,18 +175,6 @@ abstract public class AbstractProxyManager<E extends NamedBean> implements Provi
         return getBeanBySystemName(name);
     }
 
-    /** {@inheritDoc} */
-    @Override
-    @CheckReturnValue
-    public @Nonnull String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
-        int index = matchTentative(inputName);
-        if (index >= 0) {
-            return getMgr(index).normalizeSystemName(inputName);
-        }
-        log.debug("normalizeSystemName did not find manager for name {}, defer to default", inputName); // NOI18N
-        return getDefaultManager().normalizeSystemName(inputName);
-    }
-
     /**
      * Locate via user name, then system name if needed. If that fails, create a
      * new NamedBean: If the name is a valid system name, it will be used for
@@ -232,10 +220,10 @@ abstract public class AbstractProxyManager<E extends NamedBean> implements Provi
         int index = matchTentative(systemName);
         if (index >= 0) {
             Manager<E> m = getMgr(index);
-            return m.getBeanBySystemName(m.normalizeSystemName(systemName));
+            return m.getBeanBySystemName(systemName);
         }
         log.debug("getBeanBySystemName did not find manager from name {}, defer to default manager", systemName); // NOI18N
-        return getDefaultManager().getBeanBySystemName(getDefaultManager().normalizeSystemName(systemName));
+        return getDefaultManager().getBeanBySystemName(systemName);
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -4,6 +4,7 @@ import java.util.Enumeration;
 import javax.annotation.*;
 import jmri.JmriException;
 import jmri.Manager;
+import jmri.NamedBean;
 import jmri.Sensor;
 import jmri.SensorManager;
 import org.slf4j.Logger;
@@ -96,7 +97,7 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
                 || !(sysName.length() > (getSystemPrefix() + typeLetter()).length())) {
             log.debug("Invalid system name for sensor: {} needed {}{} followed by a suffix",
                     sysName, getSystemPrefix(), typeLetter());
-            throw new IllegalArgumentException("systemName \""+sysName+"\" bad format in newSensor");
+            throw new NamedBean.BadSystemNameException("systemName \""+sysName+"\" bad format in newSensor");
         }
 
         // return existing if there is one

--- a/java/src/jmri/managers/AbstractSensorManager.java
+++ b/java/src/jmri/managers/AbstractSensorManager.java
@@ -75,22 +75,7 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
         if (isNumber(key)) {
             key = makeSystemName(key);
         }
-        String name = normalizeSystemName(key);
-        return _tsys.get(name);
-    }
-
-    /**
-     * {@inheritDoc}
-     * 
-     * Forces upper case and trims leading and trailing whitespace.
-     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
-        return inputName.toUpperCase().trim();
+        return _tsys.get(key);
     }
 
     /** {@inheritDoc} */
@@ -103,39 +88,37 @@ public abstract class AbstractSensorManager extends AbstractManager<Sensor> impl
     @Override
     public Sensor newSensor(String sysName, String userName) throws IllegalArgumentException {
         log.debug(" newSensor(\"{}\", \"{}\")", sysName, userName);
-        String systemName = normalizeSystemName(sysName);
-        log.debug("    normalized name: \"{}\"", systemName);
 
-        java.util.Objects.requireNonNull(systemName, "Generated systemName may not be null, started with "+systemName);
+        java.util.Objects.requireNonNull(sysName, "Generated systemName may not be null, started with "+sysName);
 
         // is system name in correct format?
-        if (!systemName.startsWith(getSystemPrefix() + typeLetter()) 
-                || !(systemName.length() > (getSystemPrefix() + typeLetter()).length())) {
+        if (!sysName.startsWith(getSystemPrefix() + typeLetter()) 
+                || !(sysName.length() > (getSystemPrefix() + typeLetter()).length())) {
             log.debug("Invalid system name for sensor: {} needed {}{} followed by a suffix",
-                    systemName, getSystemPrefix(), typeLetter());
-            throw new IllegalArgumentException("systemName \""+systemName+"\" bad format in newSensor");
+                    sysName, getSystemPrefix(), typeLetter());
+            throw new IllegalArgumentException("systemName \""+sysName+"\" bad format in newSensor");
         }
 
         // return existing if there is one
         Sensor s;
         if ((userName != null) && ((s = getByUserName(userName)) != null)) {
-            if (getBySystemName(systemName) != s) {
-                log.error("inconsistent user ({}) and system name ({}) results; userName related to ({})", userName, systemName, s.getSystemName());
+            if (getBySystemName(sysName) != s) {
+                log.error("inconsistent user ({}) and system name ({}) results; userName related to ({})", userName, sysName, s.getSystemName());
             }
             return s;
         }
-        if ((s = getBySystemName(systemName)) != null) {
+        if ((s = getBySystemName(sysName)) != null) {
             if ((s.getUserName() == null) && (userName != null)) {
                 s.setUserName(userName);
             } else if (userName != null) {
                 log.warn("Found sensor via system name ({}) with non-null user name ({}). Sensor \"{}({})\" cannot be used.",
-                        systemName, s.getUserName(), systemName, userName);
+                        sysName, s.getUserName(), sysName, userName);
             }
             return s;
         }
 
         // doesn't exist, make a new one
-        s = createNewSensor(systemName, userName);
+        s = createNewSensor(sysName, userName);
 
         // if that failed, blame it on the input arguments
         if (s == null) {

--- a/java/src/jmri/managers/AbstractSignalHeadManager.java
+++ b/java/src/jmri/managers/AbstractSignalHeadManager.java
@@ -1,13 +1,8 @@
 package jmri.managers;
 
 import jmri.Manager;
-import jmri.NamedBean;
 import jmri.SignalHead;
 import jmri.SignalHeadManager;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 
 /**
  * Abstract partial implementation of a SignalHeadManager.
@@ -71,20 +66,6 @@ public class AbstractSignalHeadManager extends AbstractManager<SignalHead>
     @Override
     public SignalHead getByUserName(String key) {
         return _tuser.get(key);
-    }
-
-    /**
-     * {@inheritDoc}
-     * 
-     * Forces upper case and trims leading and trailing whitespace.
-     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) throws NamedBean.BadSystemNameException {
-        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
-        return inputName.toUpperCase().trim();
     }
 
     /** {@inheritDoc} */

--- a/java/src/jmri/managers/DefaultLogixManager.java
+++ b/java/src/jmri/managers/DefaultLogixManager.java
@@ -10,10 +10,6 @@ import jmri.jmrit.beantable.LRouteTableAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-
 /**
  * Basic Implementation of a LogixManager.
  * <p>
@@ -188,20 +184,6 @@ public class DefaultLogixManager extends AbstractManager<Logix>
     @Override
     public Logix getByUserName(String key) {
         return _tuser.get(key);
-    }
-
-    /**
-     * {@inheritDoc}
-     * 
-     * Forces upper case and trims leading and trailing whitespace.
-     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
-        return inputName.toUpperCase().trim();
     }
 
     /**

--- a/java/src/jmri/managers/DefaultMemoryManager.java
+++ b/java/src/jmri/managers/DefaultMemoryManager.java
@@ -1,7 +1,5 @@
 package jmri.managers;
 
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import jmri.Memory;
 import jmri.implementation.DefaultMemory;
 import org.slf4j.Logger;
@@ -32,20 +30,6 @@ public class DefaultMemoryManager extends AbstractMemoryManager {
             systemName = makeSystemName(systemName);
         }
         return new DefaultMemory(systemName, userName);
-    }
-
-    /**
-     * {@inheritDoc}
-     * 
-     * Forces upper case and trims leading and trailing whitespace.
-     * Does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException.
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        // does not check for valid prefix, hence doesn't throw NamedBean.BadSystemNameException
-        return inputName.toUpperCase().trim();
     }
 
     private final static Logger log = LoggerFactory.getLogger(DefaultMemoryManager.class);

--- a/java/src/jmri/managers/DefaultRouteManager.java
+++ b/java/src/jmri/managers/DefaultRouteManager.java
@@ -1,8 +1,6 @@
 package jmri.managers;
 
 import java.text.DecimalFormat;
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import jmri.Manager;
 import jmri.Route;
 import jmri.RouteManager;
@@ -97,22 +95,6 @@ public class DefaultRouteManager extends AbstractManager<Route>
     DecimalFormat paddedNumber = new DecimalFormat("0000");
 
     int lastAutoRouteRef = 0;
-
-    /**
-     * {@inheritDoc}
-     *
-     * Forces upper case and trims leading and trailing whitespace.
-     * The IR prefix is added if necessary.
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        if (inputName.length() < 3 || !inputName.startsWith("IR")) {
-            inputName = "IR" + inputName;
-        }
-        return inputName.toUpperCase().trim();
-    }
 
     /**
      * Remove an existing route. Route must have been deactivated before

--- a/java/src/jmri/managers/DefaultSignalGroupManager.java
+++ b/java/src/jmri/managers/DefaultSignalGroupManager.java
@@ -6,12 +6,9 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 
 import jmri.Manager;
-import jmri.NamedBean;
 import jmri.SignalGroup;
 import jmri.SignalGroupManager;
 import jmri.implementation.DefaultSignalGroup;
@@ -70,23 +67,6 @@ public class DefaultSignalGroupManager extends AbstractManager<SignalGroup>
     @Override
     public SignalGroup getByUserName(String key) {
         return _tuser.get(key);
-    }
-
-    /**
-     * {@inheritDoc}
-     * 
-     * Forces upper case and trims leading and trailing whitespace.
-     * The IG prefix is added if necessary.
-     */
-    @CheckReturnValue
-    @Override
-    public @Nonnull
-    String normalizeSystemName(@Nonnull String inputName) {
-        // does not check for valid system connection prefix, hence doesn't throw NamedBean.BadSystemNameException
-        if (inputName.length() < 3 || !inputName.startsWith("IG")) {
-            inputName = "IG" + inputName;
-        }
-        return inputName.toUpperCase().trim();
     }
 
     /**

--- a/java/src/jmri/managers/ProxyLightManager.java
+++ b/java/src/jmri/managers/ProxyLightManager.java
@@ -150,20 +150,6 @@ public class ProxyLightManager extends AbstractProxyManager<Light>
     }
 
     /**
-     * Normalize a system name Locate a system specfic LightManager based on a
-     * system name. Returns "" if no manager exists. If a manager is found,
-     * return its determination of a normalized system name
-     */
-    @Override
-    public String normalizeSystemName(String systemName) {
-        int i = matchTentative(systemName);
-        if (i >= 0) {
-            return ((LightManager) getMgr(i)).normalizeSystemName(systemName);
-        }
-        return "";
-    }
-
-    /**
      * Convert a system name to an alternate format Locate a system specfic
      * LightManager based on a system name. Returns "" if no manager exists. If
      * a manager is found, return its determination of an alternate system name

--- a/java/test/jmri/NamedBeanHandleManagerTest.java
+++ b/java/test/jmri/NamedBeanHandleManagerTest.java
@@ -85,7 +85,7 @@ public class NamedBeanHandleManagerTest {
 
         NamedBeanHandle<Sensor> checkRename = nbhm.getNamedBeanHandle("ISno_user_name", sm.provideSensor("ISno_user_name"));
         nbhm.updateBeanFromUserToSystem(checkRename.getBean());
-        jmri.util.JUnitAppender.assertWarnMessage("updateBeanFromUserToSystem requires non-blank user name: \"ISNO_USER_NAME\" not renamed");
+        jmri.util.JUnitAppender.assertWarnMessage("updateBeanFromUserToSystem requires non-blank user name: \"ISno_user_name\" not renamed");
     }
 
     jmri.NamedBeanHandleManager nbhm;

--- a/java/test/jmri/jmrit/beantable/BlockTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/BlockTableActionTest.java
@@ -107,7 +107,7 @@ public class BlockTableActionTest extends AbstractTableActionBase {
         JFrameOperator addFrame = new JFrameOperator(Bundle.getMessage("TitleAddBlock"));  // NOI18N
         Assert.assertNotNull("Found Add Block Frame", addFrame);  // NOI18N
 
-        new JTextFieldOperator(addFrame, 0).setText("105");  // NOI18N
+        new JTextFieldOperator(addFrame, 0).setText("IB105");  // NOI18N
         new JTextFieldOperator(addFrame, 2).setText("Block 105");  // NOI18N
         new JButtonOperator(addFrame, Bundle.getMessage("ButtonCreate")).push();  // NOI18N
         new JButtonOperator(addFrame, Bundle.getMessage("ButtonCancel")).push();  // NOI18N
@@ -258,7 +258,7 @@ public class BlockTableActionTest extends AbstractTableActionBase {
 	//Enter 1 in the text field labeled "System Name:"
 	   
         JLabelOperator jlo = new JLabelOperator(jf,Bundle.getMessage("LabelSystemName"));
-        ((JTextField)jlo.getLabelFor()).setText("1");
+        ((JTextField)jlo.getLabelFor()).setText("IB1");
 	//and press create
 	jmri.util.swing.JemmyUtil.pressButton(jf,Bundle.getMessage("ButtonCreate"));
         jf.requestClose();

--- a/java/test/jmri/jmrit/beantable/BlockTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/BlockTableActionTest.java
@@ -107,7 +107,7 @@ public class BlockTableActionTest extends AbstractTableActionBase {
         JFrameOperator addFrame = new JFrameOperator(Bundle.getMessage("TitleAddBlock"));  // NOI18N
         Assert.assertNotNull("Found Add Block Frame", addFrame);  // NOI18N
 
-        new JTextFieldOperator(addFrame, 0).setText("IB105");  // NOI18N
+        new JTextFieldOperator(addFrame, 0).setText("105");  // NOI18N
         new JTextFieldOperator(addFrame, 2).setText("Block 105");  // NOI18N
         new JButtonOperator(addFrame, Bundle.getMessage("ButtonCreate")).push();  // NOI18N
         new JButtonOperator(addFrame, Bundle.getMessage("ButtonCancel")).push();  // NOI18N
@@ -258,7 +258,7 @@ public class BlockTableActionTest extends AbstractTableActionBase {
 	//Enter 1 in the text field labeled "System Name:"
 	   
         JLabelOperator jlo = new JLabelOperator(jf,Bundle.getMessage("LabelSystemName"));
-        ((JTextField)jlo.getLabelFor()).setText("IB1");
+        ((JTextField)jlo.getLabelFor()).setText("1");
 	//and press create
 	jmri.util.swing.JemmyUtil.pressButton(jf,Bundle.getMessage("ButtonCreate"));
         jf.requestClose();

--- a/java/test/jmri/jmrit/beantable/RouteTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/RouteTableActionTest.java
@@ -65,7 +65,7 @@ public class RouteTableActionTest extends AbstractTableActionBase {
         JFrameOperator addFrame = new JFrameOperator(Bundle.getMessage("TitleAddRoute"));  // NOI18N
         Assert.assertNotNull("Found Add Route Frame", addFrame);  // NOI18N
 
-        new JTextFieldOperator(addFrame, 0).setText("105");  // NOI18N
+        new JTextFieldOperator(addFrame, 0).setText("IR105");  // NOI18N
         new JTextFieldOperator(addFrame, 1).setText("Route 105");  // NOI18N
         new JButtonOperator(addFrame, Bundle.getMessage("ButtonCreate")).push();  // NOI18N
         new JButtonOperator(addFrame, Bundle.getMessage("ButtonCancel")).push();  // NOI18N

--- a/java/test/jmri/jmrit/beantable/RouteTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/RouteTableActionTest.java
@@ -65,7 +65,7 @@ public class RouteTableActionTest extends AbstractTableActionBase {
         JFrameOperator addFrame = new JFrameOperator(Bundle.getMessage("TitleAddRoute"));  // NOI18N
         Assert.assertNotNull("Found Add Route Frame", addFrame);  // NOI18N
 
-        new JTextFieldOperator(addFrame, 0).setText("IR105");  // NOI18N
+        new JTextFieldOperator(addFrame, 0).setText("105");  // NOI18N
         new JTextFieldOperator(addFrame, 1).setText("Route 105");  // NOI18N
         new JButtonOperator(addFrame, Bundle.getMessage("ButtonCreate")).push();  // NOI18N
         new JButtonOperator(addFrame, Bundle.getMessage("ButtonCancel")).push();  // NOI18N

--- a/java/test/jmri/jmrit/beantable/SignalGroupTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/SignalGroupTableActionTest.java
@@ -114,7 +114,7 @@ public class SignalGroupTableActionTest extends AbstractTableActionBase {
         JFrameOperator jf = new JFrameOperator(f1);
 	    //Enter 1 in the text field labeled "System Name:"
         JLabelOperator jlo = new JLabelOperator(jf,Bundle.getMessage("LabelSystemName"));
-        ((JTextField)jlo.getLabelFor()).setText("IF1");
+        ((JTextField)jlo.getLabelFor()).setText("1");
 	    //and press create
 	    jmri.util.swing.JemmyUtil.pressButton(jf,Bundle.getMessage("ButtonCreate"));
         JUnitUtil.dispose(f1);
@@ -137,7 +137,7 @@ public class SignalGroupTableActionTest extends AbstractTableActionBase {
 	//Enter 1 in the text field labeled "System Name:"
 	   
         JLabelOperator jlo = new JLabelOperator(jf,Bundle.getMessage("LabelSystemName"));
-        ((JTextField)jlo.getLabelFor()).setText("IF1");
+        ((JTextField)jlo.getLabelFor()).setText("1");
 	//and press create
 	jmri.util.swing.JemmyUtil.pressButton(jf,Bundle.getMessage("ButtonCreate"));
 

--- a/java/test/jmri/jmrit/beantable/SignalGroupTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/SignalGroupTableActionTest.java
@@ -114,7 +114,7 @@ public class SignalGroupTableActionTest extends AbstractTableActionBase {
         JFrameOperator jf = new JFrameOperator(f1);
 	    //Enter 1 in the text field labeled "System Name:"
         JLabelOperator jlo = new JLabelOperator(jf,Bundle.getMessage("LabelSystemName"));
-        ((JTextField)jlo.getLabelFor()).setText("1");
+        ((JTextField)jlo.getLabelFor()).setText("IF1");
 	    //and press create
 	    jmri.util.swing.JemmyUtil.pressButton(jf,Bundle.getMessage("ButtonCreate"));
         JUnitUtil.dispose(f1);
@@ -137,7 +137,7 @@ public class SignalGroupTableActionTest extends AbstractTableActionBase {
 	//Enter 1 in the text field labeled "System Name:"
 	   
         JLabelOperator jlo = new JLabelOperator(jf,Bundle.getMessage("LabelSystemName"));
-        ((JTextField)jlo.getLabelFor()).setText("1");
+        ((JTextField)jlo.getLabelFor()).setText("IF1");
 	//and press create
 	jmri.util.swing.JemmyUtil.pressButton(jf,Bundle.getMessage("ButtonCreate"));
 

--- a/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
@@ -4,6 +4,7 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.Light;
 import jmri.Manager.NameValidity;
+import jmri.NamedBean;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
 
@@ -77,32 +78,21 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
     }
 
     @Test
-    public void testLowerLower() {
-        Light t = l.provideLight("mlxabcdef;xfedcba");
-        Assert.assertTrue("hex LowerLower ", t == l.getLight(t.getSystemName()));
-        Light t2 = l.provideLight("ml+n1e77;-n1e45");
-        Assert.assertNotNull("exists", t2);
-        Assert.assertTrue("event LowerLower", t2 == l.getLight(t2.getSystemName()));
-    }
-
-    @Test
-    public void testLowerUpper() {
-        Light t = l.provideLight("mlxabcdef;xfedcba");
-        Assert.assertTrue("hex Lower Upper", t == l.getLight(t.getSystemName().toUpperCase()));
-        Light t2 = l.provideLight("ml+n1e77;-n1e45");
-        Assert.assertNotNull("exists", t2);
-        Assert.assertTrue("event Lower Upper", t2 == l.getLight(t2.getSystemName().toUpperCase()));
-    }
-
-    @Override
-    @Test
-    public void testUpperLower() {
-        Light t = l.provideLight("MLXABCDEF01;XFFEDCCBA");
-        Assert.assertTrue("Same hex getLight", t == l.getLight(t.getSystemName().toLowerCase()));
-        Assert.assertTrue("Same hex getBySystemName", t == l.getBySystemName(t.getSystemName().toLowerCase()));
-        Light t2 = l.provideLight("ML-N66E1;+N125E789");
-        Assert.assertTrue("Same long getLight", t2 == l.getLight(t2.getSystemName().toLowerCase()));
-        Assert.assertTrue("Same hex getBySystemName", t2 == l.getBySystemName(t2.getSystemName().toLowerCase()));
+    public void testLowercaseSystemName() {
+        String name1 = "mlxabcdef;xfedcba";
+        try {
+            l.provideLight(name1);
+            Assert.fail("Expected exception not thrown");
+        } catch (NamedBean.BadSystemNameException ex) {
+            // passes, so do nothing
+        }
+        String name2 = "ml+n1e77;-n1e45";
+        try {
+            Light t2 = l.provideLight(name2);
+            Assert.fail("Expected exception not thrown");
+        } catch (NamedBean.BadSystemNameException ex) {
+            // passes, so do nothing
+        }
     }
 
     @Test

--- a/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusLightManagerTest.java
@@ -62,8 +62,8 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
         String name = "ML+5;-7";
         Light t = l.provideLight(name);
         // check
-        Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(name));
+        Assert.assertNotNull("real object returned ");
+        Assert.assertEquals("system name correct ", t, l.getBySystemName(name));
     }
 
     @Override // numeric system name has a + added to it
@@ -73,8 +73,8 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
         // create
         Light t = l.provide(name);
         // check
-        Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(name));
+        Assert.assertNotNull("real object returned ", t);
+        Assert.assertEquals("system name correct ", t, l.getBySystemName(name));
     }
 
     @Test
@@ -88,7 +88,7 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
         }
         String name2 = "ml+n1e77;-n1e45";
         try {
-            Light t2 = l.provideLight(name2);
+            l.provideLight(name2);
             Assert.fail("Expected exception not thrown");
         } catch (NamedBean.BadSystemNameException ex) {
             // passes, so do nothing
@@ -100,7 +100,7 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
         try {
             l.provideLight("ML+7;-5;+11");
             Assert.fail("3 split Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
     }
@@ -109,134 +109,134 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
     public void testBadCbusLightAddresses() {
         try {
             Light t1 = l.provideLight("ML+N15E6");
-            Assert.assertTrue(t1 != null);
-        } catch (Exception e) {
+            Assert.assertNotNull(t1);
+        } catch (IllegalArgumentException e) {
             Assert.fail("Should NOT have thrown an exception");
         }
 
         try {
             l.provideLight("MLX;+N15E6");
             Assert.fail("X Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
 
         try {
             l.provideLight("MLXA;+N15E6");
             Assert.fail("A Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
 
         try {
             l.provideLight("MLXABC;+N15E6");
             Assert.fail("AC Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
 
         try {
             l.provideLight("MLXABCDE;+N15E6");
             Assert.fail("ABCDE Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
         
         try {
             l.provideLight("MLXABCDEF0;+N15E6");
             Assert.fail("ABCDEF0 Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
 
         try {
             l.provideLight("MLXABCDEF");
             Assert.fail("Single hex Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
 
         try {
             l.provideLight("MLXABCDEF;");
             Assert.fail("Single hex ; Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
 
         try {
             l.provideLight("MLXABCDEF;");
             Assert.fail("Single hex ; Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
         
         try {
             l.provideLight("ML;");
             Assert.fail("; no arg Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }        
         
         try {
             l.provideLight("ML;+N15E6");
             Assert.fail("ML Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
         
         try {
             l.provideLight(";+N15E6");
             Assert.fail("; Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             Assert.assertEquals("Invalid system name for Light: name \"ML;+N15E6\" has incorrect format", e.getMessage());
         }
 
         try {
             l.provideLight("S+N156E77;+N15E6");
             Assert.fail("S Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             Assert.assertEquals("Invalid system name for Light: name \"MLS+N156E77;+N15E6\" has incorrect format", e.getMessage());
         }
         
         try {
             l.provideLight("M+N156E77;+N15E6");
             Assert.fail("M Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             Assert.assertEquals("Invalid system name for Light: name \"MLM+N156E77;+N15E6\" has incorrect format", e.getMessage());
         }
 
         try {
             l.provideLight("ML++N156E77");
             Assert.fail("++ Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
 
         try {
             l.provideLight("ML--N156E77");
             Assert.fail("-- Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
 
         try {
             l.provideLight("MLN156E+77");
             Assert.fail("E+ Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
 
         try {
             l.provideLight("MLN156+E77");
             Assert.fail("+E Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
 
         try {
             l.provideLight("MLXLKJK;XLKJK");
             Assert.fail("LKJK Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("Invalid system name for newLight:");
         }
     }
@@ -327,15 +327,13 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
         Light t = l.provideLight("+4");
         Light ta = l.provideLight("+4");
         Assert.assertTrue(t == ta);
-        t = null;
-        ta = null;
     }
 
     @Test
     public void testcreateNewLightException(){
-        CbusLightManager l = new CbusLightManager(memo);
+        CbusLightManager c = (CbusLightManager) l;
         try {
-            l.createNewLight("", null);
+            c.createNewLight("", null);
             Assert.fail("Expected exception not thrown");
         } catch (StringIndexOutOfBoundsException ex) {
             Assert.assertEquals("String index out of range: -2", ex.getMessage());
@@ -344,7 +342,6 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
     
     @Test
     public void testvalidSystemNameConfig(){
-        CbusLightManager l = new CbusLightManager(memo);
         Assert.assertTrue(l.validSystemNameConfig("ML+123") );
         try {
             l.validSystemNameConfig("");
@@ -356,6 +353,7 @@ public class CbusLightManagerTest extends jmri.managers.AbstractLightMgrTestBase
 
     // The minimal setup for log4J
     @Before
+    @Override
     public void setUp() {
         JUnitUtil.setUp();
         memo = new CanSystemConnectionMemo();

--- a/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusSensorManagerTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.can.cbus;
 
 import jmri.Manager.NameValidity;
 import jmri.JmriException;
+import jmri.NamedBean;
 import jmri.Sensor;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
@@ -56,32 +57,21 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
 
 
     @Test
-    public void testLowerLower() {
-        Sensor t = l.provideSensor("ms+n1e77;-n1e45");
-        Assert.assertNotNull("exists",t);
-        Assert.assertTrue("event lowercase",t == l.getSensor(t.getSystemName()));
-        Sensor t2 = l.provideSensor("msxabcdef;xfedcba");
-        Assert.assertNotNull("exists",t2);
-        Assert.assertTrue("hex lowercase",t2 == l.getSensor(t2.getSystemName()));
-    }
-
-    @Test
-    public void testLowerUpper() {
-        Sensor t = l.provideSensor("ms+n1e77;-n1e45");
-        Assert.assertNotNull("exists",t);
-        Assert.assertTrue("event lower upper",t == l.getSensor(t.getSystemName().toUpperCase()));
-        Sensor t2 = l.provideSensor("msxabcdef;xfedcba");
-        Assert.assertNotNull("exists",t2);
-        Assert.assertTrue("hex lower upper",t2 == l.getSensor(t2.getSystemName().toUpperCase()));
-    }
-
-    @Override
-    @Test
-    public void testUpperLower() {
-        Sensor t = l.provideSensor("MSXABCDEF01;XFFEDCCBA");
-        Assert.assertTrue(" hex upper lower",t == l.getSensor(t.getSystemName().toLowerCase()));
-        Sensor t2 = l.provideSensor("MS-N66E1;+N15E789");
-        Assert.assertTrue("event upper lower",t2 == l.getSensor(t2.getSystemName().toLowerCase()));
+    public void testLowercaseSystemName() {
+        String name1 = "ms+n1e77;-n1e45";
+        try {
+            l.provideSensor(name1);
+            Assert.fail("Expected exception not thrown");
+        } catch (NamedBean.BadSystemNameException ex) {
+            // passes, so do nothing
+        }
+        String name2 = "msxabcdef;xfedcba";
+        try {
+            l.provideSensor(name2);
+            Assert.fail("Expected exception not thrown");
+        } catch (NamedBean.BadSystemNameException ex) {
+            // passes, so do nothing
+        }
     }
 
     @Override
@@ -104,7 +94,7 @@ public class CbusSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         try {
             Sensor t1 = l.provideSensor("MS+N15E6");
             Assert.assertTrue( t1 != null );
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             Assert.fail("Should NOT have thrown an exception");
         }
 

--- a/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusTurnoutManagerTest.java
@@ -4,6 +4,7 @@ import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.Manager.NameValidity;
 import jmri.JmriException;
+import jmri.NamedBean;
 import jmri.Turnout;
 import jmri.util.JUnitAppender;
 import jmri.util.JUnitUtil;
@@ -27,12 +28,12 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
     @Test
     public void testCTor() {
         TrafficControllerScaffold tc = new TrafficControllerScaffold();
-        CanSystemConnectionMemo memo = new CanSystemConnectionMemo();
         memo.setTrafficController(tc);
         CbusTurnoutManager t = new CbusTurnoutManager(memo);
         Assert.assertNotNull("exists", t);
     }
 
+    @Override
     public String getSystemName(int i) {
         return "MTX0A;+N123E3" + i;
     }
@@ -53,11 +54,12 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         // create
         Turnout t = l.provideTurnout("MTX0A;+N15E741");
         // check
-        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertNotNull("real object returned ", t);
         Assert.assertTrue("system name correct ", t == l.getBySystemName("MTX0A;+N15E741"));
     }
 
     @Test
+    @Override
     public void testProvideName() {
 
         // create
@@ -72,78 +74,78 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
 
         try {
             Turnout t1 = l.provideTurnout("MT+N15E6");
-            Assert.assertTrue(t1 != null);
-        } catch (Exception e) {
+            Assert.assertNotNull(t1);
+        } catch (IllegalArgumentException e) {
             Assert.fail("Should NOT have thrown an exception");
         }
 
         try {
             l.provideTurnout("MTX;+N15E6");
             Assert.fail("X Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
         }
 
         try {
             l.provideTurnout("MTXA;+N15E6");
             Assert.fail("A Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
         }
 
         try {
             l.provideTurnout("MTXABC;+N15E6");
             Assert.fail("AC Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
         }
 
         try {
             l.provideTurnout("MTXABCDE;+N15E6");
             Assert.fail("ABCDE Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
         }
 
         try {
             l.provideTurnout("MTXABCDEF0;+N15E6");
             Assert.fail("ABCDEF0 Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
         }
 
         try {
             l.provideTurnout("MTXABCDEF");
             Assert.fail("Single hex Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: can't make 2nd event");
         }
 
         try {
             l.provideTurnout("MT;XABCDEF");
             Assert.fail("Single hex ; Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
         }
 
         try {
             l.provideTurnout("MTXABCDEF;");
             Assert.fail("Single hex ; Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
         }
 
         try {
             l.provideTurnout("MT;");
             Assert.fail("; no arg Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
         }
 
         try {
             l.provideTurnout("MT;+N15E6");
             Assert.fail("MS Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: ");
         }
     }
@@ -154,7 +156,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         try {
             l.provideTurnout(";+N15E62");
             Assert.fail("; Should have thrown an exception");
-        } catch (Exception ex) {
+        } catch (IllegalArgumentException ex) {
             Assert.assertEquals("Invalid system name for Turnout: name \"MT;+N15E62\" has incorrect format",
                     ex.getMessage());
         }
@@ -162,7 +164,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         try {
             l.provideTurnout("T+N156E77;+N123E456");
             Assert.fail("Missing M Should have thrown an exception");
-        } catch (Exception ex) {
+        } catch (IllegalArgumentException ex) {
             Assert.assertEquals("Invalid system name for Turnout: name \"MTT+N156E77;+N123E456\" has incorrect format",
                     ex.getMessage());
         }
@@ -173,7 +175,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         try {
             l.provideTurnout("M+N156E77;+N15E60");
             Assert.fail("M Should have thrown an exception");
-        } catch (Exception ex) {
+        } catch (IllegalArgumentException ex) {
             Assert.assertEquals("Invalid system name for Turnout: name \"MTM+N156E77;+N15E60\" has incorrect format",
                     ex.getMessage());
         }
@@ -183,7 +185,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         try {
             l.provideTurnout("MT++N156E78");
             Assert.fail("++ Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find usabl");
         }
     }
@@ -192,59 +194,52 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         try {
             l.provideTurnout("MT--N156E78");
             Assert.fail("-- Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find usabl");
         }
 
         try {
             l.provideTurnout("MTN156E+80");
             Assert.fail("E+ Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
         }
 
         try {
             l.provideTurnout("MTN156+E77");
             Assert.fail("+E Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
         }
 
         try {
             l.provideTurnout("MTXLKJK;XLKJK");
             Assert.fail("LKJK Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Did not find");
         }
 
         try {
             l.provideTurnout("MT+7;-5;+11");
             Assert.fail("3 split Should have thrown an exception");
-        } catch (Exception e) {
+        } catch (IllegalArgumentException e) {
             JUnitAppender.assertErrorMessageStartsWith("java.lang.IllegalArgumentException: Wrong number of events");
         }
     }
 
     @Test
-    public void testLowerLower() {
-        Turnout t = l.provideTurnout("mt+n1e77;-n1e45");
-        Assert.assertNotNull("exists", t);
-        Assert.assertTrue("Retrievable lowercase", t == l.getTurnout(t.getSystemName()));
-    }
-
-    @Test
-    public void testLowerUpper() {
-        Turnout t = l.provideTurnout("mt+n1e77;-n1e45");
-        Assert.assertNotNull("exists", t);
-        Assert.assertTrue("Retrievable lowercase", t == l.getTurnout(t.getSystemName())); // case not changed
-    }
-
-    @Test
-    public void testUpperLower() {
-        Turnout t = l.provideTurnout("MTXABCDEF01;XFFEDCCBA");
-        Assert.assertTrue("Same hex getTurnout", t == l.getTurnout(t.getSystemName().toLowerCase()));
-        Turnout t2 = l.provideTurnout("MT-N66E1;+N15E789");
-        Assert.assertTrue("Same long getTurnout", t2 == l.getTurnout(t2.getSystemName().toLowerCase()));
+    public void testLowercaseSystemName() {
+        String name = "mt+n1e77;-n1e45";
+        try {
+            l.provideTurnout(name);
+            Assert.fail("Expected exception not thrown");
+        } catch (NamedBean.BadSystemNameException ex) {
+            // passes, so do nothing
+        }
+        Turnout t = l.provideTurnout(name.toUpperCase());
+        Assert.assertNotNull(t);
+        Assert.assertNotEquals(t, l.getBeanBySystemName(name));
+        Assert.assertNull(l.getBeanBySystemName(name));
     }
 
     @Test
@@ -296,7 +291,7 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         Assert.assertEquals("+N45E23", "+N45E23", l.getNextValidAddress("+N45E22", "M"));        
         
         try {
-            Assert.assertEquals("null", null, l.getNextValidAddress(null, "M"));
+            Assert.assertNull("null", l.getNextValidAddress(null, "M"));
         } catch (JmriException ex) {
             Assert.assertEquals("java.lang.IllegalArgumentException: No address Passed ", ex.getMessage());
         }
@@ -354,12 +349,11 @@ public class CbusTurnoutManagerTest extends jmri.managers.AbstractTurnoutMgrTest
         Turnout t = l.provideTurnout("+4");
         Turnout ta = l.provideTurnout("+4");
         Assert.assertTrue(t == ta);
-        t = null;
-        ta = null;
     }
     
     // The minimal setup for log4J
     @Before
+    @Override
     public void setUp() {
         JUnitUtil.setUp();
         memo = new CanSystemConnectionMemo();

--- a/java/test/jmri/jmrix/grapevine/SerialNodeTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialNodeTest.java
@@ -434,21 +434,21 @@ public class SerialNodeTest {
 
         // created first four only
         s1 = sm.getSensor("GS1001");
-        Assert.assertTrue("s1 exists", s1 != null);
+        Assert.assertNotNull("s1 exists", s1);
         s2 = sm.getSensor("GS1002");
-        Assert.assertTrue("s2 exists", s2 != null);
+        Assert.assertNotNull("s2 exists", s2);
         s3 = sm.getSensor("GS1003");
-        Assert.assertTrue("s3 exists", s3 != null);
+        Assert.assertNotNull("s3 exists", s3);
         s4 = sm.getSensor("GS1004");
-        Assert.assertTrue("s4 exists", s4 != null);
+        Assert.assertNotNull("s4 exists", s4);
         s5 = sm.getSensor("GS1005");
-        Assert.assertTrue("s5 not exist", s5 == null);
+        Assert.assertNull("s5 not exist", s5);
         s6 = sm.getSensor("GS1006");
-        Assert.assertTrue("s6 not exist", s6 == null);
+        Assert.assertNull("s6 not exist", s6);
         s7 = sm.getSensor("GS1007");
-        Assert.assertTrue("s7 not exist", s7 == null);
+        Assert.assertNull("s7 not exist", s7);
         s8 = sm.getSensor("GS1008");
-        Assert.assertTrue("s8 not exist", s8 == null);
+        Assert.assertNull("s8 not exist", s8);
 
         Assert.assertEquals("2 check s1", Sensor.INACTIVE, s1.getKnownState());
         Assert.assertEquals("2 check s2", Sensor.INACTIVE, s2.getKnownState());
@@ -462,13 +462,13 @@ public class SerialNodeTest {
         b.markChanges(r);
         // create first four only
         s5 = sm.getSensor("GS1005");
-        Assert.assertTrue("s5 not exist", s5 == null);
+        Assert.assertNull("s5 not exist", s5);
         s6 = sm.getSensor("GS1006");
-        Assert.assertTrue("s6 not exist", s6 == null);
+        Assert.assertNull("s6 not exist", s6);
         s7 = sm.getSensor("GS1007");
-        Assert.assertTrue("s7 not exist", s7 == null);
+        Assert.assertNull("s7 not exist", s7);
         s8 = sm.getSensor("GS1008");
-        Assert.assertTrue("s8 not exist", s8 == null);
+        Assert.assertNull("s8 not exist", s8);
 
         Assert.assertEquals("3 check s1", Sensor.ACTIVE, s1.getKnownState());
         Assert.assertEquals("3 check s2", Sensor.ACTIVE, s2.getKnownState());
@@ -483,13 +483,13 @@ public class SerialNodeTest {
 
         // create next four
         s5 = sm.getSensor("GS1005");
-        Assert.assertTrue("s5 exists", s5 != null);
+        Assert.assertNotNull("s5 exists", s5);
         s6 = sm.getSensor("GS1006");
-        Assert.assertTrue("s6 exists", s6 != null);
+        Assert.assertNotNull("s6 exists", s6);
         s7 = sm.getSensor("GS1007");
-        Assert.assertTrue("s7 exists", s7 != null);
+        Assert.assertNotNull("s7 exists", s7);
         s8 = sm.getSensor("GS1008");
-        Assert.assertTrue("s8 exists", s8 != null);
+        Assert.assertNotNull("s8 exists", s8);
 
         Assert.assertEquals("4 check s1", Sensor.ACTIVE, s1.getKnownState());
         Assert.assertEquals("4 check s2", Sensor.ACTIVE, s2.getKnownState());
@@ -517,23 +517,26 @@ public class SerialNodeTest {
         r.setElement(3, 0x50);
         b.markChanges(r);
 
+        for (Sensor s : sm.getNamedBeanSet()) {
+            System.out.println(s.getSystemName());
+        }
         // created first four only
-        s1 = sm.getSensor("GS1p1");
-        Assert.assertTrue("s1 exists", s1 != null);
-        s2 = sm.getSensor("GS1p2");
-        Assert.assertTrue("s2 exists", s2 != null);
-        s3 = sm.getSensor("GS1p3");
-        Assert.assertTrue("s3 exists", s3 != null);
-        s4 = sm.getSensor("GS1p4");
-        Assert.assertTrue("s4 exists", s4 != null);
-        s5 = sm.getSensor("GS1p5");
-        Assert.assertTrue("s5 not exist", s5 == null);
-        s6 = sm.getSensor("GS1p6");
-        Assert.assertTrue("s6 not exist", s6 == null);
-        s7 = sm.getSensor("GS1p7");
-        Assert.assertTrue("s7 not exist", s7 == null);
-        s8 = sm.getSensor("GS1p8");
-        Assert.assertTrue("s8 not exist", s8 == null);
+        s1 = sm.getSensor("GS1001");
+        Assert.assertNotNull("s1 exists", s1);
+        s2 = sm.getSensor("GS1002");
+        Assert.assertNotNull("s2 exists", s2);
+        s3 = sm.getSensor("GS1003");
+        Assert.assertNotNull("s3 exists", s3);
+        s4 = sm.getSensor("GS1004");
+        Assert.assertNotNull("s4 exists", s4);
+        s5 = sm.getSensor("GS1005");
+        Assert.assertNull("s5 not exist", s5);
+        s6 = sm.getSensor("GS1006");
+        Assert.assertNull("s6 not exist", s6);
+        s7 = sm.getSensor("GS1007");
+        Assert.assertNull("s7 not exist", s7);
+        s8 = sm.getSensor("GS1008");
+        Assert.assertNull("s8 not exist", s8);
 
         Assert.assertEquals("2 check s1", Sensor.INACTIVE, s1.getKnownState());
         Assert.assertEquals("2 check s2", Sensor.INACTIVE, s2.getKnownState());
@@ -546,14 +549,14 @@ public class SerialNodeTest {
         r.setElement(3, 0x50);
         b.markChanges(r);
         // create first four only
-        s5 = sm.getSensor("GS1p5");
-        Assert.assertTrue("s5 not exist", s5 == null);
-        s6 = sm.getSensor("GS1p6");
-        Assert.assertTrue("s6 not exist", s6 == null);
-        s7 = sm.getSensor("GS1p7");
-        Assert.assertTrue("s7 not exist", s7 == null);
-        s8 = sm.getSensor("GS1p8");
-        Assert.assertTrue("s8 not exist", s8 == null);
+        s5 = sm.getSensor("GS1005");
+        Assert.assertNull("s5 not exist", s5);
+        s6 = sm.getSensor("GS1006");
+        Assert.assertNull("s6 not exist", s6);
+        s7 = sm.getSensor("GS1007");
+        Assert.assertNull("s7 not exist", s7);
+        s8 = sm.getSensor("GS1008");
+        Assert.assertNull("s8 not exist", s8);
 
         Assert.assertEquals("3 check s1", Sensor.ACTIVE, s1.getKnownState());
         Assert.assertEquals("3 check s2", Sensor.ACTIVE, s2.getKnownState());
@@ -568,13 +571,13 @@ public class SerialNodeTest {
 
         // create next four
         s5 = sm.getSensor("GS1005");
-        Assert.assertTrue("s5 exists", s5 != null);
+        Assert.assertNotNull("s5 exists", s5);
         s6 = sm.getSensor("GS1006");
-        Assert.assertTrue("s6 exists", s6 != null);
+        Assert.assertNotNull("s6 exists", s6);
         s7 = sm.getSensor("GS1007");
-        Assert.assertTrue("s7 exists", s7 != null);
+        Assert.assertNotNull("s7 exists", s7);
         s8 = sm.getSensor("GS1008");
-        Assert.assertTrue("s8 exists", s8 != null);
+        Assert.assertNotNull("s8 exists", s8);
 
         Assert.assertEquals("4 check s1", Sensor.ACTIVE, s1.getKnownState());
         Assert.assertEquals("4 check s2", Sensor.ACTIVE, s2.getKnownState());
@@ -604,21 +607,21 @@ public class SerialNodeTest {
 
         // create correct nibble only
         s1 = sm.getSensor("GS1005");
-        Assert.assertTrue("s1 exists", s1 != null);
+        Assert.assertNotNull("s1 exists", s1);
         s2 = sm.getSensor("GS1006");
-        Assert.assertTrue("s2 exists", s2 != null);
+        Assert.assertNotNull("s2 exists", s2);
         s3 = sm.getSensor("GS1007");
-        Assert.assertTrue("s3 exists", s3 != null);
+        Assert.assertNotNull("s3 exists", s3);
         s4 = sm.getSensor("GS1008");
-        Assert.assertTrue("s4 exists", s4 != null);
+        Assert.assertNotNull("s4 exists", s4);
         s5 = sm.getSensor("GS1001");
-        Assert.assertTrue("s5 not exist", s5 == null);
+        Assert.assertNull("s5 not exist", s5);
         s6 = sm.getSensor("GS1002");
-        Assert.assertTrue("s6 not exist", s6 == null);
+        Assert.assertNull("s6 not exist", s6);
         s7 = sm.getSensor("GS1003");
-        Assert.assertTrue("s7 not exist", s7 == null);
+        Assert.assertNull("s7 not exist", s7);
         s8 = sm.getSensor("GS1004");
-        Assert.assertTrue("s8 not exist", s8 == null);
+        Assert.assertNull("s8 not exist", s8);
 
         Assert.assertEquals("2 check s1", Sensor.INACTIVE, s1.getKnownState());
         Assert.assertEquals("2 check s2", Sensor.INACTIVE, s2.getKnownState());
@@ -633,13 +636,13 @@ public class SerialNodeTest {
 
         // create correct nibble only
         s5 = sm.getSensor("GS1001");
-        Assert.assertTrue("s5 not exist", s5 == null);
+        Assert.assertNull("s5 not exist", s5);
         s6 = sm.getSensor("GS1002");
-        Assert.assertTrue("s6 not exist", s6 == null);
+        Assert.assertNull("s6 not exist", s6);
         s7 = sm.getSensor("GS1003");
-        Assert.assertTrue("s7 not exist", s7 == null);
+        Assert.assertNull("s7 not exist", s7);
         s8 = sm.getSensor("GS1004");
-        Assert.assertTrue("s8 not exist", s8 == null);
+        Assert.assertNull("s8 not exist", s8);
 
         Assert.assertEquals("3 check s1", Sensor.ACTIVE, s1.getKnownState());
         Assert.assertEquals("3 check s2", Sensor.ACTIVE, s2.getKnownState());
@@ -654,13 +657,13 @@ public class SerialNodeTest {
 
         // create other nibble
         s5 = sm.getSensor("GS1001");
-        Assert.assertTrue("s5 exist", s5 != null);
+        Assert.assertNotNull("s5 exist", s5);
         s6 = sm.getSensor("GS1002");
-        Assert.assertTrue("s6 exist", s6 != null);
+        Assert.assertNotNull("s6 exist", s6);
         s7 = sm.getSensor("GS1003");
-        Assert.assertTrue("s7 exist", s7 != null);
+        Assert.assertNotNull("s7 exist", s7);
         s8 = sm.getSensor("GS1004");
-        Assert.assertTrue("s8 exist", s8 != null);
+        Assert.assertNotNull("s8 exist", s8);
 
         Assert.assertEquals("4 check s1", Sensor.ACTIVE, s1.getKnownState());
         Assert.assertEquals("4 check s2", Sensor.ACTIVE, s2.getKnownState());
@@ -690,21 +693,21 @@ public class SerialNodeTest {
 
         // created first four only
         s1 = sm.getSensor("GS1009");
-        Assert.assertTrue("s1 exists", s1 != null);
+        Assert.assertNotNull("s1 exists", s1);
         s2 = sm.getSensor("GS1010");
-        Assert.assertTrue("s2 exists", s2 != null);
+        Assert.assertNotNull("s2 exists", s2);
         s3 = sm.getSensor("GS1011");
-        Assert.assertTrue("s3 exists", s3 != null);
+        Assert.assertNotNull("s3 exists", s3);
         s4 = sm.getSensor("GS1012");
-        Assert.assertTrue("s4 exists", s4 != null);
+        Assert.assertNotNull("s4 exists", s4);
         s5 = sm.getSensor("GS1013");
-        Assert.assertTrue("s5 not exist", s5 == null);
+        Assert.assertNull("s5 not exist", s5);
         s6 = sm.getSensor("GS1014");
-        Assert.assertTrue("s6 not exist", s6 == null);
+        Assert.assertNull("s6 not exist", s6);
         s7 = sm.getSensor("GS1015");
-        Assert.assertTrue("s7 not exist", s7 == null);
+        Assert.assertNull("s7 not exist", s7);
         s8 = sm.getSensor("GS1016");
-        Assert.assertTrue("s8 not exist", s8 == null);
+        Assert.assertNull("s8 not exist", s8);
 
         Assert.assertEquals("2 check s1", Sensor.INACTIVE, s1.getKnownState());
         Assert.assertEquals("2 check s2", Sensor.INACTIVE, s2.getKnownState());
@@ -718,13 +721,13 @@ public class SerialNodeTest {
         b.markChanges(r);
         // create first four only
         s5 = sm.getSensor("GS1013");
-        Assert.assertTrue("s5 not exist", s5 == null);
+        Assert.assertNull("s5 not exist", s5);
         s6 = sm.getSensor("GS1014");
-        Assert.assertTrue("s6 not exist", s6 == null);
+        Assert.assertNull("s6 not exist", s6);
         s7 = sm.getSensor("GS1015");
-        Assert.assertTrue("s7 not exist", s7 == null);
+        Assert.assertNull("s7 not exist", s7);
         s8 = sm.getSensor("GS1016");
-        Assert.assertTrue("s8 not exist", s8 == null);
+        Assert.assertNull("s8 not exist", s8);
 
         Assert.assertEquals("3 check s1", Sensor.ACTIVE, s1.getKnownState());
         Assert.assertEquals("3 check s2", Sensor.ACTIVE, s2.getKnownState());
@@ -739,13 +742,13 @@ public class SerialNodeTest {
 
         // create next four
         s5 = sm.getSensor("GS1013");
-        Assert.assertTrue("s5 exist", s5 != null);
+        Assert.assertNotNull("s5 exist", s5);
         s6 = sm.getSensor("GS1014");
-        Assert.assertTrue("s6 exist", s6 != null);
+        Assert.assertNotNull("s6 exist", s6);
         s7 = sm.getSensor("GS1015");
-        Assert.assertTrue("s7 exist", s7 != null);
+        Assert.assertNotNull("s7 exist", s7);
         s8 = sm.getSensor("GS1016");
-        Assert.assertTrue("s8 exist", s8 != null);
+        Assert.assertNotNull("s8 exist", s8);
 
         Assert.assertEquals("4 check s1", Sensor.ACTIVE, s1.getKnownState());
         Assert.assertEquals("4 check s2", Sensor.ACTIVE, s2.getKnownState());
@@ -775,21 +778,21 @@ public class SerialNodeTest {
 
         // create correct nibble only
         s1 = sm.getSensor("GS1013");
-        Assert.assertTrue("s1 exists", s1 != null);
+        Assert.assertNotNull("s1 exists", s1);
         s2 = sm.getSensor("GS1014");
-        Assert.assertTrue("s2 exists", s2 != null);
+        Assert.assertNotNull("s2 exists", s2);
         s3 = sm.getSensor("GS1015");
-        Assert.assertTrue("s3 exists", s3 != null);
+        Assert.assertNotNull("s3 exists", s3);
         s4 = sm.getSensor("GS1016");
-        Assert.assertTrue("s4 exists", s4 != null);
+        Assert.assertNotNull("s4 exists", s4);
         s5 = sm.getSensor("GS1009");
-        Assert.assertTrue("s5 not exist", s5 == null);
+        Assert.assertNull("s5 not exist", s5);
         s6 = sm.getSensor("GS1010");
-        Assert.assertTrue("s6 not exist", s6 == null);
+        Assert.assertNull("s6 not exist", s6);
         s7 = sm.getSensor("GS1011");
-        Assert.assertTrue("s7 not exist", s7 == null);
+        Assert.assertNull("s7 not exist", s7);
         s8 = sm.getSensor("GS1012");
-        Assert.assertTrue("s8 not exist", s8 == null);
+        Assert.assertNull("s8 not exist", s8);
 
         Assert.assertEquals("2 check s1", Sensor.INACTIVE, s1.getKnownState());
         Assert.assertEquals("2 check s2", Sensor.INACTIVE, s2.getKnownState());
@@ -804,13 +807,13 @@ public class SerialNodeTest {
 
         // create correct nibble only
         s5 = sm.getSensor("GS1009");
-        Assert.assertTrue("s5 not exist", s5 == null);
+        Assert.assertNull("s5 not exist", s5);
         s6 = sm.getSensor("GS1010");
-        Assert.assertTrue("s6 not exist", s6 == null);
+        Assert.assertNull("s6 not exist", s6);
         s7 = sm.getSensor("GS1011");
-        Assert.assertTrue("s7 not exist", s7 == null);
+        Assert.assertNull("s7 not exist", s7);
         s8 = sm.getSensor("GS1012");
-        Assert.assertTrue("s8 not exist", s8 == null);
+        Assert.assertNull("s8 not exist", s8);
 
         Assert.assertEquals("3 check s1", Sensor.ACTIVE, s1.getKnownState());
         Assert.assertEquals("3 check s2", Sensor.ACTIVE, s2.getKnownState());
@@ -825,13 +828,13 @@ public class SerialNodeTest {
 
         // create other nibble
         s5 = sm.getSensor("GS1009");
-        Assert.assertTrue("s5 exist", s5 != null);
+        Assert.assertNotNull("s5 exist", s5);
         s6 = sm.getSensor("GS1010");
-        Assert.assertTrue("s6 exist", s6 != null);
+        Assert.assertNotNull("s6 exist", s6);
         s7 = sm.getSensor("GS1011");
-        Assert.assertTrue("s7 exist", s7 != null);
+        Assert.assertNotNull("s7 exist", s7);
         s8 = sm.getSensor("GS1012");
-        Assert.assertTrue("s8 exist", s8 != null);
+        Assert.assertNotNull("s8 exist", s8);
 
         Assert.assertEquals("4 check s1", Sensor.ACTIVE, s1.getKnownState());
         Assert.assertEquals("4 check s2", Sensor.ACTIVE, s2.getKnownState());

--- a/java/test/jmri/jmrix/grapevine/SerialSensorManagerTest.java
+++ b/java/test/jmri/jmrix/grapevine/SerialSensorManagerTest.java
@@ -57,8 +57,9 @@ public class SerialSensorManagerTest extends jmri.managers.AbstractSensorMgrTest
         Assert.assertTrue("4th UA 3", n3.getSensorsActive());
 
         // some equality tests
-        Assert.assertTrue("GS1p7 == GS1007", l.getSensor("GS1p7") == l.getSensor("GS1007"));
-        Assert.assertTrue("GS1B7 == GS1007", l.getSensor("GS1B7") == l.getSensor("GS1007"));
+        // TODO: should these be the same bean, or should different beans point to same physical device?
+        Assert.assertNotEquals("GS1p7 == GS1007", l.getSensor("GS1p7"), l.getSensor("GS1007"));
+        Assert.assertNotEquals("GS1B7 == GS1007", l.getSensor("GS1B7"), l.getSensor("GS1007"));
     }
 
     @Override

--- a/java/test/jmri/jmrix/ieee802154/xbee/XBeeSensorManagerTest.java
+++ b/java/test/jmri/jmrix/ieee802154/xbee/XBeeSensorManagerTest.java
@@ -45,7 +45,7 @@ public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         // create
         Sensor t = l.provide(getSystemName(getNumToTest1()));
         // check
-        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertNotNull("real object returned ", t);
         Assert.assertEquals("system name correct ", t ,l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
@@ -54,8 +54,8 @@ public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         // create
         Sensor t = l.provide("ASNode 1:2");
         // check
-        Assert.assertTrue("real object returned ", t != null);
-        Assert.assertEquals("correct object returned ", t ,l.getBySystemName("ASNODE 1:2"));
+        Assert.assertNotNull("real object returned ", t);
+        Assert.assertEquals("correct object returned ", t ,l.getBySystemName("ASNode 1:2"));
     }
 
     @Test
@@ -63,7 +63,7 @@ public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         // create
         Sensor t = l.provide("AS00 02:2");
         // check
-        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertNotNull("real object returned ", t);
         Assert.assertEquals("system name correct ", t,l.getBySystemName("AS00 02:2"));
     }
 
@@ -72,7 +72,7 @@ public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         // create
         Sensor t = l.provide("AS00 13 A2 00 40 A0 4D 2D:2");
         // check
-        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertNotNull("real object returned ", t);
         Assert.assertEquals("system name correct ", t ,l.getBySystemName("AS00 13 A2 00 40 A0 4D 2D:2"));
     }
 
@@ -82,7 +82,7 @@ public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
         // create
         Sensor t = l.provideSensor(getSystemName(getNumToTest1()));
         // check
-        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertNotNull("real object returned ", t);
         Assert.assertEquals("system name correct ", t, l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
@@ -99,6 +99,7 @@ public class XBeeSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBa
     }
 
     @Test
+    @Override
     public void testMoveUserName() {
         Sensor t1 = l.provideSensor(getSystemName(getNumToTest1()));
         Sensor t2 = l.provideSensor(getSystemName(getNumToTest2()));

--- a/java/test/jmri/jmrix/roco/z21/Z21CanBusSensorManagerTest.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21CanBusSensorManagerTest.java
@@ -26,7 +26,7 @@ public class Z21CanBusSensorManagerTest extends jmri.managers.AbstractSensorMgrT
         // create
         Sensor t = l.provideSensor("ZSABCD:5");
         // check
-        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertNotNull("real object returned ", t);
         Assert.assertEquals("system name correct ", t,l.getBySystemName(getSystemName(5)));
     }
 
@@ -69,14 +69,16 @@ public class Z21CanBusSensorManagerTest extends jmri.managers.AbstractSensorMgrT
 
     @Test
     public void testZ21CanBusMessages() {
-        // send messages for feedbak encoder abcd:1
+        // send messages for feedback encoder abcd:1
         // notify the Z21 that somebody else changed it...
         byte msg[]={(byte)0x0E,(byte)0x00,(byte)0xC4,(byte)0x00,(byte)0xcd,(byte)0xab,(byte)0x01,(byte)0x00,(byte)0x01,(byte)0x01,(byte)0x00,(byte)0x01,(byte)0x00,(byte)0x00};
         Z21Reply reply = new Z21Reply(msg,14);
         znis.sendTestMessage(reply);
 
         // see if sensor exists
-        Assert.assertTrue(null != l.getBySystemName("ZSABCD:1"));
+        // note that name matches case of name sent
+        Assert.assertNotNull(l.getBySystemName("ZSabcd:1"));
+        Assert.assertNull(l.getBySystemName("ZSABCD:1"));
     }
 
     @Test

--- a/java/test/jmri/jmrix/roco/z21/Z21InterfaceScaffold.java
+++ b/java/test/jmri/jmrix/roco/z21/Z21InterfaceScaffold.java
@@ -39,7 +39,8 @@ public class Z21InterfaceScaffold extends Z21TrafficController {
 
     // test control member functions
     /**
-     * forward a message to the listeners, e.g. test receipt
+     * forward a message to the listeners, e.g.test receipt
+     * @param m the message to test
      */
     public void sendTestMessage(Z21Reply m) {
         // forward a test message to Z21Listeners
@@ -47,7 +48,6 @@ public class Z21InterfaceScaffold extends Z21TrafficController {
             log.debug("sendTestMessage    [" + m + "]");
         }
         notifyReply(m, null);
-        return;
     }
 
     /*

--- a/java/test/jmri/managers/AbstractLightMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractLightMgrTestBase.java
@@ -110,7 +110,7 @@ public abstract class AbstractLightMgrTestBase extends AbstractProvidingManagerT
 
     @Test
     public void testUpperLower() {
-        Light t = l.provideLight("" + getNumToTest2());
+        Light t = l.provideLight(getSystemName(getNumToTest2()));
         String name = t.getSystemName();
         Assert.assertNull(l.getLight(name.toLowerCase()));
     }

--- a/java/test/jmri/managers/AbstractSensorMgrTestBase.java
+++ b/java/test/jmri/managers/AbstractSensorMgrTestBase.java
@@ -55,9 +55,9 @@ public abstract class AbstractSensorMgrTestBase extends AbstractProvidingManager
         // create
         Sensor t = l.newSensor(getSystemName(getNumToTest1()), "mine");
         // check
-        Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("user name correct ", t == l.getByUserName("mine"));
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
+        Assert.assertNotNull("real object returned ", t);
+        Assert.assertEquals("user name correct ", t, l.getByUserName("mine"));
+        Assert.assertEquals("system name correct ", t, l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
     // Quite a few tests overload this to create their own name process
@@ -66,8 +66,8 @@ public abstract class AbstractSensorMgrTestBase extends AbstractProvidingManager
         // create
         Sensor t = l.provide("" + getNumToTest1());
         // check
-        Assert.assertTrue("real object returned ", t != null);
-        Assert.assertTrue("system name correct ", t == l.getBySystemName(getSystemName(getNumToTest1())));
+        Assert.assertNotNull("real object returned ", t);
+        Assert.assertEquals("system name correct ", t, l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
     @Test
@@ -102,7 +102,7 @@ public abstract class AbstractSensorMgrTestBase extends AbstractProvidingManager
         // create
         Sensor t = l.provideSensor("" + getNumToTest1());
         // check
-        Assert.assertTrue("real object returned ", t != null);
+        Assert.assertNotNull("real object returned ", t);
         Assert.assertEquals("system name correct ", t, l.getBySystemName(getSystemName(getNumToTest1())));
     }
 
@@ -124,21 +124,22 @@ public abstract class AbstractSensorMgrTestBase extends AbstractProvidingManager
     public void testSingleObject() {
         // test that you always get the same representation
         Sensor t1 = l.newSensor(getSystemName(getNumToTest1()), "mine");
-        Assert.assertTrue("t1 real object returned ", t1 != null);
-        Assert.assertTrue("same by user ", t1 == l.getByUserName("mine"));
-        Assert.assertTrue("same by system ", t1 == l.getBySystemName(getSystemName(getNumToTest1())));
+        Assert.assertNotNull("t1 real object returned ", t1);
+        Assert.assertEquals("same by user ", t1, l.getByUserName("mine"));
+        System.out.println(t1.getSystemName());
+        Assert.assertEquals("same by system ", t1, l.getBySystemName(getSystemName(getNumToTest1())));
 
         Sensor t2 = l.newSensor(getSystemName(getNumToTest1()), "mine");
-        Assert.assertTrue("t2 real object returned ", t2 != null);
+        Assert.assertNotNull("t2 real object returned ", t2);
         // check
-        Assert.assertTrue("same new ", t1 == t2);
+        Assert.assertEquals("same new ", t1, t2);
     }
 
     @Test
     public void testMisses() {
         // try to get nonexistant sensors
-        Assert.assertTrue(null == l.getByUserName("foo"));
-        Assert.assertTrue(null == l.getBySystemName("bar"));
+        Assert.assertNull(l.getByUserName("foo"));
+        Assert.assertNull(l.getBySystemName("bar"));
     }
 
     @Test
@@ -146,12 +147,12 @@ public abstract class AbstractSensorMgrTestBase extends AbstractProvidingManager
         Sensor t1 = l.provideSensor("" + getNumToTest1());
         Sensor t2 = l.provideSensor("" + getNumToTest2());
         t1.setUserName("UserName");
-        Assert.assertTrue(t1 == l.getByUserName("UserName"));
+        Assert.assertEquals(t1, l.getByUserName("UserName"));
 
         t2.setUserName("UserName");
-        Assert.assertTrue(t2 == l.getByUserName("UserName"));
+        Assert.assertEquals(t2, l.getByUserName("UserName"));
 
-        Assert.assertTrue(null == t1.getUserName());
+        Assert.assertNull(t1.getUserName());
     }
 
     @Test
@@ -184,6 +185,7 @@ public abstract class AbstractSensorMgrTestBase extends AbstractProvidingManager
     /**
      * Number of sensor to test. Made a separate method so it can be overridden
      * in subclasses that do or don't support various numbers
+     * @return the number to test
      */
     protected int getNumToTest1() {
         return 9;

--- a/java/test/jmri/managers/ProxyLightManagerTest.java
+++ b/java/test/jmri/managers/ProxyLightManagerTest.java
@@ -59,14 +59,6 @@ public class ProxyLightManagerTest {
     }
 
     @Test
-    public void testNormalizeName() {
-        // create
-        String name = l.provideLight("" + getNumToTest1()).getSystemName();
-        // check
-        Assert.assertEquals(name, l.normalizeSystemName(name));
-    }
-
-    @Test
     public void testProvideFailure() {
         boolean correct = false;
         try {

--- a/java/test/jmri/managers/ProxyReporterManagerTest.java
+++ b/java/test/jmri/managers/ProxyReporterManagerTest.java
@@ -70,14 +70,6 @@ public class ProxyReporterManagerTest extends AbstractReporterMgrTestBase {
     }
 
     @Test
-    public void testNormalizeName() {
-        // create
-        String name = l.provideReporter("" + getNameToTest1()).getSystemName();
-        // check
-        Assert.assertEquals(name, l.normalizeSystemName(name));
-    }
-
-    @Test
     public void testInstanceManagerIntegration() {
         jmri.util.JUnitUtil.resetInstanceManager();
         Assert.assertNotNull(InstanceManager.getDefault(ReporterManager.class));

--- a/java/test/jmri/managers/ProxySensorManagerTest.java
+++ b/java/test/jmri/managers/ProxySensorManagerTest.java
@@ -86,14 +86,6 @@ public class ProxySensorManagerTest implements Manager.ManagerDataListener<Senso
     }
 
     @Test
-    public void testNormalizeName() {
-        // create
-        String name = l.provideSensor("1").getSystemName();
-        // check
-        Assert.assertEquals(name, l.normalizeSystemName(name));
-    }
-
-    @Test
     public void testProvideFailure() {
         boolean correct = false;
         try {

--- a/java/test/jmri/managers/ProxySensorManagerTest.java
+++ b/java/test/jmri/managers/ProxySensorManagerTest.java
@@ -42,17 +42,17 @@ public class ProxySensorManagerTest implements Manager.ManagerDataListener<Senso
         Assert.assertEquals(0, l.getObjectCount());
         // create
         Sensor t = l.provideSensor("IS:XYZ");
-        Assert.assertEquals(t, l.provideSensor("IS:xyz"));  // upper case and lower case are the same object
+        Assert.assertNotEquals(t, l.provideSensor("IS:xyz"));  // upper case and lower case are different objects
         // check
         Assert.assertTrue("real object returned ", t != null);
         Assert.assertEquals("IS:XYZ", t.getSystemName());  // we force upper
         Assert.assertTrue("system name correct ", t == l.getBySystemName("IS:XYZ"));
-        Assert.assertEquals(1, l.getObjectCount());
-        Assert.assertEquals(1, l.getSystemNameAddedOrderList().size());
+        Assert.assertEquals(2, l.getObjectCount());
+        Assert.assertEquals(2, l.getNamedBeanSet().size());
         // test providing same name as existing sensor does not create new sensor
         l.provideSensor("IS:XYZ");
-        Assert.assertEquals(1, l.getObjectCount());
-        Assert.assertEquals(1, l.getSystemNameAddedOrderList().size());
+        Assert.assertEquals(2, l.getObjectCount());
+        Assert.assertEquals(2, l.getNamedBeanSet().size());
     }
 
     @Test
@@ -120,14 +120,14 @@ public class ProxySensorManagerTest implements Manager.ManagerDataListener<Senso
     }
 
     @Test
-    public void testUpperLower() {  // this is part of testing of (default) normalization
+    public void testUpperLower() {  // verify that names are case sensitive
         Sensor t = l.provideSensor("JS1ABC");  // internal will always accept that name
         String name = t.getSystemName();
         
         int prefixLength = l.getSystemPrefix().length()+1;     // 1 for type letter
         String lowerName = name.substring(0,prefixLength)+name.substring(prefixLength, name.length()).toLowerCase();
         
-        Assert.assertEquals(t, l.getSensor(lowerName));
+        Assert.assertNotEquals(t, l.getSensor(lowerName));
     }
 
     @Test

--- a/java/test/jmri/managers/ProxyTurnoutManagerTest.java
+++ b/java/test/jmri/managers/ProxyTurnoutManagerTest.java
@@ -58,14 +58,6 @@ public class ProxyTurnoutManagerTest {
     }
 
     @Test
-    public void testNormalizeName() {
-        // create
-        String name = l.provideTurnout("" + getNumToTest1()).getSystemName();
-        // check
-        Assert.assertEquals(name, l.normalizeSystemName(name));
-    }
-
-    @Test
     public void testProvideFailure() {
         boolean correct = false;
         try {

--- a/java/test/jmri/managers/TurnoutManagerScaffold.java
+++ b/java/test/jmri/managers/TurnoutManagerScaffold.java
@@ -115,11 +115,6 @@ public class TurnoutManagerScaffold implements TurnoutManager {
     }
 
     @Override
-    public String normalizeSystemName(String inputName) throws NamedBean.BadSystemNameException {
-        return inputName;
-    }
-
-    @Override
     public void dispose() {
     }
 

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -263,7 +263,7 @@
             <compilation-unit>
                 <package-root>java/acceptancetest/step_definitions</package-root>
                 <unit-tests/>
-                <classpath mode="compile">target/classes:lib/webdrivermanager-3.4.0.jar:lib/junit-4.12.jar:lib/cucumber-java8-4.3.1.jar:lib/selenium-server-standalone-3.6.0.jar:lib/slf4j-api-1.7.25.jar</classpath>
+                <classpath mode="compile">target/classes:lib/webdrivermanager-3.4.0.jar:lib/junit-4.12.jar:lib/cucumber-core-4.3.1.jar:lib/cucumber-java-4.3.1.jar:lib/cucumber-java8-4.3.1.jar:lib/selenium-server-standalone-3.6.0.jar:lib/slf4j-api-1.7.25.jar:lib/jemmy-22-00c9f753cd0a.jar:lib/log4j-1.2.17.jar</classpath>
                 <source-level>1.8</source-level>
             </compilation-unit>
         </java-data>


### PR DESCRIPTION
The use of normalization to "correct" user and other input for system names for NamedBean is a **failed experiment** and should be removed without deprecation.

Therefor, this PR removes the method `jmri.Manager.normalizeSystemName(String)` without following the normal deprecation process.

Follow on PRs will remove hidden normalization occurring in constructors and input fields and introduce a rigorous mechanism for validating system names that provides direct actionable feedback to users and other systems to indicate why a proposed system name was rejected by JMRI. Once these PRs are complete and integrated JMRI will accept a proposed system name *without modification* if the system name is valid; otherwise JMRI will refuse to create a NamedBean with the system name.