### PR TITLE
fix: render NamedBeans properly in editor

### DIFF
--- a/java/src/jmri/swing/NamedBeanComboBox.java
+++ b/java/src/jmri/swing/NamedBeanComboBox.java
@@ -21,6 +21,8 @@ import javax.swing.text.JTextComponent;
 import com.alexandriasoftware.swing.JInputValidatorPreferences;
 import com.alexandriasoftware.swing.JInputValidator;
 import com.alexandriasoftware.swing.Validation;
+import java.awt.event.ActionListener;
+import javax.swing.ComboBoxEditor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,6 +65,13 @@ import jmri.util.ThreadingPropertyChangeListener;
  * context.", but a better tool tip (example for Signal Heads when creating a
  * Signal Mast) may be "Signal Heads not shown are assigned to another Signal
  * Mast."
+ * <p>
+ * To change the tool tip text shown when an existing bean is not selected, this
+ * class should be subclassed and the methods {@link #getBeanInUseMessage(java.lang.String, java.lang.String)},
+ * {@link #getInvalidNameFormatMessage(java.lang.String, java.lang.String, java.lang.String)},
+ * {@link #getNoMatchingBeanMessage(java.lang.String, java.lang.String)}, and
+ * {@link #getWillCreateBeanMessage(java.lang.String, java.lang.String)} should
+ * be overridden.
  *
  * @param <B> the supported type of NamedBean
  */
@@ -73,10 +82,6 @@ public class NamedBeanComboBox<B extends NamedBean> extends JComboBox<B> {
     private boolean allowNull = false;
     private boolean providing = true;
     private boolean validatingInput = true;
-    private String beanInUse = "NamedBeanComboBoxBeanInUse";
-    private String invalidNameFormat = "NamedBeanComboBoxInvalidNameFormat";
-    private String noMatchingBean = "NamedBeanComboBoxNoMatchingBean";
-    private String willCreateBean = "NamedBeanComboBoxWillCreateBean";
     private final Set<B> excludedItems = new HashSet<>();
     private final PropertyChangeListener managerListener = ThreadingPropertyChangeListener.guiListener(evt -> sort());
     private final static Logger log = LoggerFactory.getLogger(NamedBeanComboBox.class);
@@ -115,55 +120,14 @@ public class NamedBeanComboBox<B extends NamedBean> extends JComboBox<B> {
     public NamedBeanComboBox(Manager<B> manager, B selection, DisplayOptions displayOrder) {
         super();
         this.manager = manager;
-        setToolTipText(Bundle.getMessage("NamedBeanComboBoxDefaultToolTipText", this.manager.getBeanTypeHandled(true)));
+        super.setToolTipText(Bundle.getMessage("NamedBeanComboBoxDefaultToolTipText", this.manager.getBeanTypeHandled(true)));
         setDisplayOrder(displayOrder);
         NamedBeanComboBox.this.setEditable(false); // prevent overriding method call in constructor
         NamedBeanRenderer namedBeanRenderer = new NamedBeanRenderer(getRenderer());
         setRenderer(namedBeanRenderer);
         setKeySelectionManager(namedBeanRenderer);
-        Component ec = getEditor().getEditorComponent();
-        if (ec instanceof JComponent) {
-            JComponent jc = (JComponent) ec;
-            jc.setInputVerifier(new JInputValidator(jc, true, false) {
-                @Override
-                protected Validation getValidation(JComponent component, JInputValidatorPreferences preferences) {
-                    if (component instanceof JTextComponent) {
-                        JTextComponent jtc = (JTextComponent) component;
-                        String text = jtc.getText();
-                        if (text != null && !text.isEmpty()) {
-                            B bean = manager.getNamedBean(text);
-                            if (bean != null) {
-                                setSelectedItem(bean); // won't change if bean is not in model
-                                if (!bean.equals(getSelectedItem())) {
-                                    jtc.setText(text);
-                                    if (validatingInput) {
-                                        return new Validation(Validation.Type.DANGER, Bundle.getMessage(beanInUse,
-                                                manager.getBeanTypeHandled(), bean.getDisplayName(DisplayOptions.QUOTED_DISPLAYNAME)));
-                                    }
-                                }
-                            } else {
-                                if (validatingInput) {
-                                    if (providing) {
-                                        try {
-                                            manager.validateSystemNameFormat(text); // ignore output, we only want to catch exceptions
-                                        } catch (IllegalArgumentException ex) {
-                                            return new Validation(Validation.Type.DANGER,
-                                                    Bundle.getMessage(invalidNameFormat, manager.getBeanTypeHandled(), text, ex.getLocalizedMessage()), preferences);
-                                        }
-                                        return new Validation(Validation.Type.INFORMATION,
-                                                Bundle.getMessage(willCreateBean, manager.getBeanTypeHandled(), text), preferences);
-                                    } else {
-                                        return new Validation(Validation.Type.WARNING,
-                                                Bundle.getMessage(noMatchingBean, manager.getBeanTypeHandled(), text), preferences);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    return getNoneValidation();
-                }
-            });
-        }
+        NamedBeanEditor namedBeanEditor = new NamedBeanEditor(getEditor());
+        setEditor(namedBeanEditor);
         this.manager.addPropertyChangeListener("beans", managerListener);
         this.manager.addPropertyChangeListener("DisplayListName", managerListener);
         sort();
@@ -365,48 +329,63 @@ public class NamedBeanComboBox<B extends NamedBean> extends JComboBox<B> {
     }
 
     /**
-     * Set the translation key to be used when a typed in bean name matches a
-     * named bean has been included in a call to
+     * Get the localized message to display in a tooltip when a typed in bean
+     * name matches a named bean has been included in a call to
      * {@link #setExcludedItems(java.util.Set)} and {@link #isValidatingInput()}
      * is {@code true}.
      *
-     * @param beanInUseKey a translatable bundle key where {@code {0}} is the
-     *                     result of {@link jmri.Manager#getBeanTypeHandled()}
-     *                     and {1} is the result of
-     *                     {@link jmri.NamedBean#getDisplayName(DisplayOptions)}
-     *                     with {@link DisplayOptions#QUOTED_DISPLAYNAME} for
-     *                     the matching bean
+     * @param beanType    the type of bean as provided by
+     *                    {@link Manager#getBeanTypeHandled()}
+     * @param displayName the bean name as provided by
+     *                    {@link NamedBean#getDisplayName(jmri.NamedBean.DisplayOptions)}
+     *                    with the options in {@link #getDisplayOrder()}
+     * @return the localized message
      */
-    public void setNoMatchingToolTipBeanInUse(String beanInUseKey) {
-        beanInUse = beanInUseKey;
+    public String getBeanInUseMessage(String beanType, String displayName) {
+        return Bundle.getMessage("NamedBeanComboBoxBeanInUse", beanType, displayName);
     }
 
     /**
-     * Set the translation key to be used when a typed in bean name does not
+     * Get the localized message to display in a tooltip when a typed in bean
+     * name is not a valid name format for creating a bean.
+     *
+     * @param beanType  the type of bean as provided by
+     *                  {@link Manager#getBeanTypeHandled()}
+     * @param text      the typed in name
+     * @param exception the localized message text from the exception thrown by
+     *                  {@link Manager#validateSystemNameFormat(java.lang.String, java.util.Locale)}
+     * @return the localized message
+     */
+    public String getInvalidNameFormatMessage(String beanType, String text, String exception) {
+        return Bundle.getMessage("NamedBeanComboBoxInvalidNameFormat", beanType, text, exception);
+    }
+
+    /**
+     * Get the localized message to display when a typed in bean name does not
      * match a named bean, {@link #isValidatingInput()} is {@code true} and
      * {@link #isProviding()} is {@code false}.
      *
-     * @param noMatchingBeanKey a translatable bundle key where {@code {0}} is
-     *                          the result of
-     *                          {@link jmri.Manager#getBeanTypeHandled()} and
-     *                          {1} is the typed input
+     * @param beanType the type of bean as provided by
+     *                 {@link Manager#getBeanTypeHandled()}
+     * @param text     the typed in name
+     * @return the localized message
      */
-    public void setNoMatchingToolTipNoMatchingBean(String noMatchingBeanKey) {
-        noMatchingBean = noMatchingBeanKey;
+    public String getNoMatchingBeanMessage(String beanType, String text) {
+        return Bundle.getMessage("NamedBeanComboBoxNoMatchingBean", beanType, text);
     }
 
     /**
-     * Set the translation key to be used when a typed in bean name does not
+     * Get the localized message to display when a typed in bean name does not
      * match a named bean, {@link #isValidatingInput()} is {@code true} and
      * {@link #isProviding()} is {@code true}.
      *
-     * @param willCreateBeanKey a translatable bundle key where {@code {0}} is
-     *                          the result of
-     *                          {@link jmri.Manager#getBeanTypeHandled()} and
-     *                          {1} is the typed input
+     * @param beanType the type of bean as provided by
+     *                 {@link Manager#getBeanTypeHandled()}
+     * @param text     the typed in name
+     * @return the localized message
      */
-    public void setNoMatchingToolTipWillCreateBean(String willCreateBeanKey) {
-        willCreateBean = willCreateBeanKey;
+    public String getWillCreateBeanMessage(String beanType, String text) {
+        return Bundle.getMessage("NamedBeanComboBoxWillCreateBean", beanType, text);
     }
 
     public Set<B> getExcludedItems() {
@@ -425,6 +404,110 @@ public class NamedBeanComboBox<B extends NamedBean> extends JComboBox<B> {
         this.excludedItems.clear();
         this.excludedItems.addAll(excludedItems);
         sort();
+    }
+
+    private class NamedBeanEditor implements ComboBoxEditor {
+
+        private final ComboBoxEditor editor;
+
+        /**
+         * Create a NamedBeanEditor using another editor as its base. This
+         * allows the NamedBeanEditor to inherit any platform-specific behaviors
+         * that the default editor may implement.
+         *
+         * @param editor the underlying editor
+         */
+        public NamedBeanEditor(ComboBoxEditor editor) {
+            this.editor = editor;
+            Component ec = editor.getEditorComponent();
+            if (ec instanceof JComponent) {
+                JComponent jc = (JComponent) ec;
+                jc.setInputVerifier(new JInputValidator(jc, true, false) {
+                    @Override
+                    protected Validation getValidation(JComponent component, JInputValidatorPreferences preferences) {
+                        if (component instanceof JTextComponent) {
+                            JTextComponent jtc = (JTextComponent) component;
+                            String text = jtc.getText();
+                            if (text != null && !text.isEmpty()) {
+                                B bean = manager.getNamedBean(text);
+                                if (bean != null) {
+                                    setSelectedItem(bean); // won't change if bean is not in model
+                                    if (!bean.equals(getSelectedItem())) {
+                                        jtc.setText(text);
+                                        if (validatingInput) {
+                                            return new Validation(Validation.Type.DANGER,
+                                                    getBeanInUseMessage(manager.getBeanTypeHandled(), bean.getDisplayName(DisplayOptions.QUOTED_DISPLAYNAME)),
+                                                    preferences);
+                                        }
+                                    }
+                                } else {
+                                    if (validatingInput) {
+                                        if (providing) {
+                                            try {
+                                                manager.validateSystemNameFormat(text); // ignore output, we only want to catch exceptions
+                                            } catch (IllegalArgumentException ex) {
+                                                return new Validation(Validation.Type.DANGER,
+                                                        getInvalidNameFormatMessage(manager.getBeanTypeHandled(), text, ex.getLocalizedMessage()),
+                                                        preferences);
+                                            }
+                                            return new Validation(Validation.Type.INFORMATION,
+                                                    getWillCreateBeanMessage(manager.getBeanTypeHandled(), text),
+                                                    preferences);
+                                        } else {
+                                            return new Validation(Validation.Type.WARNING,
+                                                    getNoMatchingBeanMessage(manager.getBeanTypeHandled(), text),
+                                                    preferences);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        return getNoneValidation();
+                    }
+                });
+            }
+        }
+
+        @Override
+        public Component getEditorComponent() {
+            return editor.getEditorComponent();
+        }
+
+        @Override
+        public void setItem(Object anObject) {
+            Component c = getEditorComponent();
+            if (c instanceof JTextComponent) {
+                JTextComponent jtc = (JTextComponent) c;
+                if (anObject != null && anObject instanceof NamedBean) {
+                    NamedBean nb = (NamedBean) anObject;
+                    jtc.setText(nb.getDisplayName(displayOptions));
+                } else {
+                    jtc.setText("");
+                }
+            } else {
+                editor.setItem(anObject);
+            }
+        }
+
+        @Override
+        public Object getItem() {
+            return editor.getItem();
+        }
+
+        @Override
+        public void selectAll() {
+            editor.selectAll();
+        }
+
+        @Override
+        public void addActionListener(ActionListener l) {
+            editor.addActionListener(l);
+        }
+
+        @Override
+        public void removeActionListener(ActionListener l) {
+            editor.removeActionListener(l);
+        }
     }
 
     private class NamedBeanRenderer implements ListCellRenderer<B>, JComboBox.KeySelectionManager {


### PR DESCRIPTION
Use getDisplayName() instead of toString() to render the NamedBeans in the ComboBoxEditor.
Also fixes how tooltip validation messages are overridden.

Fix #7216