### PR TITLE
Change the exceptions that are thrown in managers

### DIFF
--- a/java/src/jmri/Manager.java
+++ b/java/src/jmri/Manager.java
@@ -8,6 +8,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import jmri.NamedBean.BadSystemNameException;
+import jmri.NamedBean.DuplicateSystemNameException;
 import jmri.beans.PropertyChangeProvider;
 import jmri.beans.VetoableChangeProvider;
 import jmri.jmrix.SystemConnectionMemo;
@@ -96,7 +97,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
        *
      * @param name the item to make the system name for
      * @return A system name from a user input, typically a number.
-     * @throws IllegalArgumentException if a valid name can't be created
+     * @throws BadSystemNameException if a valid name can't be created
      */
     @Nonnull
     public default String makeSystemName(@Nonnull String name) {
@@ -118,7 +119,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      * @param name      the item to make the system name for
      * @param logErrors true to log errors; false to not log errors
      * @return a valid system name
-     * @throws IllegalArgumentException if a valid name can't be created
+     * @throws BadSystemNameException if a valid name can't be created
      */
     @Nonnull
     public default String makeSystemName(@Nonnull String name, boolean logErrors) {
@@ -142,7 +143,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      * @param locale    the locale for a localized exception; this is needed for
      *                      the JMRI web server, which supports multiple locales
      * @return a valid system name
-     * @throws IllegalArgumentException if a valid name can't be created
+     * @throws BadSystemNameException if a valid name can't be created
      */
     @Nonnull
     public default String makeSystemName(@Nonnull String name, boolean logErrors, Locale locale) {
@@ -170,7 +171,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      * @param name      the system name to validate
      * @return the system name unchanged from its input so that this method can
      *         be chained or used as an parameter to another method
-     * @throws IllegalArgumentException if the name is not valid with error
+     * @throws BadSystemNameException if the name is not valid with error
      *                                      messages in the default locale
      */
     @Nonnull
@@ -198,7 +199,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      * @param locale    the locale for a localized exception; this is needed for
      *                      the JMRI web server, which supports multiple locales
      * @return the unchanged value of the name parameter
-     * @throws IllegalArgumentException if provided name is an invalid format
+     * @throws BadSystemNameException if provided name is an invalid format
      */
     @Nonnull
     public default String validateSystemNameFormat(@Nonnull String name, @Nonnull Locale locale) throws BadSystemNameException {
@@ -218,7 +219,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      * @param locale    the locale for a localized exception; this is needed for
      *                      the JMRI web server, which supports multiple locales
      * @return the unchanged value of the name parameter
-     * @throws IllegalArgumentException if provided name is an invalid format
+     * @throws BadSystemNameException if provided name is an invalid format
      */
     @Nonnull
     public default String validateSystemNamePrefix(@Nonnull String name, @Nonnull Locale locale) throws BadSystemNameException {
@@ -245,7 +246,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      * @param locale the locale for a localized exception; this is needed for
      *               the JMRI web server, which supports multiple locales
      * @return the unchanged value of the name parameter
-     * @throws IllegalArgumentException if provided name is an invalid format
+     * @throws BadSystemNameException if provided name is an invalid format
      */
     @Nonnull
     public default String validateTrimmedSystemNameFormat(@Nonnull String name, @Nonnull Locale locale) {
@@ -271,7 +272,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      * @param locale the locale for a localized exception; this is needed for
      *               the JMRI web server, which supports multiple locales
      * @return the unchanged value of the name parameter
-     * @throws IllegalArgumentException if provided name is an invalid format
+     * @throws BadSystemNameException if provided name is an invalid format
      */
     @Nonnull
     public default String validateUppercaseTrimmedSystemNameFormat(@Nonnull String name, @Nonnull Locale locale) {
@@ -298,7 +299,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      * @param locale the locale for a localized exception; this is needed for
      *               the JMRI web server, which supports multiple locales
      * @return the unchanged value of the name parameter
-     * @throws IllegalArgumentException if provided name is an invalid format
+     * @throws BadSystemNameException if provided name is an invalid format
      */
     @Nonnull
     public default String validateIntegerSystemNameFormat(@Nonnull String name, int min, int max, @Nonnull Locale locale) {
@@ -334,7 +335,7 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      * @param locale the locale for a localized exception; this is needed for
      *               the JMRI web server, which supports multiple locales
      * @return the unchanged value of the name parameter
-     * @throws IllegalArgumentException if provided name is an invalid format
+     * @throws BadSystemNameException if provided name is an invalid format
      */
     @Nonnull
     public default String validateNmraAccessorySystemNameFormat(@Nonnull String name, @Nonnull Locale locale) {
@@ -609,9 +610,9 @@ public interface Manager<E extends NamedBean> extends PropertyChangeProvider, Ve
      * The non-system-specific SignalHeadManagers use this method extensively.
      *
      * @param n the bean
-     * @throws IllegalArgumentException if a different bean with the same system
-     *                                  name is already registered in the
-     *                                  manager
+     * @throws DuplicateSystemNameException if a different bean with the same system
+     *                                      name is already registered in the
+     *                                      manager
      */
     public void register(@Nonnull E n);
 

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -641,24 +641,13 @@ public interface NamedBean extends Comparable<NamedBean>, PropertyChangeProvider
         }
 
         /**
-         * Create a exception, suitable for display to the user. This
-         * takes the same arguments as
-         * {@link jmri.Bundle#getMessage(java.lang.String, java.lang.Object...)}
-         * as it uses that method to create both the localized and loggable
-         * messages.
-         * <p>
-         * Use {@link #getLocalizedMessage()} to display the message to the
-         * user, and use {@link #getMessage()} to record the message in logs.
-         * <p>
-         * <strong>Note</strong> the message must be accessible by
-         * {@link jmri.Bundle}.
+         * Create a exception.
          *
          * @param message bundle key to be translated
-         * @param subs    One or more objects to be inserted into the message
          */
-        public DuplicateSystemNameException(String message, Object... subs) {
-            this(Bundle.getMessage(Locale.ENGLISH, message, subs),
-                    Bundle.getMessage(message, subs));
+        public DuplicateSystemNameException(String message) {
+            super(message);
+            localizedMessage = super.getMessage();
         }
 
         /**

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -686,7 +686,7 @@ public interface NamedBean extends Comparable<NamedBean>, PropertyChangeProvider
             super(logging);
             localizedMessage = display;
         }
-        
+
         @Override
         public String getLocalizedMessage() {
             return localizedMessage;

--- a/java/src/jmri/NamedBean.java
+++ b/java/src/jmri/NamedBean.java
@@ -626,6 +626,84 @@ public interface NamedBean extends Comparable<NamedBean>, PropertyChangeProvider
         }
     }
 
+    public class DuplicateSystemNameException extends IllegalArgumentException {
+
+        private final String localizedMessage;
+        
+        /**
+         * Create an exception with no message to the user or for logging. Use
+         * only when calling methods likely have alternate mechanism for
+         * allowing user to understand why exception was thrown.
+         */
+        public DuplicateSystemNameException() {
+            super();
+            localizedMessage = super.getMessage();
+        }
+
+        /**
+         * Create a exception, suitable for display to the user. This
+         * takes the same arguments as
+         * {@link jmri.Bundle#getMessage(java.lang.String, java.lang.Object...)}
+         * as it uses that method to create both the localized and loggable
+         * messages.
+         * <p>
+         * Use {@link #getLocalizedMessage()} to display the message to the
+         * user, and use {@link #getMessage()} to record the message in logs.
+         * <p>
+         * <strong>Note</strong> the message must be accessible by
+         * {@link jmri.Bundle}.
+         *
+         * @param message bundle key to be translated
+         * @param subs    One or more objects to be inserted into the message
+         */
+        public DuplicateSystemNameException(String message, Object... subs) {
+            this(Bundle.getMessage(Locale.ENGLISH, message, subs),
+                    Bundle.getMessage(message, subs));
+        }
+
+        /**
+         * Create a localized exception, suitable for display to the user. This
+         * takes the same arguments as
+         * {@link jmri.Bundle#getMessage(java.util.Locale, java.lang.String, java.lang.Object...)}
+         * as it uses that method to create both the localized and loggable
+         * messages.
+         * <p>
+         * Use {@link #getLocalizedMessage()} to display the message to the
+         * user, and use {@link #getMessage()} to record the message in logs.
+         * <p>
+         * <strong>Note</strong> the message must be accessible by
+         * {@link jmri.Bundle}.
+         *
+         * @param locale  the locale to be used
+         * @param message bundle key to be translated
+         * @param subs    One or more objects to be inserted into the message
+         */
+        public DuplicateSystemNameException(Locale locale, String message, Object... subs) {
+            this(Bundle.getMessage(locale, message, subs),
+                    Bundle.getMessage(locale, message, subs));
+        }
+
+        /**
+         * Create a localized exception, suitable for display to the user. This
+         * takes the non-localized message followed by the localized message.
+         * <p>
+         * Use {@link #getLocalizedMessage()} to display the message to the
+         * user, and use {@link #getMessage()} to record the message in logs.
+         *
+         * @param logging the English message for logging
+         * @param display the localized message for display
+         */
+        public DuplicateSystemNameException(String logging, String display) {
+            super(logging);
+            localizedMessage = display;
+        }
+        
+        @Override
+        public String getLocalizedMessage() {
+            return localizedMessage;
+        }
+    }
+
     /**
      * Display options for {@link #getDisplayName(DisplayOptions)}. The quoted
      * forms are intended to be used in sentences and messages, while the

--- a/java/src/jmri/managers/AbstractManager.java
+++ b/java/src/jmri/managers/AbstractManager.java
@@ -25,6 +25,7 @@ import jmri.ConfigureManager;
 import jmri.InstanceManager;
 import jmri.Manager;
 import jmri.NamedBean;
+import jmri.NamedBean.DuplicateSystemNameException;
 import jmri.NamedBeanPropertyDescriptor;
 import jmri.jmrix.SystemConnectionMemo;
 import jmri.NmraPacket;
@@ -207,7 +208,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
                 log.debug("the named bean is registered twice: {}", systemName);
             } else {
                 log.error("systemName is already registered: {}", systemName);
-                throw new IllegalArgumentException("systemName is already registered: " + systemName);
+                throw new DuplicateSystemNameException("systemName is already registered: " + systemName);
             }
         } else {
             // Check if the manager already has a bean with a system name that is
@@ -225,7 +226,7 @@ abstract public class AbstractManager<E extends NamedBean> implements Manager<E>
                     String msg = String.format("systemName is already registered. Current system name: %s. New system name: %s",
                             oldSysName, systemName);
                     log.error(msg);
-                    throw new IllegalArgumentException(msg);
+                    throw new DuplicateSystemNameException(msg);
                 }
             }
         }

--- a/java/test/jmri/managers/AbstractProvidingManagerTestBase.java
+++ b/java/test/jmri/managers/AbstractProvidingManagerTestBase.java
@@ -101,10 +101,10 @@ public abstract class AbstractProvidingManagerTestBase<T extends ProvidingManage
         String expectedMessage = "systemName is already registered: " + e1.getSystemName();
         try {
             // Register different bean with existing systemName.
-            // This should fail with an IllegalArgumentException.
+            // This should fail with an DuplicateSystemNameException.
             l.register(e2);
             Assert.fail("Expected exception not thrown");
-        } catch (IllegalArgumentException ex) {
+        } catch (NamedBean.DuplicateSystemNameException ex) {
             Assert.assertEquals("exception message is correct", expectedMessage, ex.getMessage());
             JUnitAppender.assertErrorMessage(expectedMessage);
         }


### PR DESCRIPTION
Suggested fix of #7324.

Changes javadoc for methods that check the system name to use BadSystemNameException instead of IllegalArgumentException.

Adds DuplicateSystemNameException that is thrown by Manager.register().