### PR TITLE
VSDecoder: bundle properties cleanup

### DIFF
--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle.properties
@@ -1,49 +1,26 @@
-## VSDecoderBundle.properties
+# VSDecoderBundle.properties
 #
-# Default properties for the jmri.jmrix.VSDecoder GUI elements
+# Default properties for the jmri.jmrit.VSDecoder GUI elements
 
-# General Items
-PromptXmlFileTypes = XML Files
-PromptVSDFileTypes = VSD Files
-
-# VSDecoder Window GUI Items
-WindowTitle = Virtual Sound Decoder
-UnsupportedAudioLibrary = Virtual Sound Decoder requires the OpenAL Library be installed. Download OpenAL from http://connect.creativelabs.com/openal/
-UnsupportedAudioLibraryTitle = Unsupported Audio Library
-
-# VSDecoder Pane Menu Items
-VSDecoderFileMenuLoadVSDFile = Load VSD File
-VSDecoderFileMenuLoadProfile = Load VSDecoder Profiles
-VSDecoderFileMenuSaveProfile = Save VSDecoder Profiles
-VSDecoderFileMenuPreferences = VSDecoder Preferences
-
-# VSDecoder Preferences Pane Items
-AutoStartEngine = Auto Start Engine
-AutoLoadVSDFile = Auto-Load VSD File
-DefaultVSDFilePath = Default VSD File Path
-DefaultVSDFileName = Default VSD File Name
-ListenerPositionTitle = Listener Position
-ExVSDecoderLabelApplyWarning=For new preferences to be fully applied, all VSDecoder windows must be closed and reopened.
-VSDecoderPrefsReset=Reset
-FieldVSDecoderPreferencesFrameTitle=Virtual Sound Decoder preferences
-
-# VSDecoder Config Pane text elements
-RosterSaveButtonToolTip = Save the current configuration to the selected Roster Entry.
-AddressSetButtonToolTip = Set the decoder address.
-SaveRoster? = Save Roster Entry
-UpdateRoster = Do you want to save these changes to your Roster file?
+# Just needed for VSDecoderPane.java (old GUI) and VSDecoderPaneTest.java
+# To remove, when "old GUI" is removed
+WindowTitle = test
+VSDecoderFileMenuLoadProfile = test
+VSDecoderFileMenuSaveProfile = test
+VSDecoderFileMenuPreferences = test
+RosterSaveButtonToolTip = test
 
 # Load VSD File action messages
-#LoadVSDFileChooserTitle = Load VSD File
+VSDecoderFileMenuLoadVSDFile = Load VSD File
 LoadVSDFileChooserFilterLabel = VSD File/s
 LoadVSDDirectoryChooserFilterLabel = VSD Directory
+VSDFileError = Error Loading VSD File
 
 # VSD File Status Messages
 VSDFileStatusNoProfiles = VSD File contains no Profiles
 VSDFileStatusNoSounds = Profile contains no defined Sounds
-VSDFileStatusMissingElement = Sound Element is missing required element
-VSDFileStatusMissingSoundFile = Sound Element is missing an audio file.
-VSDFileError = Error Loading VSD File
+VSDFileStatusMissingElement = Sound-Element is missing required element
+VSDFileStatusMissingSoundFile = Sound-Element is missing an audio file
 
 # VSD Startup Action
 VSDStartupActionText = Start Virtual Sound Decoder Manager

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_ca.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_ca.properties
@@ -1,51 +1,21 @@
-## VSDecoderBundle_ca.properties
+# VSDecoderBundle_ca.properties
 #
-# Default properties for the jmri.jmrix.VSDecoder GUI elements
+# Default properties for the jmri.jmrit.VSDecoder GUI elements
 #
-# Catalan properties for the jmri.jmrix.VSDecoder GUI elements
+# Catalan properties for the jmri.jmrit.VSDecoder GUI elements
 # Catalan translation: Joan de Castro [joan276dca@yahoo.es] 18/08/2016
 
-# General Items
-PromptXmlFileTypes = Fitxer XML
-PromptVSDFileTypes = Fitxer VSD
-
-# VSDecoder Window GUI Items
-WindowTitle = Decoder de so virtual [VSD]
-UnsupportedAudioLibrary = El decoder de so virtual necessita la instal\u00b7laci\u00f3 de la llibreria OpenAL. Pot descarregar la llibreria OpenAL de http://connect.creativelabs.com/openal/
-UnsupportedAudioLibraryTitle = Llibreria d'\u00e0udio no suportada.
-
-# VSDecoder Pane Menu Items
-VSDecoderFileMenuLoadVSDFile = Obre fitxer VSD
-VSDecoderFileMenuLoadProfile = Obre perfil VSDecoder
-VSDecoderFileMenuSaveProfile = Desa perfil VSDecoder
-VSDecoderFileMenuPreferences = Prefer\u00e8ncies VSDecoder
-
-# VSDecoder Preferences Pane Items
-AutoStartEngine = Engega motor autom\u00e0ticament
-AutoLoadVSDFile = Llegeix autom\u00e0ticament fitxer VSD
-DefaultVSDFilePath = Ubicaci\u00f3 de fitxer VSD per defecte
-DefaultVSDFileName = Nom de fitxer VSD per defecte
-ListenerPositionTitle = Posici\u00f3 oient
-ExVSDecoderLabelApplyWarning=Per aplicar les noves prefer\u00e8ncies, cal tancar totes les finestres de VSD i tornar-les a obrir.
-VSDecoderPrefsReset= Reset
-FieldVSDecoderPreferencesFrameTitle= Prefer\u00e8ncies de Decoder de So Virtual
-
-# VSDecoder Config Pane text elements
-RosterSaveButtonToolTip = Desa la configuraci\u00f3 a l'entrada de la flota seleccionada.
-AddressSetButtonToolTip = Establir l'adre\u00e7a del Decoder.
-SaveRoster? = Desa entrada de la flota
-UpdateRoster = Vols desar canvis al fitxer de la flota?
-
 # Load VSD File action messages
-#LoadVSDFileChooserTitle = Obre fitxer VSD
+VSDecoderFileMenuLoadVSDFile = Obre fitxer VSD
 LoadVSDFileChooserFilterLabel = Fitxers VSD
+LoadVSDDirectoryChooserFilterLabel = VSD Directory
+VSDFileError = Error llegint fitxer VSD
 
 # VSD File Status Messages
 VSDFileStatusNoProfiles = El fitxer VSD no cont\u00e9 perfil
 VSDFileStatusNoSounds = El perfil no cont\u00e9 sons definits
 VSDFileStatusMissingElement = Falta element de so i \u00e9s necessari
-VSDFileStatusMissingSoundFile = Element de so necessita un arxiu d'\u00e0udio.
-VSDFileError = Error llegint fitxer VSD
+VSDFileStatusMissingSoundFile = Element de so necessita un arxiu d'\u00e0udio
 
 # VSD Startup Action
 VSDStartupActionText = Inicieu el Gestor de Decoder de So Virtual

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_da.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_da.properties
@@ -1,6 +1,6 @@
 # VSDecoderBundle_da.properties
 #
-# Danish properties for the jmri.jmrix.VSDecoder GUI elements
+# Danish properties for the jmri.jmrit.VSDecoder GUI elements
 
 # This file is part of JMRI.
 #
@@ -14,45 +14,17 @@
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 # for more details.
 
-# General Items
-PromptXmlFileTypes = XML Files
-PromptVSDFileTypes = VSD Files
-
-# VSDecoder Window GUI Items
-WindowTitle = Virtual Sound Decoder
-UnsupportedAudioLibrary = Virtual Sound Decoder requires the OpenAL Library be installed. Download OpenAL from http://connect.creativelabs.com/openal/
-UnsupportedAudioLibraryTitle = Unsupported Audio Library
-
-# VSDecoder Pane Menu Items
-VSDecoderFileMenuLoadVSDFile = Load VSD File
-VSDecoderFileMenuLoadProfile = Load VSDecoder Profiles
-VSDecoderFileMenuSaveProfile = Save VSDecoder Profiles
-VSDecoderFileMenuPreferences = VSDecoder Preferences
-
-# VSDecoder Preferences Pane Items
-AutoStartEngine = Auto Start Engine
-AutoLoadVSDFile = Auto-Load VSD File
-DefaultVSDFilePath = Default VSD File Path
-DefaultVSDFileName = Default VSD File Name
-ListenerPositionTitle = Listener Position
-ExVSDecoderLabelApplyWarning=For new preferences to be fully applied, all VSDecoder windows must be closed and reopened.
-VSDecoderPrefsReset=Reset
-FieldVSDecoderPreferencesFrameTitle=Virtual Sound Decoder preferences
-
-# VSDecoder Config Pane text elements
-RosterSaveButtonToolTip = Save the current configuration to the selected Roster Entry.
-AddressSetButtonToolTip = Set the decoder address.
-SaveRoster? = Save Roster Entry
-UpdateRoster = Do you want to save these changes to your Roster file?
-
 # Load VSD File action messages
-#LoadVSDFileChooserTitle = Load VSD File
+VSDecoderFileMenuLoadVSDFile = Load VSD File
 LoadVSDFileChooserFilterLabel = VSD Files
+LoadVSDDirectoryChooserFilterLabel = VSD Directory
+VSDFileError = Error Loading VSD File
 
 # VSD File Status Messages
 VSDFileStatusNoProfiles = VSD File contains no Profiles
 VSDFileStatusNoSounds = Profile contains no defined Sounds
-VSDFileStatusMissingElement = Sound Element is missing required element
-VSDFileStatusMissingSoundFile = Sound Element is missing an audio file.
-VSDFileError = Error Loading VSD File
+VSDFileStatusMissingElement = Sound-Element is missing required element
+VSDFileStatusMissingSoundFile = Sound-Element is missing an audio file
 
+# VSD Startup Action
+VSDStartupActionText = Start Virtual Sound Decoder Manager

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_de.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_de.properties
@@ -1,30 +1,19 @@
 # VSDecoderBundle_de.properties
 # German translation by Egbert Broerse
+#
+# Default properties for the jmri.jmrit.VSDecoder GUI elements
 
-PromptXmlFileTypes=XML Dateien
-PromptVSDFileTypes=VSD Dateien
-WindowTitle=Virtueller SoundDecoder
-UnsupportedAudioLibrary=Virtueller SoundDecoder erfordert eine installierte OpenAL Library. Herunterlade OpenAL von http://connect.creativelabs.com/openal/
-UnsupportedAudioLibraryTitle=Nicht unterst\u00fctzte Audio Library
-VSDecoderFileMenuLoadVSDFile=Lade VSD Datei
-VSDecoderFileMenuLoadProfile=Lade VSD Profile
-VSDecoderFileMenuSaveProfile=Speichere VSD Profile
-VSDecoderFileMenuPreferences=VSD Voreinstellungen
-AutoStartEngine=VSD Engine automatisch anheben
-AutoLoadVSDFile=Auto-lade VSD Datei
-DefaultVSDFilePath=Standard VSD Dateipfad:
-DefaultVSDFileName=Standard VSD Dateiname:
-ListenerPositionTitle=H\u00f6rer Ort
-ExVSDecoderLabelApplyWarning=Voreinstellungen werden ganz durchgef\u00fchrt wenn alle VSD Fenster geschlossen und neu ge\u00f6ffnet sind.
-VSDecoderPrefsReset=Zur\u00fcckstellen
-FieldVSDecoderPreferencesFrameTitle=Virtueller SoundDecoder Voreinstellungen
-RosterSaveButtonToolTip=Speichere die heutige Konfiguration in den ausgew\u00e4hlten Lokparkeintrag.
-AddressSetButtonToolTip=Gebe die neue Lokadresse ein.
-SaveRoster?=Speichere Lokparkeintrag
-UpdateRoster=Die eingegeben \u00c4nderungen speichern in deine Lokparkkonfiguration?
-LoadVSDFileChooserFilterLabel=VSD Dateien
-VSDFileStatusNoProfiles=VSD Datein enth\u00e4lt keine Profile
-VSDFileStatusNoSounds=VSD Datein enth\u00e4lt keine Audiodefinitionen
-VSDFileStatusMissingElement=Audioelement fehlt ein erforderliches Teil
-VSDFileStatusMissingSoundFile=Audioelement fehlt ein Audiodatei
-VSDFileError=Fehler beim Einlesen von VSD Datei
+# Load VSD File action messages
+VSDecoderFileMenuLoadVSDFile = Lade VSD Datei
+LoadVSDFileChooserFilterLabel = VSD Dateien
+LoadVSDDirectoryChooserFilterLabel = VSD Directory
+VSDFileError = Fehler beim Einlesen der VSD Datei
+
+# VSD File Status Messages
+VSDFileStatusNoProfiles = VSD Datei enth\u00e4lt keine Profile
+VSDFileStatusNoSounds = VSD Datei enth\u00e4lt keine Audiodefinitionen
+VSDFileStatusMissingElement = Audioelement fehlt ein erforderliches Teil
+VSDFileStatusMissingSoundFile = Audioelement fehlt eine Audiodatei
+
+# VSD Startup Action
+VSDStartupActionText = Virtual Sound Decoder Manager starten

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_fr.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_fr.properties
@@ -1,6 +1,6 @@
-# VSDecoder_fr.properties
+# VSDecoderBundle_fr.properties
 #
-# French properties for the jmri.jmrix.VSDecoder GUI elements
+# French properties for the jmri.jmrit.VSDecoder GUI elements
 
 # This file is part of JMRI.
 #
@@ -16,44 +16,17 @@
 #
 # Translated by Herv\u00e9 BLOREC <bzh56420@yahoo.fr> le 2013-8-22
 
-# \u00c9l\u00e9ments Generaux
-PromptXmlFileTypes = fichiers XML
-PromptVSDFileTypes = Fichiers VSD
-
-# VSDecoder fen\u00eatre GUI Articles
-WindowTitle =  D\u00e9codeur de Son Virtual
-UnsupportedAudioLibrary = Le D\u00e9codeur Son  Virtual n\u00e9cessite l'installation de la biblioth\u00e8que OpenAL. T\u00e9l\u00e9charger OpenAL de http://connect.creativelabs.com/openal/
-UnsupportedAudioLibraryTitle = Biblioth\u00e8que Audio non pris en charge
-
-#  volet El\u00e9ments du menu VSDecoder
-VSDecoderFileMenuLoadVSDFile = Charge fichier VSD 
-VSDecoderFileMenuLoadProfile = Charge Profils de VSDecoder
-VSDecoderFileMenuSaveProfile = Enregistrer des profils de VSDecoder
-VSDecoderFileMenuPreferences = Pr\u00e9f\u00e9rences VSDecoder 
-
-# VSDecoder le panneau des pr\u00e9f\u00e9rences articles
-AutoStartEngine = D\u00e9marrage Automatique de la Machine
-AutoLoadVSDFile = Chargement Automatique Fichier VSD
-DefaultVSDFilePath = Chemin par D\u00e9faut du Fichier VSD
-DefaultVSDFileName = Default VSD Nom du Fichier
-ListenerPositionTitle = Position de l'Auditeur
-ExVSDecoderLabelApplyWarning = Pour que les nouvelles pr\u00e9f\u00e9rences puissent \u00eatre pleinement appliqu\u00e9es, toutes les fen\u00eatres VSDecoder doivent \u00eatre ferm\u00e9es et r\u00e9ouvertes.
-VSDecoderPrefsReset = R\u00e9initialiser
-FieldVSDecoderPreferencesFrameTitle = pr\u00e9f\u00e9rences du D\u00e9codeur Sonores Virtuels
-
-# VSDecoder \u00e9l\u00e9ments textuels dans le volet de config
-RosterSaveButtonToolTip = Enregistrer la configuration actuelle dans l'entr\u00e9e de la Liste choisi.
-AddressSetButtonToolTip = D\u00e9finir l'adresse du d\u00e9codeur.
-SaveRoster? = Enregistrer Entr\u00e9e Liste
-UpdateRoster = Voulez-vous enregistrer les modifications apport\u00e9es \u00e0 votre fichier Liste?
-
 # Charge messages d'action de fichiers VSD
-#LoadVSDFileChooserTitle = Charge fichier VSD
+VSDecoderFileMenuLoadVSDFile = Charge fichier VSD
 LoadVSDFileChooserFilterLabel = Fichiers VSD
+LoadVSDDirectoryChooserFilterLabel = VSD Directory
+VSDFileError = Erreur lors du chargement du fichier VSD
 
 # VSD Etat classer les messages
 VSDFileStatusNoProfiles = Le fichier VSD ne contient pas de Profils
 VSDFileStatusNoSounds = Le profil ne contient pas de Sons d\u00e9finis
 VSDFileStatusMissingElement = L'\u00c9l\u00e9ment sonore est absent dans les \u00e9l\u00e9ment requis
-VSDFileStatusMissingSoundFile = L'\u00c9l\u00e9ment sonore manque dans un fichier audio.
-VSDFileError = Erreur lors du chargement du fichier VSD
+VSDFileStatusMissingSoundFile = L'\u00c9l\u00e9ment sonore manque dans un fichier audio
+
+# VSD Startup Action
+VSDStartupActionText = Start Virtual Sound Decoder Manager

--- a/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_it.properties
+++ b/java/src/jmri/jmrit/vsdecoder/VSDecoderBundle_it.properties
@@ -1,8 +1,8 @@
-# VSDecoder_it.properties
+# VSDecoderBundle_it.properties
 #
 # Translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 #
-# Italian properties for the jmri.jmrix.VSDecoder GUI elements
+# Italian properties for the jmri.jmrit.VSDecoder GUI elements
 
 # This file is part of JMRI.
 #
@@ -16,45 +16,17 @@
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 # for more details.
 
-# General Items
-PromptXmlFileTypes = Files XML
-PromptVSDFileTypes = Files VSD
-
-# VSDecoder Window GUI Items
-WindowTitle = Decoder Sonoro Virtuale
-UnsupportedAudioLibrary = Il Decoder Sonoro Virtuale richiede l'installazione della libreria OpenAL. Puoi scaricare OpenAL da http://connect.creativelabs.com/openal/
-UnsupportedAudioLibraryTitle = Libreria Audio non supportata
-
-# VSDecoder Pane Menu Items
-VSDecoderFileMenuLoadVSDFile = Carica file VSD
-VSDecoderFileMenuLoadProfile = carica Profilo VSDecoder
-VSDecoderFileMenuSaveProfile = Salva profilo VSDecoder
-VSDecoderFileMenuPreferences = Preferenze VSDecoder
-
-# VSDecoder Preferences Pane Items
-AutoStartEngine = Auto-Start Motore
-AutoLoadVSDFile = Auto-Load file VSD
-DefaultVSDFilePath = Posizione Default file VSD
-DefaultVSDFileName = Nome Default file VSD
-ListenerPositionTitle = Posizione Ascolto
-ExVSDecoderLabelApplyWarning = Per applicare le nuove Preferenze , chiudere e riaprire tutte le finestre VSDecoder.
-VSDecoderPrefsReset = Reset
-FieldVSDecoderPreferencesFrameTitle = Preferenze Decoder Sonoro Virtuale
-
-# VSDecoder Config Pane text elements
-RosterSaveButtonToolTip = Salva la configurazione corrente nella voce selezionata del Roster.
-AddressSetButtonToolTip = Scegli l'indirizzo del Decoder.
-SaveRoster? = Salva Voce Roster
-UpdateRoster = Vuoi salvare queste modifiche nel tuo file Roster?
-
 # Load VSD File action messages
-#LoadVSDFileChooserTitle = Carica File VSD
+VSDecoderFileMenuLoadVSDFile = Carica file VSD
 LoadVSDFileChooserFilterLabel = Files VSD
+LoadVSDDirectoryChooserFilterLabel = VSD Directory
+VSDFileError = Errore caricamento file VSD
 
 # VSD File Status Messages
 VSDFileStatusNoProfiles = File VSD non contiene Profili
 VSDFileStatusNoSounds = Profilo non contiene Suoni definiti
 VSDFileStatusMissingElement = Elemento del Suono mancante e richiesto
-VSDFileStatusMissingSoundFile = Elemento del Suono mancante di file audio.
-VSDFileError = Errore caricamento file VSD
+VSDFileStatusMissingSoundFile = Elemento del Suono mancante di file audio
 
+# VSD Startup Action
+VSDStartupActionText = Start Virtual Sound Decoder Manager

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.java
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDManagerFrame.java
@@ -1,27 +1,5 @@
 package jmri.jmrit.vsdecoder.swing;
 
-/**
- * class VSDManagerFrame
- *
- * Main frame for the new GUI VSDecoder Manager Frame
- */
-
-/*
- * <hr>
- * This file is part of JMRI.
- * <p>
- * JMRI is free software; you can redistribute it and/or modify it under 
- * the terms of version 2 of the GNU General Public License as published 
- * by the Free Software Foundation. See the "COPYING" file for a copy
- * of this license.
- * <p>
- * JMRI is distributed in the hope that it will be useful, but WITHOUT 
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
- * for more details.
- *
- * @author   Mark Underwood Copyright (C) 2011
- */
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -47,9 +25,7 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.EventListenerList;
 import jmri.jmrit.vsdecoder.LoadVSDFileAction;
-import jmri.jmrit.vsdecoder.LoadXmlVSDecoderAction;
 import jmri.jmrit.vsdecoder.SoundEvent;
-import jmri.jmrit.vsdecoder.StoreXmlVSDecoderAction;
 import jmri.jmrit.vsdecoder.VSDConfig;
 import jmri.jmrit.vsdecoder.VSDecoder;
 import jmri.jmrit.vsdecoder.VSDecoderManager;
@@ -57,6 +33,26 @@ import jmri.util.JmriJFrame;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * class VSDManagerFrame
+ *
+ * Main frame for the new GUI VSDecoder Manager Frame
+ *
+ * <hr>
+ * This file is part of JMRI.
+ * <p>
+ * JMRI is free software; you can redistribute it and/or modify it under 
+ * the terms of version 2 of the GNU General Public License as published 
+ * by the Free Software Foundation. See the "COPYING" file for a copy
+ * of this license.
+ * <p>
+ * JMRI is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License 
+ * for more details.
+ *
+ * @author   Mark Underwood Copyright (C) 2011
+ */
 public class VSDManagerFrame extends JmriJFrame {
 
     public static enum PropertyChangeID {
@@ -67,7 +63,7 @@ public class VSDManagerFrame extends JmriJFrame {
     public static final Map<PropertyChangeID, String> PCIDMap;
 
     static {
-        Map<PropertyChangeID, String> aMap = new HashMap<PropertyChangeID, String>();
+        Map<PropertyChangeID, String> aMap = new HashMap<>();
         aMap.put(PropertyChangeID.MUTE, "VSDMF:Mute");
         aMap.put(PropertyChangeID.VOLUME_CHANGE, "VSDMF:VolumeChange");
         aMap.put(PropertyChangeID.ADD_DECODER, "VSDMF:AddDecoder");
@@ -77,7 +73,7 @@ public class VSDManagerFrame extends JmriJFrame {
     }
 
     // Map of Mnemonic KeyEvent values to GUI Components
-    private static final Map<String, Integer> Mnemonics = new HashMap<String, Integer>();
+    private static final Map<String, Integer> Mnemonics = new HashMap<>();
 
     static {
         // Menu
@@ -174,7 +170,7 @@ public class VSDManagerFrame extends JmriJFrame {
             }
         });
 
-        log.debug("pane size + " + decoderPane.getPreferredSize());
+        log.debug("pane size + {}", decoderPane.getPreferredSize());
         this.pack();
         this.setVisible(true);
 
@@ -186,7 +182,7 @@ public class VSDManagerFrame extends JmriJFrame {
      */
     protected void muteButtonPressed(ActionEvent e) {
         JToggleButton b = (JToggleButton) e.getSource();
-        log.debug("Mute button pressed. value = " + b.isSelected());
+        log.debug("Mute button pressed. value: {}", b.isSelected());
         firePropertyChange(PropertyChangeID.MUTE, !b.isSelected(), b.isSelected());
     }
 
@@ -201,7 +197,7 @@ public class VSDManagerFrame extends JmriJFrame {
         d.addPropertyChangeListener(new PropertyChangeListener() {
             @Override
             public void propertyChange(PropertyChangeEvent event) {
-                log.debug("property change name " + event.getPropertyName() + " old " + event.getOldValue() + " new " + event.getNewValue());
+                log.debug("property change name {}, old: {}, new: {}", event.getPropertyName(), event.getOldValue(), event.getNewValue());
                 addButtonPropertyChange(event);
             }
         });
@@ -213,14 +209,14 @@ public class VSDManagerFrame extends JmriJFrame {
      */
     protected void addButtonPropertyChange(PropertyChangeEvent event) {
         log.debug("internal config dialog handler");
-        log.debug("New Config: " + config);
+        log.debug("New Config: {}", config);
         // If this decoder already exists, don't create a new Control
         if (VSDecoderManager.instance().getVSDecoderByAddress(config.getLocoAddress().toString()) != null) {
             JOptionPane.showMessageDialog(null, Bundle.getMessage("MgrAddDuplicateMessage"));
         } else {
             VSDecoder newDecoder = VSDecoderManager.instance().getVSDecoder(config);
             if (newDecoder == null) {
-                log.info("no New Decoder constructed!" + config);
+                log.warn("no New Decoder constructed! Config: {}", config);
                 return;
             }
             VSDControl newControl = new VSDControl(config);
@@ -231,7 +227,7 @@ public class VSDManagerFrame extends JmriJFrame {
             newControl.addPropertyChangeListener(new PropertyChangeListener() {
                 @Override
                 public void propertyChange(PropertyChangeEvent event) {
-                    log.debug("property change name " + event.getPropertyName() + " old " + event.getOldValue() + " new " + event.getNewValue());
+                    log.debug("property change name {}, old: {}, new: {}", event.getPropertyName(), event.getOldValue(), event.getNewValue());
                     vsdControlPropertyChange(event);
                 }
             });
@@ -264,7 +260,7 @@ public class VSDManagerFrame extends JmriJFrame {
                 log.debug("VSD is null.");
             }
             this.removePropertyChangeListener(vsd);
-            log.debug("vsdControlPropertyChange: ID = " + PCIDMap.get(PropertyChangeID.REMOVE_DECODER) + " Old " + ov + " New " + nv);
+            log.debug("vsdControlPropertyChange. ID: {}, old: {}, new: {}", PCIDMap.get(PropertyChangeID.REMOVE_DECODER), ov, nv);
             firePropertyChange(PropertyChangeID.REMOVE_DECODER, ov, nv);
             decoderPane.remove((VSDControl) event.getSource());
             if (decoderPane.getComponentCount() == 0) {
@@ -292,7 +288,7 @@ public class VSDManagerFrame extends JmriJFrame {
      */
     protected void volumeChange(ChangeEvent e) {
         JSlider v = (JSlider) e.getSource();
-        log.debug("Volume slider moved. value = " + v.getValue());
+        log.debug("Volume slider moved. value: {}", v.getValue());
         firePropertyChange(PropertyChangeID.VOLUME_CHANGE, v.getValue(), v.getValue());
     }
 
@@ -301,17 +297,12 @@ public class VSDManagerFrame extends JmriJFrame {
         fileMenu.setMnemonic(Mnemonics.get("FileMenu")); // OK to use this different key name for Mnemonics
 
         fileMenu.add(new LoadVSDFileAction(Bundle.getMessage("VSDecoderFileMenuLoadVSDFile")));
-        fileMenu.add(new StoreXmlVSDecoderAction(Bundle.getMessage("VSDecoderFileMenuSaveProfile")));
-        fileMenu.add(new LoadXmlVSDecoderAction(Bundle.getMessage("VSDecoderFileMenuLoadProfile")));
 
         JMenu editMenu = new JMenu(Bundle.getMessage("MenuEdit"));
         editMenu.setMnemonic(Mnemonics.get("EditMenu")); // OK to use this different key name for Mnemonics
         editMenu.add(new VSDPreferencesAction(Bundle.getMessage("VSDecoderFileMenuPreferences")));
 
-        fileMenu.getItem(1).setEnabled(false); // disable XML store
-        fileMenu.getItem(2).setEnabled(false); // disable XML load
-
-        menuList = new ArrayList<JMenu>(3);
+        menuList = new ArrayList<>(2);
 
         menuList.add(fileMenu);
         menuList.add(editMenu);
@@ -319,7 +310,7 @@ public class VSDManagerFrame extends JmriJFrame {
         this.setJMenuBar(new JMenuBar());
         this.getJMenuBar().add(fileMenu);
         this.getJMenuBar().add(editMenu);
-        this.addHelpMenu("package.jmri.jmrit.vsdecoder.swing.VSDManagerFrame", true); // Fix this... needs to be help for the new frame
+        this.addHelpMenu("package.jmri.jmrit.vsdecoder.swing.VSDManagerFrame", true);
     }
 
     // VSDecoderManager Events
@@ -370,6 +361,6 @@ public class VSDManagerFrame extends JmriJFrame {
         }
     }
 
-    //public List<JMenu> getMenus() { return menuList; }
     private final static Logger log = LoggerFactory.getLogger(VSDManagerFrame.class);
+
 }

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle.properties
@@ -1,22 +1,8 @@
-## VSDSwingBundle.properties
+# VSDSwingBundle.properties
 #
-# Default properties for the jmri.jmrix.VSDecoder GUI elements
+# Default properties for the jmri.jmrit.VSDecoder GUI elements
 
 # New GUI Items
-
-#Common Items - next 10 are in VSDecoderBundle
-#VSDecoderFileMenu = File
-#VSDecoderFileMenuLoadVSDFile = Load VSD File
-#VSDecoderFileMenuLoadProfile = Load VSDecoder Profiles
-#VSDecoderFileMenuSaveProfile = Save VSDecoder Profiles
-#VSDecoderEditMenuPreferences = VSDecoder Preferences
-#VSDecoderEditMenu = Edit
-
-# Conventionalized Common Items
-#MenuItemLoadVSDFile = Load VSDecoder File
-#MenuItemSaveProfile = Save VSDecoder Profiles
-#MenuItemLoadProfile = Load VSDecoder Profiles
-#MenuItemEditPreferences = VSDecoder Preferences
 
 # VSDManagerFrame
 VSDManagerFrameTitle = Virtual Sound Decoder Manager
@@ -31,7 +17,6 @@ MgrAddDuplicateMessage = VSDecoder already exists
 
 # VSDControl
 OptionsButtonLabel = Options
-#OptionButtonPressedMessage = Option Button is not yet implemented!
 OptionsDialogTitlePrefix = Options
 BlankVSDControlLabel = No Active Decoders
 
@@ -67,7 +52,6 @@ ButtonAudioModeHeadphone = Headphones
 FieldAudioMode = Listener Mode:
 FieldOpsTabTitle = Operations Locations
 FieldListenersTabTitle = Listeners
-#ButtonClose = Close
 FieldMLFSaveDialogTitle = Save Changes
 FieldMLFSaveDialogConfirmMessage = Save Reporters and Ops Locations?
 ToolTipButtonAudioModeRoom = Use speakers in the room for VSDecoder audio
@@ -95,7 +79,10 @@ ToolTipDP_StartButton = Start or stop the Engine Sound.
 EngineStartSpeedMessage = Speed must be 0 to start engine
 
 # VSDecoder Preferences Pane Items
-VSDPrefsAutoStartEngine = Auto Start Engine
-ListenerPositionTitle = Listener Position
-VSDecoderPrefsReset=Reset
+VSDecoderFileMenuPreferences = VSDecoder Preferences
+AutoStartEngine = Auto Start Engine
+AutoLoadVSDFile = Auto-Load VSD File
+DefaultVSDFilePath = Default VSD File Path
+DefaultVSDFileName = Default VSD File Name
+ExVSDecoderLabelApplyWarning = For new preferences to be fully applied, all VSDecoder windows must be closed and reopened.
 Browse = Browse

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_ca.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_ca.properties
@@ -1,25 +1,12 @@
-## VSDSwingBundle_ca.properties
+# VSDSwingBundle_ca.properties
 #
-# Default properties for the jmri.jmrix.VSDecoder GUI elements
+# Default properties for the jmri.jmrit.VSDecoder GUI elements
 #
-# Catalan properties for the jmri.jmrix.VSDecoder GUI elements
+# Catalan properties for the jmri.jmrit.VSDecoder GUI elements
 # Translation: Joan de Castro [joan276dca@yahoo.es] 18/08/2016
 # Catalan Translation Luis Zamora (eldelinux) <eldelinux@yahoo.es> 2018/06/16
 
 # New GUI Items
-
-#Common Items
-#VSDecoderFileMenuLoadVSDFile = Obre fitxer VSD
-#VSDecoderFileMenuLoadProfile = Obre perfil de VSDecoder
-#VSDecoderFileMenuSaveProfile = Desa perfil de VSDecoder
-#VSDecoderEditMenuPreferences = Prefer\u00e8ncies de VSDecoder
-#VSDecoderEditMenu = Edita
-
-# Conventionalized Common Items
-#MenuItemLoadVSDFile = Obre perfil de VSDecoder
-#MenuItemSaveProfile = Desa perfil de VSDecoder
-#MenuItemLoadProfile = Obre perfils de VSDecoder
-#MenuItemEditPreferences = Prefer\u00e8ncies de VSDecoder
 
 # VSDManagerFrame
 VSDManagerFrameTitle = Gestor de decoders de so virtuals
@@ -34,7 +21,6 @@ MgrAddDuplicateMessage = VSDecoder ja existeix
 
 # VSDControl
 OptionsButtonLabel = Opcions
-#OptionButtonPressedMessage = Bot\u00f3 d'opcions encara no implementat
 OptionsDialogTitlePrefix = Opcions
 BlankVSDControlLabel = No hi ha decoder actiu
 
@@ -70,7 +56,6 @@ ButtonAudioModeHeadphone = Auriculars
 FieldAudioMode = Mode d'escolta:
 FieldOpsTabTitle = Lloc de funcionament
 FieldListenersTabTitle = Oients
-#ButtonClose = Tanca
 FieldMLFSaveDialogTitle = Desa canvis
 FieldMLFSaveDialogConfirmMessage = Desa reporters i lloc de funcionament?
 ToolTipButtonAudioModeRoom = Usa altaveus per l'\u00e0udio del VSDecoder
@@ -98,7 +83,9 @@ ToolTipDP_StartButton = Engega/Para so de motor.
 EngineStartSpeedMessage = La velocitat ha d'estar a 0 per engegar el motor
 
 # VSDecoder Preferences Pane Items
-VSDPrefsAutoStartEngine = Inici autom\u00e0tic de m\u00e0quina
-ListenerPositionTitle = Posici\u00f3 de l'oient
-VSDecoderPrefsReset=Reset
+VSDecoderFileMenuPreferences = Prefer\u00e8ncies de VSDecoder
+AutoStartEngine = Auto Start Engine
+AutoLoadVSDFile = Auto-Load VSD File
+DefaultVSDFilePath = Default VSD File Path
+DefaultVSDFileName = Default VSD File Name
 Browse = Navega

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_da.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_da.properties
@@ -1,21 +1,8 @@
-## VSDSwingBundle_da.properties
+# VSDSwingBundle_da.properties
 #
-# Danish properties for the jmri.jmrix.VSDecoder GUI elements
+# Danish properties for the jmri.jmrit.VSDecoder GUI elements
 
 # New GUI Items
-
-#Common Items
-#VSDecoderFileMenuLoadVSDFile = Load VSD File
-#VSDecoderFileMenuLoadProfile = Load VSDecoder Profiles
-#VSDecoderFileMenuSaveProfile = Save VSDecoder Profiles
-#VSDecoderEditMenuPreferences = VSDecoder Preferences
-#VSDecoderEditMenu = Edit
-
-# Conventionalized Common Items
-#MenuItemLoadVSDFile = Load VSDecoder Profiles
-#MenuItemSaveProfile = Save VSDecoder Profiles
-#MenuItemLoadProfile = Load VSDecoder Profiles
-#MenuItemEditPreferences = VSDecoder Preferences
 
 # VSDManagerFrame
 VSDManagerFrameTitle = Virtual Sound Decoder Manager
@@ -30,7 +17,6 @@ MgrAddDuplicateMessage = VSDecoder already exists
 
 # VSDControl
 OptionsButtonLabel = Options
-#OptionButtonPressedMessage = Option Button is not yet implemented!
 OptionsDialogTitlePrefix = Options
 BlankVSDControlLabel = No Active Decoders
 
@@ -88,10 +74,14 @@ FieldTableAzimuthInvalidValue = Value is not in the domain of definition
 # DieselPane
 ToolTipDP_ThrottleSpinner = Shows current Engine Notch (Information only. Not clickable)
 ButtonEngineStart = Engine Start
+ButtonEngineStop = Engine Off
 ToolTipDP_StartButton = Start or stop the Engine Sound.
 EngineStartSpeedMessage = Speed must be 0 to start engine
 
 # VSDecoder Preferences Pane Items
-VSDPrefsAutoStartEngine = Auto Start Engine
-ListenerPositionTitle = Listener Position
+VSDecoderFileMenuPreferences = VSDecoder Preferences
+AutoStartEngine = Auto Start Engine
+AutoLoadVSDFile = Auto-Load VSD File
+DefaultVSDFilePath = Default VSD File Path
+DefaultVSDFileName = Default VSD File Name
 Browse = Browse

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_de.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_de.properties
@@ -1,12 +1,9 @@
-## VSDSwingBundle_de.properties
+# VSDSwingBundle_de.properties
 #
-# German translation by Egbert Broerse for the jmri.jmrix.VSDecoder GUI elements
+# German translation by Egbert Broerse for the jmri.jmrit.VSDecoder GUI elements
 # This file is part of JMRI.
 #----------------------------------------
 # New GUI Items
-
-#Common Items
-# more in VSDecoderBundle
 
 # VSDManagerFrame
 VSDManagerFrameTitle=Virtueller Sounddecoder Verwalter
@@ -21,7 +18,6 @@ MgrAddDuplicateMessage = VSDecoder ist schon vorhanden
 
 # VSDControl
 OptionsButtonLabel=Optionen
-#OptionButtonPressedMessage=Optionknopf noch nicht unterst\u00fctzt!
 OptionsDialogTitlePrefix=Optionen f\u00fcr
 BlankVSDControlLabel=Keine aktive Dekoder
 
@@ -30,11 +26,11 @@ EmptyRosterBox=Keinen Lokparkeintrag ausgew\u00e4hlt
 RosterLabel=Lokpark
 ConfigSaveButtonLabel=Speichere im Lokpark
 AddressSetButtonToolTip=Klicke um eine neue Lokadresse zu w\u00e4hlen.
-RosterSaveButtonToolTip=Speichere die heutige Konfiguration in den ausgew\u00e4hlten Lokparkeintrag.
+RosterSaveButtonToolTip=Speichere die aktuelle Konfiguration in den ausgew\u00e4hlten Lokparkeintrag.
 NoLocoSelectedText=W\u00e4hle ein Profil
 LocoTabbedPaneTitle=W\u00e4hle eine Lok
 LocoTabbedPaneManualTab=Manuell
-UpdateRoster=Die eingegeben \u00c4nderungen speichern in deine Lokparkkonfiguration?
+UpdateRoster=Die eingegebenen \u00c4nderungen speichern in deine Lokparkkonfiguration?
 SaveRoster?=Speichere Lokparkeintrag
 LTPRosterTabToolTip=Auf diese Reiter kann man einen Lok vom Lokpark w\u00e4hlen.
 LTPManualTabToolTip=Auf diese Reiter kann man manuell eine Lokadresse eingeben.
@@ -57,7 +53,6 @@ ButtonAudioModeHeadphone=Kopfh\u00f6rer
 FieldAudioMode=H\u00f6rmodus:
 FieldOpsTabTitle=Betriebsorte
 FieldListenersTabTitle=H\u00f6rer
-#ButtonClose=Schlie\u00dfe
 FieldMLFSaveDialogTitle=Speichere \u00c4nderungen
 FieldMLFSaveDialogConfirmMessage=Melder und Betriebsorte speichern?
 ToolTipButtonAudioModeRoom=Nutze Lautsprecher im Raum f\u00fcr VSD Audio
@@ -69,6 +64,9 @@ ToolTipListenerTab=Gebe VSD H\u00f6rerort(e) ein
 ToolTipButtonMLFClose=Fenster schlie\u00dfen (ohne \u00c4nderungen durch zu f\u00fchren).
 ToolTipButtonMLFSave=Speichere \u00c4nderungen auf alle Reiter
 FieldTableUseColumn=Nutze Ort
+FieldTableXColumn = X
+FieldTableYColumn = Y
+FieldTableZColumn = Z
 FieldTableIsTunnelColumn=Im Tunnel
 FieldTableBearingColumn=Richtung
 FieldTableAzimuthColumn=Azimutwinkel
@@ -77,12 +75,14 @@ FieldTableAzimuthInvalidValue=Wert liegt nicht im Definitionsbereich
 # DieselPane
 ToolTipDP_ThrottleSpinner=Zeigt die aktuelle Lokgeschwindigkeitsstufe (nur informativ, nicht anpassbar)
 ButtonEngineStart=VSD Motor Start
-ButtonEngineStop= VSD Motor Aus
+ButtonEngineStop=VSD Motor Aus
 ToolTipDP_StartButton=Starte/Halte das Lokger\u00e4usch.
 EngineStartSpeedMessage=VSD Motor Start nur m\u00f6glich bei Geschwindigkeit 0
 
 # VSDecoder Preferences Pane Items
-VSDPrefsAutoStartEngine=Motor automatisch anheben
-ListenerPositionTitle=H\u00f6rerort
-VSDecoderPrefsReset=Zur\u00fcckstellen
+VSDecoderFileMenuPreferences = VSDecoder Einstellungen
+AutoStartEngine = Auto Start Maschine
+AutoLoadVSDFile = Auto-Load VSD Datei
+DefaultVSDFilePath = Default VSD Datei Pfad
+DefaultVSDFileName = Default VSD Dateiname
 Browse=Browsen

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_fr.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_fr.properties
@@ -1,8 +1,8 @@
-# VSDecoder.properties
+# VSDSwingBundle_fr.properties
 #
 # Revision $Revision$
 #
-# Default properties for the jmri.jmrix.VSDecoder GUI elements
+# Default properties for the jmri.jmrit.VSDecoder GUI elements
 
 # This file is part of JMRI.
 #
@@ -19,121 +19,84 @@
 #----------------------------------------
 # New GUI Items
 
-#Common Items
-VSDecoderFileMenu = Fichiers
-VSDecoderFileMenuLoadVSDFile = Charger Fichier VSD
-VSDecoderFileMenuLoadProfil = Charger Profils VSDecoder
-VSDecoderFileMenuSaveProfil = SauvegarderProfils VSDecoder
-VSDecoderEditMenuPreferences = Pr&#233;f&#233;rences VSDecoder
-VSDecoderEditMenu = Edit
-
-# Conventionalized Common Items
-MenuFile = File
-MenuItemLoadVSDFile = Charger Profils VSDecoder
-MenuItemSaveProfil = Sauvegarder Profils VSDecoder
-MenuItemLoadProfil = Charger Profils VSDecoder
-MenuEdit = Edit
-MenuItemEditPreferences = Pr&#233;f&#233;rences VSDecoder
-
-
 # VSDManagerFrame
 VSDManagerFrameTitle = Gestionnaire VSDecoder
-MuteButtonLabel = D&#233;sactiver
-AddButtonLabel = Ajouter D&#233;codeur
+MuteButtonLabel = D\u00E9sactiver
+AddButtonLabel = Ajouter D\u00E9codeur
 VolumePaneLabel = Volume:
 NewDecoderConfigPaneTitle = Configurer Nouveau VSDecoder
-MgrCloseButtonLabel = Fermer
 MgrVolumeToolTip = Adjuster le volume maitre pour tous les VSDecoders
-MgrMuteToolTip = D&#233;sactiver tous les VSDecoders
+MgrMuteToolTip = D\u00E9sactiver tous les VSDecoders
 MgrAddButtonToolTip = Ajouter un nouveau VSDecoder
-MgrCloseButtonToolTip = Fermer cette fen&#234;tre et couper tous les VSDecoders
+MgrAddDuplicateMessage = VSDecoder already exists
 
 # VSDControl
-ConfigButtonLabel = Configuration
 OptionsButtonLabel = Options
-DeleteButtonLabel = Effacer
-OptionButtonPressedMessage = Ce Bouton d'option n'est pas sencore install&#233;!
-ConfigDialogTitlePrefix = Configurer
 OptionsDialogTitlePrefix = Options
-BlankVSDControlLabel = Pas de D&#233;codeurs Actifs
+BlankVSDControlLabel = Pas de D\u00E9codeurs Actifs
 
 # VSDConfigDialog
-EmptyRosterBox = Pas d'Entr&#233;e Inventaire S&#233;lectionn&#233;e
+EmptyRosterBox = Pas d'Entr\u00e9e Inventaire S\u00e9lectionn\u00e9e
 RosterLabel = Inventaire
 ConfigSaveButtonLabel = Sauvegarder dans l'Inventaire
-LoadVSDFileButtonLabel = Charger fichier VSD
-AddressSetButtonLabel = D&#233;finir
-AddressSetButtonToolTip = Cliquer ici pour d&#233;finir l'adresse Loco.
-RosterSaveButtonToolTip = Sauvegarder la configuration actuelle dans l'Entr&#233;e Inventaire s&#233;lectionn&#233;e.
-CloseButtonLabel = OK
-CancelButtonLabel = Annuler
-NoLocoSelectedText = S&#233;lectionner un profil
-LocoTabbedPaneTitle = S&#233;lectionner une Loco
-LocoTabbedPaneRosterTab = Inventaire
+AddressSetButtonToolTip = Cliquer ici pour d\u00e9finir l'adresse Loco.
+RosterSaveButtonToolTip = Sauvegarder la configuration actuelle dans l'Entr\u00e9e Inventaire s\u00e9lectionn\u00e9e.
+NoLocoSelectedText = S\u00e9lectionner un profil
+LocoTabbedPaneTitle = S\u00e9lectionner une Loco
 LocoTabbedPaneManualTab = Manuel
 UpdateRoster = Voulez-vous sauvegarder ces changements dans vootre fichier Inventaire?
-SaveRoster? = Sauvegarder Entr&#233;e Inventaire
-LTPRosterTabToolTip = Utiliser cette onglet pour s&#233;lectionner une locomotive dans votre Inventaire
-LTPRosterSelectorToolTip = Choisir une locomotive dans votre Inventaire. Utilisez le s&#233;lecteur gauche pour filtrer les locomotives disponibles.
+SaveRoster? = Sauvegarder Entr\u00e9e Inventaire
+LTPRosterTabToolTip = Utiliser cette onglet pour s\u00e9lectionner une locomotive dans votre Inventaire
+LTPManualTabToolTip = Use this tab to manually set a locomotive address
+LTPRosterSelectorToolTip = Choisir une locomotive dans votre Inventaire. Utilisez le s\u00e9lecteur gauche pour filtrer les locomotives disponibles.
 LTPAddressSelectorToolTip = EntrEnter a locomotive address here, then click "Set"
-ProfilSelectorPaneTitle = S&#233;lectionner un Profil
-ProfilComboBoxToolTip = Choisir un Profil son depuis cette liste.
-ProfilLoadButtonToolTip = Charger un nouveau fichier VSD pour ajouter plus de Profils
-CD_CloseButtonToolTip = Sauvegarder ces r&#233;glages et cr&#233;er un VSDecoder.
+ProfileSelectorPaneTitle = S\u00e9lectionner un Profil
+ProfileComboBoxToolTip = Choisir un Profil son depuis cette liste.
+ProfileLoadButtonToolTip = Charger un nouveau fichier VSD pour ajouter plus de Profils
+CD_CloseButtonToolTip = Sauvegarder ces r\u00e9glages et cr\u00e9er un VSDecoder.
 CD_CancelButtonToolTip = Annuler cette configuration.
 
 # VSDOptionsDialog
-FieldSelectTrain = S&#233;lectionner Exploitation Train
-ButtonOK = OK
+FieldSelectTrain = S\u00e9lectionner Exploitation Train
 ToolTipCloseDialog = Fermer le dialogue
 
 # ManageLocationsFrame
 FieldManageLocationsFrameTitle = Gestionnaire d'Emplacements VSDecoder
-ButtonAudioModeRoom = Ambiance Pi&#232;ce
+ButtonAudioModeRoom = Ambiance Pi\u00E8ce
 ButtonAudioModeHeadphone = Casque
-FieldAudioMode = Mode &#201;couteur:
-FieldReportersTabTitle = Reporters
-FieldBlockTabTitle = Cantons
+FieldAudioMode = Mode \u00C9couteur:
 FieldOpsTabTitle = Exploitation Emplacements
-FieldListenersTabTitle = &#201;couteurs
-ButtonClose = Fermer
-ButtonSave = Sauvegarder
-FieldMLFSaveDialogTile = Sauvegarder Changements
+FieldListenersTabTitle = \u00C9couteurs
+FieldMLFSaveDialogTitle = Save Changes
 FieldMLFSaveDialogConfirmMessage = Sauvegarde les Rapports et Exploitation Emplacements?
 ToolTipButtonAudioModeRoom = Utiliser les Haut-Parleurs de la pi-ce pour le VSDecoder audio
 ToolTipButtonAudioModeHeadphone = Utiliser le casque pour VSDecoder audio
-ToolTipReporterTab = D&#233;finir les Emplacements Physiques des Rapports JMRI
-ToolTipBlockTab = D&#233;finir les Emplacements Physiques des Cantons JMRI
-ToolTipOpsTab = D&#233;finir les Emplacements Physiques de l'Exploitation Emplacements JMRI
-ToolTipListenerTab = D&#233;finir l'Emplacement (s) Ecouteur VSDecoder
-ToolTipButtonMLFClose = Fermer cette fen&#234;tre (ne sauvegarde pas les changements).
+ToolTipReporterTab = D\u00e9finir les Emplacements Physiques des Rapports JMRI
+ToolTipBlockTab = D\u00e9finir les Emplacements Physiques des Cantons JMRI
+ToolTipOpsTab = D\u00e9finir les Emplacements Physiques de l'Exploitation Emplacements JMRI
+ToolTipListenerTab = D\u00e9finir l'Emplacement (s) Ecouteur VSDecoder
+ToolTipButtonMLFClose = Fermer cette fen\u00EAtre (ne sauvegarde pas les changements).
 ToolTipButtonMLFSave = Sauvegarder les changements de tous les onglets.
-FieldTableNameColumn = Nom
 FieldTableUseColumn = Utiliser Emplacement
 FieldTableXColumn = X
 FieldTableYColumn = Y
 FieldTableZColumn = Z
 FieldTableIsTunnelColumn = Est-ce un Tunnel?
 FieldTableBearingColumn = Support
-FieldTableAzimuthColumn = Azimuth
+FieldTableAzimuthColumn = Azimut
 FieldTableAzimuthInvalidValue = Value is not in the domain of definition
 
 # DieselPane
-ToolTipDP_ThrottleSpinner = SMontrer les Machines Coch&#233;es actuellement. (Information seulement. Non cliquable)
-ButtonEngineStart = D&#233;marrage Machine
-ToolTipDP_StartButton = D&#233;marrer ou stopper le son de la Machine.
+ToolTipDP_ThrottleSpinner = SMontrer les Machines Coch\u00e9es actuellement. (Information seulement. Non cliquable)
+ButtonEngineStart = D\u00e9marrage Machine
+ButtonEngineStop = Engine Off
+ToolTipDP_StartButton = D\u00e9marrer ou stopper le son de la Machine.
 EngineStartSpeedMessage = Speed must be 0 to start engine
 
 # VSDecoder Preferences Pane Items
-VSDPrefsAutoStartEngine = D&#233;marrage auto de la Machine
-VSDPrefsAutoLoadVSDFile = Chargement Auto du fichier VSD
-VSDPrefsDefaultVSDFilePath = Chemin par d&#233;faut du fichier VSD
-VSDPrefsDefaultVSDFileName = Nom par d&#233;faut du fichier VSD
-ListenerPositionTitle = Position &#201;couteur
-VSDPrefsExVSDecoderLabelApplyWarning=Pour que les nouvelles pr&#233;f&#233;rences soient pleinement appliqu&#233;es, toutes les fen&#234;tres VSDecoder doivent &#234;tre ferm&#233;es puis r&#233;ouvertes..
-VSDecoderPrefsSave=Sauvegarder
-VSDecoderPrefsApply=Appliquer
-VSDecoderPrefsCancel=Annuler
-VSDecoderPrefsReset=R&#233;initialiser
-FieldVSDecoderPreferencesFrameTitle=Pr&#233;f&#233;rences D&#233;codeur Son Virtuel
+VSDecoderFileMenuPreferences = Pr\u00e9f\u00e9rences VSDecoder
+AutoStartEngine = D\u00E9marrage auto de la Machine
+AutoLoadVSDFile = Chargement Auto du fichier VSD
+DefaultVSDFilePath = Chemin par d\u00e9faut du fichier VSD
+DefaultVSDFileName = Nom par d\u00e9faut du fichier VSD
 Browse = Naviguer

--- a/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_it.properties
+++ b/java/src/jmri/jmrit/vsdecoder/swing/VSDSwingBundle_it.properties
@@ -1,22 +1,9 @@
-## VSDSwingBundle_it.properties
+# VSDSwingBundle_it.properties
 #
-# Italian properties for the jmri.jmrix.VSDecoder GUI elements
+# Italian properties for the jmri.jmrit.VSDecoder GUI elements
 # Translation: Enzo Fortuna (babbo_enzo@yahoo.com )
 
 # New GUI Items
-
-#Common Items
-#VSDecoderFileMenuLoadVSDFile = Carica file VSD
-#VSDecoderFileMenuLoadProfile = Carica Profilo VSDecoder
-#VSDecoderFileMenuSaveProfile = Salva Profilo VSDecoder
-#VSDecoderEditMenuPreferences = Preferenze VSDecoder
-#VSDecoderEditMenu = Modifica
-
-# Conventionalized Common Items
-#MenuItemLoadVSDFile = Carica Profilo VSDecoder
-#MenuItemSaveProfile = Salva Profilo VSDecoder
-#MenuItemLoadProfile = Carica Profili VSDecoder
-#MenuItemEditPreferences = Preferenze VSDecoder
 
 # VSDManagerFrame
 VSDManagerFrameTitle = Manager Decoder Virtuale Sonoro
@@ -31,7 +18,6 @@ MgrAddDuplicateMessage = VSDecoder already exists
 
 # VSDControl
 OptionsButtonLabel = Opzioni
-#OptionButtonPressedMessage = Pulsante Opzioni non ancora implementato
 OptionsDialogTitlePrefix = Opzioni
 BlankVSDControlLabel = Nessun decoder attivo
 
@@ -67,7 +53,6 @@ ButtonAudioModeHeadphone = Cuffie
 FieldAudioMode = Modo Ascolto:
 FieldOpsTabTitle = Posizioni Operative
 FieldListenersTabTitle = Ascoltatori
-#ButtonClose = Chiudi
 FieldMLFSaveDialogTitle = Salva Modifiche
 FieldMLFSaveDialogConfirmMessage = Salva Reporters e Posizioni?
 ToolTipButtonAudioModeRoom = Usa altoparlanti nella camera per audio VSDecoder
@@ -90,11 +75,14 @@ FieldTableAzimuthInvalidValue = Value is not in the domain of definition
 # DieselPane
 ToolTipDP_ThrottleSpinner = Visualizza Notch Loco corrente (Non cliccabile)
 ButtonEngineStart = Start Loco
+ButtonEngineStop = Engine Off
 ToolTipDP_StartButton = Start o stop Suono Loco.
 EngineStartSpeedMessage = Speed must be 0 to start engine
 
 # VSDecoder Preferences Pane Items
-VSDPrefsAutoStartEngine = Auto Start Motore
-ListenerPositionTitle = Posizione Listener
-VSDecoderPrefsReset = Reset
+VSDecoderFileMenuPreferences = Preferenze VSDecoder
+AutoStartEngine = Auto Start Motore
+AutoLoadVSDFile = Auto-Load VSD File
+DefaultVSDFilePath = Default VSD File Path
+DefaultVSDFileName = Default VSD File Name
 Browse = Cerca


### PR DESCRIPTION
Remove some properties, which exist without a Java reference.
A few changes on translations.
Some formal changes.