### PR TITLE
revert #7153; replace #7158; only reference glue code for specified tests.

### DIFF
--- a/java/acceptancetest/step_definitions/apps/ApplicationTestAcceptanceSteps.java
+++ b/java/acceptancetest/step_definitions/apps/ApplicationTestAcceptanceSteps.java
@@ -7,7 +7,6 @@ import java.io.File;
 import org.apache.commons.io.FileUtils;
 import java.nio.file.Files;
 import java.lang.reflect.Method;
-import jmri.InstanceManager;
 import jmri.ShutDownManager;
 import jmri.util.JmriJFrame;
 import jmri.util.MockShutDownManager;
@@ -26,7 +25,7 @@ public class ApplicationTestAcceptanceSteps implements En {
    String[] tags = {"@apptest"};
    File tempFolder;
    
-   public ApplicationTestAcceptanceSteps(jmri.InstanceManager instance) {
+   public ApplicationTestAcceptanceSteps() {
 
    Before(tags,() -> {
       JUnitUtil.setUp();
@@ -75,7 +74,7 @@ public class ApplicationTestAcceptanceSteps implements En {
         dismissClosingDialogs(); // this method starts a new thread
         try {
             // gracefully shutdown, but don't exit
-            ShutDownManager sdm = InstanceManager.getDefault(ShutDownManager.class);
+            ShutDownManager sdm = jmri.InstanceManager.getDefault(ShutDownManager.class);
             if (sdm instanceof MockShutDownManager) {
                 // ShutDownManagers other than MockShutDownManager really shutdown
                 sdm.shutdown();

--- a/java/test/apps/RunCucumberTest.java
+++ b/java/test/apps/RunCucumberTest.java
@@ -3,7 +3,6 @@ package apps;
 import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 import org.junit.runner.RunWith;
-import org.junit.*;
 
 /**
  * Trigger file for Cucumber tests.
@@ -25,16 +24,7 @@ import org.junit.*;
 @CucumberOptions(plugin = {"junit:cucumber-results.xml","progress","json:cucumber-results.json"},
                  features="java/acceptancetest/features/apps",
                  tags = {"not @webtest", "not @Ignore", "not @ignore"},
-                 glue = {"apps","jmri"} )
+                 glue = {"apps"})
 public class RunCucumberTest {
 
-    @BeforeClass
-    public static void setUpClass() {
-        jmri.util.JUnitUtil.setUp();
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-        jmri.util.JUnitUtil.tearDown();
-    }
 }

--- a/java/test/jmri/RunCucumberTest.java
+++ b/java/test/jmri/RunCucumberTest.java
@@ -26,7 +26,7 @@ import org.junit.BeforeClass;
 @CucumberOptions(plugin = {"junit:cucumber-results.xml","progress","json:cucumber-results.json"},
                  features="java/acceptancetest/features/web",
                  tags = {"not @webtest", "not @Ignore", "not @ignore"},
-                 glue = {"apps","jmri"} )
+                 glue = {"jmri"} )
 public class RunCucumberTest {
    
    @BeforeClass


### PR DESCRIPTION
The reasons the logging was being initialized outside of the designated Before hook was that 

1. That dependency injection was used for the application tests where it shouldn't have been
2. glue code was being loaded for all of the Cucumber tests, and the web tests use dependency injection for the instance manager.

#7158 removed issue 1, though that has been replicated here.  #7153 masked issue 2 by initializing the logging before the dependency injection could create the required InstanceManager for the web tests.