### PR TITLE
Time out and retry RosterFrameTest

### DIFF
--- a/java/test/jmri/jmrit/roster/swing/RosterFrameTest.java
+++ b/java/test/jmri/jmrit/roster/swing/RosterFrameTest.java
@@ -19,6 +19,9 @@ public class RosterFrameTest {
     @Rule
     public RetryRule retryRule = new RetryRule(3);  // allow 3 retries
 
+    @Rule // This test class was periodically stalling and causing the CI run to time out. Limit its duration.
+    public org.junit.rules.Timeout globalTimeout = org.junit.rules.Timeout.seconds(20);
+
     private RosterFrame frame = null;
 
     @Test

--- a/java/test/jmri/jmrit/roster/swing/RosterFrameTest.java
+++ b/java/test/jmri/jmrit/roster/swing/RosterFrameTest.java
@@ -21,7 +21,6 @@ public class RosterFrameTest {
 
     private RosterFrame frame = null;
 
-
     @Test
     public void testCtor() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
@@ -136,11 +135,11 @@ public class RosterFrameTest {
         //    }, "error message at end");
 
         JUnitUtil.waitFor(() ->{
-            return frame.getSelectedRosterEntries().length == 1;
-        }, "selection complete");
+                return frame.getSelectedRosterEntries().length == 1;
+            }, "selection complete");
         RosterEntry[] selected = frame.getSelectedRosterEntries();
         Assert.assertEquals("selected ", re1, selected[0]);
-	Assert.assertTrue("entry selected",frame.checkIfEntrySelected());
+	    Assert.assertTrue("entry selected",frame.checkIfEntrySelected());
         
     }
 
@@ -182,12 +181,12 @@ public class RosterFrameTest {
         // is not working.  See @Ignore above
         
         JUnitUtil.waitFor(() ->{
-            return frame.getSelectedRosterEntries().length == 2;
-        }, "selection complete");
+                return frame.getSelectedRosterEntries().length == 2;
+            }, "selection complete");
         RosterEntry[] selected = frame.getSelectedRosterEntries();
         Assert.assertEquals("selected ", re1, selected[0]);
         Assert.assertEquals("selected ", re3, selected[1]);
-	Assert.assertTrue("entry selected",frame.checkIfEntrySelected());
+	    Assert.assertTrue("entry selected",frame.checkIfEntrySelected());
                 
     }
 
@@ -228,12 +227,12 @@ public class RosterFrameTest {
         operator.pushIdentifyButton();
         
         JUnitUtil.waitFor(() ->{
-            return frame.getSelectedRosterEntries().length == 1;
-        }, "selection complete");
+                return frame.getSelectedRosterEntries().length == 1;
+            }, "selection complete");
         RosterEntry[] selected = frame.getSelectedRosterEntries();
         Assert.assertEquals("selected ", 1, selected.length);
         Assert.assertEquals("selected ", re3, selected[0]);  // 2nd address=3 selected by decoder match
-	Assert.assertTrue("entry selected",frame.checkIfEntrySelected());
+	    Assert.assertTrue("entry selected",frame.checkIfEntrySelected());
         
     }
 
@@ -244,23 +243,23 @@ public class RosterFrameTest {
         frame.setVisible(true);
         RosterFrameScaffold operator = new RosterFrameScaffold(frame.getTitle());
         Thread t = new Thread(() -> {
-	    jmri.util.swing.JemmyUtil.confirmJOptionPane(operator,"Message","","OK");
+	        jmri.util.swing.JemmyUtil.confirmJOptionPane(operator,"Message","","OK");
         });
         t.setName("Error Dialog Close Thread");
         t.start();
         // the return true case happens in the identify methods above, so
-	// we only check the return false case here.
-	Assert.assertFalse("entry not selected",frame.checkIfEntrySelected());
+	    // we only check the return false case here.
+	    Assert.assertFalse("entry not selected",frame.checkIfEntrySelected());
     }
 
     @Test
     public void testGetandSetAllowQuit() {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         frame.setVisible(true);
-	frame.allowQuit(false);
-	Assert.assertFalse("Quit Not Allowed",frame.isAllowQuit());
-	frame.allowQuit(true);
-	Assert.assertTrue("Quit Allowed",frame.isAllowQuit());
+	    frame.allowQuit(false);
+	    Assert.assertFalse("Quit Not Allowed",frame.isAllowQuit());
+	    frame.allowQuit(true);
+	    Assert.assertTrue("Quit Allowed",frame.isAllowQuit());
     }
 
     @Before
@@ -276,14 +275,14 @@ public class RosterFrameTest {
         Roster.getDefault(); // ensure exists
         if(!GraphicsEnvironment.isHeadless()){
            frame = new RosterFrame();
-	}
+	    }
     }
 
     @After
     public void tearDown() {
-	if(frame!=null) {
+	    if(frame!=null) {
            JUnitUtil.dispose(frame);
-	}
+	    }
         JUnitUtil.tearDown();
     }
 


### PR DESCRIPTION
Add timeout and retry to RosterFrameTest

This was hanging up and causing Travis graphical CI to occasionally terminate due to too much time.  This will prevent that (with retry if needed) by turning this into an error we can track down.