### PR TITLE
Add timeout to ImportRosterEngineActionTest to prevent CI time limit exceeded

### DIFF
--- a/java/test/jmri/jmrit/operations/rollingstock/engines/tools/ImportRosterEngineActionTest.java
+++ b/java/test/jmri/jmrit/operations/rollingstock/engines/tools/ImportRosterEngineActionTest.java
@@ -25,7 +25,13 @@ import org.junit.rules.TemporaryFolder;
  * @author Paul Bender Copyright (C) 2017
  */
 public class ImportRosterEngineActionTest extends OperationsTestCase {
-    
+
+    @Rule
+    public jmri.util.junit.rules.RetryRule retryRule = new jmri.util.junit.rules.RetryRule(3);  // allow 3 retries
+
+    @Rule // This test class was periodically stalling and causing the CI run to time out. Limit its duration.
+	public org.junit.rules.Timeout globalTimeout = org.junit.rules.Timeout.seconds(20);
+	    
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 


### PR DESCRIPTION
This will catch the "hung in Travis graphical" case and turn it into an error we can track down.