### PR TITLE
Don't exclude the current turnouts for the edit dialogs

### DIFF
--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -7080,6 +7080,26 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
                 }
             }
         }
+
+        if (result) {   // only need to test Turntable turnouts if we haven't failed yet...
+            //ensure that this turntable turnout is unique among turnouts in this Layout
+            for (LayoutTurntable tt : getLayoutTurntables()) {
+                for (LayoutTurntable.RayTrack ray : tt.getRayList()) {
+                    t = ray.getTurnout();
+                    if (t != null) {
+                        String sname = t.getSystemName();
+                        String uname = t.getUserName();
+                        log.debug("{}: Turntable turnout tested '{}' and '{}'.", ray.getTurnoutName(), sname, uname);
+                        if ((sname.equals(inTurnoutName))
+                                || ((uname != null) && (uname.equals(inTurnoutName)))) {
+                            result = false;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
         if (!result && (inOpenPane != null)) {
             JOptionPane.showMessageDialog(inOpenPane,
                     MessageFormat.format(Bundle.getMessage("Error4"),
@@ -10662,9 +10682,11 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
     class TurnoutComboBoxPopupMenuListener implements PopupMenuListener {
 
         private final NamedBeanComboBox<Turnout> comboBox;
+        private final List<Turnout> currentTurnouts;
 
-        public TurnoutComboBoxPopupMenuListener(NamedBeanComboBox<Turnout> comboBox) {
+        public TurnoutComboBoxPopupMenuListener(NamedBeanComboBox<Turnout> comboBox, List<Turnout> currentTurnouts) {
             this.comboBox = comboBox;
+            this.currentTurnouts = currentTurnouts;
         }
 
         @Override
@@ -10673,8 +10695,10 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             log.debug("PopupMenuWillBecomeVisible");
             Set<Turnout> l = new HashSet<>();
             comboBox.getManager().getNamedBeanSet().forEach((turnout) -> {
-                if (!validatePhysicalTurnout(turnout.getDisplayName(), null)) {
-                    l.add(turnout);
+                if (currentTurnouts == null || !currentTurnouts.contains(turnout)) {
+                    if (!validatePhysicalTurnout(turnout.getDisplayName(), null)) {
+                        l.add(turnout);
+                    }
                 }
             });
             comboBox.setExcludedItems(l);
@@ -10693,8 +10717,24 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
         }
     }
 
+    /**
+     * Create a listener that will exclude turnouts that are present in the current panel.
+     * @param comboBox The NamedBeanComboBox that contains the turnout list.
+     * @return A PopupMenuListener
+     */
     public TurnoutComboBoxPopupMenuListener newTurnoutComboBoxPopupMenuListener(NamedBeanComboBox<Turnout> comboBox) {
-        return new TurnoutComboBoxPopupMenuListener(comboBox);
+        return newTurnoutComboBoxPopupMenuListener(comboBox, null);
+    }
+
+    /**
+     * Create a listener that will exclude turnouts that are present in the current panel.
+     * The list of current turnouts are not excluded.
+     * @param comboBox The NamedBeanComboBox that contains the turnout list.
+     * @param currentTurnouts The turnouts to be left in the turnout list.
+     * @return A PopupMenuListener
+     */
+    public TurnoutComboBoxPopupMenuListener newTurnoutComboBoxPopupMenuListener(NamedBeanComboBox<Turnout> comboBox, List<Turnout> currentTurnouts) {
+        return new TurnoutComboBoxPopupMenuListener(comboBox, currentTurnouts);
     }
 
     //initialize logging

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditor.java
@@ -10695,7 +10695,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
             log.debug("PopupMenuWillBecomeVisible");
             Set<Turnout> l = new HashSet<>();
             comboBox.getManager().getNamedBeanSet().forEach((turnout) -> {
-                if (currentTurnouts == null || !currentTurnouts.contains(turnout)) {
+                if (!currentTurnouts.contains(turnout)) {
                     if (!validatePhysicalTurnout(turnout.getDisplayName(), null)) {
                         l.add(turnout);
                     }
@@ -10723,7 +10723,7 @@ public class LayoutEditor extends PanelEditor implements MouseWheelListener {
      * @return A PopupMenuListener
      */
     public TurnoutComboBoxPopupMenuListener newTurnoutComboBoxPopupMenuListener(NamedBeanComboBox<Turnout> comboBox) {
-        return newTurnoutComboBoxPopupMenuListener(comboBox, null);
+        return new TurnoutComboBoxPopupMenuListener(comboBox, new ArrayList<Turnout>());
     }
 
     /**

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutEditorBundle.properties
@@ -178,6 +178,7 @@ TurntableRadius = Turntable Radius
 TurntableRadiusHint = Enter radius (screen units) of turntable circle.
 TurntableDCCControlled = DCC Controlled Turntable
 TurnoutState = Set State
+EditTurnoutToolTip = Select a turnout, used turnouts are excluded from the list.
 
 BlkUserNameTitle = User Name Required
 BlkUserNameMsg = The selected block does not have a user name.\nPlease enter a user name for the block.

--- a/java/src/jmri/jmrit/display/layoutEditor/LayoutTrackEditors.java
+++ b/java/src/jmri/jmrit/display/layoutEditor/LayoutTrackEditors.java
@@ -465,15 +465,10 @@ public class LayoutTrackEditors {
             panel1.add(turnoutNameLabel);
 
             // add combobox to select turnout
-            editLayoutTurnout1stTurnoutComboBox = new NamedBeanComboBox<>(
-                    InstanceManager.turnoutManagerInstance(),
-                    layoutTurnout.getTurnout(),
-                    DisplayOptions.DISPLAYNAME);
+            editLayoutTurnout1stTurnoutComboBox = new NamedBeanComboBox<>
+                    (InstanceManager.getDefault(TurnoutManager.class));
+            editLayoutTurnout1stTurnoutComboBox.setToolTipText(Bundle.getMessage("EditTurnoutToolTip"));
             LayoutEditor.setupComboBox(editLayoutTurnout1stTurnoutComboBox, false, true);
-
-            editLayoutTurnout1stTurnoutComboBox.addPopupMenuListener(layoutEditor.newTurnoutComboBoxPopupMenuListener(editLayoutTurnout1stTurnoutComboBox));
-            // editLayoutTurnout1stTurnoutComboBox.setEnabledColor(Color.green.darker().darker());
-            // editLayoutTurnout1stTurnoutComboBox.setDisabledColor(Color.red);
 
             panel1.add(editLayoutTurnout1stTurnoutComboBox);
             contentPane.add(panel1);
@@ -481,16 +476,10 @@ public class LayoutTrackEditors {
             JPanel panel1a = new JPanel();
             panel1a.setLayout(new BoxLayout(panel1a, BoxLayout.Y_AXIS));
 
-            editLayoutTurnout2ndTurnoutComboBox = new NamedBeanComboBox<>(
-                    InstanceManager.turnoutManagerInstance(),
-                    layoutTurnout.getSecondTurnout(),
-                    DisplayOptions.DISPLAYNAME);
-            LayoutEditor.setupComboBox(editLayoutTurnout2ndTurnoutComboBox, false, false);
-
-            editLayoutTurnout2ndTurnoutComboBox.addPopupMenuListener(
-                    layoutEditor.newTurnoutComboBoxPopupMenuListener(editLayoutTurnout2ndTurnoutComboBox));
-            // editLayoutTurnout2ndTurnoutComboBox.setEnabledColor(Color.green.darker().darker());
-            // editLayoutTurnout2ndTurnoutComboBox.setDisabledColor(Color.red);
+            editLayoutTurnout2ndTurnoutComboBox = new NamedBeanComboBox<>
+                    (InstanceManager.getDefault(TurnoutManager.class));
+            editLayoutTurnout2ndTurnoutComboBox.setToolTipText(Bundle.getMessage("EditTurnoutToolTip"));
+            LayoutEditor.setupComboBox(editLayoutTurnout2ndTurnoutComboBox, false, true);
 
             editLayoutTurnout2ndTurnoutCheckBox.addActionListener((ActionEvent e) -> {
                 boolean additionalEnabled = editLayoutTurnout2ndTurnoutCheckBox.isSelected();
@@ -611,10 +600,20 @@ public class LayoutTrackEditors {
             contentPane.add(panel5);
         }
 
-        editLayoutTurnout1stTurnoutComboBox.setSelectedItem(layoutTurnout.getTurnout());
-
-        editLayoutTurnoutHiddenCheckBox.setSelected(layoutTurnout.isHidden());
         // Set up for Edit
+        editLayoutTurnoutHiddenCheckBox.setSelected(layoutTurnout.isHidden());
+
+        List<Turnout> currentTurnouts = new ArrayList<>();
+        currentTurnouts.add(layoutTurnout.getTurnout());
+        currentTurnouts.add(layoutTurnout.getSecondTurnout());
+
+        editLayoutTurnout1stTurnoutComboBox.setSelectedItem(layoutTurnout.getTurnout());
+        editLayoutTurnout1stTurnoutComboBox.addPopupMenuListener(
+                layoutEditor.newTurnoutComboBoxPopupMenuListener(editLayoutTurnout1stTurnoutComboBox, currentTurnouts));
+
+        editLayoutTurnout2ndTurnoutComboBox.addPopupMenuListener(
+                layoutEditor.newTurnoutComboBoxPopupMenuListener(editLayoutTurnout2ndTurnoutComboBox, currentTurnouts));
+
         BlockManager bm = InstanceManager.getDefault(BlockManager.class);
         editLayoutTurnoutBlockNameComboBox.setSelectedItem(bm.getBlock(layoutTurnout.getBlockName()));
         editLayoutTurnoutBlockNameComboBox.setEnabled(!hasNxSensorPairs(layoutTurnout.getLayoutBlock()));
@@ -956,40 +955,27 @@ public class LayoutTrackEditors {
             Container contentPane = editLayoutSlipFrame.getContentPane();
             contentPane.setLayout(new BoxLayout(contentPane, BoxLayout.Y_AXIS));
 
+            // Setup turnout A
             JPanel panel1 = new JPanel();
             panel1.setLayout(new FlowLayout());
             JLabel turnoutNameLabel = new JLabel(Bundle.getMessage("BeanNameTurnout") + " A " + Bundle.getMessage("Name"));  // NOI18N
             panel1.add(turnoutNameLabel);
-            editLayoutSlipTurnoutAComboBox = new NamedBeanComboBox<>(
-                    InstanceManager.turnoutManagerInstance(),
-                    layoutSlip.getTurnout(),
-                    DisplayOptions.DISPLAYNAME);
+            editLayoutSlipTurnoutAComboBox = new NamedBeanComboBox<>
+                    (InstanceManager.getDefault(TurnoutManager.class));
+            editLayoutSlipTurnoutAComboBox.setToolTipText(Bundle.getMessage("EditTurnoutToolTip"));
             LayoutEditor.setupComboBox(editLayoutSlipTurnoutAComboBox, false, true);
-
-            editLayoutSlipTurnoutAComboBox.addPopupMenuListener(
-                    layoutEditor.newTurnoutComboBoxPopupMenuListener(editLayoutSlipTurnoutAComboBox));
-            // editLayoutSlipTurnoutAComboBox.setEnabledColor(Color.green.darker().darker());
-            // editLayoutSlipTurnoutAComboBox.setDisabledColor(Color.red);
-
             panel1.add(editLayoutSlipTurnoutAComboBox);
             contentPane.add(panel1);
 
+            // Setup turnout B
             JPanel panel1a = new JPanel();
             panel1a.setLayout(new FlowLayout());
             JLabel turnoutBNameLabel = new JLabel(Bundle.getMessage("BeanNameTurnout") + " B " + Bundle.getMessage("Name"));  // NOI18N
             panel1a.add(turnoutBNameLabel);
-
-            editLayoutSlipTurnoutBComboBox = new NamedBeanComboBox<>(
-                    InstanceManager.turnoutManagerInstance(),
-                    layoutSlip.getTurnoutB(),
-                    DisplayOptions.DISPLAYNAME);
+            editLayoutSlipTurnoutBComboBox = new NamedBeanComboBox<>
+                    (InstanceManager.getDefault(TurnoutManager.class));
+            editLayoutSlipTurnoutBComboBox.setToolTipText(Bundle.getMessage("EditTurnoutToolTip"));
             LayoutEditor.setupComboBox(editLayoutSlipTurnoutBComboBox, false, true);
-
-            editLayoutSlipTurnoutBComboBox.addPopupMenuListener(
-                    layoutEditor.newTurnoutComboBoxPopupMenuListener(editLayoutSlipTurnoutBComboBox));
-            // editLayoutSlipTurnoutBComboBox.setEnabledColor(Color.green.darker().darker());
-            // editLayoutSlipTurnoutBComboBox.setDisabledColor(Color.red);
-
             panel1a.add(editLayoutSlipTurnoutBComboBox);
 
             contentPane.add(panel1a);
@@ -1079,8 +1065,18 @@ public class LayoutTrackEditors {
         editLayoutSlipHiddenBox.setSelected(layoutSlip.isHidden());
 
         // Set up for Edit
+        List<Turnout> currentTurnouts = new ArrayList<>();
+        currentTurnouts.add(layoutSlip.getTurnout());
+        currentTurnouts.add(layoutSlip.getTurnoutB());
+
         editLayoutSlipTurnoutAComboBox.setSelectedItem(layoutSlip.getTurnout());
+        editLayoutSlipTurnoutAComboBox.addPopupMenuListener(
+                layoutEditor.newTurnoutComboBoxPopupMenuListener(editLayoutSlipTurnoutAComboBox, currentTurnouts));
+
         editLayoutSlipTurnoutBComboBox.setSelectedItem(layoutSlip.getTurnoutB());
+        editLayoutSlipTurnoutBComboBox.addPopupMenuListener(
+                layoutEditor.newTurnoutComboBoxPopupMenuListener(editLayoutSlipTurnoutBComboBox, currentTurnouts));
+
         BlockManager bm = InstanceManager.getDefault(BlockManager.class);
         editLayoutSlipBlockNameComboBox.setSelectedItem(bm.getBlock(layoutSlip.getBlockName()));
         editLayoutSlipBlockNameComboBox.setEnabled(!hasNxSensorPairs(layoutSlip.getLayoutBlock()));
@@ -1656,6 +1652,8 @@ public class LayoutTrackEditors {
     private boolean editLayoutTurntableOpen = false;
     private boolean editLayoutTurntableNeedsRedraw = false;
 
+    private List<Turnout> turntableTurnouts = new ArrayList<>();
+
     /**
      * Edit a Turntable.
      */
@@ -1769,6 +1767,12 @@ public class LayoutTrackEditors {
     private void updateRayPanel() {
         for (Component comp : editLayoutTurntableRayPanel.getComponents()) {
             editLayoutTurntableRayPanel.remove(comp);
+        }
+
+        // Create list of turnouts to be retained in the NamedBeanComboBox
+        turntableTurnouts.clear();
+        for (LayoutTurntable.RayTrack rt : layoutTurntable.getRayList()) {
+            turntableTurnouts.add(rt.getTurnout());
         }
 
         editLayoutTurntableRayPanel.setLayout(new BoxLayout(editLayoutTurntableRayPanel, BoxLayout.Y_AXIS));
@@ -1925,13 +1929,13 @@ public class LayoutTrackEditors {
             this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
             this.add(top);
 
-            turnoutNameComboBox = new NamedBeanComboBox<>(
-                    InstanceManager.turnoutManagerInstance(),
-                    rayTrack.getTurnout(),
-                    DisplayOptions.DISPLAYNAME);
+            turnoutNameComboBox = new NamedBeanComboBox<>
+                    (InstanceManager.getDefault(TurnoutManager.class));
+            turnoutNameComboBox.setToolTipText(Bundle.getMessage("EditTurnoutToolTip"));
             LayoutEditor.setupComboBox(turnoutNameComboBox, false, true);
             turnoutNameComboBox.setSelectedItem(rayTrack.getTurnout());
-
+            turnoutNameComboBox.addPopupMenuListener(
+                    layoutEditor.newTurnoutComboBoxPopupMenuListener(turnoutNameComboBox, turntableTurnouts));
             String turnoutStateThrown = InstanceManager.turnoutManagerInstance().getThrownText();
             String turnoutStateClosed = InstanceManager.turnoutManagerInstance().getClosedText();
             String[] turnoutStates = new String[]{turnoutStateClosed, turnoutStateThrown};


### PR DESCRIPTION
The NamedBeanComboBoxes for Layout Editor turnout Edit dialogs exclude the currently selected from the available turnout list.  This is confusing and can result in removing the turnout assignment.

Issue #7262 provides more details. 