### PR TITLE
Let validation handle create button state

### DIFF
--- a/java/src/jmri/jmrit/beantable/ReporterTableAction.java
+++ b/java/src/jmri/jmrit/beantable/ReporterTableAction.java
@@ -334,7 +334,6 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
         }
         hardwareAddressTextField.setName("sysName"); // for GUI test NOI18N
         hardwareAddressTextField.setName("hwAddressTextField"); // for GUI test NOI18N
-        addButton.setEnabled(false); // start as disabled (false) until a valid entry is typed in
         addButton.setName("createButton"); // for GUI test NOI18N
         // reset statusBarLabel text
         statusBarLabel.setText(Bundle.getMessage("HardwareAddStatusEnter"));
@@ -478,7 +477,6 @@ public class ReporterTableAction extends AbstractTableAction<Reporter> {
                         addEntryToolTip));
         hardwareAddressValidator.setToolTipText(hardwareAddressTextField.getToolTipText());
         hardwareAddressValidator.verify(hardwareAddressTextField);
-        addButton.setEnabled(true); // ambiguous, so start enabled
     }
 
     void handleCreateException(String sysName) {

--- a/java/src/jmri/jmrit/beantable/SensorTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SensorTableAction.java
@@ -158,7 +158,6 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
             canAddRange(null);
         }
         hardwareAddressTextField.setName("hwAddressTextField"); // for GUI test NOI18N
-        addButton.setEnabled(false); // start as disabled (false) until a valid entry is typed in
         addButton.setName("createButton"); // for GUI test NOI18N
         // reset statusBarLabel text
         statusBarLabel.setText(Bundle.getMessage("HardwareAddStatusEnter"));
@@ -312,7 +311,6 @@ public class SensorTableAction extends AbstractTableAction<Sensor> {
                         addEntryToolTip));
         hardwareAddressValidator.setToolTipText(hardwareAddressTextField.getToolTipText());
         hardwareAddressValidator.verify(hardwareAddressTextField);
-        addButton.setEnabled(true); // ambiguous, so start enabled
     }
 
     void handleCreateException(String hwAddress) {

--- a/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
+++ b/java/src/jmri/jmrit/beantable/TurnoutTableAction.java
@@ -1092,7 +1092,6 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
             // tooltip for hardwareAddressTextField will be assigned next by canAddRange()
             canAddRange(null);
         }
-        addButton.setEnabled(false); // start as disabled (false) until a valid entry is typed in
         hardwareAddressTextField.setName("hwAddressTextField"); // for GUI test NOI18N
         addButton.setName("createButton"); // for GUI test NOI18N
         // reset statusBarLabel text
@@ -1697,9 +1696,9 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
         // Add some entry pattern checking, before assembling sName and handing it to the TurnoutManager
         String statusMessage = Bundle.getMessage("ItemCreateFeedback", Bundle.getMessage("BeanNameTurnout"));
         String errorMessage = null;
-        
+
         String lastSuccessfulAddress;
-        
+
         int iType = 0;
         int iNum = 1;
         boolean useLastBit = false;
@@ -1798,7 +1797,7 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
                         t.setUserName(uName);
                     } else if (!pref.getPreferenceState(getClassName(), "duplicateUserName")) {
                         InstanceManager.getDefault(jmri.UserPreferencesManager.class).
-                                showErrorMessage(Bundle.getMessage("ErrorTitle"), 
+                                showErrorMessage(Bundle.getMessage("ErrorTitle"),
                                         Bundle.getMessage("ErrorDuplicateUserName", uName),
                                         getClassName(), "duplicateUserName", false, true);
                     }
@@ -1877,7 +1876,6 @@ public class TurnoutTableAction extends AbstractTableAction<Turnout> {
                         addEntryToolTip));
         hardwareAddressValidator.setToolTipText(hardwareAddressTextField.getToolTipText());
         hardwareAddressValidator.verify(hardwareAddressTextField);
-        addButton.setEnabled(true); // ambiguous, so start enabled
     }
 
     void handleCreateException(Exception ex, String sysName) {


### PR DESCRIPTION
The existing Create button enable state does not match the validation state for two situations.
- The first time **Add** is selected, the **Create** button is enabled but the validation state shows a warning due to an empty system name.
- For subsequent adds, the Create button is disabled even though the previous content is in the system name field and validation shows success.  This scenario is frequently used when creating a series of system names, such as LCC system names where a hex character is being incremented.  The only way to get the Create button changed is to erase the content and re-enter it.

These problems are eliminated by removing the existing Create button state logic and letting validation handle the Create button enabled state.

The Light table is not included since its logic is quite different and behaves properly.