### PR TITLE
Prevent ClassCastException in Signal Mast Logic table

### DIFF
--- a/java/src/jmri/jmrit/beantable/SignalMastLogicTableAction.java
+++ b/java/src/jmri/jmrit/beantable/SignalMastLogicTableAction.java
@@ -304,13 +304,14 @@ public class SignalMastLogicTableAction extends AbstractTableAction<SignalMastLo
                     case SOURCEAPPCOL:
                     case COMCOL:
                     case DESTAPPCOL:
-                    case MAXSPEEDCOL:
                         return String.class;
                     case ENABLECOL:
                         return Boolean.class;
                     case EDITLOGICCOL:
                     case DELCOL:
                         return JButton.class;
+                    case MAXSPEEDCOL:
+                        return Float.class;
                     default:
                         return null;
                 }


### PR DESCRIPTION
The exception occurs when trying to sort the Max Speed column in the Signal Mast Logic table.  The column is defined as String but the max speed value is a Float.
```
2019-08-05 13:59:09,605 ptionhandler.UncaughtExceptionHandler ERROR - Uncaught Exception caught by jmri.util.exceptionhandler.UncaughtExceptionHandler [AWT-EventQueue-0]
java.lang.ClassCastException: java.lang.Float cannot be cast to java.lang.String
	at java.text.Collator.compare(Collator.java:304)
	at javax.swing.DefaultRowSorter.compare(DefaultRowSorter.java:968)
	at javax.swing.DefaultRowSorter.access$100(DefaultRowSorter.java:112)
...
```