### PR TITLE
Replace speed step mode with enum.

### DIFF
--- a/java/src/jmri/DccThrottle.java
+++ b/java/src/jmri/DccThrottle.java
@@ -23,28 +23,20 @@ public interface DccThrottle extends Throttle {
     // always positive.
     public float getSpeedIncrement();
 
-    // Handle Speed Step Information
-    // There are 4 valid speed step modes
-    public static final int SpeedStepMode128 = 1;
-    public static final int SpeedStepMode28 = 2;
-    public static final int SpeedStepMode27 = 4;
-    public static final int SpeedStepMode14 = 8;
-    public static final int SpeedStepMode28Mot = 16;
-
     /**
      * Set the speed step value. Default should be 128 speed step mode in most
      * cases
      *
      * @param Mode the current speed step mode
      */
-    public void setSpeedStepMode(int Mode);
+    public void setSpeedStepMode(SpeedStepMode Mode);
 
     /**
      * Get the current speed step value.
      *
      * @return the current speed step mode
      */
-    public int getSpeedStepMode();
+    public SpeedStepMode getSpeedStepMode();
 
     // information on consisting  (how do we set consisting?)
     // register for notification

--- a/java/src/jmri/SpeedStepMode.java
+++ b/java/src/jmri/SpeedStepMode.java
@@ -28,7 +28,8 @@ public enum SpeedStepMode {
     NMRA_DCC_14("14", 14),
     // Non-DCC speed step modes.
     MOTOROLA_28("motorola_28", 28), // Motorola 28 speed step mode.
-    TMCC_32("tmcc_32", 32); // Lionel TMCC 32 speed step mode.
+    TMCC_32("tmcc_32", 32), // Lionel TMCC 32 speed step mode.
+    INCREMENTAL("incremental", 1, 1.0f);
 
     SpeedStepMode(String name, int numSteps) {
         this(name, numSteps, 1.0f / numSteps);

--- a/java/src/jmri/SpeedStepMode.java
+++ b/java/src/jmri/SpeedStepMode.java
@@ -20,7 +20,7 @@ import java.util.EnumSet;
  */
 @javax.annotation.concurrent.Immutable
 public enum SpeedStepMode {
-    UNKNOWN("unknown", 1),
+    UNKNOWN("unknown", 1, 0.0f),
     // NMRA DCC standard speed step modes.
     NMRA_DCC_128("128", 126), // Remember there are only 126 non-stop values in 128 speed.
     NMRA_DCC_28("28", 28),
@@ -31,9 +31,13 @@ public enum SpeedStepMode {
     TMCC_32("tmcc_32", 32); // Lionel TMCC 32 speed step mode.
 
     SpeedStepMode(String name, int numSteps) {
+        this(name, numSteps, 1.0f / numSteps);
+    }
+
+    SpeedStepMode(String name, int numSteps, float increment) {
         this.name = name;
         this.numSteps = numSteps;
-        this.increment = 1.0f / numSteps;
+        this.increment = increment;
     }
 
     public final String name;

--- a/java/src/jmri/SpeedStepMode.java
+++ b/java/src/jmri/SpeedStepMode.java
@@ -20,21 +20,25 @@ import java.util.EnumSet;
  */
 @javax.annotation.concurrent.Immutable
 public enum SpeedStepMode {
-    UNKNOWN("unknown"),
+    UNKNOWN("unknown", 1),
     // NMRA DCC standard speed step modes.
-    NMRA_DCC_128("128"),
-    NMRA_DCC_28("28"),
-    NMRA_DCC_27("27"),
-    NMRA_DCC_14("14"),
+    NMRA_DCC_128("128", 126), // Remember there are only 126 non-stop values in 128 speed.
+    NMRA_DCC_28("28", 28),
+    NMRA_DCC_27("27", 27),
+    NMRA_DCC_14("14", 14),
     // Non-DCC speed step modes.
-    MOTOROLA_28("motorola_28"), // Motorola 28 speed step mode.
-    TMCC_32("tmcc_32"); // Lionel TMCC 32 speed step mode.
+    MOTOROLA_28("motorola_28", 28), // Motorola 28 speed step mode.
+    TMCC_32("tmcc_32", 32); // Lionel TMCC 32 speed step mode.
 
-    SpeedStepMode(String name) {
+    SpeedStepMode(String name, int numSteps) {
         this.name = name;
+        this.numSteps = numSteps;
+        this.increment = 1.0f / numSteps;
     }
 
     public String name;
+    public int numSteps;
+    public float increment;
 
     /**
      * Convert a human-readable string to a DCC speed step mode.

--- a/java/src/jmri/SpeedStepMode.java
+++ b/java/src/jmri/SpeedStepMode.java
@@ -20,15 +20,15 @@ import java.util.EnumSet;
  */
 @javax.annotation.concurrent.Immutable
 public enum SpeedStepMode {
-    Unknown("unknown"),
+    UNKNOWN("unknown"),
     // NMRA DCC standard speed step modes.
-    SpeedStepMode128("128"),
-    SpeedStepMode28("28"),
-    SpeedStepMode27("27"),
-    SpeedStepMode14("14"),
+    NMRA_DCC_128("128"),
+    NMRA_DCC_28("28"),
+    NMRA_DCC_27("27"),
+    NMRA_DCC_14("14"),
     // Non-DCC speed step modes.
-    SpeedStepMode28Mot("motorola_28"), // Motorola 28 speed step mode.
-    SpeedStepModeTMCC32("tmcc_32"); // Lionel TMCC 32 speed step mode.
+    MOTOROLA_28("motorola_28"), // Motorola 28 speed step mode.
+    TMCC_32("tmcc_32"); // Lionel TMCC 32 speed step mode.
 
     SpeedStepMode(String name) {
         this.name = name;
@@ -64,19 +64,19 @@ public enum SpeedStepMode {
             EnumSet<SpeedStepMode> command_station_modes,
             EnumSet<SpeedStepMode> decoder_modes) {
         EnumSet<SpeedStepMode> result = getCompatibleModes(command_station_modes, decoder_modes);
-        if(result.contains(SpeedStepMode128)) {
-            return SpeedStepMode128;
-        } else if(result.contains(SpeedStepModeTMCC32)) {
-            return SpeedStepModeTMCC32;
-        } else if(result.contains(SpeedStepMode28)) {
-            return SpeedStepMode28;
-        } else if(result.contains(SpeedStepMode28Mot)) {
-            return SpeedStepMode28Mot;
-        } else if(result.contains(SpeedStepMode27)) {
-            return SpeedStepMode27;
-        } else if(result.contains(SpeedStepMode14)) {
-            return SpeedStepMode14;
+        if(result.contains(NMRA_DCC_128)) {
+            return NMRA_DCC_128;
+        } else if(result.contains(TMCC_32)) {
+            return TMCC_32;
+        } else if(result.contains(NMRA_DCC_28)) {
+            return NMRA_DCC_28;
+        } else if(result.contains(MOTOROLA_28)) {
+            return MOTOROLA_28;
+        } else if(result.contains(NMRA_DCC_27)) {
+            return NMRA_DCC_27;
+        } else if(result.contains(NMRA_DCC_14)) {
+            return NMRA_DCC_14;
         }
-        return Unknown;
+        return UNKNOWN;
     }
 }

--- a/java/src/jmri/SpeedStepMode.java
+++ b/java/src/jmri/SpeedStepMode.java
@@ -21,11 +21,14 @@ import java.util.EnumSet;
 @javax.annotation.concurrent.Immutable
 public enum SpeedStepMode {
     Unknown("unknown"),
+    // NMRA DCC standard speed step modes.
     SpeedStepMode128("128"),
     SpeedStepMode28("28"),
     SpeedStepMode27("27"),
     SpeedStepMode14("14"),
-    SpeedStepMode28Mot("motorola_28");
+    // Non-DCC speed step modes.
+    SpeedStepMode28Mot("motorola_28"), // Motorola 28 speed step mode.
+    SpeedStepModeTMCC32("tmcc_32"); // Lionel TMCC 32 speed step mode.
 
     SpeedStepMode(String name) {
         this.name = name;
@@ -63,6 +66,8 @@ public enum SpeedStepMode {
         EnumSet<SpeedStepMode> result = getCompatibleModes(command_station_modes, decoder_modes);
         if(result.contains(SpeedStepMode128)) {
             return SpeedStepMode128;
+        } else if(result.contains(SpeedStepModeTMCC32)) {
+            return SpeedStepModeTMCC32;
         } else if(result.contains(SpeedStepMode28)) {
             return SpeedStepMode28;
         } else if(result.contains(SpeedStepMode28Mot)) {

--- a/java/src/jmri/SpeedStepMode.java
+++ b/java/src/jmri/SpeedStepMode.java
@@ -36,9 +36,9 @@ public enum SpeedStepMode {
         this.increment = 1.0f / numSteps;
     }
 
-    public String name;
-    public int numSteps;
-    public float increment;
+    public final String name;
+    public final int numSteps;
+    public final float increment;
 
     /**
      * Convert a human-readable string to a DCC speed step mode.

--- a/java/src/jmri/SpeedStepMode.java
+++ b/java/src/jmri/SpeedStepMode.java
@@ -1,0 +1,77 @@
+package jmri;
+
+import java.util.EnumSet;
+
+/**
+ * DCC Speed Step Mode.
+ *
+ * <hr>
+ * This file is part of JMRI.
+ * <p>
+ * JMRI is free software; you can redistribute it and/or modify it under the
+ * terms of version 2 of the GNU General Public License as published by the Free
+ * Software Foundation. See the "COPYING" file for a copy of this license.
+ * <p>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Austin Hendrix Copyright (C) 2019
+ */
+@javax.annotation.concurrent.Immutable
+public enum SpeedStepMode {
+    Unknown("unknown"),
+    SpeedStepMode128("128"),
+    SpeedStepMode28("28"),
+    SpeedStepMode27("27"),
+    SpeedStepMode14("14"),
+    SpeedStepMode28Mot("motorola_28");
+
+    SpeedStepMode(String name) {
+        this.name = name;
+    }
+
+    public String name;
+
+    /**
+     * Convert a human-readable string to a DCC speed step mode.
+     *
+     * @param name string version of speed step mode; example "128"
+     * @return matching SpeedStepMode
+     * @throws IllegalArgumentException if name does not correspond to a valid speed step mode.
+     */
+    static public SpeedStepMode getByName(String name) {
+        for(SpeedStepMode s : SpeedStepMode.values()) {
+            if(s.name.equals(name)) {
+                return s;
+            }
+        }
+        throw new IllegalArgumentException("Invalid speed step mode: " + name);
+    }
+
+    static public EnumSet<SpeedStepMode> getCompatibleModes(
+            EnumSet<SpeedStepMode> command_station_modes,
+            EnumSet<SpeedStepMode> decoder_modes) {
+        EnumSet<SpeedStepMode> result = command_station_modes.clone();
+        result.retainAll(decoder_modes);
+        return result;
+    }
+
+    static public SpeedStepMode bestCompatibleMode(
+            EnumSet<SpeedStepMode> command_station_modes,
+            EnumSet<SpeedStepMode> decoder_modes) {
+        EnumSet<SpeedStepMode> result = getCompatibleModes(command_station_modes, decoder_modes);
+        if(result.contains(SpeedStepMode128)) {
+            return SpeedStepMode128;
+        } else if(result.contains(SpeedStepMode28)) {
+            return SpeedStepMode28;
+        } else if(result.contains(SpeedStepMode28Mot)) {
+            return SpeedStepMode28Mot;
+        } else if(result.contains(SpeedStepMode27)) {
+            return SpeedStepMode27;
+        } else if(result.contains(SpeedStepMode14)) {
+            return SpeedStepMode14;
+        }
+        return Unknown;
+    }
+}

--- a/java/src/jmri/ThrottleManager.java
+++ b/java/src/jmri/ThrottleManager.java
@@ -1,6 +1,7 @@
 package jmri;
 
 import java.beans.PropertyChangeListener;
+import java.util.EnumSet;
 
 /**
  * Interface for allocating {@link Throttle} objects.
@@ -431,7 +432,7 @@ public interface ThrottleManager {
      *
      * @return an XOR of the possible modes specified in the throttle interface
      */
-    public int supportedSpeedModes();
+    public EnumSet<SpeedStepMode> supportedSpeedModes();
 
     /**
      * Provides a Proxy method to return the SpeedSetting, Direction, Function

--- a/java/src/jmri/jmris/srcp/JmriSRCPThrottleServer.java
+++ b/java/src/jmri/jmris/srcp/JmriSRCPThrottleServer.java
@@ -108,16 +108,16 @@ public class JmriSRCPThrottleServer extends AbstractThrottleServer {
             String StatusString = "100 INFO " + bus + " GL " + address + " ";
             StatusString += isForward ? "1 " : "0 ";
             switch (speedStepMode) {
-                case SpeedStepMode14:
+                case NMRA_DCC_14:
                     StatusString += (int) java.lang.Math.ceil(speedSetting * 14) + " " + 14;
                     break;
-                case SpeedStepMode27:
+                case NMRA_DCC_27:
                     StatusString += (int) java.lang.Math.ceil(speedSetting * 27) + " " + 27;
                     break;
-                case SpeedStepMode28:
+                case NMRA_DCC_28:
                     StatusString += (int) java.lang.Math.ceil(speedSetting * 28) + " " + 28;
                     break;
-                case SpeedStepMode128:
+                case NMRA_DCC_128:
                     StatusString += (int) java.lang.Math.ceil(speedSetting * 126) + " " + 126;
                     break;
                 default:

--- a/java/src/jmri/jmris/srcp/JmriSRCPThrottleServer.java
+++ b/java/src/jmri/jmris/srcp/JmriSRCPThrottleServer.java
@@ -11,6 +11,7 @@ import jmri.JmriException;
 import jmri.LocoAddress;
 import jmri.Throttle;
 import jmri.ThrottleManager;
+import jmri.SpeedStepMode;
 import jmri.jmris.AbstractThrottleServer;
 import jmri.jmrix.SystemConnectionMemo;
 import org.slf4j.Logger;
@@ -73,7 +74,7 @@ public class JmriSRCPThrottleServer extends AbstractThrottleServer {
             DccLocoAddress addr = new DccLocoAddress(address, !(t.canBeShortAddress(address)));
             Boolean isForward = (Boolean) t.getThrottleInfo(addr, "IsForward");
             Float speedSetting = (Float) t.getThrottleInfo(addr, "SpeedSetting");
-            Integer speedStepMode = (Integer) t.getThrottleInfo(addr, "SpeedStepMode");
+            SpeedStepMode speedStepMode = (SpeedStepMode) t.getThrottleInfo(addr, "SpeedStepMode"); // TODO(austin): fix this to return a speed step mode.
             Boolean f0 = (Boolean) t.getThrottleInfo(addr, "F0");
             Boolean f1 = (Boolean) t.getThrottleInfo(addr, "F1");
             Boolean f2 = (Boolean) t.getThrottleInfo(addr, "F2");
@@ -107,16 +108,16 @@ public class JmriSRCPThrottleServer extends AbstractThrottleServer {
             String StatusString = "100 INFO " + bus + " GL " + address + " ";
             StatusString += isForward ? "1 " : "0 ";
             switch (speedStepMode) {
-                case DccThrottle.SpeedStepMode14:
+                case SpeedStepMode14:
                     StatusString += (int) java.lang.Math.ceil(speedSetting * 14) + " " + 14;
                     break;
-                case DccThrottle.SpeedStepMode27:
+                case SpeedStepMode27:
                     StatusString += (int) java.lang.Math.ceil(speedSetting * 27) + " " + 27;
                     break;
-                case DccThrottle.SpeedStepMode28:
+                case SpeedStepMode28:
                     StatusString += (int) java.lang.Math.ceil(speedSetting * 28) + " " + 28;
                     break;
-                case DccThrottle.SpeedStepMode128:
+                case SpeedStepMode128:
                     StatusString += (int) java.lang.Math.ceil(speedSetting * 126) + " " + 126;
                     break;
                 default:

--- a/java/src/jmri/jmris/srcp/JmriSRCPThrottleServer.java
+++ b/java/src/jmri/jmris/srcp/JmriSRCPThrottleServer.java
@@ -74,7 +74,7 @@ public class JmriSRCPThrottleServer extends AbstractThrottleServer {
             DccLocoAddress addr = new DccLocoAddress(address, !(t.canBeShortAddress(address)));
             Boolean isForward = (Boolean) t.getThrottleInfo(addr, "IsForward");
             Float speedSetting = (Float) t.getThrottleInfo(addr, "SpeedSetting");
-            SpeedStepMode speedStepMode = (SpeedStepMode) t.getThrottleInfo(addr, "SpeedStepMode"); // TODO(austin): fix this to return a speed step mode.
+            SpeedStepMode speedStepMode = (SpeedStepMode) t.getThrottleInfo(addr, "SpeedStepMode");
             Boolean f0 = (Boolean) t.getThrottleInfo(addr, "F0");
             Boolean f1 = (Boolean) t.getThrottleInfo(addr, "F1");
             Boolean f2 = (Boolean) t.getThrottleInfo(addr, "F2");

--- a/java/src/jmri/jmris/srcp/JmriSRCPThrottleServer.java
+++ b/java/src/jmri/jmris/srcp/JmriSRCPThrottleServer.java
@@ -107,22 +107,7 @@ public class JmriSRCPThrottleServer extends AbstractThrottleServer {
             // and now build the output string to send
             String StatusString = "100 INFO " + bus + " GL " + address + " ";
             StatusString += isForward ? "1 " : "0 ";
-            switch (speedStepMode) {
-                case NMRA_DCC_14:
-                    StatusString += (int) java.lang.Math.ceil(speedSetting * 14) + " " + 14;
-                    break;
-                case NMRA_DCC_27:
-                    StatusString += (int) java.lang.Math.ceil(speedSetting * 27) + " " + 27;
-                    break;
-                case NMRA_DCC_28:
-                    StatusString += (int) java.lang.Math.ceil(speedSetting * 28) + " " + 28;
-                    break;
-                case NMRA_DCC_128:
-                    StatusString += (int) java.lang.Math.ceil(speedSetting * 126) + " " + 126;
-                    break;
-                default:
-                    StatusString += (int) java.lang.Math.ceil(speedSetting * 100) + " " + 100;
-            }
+            StatusString += (int) java.lang.Math.ceil(speedSetting * speedStepMode.numSteps) + " " + speedStepMode.numSteps;
             StatusString += f0 ? " 1" : " 0";
             StatusString += f1 ? " 1" : " 0";
             StatusString += f2 ? " 1" : " 0";

--- a/java/src/jmri/jmris/srcp/JmriSRCPThrottleServer.java
+++ b/java/src/jmri/jmris/srcp/JmriSRCPThrottleServer.java
@@ -107,7 +107,23 @@ public class JmriSRCPThrottleServer extends AbstractThrottleServer {
             // and now build the output string to send
             String StatusString = "100 INFO " + bus + " GL " + address + " ";
             StatusString += isForward ? "1 " : "0 ";
-            StatusString += (int) java.lang.Math.ceil(speedSetting * speedStepMode.numSteps) + " " + speedStepMode.numSteps;
+            {
+                int numSteps = 100;
+                // For NMRA DCC speed step modes, we use the number of steps from that mode.
+                // Non-NMRA modes are not supported, so for those, we fall back to 100 steps.
+                switch(speedStepMode) {
+                    case NMRA_DCC_128:
+                    case NMRA_DCC_28:
+                    case NMRA_DCC_27:
+                    case NMRA_DCC_14:
+                        numSteps = speedStepMode.numSteps;
+                        break;
+                    default:
+                        numSteps = 100;
+                        break;
+                }
+                StatusString += (int) java.lang.Math.ceil(speedSetting * numSteps) + " " + numSteps;
+            }
             StatusString += f0 ? " 1" : " 0";
             StatusString += f1 ? " 1" : " 0";
             StatusString += f2 ? " 1" : " 0";

--- a/java/src/jmri/jmrit/logix/ControlPanel.java
+++ b/java/src/jmri/jmrit/logix/ControlPanel.java
@@ -69,7 +69,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
     private int MAX_SPEED = 126;
 
     // Save the speed step mode to aid in storage of the throttle.
-    //private int _speedStepMode = SpeedStepMode.SpeedStepMode128;
+    //private int _speedStepMode = SpeedStepMode.NMRA_DCC_128;
     /**
      * Constructor.
      */
@@ -198,19 +198,19 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         // Save the old speed as a float
         float oldSpeed = (speedSlider.getValue() / (MAX_SPEED * 1.0f));
 
-        if (steps == SpeedStepMode.SpeedStepMode14) {
+        if (steps == SpeedStepMode.NMRA_DCC_14) {
             speedStep14Button.setSelected(true);
             speedStep27Button.setSelected(false);
             speedStep28Button.setSelected(false);
             speedStep128Button.setSelected(false);
             MAX_SPEED = 14;
-        } else if (steps == SpeedStepMode.SpeedStepMode27) {
+        } else if (steps == SpeedStepMode.NMRA_DCC_27) {
             speedStep14Button.setSelected(false);
             speedStep27Button.setSelected(true);
             speedStep28Button.setSelected(false);
             speedStep128Button.setSelected(false);
             MAX_SPEED = 27;
-        } else if (steps == SpeedStepMode.SpeedStepMode28) {
+        } else if (steps == SpeedStepMode.NMRA_DCC_28) {
             speedStep14Button.setSelected(false);
             speedStep27Button.setSelected(false);
             speedStep28Button.setSelected(true);
@@ -399,32 +399,32 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         speedStep14Button.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                setSpeedSteps(SpeedStepMode.SpeedStepMode14);
-                _throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode14);
+                setSpeedSteps(SpeedStepMode.NMRA_DCC_14);
+                _throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_14);
             }
         });
 
         speedStep27Button.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                setSpeedSteps(SpeedStepMode.SpeedStepMode27);
-                _throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode27);
+                setSpeedSteps(SpeedStepMode.NMRA_DCC_27);
+                _throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_27);
             }
         });
 
         speedStep28Button.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                setSpeedSteps(SpeedStepMode.SpeedStepMode28);
-                _throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
+                setSpeedSteps(SpeedStepMode.NMRA_DCC_28);
+                _throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_28);
             }
         });
 
         speedStep128Button.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                setSpeedSteps(SpeedStepMode.SpeedStepMode128);
-                _throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode128);
+                setSpeedSteps(SpeedStepMode.NMRA_DCC_128);
+                _throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_128);
             }
         });
         // set by default which speed selection method is on top
@@ -508,22 +508,22 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
      */
     private void configureAvailableSpeedStepModes() {
         EnumSet<SpeedStepMode> modes = jmri.InstanceManager.throttleManagerInstance().supportedSpeedModes();
-        if (modes.contains(SpeedStepMode.SpeedStepMode128)) {
+        if (modes.contains(SpeedStepMode.NMRA_DCC_128)) {
             speedStep128Button.setEnabled(true);
         } else {
             speedStep128Button.setEnabled(false);
         }
-        if (modes.contains(SpeedStepMode.SpeedStepMode28)) {
+        if (modes.contains(SpeedStepMode.NMRA_DCC_28)) {
             speedStep28Button.setEnabled(true);
         } else {
             speedStep28Button.setEnabled(false);
         }
-        if (modes.contains(SpeedStepMode.SpeedStepMode27)) {
+        if (modes.contains(SpeedStepMode.NMRA_DCC_27)) {
             speedStep27Button.setEnabled(true);
         } else {
             speedStep27Button.setEnabled(false);
         }
-        if (modes.contains(SpeedStepMode.SpeedStepMode14)) {
+        if (modes.contains(SpeedStepMode.NMRA_DCC_14)) {
             speedStep14Button.setEnabled(true);
         } else {
             speedStep14Button.setEnabled(false);

--- a/java/src/jmri/jmrit/logix/ControlPanel.java
+++ b/java/src/jmri/jmrit/logix/ControlPanel.java
@@ -8,6 +8,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
+import java.util.EnumSet;
+
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
 import javax.swing.JInternalFrame;
@@ -21,6 +23,8 @@ import javax.swing.WindowConstants;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import jmri.DccThrottle;
+import jmri.SpeedStepMode;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +69,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
     private int MAX_SPEED = 126;
 
     // Save the speed step mode to aid in storage of the throttle.
-    //private int _speedStepMode = DccThrottle.SpeedStepMode128;
+    //private int _speedStepMode = SpeedStepMode.SpeedStepMode128;
     /**
      * Constructor.
      */
@@ -148,7 +152,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 _emergencyStop = (speed < 0.0F);
             }
         } else if (e.getPropertyName().equals("SpeedSteps")) {
-            int steps = ((Integer) e.getNewValue()).intValue();
+            // TODO(austin): figure out where this value comes from and fix it.
+            SpeedStepMode steps = SpeedStepMode.getByName((String)e.getNewValue()); // = ((Integer) e.getNewValue()).intValue();
             setSpeedSteps(steps);
             _throttleFrame.setSpeedStepMode(steps);
         } else if (e.getPropertyName().equals("IsForward")) {
@@ -190,23 +195,23 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
      * @param steps Desired number of speed steps. One of 14,27,28,or 128.
      *              Defaults to 128 step mode
      */
-    public void setSpeedSteps(int steps) {
+    public void setSpeedSteps(SpeedStepMode steps) {
         // Save the old speed as a float
         float oldSpeed = (speedSlider.getValue() / (MAX_SPEED * 1.0f));
 
-        if (steps == DccThrottle.SpeedStepMode14) {
+        if (steps == SpeedStepMode.SpeedStepMode14) {
             speedStep14Button.setSelected(true);
             speedStep27Button.setSelected(false);
             speedStep28Button.setSelected(false);
             speedStep128Button.setSelected(false);
             MAX_SPEED = 14;
-        } else if (steps == DccThrottle.SpeedStepMode27) {
+        } else if (steps == SpeedStepMode.SpeedStepMode27) {
             speedStep14Button.setSelected(false);
             speedStep27Button.setSelected(true);
             speedStep28Button.setSelected(false);
             speedStep128Button.setSelected(false);
             MAX_SPEED = 27;
-        } else if (steps == DccThrottle.SpeedStepMode28) {
+        } else if (steps == SpeedStepMode.SpeedStepMode28) {
             speedStep14Button.setSelected(false);
             speedStep27Button.setSelected(false);
             speedStep28Button.setSelected(true);
@@ -395,32 +400,32 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         speedStep14Button.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                setSpeedSteps(DccThrottle.SpeedStepMode14);
-                _throttle.setSpeedStepMode(DccThrottle.SpeedStepMode14);
+                setSpeedSteps(SpeedStepMode.SpeedStepMode14);
+                _throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode14);
             }
         });
 
         speedStep27Button.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                setSpeedSteps(DccThrottle.SpeedStepMode27);
-                _throttle.setSpeedStepMode(DccThrottle.SpeedStepMode27);
+                setSpeedSteps(SpeedStepMode.SpeedStepMode27);
+                _throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode27);
             }
         });
 
         speedStep28Button.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                setSpeedSteps(DccThrottle.SpeedStepMode28);
-                _throttle.setSpeedStepMode(DccThrottle.SpeedStepMode28);
+                setSpeedSteps(SpeedStepMode.SpeedStepMode28);
+                _throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
             }
         });
 
         speedStep128Button.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                setSpeedSteps(DccThrottle.SpeedStepMode128);
-                _throttle.setSpeedStepMode(DccThrottle.SpeedStepMode128);
+                setSpeedSteps(SpeedStepMode.SpeedStepMode128);
+                _throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode128);
             }
         });
         // set by default which speed selection method is on top
@@ -503,23 +508,23 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
      * DCC system
      */
     private void configureAvailableSpeedStepModes() {
-        int modes = jmri.InstanceManager.throttleManagerInstance().supportedSpeedModes();
-        if ((modes & DccThrottle.SpeedStepMode128) != 0) {
+        EnumSet<SpeedStepMode> modes = jmri.InstanceManager.throttleManagerInstance().supportedSpeedModes();
+        if (modes.contains(SpeedStepMode.SpeedStepMode128)) {
             speedStep128Button.setEnabled(true);
         } else {
             speedStep128Button.setEnabled(false);
         }
-        if ((modes & DccThrottle.SpeedStepMode28) != 0) {
+        if (modes.contains(SpeedStepMode.SpeedStepMode28)) {
             speedStep28Button.setEnabled(true);
         } else {
             speedStep28Button.setEnabled(false);
         }
-        if ((modes & DccThrottle.SpeedStepMode27) != 0) {
+        if (modes.contains(SpeedStepMode.SpeedStepMode27)) {
             speedStep27Button.setEnabled(true);
         } else {
             speedStep27Button.setEnabled(false);
         }
-        if ((modes & DccThrottle.SpeedStepMode14) != 0) {
+        if (modes.contains(SpeedStepMode.SpeedStepMode14)) {
             speedStep14Button.setEnabled(true);
         } else {
             speedStep14Button.setEnabled(false);

--- a/java/src/jmri/jmrit/logix/ControlPanel.java
+++ b/java/src/jmri/jmrit/logix/ControlPanel.java
@@ -152,8 +152,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 _emergencyStop = (speed < 0.0F);
             }
         } else if (e.getPropertyName().equals("SpeedSteps")) {
-            // TODO(austin): figure out where this value comes from and fix it.
-            SpeedStepMode steps = SpeedStepMode.getByName((String)e.getNewValue()); // = ((Integer) e.getNewValue()).intValue();
+            SpeedStepMode steps = (SpeedStepMode)e.getNewValue();
             setSpeedSteps(steps);
             _throttleFrame.setSpeedStepMode(steps);
         } else if (e.getPropertyName().equals("IsForward")) {

--- a/java/src/jmri/jmrit/logix/Engineer.java
+++ b/java/src/jmri/jmrit/logix/Engineer.java
@@ -8,6 +8,7 @@ import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.NamedBean;
 import jmri.Sensor;
+import jmri.SpeedStepMode;
 import jmri.util.ThreadingUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -253,8 +254,8 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
             } else {    // let non-speed commands go before wait
                 try {
                     if (_currentCommand.equals("SPEEDSTEP")) {
-                        int step = Integer.parseInt(ts.getValue());
-                        setSpeedStepMode(step);
+                        SpeedStepMode mode = SpeedStepMode.getByName(ts.getValue());
+                        _throttle.setSpeedStepMode(mode);
                     } else if (_currentCommand.equals("FORWARD")) {
                         boolean isForward = Boolean.parseBoolean(ts.getValue());
                         _throttle.setIsForward(isForward);
@@ -313,29 +314,6 @@ public class Engineer extends Thread implements java.beans.PropertyChangeListene
         if (log.isTraceEnabled()) 
             log.debug("advanceToCommandIndex to {} - {}", _idxSkipToSpeedCommand+1, _commands.get(idx).toString());
             // Note: command indexes biased from 0 to 1 to match Warrant display of commands, which are 1-based.
-    }
-
-    private void setSpeedStepMode(int step) {
-        int stepMode = DccThrottle.SpeedStepMode128;
-        switch (step) {
-            case 14:
-                stepMode = DccThrottle.SpeedStepMode14;
-                break;
-            case 27:
-                stepMode = DccThrottle.SpeedStepMode27;
-                break;
-            case 28:
-                stepMode = DccThrottle.SpeedStepMode28;
-                break;
-            case 128:
-                stepMode = DccThrottle.SpeedStepMode128;
-                break;
-            case DccThrottle.SpeedStepMode28Mot:
-                stepMode = DccThrottle.SpeedStepMode28Mot;
-                break;
-            default:
-        }
-        _throttle.setSpeedStepMode(stepMode);
     }
 
     /**

--- a/java/src/jmri/jmrit/logix/LearnThrottleFrame.java
+++ b/java/src/jmri/jmrit/logix/LearnThrottleFrame.java
@@ -275,7 +275,6 @@ public class LearnThrottleFrame extends JmriJFrame implements java.beans.Propert
     /* from ControlPanel */
 
     protected void setSpeedStepMode(SpeedStepMode speedStep) {
-        // TODO(austin): update consumers of this.
         _warrantFrame.setThrottleCommand("SpeedStep", speedStep.name);
     }
     /* from FunctionPanel */

--- a/java/src/jmri/jmrit/logix/LearnThrottleFrame.java
+++ b/java/src/jmri/jmrit/logix/LearnThrottleFrame.java
@@ -25,6 +25,7 @@ import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.JmriException;
 import jmri.PowerManager;
+import jmri.SpeedStepMode;
 import jmri.jmrit.catalog.NamedIcon;
 import jmri.jmrit.powerpanel.PowerPane;
 import jmri.jmrit.throttle.FunctionButton;
@@ -273,8 +274,9 @@ public class LearnThrottleFrame extends JmriJFrame implements java.beans.Propert
     }
     /* from ControlPanel */
 
-    protected void setSpeedStepMode(int speedStep) {
-        _warrantFrame.setThrottleCommand("SpeedStep", Integer.toString(speedStep));
+    protected void setSpeedStepMode(SpeedStepMode speedStep) {
+        // TODO(austin): update consumers of this.
+        _warrantFrame.setThrottleCommand("SpeedStep", speedStep.name);
     }
     /* from FunctionPanel */
 

--- a/java/src/jmri/jmrit/logix/WarrantFrame.java
+++ b/java/src/jmri/jmrit/logix/WarrantFrame.java
@@ -31,10 +31,10 @@ import javax.swing.JTabbedPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.table.AbstractTableModel;
-import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.NamedBean;
 import jmri.NamedBeanHandle;
+import jmri.SpeedStepMode;
 import jmri.jmrit.picker.PickListModel;
 import jmri.jmrit.roster.RosterSpeedProfile;
 import org.slf4j.Logger;
@@ -1628,22 +1628,12 @@ public class WarrantFrame extends WarrantRoute {
                         }
                         ts.setValue(null);
                     } else if ("SPEEDSTEP".equals(cmd)) {
-                        int stepMode = Integer.parseInt((String) value);
                         try {
-                            switch (stepMode) {
-                                case 14:
-                                case 27:
-                                case 28:
-                                case 128:
-                                case DccThrottle.SpeedStepMode28Mot:
-                                    ts.setValue((String) value);
-                                    break;
-                                default:
-                                    msg = Bundle.getMessage("badStepMode");
-                                    ts.setValue(null);
-                            }
-                        } catch (NumberFormatException nfe) {
-                            msg = Bundle.getMessage("invalidNumber");
+                            // Get speed step mode, just to check that it's valid.
+                            SpeedStepMode.getByName((String)value);
+                            ts.setValue((String)value);
+                        } catch (IllegalArgumentException nfe) {
+                            msg = Bundle.getMessage("badStepMode");
                             ts.setValue(null);
                         }
                     } else if ("FORWARD".equalsIgnoreCase(cmd)) {

--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
@@ -25,6 +25,7 @@ import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.Sensor;
 import jmri.SensorManager;
+import jmri.SpeedStepMode;
 import jmri.ThrottleListener;
 import jmri.jmrit.logix.WarrantPreferences;
 import jmri.jmrit.roster.Roster;
@@ -510,17 +511,22 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
     }
 
     private void runProfile() {
-        int speedStepMode = t.getSpeedStepMode();
+        SpeedStepMode speedStepMode = t.getSpeedStepMode();
         profileIncrement = t.getSpeedIncrement();
-//        int speedStep;
-        if (speedStepMode == DccThrottle.SpeedStepMode14) {
-            profileSpeedStepMode = 14;
-        } else if (speedStepMode == DccThrottle.SpeedStepMode27) {
-            profileSpeedStepMode = 27;
-        } else if (speedStepMode == DccThrottle.SpeedStepMode28) {
-            profileSpeedStepMode = 28;
-        } else {// default to 128 speed step mode
-            profileSpeedStepMode = 126;
+        switch(speedStepMode) {
+            case SpeedStepMode14:
+                profileSpeedStepMode = 14;
+                break;
+            case SpeedStepMode27:
+                profileSpeedStepMode = 27;
+                break;
+            case SpeedStepMode28:
+                profileSpeedStepMode = 28;
+                break;
+                // TODO: handle motorola 28 speed step mode
+            default:
+                profileSpeedStepMode = 126;
+                break;
         }
         if (finishSpeedStep <= 0) {
             finishSpeedStep = profileSpeedStepMode;

--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
@@ -514,13 +514,13 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
         SpeedStepMode speedStepMode = t.getSpeedStepMode();
         profileIncrement = t.getSpeedIncrement();
         switch(speedStepMode) {
-            case SpeedStepMode14:
+            case NMRA_DCC_14:
                 profileSpeedStepMode = 14;
                 break;
-            case SpeedStepMode27:
+            case NMRA_DCC_27:
                 profileSpeedStepMode = 27;
                 break;
-            case SpeedStepMode28:
+            case NMRA_DCC_28:
                 profileSpeedStepMode = 28;
                 break;
                 // TODO: handle motorola 28 speed step mode

--- a/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
+++ b/java/src/jmri/jmrit/roster/swing/speedprofile/SpeedProfilePanel.java
@@ -513,21 +513,7 @@ class SpeedProfilePanel extends jmri.util.swing.JmriPanel implements ThrottleLis
     private void runProfile() {
         SpeedStepMode speedStepMode = t.getSpeedStepMode();
         profileIncrement = t.getSpeedIncrement();
-        switch(speedStepMode) {
-            case NMRA_DCC_14:
-                profileSpeedStepMode = 14;
-                break;
-            case NMRA_DCC_27:
-                profileSpeedStepMode = 27;
-                break;
-            case NMRA_DCC_28:
-                profileSpeedStepMode = 28;
-                break;
-                // TODO: handle motorola 28 speed step mode
-            default:
-                profileSpeedStepMode = 126;
-                break;
-        }
+        profileSpeedStepMode = speedStepMode.numSteps;
         if (finishSpeedStep <= 0) {
             finishSpeedStep = profileSpeedStepMode;
         }

--- a/java/src/jmri/jmrit/throttle/ControlPanel.java
+++ b/java/src/jmri/jmrit/throttle/ControlPanel.java
@@ -1196,9 +1196,7 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
             }
             internalAdjust = false;
         } else if (e.getPropertyName().equals("SpeedSteps")) {
-            // TODO(austin): figure out where this comes from and update to enum.
-            //int steps = ((Integer) e.getNewValue()).intValue();
-            SpeedStepMode steps = SpeedStepMode.SpeedStepMode128;
+            SpeedStepMode steps = (SpeedStepMode)e.getNewValue();
             setSpeedStepsMode(steps);
         } else if (e.getPropertyName().equals("IsForward")) {
             boolean Forward = ((Boolean) e.getNewValue()).booleanValue();

--- a/java/src/jmri/jmrit/throttle/ControlPanel.java
+++ b/java/src/jmri/jmrit/throttle/ControlPanel.java
@@ -16,6 +16,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
+import java.util.EnumSet;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
 import javax.swing.ImageIcon;
@@ -36,6 +37,7 @@ import javax.swing.event.MouseInputAdapter;
 import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
 import jmri.util.FileUtil;
@@ -237,12 +239,12 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
      * the speed step setting and the max speed for the particular loco
      *
      * @param speedStepMode Desired speed step mode. One of:
-     *                      DccThrottle.SpeedStepMode128,
-     *                      DccThrottle.SpeedStepMode28,
-     *                      DccThrottle.SpeedStepMode27,
-     *                      DccThrottle.SpeedStepMode14 step mode
+     *                      SpeedStepMode.SpeedStepMode128,
+     *                      SpeedStepMode.SpeedStepMode28,
+     *                      SpeedStepMode.SpeedStepMode27,
+     *                      SpeedStepMode.SpeedStepMode14 step mode
      */
-    private void setSpeedStepsMode(int speedStepMode) {
+    private void setSpeedStepsMode(SpeedStepMode speedStepMode) {
         internalAdjust = true;
         int maxSpeedPCT = 100;
         if (addressPanel.getRosterEntry() != null) {
@@ -252,19 +254,19 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         // Save the old speed as a float
         float oldSpeed = (speedSlider.getValue() / (maxSpeed * 1.0f));
 
-        if (speedStepMode == DccThrottle.SpeedStepMode14) {
+        if (speedStepMode == SpeedStepMode.SpeedStepMode14) {
             speedStep14Button.setSelected(true);
             speedStep27Button.setSelected(false);
             speedStep28Button.setSelected(false);
             speedStep128Button.setSelected(false);
             intSpeedSteps = 14;
-        } else if (speedStepMode == DccThrottle.SpeedStepMode27) {
+        } else if (speedStepMode == SpeedStepMode.SpeedStepMode27) {
             speedStep14Button.setSelected(false);
             speedStep27Button.setSelected(true);
             speedStep28Button.setSelected(false);
             speedStep128Button.setSelected(false);
             intSpeedSteps = 27;
-        } else if (speedStepMode == DccThrottle.SpeedStepMode28) {
+        } else if (speedStepMode == SpeedStepMode.SpeedStepMode28) {
             speedStep14Button.setSelected(false);
             speedStep27Button.setSelected(false);
             speedStep28Button.setSelected(true);
@@ -774,8 +776,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        setSpeedStepsMode(DccThrottle.SpeedStepMode14);
-                        throttle.setSpeedStepMode(DccThrottle.SpeedStepMode14);
+                        setSpeedStepsMode(SpeedStepMode.SpeedStepMode14);
+                        throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode14);
                     }
                 });
 
@@ -783,8 +785,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        setSpeedStepsMode(DccThrottle.SpeedStepMode27);
-                        throttle.setSpeedStepMode(DccThrottle.SpeedStepMode27);
+                        setSpeedStepsMode(SpeedStepMode.SpeedStepMode27);
+                        throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode27);
                     }
                 });
 
@@ -792,8 +794,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        setSpeedStepsMode(DccThrottle.SpeedStepMode28);
-                        throttle.setSpeedStepMode(DccThrottle.SpeedStepMode28);
+                        setSpeedStepsMode(SpeedStepMode.SpeedStepMode28);
+                        throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
                     }
                 });
 
@@ -801,8 +803,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        setSpeedStepsMode(DccThrottle.SpeedStepMode128);
-                        throttle.setSpeedStepMode(DccThrottle.SpeedStepMode128);
+                        setSpeedStepsMode(SpeedStepMode.SpeedStepMode128);
+                        throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode128);
                     }
                 });
 
@@ -1194,7 +1196,9 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
             }
             internalAdjust = false;
         } else if (e.getPropertyName().equals("SpeedSteps")) {
-            int steps = ((Integer) e.getNewValue()).intValue();
+            // TODO(austin): figure out where this comes from and update to enum.
+            //int steps = ((Integer) e.getNewValue()).intValue();
+            SpeedStepMode steps = SpeedStepMode.SpeedStepMode128;
             setSpeedStepsMode(steps);
         } else if (e.getPropertyName().equals("IsForward")) {
             boolean Forward = ((Boolean) e.getNewValue()).booleanValue();
@@ -1232,24 +1236,24 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
      * DCC system
      */
     private void configureAvailableSpeedStepModes() {
-        int modes = jmri.InstanceManager.throttleManagerInstance()
+        EnumSet<SpeedStepMode> modes = jmri.InstanceManager.throttleManagerInstance()
                 .supportedSpeedModes();
-        if ((modes & DccThrottle.SpeedStepMode128) != 0) {
+        if (modes.contains(SpeedStepMode.SpeedStepMode128)) {
             speedStep128Button.setEnabled(true);
         } else {
             speedStep128Button.setEnabled(false);
         }
-        if ((modes & DccThrottle.SpeedStepMode28) != 0) {
+        if (modes.contains(SpeedStepMode.SpeedStepMode28)) {
             speedStep28Button.setEnabled(true);
         } else {
             speedStep28Button.setEnabled(false);
         }
-        if ((modes & DccThrottle.SpeedStepMode27) != 0) {
+        if (modes.contains(SpeedStepMode.SpeedStepMode27)) {
             speedStep27Button.setEnabled(true);
         } else {
             speedStep27Button.setEnabled(false);
         }
-        if ((modes & DccThrottle.SpeedStepMode14) != 0) {
+        if (modes.contains(SpeedStepMode.SpeedStepMode14)) {
             speedStep14Button.setEnabled(true);
         } else {
             speedStep14Button.setEnabled(false);

--- a/java/src/jmri/jmrit/throttle/ControlPanel.java
+++ b/java/src/jmri/jmrit/throttle/ControlPanel.java
@@ -239,10 +239,10 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
      * the speed step setting and the max speed for the particular loco
      *
      * @param speedStepMode Desired speed step mode. One of:
-     *                      SpeedStepMode.SpeedStepMode128,
-     *                      SpeedStepMode.SpeedStepMode28,
-     *                      SpeedStepMode.SpeedStepMode27,
-     *                      SpeedStepMode.SpeedStepMode14 step mode
+     *                      SpeedStepMode.NMRA_DCC_128,
+     *                      SpeedStepMode.NMRA_DCC_28,
+     *                      SpeedStepMode.NMRA_DCC_27,
+     *                      SpeedStepMode.NMRA_DCC_14 step mode
      */
     private void setSpeedStepsMode(SpeedStepMode speedStepMode) {
         internalAdjust = true;
@@ -254,19 +254,19 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
         // Save the old speed as a float
         float oldSpeed = (speedSlider.getValue() / (maxSpeed * 1.0f));
 
-        if (speedStepMode == SpeedStepMode.SpeedStepMode14) {
+        if (speedStepMode == SpeedStepMode.NMRA_DCC_14) {
             speedStep14Button.setSelected(true);
             speedStep27Button.setSelected(false);
             speedStep28Button.setSelected(false);
             speedStep128Button.setSelected(false);
             intSpeedSteps = 14;
-        } else if (speedStepMode == SpeedStepMode.SpeedStepMode27) {
+        } else if (speedStepMode == SpeedStepMode.NMRA_DCC_27) {
             speedStep14Button.setSelected(false);
             speedStep27Button.setSelected(true);
             speedStep28Button.setSelected(false);
             speedStep128Button.setSelected(false);
             intSpeedSteps = 27;
-        } else if (speedStepMode == SpeedStepMode.SpeedStepMode28) {
+        } else if (speedStepMode == SpeedStepMode.NMRA_DCC_28) {
             speedStep14Button.setSelected(false);
             speedStep27Button.setSelected(false);
             speedStep28Button.setSelected(true);
@@ -776,8 +776,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        setSpeedStepsMode(SpeedStepMode.SpeedStepMode14);
-                        throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode14);
+                        setSpeedStepsMode(SpeedStepMode.NMRA_DCC_14);
+                        throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_14);
                     }
                 });
 
@@ -785,8 +785,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        setSpeedStepsMode(SpeedStepMode.SpeedStepMode27);
-                        throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode27);
+                        setSpeedStepsMode(SpeedStepMode.NMRA_DCC_27);
+                        throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_27);
                     }
                 });
 
@@ -794,8 +794,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        setSpeedStepsMode(SpeedStepMode.SpeedStepMode28);
-                        throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
+                        setSpeedStepsMode(SpeedStepMode.NMRA_DCC_28);
+                        throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_28);
                     }
                 });
 
@@ -803,8 +803,8 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
                 new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        setSpeedStepsMode(SpeedStepMode.SpeedStepMode128);
-                        throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode128);
+                        setSpeedStepsMode(SpeedStepMode.NMRA_DCC_128);
+                        throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_128);
                     }
                 });
 
@@ -1236,22 +1236,22 @@ public class ControlPanel extends JInternalFrame implements java.beans.PropertyC
     private void configureAvailableSpeedStepModes() {
         EnumSet<SpeedStepMode> modes = jmri.InstanceManager.throttleManagerInstance()
                 .supportedSpeedModes();
-        if (modes.contains(SpeedStepMode.SpeedStepMode128)) {
+        if (modes.contains(SpeedStepMode.NMRA_DCC_128)) {
             speedStep128Button.setEnabled(true);
         } else {
             speedStep128Button.setEnabled(false);
         }
-        if (modes.contains(SpeedStepMode.SpeedStepMode28)) {
+        if (modes.contains(SpeedStepMode.NMRA_DCC_28)) {
             speedStep28Button.setEnabled(true);
         } else {
             speedStep28Button.setEnabled(false);
         }
-        if (modes.contains(SpeedStepMode.SpeedStepMode27)) {
+        if (modes.contains(SpeedStepMode.NMRA_DCC_27)) {
             speedStep27Button.setEnabled(true);
         } else {
             speedStep27Button.setEnabled(false);
         }
-        if (modes.contains(SpeedStepMode.SpeedStepMode14)) {
+        if (modes.contains(SpeedStepMode.NMRA_DCC_14)) {
             speedStep14Button.setEnabled(true);
         } else {
             speedStep14Button.setEnabled(false);

--- a/java/src/jmri/jmrit/withrottle/MultiThrottleController.java
+++ b/java/src/jmri/jmrit/withrottle/MultiThrottleController.java
@@ -314,15 +314,15 @@ public class MultiThrottleController extends ThrottleController {
             // NOTE: old speed step modes use the original numeric values
             // from when speed step modes were in DccThrottle. New speed step
             // modes use the mode name.
-            case SpeedStepMode128:
+            case NMRA_DCC_128:
                 return "1";
-            case SpeedStepMode28:
+            case NMRA_DCC_28:
                  return "2";
-            case SpeedStepMode27:
+            case NMRA_DCC_27:
                 return "4";
-            case SpeedStepMode14:
+            case NMRA_DCC_14:
                 return "8";
-            case SpeedStepMode28Mot:
+            case MOTOROLA_28:
                 return "16";
             default:
                 return mode.name;

--- a/java/src/jmri/jmrit/withrottle/MultiThrottleController.java
+++ b/java/src/jmri/jmrit/withrottle/MultiThrottleController.java
@@ -4,6 +4,7 @@ import java.beans.PropertyChangeEvent;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.jmrit.roster.RosterEntry;
@@ -75,7 +76,7 @@ public class MultiThrottleController extends ThrottleController {
         if (eventName.matches("SpeedSteps")) {
             StringBuilder message = new StringBuilder(buildPacketWithChar('A'));
             message.append("s");
-            message.append(event.getNewValue().toString());
+            message.append(encodeSpeedStepMode((SpeedStepMode)event.getNewValue()));
             for (ControllerInterface listener : controllerListeners) {
                 listener.sendPacketToDevice(message.toString());
             }
@@ -193,7 +194,7 @@ public class MultiThrottleController extends ThrottleController {
     protected void sendSpeedStepMode(DccThrottle t) {
         StringBuilder message = new StringBuilder(buildPacketWithChar('A'));
         message.append("s");
-        message.append(throttle.getSpeedStepMode());
+        message.append(encodeSpeedStepMode(throttle.getSpeedStepMode()));
         for (ControllerInterface listener : controllerListeners) {
             listener.sendPacketToDevice(message.toString());
         }
@@ -305,6 +306,27 @@ public class MultiThrottleController extends ThrottleController {
         }
         
         
+    }
+
+    // Encode a SpeedStepMode to a string.
+    private static String encodeSpeedStepMode(SpeedStepMode mode) {
+        switch(mode) {
+            // NOTE: old speed step modes use the original numeric values
+            // from when speed step modes were in DccThrottle. New speed step
+            // modes use the mode name.
+            case SpeedStepMode128:
+                return "1";
+            case SpeedStepMode28:
+                 return "2";
+            case SpeedStepMode27:
+                return "4";
+            case SpeedStepMode14:
+                return "8";
+            case SpeedStepMode28Mot:
+                return "16";
+            default:
+                return mode.name;
+        }
     }
 
     private final static Logger log = LoggerFactory.getLogger(MultiThrottleController.class);

--- a/java/src/jmri/jmrit/withrottle/ThrottleController.java
+++ b/java/src/jmri/jmrit/withrottle/ThrottleController.java
@@ -452,7 +452,7 @@ public class ThrottleController implements ThrottleListener, PropertyChangeListe
                         break;
 
                     case 's':       //v>=2.0
-                        handleSpeedStepMode(SpeedStepMode.getByName(inPackage.substring(1)));
+                        handleSpeedStepMode(decodeSpeedStepMode(inPackage.substring(1)));
                         break;
 
                     case 'm':       //v>=2.0
@@ -810,6 +810,25 @@ public class ThrottleController implements ThrottleListener, PropertyChangeListe
                 break;
         }
 
+    }
+
+
+    private static SpeedStepMode decodeSpeedStepMode(String mode) {
+        // NOTE: old speed step modes use the original numeric values
+        // from when speed step modes were in DccThrottle. If the input does not match
+        // any of the old modes, decode based on the new speed step names.
+        if(mode.equals("1"))  {
+            return SpeedStepMode.SpeedStepMode128;
+        } else if(mode.equals("2")) {
+            return SpeedStepMode.SpeedStepMode28;
+        } else if(mode.equals("4")) {
+            return SpeedStepMode.SpeedStepMode27;
+        } else if(mode.equals("8")) {
+            return SpeedStepMode.SpeedStepMode14;
+        } else if(mode.equals("16")) {
+            return SpeedStepMode.SpeedStepMode28Mot;
+        }
+        return SpeedStepMode.getByName(mode);
     }
 
     private final static Logger log = LoggerFactory.getLogger(ThrottleController.class);

--- a/java/src/jmri/jmrit/withrottle/ThrottleController.java
+++ b/java/src/jmri/jmrit/withrottle/ThrottleController.java
@@ -818,15 +818,15 @@ public class ThrottleController implements ThrottleListener, PropertyChangeListe
         // from when speed step modes were in DccThrottle. If the input does not match
         // any of the old modes, decode based on the new speed step names.
         if(mode.equals("1"))  {
-            return SpeedStepMode.SpeedStepMode128;
+            return SpeedStepMode.NMRA_DCC_128;
         } else if(mode.equals("2")) {
-            return SpeedStepMode.SpeedStepMode28;
+            return SpeedStepMode.NMRA_DCC_28;
         } else if(mode.equals("4")) {
-            return SpeedStepMode.SpeedStepMode27;
+            return SpeedStepMode.NMRA_DCC_27;
         } else if(mode.equals("8")) {
-            return SpeedStepMode.SpeedStepMode14;
+            return SpeedStepMode.NMRA_DCC_14;
         } else if(mode.equals("16")) {
-            return SpeedStepMode.SpeedStepMode28Mot;
+            return SpeedStepMode.MOTOROLA_28;
         }
         return SpeedStepMode.getByName(mode);
     }

--- a/java/src/jmri/jmrit/withrottle/ThrottleController.java
+++ b/java/src/jmri/jmrit/withrottle/ThrottleController.java
@@ -41,6 +41,7 @@ import jmri.DccLocoAddress;
 import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.ThrottleListener;
 import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
@@ -451,7 +452,7 @@ public class ThrottleController implements ThrottleListener, PropertyChangeListe
                         break;
 
                     case 's':       //v>=2.0
-                        handleSpeedStepMode(Integer.parseInt(inPackage.substring(1)));
+                        handleSpeedStepMode(SpeedStepMode.getByName(inPackage.substring(1)));
                         break;
 
                     case 'm':       //v>=2.0
@@ -755,7 +756,7 @@ public class ThrottleController implements ThrottleListener, PropertyChangeListe
 
     }
 
-    protected void handleSpeedStepMode(int newMode) {
+    protected void handleSpeedStepMode(SpeedStepMode newMode) {
         throttle.setSpeedStepMode(newMode);
     }
 

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -30,7 +30,7 @@ abstract public class AbstractThrottle implements DccThrottle {
     /**
      * Question: should we set a default speed step mode so it's never zero?
      */
-    protected SpeedStepMode speedStepMode;
+    protected SpeedStepMode speedStepMode = SpeedStepMode.UNKNOWN;
     protected boolean isForward;
     protected boolean f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12;
     protected boolean f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23,

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -26,15 +26,7 @@ import jmri.ThrottleListener;
  */
 abstract public class AbstractThrottle implements DccThrottle {
 
-    public final static float SPEED_STEP_14_INCREMENT = 1.0f / 14.0f;
-    public final static float SPEED_STEP_27_INCREMENT = 1.0f / 27.0f;
-    public final static float SPEED_STEP_28_INCREMENT = 1.0f / 28.0f;
-    public final static float SPEED_STEP_32_INCREMENT = 1.0f / 32.0f;
-    public final static float SPEED_STEP_128_INCREMENT = 1.0f / 126.0f; // remember there are only 126 
-                                                                        // non-stop values in 128 speed 
-
     protected float speedSetting;
-    protected float speedIncrement;
     /**
      * Question: should we set a default speed step mode so it's never zero?
      */
@@ -834,7 +826,7 @@ abstract public class AbstractThrottle implements DccThrottle {
      */
     @Override
     public float getSpeedIncrement() {
-        return speedIncrement;
+        return speedStepMode.increment;
     }
 
     /**
@@ -1746,10 +1738,9 @@ abstract public class AbstractThrottle implements DccThrottle {
     }
 
     /**
-     * Set the speed step value and the related speedIncrement value. Default
-     * should be 128 speed step mode in most cases
+     * Set the speed step value. Default should be 128 speed step mode in most cases.
      *
-     * specific implementations should override this function
+     * Specific implementations should override this function.
      *
      * @param Mode the current speed step mode
      */
@@ -1759,24 +1750,6 @@ abstract public class AbstractThrottle implements DccThrottle {
         if (speedStepMode != Mode) {
             notifyPropertyChangeListener("SpeedSteps", this.speedStepMode,
                     this.speedStepMode = Mode);
-        }
-        switch(Mode) {
-            case NMRA_DCC_14:
-                speedIncrement = SPEED_STEP_14_INCREMENT;
-                break;
-            case NMRA_DCC_27:
-                speedIncrement = SPEED_STEP_27_INCREMENT;
-                break;
-            case NMRA_DCC_28:
-            case MOTOROLA_28:
-                speedIncrement = SPEED_STEP_28_INCREMENT;
-                break;
-            case TMCC_32:
-                speedIncrement = SPEED_STEP_32_INCREMENT;
-                break;
-            case NMRA_DCC_128:
-                speedIncrement = SPEED_STEP_128_INCREMENT;
-                break;
         }
     }
 

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -8,6 +8,7 @@ import java.util.Vector;
 import jmri.BasicRosterEntry;
 import jmri.CommandStation;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.DccLocoAddress;
 import jmri.DccThrottle;
 import jmri.InstanceManager;
@@ -36,7 +37,7 @@ abstract public class AbstractThrottle implements DccThrottle {
     /**
      * Question: should we set a default speed step mode so it's never zero?
      */
-    protected int speedStepMode;
+    protected SpeedStepMode speedStepMode;
     protected boolean isForward;
     protected boolean f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12;
     protected boolean f13, f14, f15, f16, f17, f18, f19, f20, f21, f22, f23,
@@ -1752,26 +1753,31 @@ abstract public class AbstractThrottle implements DccThrottle {
      * @param Mode the current speed step mode
      */
     @Override
-    public void setSpeedStepMode(int Mode) {
+    public void setSpeedStepMode(SpeedStepMode Mode) {
         log.debug("Speed Step Mode Change from:{} to Mode:{}",this.speedStepMode,Mode);
         if (speedStepMode != Mode) {
             notifyPropertyChangeListener("SpeedSteps", this.speedStepMode,
                     this.speedStepMode = Mode);
         }
-        if (Mode == DccThrottle.SpeedStepMode14) {
-            speedIncrement = SPEED_STEP_14_INCREMENT;
-        } else if (Mode == DccThrottle.SpeedStepMode27) {
-            speedIncrement = SPEED_STEP_27_INCREMENT;
-        } else if (Mode == DccThrottle.SpeedStepMode28) {
-            speedIncrement = SPEED_STEP_28_INCREMENT;
-        } else // default to 128 speed step mode
-        {
-            speedIncrement = SPEED_STEP_128_INCREMENT;
+        switch(Mode) {
+            case SpeedStepMode14:
+                speedIncrement = SPEED_STEP_14_INCREMENT;
+                break;
+            case SpeedStepMode27:
+                speedIncrement = SPEED_STEP_27_INCREMENT;
+                break;
+            case SpeedStepMode28:
+            case SpeedStepMode28Mot:
+                speedIncrement = SPEED_STEP_28_INCREMENT;
+                break;
+            case SpeedStepMode128:
+                speedIncrement = SPEED_STEP_128_INCREMENT;
+                break;
         }
     }
 
     @Override
-    public int getSpeedStepMode() {
+    public SpeedStepMode getSpeedStepMode() {
         return speedStepMode;
     }
 

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -29,6 +29,7 @@ abstract public class AbstractThrottle implements DccThrottle {
     public final static float SPEED_STEP_14_INCREMENT = 1.0f / 14.0f;
     public final static float SPEED_STEP_27_INCREMENT = 1.0f / 27.0f;
     public final static float SPEED_STEP_28_INCREMENT = 1.0f / 28.0f;
+    public final static float SPEED_STEP_32_INCREMENT = 1.0f / 32.0f;
     public final static float SPEED_STEP_128_INCREMENT = 1.0f / 126.0f; // remember there are only 126 
                                                                         // non-stop values in 128 speed 
 
@@ -1769,6 +1770,9 @@ abstract public class AbstractThrottle implements DccThrottle {
             case SpeedStepMode28:
             case SpeedStepMode28Mot:
                 speedIncrement = SPEED_STEP_28_INCREMENT;
+                break;
+            case SpeedStepModeTMCC32:
+                speedIncrement = SPEED_STEP_32_INCREMENT;
                 break;
             case SpeedStepMode128:
                 speedIncrement = SPEED_STEP_128_INCREMENT;

--- a/java/src/jmri/jmrix/AbstractThrottle.java
+++ b/java/src/jmri/jmrix/AbstractThrottle.java
@@ -1761,20 +1761,20 @@ abstract public class AbstractThrottle implements DccThrottle {
                     this.speedStepMode = Mode);
         }
         switch(Mode) {
-            case SpeedStepMode14:
+            case NMRA_DCC_14:
                 speedIncrement = SPEED_STEP_14_INCREMENT;
                 break;
-            case SpeedStepMode27:
+            case NMRA_DCC_27:
                 speedIncrement = SPEED_STEP_27_INCREMENT;
                 break;
-            case SpeedStepMode28:
-            case SpeedStepMode28Mot:
+            case NMRA_DCC_28:
+            case MOTOROLA_28:
                 speedIncrement = SPEED_STEP_28_INCREMENT;
                 break;
-            case SpeedStepModeTMCC32:
+            case TMCC_32:
                 speedIncrement = SPEED_STEP_32_INCREMENT;
                 break;
-            case SpeedStepMode128:
+            case NMRA_DCC_128:
                 speedIncrement = SPEED_STEP_128_INCREMENT;
                 break;
         }

--- a/java/src/jmri/jmrix/AbstractThrottleManager.java
+++ b/java/src/jmri/jmrix/AbstractThrottleManager.java
@@ -3,6 +3,7 @@ package jmri.jmrix;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Vector;
@@ -11,6 +12,7 @@ import jmri.BasicRosterEntry;
 import jmri.DccLocoAddress;
 import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.Throttle;
 import jmri.ThrottleListener;
 import jmri.ThrottleManager;
@@ -702,8 +704,8 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
      * possible modes specifed by the DccThrottle interface
      */
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128);
     }
     
     /**

--- a/java/src/jmri/jmrix/AbstractThrottleManager.java
+++ b/java/src/jmri/jmrix/AbstractThrottleManager.java
@@ -705,7 +705,7 @@ abstract public class AbstractThrottleManager implements ThrottleManager {
      */
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128);
     }
     
     /**

--- a/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
@@ -42,6 +42,7 @@ import jmri.PowerManager;
 import jmri.ProgListener;
 import jmri.Programmer;
 import jmri.ProgrammerException;
+import jmri.SpeedStepMode;
 import jmri.ThrottleListener;
 import jmri.jmrit.DccLocoAddressSelector;
 import jmri.jmrit.roster.RosterEntry;
@@ -1727,8 +1728,8 @@ public class SpeedoConsoleFrame extends JmriJFrame implements SpeedoListener,
 
         throttle = t;
         log.info("Throttle acquired");
-        throttle.setSpeedStepMode(DccThrottle.SpeedStepMode28);
-        if (throttle.getSpeedStepMode() != DccThrottle.SpeedStepMode28) {
+        throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
+        if (throttle.getSpeedStepMode() != SpeedStepMode.SpeedStepMode28) {
             log.error("Failed to set 28 step mode");
             statusLabel.setText(Bundle.getMessage("ThrottleError28"));
             InstanceManager.throttleManagerInstance().releaseThrottle(throttle, this);

--- a/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
+++ b/java/src/jmri/jmrix/bachrus/SpeedoConsoleFrame.java
@@ -1728,8 +1728,8 @@ public class SpeedoConsoleFrame extends JmriJFrame implements SpeedoListener,
 
         throttle = t;
         log.info("Throttle acquired");
-        throttle.setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
-        if (throttle.getSpeedStepMode() != SpeedStepMode.SpeedStepMode28) {
+        throttle.setSpeedStepMode(SpeedStepMode.NMRA_DCC_28);
+        if (throttle.getSpeedStepMode() != SpeedStepMode.NMRA_DCC_28) {
             log.error("Failed to set 28 step mode");
             statusLabel.setText(Bundle.getMessage("ThrottleError28"));
             InstanceManager.throttleManagerInstance().releaseThrottle(throttle, this);

--- a/java/src/jmri/jmrix/can/cbus/CbusThrottle.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusThrottle.java
@@ -95,7 +95,6 @@ public class CbusThrottle extends AbstractThrottle {
 //            case CbusConstants.DEC_MODE_14: this.speedIncrement = 8; break;
 //        }
         // Only 128 speed step supported at the moment
-        this.speedIncrement = SPEED_STEP_128_INCREMENT;
         this.speedStepMode = SpeedStepMode.NMRA_DCC_128;
 
         // start periodically sending keep alives, to keep this

--- a/java/src/jmri/jmrix/can/cbus/CbusThrottle.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusThrottle.java
@@ -96,6 +96,7 @@ public class CbusThrottle extends AbstractThrottle {
 //        }
         // Only 128 speed step supported at the moment
         this.speedIncrement = SPEED_STEP_128_INCREMENT;
+        this.speedStepMode = SpeedStepMode.SpeedStepMode128;
 
         // start periodically sending keep alives, to keep this
         // attached

--- a/java/src/jmri/jmrix/can/cbus/CbusThrottle.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusThrottle.java
@@ -1,8 +1,8 @@
 package jmri.jmrix.can.cbus;
 
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.Throttle;
@@ -127,15 +127,15 @@ public class CbusThrottle extends AbstractThrottle {
      *              speed step mode in most cases
      */
     @Override
-    public void setSpeedStepMode(int Mode) {
+    public void setSpeedStepMode(SpeedStepMode Mode) {
         int mode;
         speedStepMode = Mode;
         super.setSpeedStepMode(speedStepMode);
         switch (speedStepMode) {
-            case DccThrottle.SpeedStepMode28:
+            case SpeedStepMode28:
                 mode = CbusConstants.CBUS_SS_28;
                 break;
-            case DccThrottle.SpeedStepMode14:
+            case SpeedStepMode14:
                 mode = CbusConstants.CBUS_SS_14;
                 break;
             default:

--- a/java/src/jmri/jmrix/can/cbus/CbusThrottle.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusThrottle.java
@@ -96,7 +96,7 @@ public class CbusThrottle extends AbstractThrottle {
 //        }
         // Only 128 speed step supported at the moment
         this.speedIncrement = SPEED_STEP_128_INCREMENT;
-        this.speedStepMode = SpeedStepMode.SpeedStepMode128;
+        this.speedStepMode = SpeedStepMode.NMRA_DCC_128;
 
         // start periodically sending keep alives, to keep this
         // attached
@@ -133,10 +133,10 @@ public class CbusThrottle extends AbstractThrottle {
         speedStepMode = Mode;
         super.setSpeedStepMode(speedStepMode);
         switch (speedStepMode) {
-            case SpeedStepMode28:
+            case NMRA_DCC_28:
                 mode = CbusConstants.CBUS_SS_28;
                 break;
-            case SpeedStepMode14:
+            case NMRA_DCC_14:
                 mode = CbusConstants.CBUS_SS_14;
                 break;
             default:

--- a/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java
@@ -728,9 +728,9 @@ public class CbusThrottleManager extends AbstractThrottleManager implements  Can
      */
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128
-                , SpeedStepMode.SpeedStepMode28
-                , SpeedStepMode.SpeedStepMode14);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128
+                , SpeedStepMode.NMRA_DCC_28
+                , SpeedStepMode.NMRA_DCC_14);
     }
 
     /**

--- a/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java
+++ b/java/src/jmri/jmrix/can/cbus/CbusThrottleManager.java
@@ -1,11 +1,13 @@
 package jmri.jmrix.can.cbus;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import javax.swing.JOptionPane;
 import jmri.DccLocoAddress;
 import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.ThrottleListener;
 import jmri.ThrottleListener.DecisionType;
 import jmri.ThrottleManager;
@@ -725,10 +727,10 @@ public class CbusThrottleManager extends AbstractThrottleManager implements  Can
      * possible modes specifed by the DccThrottle interface
      */
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128
-                | DccThrottle.SpeedStepMode28
-                | DccThrottle.SpeedStepMode14);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128
+                , SpeedStepMode.SpeedStepMode28
+                , SpeedStepMode.SpeedStepMode14);
     }
 
     /**

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
@@ -2,8 +2,8 @@ package jmri.jmrix.dccpp;
 
 import java.util.concurrent.LinkedBlockingQueue;
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +56,7 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
             log.error("LocoAddress {} is not a DccLocoAddress",address);
         }
         this.speedIncrement = SPEED_STEP_128_INCREMENT;
-        this.speedStepMode = DccThrottle.SpeedStepMode128;
+        this.speedStepMode = SpeedStepMode.SpeedStepMode128;
 
         requestList = new LinkedBlockingQueue<RequestMessage>();
         log.debug("DCCppThrottle constructor called for address {}", address);
@@ -207,7 +207,7 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
      * setting, even though we store it.
      */
     @Override
-    public void setSpeedStepMode(int Mode) {
+    public void setSpeedStepMode(SpeedStepMode Mode) {
         super.setSpeedStepMode(Mode);
     }
 

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
@@ -56,7 +56,7 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
             log.error("LocoAddress {} is not a DccLocoAddress",address);
         }
         this.speedIncrement = SPEED_STEP_128_INCREMENT;
-        this.speedStepMode = SpeedStepMode.SpeedStepMode128;
+        this.speedStepMode = SpeedStepMode.NMRA_DCC_128;
 
         requestList = new LinkedBlockingQueue<RequestMessage>();
         log.debug("DCCppThrottle constructor called for address {}", address);

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottle.java
@@ -55,7 +55,6 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
         else {
             log.error("LocoAddress {} is not a DccLocoAddress",address);
         }
-        this.speedIncrement = SPEED_STEP_128_INCREMENT;
         this.speedStepMode = SpeedStepMode.NMRA_DCC_128;
 
         requestList = new LinkedBlockingQueue<RequestMessage>();
@@ -240,14 +239,6 @@ public class DCCppThrottle extends AbstractThrottle implements DCCppListener {
 
     protected int getDccAddressLow() {
         return DCCppCommandStation.getDCCAddressLow(this.address);
-    }
-
-
-    // to handle quantized speed. Note this can change! Valued returned is
-    // always positive.
-    @Override
-    public float getSpeedIncrement() {
-        return speedIncrement;
     }
 
     // Handle incoming messages for This throttle.

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
@@ -122,7 +122,7 @@ public class DCCppThrottleManager extends AbstractThrottleManager implements DCC
      */
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128); }
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128); }
 
     // Handle incoming messages for throttles.
     @Override

--- a/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
+++ b/java/src/jmri/jmrix/dccpp/DCCppThrottleManager.java
@@ -1,7 +1,9 @@
 package jmri.jmrix.dccpp;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.ThrottleManager;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
@@ -119,8 +121,8 @@ public class DCCppThrottleManager extends AbstractThrottleManager implements DCC
      * 14,27,28 and 128 speed step modes
      */
     @Override
-    public int supportedSpeedModes() {
-        return (jmri.DccThrottle.SpeedStepMode128); }
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128); }
 
     // Handle incoming messages for throttles.
     @Override

--- a/java/src/jmri/jmrix/debugthrottle/DebugThrottle.java
+++ b/java/src/jmri/jmrix/debugthrottle/DebugThrottle.java
@@ -42,7 +42,7 @@ public class DebugThrottle extends AbstractThrottle {
         this.isForward = true;
 
         this.address = address;
-        setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
+        setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
     }
 
     DccLocoAddress address;

--- a/java/src/jmri/jmrix/debugthrottle/DebugThrottle.java
+++ b/java/src/jmri/jmrix/debugthrottle/DebugThrottle.java
@@ -42,7 +42,7 @@ public class DebugThrottle extends AbstractThrottle {
         this.isForward = true;
 
         this.address = address;
-        setSpeedStepMode(jmri.DccThrottle.SpeedStepMode128);
+        setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
     }
 
     DccLocoAddress address;

--- a/java/src/jmri/jmrix/debugthrottle/DebugThrottleManager.java
+++ b/java/src/jmri/jmrix/debugthrottle/DebugThrottleManager.java
@@ -88,10 +88,10 @@ public class DebugThrottleManager extends AbstractThrottleManager {
      */
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128
-                , SpeedStepMode.SpeedStepMode28
-                , SpeedStepMode.SpeedStepMode27
-                , SpeedStepMode.SpeedStepMode14);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128
+                , SpeedStepMode.NMRA_DCC_28
+                , SpeedStepMode.NMRA_DCC_27
+                , SpeedStepMode.NMRA_DCC_14);
     }
 
     private final static Logger log = LoggerFactory.getLogger(DebugThrottleManager.class);

--- a/java/src/jmri/jmrix/debugthrottle/DebugThrottleManager.java
+++ b/java/src/jmri/jmrix/debugthrottle/DebugThrottleManager.java
@@ -1,8 +1,10 @@
 package jmri.jmrix.debugthrottle;
 
+import java.util.EnumSet;
 import jmri.DccLocoAddress;
 import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,11 +87,11 @@ public class DebugThrottleManager extends AbstractThrottleManager {
      * possible modes specified by the DccThrottle interface
      */
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128
-                | DccThrottle.SpeedStepMode28
-                | DccThrottle.SpeedStepMode27
-                | DccThrottle.SpeedStepMode14);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128
+                , SpeedStepMode.SpeedStepMode28
+                , SpeedStepMode.SpeedStepMode27
+                , SpeedStepMode.SpeedStepMode14);
     }
 
     private final static Logger log = LoggerFactory.getLogger(DebugThrottleManager.class);

--- a/java/src/jmri/jmrix/direct/ThrottleManager.java
+++ b/java/src/jmri/jmrix/direct/ThrottleManager.java
@@ -1,8 +1,10 @@
 package jmri.jmrix.direct;
 
+import java.util.EnumSet;
 import jmri.CommandStation;
 import jmri.DccLocoAddress;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import jmri.jmrix.direct.DirectSystemConnectionMemo;
 import org.slf4j.Logger;

--- a/java/src/jmri/jmrix/easydcc/EasyDccThrottle.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccThrottle.java
@@ -3,6 +3,7 @@ package jmri.jmrix.easydcc;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jmri.DccLocoAddress;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
 
 /**
@@ -25,7 +26,7 @@ public class EasyDccThrottle extends AbstractThrottle {
      */
     public EasyDccThrottle(EasyDccSystemConnectionMemo memo, DccLocoAddress address) {
         super(memo);
-        super.speedStepMode = SpeedStepMode128;
+        super.speedStepMode = SpeedStepMode.SpeedStepMode128;
         tc = memo.getTrafficController();
 
         // cache settings. It would be better to read the
@@ -143,7 +144,7 @@ public class EasyDccThrottle extends AbstractThrottle {
 
         byte[] result;
 
-        if (super.speedStepMode == SpeedStepMode128) {
+        if (super.speedStepMode == SpeedStepMode.SpeedStepMode128) {
             int value = (int) ((127 - 1) * speed);     // -1 for rescale to avoid estop
             if (value > 0) {
                 value = value + 1;  // skip estop

--- a/java/src/jmri/jmrix/easydcc/EasyDccThrottle.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccThrottle.java
@@ -26,7 +26,7 @@ public class EasyDccThrottle extends AbstractThrottle {
      */
     public EasyDccThrottle(EasyDccSystemConnectionMemo memo, DccLocoAddress address) {
         super(memo);
-        super.speedStepMode = SpeedStepMode.SpeedStepMode128;
+        super.speedStepMode = SpeedStepMode.NMRA_DCC_128;
         tc = memo.getTrafficController();
 
         // cache settings. It would be better to read the
@@ -144,7 +144,7 @@ public class EasyDccThrottle extends AbstractThrottle {
 
         byte[] result;
 
-        if (super.speedStepMode == SpeedStepMode.SpeedStepMode128) {
+        if (super.speedStepMode == SpeedStepMode.NMRA_DCC_128) {
             int value = (int) ((127 - 1) * speed);     // -1 for rescale to avoid estop
             if (value > 0) {
                 value = value + 1;  // skip estop

--- a/java/src/jmri/jmrix/easydcc/EasyDccThrottleManager.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccThrottleManager.java
@@ -86,7 +86,7 @@ public class EasyDccThrottleManager extends AbstractThrottleManager {
 
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128, SpeedStepMode.NMRA_DCC_28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/easydcc/EasyDccThrottleManager.java
+++ b/java/src/jmri/jmrix/easydcc/EasyDccThrottleManager.java
@@ -1,8 +1,9 @@
 package jmri.jmrix.easydcc;
 
+import java.util.EnumSet;
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,8 +85,8 @@ public class EasyDccThrottleManager extends AbstractThrottleManager {
     }
 
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128 | DccThrottle.SpeedStepMode28);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
@@ -142,7 +142,7 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
         }
         if (getSpeedStepMode() == SpeedStepMode.NMRA_DCC_28) {
             int step = (int) Math.ceil(lSpeed / 4.65);
-            return step * SPEED_STEP_28_INCREMENT;
+            return step * getSpeedIncrement();
         }
         return ((lSpeed) / 126.f);
     }

--- a/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
@@ -36,7 +36,7 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
 
     public EcosDccThrottle(DccLocoAddress address, EcosSystemConnectionMemo memo, boolean control) {
         super(memo);
-        super.speedStepMode = SpeedStepMode.SpeedStepMode128;
+        super.speedStepMode = SpeedStepMode.NMRA_DCC_128;
         p = memo.getPreferenceManager();
         tc = memo.getTrafficController();
         objEcosLocoManager = memo.getLocoAddressManager();
@@ -140,7 +140,7 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
         if (lSpeed == 0) {
             return 0.0f;
         }
-        if (getSpeedStepMode() == SpeedStepMode.SpeedStepMode28) {
+        if (getSpeedStepMode() == SpeedStepMode.NMRA_DCC_28) {
             int step = (int) Math.ceil(lSpeed / 4.65);
             return step * SPEED_STEP_28_INCREMENT;
         }
@@ -701,11 +701,11 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
                     } else if (line.contains("protocol")) {
                         String pro = EcosReply.getContentDetails(line, "protocol");
                         if (pro.equals("DCC128")) {
-                            setSpeedStepMode(SpeedStepMode.SpeedStepMode128);
+                            setSpeedStepMode(SpeedStepMode.NMRA_DCC_128);
                         } else if (pro.equals("DCC28")) {
-                            setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
+                            setSpeedStepMode(SpeedStepMode.NMRA_DCC_28);
                         } else if (pro.equals("DCC14")) {
-                            setSpeedStepMode(SpeedStepMode.SpeedStepMode14);
+                            setSpeedStepMode(SpeedStepMode.NMRA_DCC_14);
                         }
                     } else if (line.contains("func[")) {
                         String funcStr = EcosReply.getContentDetails(line, "func");

--- a/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottle.java
@@ -6,6 +6,7 @@ import javax.swing.JOptionPane;
 import jmri.DccLocoAddress;
 import jmri.LocoAddress;
 import jmri.Throttle;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +36,7 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
 
     public EcosDccThrottle(DccLocoAddress address, EcosSystemConnectionMemo memo, boolean control) {
         super(memo);
-        super.speedStepMode = SpeedStepMode128;
+        super.speedStepMode = SpeedStepMode.SpeedStepMode128;
         p = memo.getPreferenceManager();
         tc = memo.getTrafficController();
         objEcosLocoManager = memo.getLocoAddressManager();
@@ -139,7 +140,7 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
         if (lSpeed == 0) {
             return 0.0f;
         }
-        if (getSpeedStepMode() == jmri.DccThrottle.SpeedStepMode28) {
+        if (getSpeedStepMode() == SpeedStepMode.SpeedStepMode28) {
             int step = (int) Math.ceil(lSpeed / 4.65);
             return step * SPEED_STEP_28_INCREMENT;
         }
@@ -700,11 +701,11 @@ public class EcosDccThrottle extends AbstractThrottle implements EcosListener {
                     } else if (line.contains("protocol")) {
                         String pro = EcosReply.getContentDetails(line, "protocol");
                         if (pro.equals("DCC128")) {
-                            setSpeedStepMode(SpeedStepMode128);
+                            setSpeedStepMode(SpeedStepMode.SpeedStepMode128);
                         } else if (pro.equals("DCC28")) {
-                            setSpeedStepMode(SpeedStepMode28);
+                            setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
                         } else if (pro.equals("DCC14")) {
-                            setSpeedStepMode(SpeedStepMode14);
+                            setSpeedStepMode(SpeedStepMode.SpeedStepMode14);
                         }
                     } else if (line.contains("func[")) {
                         String funcStr = EcosReply.getContentDetails(line, "func");

--- a/java/src/jmri/jmrix/ecos/EcosDccThrottleManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottleManager.java
@@ -1,8 +1,9 @@
 package jmri.jmrix.ecos;
 
+import java.util.EnumSet;
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,8 +108,8 @@ public class EcosDccThrottleManager extends AbstractThrottleManager implements E
     }
 
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128 | DccThrottle.SpeedStepMode28 | DccThrottle.SpeedStepMode14);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28, SpeedStepMode.SpeedStepMode14);
     }
 
     public void throttleSetup(EcosDccThrottle throttle, LocoAddress address, boolean result) {

--- a/java/src/jmri/jmrix/ecos/EcosDccThrottleManager.java
+++ b/java/src/jmri/jmrix/ecos/EcosDccThrottleManager.java
@@ -109,7 +109,7 @@ public class EcosDccThrottleManager extends AbstractThrottleManager implements E
 
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28, SpeedStepMode.SpeedStepMode14);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128, SpeedStepMode.NMRA_DCC_28, SpeedStepMode.NMRA_DCC_14);
     }
 
     public void throttleSetup(EcosDccThrottle throttle, LocoAddress address, boolean result) {

--- a/java/src/jmri/jmrix/ecos/EcosLocoAddress.java
+++ b/java/src/jmri/jmrix/ecos/EcosLocoAddress.java
@@ -2,8 +2,8 @@ package jmri.jmrix.ecos;
 
 import java.util.HashMap;
 import java.util.List;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrit.roster.Roster;
 import jmri.jmrit.roster.RosterEntry;
 
@@ -20,7 +20,7 @@ public class EcosLocoAddress implements jmri.LocoAddress {
     private String _rosterId = null;
     private String _ecosProtocolString = null;
     private LocoAddress.Protocol _protocol = LocoAddress.Protocol.DCC;
-    private int _speedSteps = DccThrottle.SpeedStepMode128;
+    private SpeedStepMode _speedSteps = SpeedStepMode.SpeedStepMode128;
     boolean direction;
     int currentSpeed;
     private boolean doNotAddToRoster = false;
@@ -174,7 +174,7 @@ public class EcosLocoAddress implements jmri.LocoAddress {
     }
 
     //@TODO Need to udate this to return the new Protocol option from LocoAddress
-    public int getSpeedStepMode() {
+    public SpeedStepMode getSpeedStepMode() {
         return _speedSteps;
     }
 
@@ -193,13 +193,13 @@ public class EcosLocoAddress implements jmri.LocoAddress {
             _protocol = LocoAddress.Protocol.SELECTRIX;
         }
         if (protocol.endsWith("128")) {
-            _speedSteps = DccThrottle.SpeedStepMode128;
+            _speedSteps = SpeedStepMode.SpeedStepMode128;
         } else if (protocol.endsWith("28")) {
-            _speedSteps = DccThrottle.SpeedStepMode28;
+            _speedSteps = SpeedStepMode.SpeedStepMode28;
         } else if (protocol.endsWith("27")) {
-            _speedSteps = DccThrottle.SpeedStepMode27;
+            _speedSteps = SpeedStepMode.SpeedStepMode27;
         } else if (protocol.endsWith("14")) {
-            _speedSteps = DccThrottle.SpeedStepMode14;
+            _speedSteps = SpeedStepMode.SpeedStepMode14;
         }
     }
 

--- a/java/src/jmri/jmrix/ecos/EcosLocoAddress.java
+++ b/java/src/jmri/jmrix/ecos/EcosLocoAddress.java
@@ -20,7 +20,7 @@ public class EcosLocoAddress implements jmri.LocoAddress {
     private String _rosterId = null;
     private String _ecosProtocolString = null;
     private LocoAddress.Protocol _protocol = LocoAddress.Protocol.DCC;
-    private SpeedStepMode _speedSteps = SpeedStepMode.SpeedStepMode128;
+    private SpeedStepMode _speedSteps = SpeedStepMode.NMRA_DCC_128;
     boolean direction;
     int currentSpeed;
     private boolean doNotAddToRoster = false;
@@ -193,13 +193,13 @@ public class EcosLocoAddress implements jmri.LocoAddress {
             _protocol = LocoAddress.Protocol.SELECTRIX;
         }
         if (protocol.endsWith("128")) {
-            _speedSteps = SpeedStepMode.SpeedStepMode128;
+            _speedSteps = SpeedStepMode.NMRA_DCC_128;
         } else if (protocol.endsWith("28")) {
-            _speedSteps = SpeedStepMode.SpeedStepMode28;
+            _speedSteps = SpeedStepMode.NMRA_DCC_28;
         } else if (protocol.endsWith("27")) {
-            _speedSteps = SpeedStepMode.SpeedStepMode27;
+            _speedSteps = SpeedStepMode.NMRA_DCC_27;
         } else if (protocol.endsWith("14")) {
-            _speedSteps = SpeedStepMode.SpeedStepMode14;
+            _speedSteps = SpeedStepMode.NMRA_DCC_14;
         }
     }
 

--- a/java/src/jmri/jmrix/lenz/XNetConsist.java
+++ b/java/src/jmri/jmrix/lenz/XNetConsist.java
@@ -553,7 +553,7 @@ public class XNetConsist extends jmri.implementation.DccConsist implements XNetL
      */
     private void sendDirection(DccLocoAddress address, boolean isForward) {
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(address.getNumber(),
-                jmri.DccThrottle.SpeedStepMode28,
+                jmri.SpeedStepMode.SpeedStepMode28,
                 (float) 0.0,
                 isForward);
         // now, we send the message to the command station

--- a/java/src/jmri/jmrix/lenz/XNetConsist.java
+++ b/java/src/jmri/jmrix/lenz/XNetConsist.java
@@ -553,7 +553,7 @@ public class XNetConsist extends jmri.implementation.DccConsist implements XNetL
      */
     private void sendDirection(DccLocoAddress address, boolean isForward) {
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(address.getNumber(),
-                jmri.SpeedStepMode.SpeedStepMode28,
+                jmri.SpeedStepMode.NMRA_DCC_28,
                 (float) 0.0,
                 isForward);
         // now, we send the message to the command station

--- a/java/src/jmri/jmrix/lenz/XNetMessage.java
+++ b/java/src/jmri/jmrix/lenz/XNetMessage.java
@@ -3,6 +3,7 @@ package jmri.jmrix.lenz;
 import java.io.Serializable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import jmri.SpeedStepMode;
 
 /**
  * Represents a single command or response on the XpressNet.
@@ -756,7 +757,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
      * @param isForward true for forward, false for reverse.
      */
     public static XNetMessage getSpeedAndDirectionMsg(int address,
-            int speedStepMode,
+            SpeedStepMode speedStepMode,
             float speed,
             boolean isForward) {
         XNetMessage msg = new XNetMessage(6);
@@ -764,7 +765,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
         int element4value = 0;   /* this is for holding the speed and
          direction setting */
 
-        if (speedStepMode == jmri.DccThrottle.SpeedStepMode128) {
+        if (speedStepMode == SpeedStepMode.SpeedStepMode128) {
             // We're in 128 speed step mode
             msg.setElement(1, XNetConstants.LOCO_SPEED_128);
             // Now, we need to figure out what to send in element 4
@@ -776,7 +777,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
             if (speedVal >= 1) {
                 element4value = speedVal + 1;
             }
-        } else if (speedStepMode == jmri.DccThrottle.SpeedStepMode28) {
+        } else if (speedStepMode == SpeedStepMode.SpeedStepMode28) {
             // We're in 28 speed step mode
             msg.setElement(1, XNetConstants.LOCO_SPEED_28);
             // Now, we need to figure out what to send in element 4
@@ -790,7 +791,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
             // but other bits are in order from 0-3
             element4value = ((speedVal & 0x1e) >> 1)
                     + ((speedVal & 0x01) << 4);
-        } else if (speedStepMode == jmri.DccThrottle.SpeedStepMode27) {
+        } else if (speedStepMode == SpeedStepMode.SpeedStepMode27) {
             // We're in 27 speed step mode
             msg.setElement(1, XNetConstants.LOCO_SPEED_27);
             // Now, we need to figure out what to send in element 4

--- a/java/src/jmri/jmrix/lenz/XNetMessage.java
+++ b/java/src/jmri/jmrix/lenz/XNetMessage.java
@@ -765,7 +765,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
         int element4value = 0;   /* this is for holding the speed and
          direction setting */
 
-        if (speedStepMode == SpeedStepMode.SpeedStepMode128) {
+        if (speedStepMode == SpeedStepMode.NMRA_DCC_128) {
             // We're in 128 speed step mode
             msg.setElement(1, XNetConstants.LOCO_SPEED_128);
             // Now, we need to figure out what to send in element 4
@@ -777,7 +777,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
             if (speedVal >= 1) {
                 element4value = speedVal + 1;
             }
-        } else if (speedStepMode == SpeedStepMode.SpeedStepMode28) {
+        } else if (speedStepMode == SpeedStepMode.NMRA_DCC_28) {
             // We're in 28 speed step mode
             msg.setElement(1, XNetConstants.LOCO_SPEED_28);
             // Now, we need to figure out what to send in element 4
@@ -791,7 +791,7 @@ public class XNetMessage extends jmri.jmrix.AbstractMRMessage implements Seriali
             // but other bits are in order from 0-3
             element4value = ((speedVal & 0x1e) >> 1)
                     + ((speedVal & 0x01) << 4);
-        } else if (speedStepMode == SpeedStepMode.SpeedStepMode27) {
+        } else if (speedStepMode == SpeedStepMode.NMRA_DCC_27) {
             // We're in 27 speed step mode
             msg.setElement(1, XNetConstants.LOCO_SPEED_27);
             // Now, we need to figure out what to send in element 4

--- a/java/src/jmri/jmrix/lenz/XNetThrottle.java
+++ b/java/src/jmri/jmrix/lenz/XNetThrottle.java
@@ -56,7 +56,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
         super(memo);
         this.tc = controller;
         this.setDccAddress(address.getNumber());
-        this.speedIncrement = SPEED_STEP_128_INCREMENT;
         this.speedStepMode = jmri.SpeedStepMode.NMRA_DCC_128;
         //       this.isForward=true;
         setIsAvailable(false);
@@ -363,15 +362,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
         return;
     }
 
-    /**
-     * Handle quantized speed. Note this can change!
-     * Value returned is always positive.
-     */
-    @Override
-    public float getSpeedIncrement() {
-        return speedIncrement;
-    }
-
     // Handle incoming messages for This throttle.
     @Override
     public void message(XNetReply l) {
@@ -626,7 +616,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
         }
         if ((b1 & 0x01) == 0x01) {
             log.trace("Speed Step setting 27");
-            this.speedIncrement = SPEED_STEP_27_INCREMENT;
             if (this.speedStepMode != SpeedStepMode.NMRA_DCC_27) {
                 notifyPropertyChangeListener("SpeedSteps",
                         this.speedStepMode,
@@ -634,7 +623,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
             }
         } else if ((b1 & 0x02) == 0x02) {
             log.trace("Speed Step setting 28");
-            this.speedIncrement = SPEED_STEP_28_INCREMENT;
             if (this.speedStepMode != SpeedStepMode.NMRA_DCC_28) {
                 notifyPropertyChangeListener("SpeedSteps",
                         this.speedStepMode,
@@ -642,7 +630,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
             }
         } else if ((b1 & 0x04) == 0x04) {
             log.trace("Speed Step setting 128");
-            this.speedIncrement = SPEED_STEP_128_INCREMENT;
             if (this.speedStepMode != SpeedStepMode.NMRA_DCC_128) {
                 notifyPropertyChangeListener("SpeedSteps",
                         this.speedStepMode,
@@ -650,7 +637,6 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
             }
         } else {
             log.trace("Speed Step setting 14");
-            this.speedIncrement = SPEED_STEP_14_INCREMENT;
             if (this.speedStepMode != SpeedStepMode.NMRA_DCC_14) {
                 notifyPropertyChangeListener("SpeedSteps",
                         this.speedStepMode,

--- a/java/src/jmri/jmrix/lenz/XNetThrottle.java
+++ b/java/src/jmri/jmrix/lenz/XNetThrottle.java
@@ -1,12 +1,11 @@
 package jmri.jmrix.lenz;
 
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
 import jmri.Throttle;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
 
 import org.slf4j.Logger;
@@ -58,7 +57,7 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
         this.tc = controller;
         this.setDccAddress(address.getNumber());
         this.speedIncrement = SPEED_STEP_128_INCREMENT;
-        this.speedStepMode = DccThrottle.SpeedStepMode128;
+        this.speedStepMode = jmri.SpeedStepMode.SpeedStepMode128;
         //       this.isForward=true;
         setIsAvailable(false);
 
@@ -266,7 +265,7 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
      *              speed step mode in most cases
      */
     @Override
-    public void setSpeedStepMode(int Mode) {
+    public void setSpeedStepMode(SpeedStepMode Mode) {
         super.setSpeedStepMode(Mode);
         // On a lenz system, we need to send the speed to make sure the 
         // command station knows about the change.
@@ -628,34 +627,34 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
         if ((b1 & 0x01) == 0x01) {
             log.trace("Speed Step setting 27");
             this.speedIncrement = SPEED_STEP_27_INCREMENT;
-            if (this.speedStepMode != DccThrottle.SpeedStepMode27) {
+            if (this.speedStepMode != SpeedStepMode.SpeedStepMode27) {
                 notifyPropertyChangeListener("SpeedSteps",
-                        Integer.valueOf(this.speedStepMode),
-                        Integer.valueOf(this.speedStepMode = DccThrottle.SpeedStepMode27));
+                        this.speedStepMode,
+                        this.speedStepMode = SpeedStepMode.SpeedStepMode27);
             }
         } else if ((b1 & 0x02) == 0x02) {
             log.trace("Speed Step setting 28");
             this.speedIncrement = SPEED_STEP_28_INCREMENT;
-            if (this.speedStepMode != DccThrottle.SpeedStepMode28) {
+            if (this.speedStepMode != SpeedStepMode.SpeedStepMode28) {
                 notifyPropertyChangeListener("SpeedSteps",
-                        Integer.valueOf(this.speedStepMode),
-                        Integer.valueOf(this.speedStepMode = DccThrottle.SpeedStepMode28));
+                        this.speedStepMode,
+                        this.speedStepMode = SpeedStepMode.SpeedStepMode28);
             }
         } else if ((b1 & 0x04) == 0x04) {
             log.trace("Speed Step setting 128");
             this.speedIncrement = SPEED_STEP_128_INCREMENT;
-            if (this.speedStepMode != DccThrottle.SpeedStepMode128) {
+            if (this.speedStepMode != SpeedStepMode.SpeedStepMode128) {
                 notifyPropertyChangeListener("SpeedSteps",
-                        Integer.valueOf(this.speedStepMode),
-                        Integer.valueOf(this.speedStepMode = DccThrottle.SpeedStepMode128));
+                        this.speedStepMode,
+                        this.speedStepMode = SpeedStepMode.SpeedStepMode128);
             }
         } else {
             log.trace("Speed Step setting 14");
             this.speedIncrement = SPEED_STEP_14_INCREMENT;
-            if (this.speedStepMode != DccThrottle.SpeedStepMode14) {
+            if (this.speedStepMode != SpeedStepMode.SpeedStepMode14) {
                 notifyPropertyChangeListener("SpeedSteps",
-                        Integer.valueOf(this.speedStepMode),
-                        Integer.valueOf(this.speedStepMode = DccThrottle.SpeedStepMode14));
+                        this.speedStepMode,
+                        this.speedStepMode = SpeedStepMode.SpeedStepMode14);
             }
         }
     }
@@ -684,7 +683,7 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
             }
         }
 
-        if (this.speedStepMode == DccThrottle.SpeedStepMode128) {
+        if (this.speedStepMode == SpeedStepMode.SpeedStepMode128) {
             // We're in 128 speed step mode
             int speedVal = b2 & 0x7f;
             // The first speed step used is actually at 2 for 128 
@@ -701,7 +700,7 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
                         Float.valueOf(this.speedSetting
                                 = (float) speedVal / (float) 126));
             }
-        } else if (this.speedStepMode == DccThrottle.SpeedStepMode28) {
+        } else if (this.speedStepMode == SpeedStepMode.SpeedStepMode28) {
             // We're in 28 speed step mode
             // We have to re-arange the bits, since bit 4 is the LSB,
             // but other bits are in order from 0-3
@@ -721,7 +720,7 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
                         Float.valueOf(this.speedSetting
                                 = (float) speedVal / (float) 28));
             }
-        } else if (this.speedStepMode == DccThrottle.SpeedStepMode27) {
+        } else if (this.speedStepMode == SpeedStepMode.SpeedStepMode27) {
             // We're in 27 speed step mode
             // We have to re-arange the bits, since bit 4 is the LSB,
             // but other bits are in order from 0-3

--- a/java/src/jmri/jmrix/lenz/XNetThrottle.java
+++ b/java/src/jmri/jmrix/lenz/XNetThrottle.java
@@ -57,7 +57,7 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
         this.tc = controller;
         this.setDccAddress(address.getNumber());
         this.speedIncrement = SPEED_STEP_128_INCREMENT;
-        this.speedStepMode = jmri.SpeedStepMode.SpeedStepMode128;
+        this.speedStepMode = jmri.SpeedStepMode.NMRA_DCC_128;
         //       this.isForward=true;
         setIsAvailable(false);
 
@@ -627,34 +627,34 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
         if ((b1 & 0x01) == 0x01) {
             log.trace("Speed Step setting 27");
             this.speedIncrement = SPEED_STEP_27_INCREMENT;
-            if (this.speedStepMode != SpeedStepMode.SpeedStepMode27) {
+            if (this.speedStepMode != SpeedStepMode.NMRA_DCC_27) {
                 notifyPropertyChangeListener("SpeedSteps",
                         this.speedStepMode,
-                        this.speedStepMode = SpeedStepMode.SpeedStepMode27);
+                        this.speedStepMode = SpeedStepMode.NMRA_DCC_27);
             }
         } else if ((b1 & 0x02) == 0x02) {
             log.trace("Speed Step setting 28");
             this.speedIncrement = SPEED_STEP_28_INCREMENT;
-            if (this.speedStepMode != SpeedStepMode.SpeedStepMode28) {
+            if (this.speedStepMode != SpeedStepMode.NMRA_DCC_28) {
                 notifyPropertyChangeListener("SpeedSteps",
                         this.speedStepMode,
-                        this.speedStepMode = SpeedStepMode.SpeedStepMode28);
+                        this.speedStepMode = SpeedStepMode.NMRA_DCC_28);
             }
         } else if ((b1 & 0x04) == 0x04) {
             log.trace("Speed Step setting 128");
             this.speedIncrement = SPEED_STEP_128_INCREMENT;
-            if (this.speedStepMode != SpeedStepMode.SpeedStepMode128) {
+            if (this.speedStepMode != SpeedStepMode.NMRA_DCC_128) {
                 notifyPropertyChangeListener("SpeedSteps",
                         this.speedStepMode,
-                        this.speedStepMode = SpeedStepMode.SpeedStepMode128);
+                        this.speedStepMode = SpeedStepMode.NMRA_DCC_128);
             }
         } else {
             log.trace("Speed Step setting 14");
             this.speedIncrement = SPEED_STEP_14_INCREMENT;
-            if (this.speedStepMode != SpeedStepMode.SpeedStepMode14) {
+            if (this.speedStepMode != SpeedStepMode.NMRA_DCC_14) {
                 notifyPropertyChangeListener("SpeedSteps",
                         this.speedStepMode,
-                        this.speedStepMode = SpeedStepMode.SpeedStepMode14);
+                        this.speedStepMode = SpeedStepMode.NMRA_DCC_14);
             }
         }
     }
@@ -683,7 +683,7 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
             }
         }
 
-        if (this.speedStepMode == SpeedStepMode.SpeedStepMode128) {
+        if (this.speedStepMode == SpeedStepMode.NMRA_DCC_128) {
             // We're in 128 speed step mode
             int speedVal = b2 & 0x7f;
             // The first speed step used is actually at 2 for 128 
@@ -700,7 +700,7 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
                         Float.valueOf(this.speedSetting
                                 = (float) speedVal / (float) 126));
             }
-        } else if (this.speedStepMode == SpeedStepMode.SpeedStepMode28) {
+        } else if (this.speedStepMode == SpeedStepMode.NMRA_DCC_28) {
             // We're in 28 speed step mode
             // We have to re-arange the bits, since bit 4 is the LSB,
             // but other bits are in order from 0-3
@@ -720,7 +720,7 @@ public class XNetThrottle extends AbstractThrottle implements XNetListener {
                         Float.valueOf(this.speedSetting
                                 = (float) speedVal / (float) 28));
             }
-        } else if (this.speedStepMode == SpeedStepMode.SpeedStepMode27) {
+        } else if (this.speedStepMode == SpeedStepMode.NMRA_DCC_27) {
             // We're in 27 speed step mode
             // We have to re-arange the bits, since bit 4 is the LSB,
             // but other bits are in order from 0-3

--- a/java/src/jmri/jmrix/lenz/XNetThrottleManager.java
+++ b/java/src/jmri/jmrix/lenz/XNetThrottleManager.java
@@ -1,7 +1,9 @@
 package jmri.jmrix.lenz;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,11 +117,11 @@ public class XNetThrottleManager extends AbstractThrottleManager implements XNet
      * 14,27,28 and 128 speed step modes
      */
     @Override
-    public int supportedSpeedModes() {
-        return (jmri.DccThrottle.SpeedStepMode128
-                | jmri.DccThrottle.SpeedStepMode28
-                | jmri.DccThrottle.SpeedStepMode27
-                | jmri.DccThrottle.SpeedStepMode14);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128
+                , SpeedStepMode.SpeedStepMode28
+                , SpeedStepMode.SpeedStepMode27
+                , SpeedStepMode.SpeedStepMode14);
     }
 
     /**

--- a/java/src/jmri/jmrix/lenz/XNetThrottleManager.java
+++ b/java/src/jmri/jmrix/lenz/XNetThrottleManager.java
@@ -118,10 +118,10 @@ public class XNetThrottleManager extends AbstractThrottleManager implements XNet
      */
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128
-                , SpeedStepMode.SpeedStepMode28
-                , SpeedStepMode.SpeedStepMode27
-                , SpeedStepMode.SpeedStepMode14);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128
+                , SpeedStepMode.NMRA_DCC_28
+                , SpeedStepMode.NMRA_DCC_27
+                , SpeedStepMode.NMRA_DCC_14);
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -1,10 +1,12 @@
 package jmri.jmrix.loconet;
 
+import java.util.EnumSet;
 import java.util.Hashtable;
 import java.util.concurrent.LinkedBlockingQueue;
 import jmri.DccLocoAddress;
 import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.ThrottleListener;
 import jmri.ThrottleManager;
 import jmri.jmrix.AbstractThrottleManager;
@@ -187,11 +189,11 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
      * @return an integer containing the combined speed step modes supported
      */
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128
-                | DccThrottle.SpeedStepMode28
-                | DccThrottle.SpeedStepMode28Mot
-                | DccThrottle.SpeedStepMode14);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128
+                , SpeedStepMode.SpeedStepMode28
+                , SpeedStepMode.SpeedStepMode28Mot
+                , SpeedStepMode.SpeedStepMode14);
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/LnThrottleManager.java
+++ b/java/src/jmri/jmrix/loconet/LnThrottleManager.java
@@ -190,10 +190,10 @@ public class LnThrottleManager extends AbstractThrottleManager implements SlotLi
      */
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128
-                , SpeedStepMode.SpeedStepMode28
-                , SpeedStepMode.SpeedStepMode28Mot
-                , SpeedStepMode.SpeedStepMode14);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128
+                , SpeedStepMode.NMRA_DCC_28
+                , SpeedStepMode.MOTOROLA_28
+                , SpeedStepMode.NMRA_DCC_14);
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -1,11 +1,13 @@
 package jmri.jmrix.loconet;
 
+import java.util.EnumSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nullable;
 import jmri.DccLocoAddress;
 import jmri.DccThrottle;
 import jmri.LocoAddress;
 import jmri.Throttle;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,15 +108,15 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         switch (slot.decoderType()) {
             case LnConstants.DEC_MODE_128:
             case LnConstants.DEC_MODE_128A:
-                setSpeedStepMode(DccThrottle.SpeedStepMode128);
+                setSpeedStepMode(SpeedStepMode.SpeedStepMode128);
                 break;
             case LnConstants.DEC_MODE_28:
             case LnConstants.DEC_MODE_28A:
             case LnConstants.DEC_MODE_28TRI:
-                setSpeedStepMode(DccThrottle.SpeedStepMode28);
+                setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
                 break;
             case LnConstants.DEC_MODE_14:
-                setSpeedStepMode(DccThrottle.SpeedStepMode14);
+                setSpeedStepMode(SpeedStepMode.SpeedStepMode14);
                 break;
             default:
                 log.warn("Unhandled decoder type: {}", slot.decoderType());
@@ -150,13 +152,13 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         } else if (lSpeed == 1) {
             return -1.f;   // estop
         }
-        if (getSpeedStepMode() == DccThrottle.SpeedStepMode28) {
+        if (getSpeedStepMode() == SpeedStepMode.SpeedStepMode28) {
             if (lSpeed <= 15) //Value less than 15 is in the stop/estop range bracket
             {
                 return 0.f;
             }
             return (((lSpeed - 12) / 4f) / 28.f);
-        } else if (getSpeedStepMode() == DccThrottle.SpeedStepMode14) {
+        } else if (getSpeedStepMode() == SpeedStepMode.SpeedStepMode14) {
             if (lSpeed <= 15) //Value less than 15 is in the stop/estop range bracket
             {
                 return 0.f;
@@ -188,12 +190,12 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
             return speed; // return idle and emergency stop
         }
         switch (this.getSpeedStepMode()) {
-            case DccThrottle.SpeedStepMode28:
-            case DccThrottle.SpeedStepMode28Mot:
+            case SpeedStepMode28:
+            case SpeedStepMode28Mot:
                 return (int) ((fSpeed * 28) * 4) + 12;
-            case DccThrottle.SpeedStepMode14:
+            case SpeedStepMode14:
                 return (int) ((fSpeed * 14) * 8) + 8;
-            case DccThrottle.SpeedStepMode128:
+            case SpeedStepMode128:
                 return speed;
             default:
                 log.warn("Unhandled speed step: {}", this.getSpeedStepMode());
@@ -564,20 +566,20 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         switch (slot.decoderType()) {
             case LnConstants.DEC_MODE_128:
             case LnConstants.DEC_MODE_128A:
-                if(DccThrottle.SpeedStepMode128 != getSpeedStepMode()) {
-                   setSpeedStepMode(DccThrottle.SpeedStepMode128);
+                if(SpeedStepMode.SpeedStepMode128 != getSpeedStepMode()) {
+                   setSpeedStepMode(SpeedStepMode.SpeedStepMode128);
                 }
                 break;
             case LnConstants.DEC_MODE_28:
             case LnConstants.DEC_MODE_28A:
             case LnConstants.DEC_MODE_28TRI:
-                if(DccThrottle.SpeedStepMode28 != getSpeedStepMode()) {
-                   setSpeedStepMode(DccThrottle.SpeedStepMode28);
+                if(SpeedStepMode.SpeedStepMode28 != getSpeedStepMode()) {
+                   setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
                 }
                 break;
             case LnConstants.DEC_MODE_14:
-                if(DccThrottle.SpeedStepMode14 != getSpeedStepMode()) {
-                   setSpeedStepMode(DccThrottle.SpeedStepMode14);
+                if(SpeedStepMode.SpeedStepMode14 != getSpeedStepMode()) {
+                   setSpeedStepMode(SpeedStepMode.SpeedStepMode14);
                 }
                 break;
             default:
@@ -742,7 +744,7 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
      *             speed step mode in most cases
      */
     @Override
-    public void setSpeedStepMode(int Mode) {
+    public void setSpeedStepMode(SpeedStepMode Mode) {
         int status = slot.slotStatus();
         if (log.isDebugEnabled()) {
             log.debug("Speed Step Mode Change to Mode: " + Mode // NOI18N
@@ -753,19 +755,19 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
             notifyPropertyChangeListener("SpeedSteps", this.speedStepMode, // NOI18N
                     this.speedStepMode = Mode);
         }
-        if (Mode == DccThrottle.SpeedStepMode14) {
+        if (Mode == SpeedStepMode.SpeedStepMode14) {
             speedIncrement = SPEED_STEP_14_INCREMENT;
             log.debug("14 speed step change"); // NOI18N
             status = status & ((~LnConstants.DEC_MODE_MASK)
                     | LnConstants.STAT1_SL_SPDEX)
                     | LnConstants.DEC_MODE_14;
-        } else if (Mode == DccThrottle.SpeedStepMode28Mot) {
+        } else if (Mode == SpeedStepMode.SpeedStepMode28Mot) {
             speedIncrement = SPEED_STEP_28_INCREMENT;
             log.debug("28-Tristate speed step change");
             status = status & ((~LnConstants.DEC_MODE_MASK)
                     | LnConstants.STAT1_SL_SPDEX)
                     | LnConstants.DEC_MODE_28TRI;
-        } else if (Mode == DccThrottle.SpeedStepMode28) {
+        } else if (Mode == SpeedStepMode.SpeedStepMode28) {
             speedIncrement = SPEED_STEP_28_INCREMENT;
             log.debug("28 speed step change");
             status = status & ((~LnConstants.DEC_MODE_MASK)

--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -108,15 +108,15 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         switch (slot.decoderType()) {
             case LnConstants.DEC_MODE_128:
             case LnConstants.DEC_MODE_128A:
-                setSpeedStepMode(SpeedStepMode.SpeedStepMode128);
+                setSpeedStepMode(SpeedStepMode.NMRA_DCC_128);
                 break;
             case LnConstants.DEC_MODE_28:
             case LnConstants.DEC_MODE_28A:
             case LnConstants.DEC_MODE_28TRI:
-                setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
+                setSpeedStepMode(SpeedStepMode.NMRA_DCC_28);
                 break;
             case LnConstants.DEC_MODE_14:
-                setSpeedStepMode(SpeedStepMode.SpeedStepMode14);
+                setSpeedStepMode(SpeedStepMode.NMRA_DCC_14);
                 break;
             default:
                 log.warn("Unhandled decoder type: {}", slot.decoderType());
@@ -152,13 +152,13 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         } else if (lSpeed == 1) {
             return -1.f;   // estop
         }
-        if (getSpeedStepMode() == SpeedStepMode.SpeedStepMode28) {
+        if (getSpeedStepMode() == SpeedStepMode.NMRA_DCC_28) {
             if (lSpeed <= 15) //Value less than 15 is in the stop/estop range bracket
             {
                 return 0.f;
             }
             return (((lSpeed - 12) / 4f) / 28.f);
-        } else if (getSpeedStepMode() == SpeedStepMode.SpeedStepMode14) {
+        } else if (getSpeedStepMode() == SpeedStepMode.NMRA_DCC_14) {
             if (lSpeed <= 15) //Value less than 15 is in the stop/estop range bracket
             {
                 return 0.f;
@@ -190,12 +190,12 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
             return speed; // return idle and emergency stop
         }
         switch (this.getSpeedStepMode()) {
-            case SpeedStepMode28:
-            case SpeedStepMode28Mot:
+            case NMRA_DCC_28:
+            case MOTOROLA_28:
                 return (int) ((fSpeed * 28) * 4) + 12;
-            case SpeedStepMode14:
+            case NMRA_DCC_14:
                 return (int) ((fSpeed * 14) * 8) + 8;
-            case SpeedStepMode128:
+            case NMRA_DCC_128:
                 return speed;
             default:
                 log.warn("Unhandled speed step: {}", this.getSpeedStepMode());
@@ -566,20 +566,20 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
         switch (slot.decoderType()) {
             case LnConstants.DEC_MODE_128:
             case LnConstants.DEC_MODE_128A:
-                if(SpeedStepMode.SpeedStepMode128 != getSpeedStepMode()) {
-                   setSpeedStepMode(SpeedStepMode.SpeedStepMode128);
+                if(SpeedStepMode.NMRA_DCC_128 != getSpeedStepMode()) {
+                   setSpeedStepMode(SpeedStepMode.NMRA_DCC_128);
                 }
                 break;
             case LnConstants.DEC_MODE_28:
             case LnConstants.DEC_MODE_28A:
             case LnConstants.DEC_MODE_28TRI:
-                if(SpeedStepMode.SpeedStepMode28 != getSpeedStepMode()) {
-                   setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
+                if(SpeedStepMode.NMRA_DCC_28 != getSpeedStepMode()) {
+                   setSpeedStepMode(SpeedStepMode.NMRA_DCC_28);
                 }
                 break;
             case LnConstants.DEC_MODE_14:
-                if(SpeedStepMode.SpeedStepMode14 != getSpeedStepMode()) {
-                   setSpeedStepMode(SpeedStepMode.SpeedStepMode14);
+                if(SpeedStepMode.NMRA_DCC_14 != getSpeedStepMode()) {
+                   setSpeedStepMode(SpeedStepMode.NMRA_DCC_14);
                 }
                 break;
             default:
@@ -755,19 +755,19 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
             notifyPropertyChangeListener("SpeedSteps", this.speedStepMode, // NOI18N
                     this.speedStepMode = Mode);
         }
-        if (Mode == SpeedStepMode.SpeedStepMode14) {
+        if (Mode == SpeedStepMode.NMRA_DCC_14) {
             speedIncrement = SPEED_STEP_14_INCREMENT;
             log.debug("14 speed step change"); // NOI18N
             status = status & ((~LnConstants.DEC_MODE_MASK)
                     | LnConstants.STAT1_SL_SPDEX)
                     | LnConstants.DEC_MODE_14;
-        } else if (Mode == SpeedStepMode.SpeedStepMode28Mot) {
+        } else if (Mode == SpeedStepMode.MOTOROLA_28) {
             speedIncrement = SPEED_STEP_28_INCREMENT;
             log.debug("28-Tristate speed step change");
             status = status & ((~LnConstants.DEC_MODE_MASK)
                     | LnConstants.STAT1_SL_SPDEX)
                     | LnConstants.DEC_MODE_28TRI;
-        } else if (Mode == SpeedStepMode.SpeedStepMode28) {
+        } else if (Mode == SpeedStepMode.NMRA_DCC_28) {
             speedIncrement = SPEED_STEP_28_INCREMENT;
             log.debug("28 speed step change");
             status = status & ((~LnConstants.DEC_MODE_MASK)

--- a/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetThrottle.java
@@ -756,19 +756,16 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
                     this.speedStepMode = Mode);
         }
         if (Mode == SpeedStepMode.NMRA_DCC_14) {
-            speedIncrement = SPEED_STEP_14_INCREMENT;
             log.debug("14 speed step change"); // NOI18N
             status = status & ((~LnConstants.DEC_MODE_MASK)
                     | LnConstants.STAT1_SL_SPDEX)
                     | LnConstants.DEC_MODE_14;
         } else if (Mode == SpeedStepMode.MOTOROLA_28) {
-            speedIncrement = SPEED_STEP_28_INCREMENT;
             log.debug("28-Tristate speed step change");
             status = status & ((~LnConstants.DEC_MODE_MASK)
                     | LnConstants.STAT1_SL_SPDEX)
                     | LnConstants.DEC_MODE_28TRI;
         } else if (Mode == SpeedStepMode.NMRA_DCC_28) {
-            speedIncrement = SPEED_STEP_28_INCREMENT;
             log.debug("28 speed step change");
             status = status & ((~LnConstants.DEC_MODE_MASK)
                     | LnConstants.STAT1_SL_SPDEX);
@@ -776,7 +773,6 @@ public class LocoNetThrottle extends AbstractThrottle implements SlotListener {
             // it unfortunately shows a INT_VACUOUS_BIT_OPERATION in SpotBugs
             // and I don't want to annote that around this entire long method
         } else { // default to 128 speed step mode
-            speedIncrement = SPEED_STEP_128_INCREMENT;
             log.debug("128 speed step change");
             status = status & ((~LnConstants.DEC_MODE_MASK)
                     | LnConstants.STAT1_SL_SPDEX)

--- a/java/src/jmri/jmrix/loconet/Pr2Throttle.java
+++ b/java/src/jmri/jmrix/loconet/Pr2Throttle.java
@@ -2,8 +2,8 @@ package jmri.jmrix.loconet;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +31,7 @@ public class Pr2Throttle extends AbstractThrottle {
         super(memo);
         this.address = address;
         addr = address.getNumber();
-        setSpeedStepMode(DccThrottle.SpeedStepMode28);
+        setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
         this.speedIncrement = 1;  // 128 step mode only
     }
 
@@ -47,13 +47,13 @@ public class Pr2Throttle extends AbstractThrottle {
         } else if (lSpeed == 1) {
             return -1.f;   // estop
         }
-        if (getSpeedStepMode() == DccThrottle.SpeedStepMode28) {
+        if (getSpeedStepMode() == SpeedStepMode.SpeedStepMode28) {
             if (lSpeed <= 15) //Value less than 15 is in the stop/estop range bracket
             {
                 return 0.f;
             }
             return (((lSpeed - 12) / 4f) / 28.f);
-        } else if (getSpeedStepMode() == DccThrottle.SpeedStepMode14) {
+        } else if (getSpeedStepMode() == SpeedStepMode.SpeedStepMode14) {
             if (lSpeed <= 15) //Value less than 15 is in the stop/estop range bracket
             {
                 return 0.f;
@@ -78,10 +78,10 @@ public class Pr2Throttle extends AbstractThrottle {
     protected int intSpeed(float fSpeed) {
         if (fSpeed< 0.) return 1;  // what the parent class does
         switch (this.getSpeedStepMode()) {
-            case DccThrottle.SpeedStepMode28:
-            case DccThrottle.SpeedStepMode28Mot:
+            case SpeedStepMode28:
+            case SpeedStepMode28Mot:
                 return (int) ((fSpeed * 28) * 4) + 12;
-            case DccThrottle.SpeedStepMode14:
+            case SpeedStepMode14:
                 return (int) ((fSpeed * 14) * 8) + 8;
                 
             default:

--- a/java/src/jmri/jmrix/loconet/Pr2Throttle.java
+++ b/java/src/jmri/jmrix/loconet/Pr2Throttle.java
@@ -31,7 +31,7 @@ public class Pr2Throttle extends AbstractThrottle {
         super(memo);
         this.address = address;
         addr = address.getNumber();
-        setSpeedStepMode(SpeedStepMode.SpeedStepMode28);
+        setSpeedStepMode(SpeedStepMode.NMRA_DCC_28);
         this.speedIncrement = 1;  // 128 step mode only
     }
 
@@ -47,13 +47,13 @@ public class Pr2Throttle extends AbstractThrottle {
         } else if (lSpeed == 1) {
             return -1.f;   // estop
         }
-        if (getSpeedStepMode() == SpeedStepMode.SpeedStepMode28) {
+        if (getSpeedStepMode() == SpeedStepMode.NMRA_DCC_28) {
             if (lSpeed <= 15) //Value less than 15 is in the stop/estop range bracket
             {
                 return 0.f;
             }
             return (((lSpeed - 12) / 4f) / 28.f);
-        } else if (getSpeedStepMode() == SpeedStepMode.SpeedStepMode14) {
+        } else if (getSpeedStepMode() == SpeedStepMode.NMRA_DCC_14) {
             if (lSpeed <= 15) //Value less than 15 is in the stop/estop range bracket
             {
                 return 0.f;
@@ -78,10 +78,10 @@ public class Pr2Throttle extends AbstractThrottle {
     protected int intSpeed(float fSpeed) {
         if (fSpeed< 0.) return 1;  // what the parent class does
         switch (this.getSpeedStepMode()) {
-            case SpeedStepMode28:
-            case SpeedStepMode28Mot:
+            case NMRA_DCC_28:
+            case MOTOROLA_28:
                 return (int) ((fSpeed * 28) * 4) + 12;
-            case SpeedStepMode14:
+            case NMRA_DCC_14:
                 return (int) ((fSpeed * 14) * 8) + 8;
                 
             default:

--- a/java/src/jmri/jmrix/loconet/Pr2Throttle.java
+++ b/java/src/jmri/jmrix/loconet/Pr2Throttle.java
@@ -32,7 +32,6 @@ public class Pr2Throttle extends AbstractThrottle {
         this.address = address;
         addr = address.getNumber();
         setSpeedStepMode(SpeedStepMode.NMRA_DCC_28);
-        this.speedIncrement = 1;  // 128 step mode only
     }
 
     /**

--- a/java/src/jmri/jmrix/marklin/MarklinThrottle.java
+++ b/java/src/jmri/jmrix/marklin/MarklinThrottle.java
@@ -41,7 +41,7 @@ public class MarklinThrottle extends AbstractThrottle implements MarklinListener
         this.address = address;
         this.isForward = true;
 
-        setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
+        setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
         tc.addMarklinListener(this);
         tc.sendMarklinMessage(MarklinMessage.getQryLocoSpeed(getCANAddress()), this);
         tc.sendMarklinMessage(MarklinMessage.getQryLocoDirection(getCANAddress()), this);
@@ -181,18 +181,18 @@ public class MarklinThrottle extends AbstractThrottle implements MarklinListener
         boolean isLong = ((jmri.ThrottleManager) adapterMemo.get(jmri.ThrottleManager.class)).canBeLongAddress(address.getNumber());
         switch (address.getProtocol()) {
             case DCC:
-                if (Mode == SpeedStepMode.SpeedStepMode28 && isLong) {
+                if (Mode == SpeedStepMode.NMRA_DCC_28 && isLong) {
                     tc.sendMarklinMessage(MarklinMessage.setLocoSpeedSteps(getCANAddress(), MarklinConstants.STEPLONG28), this);
-                } else if (Mode == SpeedStepMode.SpeedStepMode28 && !isLong) {
+                } else if (Mode == SpeedStepMode.NMRA_DCC_28 && !isLong) {
                     tc.sendMarklinMessage(MarklinMessage.setLocoSpeedSteps(getCANAddress(), MarklinConstants.STEPSHORT28), this);
-                } else if (Mode == SpeedStepMode.SpeedStepMode128 && isLong) {
+                } else if (Mode == SpeedStepMode.NMRA_DCC_128 && isLong) {
                     tc.sendMarklinMessage(MarklinMessage.setLocoSpeedSteps(getCANAddress(), MarklinConstants.STEPLONG128), this);
-                } else if (Mode == SpeedStepMode.SpeedStepMode128 && !isLong) {
+                } else if (Mode == SpeedStepMode.NMRA_DCC_128 && !isLong) {
                     tc.sendMarklinMessage(MarklinMessage.setLocoSpeedSteps(getCANAddress(), MarklinConstants.STEPSHORT128), this);
                 }
                 break;
             default:
-                Mode = SpeedStepMode.SpeedStepMode28;
+                Mode = SpeedStepMode.NMRA_DCC_28;
                 break;
         }
         super.setSpeedStepMode(Mode);

--- a/java/src/jmri/jmrix/marklin/MarklinThrottle.java
+++ b/java/src/jmri/jmrix/marklin/MarklinThrottle.java
@@ -1,8 +1,8 @@
 package jmri.jmrix.marklin;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.Throttle;
 import jmri.jmrix.AbstractThrottle;
 import org.slf4j.Logger;
@@ -41,7 +41,7 @@ public class MarklinThrottle extends AbstractThrottle implements MarklinListener
         this.address = address;
         this.isForward = true;
 
-        setSpeedStepMode(jmri.DccThrottle.SpeedStepMode128);
+        setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
         tc.addMarklinListener(this);
         tc.sendMarklinMessage(MarklinMessage.getQryLocoSpeed(getCANAddress()), this);
         tc.sendMarklinMessage(MarklinMessage.getQryLocoDirection(getCANAddress()), this);
@@ -173,7 +173,7 @@ public class MarklinThrottle extends AbstractThrottle implements MarklinListener
     MarklinTrafficController tc;
 
     @Override
-    public void setSpeedStepMode(int Mode) {
+    public void setSpeedStepMode(SpeedStepMode Mode) {
         if (log.isDebugEnabled()) {
             log.debug("Speed Step Mode Change to Mode: " + Mode
                     + " Current mode is: " + this.speedStepMode);
@@ -181,18 +181,18 @@ public class MarklinThrottle extends AbstractThrottle implements MarklinListener
         boolean isLong = ((jmri.ThrottleManager) adapterMemo.get(jmri.ThrottleManager.class)).canBeLongAddress(address.getNumber());
         switch (address.getProtocol()) {
             case DCC:
-                if (Mode == DccThrottle.SpeedStepMode28 && isLong) {
+                if (Mode == SpeedStepMode.SpeedStepMode28 && isLong) {
                     tc.sendMarklinMessage(MarklinMessage.setLocoSpeedSteps(getCANAddress(), MarklinConstants.STEPLONG28), this);
-                } else if (Mode == DccThrottle.SpeedStepMode28 && !isLong) {
+                } else if (Mode == SpeedStepMode.SpeedStepMode28 && !isLong) {
                     tc.sendMarklinMessage(MarklinMessage.setLocoSpeedSteps(getCANAddress(), MarklinConstants.STEPSHORT28), this);
-                } else if (Mode == DccThrottle.SpeedStepMode128 && isLong) {
+                } else if (Mode == SpeedStepMode.SpeedStepMode128 && isLong) {
                     tc.sendMarklinMessage(MarklinMessage.setLocoSpeedSteps(getCANAddress(), MarklinConstants.STEPLONG128), this);
-                } else if (Mode == DccThrottle.SpeedStepMode128 && !isLong) {
+                } else if (Mode == SpeedStepMode.SpeedStepMode128 && !isLong) {
                     tc.sendMarklinMessage(MarklinMessage.setLocoSpeedSteps(getCANAddress(), MarklinConstants.STEPSHORT128), this);
                 }
                 break;
             default:
-                Mode = DccThrottle.SpeedStepMode28;
+                Mode = SpeedStepMode.SpeedStepMode28;
                 break;
         }
         super.setSpeedStepMode(Mode);

--- a/java/src/jmri/jmrix/marklin/MarklinThrottleManager.java
+++ b/java/src/jmri/jmrix/marklin/MarklinThrottleManager.java
@@ -108,7 +108,7 @@ public class MarklinThrottleManager extends AbstractThrottleManager implements M
 
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128, SpeedStepMode.NMRA_DCC_28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/marklin/MarklinThrottleManager.java
+++ b/java/src/jmri/jmrix/marklin/MarklinThrottleManager.java
@@ -1,8 +1,8 @@
 package jmri.jmrix.marklin;
 
-import jmri.DccLocoAddress;
-import jmri.DccThrottle;
+import java.util.EnumSet;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,8 +107,8 @@ public class MarklinThrottleManager extends AbstractThrottleManager implements M
     }
 
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128 | DccThrottle.SpeedStepMode28);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/mrc/MrcThrottle.java
+++ b/java/src/jmri/jmrix/mrc/MrcThrottle.java
@@ -32,7 +32,7 @@ public class MrcThrottle extends AbstractThrottle implements MrcTrafficListener 
     public MrcThrottle(MrcSystemConnectionMemo memo, DccLocoAddress address) {
         super(memo);
         this.tc = memo.getMrcTrafficController();
-        super.speedStepMode = jmri.SpeedStepMode.SpeedStepMode128;
+        super.speedStepMode = jmri.SpeedStepMode.NMRA_DCC_128;
 
         // cache settings. It would be better to read the
         // actual state, but I don't know how to do this
@@ -208,7 +208,7 @@ public class MrcThrottle extends AbstractThrottle implements MrcTrafficListener 
         this.speedSetting = speed;
         MrcMessage m;
         int value;
-        if (super.speedStepMode == jmri.SpeedStepMode.SpeedStepMode128) {
+        if (super.speedStepMode == jmri.SpeedStepMode.NMRA_DCC_128) {
             log.debug("setSpeedSetting= {}", speed); //IN18N
             //MRC use a value between 0-127 no matter what the controller is set to
             value = (int) ((127 - 1) * speed);     // -1 for rescale to avoid estop

--- a/java/src/jmri/jmrix/mrc/MrcThrottle.java
+++ b/java/src/jmri/jmrix/mrc/MrcThrottle.java
@@ -32,7 +32,7 @@ public class MrcThrottle extends AbstractThrottle implements MrcTrafficListener 
     public MrcThrottle(MrcSystemConnectionMemo memo, DccLocoAddress address) {
         super(memo);
         this.tc = memo.getMrcTrafficController();
-        super.speedStepMode = SpeedStepMode128;
+        super.speedStepMode = jmri.SpeedStepMode.SpeedStepMode128;
 
         // cache settings. It would be better to read the
         // actual state, but I don't know how to do this
@@ -208,7 +208,7 @@ public class MrcThrottle extends AbstractThrottle implements MrcTrafficListener 
         this.speedSetting = speed;
         MrcMessage m;
         int value;
-        if (super.speedStepMode == SpeedStepMode128) {
+        if (super.speedStepMode == jmri.SpeedStepMode.SpeedStepMode128) {
             log.debug("setSpeedSetting= {}", speed); //IN18N
             //MRC use a value between 0-127 no matter what the controller is set to
             value = (int) ((127 - 1) * speed);     // -1 for rescale to avoid estop

--- a/java/src/jmri/jmrix/mrc/MrcThrottleManager.java
+++ b/java/src/jmri/jmrix/mrc/MrcThrottleManager.java
@@ -1,8 +1,9 @@
 package jmri.jmrix.mrc;
 
+import java.util.EnumSet;
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,8 +71,8 @@ public class MrcThrottleManager extends AbstractThrottleManager {
     }
 
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128 | DccThrottle.SpeedStepMode28);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/mrc/MrcThrottleManager.java
+++ b/java/src/jmri/jmrix/mrc/MrcThrottleManager.java
@@ -72,7 +72,7 @@ public class MrcThrottleManager extends AbstractThrottleManager {
 
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128, SpeedStepMode.NMRA_DCC_28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/nce/NceThrottle.java
+++ b/java/src/jmri/jmrix/nce/NceThrottle.java
@@ -33,7 +33,7 @@ public class NceThrottle extends AbstractThrottle {
     public NceThrottle(NceSystemConnectionMemo memo, DccLocoAddress address) {
         super(memo);
         this.tc = memo.getNceTrafficController();
-        setSpeedStepMode(SpeedStepMode128);
+        setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
 
         // cache settings. It would be better to read the
         // actual state, but I don't know how to do this
@@ -306,7 +306,7 @@ public class NceThrottle extends AbstractThrottle {
                                 : NceBinaryCommand.LOCO_CMD_REV_ESTOP),
                         (byte) 0);
 
-            } else if (super.speedStepMode == SpeedStepMode128) {
+            } else if (super.speedStepMode == jmri.SpeedStepMode.SpeedStepMode128) {
                 bl = NceBinaryCommand.nceLocoCmd(locoAddr,
                         (isForward ? NceBinaryCommand.LOCO_CMD_FWD_128SPEED
                                 : NceBinaryCommand.LOCO_CMD_REV_128SPEED),
@@ -326,7 +326,7 @@ public class NceThrottle extends AbstractThrottle {
             byte[] bl;
             int value;
 
-            if (super.speedStepMode == SpeedStepMode128) {
+            if (super.speedStepMode == jmri.SpeedStepMode.SpeedStepMode128) {
                 value = (int) ((127 - 1) * speed);     // -1 for rescale to avoid estop
                 if (value > 0) {
                     value = value + 1;  // skip estop

--- a/java/src/jmri/jmrix/nce/NceThrottle.java
+++ b/java/src/jmri/jmrix/nce/NceThrottle.java
@@ -33,7 +33,7 @@ public class NceThrottle extends AbstractThrottle {
     public NceThrottle(NceSystemConnectionMemo memo, DccLocoAddress address) {
         super(memo);
         this.tc = memo.getNceTrafficController();
-        setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
+        setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
 
         // cache settings. It would be better to read the
         // actual state, but I don't know how to do this
@@ -306,7 +306,7 @@ public class NceThrottle extends AbstractThrottle {
                                 : NceBinaryCommand.LOCO_CMD_REV_ESTOP),
                         (byte) 0);
 
-            } else if (super.speedStepMode == jmri.SpeedStepMode.SpeedStepMode128) {
+            } else if (super.speedStepMode == jmri.SpeedStepMode.NMRA_DCC_128) {
                 bl = NceBinaryCommand.nceLocoCmd(locoAddr,
                         (isForward ? NceBinaryCommand.LOCO_CMD_FWD_128SPEED
                                 : NceBinaryCommand.LOCO_CMD_REV_128SPEED),
@@ -326,7 +326,7 @@ public class NceThrottle extends AbstractThrottle {
             byte[] bl;
             int value;
 
-            if (super.speedStepMode == jmri.SpeedStepMode.SpeedStepMode128) {
+            if (super.speedStepMode == jmri.SpeedStepMode.NMRA_DCC_128) {
                 value = (int) ((127 - 1) * speed);     // -1 for rescale to avoid estop
                 if (value > 0) {
                     value = value + 1;  // skip estop

--- a/java/src/jmri/jmrix/nce/NceThrottleManager.java
+++ b/java/src/jmri/jmrix/nce/NceThrottleManager.java
@@ -71,7 +71,7 @@ public class NceThrottleManager extends AbstractThrottleManager {
 
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128, SpeedStepMode.NMRA_DCC_28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/nce/NceThrottleManager.java
+++ b/java/src/jmri/jmrix/nce/NceThrottleManager.java
@@ -1,8 +1,9 @@
 package jmri.jmrix.nce;
 
+import java.util.EnumSet;
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,8 +70,8 @@ public class NceThrottleManager extends AbstractThrottleManager {
     }
 
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128 | DccThrottle.SpeedStepMode28);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/roco/z21/Z21XNetMessage.java
+++ b/java/src/jmri/jmrix/roco/z21/Z21XNetMessage.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.roco.z21;
 
 import java.io.Serializable;
+import jmri.SpeedStepMode;
 import jmri.jmrix.lenz.XNetConstants;
 import jmri.jmrix.lenz.XNetMessage;
 
@@ -140,7 +141,7 @@ public class Z21XNetMessage extends jmri.jmrix.lenz.XNetMessage {
      *              and 1).  A negative value indicates emergency stop.
      * @param isForward true for forward, false for reverse.
      */
-    public static XNetMessage getZ21LanXSetLocoDriveMsg(int address, int speedMode, float speed, boolean isForward) {
+    public static XNetMessage getZ21LanXSetLocoDriveMsg(int address, SpeedStepMode speedMode, float speed, boolean isForward) {
         XNetMessage msg = XNetMessage.getSpeedAndDirectionMsg(address,
                         speedMode,speed,isForward);
         msg.setBroadcastReply();

--- a/java/src/jmri/jmrix/sprog/SprogCSThrottle.java
+++ b/java/src/jmri/jmrix/sprog/SprogCSThrottle.java
@@ -1,8 +1,8 @@
 package jmri.jmrix.sprog;
 
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
 
 import org.slf4j.Logger;
@@ -120,8 +120,8 @@ public class SprogCSThrottle extends AbstractThrottle {
      */
     @Override
     public void setSpeedSetting(float speed) {
-        int mode = getSpeedStepMode();
-        if ((mode & DccThrottle.SpeedStepMode28) != 0) {
+        SpeedStepMode mode = getSpeedStepMode();
+        if (mode == SpeedStepMode.SpeedStepMode28) {
             // 28 step mode speed commands are 
             // stop, estop, stop, estop, 4, 5, ..., 31
             float oldSpeed = this.speedSetting;
@@ -136,7 +136,7 @@ public class SprogCSThrottle extends AbstractThrottle {
             if (value < 0) {
                 value = 1;        // emergency stop
             }
-            commandStation.setSpeed(DccThrottle.SpeedStepMode28, address, value, isForward);
+            commandStation.setSpeed(SpeedStepMode.SpeedStepMode28, address, value, isForward);
             if (Math.abs(oldSpeed - this.speedSetting) > 0.0001) {
                 notifyPropertyChangeListener("SpeedSetting", oldSpeed, this.speedSetting);
             }
@@ -155,7 +155,7 @@ public class SprogCSThrottle extends AbstractThrottle {
             if (value < 0) {
                 value = 1;        // emergency stop
             }
-            commandStation.setSpeed(DccThrottle.SpeedStepMode128, address, value, isForward);
+            commandStation.setSpeed(SpeedStepMode.SpeedStepMode128, address, value, isForward);
             if (Math.abs(oldSpeed - this.speedSetting) > 0.0001) {
                 notifyPropertyChangeListener("SpeedSetting", oldSpeed, this.speedSetting);
             }

--- a/java/src/jmri/jmrix/sprog/SprogCSThrottle.java
+++ b/java/src/jmri/jmrix/sprog/SprogCSThrottle.java
@@ -121,7 +121,7 @@ public class SprogCSThrottle extends AbstractThrottle {
     @Override
     public void setSpeedSetting(float speed) {
         SpeedStepMode mode = getSpeedStepMode();
-        if (mode == SpeedStepMode.SpeedStepMode28) {
+        if (mode == SpeedStepMode.NMRA_DCC_28) {
             // 28 step mode speed commands are 
             // stop, estop, stop, estop, 4, 5, ..., 31
             float oldSpeed = this.speedSetting;
@@ -136,7 +136,7 @@ public class SprogCSThrottle extends AbstractThrottle {
             if (value < 0) {
                 value = 1;        // emergency stop
             }
-            commandStation.setSpeed(SpeedStepMode.SpeedStepMode28, address, value, isForward);
+            commandStation.setSpeed(SpeedStepMode.NMRA_DCC_28, address, value, isForward);
             if (Math.abs(oldSpeed - this.speedSetting) > 0.0001) {
                 notifyPropertyChangeListener("SpeedSetting", oldSpeed, this.speedSetting);
             }
@@ -155,7 +155,7 @@ public class SprogCSThrottle extends AbstractThrottle {
             if (value < 0) {
                 value = 1;        // emergency stop
             }
-            commandStation.setSpeed(SpeedStepMode.SpeedStepMode128, address, value, isForward);
+            commandStation.setSpeed(SpeedStepMode.NMRA_DCC_128, address, value, isForward);
             if (Math.abs(oldSpeed - this.speedSetting) > 0.0001) {
                 notifyPropertyChangeListener("SpeedSetting", oldSpeed, this.speedSetting);
             }

--- a/java/src/jmri/jmrix/sprog/SprogCSThrottleManager.java
+++ b/java/src/jmri/jmrix/sprog/SprogCSThrottleManager.java
@@ -1,8 +1,9 @@
 package jmri.jmrix.sprog;
 
+import java.util.EnumSet;
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,8 +46,8 @@ public class SprogCSThrottleManager extends AbstractThrottleManager {
      * possible modes specified by the DccThrottle interface
      */
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128 | DccThrottle.SpeedStepMode28);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
     }
 
     /**

--- a/java/src/jmri/jmrix/sprog/SprogCSThrottleManager.java
+++ b/java/src/jmri/jmrix/sprog/SprogCSThrottleManager.java
@@ -47,7 +47,7 @@ public class SprogCSThrottleManager extends AbstractThrottleManager {
      */
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128, SpeedStepMode.NMRA_DCC_28);
     }
 
     /**

--- a/java/src/jmri/jmrix/sprog/SprogCommandStation.java
+++ b/java/src/jmri/jmrix/sprog/SprogCommandStation.java
@@ -305,7 +305,7 @@ public class SprogCommandStation implements CommandStation, SprogListener, Runna
      * new speed is actually sent to the hardware.
      *
      */
-    public void setSpeed(int mode, DccLocoAddress address, int spd, boolean isForward) {
+    public void setSpeed(jmri.SpeedStepMode mode, DccLocoAddress address, int spd, boolean isForward) {
         SprogSlot s = this.findAddressSpeedPacket(address);
         if (s != null) { // May need an error here - if all slots are full!
             s.setSpeed(mode, address.getNumber(), address.isLongAddress(), spd, isForward);

--- a/java/src/jmri/jmrix/sprog/SprogSlot.java
+++ b/java/src/jmri/jmrix/sprog/SprogSlot.java
@@ -2,7 +2,7 @@ package jmri.jmrix.sprog;
 
 import java.util.Arrays;
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
+import jmri.SpeedStepMode;
 import jmri.NmraPacket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 public class SprogSlot {
 
     private boolean speedPacket = false;
-    private int speedMode = DccThrottle.SpeedStepMode128;
+    private SpeedStepMode speedMode = SpeedStepMode.SpeedStepMode128;
 
     public SprogSlot(int num) {
         payload = new byte[SprogConstants.MAX_PACKET_LENGTH];
@@ -109,7 +109,7 @@ public class SprogSlot {
         return speedPacket;
     }
 
-    public void setSpeed(int mode, int address, boolean isLongAddress, int speed, boolean forward) {
+    public void setSpeed(SpeedStepMode mode, int address, boolean isLongAddress, int speed, boolean forward) {
         addr = address;
         isLong = isLongAddress;
         spd = speed;
@@ -117,7 +117,7 @@ public class SprogSlot {
         this.speedMode = mode;
         this.f0to4Packet = false;
         this.forward = forward;
-        if ((mode & DccThrottle.SpeedStepMode28) != 0) {
+        if (mode == SpeedStepMode.SpeedStepMode28) {
             this.payload = jmri.NmraPacket.speedStep28Packet(true, addr,
                     isLong, spd, forward);
         } else {

--- a/java/src/jmri/jmrix/sprog/SprogSlot.java
+++ b/java/src/jmri/jmrix/sprog/SprogSlot.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 public class SprogSlot {
 
     private boolean speedPacket = false;
-    private SpeedStepMode speedMode = SpeedStepMode.SpeedStepMode128;
+    private SpeedStepMode speedMode = SpeedStepMode.NMRA_DCC_128;
 
     public SprogSlot(int num) {
         payload = new byte[SprogConstants.MAX_PACKET_LENGTH];
@@ -117,7 +117,7 @@ public class SprogSlot {
         this.speedMode = mode;
         this.f0to4Packet = false;
         this.forward = forward;
-        if (mode == SpeedStepMode.SpeedStepMode28) {
+        if (mode == SpeedStepMode.NMRA_DCC_28) {
             this.payload = jmri.NmraPacket.speedStep28Packet(true, addr,
                     isLong, spd, forward);
         } else {

--- a/java/src/jmri/jmrix/sprog/SprogThrottle.java
+++ b/java/src/jmri/jmrix/sprog/SprogThrottle.java
@@ -1,9 +1,9 @@
 package jmri.jmrix.sprog;
 
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,7 +129,7 @@ public class SprogThrottle extends AbstractThrottle {
      *             step mode in most cases
      */
     @Override
-    public void setSpeedStepMode(int Mode) {
+    public void setSpeedStepMode(SpeedStepMode Mode) {
         SprogMessage m;
         int mode = address.isLongAddress()
                 ? SprogConstants.LONG_ADD : 0;
@@ -143,14 +143,14 @@ public class SprogThrottle extends AbstractThrottle {
             log.debug("Speed Step Mode Change to Mode: " + Mode
                     + " Current mode is: " + this.speedStepMode);
         }
-        if (Mode == DccThrottle.SpeedStepMode14) {
+        if (Mode == SpeedStepMode.SpeedStepMode14) {
             mode += 0x200;
             speedIncrement = SPEED_STEP_14_INCREMENT;
-        } else if (Mode == DccThrottle.SpeedStepMode27) {
+        } else if (Mode == SpeedStepMode.SpeedStepMode27) {
             log.error("Requested Speed Step Mode 27 not supported Current mode is: "
                     + this.speedStepMode);
             return;
-        } else if (Mode == DccThrottle.SpeedStepMode28) {
+        } else if (Mode == SpeedStepMode.SpeedStepMode28) {
             mode += 0x400;
             speedIncrement = SPEED_STEP_28_INCREMENT;
         } else { // default to 128 speed step mode
@@ -159,7 +159,7 @@ public class SprogThrottle extends AbstractThrottle {
         }
         m = new SprogMessage("M h" + Integer.toHexString(mode));
         ((SprogSystemConnectionMemo)adapterMemo).getSprogTrafficController().sendSprogMessage(m, null);
-        if ((speedStepMode != Mode) && (Mode != DccThrottle.SpeedStepMode27)) {
+        if ((speedStepMode != Mode) && (Mode != SpeedStepMode.SpeedStepMode27)) {
             notifyPropertyChangeListener("SpeedSteps", this.speedStepMode,
                     this.speedStepMode = Mode);
         }
@@ -175,8 +175,8 @@ public class SprogThrottle extends AbstractThrottle {
      */
     @Override
     public void setSpeedSetting(float speed) {
-        int mode = getSpeedStepMode();
-        if ((mode & DccThrottle.SpeedStepMode28) != 0) {
+        SpeedStepMode mode = getSpeedStepMode();
+        if (mode == SpeedStepMode.SpeedStepMode28) {
             // 28 step mode speed commands are 
             // stop, estop, stop, estop, 4, 5, ..., 31
             float oldSpeed = this.speedSetting;

--- a/java/src/jmri/jmrix/sprog/SprogThrottle.java
+++ b/java/src/jmri/jmrix/sprog/SprogThrottle.java
@@ -145,17 +145,14 @@ public class SprogThrottle extends AbstractThrottle {
         }
         if (Mode == SpeedStepMode.NMRA_DCC_14) {
             mode += 0x200;
-            speedIncrement = SPEED_STEP_14_INCREMENT;
         } else if (Mode == SpeedStepMode.NMRA_DCC_27) {
             log.error("Requested Speed Step Mode 27 not supported Current mode is: "
                     + this.speedStepMode);
             return;
         } else if (Mode == SpeedStepMode.NMRA_DCC_28) {
             mode += 0x400;
-            speedIncrement = SPEED_STEP_28_INCREMENT;
         } else { // default to 128 speed step mode
             mode += 0x800;
-            speedIncrement = SPEED_STEP_128_INCREMENT;
         }
         m = new SprogMessage("M h" + Integer.toHexString(mode));
         ((SprogSystemConnectionMemo)adapterMemo).getSprogTrafficController().sendSprogMessage(m, null);

--- a/java/src/jmri/jmrix/sprog/SprogThrottle.java
+++ b/java/src/jmri/jmrix/sprog/SprogThrottle.java
@@ -143,14 +143,14 @@ public class SprogThrottle extends AbstractThrottle {
             log.debug("Speed Step Mode Change to Mode: " + Mode
                     + " Current mode is: " + this.speedStepMode);
         }
-        if (Mode == SpeedStepMode.SpeedStepMode14) {
+        if (Mode == SpeedStepMode.NMRA_DCC_14) {
             mode += 0x200;
             speedIncrement = SPEED_STEP_14_INCREMENT;
-        } else if (Mode == SpeedStepMode.SpeedStepMode27) {
+        } else if (Mode == SpeedStepMode.NMRA_DCC_27) {
             log.error("Requested Speed Step Mode 27 not supported Current mode is: "
                     + this.speedStepMode);
             return;
-        } else if (Mode == SpeedStepMode.SpeedStepMode28) {
+        } else if (Mode == SpeedStepMode.NMRA_DCC_28) {
             mode += 0x400;
             speedIncrement = SPEED_STEP_28_INCREMENT;
         } else { // default to 128 speed step mode
@@ -159,7 +159,7 @@ public class SprogThrottle extends AbstractThrottle {
         }
         m = new SprogMessage("M h" + Integer.toHexString(mode));
         ((SprogSystemConnectionMemo)adapterMemo).getSprogTrafficController().sendSprogMessage(m, null);
-        if ((speedStepMode != Mode) && (Mode != SpeedStepMode.SpeedStepMode27)) {
+        if ((speedStepMode != Mode) && (Mode != SpeedStepMode.NMRA_DCC_27)) {
             notifyPropertyChangeListener("SpeedSteps", this.speedStepMode,
                     this.speedStepMode = Mode);
         }
@@ -176,7 +176,7 @@ public class SprogThrottle extends AbstractThrottle {
     @Override
     public void setSpeedSetting(float speed) {
         SpeedStepMode mode = getSpeedStepMode();
-        if (mode == SpeedStepMode.SpeedStepMode28) {
+        if (mode == SpeedStepMode.NMRA_DCC_28) {
             // 28 step mode speed commands are 
             // stop, estop, stop, estop, 4, 5, ..., 31
             float oldSpeed = this.speedSetting;

--- a/java/src/jmri/jmrix/sprog/SprogThrottleManager.java
+++ b/java/src/jmri/jmrix/sprog/SprogThrottleManager.java
@@ -1,8 +1,9 @@
 package jmri.jmrix.sprog;
 
+import java.util.EnumSet;
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,8 +76,8 @@ public class SprogThrottleManager extends AbstractThrottleManager {
      * possible modes specified by the DccThrottle interface.
      */
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128 | DccThrottle.SpeedStepMode28);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
     }
 
     /**

--- a/java/src/jmri/jmrix/sprog/SprogThrottleManager.java
+++ b/java/src/jmri/jmrix/sprog/SprogThrottleManager.java
@@ -77,7 +77,7 @@ public class SprogThrottleManager extends AbstractThrottleManager {
      */
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128, SpeedStepMode.NMRA_DCC_28);
     }
 
     /**

--- a/java/src/jmri/jmrix/srcp/SRCPThrottle.java
+++ b/java/src/jmri/jmrix/srcp/SRCPThrottle.java
@@ -25,7 +25,7 @@ public class SRCPThrottle extends AbstractThrottle {
      */
     public SRCPThrottle(SRCPBusConnectionMemo memo, DccLocoAddress address) {
         // default to 128 speed steps with 28 functions and NMRA protocl.
-        this(memo, address, "N", SpeedStepMode.SpeedStepMode128, 28);
+        this(memo, address, "N", SpeedStepMode.NMRA_DCC_128, 28);
     }
 
     public SRCPThrottle(SRCPBusConnectionMemo memo, DccLocoAddress address,
@@ -213,16 +213,16 @@ public class SRCPThrottle extends AbstractThrottle {
     public void setSpeedStepMode(SpeedStepMode Mode) {
         super.setSpeedStepMode(Mode);
         switch (Mode) {
-            case SpeedStepMode14:
+            case NMRA_DCC_14:
                 maxsteps = 14;
                 break;
-            case SpeedStepMode27:
+            case NMRA_DCC_27:
                 maxsteps = 27;
                 break;
-            case SpeedStepMode28:
+            case NMRA_DCC_28:
                 maxsteps = 28;
                 break;
-            case SpeedStepMode128:
+            case NMRA_DCC_128:
             default:
                 maxsteps = 126;
         }

--- a/java/src/jmri/jmrix/srcp/SRCPThrottle.java
+++ b/java/src/jmri/jmrix/srcp/SRCPThrottle.java
@@ -77,7 +77,7 @@ public class SRCPThrottle extends AbstractThrottle {
                 + (address.getNumber())
                 + " " + protocol + " "
                 + (address.isLongAddress() ? " 2 " : " 1 ")
-                + maxsteps + " "
+                + speedStepMode.numSteps + " "
                 + functions + "\n";
         memo.getTrafficController()
                 .sendSRCPMessage(new SRCPMessage(msg), null);
@@ -155,7 +155,6 @@ public class SRCPThrottle extends AbstractThrottle {
 
     private DccLocoAddress address;
     private int bus;
-    private int maxsteps;
 
     /**
      * Send the complete status
@@ -168,9 +167,9 @@ public class SRCPThrottle extends AbstractThrottle {
 
         // direction and speed
         msg += (isForward ? " 1" : " 0");
-        msg += " " + ((int) (speedSetting * maxsteps));
+        msg += " " + ((int) (speedSetting * speedStepMode.numSteps));
         msg += " ";
-        msg += maxsteps;
+        msg += speedStepMode.numSteps;
 
         // now add the functions
         msg += f0 ? " 1" : " 0";
@@ -207,25 +206,6 @@ public class SRCPThrottle extends AbstractThrottle {
         SRCPMessage m = new SRCPMessage(msg + "\n");
 
         ((SRCPBusConnectionMemo) adapterMemo).getTrafficController().sendSRCPMessage(m, null);
-    }
-
-    @Override
-    public void setSpeedStepMode(SpeedStepMode Mode) {
-        super.setSpeedStepMode(Mode);
-        switch (Mode) {
-            case NMRA_DCC_14:
-                maxsteps = 14;
-                break;
-            case NMRA_DCC_27:
-                maxsteps = 27;
-                break;
-            case NMRA_DCC_28:
-                maxsteps = 28;
-                break;
-            case NMRA_DCC_128:
-            default:
-                maxsteps = 126;
-        }
     }
 
     @Override

--- a/java/src/jmri/jmrix/srcp/SRCPThrottle.java
+++ b/java/src/jmri/jmrix/srcp/SRCPThrottle.java
@@ -77,7 +77,7 @@ public class SRCPThrottle extends AbstractThrottle {
                 + (address.getNumber())
                 + " " + protocol + " "
                 + (address.isLongAddress() ? " 2 " : " 1 ")
-                + speedStepMode.numSteps + " "
+                + maxsteps + " "
                 + functions + "\n";
         memo.getTrafficController()
                 .sendSRCPMessage(new SRCPMessage(msg), null);
@@ -155,6 +155,7 @@ public class SRCPThrottle extends AbstractThrottle {
 
     private DccLocoAddress address;
     private int bus;
+    private int maxsteps;
 
     /**
      * Send the complete status
@@ -167,9 +168,9 @@ public class SRCPThrottle extends AbstractThrottle {
 
         // direction and speed
         msg += (isForward ? " 1" : " 0");
-        msg += " " + ((int) (speedSetting * speedStepMode.numSteps));
+        msg += " " + ((int) (speedSetting * maxsteps));
         msg += " ";
-        msg += speedStepMode.numSteps;
+        msg += maxsteps;
 
         // now add the functions
         msg += f0 ? " 1" : " 0";
@@ -206,6 +207,22 @@ public class SRCPThrottle extends AbstractThrottle {
         SRCPMessage m = new SRCPMessage(msg + "\n");
 
         ((SRCPBusConnectionMemo) adapterMemo).getTrafficController().sendSRCPMessage(m, null);
+    }
+
+    @Override	
+    public void setSpeedStepMode(SpeedStepMode Mode) {	
+        super.setSpeedStepMode(Mode);	
+        switch (Mode) {	
+            case NMRA_DCC_14:	
+            case NMRA_DCC_27:	
+            case NMRA_DCC_28:	
+            case NMRA_DCC_128:
+                maxsteps = Mode.numSteps;
+                break;	
+            default:	
+                maxsteps = 126;	
+                break;
+        }	
     }
 
     @Override

--- a/java/src/jmri/jmrix/srcp/SRCPThrottle.java
+++ b/java/src/jmri/jmrix/srcp/SRCPThrottle.java
@@ -3,6 +3,7 @@ package jmri.jmrix.srcp;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jmri.DccLocoAddress;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
 
 /**
@@ -24,11 +25,11 @@ public class SRCPThrottle extends AbstractThrottle {
      */
     public SRCPThrottle(SRCPBusConnectionMemo memo, DccLocoAddress address) {
         // default to 128 speed steps with 28 functions and NMRA protocl.
-        this(memo, address, "N", SpeedStepMode128, 28);
+        this(memo, address, "N", SpeedStepMode.SpeedStepMode128, 28);
     }
 
     public SRCPThrottle(SRCPBusConnectionMemo memo, DccLocoAddress address,
-            String protocol, int mode, int functions) {
+            String protocol, SpeedStepMode mode, int functions) {
         super(memo);
         if (!protocol.equals("N")) {
             throw new IllegalArgumentException("Protocol " + protocol + " not supported");
@@ -209,7 +210,7 @@ public class SRCPThrottle extends AbstractThrottle {
     }
 
     @Override
-    public void setSpeedStepMode(int Mode) {
+    public void setSpeedStepMode(SpeedStepMode Mode) {
         super.setSpeedStepMode(Mode);
         switch (Mode) {
             case SpeedStepMode14:

--- a/java/src/jmri/jmrix/srcp/SRCPThrottleManager.java
+++ b/java/src/jmri/jmrix/srcp/SRCPThrottleManager.java
@@ -1,8 +1,9 @@
 package jmri.jmrix.srcp;
 
+import java.util.EnumSet;
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,8 +82,8 @@ public class SRCPThrottleManager extends AbstractThrottleManager {
     }
 
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128 | DccThrottle.SpeedStepMode28);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/srcp/SRCPThrottleManager.java
+++ b/java/src/jmri/jmrix/srcp/SRCPThrottleManager.java
@@ -83,7 +83,8 @@ public class SRCPThrottleManager extends AbstractThrottleManager {
 
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.NMRA_DCC_128, SpeedStepMode.NMRA_DCC_28);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128, SpeedStepMode.NMRA_DCC_28,
+            SpeedStepMode.NMRA_DCC_27, SpeedStepMode.NMRA_DCC_14);
     }
 
     @Override

--- a/java/src/jmri/jmrix/srcp/SRCPThrottleManager.java
+++ b/java/src/jmri/jmrix/srcp/SRCPThrottleManager.java
@@ -83,7 +83,7 @@ public class SRCPThrottleManager extends AbstractThrottleManager {
 
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128, SpeedStepMode.NMRA_DCC_28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/tams/TamsThrottle.java
+++ b/java/src/jmri/jmrix/tams/TamsThrottle.java
@@ -39,7 +39,7 @@ public class TamsThrottle extends AbstractThrottle implements TamsListener {
 
     public TamsThrottle(TamsSystemConnectionMemo memo, DccLocoAddress address) {
         super(memo);
-        super.speedStepMode = SpeedStepMode128;
+        super.speedStepMode = jmri.SpeedStepMode.SpeedStepMode128;
         tc = memo.getTrafficController();
 
         // cache settings. It would be better to read the
@@ -259,7 +259,7 @@ public class TamsThrottle extends AbstractThrottle implements TamsListener {
             return 0.f;
         } else if (lSpeed == 1) {
             return -1.f;   // estop
-        } else if (super.speedStepMode == SpeedStepMode128) {
+        } else if (super.speedStepMode == jmri.SpeedStepMode.SpeedStepMode128) {
             return ((lSpeed - 1) / 126.f);
         } else {
             return (int) (lSpeed * 27.f + 0.5) + 1;

--- a/java/src/jmri/jmrix/tams/TamsThrottle.java
+++ b/java/src/jmri/jmrix/tams/TamsThrottle.java
@@ -39,7 +39,7 @@ public class TamsThrottle extends AbstractThrottle implements TamsListener {
 
     public TamsThrottle(TamsSystemConnectionMemo memo, DccLocoAddress address) {
         super(memo);
-        super.speedStepMode = jmri.SpeedStepMode.SpeedStepMode128;
+        super.speedStepMode = jmri.SpeedStepMode.NMRA_DCC_128;
         tc = memo.getTrafficController();
 
         // cache settings. It would be better to read the
@@ -259,7 +259,7 @@ public class TamsThrottle extends AbstractThrottle implements TamsListener {
             return 0.f;
         } else if (lSpeed == 1) {
             return -1.f;   // estop
-        } else if (super.speedStepMode == jmri.SpeedStepMode.SpeedStepMode128) {
+        } else if (super.speedStepMode == jmri.SpeedStepMode.NMRA_DCC_128) {
             return ((lSpeed - 1) / 126.f);
         } else {
             return (int) (lSpeed * 27.f + 0.5) + 1;

--- a/java/src/jmri/jmrix/tams/TamsThrottleManager.java
+++ b/java/src/jmri/jmrix/tams/TamsThrottleManager.java
@@ -108,7 +108,7 @@ public class TamsThrottleManager extends AbstractThrottleManager implements Tams
 
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128, SpeedStepMode.NMRA_DCC_28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/tams/TamsThrottleManager.java
+++ b/java/src/jmri/jmrix/tams/TamsThrottleManager.java
@@ -1,8 +1,9 @@
 package jmri.jmrix.tams;
 
+import java.util.EnumSet;
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,8 +107,8 @@ public class TamsThrottleManager extends AbstractThrottleManager implements Tams
     }
 
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128 | DccThrottle.SpeedStepMode28);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/tmcc/SerialThrottle.java
+++ b/java/src/jmri/jmrix/tmcc/SerialThrottle.java
@@ -3,6 +3,7 @@ package jmri.jmrix.tmcc;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jmri.DccLocoAddress;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
 
 /**
@@ -52,6 +53,8 @@ public class SerialThrottle extends AbstractThrottle {
         this.f21 = false;
         this.address = address;
         this.isForward = true;
+        this.speedStepMode = SpeedStepMode.SpeedStepModeTMCC32;
+        this.speedIncrement = SPEED_STEP_32_INCREMENT;
 
     }
 

--- a/java/src/jmri/jmrix/tmcc/SerialThrottle.java
+++ b/java/src/jmri/jmrix/tmcc/SerialThrottle.java
@@ -53,7 +53,7 @@ public class SerialThrottle extends AbstractThrottle {
         this.f21 = false;
         this.address = address;
         this.isForward = true;
-        this.speedStepMode = SpeedStepMode.SpeedStepModeTMCC32;
+        this.speedStepMode = SpeedStepMode.TMCC_32;
         this.speedIncrement = SPEED_STEP_32_INCREMENT;
 
     }

--- a/java/src/jmri/jmrix/tmcc/SerialThrottle.java
+++ b/java/src/jmri/jmrix/tmcc/SerialThrottle.java
@@ -288,8 +288,6 @@ public class SerialThrottle extends AbstractThrottle {
      */
     @Override
     public void setSpeedStepMode(jmri.SpeedStepMode Mode) {
-        // TODO(austin): figure out what this is supposed to do and fix it.
-        //speedStepMode = 32;
     }
 
     @Override

--- a/java/src/jmri/jmrix/tmcc/SerialThrottle.java
+++ b/java/src/jmri/jmrix/tmcc/SerialThrottle.java
@@ -287,8 +287,9 @@ public class SerialThrottle extends AbstractThrottle {
      * @param Mode ignored, as only 32 is valid
      */
     @Override
-    public void setSpeedStepMode(int Mode) {
-        speedStepMode = 32;
+    public void setSpeedStepMode(jmri.SpeedStepMode Mode) {
+        // TODO(austin): figure out what this is supposed to do and fix it.
+        //speedStepMode = 32;
     }
 
     @Override

--- a/java/src/jmri/jmrix/tmcc/SerialThrottle.java
+++ b/java/src/jmri/jmrix/tmcc/SerialThrottle.java
@@ -54,8 +54,6 @@ public class SerialThrottle extends AbstractThrottle {
         this.address = address;
         this.isForward = true;
         this.speedStepMode = SpeedStepMode.TMCC_32;
-        this.speedIncrement = SPEED_STEP_32_INCREMENT;
-
     }
 
     private DccLocoAddress address;

--- a/java/src/jmri/jmrix/tmcc/SerialThrottleManager.java
+++ b/java/src/jmri/jmrix/tmcc/SerialThrottleManager.java
@@ -1,7 +1,9 @@
 package jmri.jmrix.tmcc;
 
+import java.util.EnumSet;
 import jmri.DccLocoAddress;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,6 +65,15 @@ public class SerialThrottleManager extends AbstractThrottleManager {
     @Override
     public boolean addressTypeUnique() {
         return false;
+    }
+
+        /**
+     * What speed modes are supported by this system? value should be xor of
+     * possible modes specifed by the DccThrottle interface
+     */
+    @Override
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepModeTMCC32);
     }
 
     private final static Logger log = LoggerFactory.getLogger(SerialThrottleManager.class);

--- a/java/src/jmri/jmrix/tmcc/SerialThrottleManager.java
+++ b/java/src/jmri/jmrix/tmcc/SerialThrottleManager.java
@@ -73,7 +73,7 @@ public class SerialThrottleManager extends AbstractThrottleManager {
      */
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepModeTMCC32);
+        return EnumSet.of(SpeedStepMode.TMCC_32);
     }
 
     private final static Logger log = LoggerFactory.getLogger(SerialThrottleManager.class);

--- a/java/src/jmri/jmrix/xpa/XpaThrottle.java
+++ b/java/src/jmri/jmrix/xpa/XpaThrottle.java
@@ -27,7 +27,7 @@ public class XpaThrottle extends AbstractThrottle {
     public XpaThrottle(LocoAddress address, XpaTrafficController t) {
         super(null);
         this.address = address.getNumber();
-        this.speedStepMode = SpeedStepMode.NMRA_DCC_128;
+        this.speedStepMode = SpeedStepMode.INCREMENTAL;
         this.isForward = true;
         this.speedSetting = 0;
         this.f0 = false;

--- a/java/src/jmri/jmrix/xpa/XpaThrottle.java
+++ b/java/src/jmri/jmrix/xpa/XpaThrottle.java
@@ -2,6 +2,7 @@ package jmri.jmrix.xpa;
 
 import jmri.DccLocoAddress;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +27,7 @@ public class XpaThrottle extends AbstractThrottle {
     public XpaThrottle(LocoAddress address, XpaTrafficController t) {
         super(null);
         this.address = address.getNumber();
-        this.speedIncrement = 1;
+        this.speedStepMode = SpeedStepMode.NMRA_DCC_128;
         this.isForward = true;
         this.speedSetting = 0;
         this.f0 = false;

--- a/java/src/jmri/jmrix/xpa/XpaThrottleManager.java
+++ b/java/src/jmri/jmrix/xpa/XpaThrottleManager.java
@@ -1,7 +1,9 @@
 package jmri.jmrix.xpa;
 
+import java.util.EnumSet;
+
 import jmri.LocoAddress;
-import jmri.ThrottleManager;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 
 /**
@@ -79,4 +81,12 @@ public class XpaThrottleManager extends AbstractThrottleManager {
         return (num >= 100);
     }
 
+    /**
+     * What speed modes are supported by this system? value should be xor of
+     * possible modes specifed by the DccThrottle interface
+     */
+    @Override
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.INCREMENTAL);
+    }
 }

--- a/java/src/jmri/jmrix/zimo/Mx1Throttle.java
+++ b/java/src/jmri/jmrix/zimo/Mx1Throttle.java
@@ -28,7 +28,7 @@ public class Mx1Throttle extends AbstractThrottle implements Mx1Listener {
     public Mx1Throttle(Mx1SystemConnectionMemo memo, DccLocoAddress address) {
         super(memo);
         this.tc = memo.getMx1TrafficController();
-        super.speedStepMode = jmri.SpeedStepMode.SpeedStepMode128;
+        super.speedStepMode = jmri.SpeedStepMode.NMRA_DCC_128;
 
         // cache settings. It would be better to read the
         // actual state, but I don't know how to do this
@@ -204,7 +204,7 @@ public class Mx1Throttle extends AbstractThrottle implements Mx1Listener {
         int value = 0;
         int cData1 = (isForward ? 0x20 : 0x00);
         cData1 = cData1 + (f0 ? 0x10 : 0x00);
-        if (super.speedStepMode == jmri.SpeedStepMode.SpeedStepMode128) {
+        if (super.speedStepMode == jmri.SpeedStepMode.NMRA_DCC_128) {
             //m = Mx1Message.getSendSpeed128(addressLo, addressHi, value);
             value = (int) ((127 - 1) * speedSetting);     // -1 for rescale to avoid estop
             if (value > 0) {
@@ -218,7 +218,7 @@ public class Mx1Throttle extends AbstractThrottle implements Mx1Listener {
             }
             value = (value & 0x7F);
             cData1 = cData1 + 0xc;
-        } else if (super.speedStepMode == jmri.SpeedStepMode.SpeedStepMode28) {
+        } else if (super.speedStepMode == jmri.SpeedStepMode.NMRA_DCC_28) {
             value = (int) ((28) * speedSetting); // -1 for rescale to avoid estop
             if (value > 0) {
                 value = value + 3; // skip estop

--- a/java/src/jmri/jmrix/zimo/Mx1Throttle.java
+++ b/java/src/jmri/jmrix/zimo/Mx1Throttle.java
@@ -28,7 +28,7 @@ public class Mx1Throttle extends AbstractThrottle implements Mx1Listener {
     public Mx1Throttle(Mx1SystemConnectionMemo memo, DccLocoAddress address) {
         super(memo);
         this.tc = memo.getMx1TrafficController();
-        super.speedStepMode = SpeedStepMode128;
+        super.speedStepMode = jmri.SpeedStepMode.SpeedStepMode128;
 
         // cache settings. It would be better to read the
         // actual state, but I don't know how to do this
@@ -204,7 +204,7 @@ public class Mx1Throttle extends AbstractThrottle implements Mx1Listener {
         int value = 0;
         int cData1 = (isForward ? 0x20 : 0x00);
         cData1 = cData1 + (f0 ? 0x10 : 0x00);
-        if (super.speedStepMode == SpeedStepMode128) {
+        if (super.speedStepMode == jmri.SpeedStepMode.SpeedStepMode128) {
             //m = Mx1Message.getSendSpeed128(addressLo, addressHi, value);
             value = (int) ((127 - 1) * speedSetting);     // -1 for rescale to avoid estop
             if (value > 0) {
@@ -218,7 +218,7 @@ public class Mx1Throttle extends AbstractThrottle implements Mx1Listener {
             }
             value = (value & 0x7F);
             cData1 = cData1 + 0xc;
-        } else if (super.speedStepMode == SpeedStepMode28) {
+        } else if (super.speedStepMode == jmri.SpeedStepMode.SpeedStepMode28) {
             value = (int) ((28) * speedSetting); // -1 for rescale to avoid estop
             if (value > 0) {
                 value = value + 3; // skip estop

--- a/java/src/jmri/jmrix/zimo/Mx1ThrottleManager.java
+++ b/java/src/jmri/jmrix/zimo/Mx1ThrottleManager.java
@@ -72,7 +72,7 @@ public class Mx1ThrottleManager extends AbstractThrottleManager {
 
     @Override
     public EnumSet<SpeedStepMode> supportedSpeedModes() {
-        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
+        return EnumSet.of(SpeedStepMode.NMRA_DCC_128, SpeedStepMode.NMRA_DCC_28);
     }
 
     @Override

--- a/java/src/jmri/jmrix/zimo/Mx1ThrottleManager.java
+++ b/java/src/jmri/jmrix/zimo/Mx1ThrottleManager.java
@@ -1,8 +1,9 @@
 package jmri.jmrix.zimo;
 
+import java.util.EnumSet;
 import jmri.DccLocoAddress;
-import jmri.DccThrottle;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.AbstractThrottleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,8 +71,8 @@ public class Mx1ThrottleManager extends AbstractThrottleManager {
     }
 
     @Override
-    public int supportedSpeedModes() {
-        return (DccThrottle.SpeedStepMode128 | DccThrottle.SpeedStepMode28);
+    public EnumSet<SpeedStepMode> supportedSpeedModes() {
+        return EnumSet.of(SpeedStepMode.SpeedStepMode128, SpeedStepMode.SpeedStepMode28);
     }
 
     @Override

--- a/java/src/jmri/server/json/package-info.java
+++ b/java/src/jmri/server/json/package-info.java
@@ -147,7 +147,7 @@
  * Starting with 5.0.0, the JSON protocol version follows semantic version
  * rules, prior to that the version is just a major.minor version.
  * <dl>
- * <dt>5.1.0 (JMRI 4.17.2)</dt>
+ * <dt>6.0.0 (JMRI 4.17.3)</dt>
  * <dd>
  * <ul>
  * <li>Updates the throttle "speedSteps" field to a string so that it can 

--- a/java/src/jmri/server/json/package-info.java
+++ b/java/src/jmri/server/json/package-info.java
@@ -147,6 +147,13 @@
  * Starting with 5.0.0, the JSON protocol version follows semantic version
  * rules, prior to that the version is just a major.minor version.
  * <dl>
+ * <dt>5.1.0 (JMRI 4.17.2)</dt>
+ * <dd>
+ * <ul>
+ * <li>Updates the throttle "speedSteps" field to a string so that it can 
+ * represent the Motorola 28 speed step mode.</li>
+ * </ul>
+ * </dd>
  * <dt>5.0.0 (JMRI 4.15.4 with further changes in 4.15.6)</dt>
  * <dd>
  * <ul>

--- a/java/src/jmri/server/json/package-info.java
+++ b/java/src/jmri/server/json/package-info.java
@@ -147,13 +147,6 @@
  * Starting with 5.0.0, the JSON protocol version follows semantic version
  * rules, prior to that the version is just a major.minor version.
  * <dl>
- * <dt>6.0.0 (JMRI 4.17.3)</dt>
- * <dd>
- * <ul>
- * <li>Updates the throttle "speedSteps" field to a string so that it can 
- * represent the Motorola 28 speed step mode.</li>
- * </ul>
- * </dd>
  * <dt>5.0.0 (JMRI 4.15.4 with further changes in 4.15.6)</dt>
  * <dd>
  * <ul>

--- a/java/src/jmri/server/json/throttle/JsonThrottle.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottle.java
@@ -73,7 +73,7 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
      */
     public static final String CLIENTS = "clients"; // NOI18N
     private Throttle throttle;
-    private int speedSteps = 1;
+    private SpeedStepMode speedSteps = SpeedStepMode.SpeedStepMode128;
     private DccLocoAddress address = null;
     private static final Logger log = LoggerFactory.getLogger(JsonThrottle.class);
 
@@ -356,22 +356,7 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
         log.debug("Found throttle {}", throttle.getLocoAddress());
         this.throttle = throttle;
         throttle.addPropertyChangeListener(this);
-        switch (throttle.getSpeedStepMode()) {
-            case SpeedStepMode14:
-                this.speedSteps = 14;
-                break;
-            case SpeedStepMode27:
-                this.speedSteps = 27;
-                break;
-            case SpeedStepMode28:
-            case SpeedStepMode28Mot:
-                this.speedSteps = 28;
-                break;
-            case SpeedStepMode128:
-            default:
-                this.speedSteps = 126;
-                break;
-        }
+        this.speedSteps = throttle.getSpeedStepMode();
         this.sendStatus();
     }
 
@@ -465,7 +450,7 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
         data.put(Throttle.F26, this.throttle.getF26());
         data.put(Throttle.F27, this.throttle.getF27());
         data.put(Throttle.F28, this.throttle.getF28());
-        data.put(SPEED_STEPS, this.speedSteps);
+        data.put(SPEED_STEPS, this.speedSteps.name);
         data.put(CLIENTS, InstanceManager.getDefault(JsonThrottleManager.class).getServers(this).size());
         if (this.throttle.getRosterEntry() != null) {
             data.put(ROSTER_ENTRY, this.throttle.getRosterEntry().getId());

--- a/java/src/jmri/server/json/throttle/JsonThrottle.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottle.java
@@ -24,10 +24,8 @@ import jmri.DccLocoAddress;
 import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.LocoAddress;
-import jmri.SpeedStepMode;
 import jmri.Throttle;
 import jmri.ThrottleListener;
-import jmri.ThrottleManager;
 import jmri.jmrit.roster.Roster;
 import jmri.server.json.JSON;
 import jmri.server.json.JsonException;
@@ -73,7 +71,7 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
      */
     public static final String CLIENTS = "clients"; // NOI18N
     private Throttle throttle;
-    private SpeedStepMode speedSteps = SpeedStepMode.NMRA_DCC_128;
+    private int speedSteps = 1; // Number of speed steps.
     private DccLocoAddress address = null;
     private static final Logger log = LoggerFactory.getLogger(JsonThrottle.class);
 
@@ -356,7 +354,7 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
         log.debug("Found throttle {}", throttle.getLocoAddress());
         this.throttle = throttle;
         throttle.addPropertyChangeListener(this);
-        this.speedSteps = throttle.getSpeedStepMode();
+        this.speedSteps = throttle.getSpeedStepMode().numSteps;
         this.sendStatus();
     }
 
@@ -450,7 +448,7 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
         data.put(Throttle.F26, this.throttle.getF26());
         data.put(Throttle.F27, this.throttle.getF27());
         data.put(Throttle.F28, this.throttle.getF28());
-        data.put(SPEED_STEPS, this.speedSteps.name);
+        data.put(SPEED_STEPS, this.speedSteps);
         data.put(CLIENTS, InstanceManager.getDefault(JsonThrottleManager.class).getServers(this).size());
         if (this.throttle.getRosterEntry() != null) {
             data.put(ROSTER_ENTRY, this.throttle.getRosterEntry().getId());

--- a/java/src/jmri/server/json/throttle/JsonThrottle.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottle.java
@@ -73,7 +73,7 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
      */
     public static final String CLIENTS = "clients"; // NOI18N
     private Throttle throttle;
-    private SpeedStepMode speedSteps = SpeedStepMode.SpeedStepMode128;
+    private SpeedStepMode speedSteps = SpeedStepMode.NMRA_DCC_128;
     private DccLocoAddress address = null;
     private static final Logger log = LoggerFactory.getLogger(JsonThrottle.class);
 

--- a/java/src/jmri/server/json/throttle/JsonThrottle.java
+++ b/java/src/jmri/server/json/throttle/JsonThrottle.java
@@ -24,6 +24,7 @@ import jmri.DccLocoAddress;
 import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.Throttle;
 import jmri.ThrottleListener;
 import jmri.ThrottleManager;
@@ -356,17 +357,17 @@ public class JsonThrottle implements ThrottleListener, PropertyChangeListener {
         this.throttle = throttle;
         throttle.addPropertyChangeListener(this);
         switch (throttle.getSpeedStepMode()) {
-            case DccThrottle.SpeedStepMode14:
+            case SpeedStepMode14:
                 this.speedSteps = 14;
                 break;
-            case DccThrottle.SpeedStepMode27:
+            case SpeedStepMode27:
                 this.speedSteps = 27;
                 break;
-            case DccThrottle.SpeedStepMode28:
-            case DccThrottle.SpeedStepMode28Mot:
+            case SpeedStepMode28:
+            case SpeedStepMode28Mot:
                 this.speedSteps = 28;
                 break;
-            case DccThrottle.SpeedStepMode128:
+            case SpeedStepMode128:
             default:
                 this.speedSteps = 126;
                 break;

--- a/java/src/jmri/server/json/throttle/throttle-client.json
+++ b/java/src/jmri/server/json/throttle/throttle-client.json
@@ -141,7 +141,7 @@
 			"description": "true if function on; false otherwise"
 		},
 		"speedSteps": {
-			"type": "integer",
+			"type": "string",
 			"description": "Number of steps between idle and full throttle"
 		},
 		"clients": {

--- a/java/src/jmri/server/json/throttle/throttle-client.json
+++ b/java/src/jmri/server/json/throttle/throttle-client.json
@@ -141,7 +141,7 @@
 			"description": "true if function on; false otherwise"
 		},
 		"speedSteps": {
-			"type": "string",
+			"type": "integer",
 			"description": "Number of steps between idle and full throttle"
 		},
 		"clients": {

--- a/java/src/jmri/server/json/throttle/throttle-server.json
+++ b/java/src/jmri/server/json/throttle/throttle-server.json
@@ -137,7 +137,7 @@
 			"description": "true if function on; false otherwise"
 		},
 		"speedSteps": {
-			"type": "integer",
+			"type": "string",
 			"description": "Number of steps between idle and full throttle"
 		},
 		"clients": {

--- a/java/src/jmri/server/json/throttle/throttle-server.json
+++ b/java/src/jmri/server/json/throttle/throttle-server.json
@@ -137,7 +137,7 @@
 			"description": "true if function on; false otherwise"
 		},
 		"speedSteps": {
-			"type": "string",
+			"type": "integer",
 			"description": "Number of steps between idle and full throttle"
 		},
 		"clients": {

--- a/java/test/jmri/jmrit/withrottle/MultiThrottleControllerTest.java
+++ b/java/test/jmri/jmrit/withrottle/MultiThrottleControllerTest.java
@@ -150,11 +150,11 @@ public class MultiThrottleControllerTest {
     public void testSpeedStepsPropertyChange() {
        jmri.DccThrottle t = new jmri.jmrix.debugthrottle.DebugThrottle(new jmri.DccLocoAddress(1,false),null);
        controller.notifyThrottleFound(t);
-       t.setSpeedStepMode(jmri.DccThrottle.SpeedStepMode14);
+       t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode14);
        Assert.assertEquals("outgoing message after property change", "MAAtest<;>s8",cis.getLastPacket() );
-       t.setSpeedStepMode(jmri.DccThrottle.SpeedStepMode28);
+       t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode28);
        Assert.assertEquals("outgoing message after property change", "MAAtest<;>s2",cis.getLastPacket() );
-       t.setSpeedStepMode(jmri.DccThrottle.SpeedStepMode128);
+       t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
        Assert.assertEquals("outgoing message after property change", "MAAtest<;>s1",cis.getLastPacket() );
     }
 

--- a/java/test/jmri/jmrit/withrottle/MultiThrottleControllerTest.java
+++ b/java/test/jmri/jmrit/withrottle/MultiThrottleControllerTest.java
@@ -150,11 +150,11 @@ public class MultiThrottleControllerTest {
     public void testSpeedStepsPropertyChange() {
        jmri.DccThrottle t = new jmri.jmrix.debugthrottle.DebugThrottle(new jmri.DccLocoAddress(1,false),null);
        controller.notifyThrottleFound(t);
-       t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode14);
+       t.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_14);
        Assert.assertEquals("outgoing message after property change", "MAAtest<;>s8",cis.getLastPacket() );
-       t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode28);
+       t.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_28);
        Assert.assertEquals("outgoing message after property change", "MAAtest<;>s2",cis.getLastPacket() );
-       t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
+       t.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
        Assert.assertEquals("outgoing message after property change", "MAAtest<;>s1",cis.getLastPacket() );
     }
 

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -7,6 +7,7 @@ import jmri.BasicRosterEntry;
 import jmri.DccLocoAddress;
 import jmri.InstanceManager;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.ThrottleListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1412,8 +1413,7 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testSetSpeedStepMode() {
-        int Mode = 0;
-        instance.setSpeedStepMode(Mode);
+        instance.setSpeedStepMode(SpeedStepMode.SpeedStepMode128);
     }
 
     /**
@@ -1421,8 +1421,8 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testGetSpeedStepMode() {
-        int expResult = 0;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = null;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -767,7 +767,7 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testGetSpeedIncrement() {
-        float expResult = 1.0F;
+        float expResult = 0.0F;
         float result = instance.getSpeedIncrement();
         Assert.assertEquals(expResult, result, 0.0);
     }

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -767,7 +767,7 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testGetSpeedIncrement() {
-        float expResult = 0.0F;
+        float expResult = 1.0F;
         float result = instance.getSpeedIncrement();
         Assert.assertEquals(expResult, result, 0.0);
     }
@@ -1421,7 +1421,7 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = null;
+        SpeedStepMode expResult = SpeedStepMode.UNKNOWN;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/AbstractThrottleTest.java
+++ b/java/test/jmri/jmrix/AbstractThrottleTest.java
@@ -1413,7 +1413,7 @@ public class AbstractThrottleTest {
      */
     @Test
     public void testSetSpeedStepMode() {
-        instance.setSpeedStepMode(SpeedStepMode.SpeedStepMode128);
+        instance.setSpeedStepMode(SpeedStepMode.NMRA_DCC_128);
     }
 
     /**

--- a/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
@@ -4,6 +4,7 @@ import jmri.DccLocoAddress;
 import jmri.DccThrottle;
 import jmri.InstanceManager;
 import jmri.LocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.can.CanMessage;
 import jmri.jmrix.can.CanReply;
 import jmri.jmrix.can.CanSystemConnectionMemo;
@@ -184,8 +185,8 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
         
         Assert.assertEquals("speed setting",0.0f,cbtmb.getThrottleInfo(addr,"SpeedSetting"));
         Assert.assertEquals("speed increment",(1.0f/126.0f),cbtmb.getThrottleInfo(addr,"SpeedIncrement"));
-        Assert.assertEquals("speed step mode",CbusConstants.CBUS_SS_128,cbtmb.getThrottleInfo(addr,"SpeedStepMode"));
-        
+        Assert.assertEquals("speed step mode",SpeedStepMode.SpeedStepMode128,cbtmb.getThrottleInfo(addr,"SpeedStepMode"));
+
         CanReply r = new CanReply( new int[]{CbusConstants.CBUS_DSPD, 1, 0 },0x12 );
         cbtmb.reply(r);
         Assert.assertEquals("speed setting 0",0.0f,cbtmb.getThrottleInfo(addr,"SpeedSetting"));

--- a/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusThrottleManagerTest.java
@@ -185,7 +185,7 @@ public class CbusThrottleManagerTest extends jmri.managers.AbstractThrottleManag
         
         Assert.assertEquals("speed setting",0.0f,cbtmb.getThrottleInfo(addr,"SpeedSetting"));
         Assert.assertEquals("speed increment",(1.0f/126.0f),cbtmb.getThrottleInfo(addr,"SpeedIncrement"));
-        Assert.assertEquals("speed step mode",SpeedStepMode.SpeedStepMode128,cbtmb.getThrottleInfo(addr,"SpeedStepMode"));
+        Assert.assertEquals("speed step mode",SpeedStepMode.NMRA_DCC_128,cbtmb.getThrottleInfo(addr,"SpeedStepMode"));
 
         CanReply r = new CanReply( new int[]{CbusConstants.CBUS_DSPD, 1, 0 },0x12 );
         cbtmb.reply(r);

--- a/java/test/jmri/jmrix/can/cbus/CbusThrottleTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusThrottleTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.can.cbus;
 
 import jmri.DccLocoAddress;
+import jmri.SpeedStepMode;
 import jmri.jmrix.can.CanSystemConnectionMemo;
 import jmri.jmrix.can.TrafficControllerScaffold;
 import jmri.util.JUnitUtil;
@@ -29,6 +30,17 @@ public class CbusThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         float expResult = 1.0F/126.0F;
         float result = instance.getSpeedIncrement();
         Assert.assertEquals(expResult, result, 0.0);
+    }
+
+    /**
+     * Test of getSpeedStepMode method, of class AbstractThrottle.
+     */
+    @Override
+    @Test
+    public void testGetSpeedStepMode() {
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
+        SpeedStepMode result = instance.getSpeedStepMode();
+        Assert.assertEquals(expResult, result);
     }
 
     /**

--- a/java/test/jmri/jmrix/dccpp/DCCppThrottleTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppThrottleTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.dccpp;
 
+import jmri.SpeedStepMode;
 import jmri.util.JUnitUtil;
 import org.junit.Assert;
 import org.junit.After;
@@ -42,8 +43,8 @@ public class DCCppThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 1;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/java/test/jmri/jmrix/dccpp/DCCppThrottleTest.java
+++ b/java/test/jmri/jmrix/dccpp/DCCppThrottleTest.java
@@ -43,7 +43,7 @@ public class DCCppThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/debugthrottle/DebugThrottleTest.java
+++ b/java/test/jmri/jmrix/debugthrottle/DebugThrottleTest.java
@@ -46,7 +46,7 @@ public class DebugThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/debugthrottle/DebugThrottleTest.java
+++ b/java/test/jmri/jmrix/debugthrottle/DebugThrottleTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.debugthrottle;
 
+import jmri.SpeedStepMode;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -45,8 +46,8 @@ public class DebugThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 1;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/java/test/jmri/jmrix/easydcc/EasyDccThrottleTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccThrottleTest.java
@@ -42,6 +42,17 @@ public class EasyDccThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
+    
+    /**
+     * Test of getSpeedIncrement method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testGetSpeedIncrement() {
+        float expResult = SpeedStepMode.NMRA_DCC_128.increment;
+        float result = instance.getSpeedIncrement();
+        Assert.assertEquals(expResult, result, 0.0);
+    }
 
     /**
      * Test of setF0 method, of class AbstractThrottle.

--- a/java/test/jmri/jmrix/easydcc/EasyDccThrottleTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccThrottleTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.easydcc;
 
+import jmri.SpeedStepMode;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -37,8 +38,8 @@ public class EasyDccThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 1;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/java/test/jmri/jmrix/easydcc/EasyDccThrottleTest.java
+++ b/java/test/jmri/jmrix/easydcc/EasyDccThrottleTest.java
@@ -38,7 +38,7 @@ public class EasyDccThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/ecos/EcosDccThrottleTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosDccThrottleTest.java
@@ -39,6 +39,17 @@ public class EcosDccThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
+    
+    /**
+     * Test of getSpeedIncrement method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testGetSpeedIncrement() {
+        float expResult = SpeedStepMode.NMRA_DCC_128.increment;
+        float result = instance.getSpeedIncrement();
+        Assert.assertEquals(expResult, result, 0.0);
+    }
 
     /**
      * Test of setSpeedSetting method, of class AbstractThrottle.

--- a/java/test/jmri/jmrix/ecos/EcosDccThrottleTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosDccThrottleTest.java
@@ -35,7 +35,7 @@ public class EcosDccThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/ecos/EcosDccThrottleTest.java
+++ b/java/test/jmri/jmrix/ecos/EcosDccThrottleTest.java
@@ -1,6 +1,8 @@
 package jmri.jmrix.ecos;
 
 import java.awt.GraphicsEnvironment;
+
+import jmri.SpeedStepMode;
 import jmri.util.JUnitUtil;
 import jmri.util.junit.annotations.*;
 import org.junit.*;
@@ -33,8 +35,8 @@ public class EcosDccThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 1;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/java/test/jmri/jmrix/lenz/XNetMessageTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetMessageTest.java
@@ -842,7 +842,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetSpeedAndDirectionMsg(){
        // 128 speed step mode, forward direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode128,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0.5f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x13,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -851,7 +851,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x21,msg.getElement(5));
 
        // 128 speed step mode, reverse direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode128,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0.5f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x13,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -860,7 +860,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xA1,msg.getElement(5));
 
        // 128 speed step mode, forward direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode128,0f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x13,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -869,7 +869,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x61,msg.getElement(5));
 
        // 128 speed step mode, reverse direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode128,0f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x13,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -878,7 +878,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xE1,msg.getElement(5));
 
        // 28 speed step mode, forward direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode28,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0.5f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x12,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -887,7 +887,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x78,msg.getElement(5));
 
        // 28 speed step mode, reverse direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode28,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0.5f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x12,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -896,7 +896,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xF8,msg.getElement(5));
 
        // 28 speed step mode, forward direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode28,0f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x12,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -905,7 +905,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x60,msg.getElement(5));
 
        // 28 speed step mode, reverse direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode28,0f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x12,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -914,7 +914,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xE0,msg.getElement(5));
 
        // 27 speed step mode, forward direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode27,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0.5f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x11,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -923,7 +923,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x7B,msg.getElement(5));
 
        // 27 speed step mode, reverse direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode27,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0.5f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x11,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -932,7 +932,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xFB,msg.getElement(5));
 
        // 27 speed step mode, forward direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode27,0f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x11,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -941,7 +941,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x63,msg.getElement(5));
 
        // 27 speed step mode, reverse direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode27,0,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x11,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -950,7 +950,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xE3,msg.getElement(5));
 
        // 14 speed step mode, forward direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode14,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0.5f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x10,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -959,7 +959,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x6A,msg.getElement(5));
 
        // 14 speed step mode, reverse direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode14,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0.5f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x10,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -968,7 +968,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xEA,msg.getElement(5));
 
        // 14 speed step mode, forward direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode14,0f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x10,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -977,7 +977,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x62,msg.getElement(5));
 
        // 14 speed step mode, reverse direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode14,0f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x10,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -988,49 +988,49 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
 
     @Test
     public void testToMonitorStringSpeedAndDirectin128SpeedSteps(){
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode128,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0.5f,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 64 and direction Forward in 128 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode128,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0.5f,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 64 and direction Reverse in 128 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode128,0,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Forward in 128 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode128,0,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Reverse in 128 Speed Step Mode.",msg.toMonitorString());
     }
 
     @Test
     public void testToMonitorStringSpeedAndDirectin28SpeedSteps(){
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode28,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0.5f,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 14 and direction Forward in 28 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode28,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0.5f,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 14 and direction Reverse in 28 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode28,0,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Forward in 28 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode28,0,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Reverse in 28 Speed Step Mode.",msg.toMonitorString());
     }
 
     @Test
     public void testToMonitorStringSpeedAndDirectin27SpeedSteps(){
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode27,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0.5f,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 14 and direction Forward in 27 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode27,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0.5f,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 14 and direction Reverse in 27 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode27,0,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Forward in 27 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode27,0,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Reverse in 27 Speed Step Mode.",msg.toMonitorString());
     }
 
     @Test
     public void testToMonitorStringSpeedAndDirectin14SpeedSteps(){
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode14,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0.5f,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 8 and direction Forward in 14 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode14,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0.5f,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 8 and direction Reverse in 14 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode14,0,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Forward in 14 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.DccThrottle.SpeedStepMode14,0,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Reverse in 14 Speed Step Mode.",msg.toMonitorString());
     }
 

--- a/java/test/jmri/jmrix/lenz/XNetMessageTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetMessageTest.java
@@ -842,7 +842,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
     @Test
     public void testGetSpeedAndDirectionMsg(){
        // 128 speed step mode, forward direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_128,0.5f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x13,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -851,7 +851,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x21,msg.getElement(5));
 
        // 128 speed step mode, reverse direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_128,0.5f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x13,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -860,7 +860,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xA1,msg.getElement(5));
 
        // 128 speed step mode, forward direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_128,0f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x13,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -869,7 +869,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x61,msg.getElement(5));
 
        // 128 speed step mode, reverse direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_128,0f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x13,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -878,7 +878,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xE1,msg.getElement(5));
 
        // 28 speed step mode, forward direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_28,0.5f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x12,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -887,7 +887,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x78,msg.getElement(5));
 
        // 28 speed step mode, reverse direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_28,0.5f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x12,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -896,7 +896,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xF8,msg.getElement(5));
 
        // 28 speed step mode, forward direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_28,0f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x12,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -905,7 +905,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x60,msg.getElement(5));
 
        // 28 speed step mode, reverse direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_28,0f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x12,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -914,7 +914,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xE0,msg.getElement(5));
 
        // 27 speed step mode, forward direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_27,0.5f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x11,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -923,7 +923,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x7B,msg.getElement(5));
 
        // 27 speed step mode, reverse direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_27,0.5f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x11,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -932,7 +932,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xFB,msg.getElement(5));
 
        // 27 speed step mode, forward direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_27,0f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x11,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -941,7 +941,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x63,msg.getElement(5));
 
        // 27 speed step mode, reverse direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_27,0,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x11,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -950,7 +950,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xE3,msg.getElement(5));
 
        // 14 speed step mode, forward direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_14,0.5f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x10,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -959,7 +959,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x6A,msg.getElement(5));
 
        // 14 speed step mode, reverse direction.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_14,0.5f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x10,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -968,7 +968,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0xEA,msg.getElement(5));
 
        // 14 speed step mode, forward direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_14,0f,true);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x10,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -977,7 +977,7 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
        Assert.assertEquals(0x62,msg.getElement(5));
 
        // 14 speed step mode, reverse direction, speed 0.
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_14,0f,false);
        Assert.assertEquals(0xE4,msg.getElement(0));
        Assert.assertEquals(0x10,msg.getElement(1));
        Assert.assertEquals(0xC4,msg.getElement(2));
@@ -988,49 +988,49 @@ public class XNetMessageTest extends jmri.jmrix.AbstractMessageTestBase {
 
     @Test
     public void testToMonitorStringSpeedAndDirectin128SpeedSteps(){
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_128,0.5f,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 64 and direction Forward in 128 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_128,0.5f,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 64 and direction Reverse in 128 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_128,0,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Forward in 128 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode128,0,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_128,0,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Reverse in 128 Speed Step Mode.",msg.toMonitorString());
     }
 
     @Test
     public void testToMonitorStringSpeedAndDirectin28SpeedSteps(){
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_28,0.5f,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 14 and direction Forward in 28 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_28,0.5f,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 14 and direction Reverse in 28 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_28,0,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Forward in 28 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode28,0,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_28,0,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Reverse in 28 Speed Step Mode.",msg.toMonitorString());
     }
 
     @Test
     public void testToMonitorStringSpeedAndDirectin27SpeedSteps(){
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_27,0.5f,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 14 and direction Forward in 27 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_27,0.5f,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 14 and direction Reverse in 27 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_27,0,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Forward in 27 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode27,0,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_27,0,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Reverse in 27 Speed Step Mode.",msg.toMonitorString());
     }
 
     @Test
     public void testToMonitorStringSpeedAndDirectin14SpeedSteps(){
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0.5f,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_14,0.5f,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 8 and direction Forward in 14 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0.5f,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_14,0.5f,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 8 and direction Reverse in 14 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0,true);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_14,0,true);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Forward in 14 Speed Step Mode.",msg.toMonitorString());
-       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.SpeedStepMode14,0,false);
+       msg = XNetMessage.getSpeedAndDirectionMsg(1234,jmri.SpeedStepMode.NMRA_DCC_14,0,false);
        Assert.assertEquals("Monitor String","Mobile Decoder Operations Request: Set Address 1234 to Speed Step 0 and direction Reverse in 14 Speed Step Mode.",msg.toMonitorString());
     }
 

--- a/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.lenz;
 
 import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -97,7 +98,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // and verify all the data was set correctly.
 
         // getSpeedStepMode returns the right mode and
-        Assert.assertEquals("SpeedStepMode",jmri.DccThrottle.SpeedStepMode128,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode128,t.getSpeedStepMode());
         // get speedIncrement reports the correct value.
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_128_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
@@ -191,7 +192,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.DccThrottle.SpeedStepMode14,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode14,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_14_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
@@ -281,7 +282,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.DccThrottle.SpeedStepMode28,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode28,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_28_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
@@ -360,7 +361,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.DccThrottle.SpeedStepMode128,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode128,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_128_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
@@ -454,7 +455,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.DccThrottle.SpeedStepMode27,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode27,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_27_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
@@ -1086,7 +1087,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // in this case, we are sending a request to change the speed step mode.
 
-        t.setSpeedStepMode(jmri.DccThrottle.SpeedStepMode128);
+        t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
 
         while (n == tc.outbound.size()) {
         } // busy loop.  Wait for
@@ -1107,7 +1108,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.DccThrottle.SpeedStepMode128,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode128,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_128_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
         t.throttleDispose();
     }
@@ -1121,7 +1122,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // in this case, we are sending a request to change the speed step mode.
 
-        t.setSpeedStepMode(jmri.DccThrottle.SpeedStepMode28);
+        t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode28);
 
         while (n == tc.outbound.size()) {
         } // busy loop.  Wait for
@@ -1142,7 +1143,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.DccThrottle.SpeedStepMode28,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode28,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_28_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
         t.throttleDispose();
     }
@@ -1156,7 +1157,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // in this case, we are sending a request to change the speed step mode.
 
-        t.setSpeedStepMode(jmri.DccThrottle.SpeedStepMode27);
+        t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode27);
 
         while (n == tc.outbound.size()) {
         } // busy loop.  Wait for
@@ -1177,7 +1178,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.DccThrottle.SpeedStepMode27,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode27,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_27_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
         t.throttleDispose();
     }
@@ -1191,7 +1192,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // in this case, we are sending a request to change the speed step mode.
 
-        t.setSpeedStepMode(jmri.DccThrottle.SpeedStepMode14);
+        t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode14);
 
         while (n == tc.outbound.size()) {
         } // busy loop.  Wait for
@@ -1212,7 +1213,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.DccThrottle.SpeedStepMode14,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode14,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_14_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
         t.throttleDispose();
     }
@@ -1223,8 +1224,8 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 1;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
@@ -100,7 +100,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // getSpeedStepMode returns the right mode and
         Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_128,t.getSpeedStepMode());
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_128_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
+        Assert.assertEquals("SpeedStep Increment",(1.0f/126.0f),t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
         Assert.assertEquals("Speed 0.0",0.0,t.getSpeedSetting(),0.0);
@@ -193,7 +193,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
         Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_14,t.getSpeedStepMode());
-        Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_14_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
+        Assert.assertEquals("SpeedStep Increment",(1.0f/14.0f),t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
         Assert.assertEquals("Speed 0.0",0.0,t.getSpeedSetting(),0.0);
@@ -283,7 +283,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
         Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_28,t.getSpeedStepMode());
-        Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_28_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
+        Assert.assertEquals("SpeedStep Increment",(1.0f/28.0f),t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
         Assert.assertEquals("Speed 0.0",0.0,t.getSpeedSetting(),0.0);
@@ -362,7 +362,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
         Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_128,t.getSpeedStepMode());
-        Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_128_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
+        Assert.assertEquals("SpeedStep Increment",(1.0f/126.0f),t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
         Assert.assertEquals("Speed 0.0",0.0,t.getSpeedSetting(),0.0);
@@ -456,7 +456,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
         Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_27,t.getSpeedStepMode());
-        Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_27_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
+        Assert.assertEquals("SpeedStep Increment",(1.0f/27.0f),t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
         Assert.assertEquals("Speed 0.0",0.0,t.getSpeedSetting(),0.0);
@@ -1109,7 +1109,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
         Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_128,t.getSpeedStepMode());
-        Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_128_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
+        Assert.assertEquals("SpeedStep Increment",(1.0f/126.0f),t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
         t.throttleDispose();
     }
 
@@ -1144,7 +1144,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
         Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_28,t.getSpeedStepMode());
-        Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_28_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
+        Assert.assertEquals("SpeedStep Increment",(1.0f/28.0f),t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
         t.throttleDispose();
     }
 
@@ -1179,7 +1179,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
         Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_27,t.getSpeedStepMode());
-        Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_27_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
+        Assert.assertEquals("SpeedStep Increment",(1.0f/27.0f),t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
         t.throttleDispose();
     }
 
@@ -1214,7 +1214,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
         Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_14,t.getSpeedStepMode());
-        Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_14_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
+        Assert.assertEquals("SpeedStep Increment",(1.0f/14.0f),t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
         t.throttleDispose();
     }
 

--- a/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/XNetThrottleTest.java
@@ -98,7 +98,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         // and verify all the data was set correctly.
 
         // getSpeedStepMode returns the right mode and
-        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode128,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_128,t.getSpeedStepMode());
         // get speedIncrement reports the correct value.
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_128_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
@@ -192,7 +192,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode14,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_14,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_14_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
@@ -282,7 +282,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode28,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_28,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_28_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
@@ -361,7 +361,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode128,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_128,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_128_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
@@ -455,7 +455,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode27,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_27,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_27_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
 
         // test that the speed value is the expected value
@@ -1087,7 +1087,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // in this case, we are sending a request to change the speed step mode.
 
-        t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
+        t.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
 
         while (n == tc.outbound.size()) {
         } // busy loop.  Wait for
@@ -1108,7 +1108,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode128,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_128,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_128_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
         t.throttleDispose();
     }
@@ -1122,7 +1122,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // in this case, we are sending a request to change the speed step mode.
 
-        t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode28);
+        t.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_28);
 
         while (n == tc.outbound.size()) {
         } // busy loop.  Wait for
@@ -1143,7 +1143,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode28,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_28,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_28_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
         t.throttleDispose();
     }
@@ -1157,7 +1157,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // in this case, we are sending a request to change the speed step mode.
 
-        t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode27);
+        t.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_27);
 
         while (n == tc.outbound.size()) {
         } // busy loop.  Wait for
@@ -1178,7 +1178,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode27,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_27,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_27_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
         t.throttleDispose();
     }
@@ -1192,7 +1192,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // in this case, we are sending a request to change the speed step mode.
 
-        t.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode14);
+        t.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_14);
 
         while (n == tc.outbound.size()) {
         } // busy loop.  Wait for
@@ -1213,7 +1213,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
 
         // and finaly, verify that getSpeedStepMode returns the right mode and
         // get speedIncrement reports the correct value.
-        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.SpeedStepMode14,t.getSpeedStepMode());
+        Assert.assertEquals("SpeedStepMode",jmri.SpeedStepMode.NMRA_DCC_14,t.getSpeedStepMode());
         Assert.assertEquals("SpeedStep Increment",jmri.jmrix.AbstractThrottle.SPEED_STEP_14_INCREMENT,t.getSpeedIncrement(),0.0); // the speed increments are constants, so if there is deviation, that is an error.
         t.throttleDispose();
     }
@@ -1224,7 +1224,7 @@ public class XNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetThrottleTest.java
@@ -28,7 +28,7 @@ public class EliteXNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetThrottleTest.java
+++ b/java/test/jmri/jmrix/lenz/hornbyelite/EliteXNetThrottleTest.java
@@ -2,6 +2,7 @@ package jmri.jmrix.lenz.hornbyelite;
 
 import jmri.jmrix.lenz.XNetInterfaceScaffold;
 import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,8 +28,8 @@ public class EliteXNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 1;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/java/test/jmri/jmrix/loconet/Ib1ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib1ThrottleTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.loconet;
 
 import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 import org.junit.*;
 
 /**
@@ -33,8 +34,8 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 2;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode28;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 
@@ -56,7 +57,7 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void testGetSpeed_float() {
         // set speed step mode to 128.
-        instance.setSpeedStepMode(jmri.DccThrottle.SpeedStepMode128);
+        instance.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
         Assert.assertEquals("Full Speed", 127, ((LocoNetThrottle)instance).intSpeed(1.0F));
         float incre = 0.007874016f;
         float speed = incre;

--- a/java/test/jmri/jmrix/loconet/Ib1ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib1ThrottleTest.java
@@ -34,7 +34,7 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode28;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_28;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
@@ -57,7 +57,7 @@ public class Ib1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void testGetSpeed_float() {
         // set speed step mode to 128.
-        instance.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
+        instance.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
         Assert.assertEquals("Full Speed", 127, ((LocoNetThrottle)instance).intSpeed(1.0F));
         float incre = 0.007874016f;
         float speed = incre;

--- a/java/test/jmri/jmrix/loconet/Ib2ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib2ThrottleTest.java
@@ -34,7 +34,7 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode28;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_28;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
@@ -57,7 +57,7 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void testGetSpeed_float() {
         // set speed step mode to 128.
-        instance.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
+        instance.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
         Assert.assertEquals("Full Speed", 127, ((LocoNetThrottle)instance).intSpeed(1.0F));
         float incre = 0.007874016f;
         float speed = incre;

--- a/java/test/jmri/jmrix/loconet/Ib2ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Ib2ThrottleTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.loconet;
 
 import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 import org.junit.*;
 
 /**
@@ -33,8 +34,8 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 2;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode28;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 
@@ -56,7 +57,7 @@ public class Ib2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void testGetSpeed_float() {
         // set speed step mode to 128.
-        instance.setSpeedStepMode(jmri.DccThrottle.SpeedStepMode128);
+        instance.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
         Assert.assertEquals("Full Speed", 127, ((LocoNetThrottle)instance).intSpeed(1.0F));
         float incre = 0.007874016f;
         float speed = incre;

--- a/java/test/jmri/jmrix/loconet/LocoNetThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetThrottleTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.loconet;
 
 import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 import org.junit.*;
 
 public class LocoNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
@@ -105,8 +106,8 @@ public class LocoNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 2;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode28;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 
@@ -128,7 +129,7 @@ public class LocoNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void testGetSpeed_float() {
         // set speed step mode to 128.
-        instance.setSpeedStepMode(jmri.DccThrottle.SpeedStepMode128);
+        instance.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
         Assert.assertEquals("Full Speed", 127, ((LocoNetThrottle)instance).intSpeed(1.0F));
         float incre = 0.007874016f;
         float speed = incre;

--- a/java/test/jmri/jmrix/loconet/LocoNetThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/LocoNetThrottleTest.java
@@ -106,7 +106,7 @@ public class LocoNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode28;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_28;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
@@ -129,7 +129,7 @@ public class LocoNetThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void testGetSpeed_float() {
         // set speed step mode to 128.
-        instance.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode128);
+        instance.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_128);
         Assert.assertEquals("Full Speed", 127, ((LocoNetThrottle)instance).intSpeed(1.0F));
         float incre = 0.007874016f;
         float speed = incre;

--- a/java/test/jmri/jmrix/loconet/Pr2ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Pr2ThrottleTest.java
@@ -25,7 +25,7 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode28;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_28;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
@@ -48,7 +48,7 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void testGetSpeed_float() {
         // set speed step mode to 28 (PR2Throttle does not support 128?)
-        instance.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode28);
+        instance.setSpeedStepMode(jmri.SpeedStepMode.NMRA_DCC_28);
         Assert.assertEquals("Full Speed", 124, ((Pr2Throttle)instance).intSpeed(1.0F)); // 124 from class source
         float incre = 1.F/(112F-1F); // not clear where the -1 comes from
         float speed = incre;

--- a/java/test/jmri/jmrix/loconet/Pr2ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Pr2ThrottleTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.loconet;
 
 import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 import org.junit.*;
 
 /**
@@ -24,8 +25,8 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = jmri.DccThrottle.SpeedStepMode28;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode28;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 
@@ -47,7 +48,7 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     public void testGetSpeed_float() {
         // set speed step mode to 28 (PR2Throttle does not support 128?)
-        instance.setSpeedStepMode(jmri.DccThrottle.SpeedStepMode28);
+        instance.setSpeedStepMode(jmri.SpeedStepMode.SpeedStepMode28);
         Assert.assertEquals("Full Speed", 124, ((Pr2Throttle)instance).intSpeed(1.0F)); // 124 from class source
         float incre = 1.F/(112F-1F); // not clear where the -1 comes from
         float speed = incre;

--- a/java/test/jmri/jmrix/loconet/Pr2ThrottleTest.java
+++ b/java/test/jmri/jmrix/loconet/Pr2ThrottleTest.java
@@ -36,7 +36,7 @@ public class Pr2ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedIncrement() {
-        float expResult = 1.0F;
+        float expResult = SpeedStepMode.NMRA_DCC_28.increment;
         float result = instance.getSpeedIncrement();
         Assert.assertEquals(expResult, result, 0.0);
     }

--- a/java/test/jmri/jmrix/marklin/MarklinThrottleTest.java
+++ b/java/test/jmri/jmrix/marklin/MarklinThrottleTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.marklin;
 
 import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -45,8 +46,8 @@ public class MarklinThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 2; 
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode28;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/java/test/jmri/jmrix/marklin/MarklinThrottleTest.java
+++ b/java/test/jmri/jmrix/marklin/MarklinThrottleTest.java
@@ -46,7 +46,7 @@ public class MarklinThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode28;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_28;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/mrc/MrcThrottleTest.java
+++ b/java/test/jmri/jmrix/mrc/MrcThrottleTest.java
@@ -35,7 +35,7 @@ public class MrcThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/mrc/MrcThrottleTest.java
+++ b/java/test/jmri/jmrix/mrc/MrcThrottleTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.mrc;
 
 import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,8 +35,8 @@ public class MrcThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 1;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/java/test/jmri/jmrix/mrc/MrcThrottleTest.java
+++ b/java/test/jmri/jmrix/mrc/MrcThrottleTest.java
@@ -39,6 +39,17 @@ public class MrcThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
+    
+    /**
+     * Test of getSpeedIncrement method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testGetSpeedIncrement() {
+        float expResult = SpeedStepMode.NMRA_DCC_128.increment;
+        float result = instance.getSpeedIncrement();
+        Assert.assertEquals(expResult, result, 0.0);
+    }
 
     /**
      * Test of setF0 method, of class AbstractThrottle.

--- a/java/test/jmri/jmrix/nce/NceThrottleTest.java
+++ b/java/test/jmri/jmrix/nce/NceThrottleTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.nce;
 
 import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -48,8 +49,8 @@ public class NceThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 1;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/java/test/jmri/jmrix/nce/NceThrottleTest.java
+++ b/java/test/jmri/jmrix/nce/NceThrottleTest.java
@@ -49,7 +49,7 @@ public class NceThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/srcp/SRCPThrottleTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPThrottleTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.srcp;
 
 import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -48,8 +49,8 @@ public class SRCPThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 1;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/java/test/jmri/jmrix/srcp/SRCPThrottleTest.java
+++ b/java/test/jmri/jmrix/srcp/SRCPThrottleTest.java
@@ -49,7 +49,7 @@ public class SRCPThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/tams/TamsThrottleTest.java
+++ b/java/test/jmri/jmrix/tams/TamsThrottleTest.java
@@ -35,7 +35,7 @@ public class TamsThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/tams/TamsThrottleTest.java
+++ b/java/test/jmri/jmrix/tams/TamsThrottleTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.tams;
 
 import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,8 +35,8 @@ public class TamsThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 1;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/java/test/jmri/jmrix/tams/TamsThrottleTest.java
+++ b/java/test/jmri/jmrix/tams/TamsThrottleTest.java
@@ -39,6 +39,17 @@ public class TamsThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
+    
+    /**
+     * Test of getSpeedIncrement method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testGetSpeedIncrement() {
+        float expResult = SpeedStepMode.NMRA_DCC_128.increment;
+        float result = instance.getSpeedIncrement();
+        Assert.assertEquals(expResult, result, 0.0);
+    }
 
     /**
      * Test of setF0 method, of class AbstractThrottle.

--- a/java/test/jmri/jmrix/tmcc/SerialThrottleTest.java
+++ b/java/test/jmri/jmrix/tmcc/SerialThrottleTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.tmcc;
 
+import jmri.SpeedStepMode;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -26,6 +27,28 @@ public class SerialThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         boolean expResult = true;
         boolean result = instance.getIsForward();
         Assert.assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of getSpeedStepMode method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testGetSpeedStepMode() {
+        SpeedStepMode expResult = SpeedStepMode.TMCC_32;
+        SpeedStepMode result = instance.getSpeedStepMode();
+        Assert.assertEquals(expResult, result);
+    }
+    
+    /**
+     * Test of getSpeedIncrement method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testGetSpeedIncrement() {
+        float expResult = SpeedStepMode.TMCC_32.increment;
+        float result = instance.getSpeedIncrement();
+        Assert.assertEquals(expResult, result, 0.0);
     }
 
     /**

--- a/java/test/jmri/jmrix/xpa/XpaThrottleTest.java
+++ b/java/test/jmri/jmrix/xpa/XpaThrottleTest.java
@@ -1,5 +1,6 @@
 package jmri.jmrix.xpa;
 
+import jmri.SpeedStepMode;
 import jmri.util.JUnitUtil;
 import org.junit.Assert;
 import org.junit.After;
@@ -27,11 +28,21 @@ public class XpaThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     @Test
     public void testGetSpeedIncrement() {
-        float expResult = 1.0F;
+        float expResult = 1.0F / 126.0f;
         float result = instance.getSpeedIncrement();
         Assert.assertEquals(expResult, result, 0.0);
     }
 
+    /**
+     * Test of getSpeedStepMode method, of class AbstractThrottle.
+     */
+    @Override
+    @Test
+    public void testGetSpeedStepMode() {
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
+        SpeedStepMode result = instance.getSpeedStepMode();
+        Assert.assertEquals(expResult, result);
+    }
     /**
      * Test of getIsForward method, of class AbstractThrottle.
      */

--- a/java/test/jmri/jmrix/xpa/XpaThrottleTest.java
+++ b/java/test/jmri/jmrix/xpa/XpaThrottleTest.java
@@ -28,7 +28,7 @@ public class XpaThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     @Test
     public void testGetSpeedIncrement() {
-        float expResult = 1.0F / 126.0f;
+        float expResult = 1.0F;
         float result = instance.getSpeedIncrement();
         Assert.assertEquals(expResult, result, 0.0);
     }
@@ -39,7 +39,7 @@ public class XpaThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Override
     @Test
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
+        SpeedStepMode expResult = SpeedStepMode.INCREMENTAL;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/zimo/Mx1ThrottleTest.java
+++ b/java/test/jmri/jmrix/zimo/Mx1ThrottleTest.java
@@ -37,7 +37,7 @@ public class Mx1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode expResult = SpeedStepMode.NMRA_DCC_128;
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }

--- a/java/test/jmri/jmrix/zimo/Mx1ThrottleTest.java
+++ b/java/test/jmri/jmrix/zimo/Mx1ThrottleTest.java
@@ -41,6 +41,17 @@ public class Mx1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
         SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
+    
+    /**
+     * Test of getSpeedIncrement method, of class AbstractThrottle.
+     */
+    @Test
+    @Override
+    public void testGetSpeedIncrement() {
+        float expResult = SpeedStepMode.NMRA_DCC_128.increment;
+        float result = instance.getSpeedIncrement();
+        Assert.assertEquals(expResult, result, 0.0);
+    }
 
     /**
      * Test of setF0 method, of class AbstractThrottle.

--- a/java/test/jmri/jmrix/zimo/Mx1ThrottleTest.java
+++ b/java/test/jmri/jmrix/zimo/Mx1ThrottleTest.java
@@ -1,6 +1,7 @@
 package jmri.jmrix.zimo;
 
 import jmri.util.JUnitUtil;
+import jmri.SpeedStepMode;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,8 +37,8 @@ public class Mx1ThrottleTest extends jmri.jmrix.AbstractThrottleTest {
     @Test
     @Override
     public void testGetSpeedStepMode() {
-        int expResult = 1;
-        int result = instance.getSpeedStepMode();
+        SpeedStepMode expResult = SpeedStepMode.SpeedStepMode128;
+        SpeedStepMode result = instance.getSpeedStepMode();
         Assert.assertEquals(expResult, result);
     }
 

--- a/jython/AutoDispatcher2.py
+++ b/jython/AutoDispatcher2.py
@@ -4955,11 +4955,11 @@ class ADlocomotive :
                   + self.name + " (" + str(self.address) + ")")
                 self.leadThrottle = self.throttle
             speedStepMode = self.throttle.getSpeedStepMode()
-            if speedStepMode == SpeedStepMode.SpeedStepMode128 :
+            if speedStepMode == SpeedStepMode.NMRA_DCC_128 :
                 self.stepsNumber = 126.
-            elif speedStepMode == SpeedStepMode.SpeedStepMode28 :
+            elif speedStepMode == SpeedStepMode.NMRA_DCC_28 :
                 self.stepsNumber = 28.
-            elif speedStepMode == SpeedStepMode.SpeedStepMode27 :
+            elif speedStepMode == SpeedStepMode.NMRA_DCC_27 :
                 self.stepsNumber = 27.
             else :
                 self.stepsNumber = 14.

--- a/jython/AutoDispatcher2.py
+++ b/jython/AutoDispatcher2.py
@@ -4955,11 +4955,11 @@ class ADlocomotive :
                   + self.name + " (" + str(self.address) + ")")
                 self.leadThrottle = self.throttle
             speedStepMode = self.throttle.getSpeedStepMode()
-            if speedStepMode == DccThrottle.SpeedStepMode128 :
+            if speedStepMode == SpeedStepMode.SpeedStepMode128 :
                 self.stepsNumber = 126.
-            elif speedStepMode == DccThrottle.SpeedStepMode28 :
+            elif speedStepMode == SpeedStepMode.SpeedStepMode28 :
                 self.stepsNumber = 28.
-            elif speedStepMode == DccThrottle.SpeedStepMode27 :
+            elif speedStepMode == SpeedStepMode.SpeedStepMode27 :
                 self.stepsNumber = 27.
             else :
                 self.stepsNumber = 14.


### PR DESCRIPTION
As preparation for adding the speed step mode to the roster and decoder entries, I've replaced with it an enum that has a consistent and human-readable string representation.

There are a few places where I was uncertain how to make the necessary updates; particularly where the speed step mode is passed through the vent notification system.

I also discovered that the SerialThrottle uses a speed step mode of `32`, which I didn't see anywhere else in JMRI and which doesn't really seem to mean anything. I wasn't sure how to update that.

JMRI-developers thread: https://jmri-developers.groups.io/g/jmri/topic/dynamically_setting_speed/32312582