### PR TITLE
LnSensorManager deprecation of one sensor numbering format

### DIFF
--- a/java/src/jmri/jmrix/loconet/LnSensorManager.java
+++ b/java/src/jmri/jmrix/loconet/LnSensorManager.java
@@ -3,6 +3,7 @@ package jmri.jmrix.loconet;
 import java.util.Locale;
 import jmri.JmriException;
 import jmri.Sensor;
+import jmri.util.Log4JUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,6 +136,11 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
     @Override
     public String createSystemName(String curAddress, String prefix) throws JmriException {
         if (curAddress.contains(":")) {
+            
+            // NOTE: This format is deprecated on 30Aug2019 account the format cannot be used under
+            // normal circumstances.  It is retained for the normal deprecation period in order
+            // to support any atypical usage patterns.
+            
             int board = 0;
             int channel = 0;
             // Address format passed is in the form of board:channel or T:turnout address
@@ -161,6 +167,8 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
             } else {
                 iName = 16 * board + channel - 16;
             }
+            jmri.util.Log4JUtil.warnOnce(log, "LnSensorManager.createSystemName(curAddress, prefix) support for curAddress using the '{}' format is deprecated and will be removed in a future JMRI release.  Use the curAddress format '{}' instead.",
+                    curAddress, iName);
         } else {
             // Entered in using the old format
             try {

--- a/java/src/jmri/jmrix/loconet/LnSensorManager.java
+++ b/java/src/jmri/jmrix/loconet/LnSensorManager.java
@@ -137,9 +137,10 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
     public String createSystemName(String curAddress, String prefix) throws JmriException {
         if (curAddress.contains(":")) {
             
-            // NOTE: This format is deprecated on 30Aug2019 account the format cannot be used under
-            // normal circumstances.  It is retained for the normal deprecation period in order
-            // to support any atypical usage patterns.
+            // NOTE: This format is deprecated in JMRI 4.17.4 on account the 
+            // "byte:bit" format cannot be used under normal JMRI usage 
+            // circumstances.  It is retained for the normal deprecation period 
+            // in order to support any atypical usage patterns.
             
             int board = 0;
             int channel = 0;
@@ -167,7 +168,8 @@ public class LnSensorManager extends jmri.managers.AbstractSensorManager impleme
             } else {
                 iName = 16 * board + channel - 16;
             }
-            jmri.util.Log4JUtil.warnOnce(log, "LnSensorManager.createSystemName(curAddress, prefix) support for curAddress using the '{}' format is deprecated and will be removed in a future JMRI release.  Use the curAddress format '{}' instead.",
+            jmri.util.Log4JUtil.warnOnce(log, 
+                    "LnSensorManager.createSystemName(curAddress, prefix) support for curAddress using the '{}' format is deprecated as of JMRI 4.17.4 and will be removed in a future JMRI release.  Use the curAddress format '{}' instead.",
                     curAddress, iName);
         } else {
             // Entered in using the old format

--- a/java/test/jmri/jmrix/loconet/LnSensorManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnSensorManagerTest.java
@@ -91,6 +91,20 @@ public class LnSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase
 
     }
 
+    @Test
+    public void testDeprecationWarningSensorNumberFormat() {
+        boolean excep= false;
+        String s = "";
+        try {
+            s = l.createSystemName("3:5", "L");
+        } catch (jmri.JmriException e) {
+            excep = true;
+        }
+        Assert.assertEquals("no exception during createSystemName for arguments '3:5', 'L'", false, excep);
+        Assert.assertEquals("check createSystemName for arguments '3:5', 'L'", "LS37", s);
+        jmri.util.JUnitAppender.assertWarnMessage("LnSensorManager.createSystemName(curAddress, prefix) support for curAddress using the '3:5' format is deprecated and will be removed in a future JMRI release.  Use the curAddress format '37' instead.");
+    }
+
     // The minimal setup for log4J
     @Override
     @Before
@@ -115,5 +129,5 @@ public class LnSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase
     }
 
     private final static Logger log = LoggerFactory.getLogger(LnSensorManagerTest.class);
-    
+
 }

--- a/java/test/jmri/jmrix/loconet/LnSensorManagerTest.java
+++ b/java/test/jmri/jmrix/loconet/LnSensorManagerTest.java
@@ -102,7 +102,8 @@ public class LnSensorManagerTest extends jmri.managers.AbstractSensorMgrTestBase
         }
         Assert.assertEquals("no exception during createSystemName for arguments '3:5', 'L'", false, excep);
         Assert.assertEquals("check createSystemName for arguments '3:5', 'L'", "LS37", s);
-        jmri.util.JUnitAppender.assertWarnMessage("LnSensorManager.createSystemName(curAddress, prefix) support for curAddress using the '3:5' format is deprecated and will be removed in a future JMRI release.  Use the curAddress format '37' instead.");
+        jmri.util.JUnitAppender.assertWarnMessage(
+                "LnSensorManager.createSystemName(curAddress, prefix) support for curAddress using the '3:5' format is deprecated as of JMRI 4.17.4 and will be removed in a future JMRI release.  Use the curAddress format '37' instead.");
     }
 
     // The minimal setup for log4J


### PR DESCRIPTION
`loconet.LnSensorManager.createSystemName(String curAddress, String prefix)` supports two formats for `curAddress`.  One is a simple number, and is consistent with sensor numbering as seen on Digitrax throttles.  This format remains valid.

The other format is "x:y" where "x" represents a board number, and "y" represents a bit number.  This is similar to CMRI's "board:bit" format.  But many LocoNet devices do not implement a "board number" and most LocoNet devices do not implement 16 bits (as assumed by the existing code in `createSystemName()`.  The format is therefore of minimal use in the LocoNet environment.

The `createSystemName()` method is typically used only to compute a subsequent sensor number when adding multiple sensors via the Tools->Tables->Sensors "Add Sensor" GUI tool.  That tool does not allow entering the "board:bit" format as a starting sensor number, so the tool will never exercise that portion of `createSystemName()` which implements the "board:bit" format.

It is possible for jython programs to use the `createSystemName()` method.  It is also possible that JMRI could be used as a library for some other program.  Those uses could potentially make use of the "board:bit" format.

Deprecating the "board:bit" format allows near-term `createSystemName()` "board:bit" functionality by any jython or external program which currently uses that feature.  

With this P/R, when the "board"bit" format is used, the System Console will log a one-time warning stating that the format is being deprecated.