### PR TITLE
Fix warnings introduced in PR 7163

### DIFF
--- a/java/src/jmri/implementation/AbstractNamedBean.java
+++ b/java/src/jmri/implementation/AbstractNamedBean.java
@@ -106,6 +106,9 @@ public abstract class AbstractNamedBean implements NamedBean {
     }
 
     /** {@inheritDoc} */
+    // The reason for having this method here, and the reason for the
+    // SuppressWarning, is to prevent subclasses from implementing it.
+    @SuppressWarnings("deprecation")
     @Override
     @CheckReturnValue
     @Nonnull
@@ -114,6 +117,9 @@ public abstract class AbstractNamedBean implements NamedBean {
     }
 
     /** {@inheritDoc} */
+    // The reason for having this method here, and the reason for the
+    // SuppressWarning, is to prevent subclasses from implementing it.
+    @SuppressWarnings("deprecation")
     @Override
     @CheckReturnValue
     @Nonnull

--- a/java/src/jmri/jmrit/entryexit/DestinationPoints.java
+++ b/java/src/jmri/jmrit/entryexit/DestinationPoints.java
@@ -30,7 +30,7 @@ import jmri.jmrit.display.layoutEditor.LayoutTurnout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DestinationPoints extends jmri.implementation.AbstractNamedBean implements NamedBean {
+public class DestinationPoints extends jmri.implementation.AbstractNamedBean {
 
     @Override
     public String getBeanType() {


### PR DESCRIPTION
Suppresses deprecation warnings in AbstractNamedBean and fixes the warnings in DestinationPoints.

See discussion in PR #7163.