### PR TITLE
WIP: NamedBeanComparator - Possible bug in JMRI --- DO NOT MERGE!!!

### DIFF
--- a/java/test/jmri/NamedBeanComparatorTest.java
+++ b/java/test/jmri/NamedBeanComparatorTest.java
@@ -1,0 +1,61 @@
+package jmri;
+
+import jmri.JmriException;
+import jmri.util.JUnitUtil;
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Test NamedBeanComparator
+ * @author Daniel Bergqvist Copyright (C) 2019
+ */
+public class NamedBeanComparatorTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testNamedBeanComparator() {
+        jmri.NamedBean a = new MyBean("IQDE:000014");
+        jmri.NamedBean b = new MyBean("IQDE:00014");
+        jmri.util.NamedBeanComparator<jmri.NamedBean> c = new jmri.util.NamedBeanComparator<>();
+        System.out.format("Result: %s, %s, %d%n", a.getSystemName(), b.getSystemName(), c.compare(a, b));
+        Assert.assertNotEquals("The named beans have different names", 0, c.compare(a, b));
+    }
+
+    @Before
+    public void setUp() {
+        JUnitUtil.setUp();
+    }
+
+    @After
+    public void tearDown() {
+        JUnitUtil.tearDown();
+    }
+
+
+
+    private class MyBean extends jmri.implementation.AbstractNamedBean {
+
+        MyBean(String sysName) {
+            super(sysName);
+        }
+
+        @Override
+        public void setState(int s) throws JmriException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public int getState() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getBeanType() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+    }
+
+}

--- a/java/test/jmri/PackageTest.java
+++ b/java/test/jmri/PackageTest.java
@@ -16,6 +16,7 @@ import org.junit.runners.Suite;
     NamedBeanTest.class,
     LightTest.class,
     ManagerTest.class,
+    NamedBeanComparatorTest.class,
     NmraPacketTest.class,
     ConditionalTest.class,
     ConditionalVariableTest.class,

--- a/java/test/jmri/jmrix/loconet/LnLightManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnLightManagerTest.java
@@ -1,5 +1,7 @@
 package jmri.jmrix.loconet;
 
+import jmri.Light;
+import jmri.LightManager;
 import jmri.util.JUnitUtil;
 import org.junit.After;
 import org.junit.Assert;
@@ -21,6 +23,29 @@ public class LnLightManagerTest {
         Assert.assertNotNull("exists",t);
     }
 
+    @Test
+    public void testManager() {
+        LocoNetSystemConnectionMemo memo = new LocoNetSystemConnectionMemo();
+        LnTrafficController lnis = new LocoNetInterfaceScaffold(memo);
+        memo.setLnTrafficController(lnis);
+        LnLightManager lm = new LnLightManager(memo);
+        Assert.assertNotNull("exists",lm);
+        LnLight light1 = new LnLight("LL1", lnis, lm);
+        LnLight light2 = new LnLight("LL01", lnis, lm);
+        lm.register(light1);
+        lm.register(light2);
+        for (Light l : lm.getNamedBeanSet()) {
+            System.out.format("Light: %s%n", l.getSystemName());
+        }
+        
+        System.out.format("Light light1: %s%n", lm.getBySystemName("LL1"));
+        System.out.format("Light light2: %s%n", lm.getBySystemName("LL01"));
+        
+        Assert.assertEquals("lights are equal",
+                lm.getBySystemName("LL1"),
+                lm.getBySystemName("LL01"));
+    }
+    
     @Before
     public void setUp() {
         JUnitUtil.setUp();


### PR DESCRIPTION
During development of LogixNG, I have been hit by a bus. I have assumed that the system names `IQDE:000014` and `IQDE:00014` are different, but they are not.

`AbstractManager.register()` tries to put the bean `IQDE:000014` into the field `_beans`, but since `_beans` already contains `IQDE:00014`, the bean `IQDE:000014` is not added.

I suppose this is a bug, but I'm not sure, so I created this PR to demonstrate the problem. I think that the test in this PR should succed, but it fails since `NamedBeanComparator.compare()` thinks `IQDE:000014` and `IQDE:00014` are equal.

Note that `AbstractNamedBean.register()` first tries to find the bean before adding it, but since `getBeanBySystemName("IQDE:000014")` does not return the bean `IQDE:00014`, there is no error message that the bean already exists.