### PR TITLE
Fix outdated references to roster-config.xml

### DIFF
--- a/java/src/jmri/BasicRosterEntry.java
+++ b/java/src/jmri/BasicRosterEntry.java
@@ -56,7 +56,8 @@ public interface BasicRosterEntry {
 
     /**
      * Create an XML element to represent this Entry. This member has to remain
-     * synchronized with the detailed DTD in roster-config.xml.
+     * synchronized with the detailed schema in
+     * xml/schema/locomotive-config.xsd.
      *
      * @return Contents in a JDOM Element
      */

--- a/java/src/jmri/jmrit/roster/RosterEntry.java
+++ b/java/src/jmri/jmrit/roster/RosterEntry.java
@@ -635,8 +635,8 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
     /**
      * Construct this Entry from XML.
      * <p>
-     * This member has to remain synchronized with the detailed DTD in
-     * roster-config.xml
+     * This member has to remain synchronized with the detailed schema in
+     * xml/schema/locomotive-config.xsd.
      *
      * @param e Locomotive XML element
      */
@@ -1136,8 +1136,8 @@ public class RosterEntry extends ArbitraryBean implements RosterObject, BasicRos
     /**
      * Create an XML element to represent this Entry.
      * <p>
-     * This member has to remain synchronized with the detailed DTD in
-     * roster-config.xml.
+     * This member has to remain synchronized with the detailed schema in
+     * xml/schema/locomotive-config.xsd.
      *
      * @return Contents in a JDOM Element
      */

--- a/java/src/jmri/jmrix/nce/consist/NceConsistRosterEntry.java
+++ b/java/src/jmri/jmrix/nce/consist/NceConsistRosterEntry.java
@@ -265,7 +265,7 @@ public class NceConsistRosterEntry {
 
     /**
      * Construct this Entry from XML. This member has to remain synchronized
-     * with the detailed DTD in consist-roster-config.xml
+     * with the detailed DTD in xml/DTD/consist-roster-config.dtd.
      *
      * @param e Consist XML element
      */
@@ -384,7 +384,7 @@ public class NceConsistRosterEntry {
 
     /**
      * Create an XML element to represent this Entry. This member has to remain
-     * synchronized with the detailed DTD in consist-roster-config.xml.
+     * synchronized with the detailed DTD in xml/DTD/consist-roster-config.dtd.
      *
      * @return Contents in a JDOM Element
      */


### PR DESCRIPTION
I found a few references to roster-config.xml and was told that they're outdated, and that the roster schema now lives in `xml/schema/locomotive-config.xsd`, so I updated the comments to match that.