### PR TITLE
fix NPEs associated with LnSensorManager, fix test-time NPEs

### DIFF
--- a/java/src/jmri/jmrix/loconet/LnPacketizer.java
+++ b/java/src/jmri/jmrix/loconet/LnPacketizer.java
@@ -64,7 +64,7 @@ public class LnPacketizer extends LnTrafficController {
      */
     @Override
     public boolean status() {
-        return (ostream != null && istream != null);
+        return (ostream != null && istream != null && xmtThread != null && rcvThread != null);
     }
 
     /**

--- a/java/src/jmri/jmrix/loconet/LnSensorManager.java
+++ b/java/src/jmri/jmrix/loconet/LnSensorManager.java
@@ -40,7 +40,7 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
     public LocoNetSystemConnectionMemo getMemo() {
         return (LocoNetSystemConnectionMemo) memo;
     }
-    
+
     // to free resources when no longer used
     @Override
     public void dispose() {
@@ -265,6 +265,16 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
         @Override
         public void run() {
             sm.setUpdateBusy();
+            while (!tc.status()) {
+                try {
+                    // Delay 500 mSec to allow init of traffic controller, listeners.
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt(); // retain if needed later
+                    sm.setUpdateNotBusy();
+                    return; // and stop work
+                }
+            }
             byte sw1[] = {0x78, 0x79, 0x7a, 0x7b, 0x78, 0x79, 0x7a, 0x7b};
             byte sw2[] = {0x27, 0x27, 0x27, 0x27, 0x07, 0x07, 0x07, 0x07};
             // create and initialize LocoNet message
@@ -281,7 +291,7 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
                 }
                 msg.setElement(1, sw1[k]);
                 msg.setElement(2, sw2[k]);
-                        
+
                 tc.sendLocoNetMessage(msg);
                 log.debug("LnSensorUpdate sent");
             }


### PR DESCRIPTION
Addresses those `LnSensorManager` NPEs reported in #7318 .

The reported NPEs occur because, occasionally and unpredictably, the `LnPacketizer` transmit thread is not fully configured when the `LnSensorManager` attempts to interrogate LocoNet devices.

The fix involves improving `LnPacketizer.status()` reporting to fully reflect its status, and improving the `LnSensorManager` interrogation thread so that it delays until the traffic controller's `status()` (which it gets from the LnPacketizer instance) comes back `true`.
