### PR TITLE
Drop redundant interfaces

### DIFF
--- a/java/ecj.warning.options
+++ b/java/ecj.warning.options
@@ -78,6 +78,9 @@
 -warn:+includeAssertNull
 -warn:+inheritNullAnnot
 -warn:+intfAnnotation
+  # redundant super-interfaces
+-warn:+intfRedundant
+
 -warn:+intfNonInherited
 -warn:+maskedCatchBlocks
 -warn:+noEffectAssign
@@ -105,10 +108,6 @@
 
   # no real cost to using implicit boxing/unboxing, and it's just easier
 -warn:-boxing
-
-  # redundant super-interfaces: this is a design-style issue
-  # our inheritance tree doesn't insist on single-access to parent interfaces
--warn:-intfRedundant
 
   # non-NLS string literals (mostly missing // $ NON-NLS)
 -warn:-nls

--- a/java/ecj.warning.options-ci
+++ b/java/ecj.warning.options-ci
@@ -71,6 +71,9 @@
 -err:+includeAssertNull
 -err:+inheritNullAnnot
 -err:+intfAnnotation
+  # redundant super-interfaces
+-err:+intfRedundant
+
 -err:+intfNonInherited
 -err:+maskedCatchBlocks
 -err:+noEffectAssign
@@ -95,7 +98,6 @@
 
 # Checks we choose not to enforce as our common style
 -warn:-boxing
--warn:-intfRedundant
 -warn:-nls
 -warn:-paramAssign
 -warn:-serial

--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -1,7 +1,6 @@
 package jmri;
 
 import java.beans.PropertyChangeEvent;
-import java.beans.VetoableChangeListener;
 import java.text.DecimalFormat;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -34,7 +33,7 @@ import jmri.managers.AbstractManager;
  *
  * @author Bob Jacobsen Copyright (C) 2006
  */
-public class BlockManager extends AbstractManager<Block> implements ProvidingManager<Block>, VetoableChangeListener, InstanceManagerAutoDefault {
+public class BlockManager extends AbstractManager<Block> implements ProvidingManager<Block>, InstanceManagerAutoDefault {
 
     private final String powerManagerChangeName;
 

--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -1,7 +1,6 @@
 package jmri;
 
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.beans.VetoableChangeListener;
 import java.text.DecimalFormat;
 import java.time.Instant;
@@ -35,7 +34,7 @@ import jmri.managers.AbstractManager;
  *
  * @author Bob Jacobsen Copyright (C) 2006
  */
-public class BlockManager extends AbstractManager<Block> implements ProvidingManager<Block>, PropertyChangeListener, VetoableChangeListener, InstanceManagerAutoDefault {
+public class BlockManager extends AbstractManager<Block> implements ProvidingManager<Block>, VetoableChangeListener, InstanceManagerAutoDefault {
 
     private final String powerManagerChangeName;
 

--- a/java/src/jmri/SectionManager.java
+++ b/java/src/jmri/SectionManager.java
@@ -1,6 +1,5 @@
 package jmri;
 
-import java.beans.PropertyChangeListener;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +32,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dave Duchamp Copyright (C) 2008
  */
-public class SectionManager extends AbstractManager<Section> implements PropertyChangeListener, InstanceManagerAutoDefault {
+public class SectionManager extends AbstractManager<Section> implements InstanceManagerAutoDefault {
 
     public SectionManager() {
         super();

--- a/java/src/jmri/TransitManager.java
+++ b/java/src/jmri/TransitManager.java
@@ -1,6 +1,5 @@
 package jmri;
 
-import java.beans.PropertyChangeListener;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import jmri.managers.AbstractManager;
@@ -28,7 +27,7 @@ import jmri.managers.AbstractManager;
  *
  * @author Dave Duchamp Copyright (C) 2008, 2011
  */
-public class TransitManager extends AbstractManager<Transit> implements PropertyChangeListener, InstanceManagerAutoDefault {
+public class TransitManager extends AbstractManager<Transit> implements InstanceManagerAutoDefault {
 
     public TransitManager() {
         super();

--- a/java/src/jmri/implementation/NmraConsist.java
+++ b/java/src/jmri/implementation/NmraConsist.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Paul Bender Copyright (C) 2011
  */
-public class NmraConsist extends DccConsist implements Consist {
+public class NmraConsist extends DccConsist {
         
     private CommandStation commandStation = null;
 

--- a/java/src/jmri/implementation/SignalHeadSignalMast.java
+++ b/java/src/jmri/implementation/SignalHeadSignalMast.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (C) 2009
  */
-public class SignalHeadSignalMast extends AbstractSignalMast implements java.beans.VetoableChangeListener {
+public class SignalHeadSignalMast extends AbstractSignalMast {
 
     public SignalHeadSignalMast(String systemName, String userName) {
         super(systemName, userName);

--- a/java/src/jmri/jmris/simpleserver/parser/SimpleVisitor.java
+++ b/java/src/jmri/jmris/simpleserver/parser/SimpleVisitor.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
  * parser for the SimpleServer protocol and the JMRI back end.
  * @author Paul Bender Copyright (C) 2016
  */
-public class SimpleVisitor extends JmriServerParserDefaultVisitor implements JmriServerParserVisitor {
+public class SimpleVisitor extends JmriServerParserDefaultVisitor {
 
     private String outputString = null;
 

--- a/java/src/jmri/jmris/srcp/parser/SRCPVisitor.java
+++ b/java/src/jmri/jmris/srcp/parser/SRCPVisitor.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
  * parser for the SRCP protocol and the JMRI back end.
  * @author Paul Bender Copyright (C) 2010
  */
-public class SRCPVisitor extends SRCPParserDefaultVisitor implements SRCPParserVisitor {
+public class SRCPVisitor extends SRCPParserDefaultVisitor {
 
     private String outputString = null;
 

--- a/java/src/jmri/jmrit/beantable/AudioTableAction.java
+++ b/java/src/jmri/jmrit/beantable/AudioTableAction.java
@@ -2,7 +2,6 @@ package jmri.jmrit.beantable;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
-import java.beans.PropertyChangeListener;
 import java.util.ResourceBundle;
 import javax.swing.JButton;
 import javax.swing.JMenu;
@@ -260,7 +259,7 @@ public class AudioTableAction extends AbstractTableAction<Audio> {
     /**
      * Define abstract AudioTableDataModel
      */
-    abstract public class AudioTableDataModel extends BeanTableDataModel<Audio> implements PropertyChangeListener {
+    abstract public class AudioTableDataModel extends BeanTableDataModel<Audio> {
 
         char subType;
 

--- a/java/src/jmri/jmrit/beantable/RowComboBoxPanel.java
+++ b/java/src/jmri/jmrit/beantable/RowComboBoxPanel.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class RowComboBoxPanel
         extends    DefaultCellEditor
-        implements TableCellEditor, TableCellRenderer {
+        implements TableCellRenderer {
 
     /**
      * The surrounding panel for the combobox.

--- a/java/src/jmri/jmrit/catalog/DirectorySearcher.java
+++ b/java/src/jmri/jmrit/catalog/DirectorySearcher.java
@@ -192,7 +192,7 @@ public class DirectorySearcher implements InstanceManagerAutoDefault {
                 Bundle.getMessage("MessageTitle"), JOptionPane.INFORMATION_MESSAGE);
     }
 
-    class Seacher extends Thread implements Runnable {
+    class Seacher extends Thread {
 
         File dir;
         boolean quit = false;

--- a/java/src/jmri/jmrit/display/BlockContentsIcon.java
+++ b/java/src/jmri/jmrit/display/BlockContentsIcon.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (c) 2004
  */
-public class BlockContentsIcon extends MemoryIcon implements java.beans.PropertyChangeListener {
+public class BlockContentsIcon extends MemoryIcon {
 
     private NamedIcon defaultIcon = null;
     java.util.HashMap<String, NamedIcon> map = null;

--- a/java/src/jmri/jmrit/display/palette/MemoryItemPanel.java
+++ b/java/src/jmri/jmrit/display/palette/MemoryItemPanel.java
@@ -28,7 +28,7 @@ import jmri.jmrit.picker.PickListModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MemoryItemPanel extends TableItemPanel<Memory> implements ChangeListener, ListSelectionListener {
+public class MemoryItemPanel extends TableItemPanel<Memory> implements ChangeListener {
 
     enum Type {
         READONLY, READWRITE, SPINNER, COMBO

--- a/java/src/jmri/jmrit/display/palette/SignalMastItemPanel.java
+++ b/java/src/jmri/jmrit/display/palette/SignalMastItemPanel.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * @author Pete Cressman Copyright (c) 2010, 2011
  * @author Egbert Broerse 2017
  */
-public class SignalMastItemPanel extends TableItemPanel<SignalMast> implements ListSelectionListener {
+public class SignalMastItemPanel extends TableItemPanel<SignalMast> {
 
     SignalMast _mast;
     private HashMap<String, NamedIcon> _iconMastMap;

--- a/java/src/jmri/jmrit/logix/Engineer.java
+++ b/java/src/jmri/jmrit/logix/Engineer.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 /*
  * ************************ Thread running the train ****************
  */
-public class Engineer extends Thread implements Runnable, java.beans.PropertyChangeListener {
+public class Engineer extends Thread implements java.beans.PropertyChangeListener {
 
     private int _idxCurrentCommand;     // current throttle command
     private String _currentCommand;
@@ -1017,7 +1017,7 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
         if (log.isDebugEnabled()) log.debug("Exit runWarrant - " + msg);
     }
 
-    static private class CheckForTermination extends Thread implements Runnable {
+    static private class CheckForTermination extends Thread {
 
         Warrant oldWarrant;
         Warrant newWarrant;
@@ -1087,7 +1087,7 @@ public class Engineer extends Thread implements Runnable, java.beans.PropertyCha
     /*
      * *************************************************************************************
      */
-     class ThrottleRamp extends Thread implements Runnable {
+     class ThrottleRamp extends Thread {
 
          private RampData _rampData;
          private String _endSpeedType;

--- a/java/src/jmri/jmrit/logix/OBlockManager.java
+++ b/java/src/jmri/jmrit/logix/OBlockManager.java
@@ -28,7 +28,7 @@ import jmri.managers.AbstractManager;
  * @author Pete Cressman Copyright (C) 2009
  */
 public class OBlockManager extends AbstractManager<OBlock>
-        implements java.beans.PropertyChangeListener, jmri.InstanceManagerAutoDefault {
+        implements jmri.InstanceManagerAutoDefault {
 
     public OBlockManager() {
         super();

--- a/java/src/jmri/jmrit/logix/PortalManager.java
+++ b/java/src/jmri/jmrit/logix/PortalManager.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * @author Pete Cressman Copyright (C) 2014
  */
 public class PortalManager extends AbstractManager<Portal>
-        implements java.beans.PropertyChangeListener, jmri.InstanceManagerAutoDefault {
+        implements jmri.InstanceManagerAutoDefault {
 
     private int _nextSName = 1;
 

--- a/java/src/jmri/jmrit/logix/Warrant.java
+++ b/java/src/jmri/jmrit/logix/Warrant.java
@@ -2236,7 +2236,7 @@ public class Warrant extends jmri.implementation.AbstractNamedBean implements Th
         return Bundle.getMessage("BeanNameWarrant");
     }
 
-    private class CommandDelay extends Thread implements Runnable {
+    private class CommandDelay extends Thread {
 
         String nextSpeedType;
         long _startTime = 0;

--- a/java/src/jmri/jmrit/logix/WarrantManager.java
+++ b/java/src/jmri/jmrit/logix/WarrantManager.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  * @author Pete Cressman Copyright (C) 2009
  */
 public class WarrantManager extends AbstractManager<Warrant>
-        implements java.beans.PropertyChangeListener, jmri.InstanceManagerAutoDefault {
+        implements jmri.InstanceManagerAutoDefault {
     
     private HashMap<String, RosterSpeedProfile> _mergeProfiles;
     private HashMap<String, RosterSpeedProfile> _sessionProfiles;

--- a/java/src/jmri/jmrit/operations/locations/InterchangeEditFrame.java
+++ b/java/src/jmri/jmrit/operations/locations/InterchangeEditFrame.java
@@ -14,7 +14,7 @@ import jmri.jmrit.operations.locations.tools.TrackDestinationEditAction;
  *
  * @author Dan Boudreau Copyright (C) 2008, 2011, 2012
  */
-public class InterchangeEditFrame extends TrackEditFrame implements java.beans.PropertyChangeListener {
+public class InterchangeEditFrame extends TrackEditFrame {
 
     public InterchangeEditFrame() {
         super();

--- a/java/src/jmri/jmrit/operations/locations/SpurEditFrame.java
+++ b/java/src/jmri/jmrit/operations/locations/SpurEditFrame.java
@@ -28,7 +28,7 @@ import jmri.jmrit.operations.setup.Control;
  *
  * @author Dan Boudreau Copyright (C) 2008, 2011
  */
-public class SpurEditFrame extends TrackEditFrame implements java.beans.PropertyChangeListener {
+public class SpurEditFrame extends TrackEditFrame {
 
     // labels, buttons, etc. for spurs
     JLabel textSchedule = new JLabel(Bundle.getMessage("DeliverySchedule"));

--- a/java/src/jmri/jmrit/operations/locations/StagingEditFrame.java
+++ b/java/src/jmri/jmrit/operations/locations/StagingEditFrame.java
@@ -18,7 +18,7 @@ import jmri.jmrit.operations.trains.Train;
  *
  * @author Dan Boudreau Copyright (C) 2008, 2011
  */
-public class StagingEditFrame extends TrackEditFrame implements java.beans.PropertyChangeListener {
+public class StagingEditFrame extends TrackEditFrame {
 
     // check boxes
     JCheckBox swapLoadsCheckBox = new JCheckBox(Bundle.getMessage("SwapCarLoads"));

--- a/java/src/jmri/jmrit/operations/locations/YardEditFrame.java
+++ b/java/src/jmri/jmrit/operations/locations/YardEditFrame.java
@@ -12,7 +12,7 @@ import jmri.jmrit.operations.locations.tools.ShowTrainsServingLocationAction;
  *
  * @author Dan Boudreau Copyright (C) 2008
  */
-public class YardEditFrame extends TrackEditFrame implements java.beans.PropertyChangeListener {
+public class YardEditFrame extends TrackEditFrame {
 
     public YardEditFrame() {
         super();

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/CarEditFrame.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/CarEditFrame.java
@@ -30,7 +30,7 @@ import jmri.jmrit.operations.setup.Setup;
  *
  * @author Dan Boudreau Copyright (C) 2008, 2010, 2011, 2014, 2018
  */
-public class CarEditFrame extends RollingStockEditFrame implements java.beans.PropertyChangeListener {
+public class CarEditFrame extends RollingStockEditFrame {
 
     protected static final ResourceBundle rb = ResourceBundle
             .getBundle("jmri.jmrit.operations.rollingstock.cars.JmritOperationsCarsBundle");

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/CarSetFrame.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/CarSetFrame.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dan Boudreau Copyright (C) 2008, 2010, 2011, 2013, 2014
  */
-public class CarSetFrame extends RollingStockSetFrame<Car> implements java.beans.PropertyChangeListener {
+public class CarSetFrame extends RollingStockSetFrame<Car> {
 
     protected static final ResourceBundle rb = ResourceBundle
             .getBundle("jmri.jmrit.operations.rollingstock.cars.JmritOperationsCarsBundle");

--- a/java/src/jmri/jmrit/operations/rollingstock/cars/CarsSetFrame.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/cars/CarsSetFrame.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Dan Boudreau Copyright (C) 2011, 2013
  */
-public class CarsSetFrame extends CarSetFrame implements java.beans.PropertyChangeListener {
+public class CarsSetFrame extends CarSetFrame {
 
     CarsTableModel _carsTableModel;
     JTable _carsTable;

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/EngineEditFrame.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/EngineEditFrame.java
@@ -26,7 +26,7 @@ import jmri.jmrit.operations.setup.Control;
  *
  * @author Dan Boudreau Copyright (C) 2008, 2011, 2018
  */
-public class EngineEditFrame extends RollingStockEditFrame implements java.beans.PropertyChangeListener {
+public class EngineEditFrame extends RollingStockEditFrame {
 
     protected static final ResourceBundle rb = ResourceBundle
             .getBundle("jmri.jmrit.operations.rollingstock.engines.JmritOperationsEnginesBundle");

--- a/java/src/jmri/jmrit/operations/rollingstock/engines/EngineSetFrame.java
+++ b/java/src/jmri/jmrit/operations/rollingstock/engines/EngineSetFrame.java
@@ -12,8 +12,7 @@ import jmri.jmrit.operations.rollingstock.RollingStockSetFrame;
  *
  * @author Dan Boudreau Copyright (C) 2008, 2010
  */
-public class EngineSetFrame extends RollingStockSetFrame<Engine> implements
-        java.beans.PropertyChangeListener {
+public class EngineSetFrame extends RollingStockSetFrame<Engine> {
 
     protected static final ResourceBundle rb = ResourceBundle
             .getBundle("jmri.jmrit.operations.rollingstock.engines.JmritOperationsEnginesBundle");

--- a/java/src/jmri/jmrit/picker/PickListModel.java
+++ b/java/src/jmri/jmrit/picker/PickListModel.java
@@ -1,6 +1,5 @@
 package jmri.jmrit.picker;
 
-import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -47,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * @param <E> the supported type of NamedBean
  * @author Pete Cressman Copyright (C) 2009, 2010
  */
-public abstract class PickListModel<E extends NamedBean> extends BeanTableDataModel<E> implements PropertyChangeListener {
+public abstract class PickListModel<E extends NamedBean> extends BeanTableDataModel<E> {
 
     protected ArrayList<E> _pickList;
     protected String _name;

--- a/java/src/jmri/jmrit/roster/swing/RosterTable.java
+++ b/java/src/jmri/jmrit/roster/swing/RosterTable.java
@@ -352,7 +352,7 @@ public class RosterTable extends JmriPanel implements RosterEntrySelector, Roste
         }
     }
 
-    public class RosterCellEditor extends DefaultCellEditor implements TableCellEditor {
+    public class RosterCellEditor extends DefaultCellEditor {
 
         public RosterCellEditor() {
             super(new JTextField() {

--- a/java/src/jmri/jmrit/symbolicprog/CompositeVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/CompositeVariableValue.java
@@ -4,7 +4,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -48,7 +47,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2005, 2013
  */
-public class CompositeVariableValue extends EnumVariableValue implements ActionListener, PropertyChangeListener {
+public class CompositeVariableValue extends EnumVariableValue implements ActionListener {
 
     public CompositeVariableValue(String name, String comment, String cvName,
             boolean readOnly, boolean infoOnly, boolean writeOnly, boolean opsOnly,

--- a/java/src/jmri/jmrit/symbolicprog/CompositeVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/CompositeVariableValue.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2005, 2013
  */
-public class CompositeVariableValue extends EnumVariableValue implements ActionListener {
+public class CompositeVariableValue extends EnumVariableValue {
 
     public CompositeVariableValue(String name, String comment, String cvName,
             boolean readOnly, boolean infoOnly, boolean writeOnly, boolean opsOnly,

--- a/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/DecVariableValue.java
@@ -6,7 +6,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
-import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -23,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2001
  */
 public class DecVariableValue extends VariableValue
-        implements ActionListener, PropertyChangeListener, FocusListener {
+        implements ActionListener, FocusListener {
 
     public DecVariableValue(String name, String comment, String cvName,
             boolean readOnly, boolean infoOnly, boolean writeOnly, boolean opsOnly,

--- a/java/src/jmri/jmrit/symbolicprog/LongAddrVariableValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/LongAddrVariableValue.java
@@ -6,7 +6,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
-import java.beans.PropertyChangeListener;
 import java.util.HashMap;
 import javax.annotation.Nonnull;
 import javax.swing.JLabel;
@@ -22,7 +21,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class LongAddrVariableValue extends VariableValue
-        implements ActionListener, PropertyChangeListener, FocusListener {
+        implements ActionListener, FocusListener {
 
     public LongAddrVariableValue(@Nonnull String name, @Nonnull String comment, @Nonnull String cvName,
             boolean readOnly, boolean infoOnly, boolean writeOnly, boolean opsOnly,

--- a/java/src/jmri/jmrit/symbolicprog/SpeedTableVarValue.java
+++ b/java/src/jmri/jmrit/symbolicprog/SpeedTableVarValue.java
@@ -5,7 +5,6 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -74,7 +73,7 @@ import org.slf4j.LoggerFactory;
  * @author Dave Heap - generate cvList array to incorporate Vstart {@literal &} Vhigh
  *
  */
-public class SpeedTableVarValue extends VariableValue implements PropertyChangeListener, ChangeListener {
+public class SpeedTableVarValue extends VariableValue implements ChangeListener {
 
     int nValues;
     int numCvs;

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneOpsProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneOpsProgFrame.java
@@ -16,8 +16,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (C) 2002, 2008
  */
-public class PaneOpsProgFrame extends PaneProgFrame
-        implements java.beans.PropertyChangeListener {
+public class PaneOpsProgFrame extends PaneProgFrame {
 
     JPanel modePane;
 

--- a/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneServiceProgFrame.java
+++ b/java/src/jmri/jmrit/symbolicprog/tabbedframe/PaneServiceProgFrame.java
@@ -15,8 +15,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (C) 2002, 2008
  */
-public class PaneServiceProgFrame extends PaneProgFrame
-        implements java.beans.PropertyChangeListener {
+public class PaneServiceProgFrame extends PaneProgFrame {
 
     jmri.jmrit.progsupport.ProgModeSelector modePane;
 

--- a/java/src/jmri/jmrit/vsdecoder/BoolTrigger.java
+++ b/java/src/jmri/jmrit/vsdecoder/BoolTrigger.java
@@ -17,12 +17,11 @@ package jmri.jmrit.vsdecoder;
  * @author   Mark Underwood Copyright (C) 2011
  */
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class BoolTrigger extends Trigger implements PropertyChangeListener {
+class BoolTrigger extends Trigger {
 
     boolean match_value;
 

--- a/java/src/jmri/jmrit/vsdecoder/ButtonTrigger.java
+++ b/java/src/jmri/jmrit/vsdecoder/ButtonTrigger.java
@@ -21,13 +21,12 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import javax.swing.AbstractButton;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ButtonTrigger extends Trigger implements PropertyChangeListener, ActionListener, MouseListener {
+public class ButtonTrigger extends Trigger implements ActionListener, MouseListener {
 
     enum ButtonAction {
     }

--- a/java/src/jmri/jmrit/vsdecoder/EngineSoundEvent.java
+++ b/java/src/jmri/jmrit/vsdecoder/EngineSoundEvent.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Underwood Copyright (C) 2011
  * @author Klaus Killinger Copyright (C) 2018
  */
-public class EngineSoundEvent extends SoundEvent implements PropertyChangeListener {
+public class EngineSoundEvent extends SoundEvent {
 
     EnginePane engine_pane;
 

--- a/java/src/jmri/jmrit/vsdecoder/FloatTrigger.java
+++ b/java/src/jmri/jmrit/vsdecoder/FloatTrigger.java
@@ -18,12 +18,11 @@ package jmri.jmrit.vsdecoder;
  * 
  */
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class FloatTrigger extends Trigger implements PropertyChangeListener {
+class FloatTrigger extends Trigger {
 
     Float match_value;
     CompareType compare_type;

--- a/java/src/jmri/jmrit/vsdecoder/IntTrigger.java
+++ b/java/src/jmri/jmrit/vsdecoder/IntTrigger.java
@@ -17,12 +17,11 @@ package jmri.jmrit.vsdecoder;
  * @author   Mark Underwood Copyright (C) 2011
  */
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class IntTrigger extends Trigger implements PropertyChangeListener {
+class IntTrigger extends Trigger {
 
     int notch;
     CompareType compare_type;

--- a/java/src/jmri/jmrit/vsdecoder/MomentarySoundEvent.java
+++ b/java/src/jmri/jmrit/vsdecoder/MomentarySoundEvent.java
@@ -16,14 +16,13 @@ package jmri.jmrit.vsdecoder;
  *
  * @author   Mark Underwood Copyright (C) 2011
  */
-import java.beans.PropertyChangeListener;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MomentarySoundEvent extends SoundEvent implements PropertyChangeListener {
+public class MomentarySoundEvent extends SoundEvent {
 
     JButton button;
 

--- a/java/src/jmri/jmrit/vsdecoder/NotchTrigger.java
+++ b/java/src/jmri/jmrit/vsdecoder/NotchTrigger.java
@@ -17,12 +17,11 @@ package jmri.jmrit.vsdecoder;
  * @author   Mark Underwood Copyright (C) 2011
  */
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class NotchTrigger extends Trigger implements PropertyChangeListener {
+class NotchTrigger extends Trigger {
 
     int current_notch, prev_notch;
 

--- a/java/src/jmri/jmrit/vsdecoder/ThrottleTrigger.java
+++ b/java/src/jmri/jmrit/vsdecoder/ThrottleTrigger.java
@@ -17,12 +17,11 @@ package jmri.jmrit.vsdecoder;
  * @author   Mark Underwood Copyright (C) 2011
  */
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class ThrottleTrigger extends Trigger implements PropertyChangeListener {
+class ThrottleTrigger extends Trigger {
 
     int current_notch, prev_notch;
 

--- a/java/src/jmri/jmrit/vsdecoder/ToggleSoundEvent.java
+++ b/java/src/jmri/jmrit/vsdecoder/ToggleSoundEvent.java
@@ -16,14 +16,13 @@ package jmri.jmrit.vsdecoder;
  *
  * @author   Mark Underwood Copyright (C) 2011
  */
-import java.beans.PropertyChangeListener;
 import javax.swing.JComponent;
 import javax.swing.JToggleButton;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ToggleSoundEvent extends SoundEvent implements PropertyChangeListener {
+public class ToggleSoundEvent extends SoundEvent {
 
     JToggleButton button;
 

--- a/java/src/jmri/jmrix/acela/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/acela/serialdriver/SerialDriverAdapter.java
@@ -28,7 +28,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author Bob Coleman, Copyright (C) 2007, 2008 Based on MRC example, modified
  * to establish Acela support.
  */
-public class SerialDriverAdapter extends AcelaPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends AcelaPortController {
 
     public SerialDriverAdapter() {
         super(new AcelaSystemConnectionMemo());

--- a/java/src/jmri/jmrix/bachrus/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/bachrus/serialdriver/SerialDriverAdapter.java
@@ -32,7 +32,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author Bob Jacobsen Copyright (C) 2001, 2002
  * @author Andrew Crosland Copyright (C) 2010
  */
-public class SerialDriverAdapter extends SpeedoPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends SpeedoPortController {
 
     public SerialDriverAdapter() {
         super(new SpeedoSystemConnectionMemo());

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/can2usbino/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/can2usbino/serialdriver/SerialDriverAdapter.java
@@ -19,7 +19,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author Andrew Crosland Copyright (C) 2008
  * @author Bob Jacobsen Copyright (C) 2009, 2012
  */
-public class SerialDriverAdapter extends GcSerialDriverAdapter implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends GcSerialDriverAdapter {
 
     public SerialDriverAdapter() {
         super();

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/canrs/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/canrs/serialdriver/SerialDriverAdapter.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  * @author Andrew Crosland Copyright (C) 2008
  * @author Bob Jacobsen Copyright (C) 2009
  */
-public class SerialDriverAdapter extends GcSerialDriverAdapter implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends GcSerialDriverAdapter {
 
     public SerialDriverAdapter() {
         super();

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/canusb/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/canusb/serialdriver/SerialDriverAdapter.java
@@ -11,7 +11,7 @@ import jmri.jmrix.can.adapters.gridconnect.GcSerialDriverAdapter;
  * @author Andrew Crosland Copyright (C) 2008
  * @author Bob Jacobsen Copyright (C) 2009
  */
-public class SerialDriverAdapter extends GcSerialDriverAdapter implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends GcSerialDriverAdapter {
 
     /**
      * {@inheritDoc}

--- a/java/src/jmri/jmrix/can/adapters/gridconnect/lccbuffer/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/gridconnect/lccbuffer/serialdriver/SerialDriverAdapter.java
@@ -11,7 +11,7 @@ import jmri.jmrix.can.adapters.gridconnect.GcSerialDriverAdapter;
  * @author Andrew Crosland Copyright (C) 2008
  * @author Bob Jacobsen Copyright (C) 2009
  */
-public class SerialDriverAdapter extends GcSerialDriverAdapter implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends GcSerialDriverAdapter {
 
     /**
      * {@inheritDoc}

--- a/java/src/jmri/jmrix/can/adapters/lawicell/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/lawicell/SerialDriverAdapter.java
@@ -20,7 +20,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author Bob Jacobsen Copyright (C) 2001, 2002, 2008
  * @author Andrew Crosland Copyright (C) 2008
  */
-public class SerialDriverAdapter extends PortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends PortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/can/adapters/lawicell/canusb/serialdriver/CanUsbDriverAdapter.java
+++ b/java/src/jmri/jmrix/can/adapters/lawicell/canusb/serialdriver/CanUsbDriverAdapter.java
@@ -10,8 +10,7 @@ package jmri.jmrix.can.adapters.lawicell.canusb.serialdriver;
  * @author Andrew Crosland Copyright (C) 2008
  * @author Bob Jacobsen Copyright (C) 2008, 2010
  */
-public class CanUsbDriverAdapter extends jmri.jmrix.can.adapters.lawicell.SerialDriverAdapter
-        implements jmri.jmrix.SerialPortAdapter {
+public class CanUsbDriverAdapter extends jmri.jmrix.can.adapters.lawicell.SerialDriverAdapter {
 
     /**
      * {@inheritDoc}

--- a/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * @author Andrew Crosland Copyright (C) 2009
  * @author Steve Young Copyright (C) 2019
  */
-public class CbusThrottleManager extends AbstractThrottleManager implements ThrottleManager, CanListener {
+public class CbusThrottleManager extends AbstractThrottleManager implements  CanListener {
 
     private boolean _handleExpected = false;
     private boolean _handleExpectedSecondLevelRequest = false;

--- a/java/src/jmri/jmrix/can/cbus/node/CbusNodeFromFcu.java
+++ b/java/src/jmri/jmrix/can/cbus/node/CbusNodeFromFcu.java
@@ -14,7 +14,7 @@ import jmri.jmrix.can.TrafficController;
  *
  * @author Steve Young Copyright (C) 2019
  */
-public class CbusNodeFromFcu extends CbusNode implements CanListener {
+public class CbusNodeFromFcu extends CbusNode {
     
     public CbusNodeFromFcu ( CanSystemConnectionMemo connmemo, int nodenumber ){
         super( connmemo, nodenumber );  

--- a/java/src/jmri/jmrix/can/cbus/simulator/CbusDummyNode.java
+++ b/java/src/jmri/jmrix/can/cbus/simulator/CbusDummyNode.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * @see CbusSimulator
  * @since 4.15.2
  */
-public class CbusDummyNode extends CbusNode implements CanListener {
+public class CbusDummyNode extends CbusNode {
     
     private TrafficController tc;
     private CanSystemConnectionMemo memo;

--- a/java/src/jmri/jmrix/cmri/serial/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/cmri/serial/serialdriver/SerialDriverAdapter.java
@@ -22,7 +22,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Bob Jacobsen Copyright (C) 2002
  */
-public class SerialDriverAdapter extends SerialPortAdapter implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends SerialPortAdapter {
 
     public SerialDriverAdapter() {
         super(new CMRISystemConnectionMemo());

--- a/java/src/jmri/jmrix/dcc4pc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/dcc4pc/serialdriver/SerialDriverAdapter.java
@@ -26,7 +26,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Kevin Dickerson Copyright (C) 2012
  */
-public class SerialDriverAdapter extends Dcc4PcPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends Dcc4PcPortController {
 
     public SerialDriverAdapter() {
         super(new Dcc4PcSystemConnectionMemo());

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  *
  * Based on XNetThrottleManager by Paul Bender
  */
-public class DCCppThrottleManager extends AbstractThrottleManager implements ThrottleManager, DCCppListener {
+public class DCCppThrottleManager extends AbstractThrottleManager implements DCCppListener {
 
     protected HashMap<LocoAddress, DCCppThrottle> throttles = new HashMap<LocoAddress, DCCppThrottle>(5);
 

--- a/java/src/jmri/jmrix/dccpp/dccppovertcp/DCCppTcpDriverAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/dccppovertcp/DCCppTcpDriverAdapter.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  * @author Alex Shepherd Copyright (C) 2003, 2006
  * @author Mark Underwood Copyright (C) 2015
  */
-public class DCCppTcpDriverAdapter extends DCCppNetworkPortController implements DCCppPortController {
+public class DCCppTcpDriverAdapter extends DCCppNetworkPortController {
     
     public DCCppTcpDriverAdapter() {
         super(new DCCppSystemConnectionMemo());

--- a/java/src/jmri/jmrix/dccpp/serial/DCCppAdapter.java
+++ b/java/src/jmri/jmrix/dccpp/serial/DCCppAdapter.java
@@ -28,7 +28,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * Based on jmri.jmirx.lenz.liusb.LIUSBAdapter by Paul Bender
  */
-public class DCCppAdapter extends DCCppSerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class DCCppAdapter extends DCCppSerialPortController {
 
     public DCCppAdapter() {
         super();

--- a/java/src/jmri/jmrix/direct/serial/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/direct/serial/SerialDriverAdapter.java
@@ -27,7 +27,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2002, 2004
  */
-public class SerialDriverAdapter extends PortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends PortController {
 
     Vector<String> portNameVector = null;
     SerialPort activeSerialPort = null;

--- a/java/src/jmri/jmrix/direct/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/direct/simulator/SimulatorAdapter.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Underwood, Copyright (C) 2015
  * @author Egbert Broerse, Copyright (C) 2018
  */
-public class SimulatorAdapter extends PortController implements jmri.jmrix.SerialPortAdapter, Runnable {
+public class SimulatorAdapter extends PortController implements Runnable {
 
     // private control members
     private boolean opened = false;

--- a/java/src/jmri/jmrix/easydcc/EasyDccNetworkPortController.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccNetworkPortController.java
@@ -7,7 +7,7 @@ import jmri.jmrix.SystemConnectionMemo;
  *
  * @author Bob Jacobsen Copyright (C) 2001
  */
-public abstract class EasyDccNetworkPortController extends jmri.jmrix.AbstractNetworkPortController implements jmri.jmrix.NetworkPortAdapter {
+public abstract class EasyDccNetworkPortController extends jmri.jmrix.AbstractNetworkPortController {
 
     /**
      * Base class. Implementations will provide InputStream and OutputStream

--- a/java/src/jmri/jmrix/easydcc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/easydcc/serialdriver/SerialDriverAdapter.java
@@ -26,7 +26,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2002
  */
-public class SerialDriverAdapter extends EasyDccPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends EasyDccPortController {
 
     public SerialDriverAdapter() {
         super(new EasyDccSystemConnectionMemo("E", "EasyDCC via Serial")); // pass customized user name

--- a/java/src/jmri/jmrix/easydcc/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/easydcc/simulator/SimulatorAdapter.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Underwood, Copyright (C) 2015
  * @author Egbert Broerse, Copyright (C) 2017
  */
-public class SimulatorAdapter extends EasyDccPortController implements jmri.jmrix.SerialPortAdapter, Runnable {
+public class SimulatorAdapter extends EasyDccPortController implements Runnable {
 
     // private control members
     private boolean opened = false;

--- a/java/src/jmri/jmrix/ecos/EcosLocoAddressManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosLocoAddressManager.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kevin Dickerson
  */
-public class EcosLocoAddressManager extends jmri.managers.AbstractManager<NamedBean> implements java.beans.PropertyChangeListener, EcosListener {
+public class EcosLocoAddressManager extends jmri.managers.AbstractManager<NamedBean> implements EcosListener {
 
     private Hashtable<String, EcosLocoAddress> _tecos = new Hashtable<String, EcosLocoAddress>();   // stores known Ecos Object ids to DCC
     private Hashtable<Integer, EcosLocoAddress> _tdcc = new Hashtable<Integer, EcosLocoAddress>();  // stores known DCC Address to Ecos Object ids

--- a/java/src/jmri/jmrix/ecos/networkdriver/NetworkDriverAdapter.java
+++ b/java/src/jmri/jmrix/ecos/networkdriver/NetworkDriverAdapter.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2002, 2003, 2008
  */
-public class NetworkDriverAdapter extends EcosPortController implements jmri.jmrix.NetworkPortAdapter {
+public class NetworkDriverAdapter extends EcosPortController {
 
     public NetworkDriverAdapter() {
         super(new jmri.jmrix.ecos.EcosSystemConnectionMemo());

--- a/java/src/jmri/jmrix/grapevine/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/grapevine/serialdriver/SerialDriverAdapter.java
@@ -22,7 +22,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Bob Jacobsen Copyright (C) 2006, 2007
  */
-public class SerialDriverAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends SerialPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/grapevine/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/grapevine/simulator/SimulatorAdapter.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Underwood, Copyright (C) 2015
  * @author Egbert Broerse, Copyright (C) 2018
  */
-public class SimulatorAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter, Runnable {
+public class SimulatorAdapter extends SerialPortController implements Runnable {
 
     // private control members
     private boolean opened = false;

--- a/java/src/jmri/jmrix/ieee802154/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/ieee802154/serialdriver/SerialDriverAdapter.java
@@ -25,7 +25,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author kcameron Copyright (C) 2011
  * @author Paul Bender Copyright (C) 2013
  */
-public class SerialDriverAdapter extends IEEE802154PortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends IEEE802154PortController {
 
     protected SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/ieee802154/xbee/XBeeAdapter.java
+++ b/java/src/jmri/jmrix/ieee802154/xbee/XBeeAdapter.java
@@ -13,7 +13,7 @@ import purejavacomm.*;
  *
  * @author Paul Bender Copyright (C) 2013
  */
-public class XBeeAdapter extends jmri.jmrix.ieee802154.serialdriver.SerialDriverAdapter implements jmri.jmrix.SerialPortAdapter, IConnectionInterface, SerialPortEventListener {
+public class XBeeAdapter extends jmri.jmrix.ieee802154.serialdriver.SerialDriverAdapter implements IConnectionInterface, SerialPortEventListener {
 
     private boolean iConnectionOpened = false;
 

--- a/java/src/jmri/jmrix/internal/InternalAdapter.java
+++ b/java/src/jmri/jmrix/internal/InternalAdapter.java
@@ -11,8 +11,7 @@ import java.util.Arrays;
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2002
  */
-public class InternalAdapter extends jmri.jmrix.AbstractSerialPortController
-        implements jmri.jmrix.PortAdapter {
+public class InternalAdapter extends jmri.jmrix.AbstractSerialPortController {
 
     // private control members
     private boolean opened = false;

--- a/java/src/jmri/jmrix/lenz/hornbyelite/EliteAdapter.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/EliteAdapter.java
@@ -25,7 +25,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author Bob Jacobsen Copyright (C) 2002
  * @author Paul Bender, Copyright (C) 2003,2008-2010
  */
-public class EliteAdapter extends XNetSerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class EliteAdapter extends XNetSerialPortController {
 
     public EliteAdapter() {
         super(new EliteXNetSystemConnectionMemo());

--- a/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetProgrammer.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetProgrammer.java
@@ -25,7 +25,7 @@ import jmri.jmrix.lenz.XNetTrafficController;
  *
  * @author Paul Bender Copyright (c) 2008
  */
-public class EliteXNetProgrammer extends XNetProgrammer implements XNetListener {
+public class EliteXNetProgrammer extends XNetProgrammer {
 
     // Message timeout lengths.  These have been determined by
     // experimentation, and may need to be adjusted

--- a/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetThrottleManager.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetThrottleManager.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Paul Bender Copyright (C) 2008
  */
-public class EliteXNetThrottleManager extends jmri.jmrix.lenz.XNetThrottleManager implements ThrottleManager {
+public class EliteXNetThrottleManager extends jmri.jmrix.lenz.XNetThrottleManager {
 
     /**
      * Constructor.

--- a/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetTurnoutManager.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/EliteXNetTurnoutManager.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Paul Bender Copyright (C) 2008
  */
-public class EliteXNetTurnoutManager extends jmri.jmrix.lenz.XNetTurnoutManager implements jmri.jmrix.lenz.XNetListener {
+public class EliteXNetTurnoutManager extends jmri.jmrix.lenz.XNetTurnoutManager {
 
     public EliteXNetTurnoutManager(jmri.jmrix.lenz.XNetTrafficController controller, String prefix) {
         super(controller, prefix);

--- a/java/src/jmri/jmrix/lenz/hornbyelite/HornbyEliteCommandStation.java
+++ b/java/src/jmri/jmrix/lenz/hornbyelite/HornbyEliteCommandStation.java
@@ -6,7 +6,7 @@ package jmri.jmrix.lenz.hornbyelite;
  *
  * @author Paul Bender Copyright (C) 2008
  */
-public class HornbyEliteCommandStation extends jmri.jmrix.lenz.LenzCommandStation implements jmri.CommandStation {
+public class HornbyEliteCommandStation extends jmri.jmrix.lenz.LenzCommandStation {
 
     /**
      * The Hornby Elite does support Ops Mode programming.

--- a/java/src/jmri/jmrix/lenz/li100/LI100Adapter.java
+++ b/java/src/jmri/jmrix/lenz/li100/LI100Adapter.java
@@ -24,7 +24,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author Bob Jacobsen Copyright (C) 2002
  * @author Paul Bender, Copyright (C) 2003-2010
  */
-public class LI100Adapter extends XNetSerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class LI100Adapter extends XNetSerialPortController {
 
     public LI100Adapter() {
         super();

--- a/java/src/jmri/jmrix/lenz/li100/LI100XNetProgrammer.java
+++ b/java/src/jmri/jmrix/lenz/li100/LI100XNetProgrammer.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender Copyright (c) 2003, 2004, 2005, 2009
  * @author Giorgio Terdina Copyright (c) 2007
  */
-public class LI100XNetProgrammer extends XNetProgrammer implements XNetListener {
+public class LI100XNetProgrammer extends XNetProgrammer {
 
     static private final int RETURNSENT = 3;
 

--- a/java/src/jmri/jmrix/lenz/li100f/LI100fAdapter.java
+++ b/java/src/jmri/jmrix/lenz/li100f/LI100fAdapter.java
@@ -26,7 +26,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author Bob Jacobsen Copyright (C) 2002
  * @author Paul Bender, Copyright (C) 2003-2010
  */
-public class LI100fAdapter extends XNetSerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class LI100fAdapter extends XNetSerialPortController {
 
     public LI100fAdapter() {
         super();

--- a/java/src/jmri/jmrix/lenz/li101/LI101Adapter.java
+++ b/java/src/jmri/jmrix/lenz/li101/LI101Adapter.java
@@ -26,7 +26,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author Bob Jacobsen Copyright (C) 2002
  * @author Paul Bender, Copyright (C) 2003-2010
  */
-public class LI101Adapter extends XNetSerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class LI101Adapter extends XNetSerialPortController {
 
     public LI101Adapter() {
         super();

--- a/java/src/jmri/jmrix/lenz/liusb/LIUSBAdapter.java
+++ b/java/src/jmri/jmrix/lenz/liusb/LIUSBAdapter.java
@@ -24,7 +24,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Paul Bender Copyright (C) 2005-2010
  */
-public class LIUSBAdapter extends XNetSerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class LIUSBAdapter extends XNetSerialPortController {
 
     public LIUSBAdapter() {
         super();

--- a/java/src/jmri/jmrix/lenz/xntcp/XnTcpAdapter.java
+++ b/java/src/jmri/jmrix/lenz/xntcp/XnTcpAdapter.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * AbstractNetworkController. GT - May 2011 - Fixed problems arising from recent
  * refactoring
  */
-public class XnTcpAdapter extends XNetNetworkPortController implements jmri.jmrix.lenz.XNetPortController {
+public class XnTcpAdapter extends XNetNetworkPortController {
 
     static final int DEFAULT_UDP_PORT = 61234;
     static final int DEFAULT_TCP_PORT = 61235;

--- a/java/src/jmri/jmrix/lenz/ztc640/ZTC640Adapter.java
+++ b/java/src/jmri/jmrix/lenz/ztc640/ZTC640Adapter.java
@@ -25,7 +25,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author Bob Jacobsen Copyright (C) 2002
  * @author Paul Bender, Copyright (C) 2003-2010
  */
-public class ZTC640Adapter extends XNetSerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class ZTC640Adapter extends XNetSerialPortController {
 
     public ZTC640Adapter() {
         super();

--- a/java/src/jmri/jmrix/loconet/LnPowerManager.java
+++ b/java/src/jmri/jmrix/loconet/LnPowerManager.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  */
 public class LnPowerManager
         extends jmri.managers.AbstractPowerManager
-        implements PowerManager, LocoNetListener {
+        implements LocoNetListener {
 
     public LnPowerManager(LocoNetSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/loconet/LnReporter.java
+++ b/java/src/jmri/jmrix/loconet/LnReporter.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2007
  */
-public class LnReporter extends AbstractIdTagReporter implements LocoNetListener, PhysicalLocationReporter, CollectingReporter {
+public class LnReporter extends AbstractIdTagReporter implements LocoNetListener, CollectingReporter {
 
     public LnReporter(int number, LnTrafficController tc, String prefix) {  // a human-readable Reporter number must be specified!
         super(prefix + "R" + number);  // can't use prefix here, as still in construction

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2001
  * @author B. Milhaupt, Copyright (C) 2018
  */
-public class LnThrottleManager extends AbstractThrottleManager implements ThrottleManager, SlotListener {
+public class LnThrottleManager extends AbstractThrottleManager implements SlotListener {
 
     protected SlotManager slotManager;
     protected LnTrafficController tc;

--- a/java/src/jmri/jmrix/loconet/UhlenbrockSlotManager.java
+++ b/java/src/jmri/jmrix/loconet/UhlenbrockSlotManager.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Lisby Copyright (C) 2014
  */
-public class UhlenbrockSlotManager extends SlotManager implements LocoNetListener {
+public class UhlenbrockSlotManager extends SlotManager {
 
     public UhlenbrockSlotManager(LnTrafficController tc) {
         super(tc);

--- a/java/src/jmri/jmrix/loconet/UhlenbrockSlotManager.java
+++ b/java/src/jmri/jmrix/loconet/UhlenbrockSlotManager.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Lisby Copyright (C) 2014
  */
-public class UhlenbrockSlotManager extends SlotManager implements LocoNetListener, CommandStation {
+public class UhlenbrockSlotManager extends SlotManager implements LocoNetListener {
 
     public UhlenbrockSlotManager(LnTrafficController tc) {
         super(tc);

--- a/java/src/jmri/jmrix/loconet/bluetooth/LocoNetBluetoothAdapter.java
+++ b/java/src/jmri/jmrix/loconet/bluetooth/LocoNetBluetoothAdapter.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Provide access to LocoNet via a LocoNet Bluetooth adapter.
  */
-public class LocoNetBluetoothAdapter extends LnPortController implements jmri.jmrix.SerialPortAdapter {
+public class LocoNetBluetoothAdapter extends LnPortController {
 
     public LocoNetBluetoothAdapter() {
         this(new LocoNetSystemConnectionMemo());

--- a/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/loconet/downloader/LoaderPane.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * @author B. Milhaupt Copyright (C) 2013, 2014, 2017
  */
 public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
-        implements ActionListener, jmri.jmrix.loconet.swing.LnPanelInterface {
+        implements jmri.jmrix.loconet.swing.LnPanelInterface {
 
     /**
      * LnPanelInterface implementation makes "memo" object available as convenience

--- a/java/src/jmri/jmrix/loconet/hexfile/LnHexFilePort.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/LnHexFilePort.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Bob Jacobsen Copyright (C) 2001
  */
-public class LnHexFilePort extends LnPortController implements Runnable, jmri.jmrix.SerialPortAdapter {
+public class LnHexFilePort extends LnPortController implements Runnable {
 
     volatile BufferedReader sFile = null;
 

--- a/java/src/jmri/jmrix/loconet/hexfile/LnSensorManager.java
+++ b/java/src/jmri/jmrix/loconet/hexfile/LnSensorManager.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kevin Dickerson Copyright (C) 2001
  */
-public class LnSensorManager extends jmri.jmrix.loconet.LnSensorManager implements LocoNetListener {
+public class LnSensorManager extends jmri.jmrix.loconet.LnSensorManager {
 
     public LnSensorManager(LnTrafficController tc, String prefix) {
         super(tc, prefix);

--- a/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
+++ b/java/src/jmri/jmrix/loconet/locobuffer/LocoBufferAdapter.java
@@ -27,7 +27,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2008, 2010
  */
-public class LocoBufferAdapter extends LnPortController implements jmri.jmrix.SerialPortAdapter {
+public class LocoBufferAdapter extends LnPortController {
 
     public LocoBufferAdapter() {
         this(new LocoNetSystemConnectionMemo());

--- a/java/src/jmri/jmrix/loconet/ms100/MS100Adapter.java
+++ b/java/src/jmri/jmrix/loconet/ms100/MS100Adapter.java
@@ -29,7 +29,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Bob Jacobsen Copyright (C) 2001
  */
-public class MS100Adapter extends LnPortController implements jmri.jmrix.SerialPortAdapter {
+public class MS100Adapter extends LnPortController {
 
     public MS100Adapter() {
         super(new LocoNetSystemConnectionMemo());

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockLnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockLnThrottleManager.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  * @see jmri.jmrix.loconet.SlotManager
  * @author Bob Jacobsen Copyright (C) 2001
  */
-public class UhlenbrockLnThrottleManager extends LnThrottleManager implements ThrottleManager, SlotListener {
+public class UhlenbrockLnThrottleManager extends LnThrottleManager implements SlotListener {
 
     public UhlenbrockLnThrottleManager(UhlenbrockSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockLnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/uhlenbrock/UhlenbrockLnThrottleManager.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  * @see jmri.jmrix.loconet.SlotManager
  * @author Bob Jacobsen Copyright (C) 2001
  */
-public class UhlenbrockLnThrottleManager extends LnThrottleManager implements SlotListener {
+public class UhlenbrockLnThrottleManager extends LnThrottleManager {
 
     public UhlenbrockLnThrottleManager(UhlenbrockSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/maple/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/maple/serialdriver/SerialDriverAdapter.java
@@ -21,7 +21,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Bob Jacobsen Copyright (C) 2002
  */
-public class SerialDriverAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends SerialPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/maple/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/maple/simulator/SimulatorAdapter.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Underwood, Copyright (C) 2015
  * @author Egbert Broerse, Copyright (C) 2018
  */
-public class SimulatorAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter, Runnable {
+public class SimulatorAdapter extends SerialPortController implements Runnable {
 
     // private control members
     private boolean opened = false;

--- a/java/src/jmri/jmrix/marklin/networkdriver/NetworkDriverAdapter.java
+++ b/java/src/jmri/jmrix/marklin/networkdriver/NetworkDriverAdapter.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2001, 2002, 2003, 2008
  * @author Kevin Dickerson Copyright (C) 2012
  */
-public class NetworkDriverAdapter extends MarklinPortController implements jmri.jmrix.NetworkPortAdapter {
+public class NetworkDriverAdapter extends MarklinPortController {
 
     protected DatagramSocket datagramSocketConn = null;
 

--- a/java/src/jmri/jmrix/mrc/MrcPowerManager.java
+++ b/java/src/jmri/jmrix/mrc/MrcPowerManager.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MrcPowerManager
         extends jmri.managers.AbstractPowerManager
-        implements PowerManager, MrcTrafficListener {
+        implements MrcTrafficListener {
 
     public MrcPowerManager(MrcSystemConnectionMemo memo) {
         super(memo);

--- a/java/src/jmri/jmrix/mrc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/mrc/serialdriver/SerialDriverAdapter.java
@@ -25,7 +25,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2002
  */
-public class SerialDriverAdapter extends MrcPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends MrcPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/mrc/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/mrc/simulator/SimulatorAdapter.java
@@ -20,8 +20,7 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender, Copyright (C) 2009
  * @author Daniel Boudreau Copyright (C) 2010
  */
-public class SimulatorAdapter extends MrcPortController implements
-        jmri.jmrix.SerialPortAdapter, Runnable {
+public class SimulatorAdapter extends MrcPortController implements Runnable {
 
     // private control members
     private boolean opened = false;

--- a/java/src/jmri/jmrix/nce/clockmon/ClockMonPanel.java
+++ b/java/src/jmri/jmrix/nce/clockmon/ClockMonPanel.java
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
  * @author Ken Cameron Copyright (C) 2007
  * derived from loconet.clockmonframe by Bob Jacobson Copyright (C) 2003
  */
-public class ClockMonPanel extends jmri.jmrix.nce.swing.NcePanel implements NcePanelInterface, NceListener {
+public class ClockMonPanel extends jmri.jmrix.nce.swing.NcePanel implements NceListener {
 
     public static final int CS_CLOCK_MEM_ADDR = 0xDC00;
     public static final int CS_CLOCK_MEM_SIZE = 0x10;

--- a/java/src/jmri/jmrix/nce/macro/NceMacroEditPanel.java
+++ b/java/src/jmri/jmrix/nce/macro/NceMacroEditPanel.java
@@ -71,7 +71,7 @@ import org.slf4j.LoggerFactory;
  * @author Dan Boudreau Copyright (C) 2007
  * @author Ken Cameron Copyright (C) 2013
  */
-public class NceMacroEditPanel extends jmri.jmrix.nce.swing.NcePanel implements NcePanelInterface, jmri.jmrix.nce.NceListener {
+public class NceMacroEditPanel extends jmri.jmrix.nce.swing.NcePanel implements jmri.jmrix.nce.NceListener {
     
     private NceTrafficController tc = null;
     private int maxNumMacros = CabMemorySerial.CS_MAX_MACRO;

--- a/java/src/jmri/jmrix/nce/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/nce/serialdriver/SerialDriverAdapter.java
@@ -25,7 +25,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author Bob Jacobsen Copyright (C) 2001, 2002
  * @author ken ccameron Copyright (C) 2013
  */
-public class SerialDriverAdapter extends NcePortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends NcePortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/nce/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/nce/simulator/SimulatorAdapter.java
@@ -96,8 +96,7 @@ import org.slf4j.LoggerFactory;
  * @author Paul Bender, Copyright (C) 2009
  * @author Daniel Boudreau Copyright (C) 2010
  */
-public class SimulatorAdapter extends NcePortController implements
-        jmri.jmrix.SerialPortAdapter, Runnable {
+public class SimulatorAdapter extends NcePortController implements Runnable {
 
     // private control members
     private boolean opened = false;

--- a/java/src/jmri/jmrix/oaktree/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/oaktree/serialdriver/SerialDriverAdapter.java
@@ -21,7 +21,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Bob Jacobsen Copyright (C) 2006
  */
-public class SerialDriverAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends SerialPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/oaktree/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/oaktree/simulator/SimulatorAdapter.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Underwood, Copyright (C) 2015
  * @author Egbert Broerse, Copyright (C) 2018
  */
-public class SimulatorAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter, Runnable {
+public class SimulatorAdapter extends SerialPortController implements Runnable {
 
     // private control members
     private boolean opened = false;

--- a/java/src/jmri/jmrix/openlcb/OlcbProgrammerManager.java
+++ b/java/src/jmri/jmrix/openlcb/OlcbProgrammerManager.java
@@ -39,7 +39,7 @@ import jmri.ProgrammingMode;
  * @author Bob Jacobsen Copyright (C) 2015
  * @since 4.1.1
  */
-public class OlcbProgrammerManager extends jmri.managers.DefaultProgrammerManager implements jmri.AddressedProgrammerManager {
+public class OlcbProgrammerManager extends jmri.managers.DefaultProgrammerManager {
 
     public OlcbProgrammerManager(Programmer pProgrammer) {
         super(pProgrammer);

--- a/java/src/jmri/jmrix/openlcb/swing/downloader/LoaderPane.java
+++ b/java/src/jmri/jmrix/openlcb/swing/downloader/LoaderPane.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * 2016
  */
 public class LoaderPane extends jmri.jmrix.AbstractLoaderPane
-        implements ActionListener, jmri.jmrix.can.swing.CanPanelInterface {
+        implements jmri.jmrix.can.swing.CanPanelInterface {
 
     protected CanSystemConnectionMemo memo;
     Connection connection;

--- a/java/src/jmri/jmrix/pi/RaspberryPiAdapter.java
+++ b/java/src/jmri/jmrix/pi/RaspberryPiAdapter.java
@@ -13,8 +13,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2001, 2002
  * @author Paul Bender Copyright (C) 2015
  */
-public class RaspberryPiAdapter extends jmri.jmrix.AbstractPortController
-        implements jmri.jmrix.PortAdapter {
+public class RaspberryPiAdapter extends jmri.jmrix.AbstractPortController {
 
     // in theory gpio can be static, because there will only ever
     // be one, but the library handles the details that make it a

--- a/java/src/jmri/jmrix/pi/RaspberryPiTurnout.java
+++ b/java/src/jmri/jmrix/pi/RaspberryPiTurnout.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  * 
  * @author Paul Bender Copyright (C) 2015 
  */
-public class RaspberryPiTurnout extends AbstractTurnout implements Turnout, java.io.Serializable {
+public class RaspberryPiTurnout extends AbstractTurnout implements java.io.Serializable {
 
     // in theory gpio can be static, because there will only ever
     // be one, but the library handles the details that make it a 

--- a/java/src/jmri/jmrix/powerline/cm11/SpecificDriverAdapter.java
+++ b/java/src/jmri/jmrix/powerline/cm11/SpecificDriverAdapter.java
@@ -24,7 +24,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * multiple connection
  * @author kcameron Copyright (C) 2011
  */
-public class SpecificDriverAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class SpecificDriverAdapter extends SerialPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/powerline/cp290/SpecificDriverAdapter.java
+++ b/java/src/jmri/jmrix/powerline/cp290/SpecificDriverAdapter.java
@@ -24,7 +24,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * multiple connection
  * @author kcameron Copyright (C) 2011
  */
-public class SpecificDriverAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class SpecificDriverAdapter extends SerialPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/powerline/insteon2412s/SpecificDriverAdapter.java
+++ b/java/src/jmri/jmrix/powerline/insteon2412s/SpecificDriverAdapter.java
@@ -24,7 +24,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * multiple connection
  * @author kcameron Copyright (C) 2011
  */
-public class SpecificDriverAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class SpecificDriverAdapter extends SerialPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/powerline/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/powerline/serialdriver/SerialDriverAdapter.java
@@ -24,7 +24,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author Ken Cameron, (C) 2009, sensors from poll replies Converted to multiple connection
  * @author kcameron Copyright (C) 2011
  */
-public class SerialDriverAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends SerialPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/powerline/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/powerline/simulator/SimulatorAdapter.java
@@ -22,8 +22,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2006, 2007, 2008 Converted to multiple connection
  * @author kcameron Copyright (C) 2011
  */
-public class SimulatorAdapter extends SerialPortController implements
-        jmri.jmrix.SerialPortAdapter, Runnable {
+public class SimulatorAdapter extends SerialPortController implements Runnable {
 
     // private control members
     private boolean opened = false;

--- a/java/src/jmri/jmrix/qsi/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/qsi/serialdriver/SerialDriverAdapter.java
@@ -29,7 +29,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2002
  */
-public class SerialDriverAdapter extends QsiPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends QsiPortController {
 
     public SerialDriverAdapter() {
         super(new QsiSystemConnectionMemo());

--- a/java/src/jmri/jmrix/rfid/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/rfid/serialdriver/SerialDriverAdapter.java
@@ -39,7 +39,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author B. Milhaupt Copyright (C) 2017
  * @since 2.11.4
  */
-public class SerialDriverAdapter extends RfidPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends RfidPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/roco/RocoCommandStation.java
+++ b/java/src/jmri/jmrix/roco/RocoCommandStation.java
@@ -7,7 +7,7 @@ package jmri.jmrix.roco;
  * @author	Bob Jacobsen Copyright (C) 2001 
  * @author  Paul Bender Copyright (C) 2016
  */
-public class RocoCommandStation extends jmri.jmrix.lenz.LenzCommandStation implements jmri.CommandStation {
+public class RocoCommandStation extends jmri.jmrix.lenz.LenzCommandStation {
 
     /*
      * We need to register for logging

--- a/java/src/jmri/jmrix/roco/z21/RocoZ21CommandStation.java
+++ b/java/src/jmri/jmrix/roco/z21/RocoZ21CommandStation.java
@@ -31,7 +31,7 @@ package jmri.jmrix.roco.z21;
  * @author	Bob Jacobsen Copyright (C) 2001 
  * @author      Paul Bender Copyright (C) 2016
  */
-public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation implements jmri.CommandStation {
+public class RocoZ21CommandStation extends jmri.jmrix.roco.RocoCommandStation {
 
     private int broadcast_flags = 0; // holds the value of the broadcast flags.
     private int serial_number = 0; // holds the serial number of the Z21.

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetMessage.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetMessage.java
@@ -14,7 +14,7 @@ import jmri.jmrix.lenz.XNetMessage;
  * @author	Bob Jacobsen Copyright (C) 2002
  * @author	Paul Bender Copyright (C) 2003-2010
  */
-public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage implements Serializable {
+public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage {
 
 //    static private int _nRetries = 5;
 

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetOpsModeProgrammer.java
@@ -23,7 +23,7 @@ import jmri.jmrix.loconet.LnTrafficController;
  * @see jmri.Programmer
  * @author Paul Bender Copyright (C) 2018
  */
-public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgrammer implements XNetListener, AddressedProgrammer, LocoNetListener {
+public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgrammer implements AddressedProgrammer, LocoNetListener {
 
     private int _cv;
     private LnTrafficController lnTC;

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetOpsModeProgrammer.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetOpsModeProgrammer.java
@@ -23,7 +23,7 @@ import jmri.jmrix.loconet.LnTrafficController;
  * @see jmri.Programmer
  * @author Paul Bender Copyright (C) 2018
  */
-public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgrammer implements AddressedProgrammer, LocoNetListener {
+public class Z21XNetOpsModeProgrammer extends jmri.jmrix.lenz.XNetOpsModeProgrammer implements LocoNetListener {
 
     private int _cv;
     private LnTrafficController lnTC;

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetTurnout.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetTurnout.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Paul Bender Copyright (C) 2016
  */
-public class Z21XNetTurnout extends XNetTurnout implements XNetListener {
+public class Z21XNetTurnout extends XNetTurnout {
 
     public Z21XNetTurnout(String prefix, int pNumber, XNetTrafficController controller) {  
         super(prefix,pNumber,controller);

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetTurnoutManager.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetTurnoutManager.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author	Paul Bender Copyright (C) 2016 
  */
-public class Z21XNetTurnoutManager extends XNetTurnoutManager implements XNetListener {
+public class Z21XNetTurnoutManager extends XNetTurnoutManager {
 
     public Z21XNetTurnoutManager(XNetTrafficController controller, String prefix) {
         super(controller, prefix);

--- a/java/src/jmri/jmrix/secsi/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/secsi/serialdriver/SerialDriverAdapter.java
@@ -21,7 +21,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Bob Jacobsen Copyright (C) 2006, 2007
  */
-public class SerialDriverAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends SerialPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/secsi/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/secsi/simulator/SimulatorAdapter.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Underwood, Copyright (C) 2015
  * @author Egbert Broerse, Copyright (C) 2018
  */
-public class SimulatorAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter, Runnable {
+public class SimulatorAdapter extends SerialPortController implements Runnable {
 
     // private control members
     private boolean opened = false;

--- a/java/src/jmri/jmrix/serialsensor/SerialSensorAdapter.java
+++ b/java/src/jmri/jmrix/serialsensor/SerialSensorAdapter.java
@@ -28,8 +28,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author	Bob Jacobsen Copyright (C) 2003
  */
-public class SerialSensorAdapter extends AbstractSerialPortController
-        implements jmri.jmrix.SerialPortAdapter {
+public class SerialSensorAdapter extends AbstractSerialPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/sprog/SprogPowerManager.java
+++ b/java/src/jmri/jmrix/sprog/SprogPowerManager.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2001
  */
 public class SprogPowerManager extends jmri.managers.AbstractPowerManager
-        implements PowerManager, SprogListener {
+        implements SprogListener {
 
     SprogTrafficController trafficController = null;
 

--- a/java/src/jmri/jmrix/sprog/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/sprog/serialdriver/SerialDriverAdapter.java
@@ -32,7 +32,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author Bob Jacobsen Copyright (C) 2001, 2002
  */
-public class SerialDriverAdapter extends SprogPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends SprogPortController {
 
     public SerialDriverAdapter() {
         super(new SprogSystemConnectionMemo(SprogMode.SERVICE));

--- a/java/src/jmri/jmrix/srcp/networkdriver/NetworkDriverAdapter.java
+++ b/java/src/jmri/jmrix/srcp/networkdriver/NetworkDriverAdapter.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
  * @author	Bob Jacobsen Copyright (C) 2001, 2002, 2003, 2008
  * @author	Paul Bender Copyright (C) 2010
  */
-public class NetworkDriverAdapter extends SRCPPortController implements jmri.jmrix.NetworkPortAdapter {
+public class NetworkDriverAdapter extends SRCPPortController {
 
     public NetworkDriverAdapter() {
         super(new jmri.jmrix.srcp.SRCPSystemConnectionMemo());

--- a/java/src/jmri/jmrix/srcp/parser/SRCPClientVisitor.java
+++ b/java/src/jmri/jmrix/srcp/parser/SRCPClientVisitor.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
  * parser for the SRCP protocol and the JMRI front end.
  * @author Paul Bender Copyright (C) 2011
  */
-public class SRCPClientVisitor extends SRCPClientParserDefaultVisitor implements jmri.jmrix.srcp.parser.SRCPClientParserVisitor {
+public class SRCPClientVisitor extends SRCPClientParserDefaultVisitor {
 
     @Override
     public Object visit(ASTinfo node, Object data) {

--- a/java/src/jmri/jmrix/tams/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/tams/serialdriver/SerialDriverAdapter.java
@@ -25,7 +25,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author	Kevin Dickerson Copyright (C) 2012
  */
-public class SerialDriverAdapter extends TamsPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends TamsPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/tams/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/tams/simulator/SimulatorAdapter.java
@@ -24,8 +24,7 @@ import org.slf4j.LoggerFactory;
  * @author Daniel Boudreau Copyright (C) 2010
  * 
  */
-public class SimulatorAdapter extends TamsPortController implements
-        jmri.jmrix.SerialPortAdapter, Runnable {
+public class SimulatorAdapter extends TamsPortController implements Runnable {
 
     // private control members
     private boolean opened = false;

--- a/java/src/jmri/jmrix/tmcc/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/tmcc/serialdriver/SerialDriverAdapter.java
@@ -24,7 +24,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author	Bob Jacobsen Copyright (C) 2006
  */
-public class SerialDriverAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends SerialPortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/tmcc/simulator/SimulatorAdapter.java
+++ b/java/src/jmri/jmrix/tmcc/simulator/SimulatorAdapter.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Underwood, Copyright (C) 2015
  * @author Egbert Broerse, Copyright (C) 2017
  */
-public class SimulatorAdapter extends SerialPortController implements jmri.jmrix.SerialPortAdapter, Runnable {
+public class SimulatorAdapter extends SerialPortController implements Runnable {
 
     // private control members
     private boolean opened = false;

--- a/java/src/jmri/jmrix/wangrow/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/wangrow/serialdriver/SerialDriverAdapter.java
@@ -32,7 +32,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author	Bob Jacobsen Copyright (C) 2001, 2002
  */
-public class SerialDriverAdapter extends NcePortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends NcePortController {
 
     SerialPort activeSerialPort = null;
 

--- a/java/src/jmri/jmrix/xpa/XpaThrottleManager.java
+++ b/java/src/jmri/jmrix/xpa/XpaThrottleManager.java
@@ -9,7 +9,7 @@ import jmri.jmrix.AbstractThrottleManager;
  *
  * @author Paul Bender Copyright (C) 2004
  */
-public class XpaThrottleManager extends AbstractThrottleManager implements ThrottleManager {
+public class XpaThrottleManager extends AbstractThrottleManager {
 
     private XpaTrafficController tc = null;
 

--- a/java/src/jmri/jmrix/xpa/serialdriver/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/xpa/serialdriver/SerialDriverAdapter.java
@@ -28,7 +28,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author	Paul Bender Copyright (C) 2004
  */
-public class SerialDriverAdapter extends XpaPortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends XpaPortController {
 
     public SerialDriverAdapter() {
 

--- a/java/src/jmri/jmrix/zimo/Mx1Message.java
+++ b/java/src/jmri/jmrix/zimo/Mx1Message.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  * Adapted by Sip Bosch for use with zimo MX-1
  *
  */
-public class Mx1Message extends jmri.jmrix.NetMessage implements Serializable {
+public class Mx1Message extends jmri.jmrix.NetMessage {
 
     public Mx1Message(int len) {
         this(len, Mx1Packetizer.ASCII);

--- a/java/src/jmri/jmrix/zimo/mx1/Mx1Adapter.java
+++ b/java/src/jmri/jmrix/zimo/mx1/Mx1Adapter.java
@@ -25,7 +25,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * @author	Bob Jacobsen Copyright (C) 2002
  */
-public class Mx1Adapter extends Mx1PortController implements jmri.jmrix.SerialPortAdapter {
+public class Mx1Adapter extends Mx1PortController {
 
     public Mx1Adapter() {
         super(new Mx1SystemConnectionMemo());

--- a/java/src/jmri/jmrix/zimo/mxulf/SerialDriverAdapter.java
+++ b/java/src/jmri/jmrix/zimo/mxulf/SerialDriverAdapter.java
@@ -25,7 +25,7 @@ import purejavacomm.UnsupportedCommOperationException;
  *
  * Adapted for use with Zimo MXULF by Kevin Dickerson
  */
-public class SerialDriverAdapter extends Mx1PortController implements jmri.jmrix.SerialPortAdapter {
+public class SerialDriverAdapter extends Mx1PortController {
 
     public SerialDriverAdapter() {
         super(new Mx1SystemConnectionMemo());

--- a/java/src/jmri/jmrix/ztc/ztc611/ZTC611Adapter.java
+++ b/java/src/jmri/jmrix/ztc/ztc611/ZTC611Adapter.java
@@ -24,7 +24,7 @@ import purejavacomm.UnsupportedCommOperationException;
  * @author Bob Jacobsen Copyright (C) 2002
  * @author Paul Bender, Copyright (C) 2003-2017
  */
-public class ZTC611Adapter extends XNetSerialPortController implements jmri.jmrix.SerialPortAdapter {
+public class ZTC611Adapter extends XNetSerialPortController {
 
     public ZTC611Adapter() {
         super();

--- a/java/src/jmri/jmrix/ztc/ztc611/ZTC611XNetTurnoutManager.java
+++ b/java/src/jmri/jmrix/ztc/ztc611/ZTC611XNetTurnoutManager.java
@@ -11,7 +11,7 @@ import jmri.jmrix.lenz.XNetAddress;
  *
  * @author Paul Bender Copyright (C) 2008, 2017
  */
-public class ZTC611XNetTurnoutManager extends jmri.jmrix.lenz.XNetTurnoutManager implements jmri.jmrix.lenz.XNetListener {
+public class ZTC611XNetTurnoutManager extends jmri.jmrix.lenz.XNetTurnoutManager {
 
     public ZTC611XNetTurnoutManager(jmri.jmrix.lenz.XNetTrafficController controller, String prefix) {
         super(controller, prefix);

--- a/java/src/jmri/managers/AbstractLightManager.java
+++ b/java/src/jmri/managers/AbstractLightManager.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  * @author Dave Duchamp Copyright (C) 2004
  */
 public abstract class AbstractLightManager extends AbstractManager<Light>
-        implements LightManager, java.beans.PropertyChangeListener {
+        implements LightManager {
 
     /**
      * Create a new LightManager instance.

--- a/java/src/jmri/managers/AbstractSignalHeadManager.java
+++ b/java/src/jmri/managers/AbstractSignalHeadManager.java
@@ -17,7 +17,7 @@ import jmri.SignalHeadManager;
  * @author Bob Jacobsen Copyright (C) 2003
  */
 public class AbstractSignalHeadManager extends AbstractManager<SignalHead>
-        implements SignalHeadManager, java.beans.PropertyChangeListener {
+        implements SignalHeadManager {
 
     public AbstractSignalHeadManager() {
         super();

--- a/java/src/jmri/managers/AbstractTurnoutManager.java
+++ b/java/src/jmri/managers/AbstractTurnoutManager.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2001
  */
 public abstract class AbstractTurnoutManager extends AbstractManager<Turnout>
-        implements TurnoutManager, java.beans.VetoableChangeListener {
+        implements TurnoutManager {
 
     public AbstractTurnoutManager() {
         //super(Manager.TURNOUTS);

--- a/java/src/jmri/managers/DefaultConditionalManager.java
+++ b/java/src/jmri/managers/DefaultConditionalManager.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * @author Pete Cresman Copyright (C) 2009
  */
 public class DefaultConditionalManager extends AbstractManager<Conditional>
-        implements ConditionalManager, java.beans.PropertyChangeListener {
+        implements ConditionalManager {
 
     public DefaultConditionalManager() {
         super();

--- a/java/src/jmri/managers/DefaultLogixManager.java
+++ b/java/src/jmri/managers/DefaultLogixManager.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * @author Dave Duchamp Copyright (C) 2007
  */
 public class DefaultLogixManager extends AbstractManager<Logix>
-        implements LogixManager, java.beans.PropertyChangeListener {
+        implements LogixManager {
 
     public DefaultLogixManager() {
         super();

--- a/java/src/jmri/managers/DefaultRouteManager.java
+++ b/java/src/jmri/managers/DefaultRouteManager.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  * @author Dave Duchamp Copyright (C) 2004
  */
 public class DefaultRouteManager extends AbstractManager<Route>
-        implements RouteManager, java.beans.PropertyChangeListener, java.beans.VetoableChangeListener {
+        implements RouteManager, java.beans.VetoableChangeListener {
 
     public DefaultRouteManager() {
         super();

--- a/java/src/jmri/managers/DefaultRouteManager.java
+++ b/java/src/jmri/managers/DefaultRouteManager.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  * @author Dave Duchamp Copyright (C) 2004
  */
 public class DefaultRouteManager extends AbstractManager<Route>
-        implements RouteManager, java.beans.VetoableChangeListener {
+        implements RouteManager {
 
     public DefaultRouteManager() {
         super();

--- a/java/src/jmri/managers/DefaultSignalGroupManager.java
+++ b/java/src/jmri/managers/DefaultSignalGroupManager.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2009, 2018
  */
 public class DefaultSignalGroupManager extends AbstractManager<SignalGroup>
-        implements SignalGroupManager, java.beans.PropertyChangeListener {
+        implements SignalGroupManager {
 
     public DefaultSignalGroupManager() {
         super();

--- a/java/src/jmri/managers/DefaultSignalMastLogicManager.java
+++ b/java/src/jmri/managers/DefaultSignalMastLogicManager.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DefaultSignalMastLogicManager
         extends AbstractManager<SignalMastLogic>
-        implements jmri.SignalMastLogicManager, java.beans.VetoableChangeListener {
+        implements jmri.SignalMastLogicManager {
 
     public DefaultSignalMastLogicManager() {
         registerSelf();

--- a/java/src/jmri/managers/DefaultSignalMastManager.java
+++ b/java/src/jmri/managers/DefaultSignalMastManager.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2009
  */
 public class DefaultSignalMastManager extends AbstractManager<SignalMast>
-        implements SignalMastManager, java.beans.PropertyChangeListener {
+        implements SignalMastManager {
 
     public DefaultSignalMastManager() {
         super();

--- a/java/src/jmri/managers/DefaultSignalSystemManager.java
+++ b/java/src/jmri/managers/DefaultSignalSystemManager.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  * @author Bob Jacobsen Copyright (C) 2009
  */
 public class DefaultSignalSystemManager extends AbstractManager<SignalSystem>
-        implements SignalSystemManager, java.beans.PropertyChangeListener {
+        implements SignalSystemManager {
 
     public DefaultSignalSystemManager() {
         super();

--- a/java/test/jmri/jmrit/display/EditorScaffold.java
+++ b/java/test/jmri/jmrit/display/EditorScaffold.java
@@ -19,8 +19,7 @@ import java.awt.event.MouseMotionListener;
  * @author Paul Bender Copyright (c) 2016
  *
  */
-public class EditorScaffold extends Editor implements MouseListener, MouseMotionListener,
-        ActionListener, KeyListener, java.beans.VetoableChangeListener {
+public class EditorScaffold extends Editor {
 
     public EditorScaffold() {
         this("foo");

--- a/java/test/jmri/jmrit/display/palette/ColorDialogTest.java
+++ b/java/test/jmri/jmrit/display/palette/ColorDialogTest.java
@@ -87,7 +87,7 @@ public class ColorDialogTest {
         _cpe.putItem(_pos);
     }
 
-    class BlockedThread extends Thread implements Runnable {
+    class BlockedThread extends Thread {
         ColorDialog _cd;
         ControlPanelEditor _cpe;
         JComponent _target;


### PR DESCRIPTION
A redundant interface is when a `implements` clause is added that's not needed because that interface  is already included in a superclass, i.e.
```
 class Foo extends MyPropertyChangeListener implements PropertyChangeListener
```
when 
```
class MyPropertyChangeListener implements PropertyChangeListener
```

Although formally correct Java allowed by the compilers, these make the Javadoc and class diagrams more complicated, and in general it's better to reduce redundancy.

This PR removes the ones in current code, then sets the `ecj` options so that the various warnings steps will flag any new occurrences.