### PR TITLE
Restrict IdentifyDecoder PAGEMODE fallback initiation to test1 (CV8).

### DIFF
--- a/java/src/jmri/jmrit/AbstractIdentify.java
+++ b/java/src/jmri/jmrit/AbstractIdentify.java
@@ -122,9 +122,9 @@ public abstract class AbstractIdentify implements jmri.ProgListener {
                 state--;
                 retry++;
                 value = lastValue;  // Restore the last good value. Needed for retries.
-            } else if (programmer.getMode() != ProgrammingMode.PAGEMODE
+            } else if (state == 1 && programmer.getMode() != ProgrammingMode.PAGEMODE
                     && programmer.getSupportedModes().contains(ProgrammingMode.PAGEMODE)) {
-                programmer.setMode(ProgrammingMode.PAGEMODE);
+                programmer.setMode(ProgrammingMode.PAGEMODE); // Try paged mode only if test1 (CV8)
                 retry = 0;
                 state--;
                 value = lastValue;  // Restore the last good value. Needed for retries.

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -295,7 +295,7 @@ public class IdentifyDecoderTest {
 
     /**
      * Test Hornby decoder with CV159 not available, hence productID is -1.
-     * Test with 2 retries on CV8 to trigger PAGEMODE
+     * Test with 5 fails on CV8 to trigger PAGEMODE and not abort.
      */
     @Test
     public void testIdentifyHornby4() { // CV159 not available hence productID is -1
@@ -325,7 +325,7 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("running after 1 ", true, i.isRunning());
         Assert.assertEquals("Test isOptionalCv() after 1", i.isOptionalCv(), false);
 
-        // simulate 6 retries on CV8 to strigger swap to PAGEMODE, start 7
+        // simulate 5 failures on CV8 to trigger swap to PAGEMODE, start 7
         i.programmingOpReply(21, 2);
         i.programmingOpReply(31, 2);
         i.programmingOpReply(41, 2);
@@ -341,7 +341,7 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("found model ID ", -1, i.modelID);
         Assert.assertEquals("found product ID ", -1, i.productID);
 
-        // simulate 2 retries on CV7, start 159
+        // simulate 2 failures on CV7, start 159
         i.programmingOpReply(22, 2);
         i.programmingOpReply(32, 2);
         i.programmingOpReply(88, 0);
@@ -372,7 +372,7 @@ public class IdentifyDecoderTest {
     }
 
     /**
-     * Test Hornby decoder with only 2 retries on CV8 but 3 on CV7.
+     * Test Hornby decoder with only 2 failures on CV8 but 3 on CV7.
      * Should fail as shouldn't switch to PAGEMODE.
      */
     @Test
@@ -403,7 +403,7 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("running after 1 ", true, i.isRunning());
         Assert.assertEquals("Test isOptionalCv() after 1", i.isOptionalCv(), false);
 
-        // simulate 2 retries on CV8, start 7
+        // simulate 2 failures on CV8, start 7
         i.programmingOpReply(21, 2);
         i.programmingOpReply(31, 2);
         i.programmingOpReply(48, 0);
@@ -416,7 +416,7 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("found model ID ", -1, i.modelID);
         Assert.assertEquals("found product ID ", -1, i.productID);
 
-        // simulate 3 retries on CV7, to create fail since not switched to PAGEMODE
+        // simulate 3 failures on CV7, to create fail since not switched to PAGEMODE
         i.programmingOpReply(22, 2);
         i.programmingOpReply(32, 2);
         i.programmingOpReply(42, 2);

--- a/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
+++ b/java/test/jmri/jmrit/decoderdefn/IdentifyDecoderTest.java
@@ -295,9 +295,88 @@ public class IdentifyDecoderTest {
 
     /**
      * Test Hornby decoder with CV159 not available, hence productID is -1.
+     * Test with 2 retries on CV8 to trigger PAGEMODE
      */
     @Test
     public void testIdentifyHornby4() { // CV159 not available hence productID is -1
+        // create our test object
+        IdentifyDecoder i = new IdentifyDecoder(p) {
+            @Override
+            public void done(int mfgID, int modelID, int productID) {
+            }
+
+            @Override
+            public void message(String m) {
+            }
+
+            @Override
+            public void error() {
+            }
+        };
+
+        Assert.assertEquals("found mfg ID ", -1, i.mfgID);
+        Assert.assertEquals("found model ID ", -1, i.modelID);
+        Assert.assertEquals("found product ID ", -1, i.productID);
+        Assert.assertEquals("Test isOptionalCv() before start", i.isOptionalCv(), false);
+        Assert.assertEquals("Programming mode before start", ProgrammingMode.DIRECTMODE, p.getMode());
+
+        i.start();
+        Assert.assertEquals("step 1 reads CV ", 8, cvRead);
+        Assert.assertEquals("running after 1 ", true, i.isRunning());
+        Assert.assertEquals("Test isOptionalCv() after 1", i.isOptionalCv(), false);
+
+        // simulate 6 retries on CV8 to strigger swap to PAGEMODE, start 7
+        i.programmingOpReply(21, 2);
+        i.programmingOpReply(31, 2);
+        i.programmingOpReply(41, 2);
+        i.programmingOpReply(51, 2);
+        i.programmingOpReply(61, 2);
+        i.programmingOpReply(48, 0);
+        Assert.assertEquals("step 2 reads CV ", 7, cvRead);
+        Assert.assertEquals("running after 2 ", true, i.isRunning());
+        Assert.assertEquals("Test isOptionalCv() after 2", i.isOptionalCv(), false);
+        Assert.assertEquals("Programming mode after 2", ProgrammingMode.PAGEMODE, p.getMode());
+
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found model ID ", -1, i.modelID);
+        Assert.assertEquals("found product ID ", -1, i.productID);
+
+        // simulate 2 retries on CV7, start 159
+        i.programmingOpReply(22, 2);
+        i.programmingOpReply(32, 2);
+        i.programmingOpReply(88, 0);
+        Assert.assertEquals("step 3 reads CV ", 159, cvRead);
+        Assert.assertEquals("running after 3 ", true, i.isRunning());
+        Assert.assertEquals("Test isOptionalCv() after 3", i.isOptionalCv(), true);
+        Assert.assertEquals("Programming mode after 3", ProgrammingMode.PAGEMODE, p.getMode());
+
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found model ID ", 88, i.modelID);
+        Assert.assertEquals("found product ID ", -1, i.productID);
+
+        // simulate CV read read fail on CV159, ends
+        i.programmingOpReply(145, 2);
+        i.programmingOpReply(145, 2);
+        i.programmingOpReply(145, 2);
+        Assert.assertEquals("running after 4 ", false, i.isRunning());
+        Assert.assertEquals("Test isOptionalCv() after 4", i.isOptionalCv(), true);
+        Assert.assertEquals("Programming mode after 4", ProgrammingMode.DIRECTMODE, p.getMode());
+
+        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
+        Assert.assertEquals("found model ID ", 88, i.modelID);
+        Assert.assertEquals("found product ID ", -1, i.productID);
+
+        jmri.util.JUnitAppender.assertWarnMessage("error 2 readng CV 8, trying Paged mode");
+        jmri.util.JUnitAppender.assertWarnMessage("Restoring Direct mode");
+        jmri.util.JUnitAppender.assertWarnMessage("CV 159 is optional. Will assume not present...");
+    }
+
+    /**
+     * Test Hornby decoder with only 2 retries on CV8 but 3 on CV7.
+     * Should fail as shouldn't switch to PAGEMODE.
+     */
+    @Test
+    public void testIdentifyHornby5() { // CV159 not available hence productID is -1
         // create our test object
         IdentifyDecoder i = new IdentifyDecoder(p) {
             @Override
@@ -337,37 +416,20 @@ public class IdentifyDecoderTest {
         Assert.assertEquals("found model ID ", -1, i.modelID);
         Assert.assertEquals("found product ID ", -1, i.productID);
 
-        // simulate 7 retries on CV7, start 159
+        // simulate 3 retries on CV7, to create fail since not switched to PAGEMODE
         i.programmingOpReply(22, 2);
         i.programmingOpReply(32, 2);
         i.programmingOpReply(42, 2);
-        i.programmingOpReply(52, 2);
-        i.programmingOpReply(62, 2);
-        i.programmingOpReply(88, 0);
-        Assert.assertEquals("step 3 reads CV ", 159, cvRead);
-        Assert.assertEquals("running after 3 ", true, i.isRunning());
-        Assert.assertEquals("Test isOptionalCv() after 3", i.isOptionalCv(), true);
-        Assert.assertEquals("Programming mode after 3", ProgrammingMode.PAGEMODE, p.getMode());
+        Assert.assertEquals("step 2 reads CV ", 7, cvRead);
+        Assert.assertEquals("running after 2 ", false, i.isRunning());
+        Assert.assertEquals("Programming mode after 3", ProgrammingMode.DIRECTMODE, p.getMode());
 
         Assert.assertEquals("found mfg ID ", 48, i.mfgID);
-        Assert.assertEquals("found model ID ", 88, i.modelID);
+        Assert.assertEquals("found model ID ", -1, i.modelID);
         Assert.assertEquals("found product ID ", -1, i.productID);
 
-        // simulate CV read read fail on CV159, ends
-        i.programmingOpReply(145, 2);
-        i.programmingOpReply(145, 2);
-        i.programmingOpReply(145, 2);
-        Assert.assertEquals("running after 4 ", false, i.isRunning());
-        Assert.assertEquals("Test isOptionalCv() after 4", i.isOptionalCv(), true);
-        Assert.assertEquals("Programming mode after 4", ProgrammingMode.DIRECTMODE, p.getMode());
-
-        Assert.assertEquals("found mfg ID ", 48, i.mfgID);
-        Assert.assertEquals("found model ID ", 88, i.modelID);
-        Assert.assertEquals("found product ID ", -1, i.productID);
-        
-        jmri.util.JUnitAppender.assertWarnMessage("error 2 readng CV 7, trying Paged mode");
-        jmri.util.JUnitAppender.assertWarnMessage("Restoring Direct mode");
-        jmri.util.JUnitAppender.assertWarnMessage("CV 159 is optional. Will assume not present...");
+        jmri.util.JUnitAppender.assertWarnMessage("Stopping due to error: "
+                            + p.decodeErrorCode(2));
     }
 
     /**


### PR DESCRIPTION
Prompted by a [jmriusers thread](https://groups.io/g/jmriusers/topic/32681716#162388).

Tests reveal some combinations of DCC system and modern sound decoders are prone to return false CV read values rather than a fail in Paged Mode reads under poor-contact conditions.

The intention of Fallback to Paged Mode was to allow identification of legacy decoders that do not support more modern modes (by switching to PAGEMODE for the rest of the identification process after three read failures).

This PR restricts initiation of PAGEMODE to test1 (CV8) read failures only. This ensures that legacy decoders can still be read, but if CV8 can be read in the preferred mode fallback will not occur during the remainder of the identification process (three attempts are still allowed for all CVs).