### PR TITLE
stop auto-generating tooltips

### DIFF
--- a/java/src/jmri/jmrit/display/Editor.java
+++ b/java/src/jmri/jmrit/display/Editor.java
@@ -2693,7 +2693,8 @@ abstract public class Editor extends JmriJFrame implements MouseListener, MouseM
      */
     public void showToolTip(Positionable selection, MouseEvent event) {
         ToolTip tip = selection.getToolTip();
-        if (tip.getText() == null || tip.getText().isEmpty()) {
+        String txt = tip.getText();
+        if (txt == null || txt.isEmpty()) {
             return;
         }
         tip.setLocation(selection.getX() + selection.getWidth() / 2, selection.getY() + selection.getHeight());

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -10192,10 +10192,10 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             @Nonnull Positionable selection,
             @Nonnull MouseEvent event) {
         ToolTip tip = selection.getToolTip();
-        tip.setLocation(selection.getX() + selection.getWidth() / 2, selection.getY() + selection.getHeight());
         if (tip.getText() == null || tip.getText().isEmpty()) {
-            tip.setText(selection.getNameString());
+            return;
         }
+        tip.setLocation(selection.getX() + selection.getWidth() / 2, selection.getY() + selection.getHeight());
         setToolTip(tip);
     }
 

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -10192,7 +10192,8 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             @Nonnull Positionable selection,
             @Nonnull MouseEvent event) {
         ToolTip tip = selection.getToolTip();
-        if (tip.getText() == null || tip.getText().isEmpty()) {
+        String txt = tip.getText();
+        if (txt == null || txt.isEmpty()) {
             return;
         }
         tip.setLocation(selection.getX() + selection.getWidth() / 2, selection.getY() + selection.getHeight());


### PR DESCRIPTION
Currently, all labels and icons on layouteditor get an auto-generated tooltip "Text Label" or "Icon" when you hover over them. If you remove it, it is added back on subsequent hover. These generated tooltips are then saved with the panel when saved.

This PR removes that behavior, so if you remove or blank the tooltip, it stays that way.

NOTE: the Panel Editor has this same code, so maybe it should be removed there as well?