### PR TITLE
Thread was holding monitor in LightTableActionTest ImageIndexEditorTest

### DIFF
--- a/java/test/jmri/jmrit/beantable/LightTableActionTest.java
+++ b/java/test/jmri/jmrit/beantable/LightTableActionTest.java
@@ -719,12 +719,11 @@ public class LightTableActionTest extends AbstractTableActionBase {
     @Override
     public void setUp() {
         jmri.util.JUnitUtil.setUp();
-
+        jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.resetProfileManager();
         jmri.util.JUnitUtil.initInternalLightManager();
         jmri.util.JUnitUtil.initInternalSensorManager();
         jmri.util.JUnitUtil.initInternalTurnoutManager();
-        jmri.util.JUnitUtil.resetInstanceManager();
         jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
         helpTarget = "package.jmri.jmrit.beantable.LightTable";
         a = new LightTableAction();
@@ -734,10 +733,7 @@ public class LightTableActionTest extends AbstractTableActionBase {
     @Override
     public void tearDown() {
         a = null;
-        jmri.util.JUnitUtil.resetInstanceManager();
-        jmri.util.JUnitUtil.initDefaultUserMessagePreferences();
         jmri.util.JUnitUtil.tearDown();
-
     }
 
     // private final static Logger log = LoggerFactory.getLogger(LightTableActionTest.class);

--- a/java/test/jmri/jmrit/catalog/ImageIndexEditorTest.java
+++ b/java/test/jmri/jmrit/catalog/ImageIndexEditorTest.java
@@ -36,6 +36,7 @@ public class ImageIndexEditorTest {
     @Before
     public void setUp() throws Exception {
         JUnitUtil.setUp();
+        JUnitUtil.resetInstanceManager();
         JUnitUtil.resetProfileManager();
         JUnitUtil.initShutDownManager();
     }

--- a/java/test/jmri/jmrix/can/cbus/CbusFilterTest.java
+++ b/java/test/jmri/jmrix/can/cbus/CbusFilterTest.java
@@ -12,8 +12,8 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+// import org.slf4j.Logger;
+// import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -52,14 +52,14 @@ public class CbusFilterTest {
         @Override
         public void passIncrement(int id){ 
             _increments.addElement(id);
-            log.info("passIncrement id {} vector {}",id,_increments);
+            // log.info("passIncrement id {} vector {}",id,_increments);
         }
         
         @Override
         public void addNode(int nodenum, int position) {
             Assert.assertFalse("Node already in list",_nodes.contains(position));
             _nodes.addElement(nodenum);
-            log.info("nodenum position {} {} vector {}",nodenum,position,_nodes);
+            // log.info("nodenum position {} {} vector {}",nodenum,position,_nodes);
         }
     }
 
@@ -771,6 +771,6 @@ public class CbusFilterTest {
         _nodes = null;
     }
 
-    private final static Logger log = LoggerFactory.getLogger(CbusFilterTest.class);
+    // private final static Logger log = LoggerFactory.getLogger(CbusFilterTest.class);
 
 }


### PR DESCRIPTION
In latest console logs there are 2 tests with WARN  - Thread was holding monitor
http://builds.jmri.org/jenkins/job/Development/job/AllTest/lastBuild/consoleFull

eg. 
```
[junit] WARN  - Thread was holding monitor java.lang.Class@34679229 from jmri.InstanceManager.getInstance(InstanceManager.java:321) [main] jmri.util.ThreadingUtil.?()
    [junit] java.lang.Exception: traceback
    [junit] 	at jmri.util.ThreadingUtil.warnLocks(ThreadingUtil.java:321)
    [junit] 	at jmri.util.ThreadingUtil.runOnGUI(ThreadingUtil.java:114)
    [junit] 	at jmri.util.ThreadingPropertyChangeListener.propertyChange(ThreadingPropertyChangeListener.java:26)
```
at jmri.jmrit.beantable.LightTableActionTest.testAddAndInvoke(LightTableActionTest.java:69)
at jmri.jmrit.catalog.ImageIndexEditorTest.testShow(ImageIndexEditorTest.java:23)
