### PR TITLE
Readability fixes for loco address

### DIFF
--- a/java/src/jmri/jmrix/AbstractThrottleManager.java
+++ b/java/src/jmri/jmrix/AbstractThrottleManager.java
@@ -73,7 +73,10 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
      */
     @Override
     public LocoAddress.Protocol[] getAddressProtocolTypes() {
-        return new LocoAddress.Protocol[]{LocoAddress.Protocol.DCC, LocoAddress.Protocol.DCC_SHORT, LocoAddress.Protocol.DCC_LONG};
+        return new LocoAddress.Protocol[]{
+            LocoAddress.Protocol.DCC,
+            LocoAddress.Protocol.DCC_SHORT,
+            LocoAddress.Protocol.DCC_LONG};
     }
 
     /**

--- a/java/src/jmri/jmrix/ecos/EcosDccThrottleManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottleManager.java
@@ -90,7 +90,8 @@ public class EcosDccThrottleManager extends AbstractThrottleManager implements E
 
     @Override
     public LocoAddress.Protocol[] getAddressProtocolTypes() {
-        return new LocoAddress.Protocol[]{LocoAddress.Protocol.DCC,
+        return new LocoAddress.Protocol[]{
+            LocoAddress.Protocol.DCC,
             LocoAddress.Protocol.MFX,
             LocoAddress.Protocol.MOTOROLA,
             LocoAddress.Protocol.SELECTRIX,


### PR DESCRIPTION
I found these parts of the throttle address protocol code difficult to read, so I reformatted them slightly.