### PR TITLE
update LocoNet dispose methods

### DIFF
--- a/java/src/jmri/jmrix/loconet/CsOpSwAccess.java
+++ b/java/src/jmri/jmrix/loconet/CsOpSwAccess.java
@@ -429,8 +429,12 @@ public class CsOpSwAccess implements LocoNetListener {
      * 
      */
     public void dispose() {
-        csOpSwAccessTimer.stop();
-        csOpSwValidTimer.stop();
+        if (csOpSwAccessTimer != null) {
+            csOpSwAccessTimer.stop();
+        }
+        if (csOpSwValidTimer != null) {
+            csOpSwValidTimer.stop();
+        }
     }
 
     // initialize logging

--- a/java/src/jmri/jmrix/loconet/CsOpSwAccess.java
+++ b/java/src/jmri/jmrix/loconet/CsOpSwAccess.java
@@ -421,6 +421,17 @@ public class CsOpSwAccess implements LocoNetListener {
     public CmdStnOpSwStateType getState() {
         return cmdStnOpSwState;
     }
+    
+    /**
+     * Dispose of object's helper objects
+     * 
+     * Stops the timers
+     * 
+     */
+    public void dispose() {
+        csOpSwAccessTimer.stop();
+        csOpSwValidTimer.stop();
+    }
 
     // initialize logging
     private final static Logger log = LoggerFactory.getLogger(CsOpSwAccess.class);

--- a/java/src/jmri/jmrix/loconet/LnReporter.java
+++ b/java/src/jmri/jmrix/loconet/LnReporter.java
@@ -194,14 +194,6 @@ public class LnReporter extends AbstractIdTagReporter implements CollectingRepor
     int lastLoco = -1;
 
     /**
-      * {@inheritDoc}
-      */
-    @Override
-    public void dispose() {
-        super.dispose();
-    }
-
-    /**
      * Parses out a (possibly old) LnReporter-generated report string to extract info used by
      * the public PhysicalLocationReporter methods.  Returns a Matcher that, if successful, should
      * have the following groups defined.

--- a/java/src/jmri/jmrix/loconet/LocoNetConsist.java
+++ b/java/src/jmri/jmrix/loconet/LocoNetConsist.java
@@ -64,12 +64,6 @@ public class LocoNetConsist extends jmri.implementation.DccConsist implements Sl
         throttleManager.requestThrottle(consistAddress, this, false);
     }
 
-    // Clean Up local storage
-    @Override
-    public void dispose() {
-        super.dispose();
-    }
-
     // Set the Consist Type
     @Override
     public void setConsistType(int consist_type) {

--- a/java/src/jmri/jmrix/loconet/SE8cSignalHead.java
+++ b/java/src/jmri/jmrix/loconet/SE8cSignalHead.java
@@ -224,6 +224,7 @@ public class SE8cSignalHead extends DefaultSignalHead implements LocoNetListener
     @Override
     public void dispose() {
         tc.removeLocoNetListener(~0, this);
+        super.dispose();
     }
 
     // data members


### PR DESCRIPTION
- remove some overriding dispose methods which simply invoked super.dispose().

- added a dispose methods where it was missing.

- added a missing invocation of super.dispose().
