### PR TITLE
Possible fix for baud rate issue in 4.16.1

### DIFF
--- a/java/src/jmri/jmrix/AbstractSerialPortController.java
+++ b/java/src/jmri/jmrix/AbstractSerialPortController.java
@@ -211,13 +211,8 @@ abstract public class AbstractSerialPortController extends AbstractPortControlle
 
     @Override
     public void configureBaudIndex(int index) {
-        if ((validBaudNumbers() != null) && (validBaudNumbers().length > 0)) {
-            for (int i = 0; i < validBaudNumbers().length; i++) {
-                if (validBaudRates()[i].equals(mBaudRate)) {
-                    mBaudRate = validBaudRates()[i];
-                    break;
-                }
-            }
+        if ((validBaudRates() != null) && (validBaudRates().length > index)) {
+            mBaudRate = validBaudRates()[index];
         } else {
             log.debug("no baud rates in array"); // expected for simulators extending serialPortAdapter, mBaudRate already null
         }


### PR DESCRIPTION
This extracts what I suspect is the most import change in #7299, in the hope that it will fix the baud rate issues reported with the 4.16 release.

I don't have any of the affected hardware, so I do not have an easy way to test this.