### PR TITLE
Fix memory system name comparision

### DIFF
--- a/java/src/jmri/implementation/AbstractMemory.java
+++ b/java/src/jmri/implementation/AbstractMemory.java
@@ -1,6 +1,9 @@
 package jmri.implementation;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import jmri.Memory;
+import jmri.NamedBean;
 
 /**
  * Base for the Memory interface.
@@ -38,6 +41,17 @@ public abstract class AbstractMemory extends AbstractNamedBean implements Memory
         _current = v;
         // notify
         firePropertyChange("value", old, _current);
+    }
+    
+    /**
+     * {@inheritDoc} 
+     * 
+     * Do a string comparison.
+     */
+    @CheckReturnValue
+    @Override
+    public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull NamedBean n) {
+        return suffix1.compareTo(suffix2);
     }
 
     // internal data members

--- a/java/src/jmri/implementation/AbstractStringIO.java
+++ b/java/src/jmri/implementation/AbstractStringIO.java
@@ -1,5 +1,6 @@
 package jmri.implementation;
 
+import javax.annotation.CheckReturnValue;
 import jmri.JmriException;
 import jmri.NamedBean;
 import jmri.StringIO;
@@ -113,6 +114,17 @@ public abstract class AbstractStringIO extends AbstractNamedBean implements Stri
     @Nonnull
     public String getBeanType() {
         return Bundle.getMessage("BeanNameStringIO");
+    }
+
+    /**
+     * {@inheritDoc} 
+     * 
+     * Do a string comparison.
+     */
+    @CheckReturnValue
+    @Override
+    public int compareSystemNameSuffix(@Nonnull String suffix1, @Nonnull String suffix2, @Nonnull NamedBean n) {
+        return suffix1.compareTo(suffix2);
     }
 
     /** {@inheritDoc} */

--- a/java/test/jmri/implementation/AbstractStringIOTest.java
+++ b/java/test/jmri/implementation/AbstractStringIOTest.java
@@ -21,10 +21,10 @@ public class AbstractStringIOTest {
     
     @Test
     public void testSystemNames() {
-        MyAbstractStringIO myStringIO_1 = new MyAbstractStringIO("IS1");
-        MyAbstractStringIO myStringIO_2 = new MyAbstractStringIO("IS01");
-        Assert.assertEquals("StringIO system name is correct", "IS1", myStringIO_1.getSystemName());
-        Assert.assertEquals("StringIO system name is correct", "IS01", myStringIO_2.getSystemName());
+        MyAbstractStringIO myStringIO_1 = new MyAbstractStringIO("IZ1");
+        MyAbstractStringIO myStringIO_2 = new MyAbstractStringIO("IZ01");
+        Assert.assertEquals("StringIO system name is correct", "IZ1", myStringIO_1.getSystemName());
+        Assert.assertEquals("StringIO system name is correct", "IZ01", myStringIO_2.getSystemName());
         Assert.assertNotEquals("StringIOs are different", myStringIO_1, myStringIO_2);
         Assert.assertNotEquals("StringIO compareTo returns not zero", 0, myStringIO_1.compareTo(myStringIO_2));
     }
@@ -56,7 +56,7 @@ public class AbstractStringIOTest {
                 "8:20. Trai".equals(myStringIO.getKnownStringValue()));
         
         Assert.assertTrue("toString() matches",
-                "jmri.implementation.AbstractStringIOTest$MyAbstractStringIO (MySystemName)".equals(myStringIO.toString()));
+                "jmri.implementation.AbstractStringIOTest$MyAbstractStringIO (IZMySystemName)".equals(myStringIO.toString()));
         
         Assert.assertTrue("getBeanType() matches", "String I/O".equals(myStringIO.getBeanType()));
     }
@@ -78,7 +78,7 @@ public class AbstractStringIOTest {
         private boolean _cut = false;
         
         MyAbstractStringIO() {
-            super("MySystemName");
+            super("IZMySystemName");
         }
 
         MyAbstractStringIO(String sysName) {
@@ -86,7 +86,7 @@ public class AbstractStringIOTest {
         }
 
         MyAbstractStringIO(int maxLen, boolean cut) {
-            super("MySystemName");
+            super("IZMySystemName");
             _maxLen = maxLen;
             _cut = cut;
         }

--- a/java/test/jmri/implementation/AbstractStringIOTest.java
+++ b/java/test/jmri/implementation/AbstractStringIOTest.java
@@ -27,7 +27,12 @@ public class AbstractStringIOTest {
         Assert.assertEquals("StringIO system name is correct", "IZ01", myStringIO_2.getSystemName());
         Assert.assertNotEquals("StringIOs are different", myStringIO_1, myStringIO_2);
         Assert.assertNotEquals("StringIO compareTo returns not zero", 0, myStringIO_1.compareTo(myStringIO_2));
-        
+    }
+    
+    @Test
+    public void testCompareSystemNameSuffix() {
+        MyAbstractStringIO myStringIO_1 = new MyAbstractStringIO("IZ1");
+        MyAbstractStringIO myStringIO_2 = new MyAbstractStringIO("IZ01");
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 -1, myStringIO_1.compareSystemNameSuffix("01", "1", myStringIO_2));
         Assert.assertEquals("compareSystemNameSuffix returns correct value",

--- a/java/test/jmri/implementation/AbstractStringIOTest.java
+++ b/java/test/jmri/implementation/AbstractStringIOTest.java
@@ -27,6 +27,15 @@ public class AbstractStringIOTest {
         Assert.assertEquals("StringIO system name is correct", "IZ01", myStringIO_2.getSystemName());
         Assert.assertNotEquals("StringIOs are different", myStringIO_1, myStringIO_2);
         Assert.assertNotEquals("StringIO compareTo returns not zero", 0, myStringIO_1.compareTo(myStringIO_2));
+        
+        Assert.assertEquals("compareSystemNameSuffix returns correct value",
+                -1, myStringIO_1.compareSystemNameSuffix("01", "1", myStringIO_2));
+        Assert.assertEquals("compareSystemNameSuffix returns correct value",
+                0, myStringIO_1.compareSystemNameSuffix("1", "1", myStringIO_2));
+        Assert.assertEquals("compareSystemNameSuffix returns correct value",
+                0, myStringIO_1.compareSystemNameSuffix("01", "01", myStringIO_2));
+        Assert.assertEquals("compareSystemNameSuffix returns correct value",
+                +1, myStringIO_1.compareSystemNameSuffix("1", "01", myStringIO_2));
     }
     
     @Test

--- a/java/test/jmri/implementation/AbstractStringIOTest.java
+++ b/java/test/jmri/implementation/AbstractStringIOTest.java
@@ -25,6 +25,12 @@ public class AbstractStringIOTest {
         MyAbstractStringIO myStringIO_2 = new MyAbstractStringIO("IZ01");
         Assert.assertEquals("StringIO system name is correct", "IZ1", myStringIO_1.getSystemName());
         Assert.assertEquals("StringIO system name is correct", "IZ01", myStringIO_2.getSystemName());
+    }
+    
+    @Test
+    public void testCompareTo() {
+        MyAbstractStringIO myStringIO_1 = new MyAbstractStringIO("IZ1");
+        MyAbstractStringIO myStringIO_2 = new MyAbstractStringIO("IZ01");
         Assert.assertNotEquals("StringIOs are different", myStringIO_1, myStringIO_2);
         Assert.assertNotEquals("StringIO compareTo returns not zero", 0, myStringIO_1.compareTo(myStringIO_2));
     }

--- a/java/test/jmri/implementation/AbstractStringIOTest.java
+++ b/java/test/jmri/implementation/AbstractStringIOTest.java
@@ -20,6 +20,16 @@ public class AbstractStringIOTest {
     }
     
     @Test
+    public void testSystemNames() {
+        MyAbstractStringIO myStringIO_1 = new MyAbstractStringIO("IS1");
+        MyAbstractStringIO myStringIO_2 = new MyAbstractStringIO("IS01");
+        Assert.assertEquals("StringIO system name is correct", "IS1", myStringIO_1.getSystemName());
+        Assert.assertEquals("StringIO system name is correct", "IS01", myStringIO_2.getSystemName());
+        Assert.assertNotEquals("StringIOs are different", myStringIO_1, myStringIO_2);
+        Assert.assertNotEquals("StringIO compareTo returns not zero", 0, myStringIO_1.compareTo(myStringIO_2));
+    }
+    
+    @Test
     public void testStringIO() throws JmriException {
         MyAbstractStringIO myStringIO = new MyAbstractStringIO();
         myStringIO.setCommandedStringValue("8:20. Train 21 to Vaxjo");
@@ -69,6 +79,10 @@ public class AbstractStringIOTest {
         
         MyAbstractStringIO() {
             super("MySystemName");
+        }
+
+        MyAbstractStringIO(String sysName) {
+            super(sysName);
         }
 
         MyAbstractStringIO(int maxLen, boolean cut) {

--- a/java/test/jmri/implementation/DefaultMemoryTest.java
+++ b/java/test/jmri/implementation/DefaultMemoryTest.java
@@ -18,6 +18,16 @@ public class DefaultMemoryTest {
         Assert.assertNotNull("exists",t);
     }
 
+    @Test
+    public void testSystemNames() {
+        DefaultMemory myMemory_1 = new DefaultMemory("IM1");
+        DefaultMemory myMemory_2 = new DefaultMemory("IM01");
+        Assert.assertEquals("Memory system name is correct", "IM1", myMemory_1.getSystemName());
+        Assert.assertEquals("Memory system name is correct", "IM01", myMemory_2.getSystemName());
+        Assert.assertNotEquals("Memory's are different", myMemory_1, myMemory_2);
+        Assert.assertNotEquals("Memory compareTo returns not zero", 0, myMemory_1.compareTo(myMemory_2));
+    }
+
     // The minimal setup for log4J
     @Before
     public void setUp() {

--- a/java/test/jmri/implementation/DefaultMemoryTest.java
+++ b/java/test/jmri/implementation/DefaultMemoryTest.java
@@ -26,6 +26,15 @@ public class DefaultMemoryTest {
         Assert.assertEquals("Memory system name is correct", "IM01", myMemory_2.getSystemName());
         Assert.assertNotEquals("Memory's are different", myMemory_1, myMemory_2);
         Assert.assertNotEquals("Memory compareTo returns not zero", 0, myMemory_1.compareTo(myMemory_2));
+        
+        Assert.assertEquals("compareSystemNameSuffix returns correct value",
+                -1, myMemory_1.compareSystemNameSuffix("01", "1", myMemory_2));
+        Assert.assertEquals("compareSystemNameSuffix returns correct value",
+                0, myMemory_1.compareSystemNameSuffix("1", "1", myMemory_2));
+        Assert.assertEquals("compareSystemNameSuffix returns correct value",
+                0, myMemory_1.compareSystemNameSuffix("01", "01", myMemory_2));
+        Assert.assertEquals("compareSystemNameSuffix returns correct value",
+                +1, myMemory_1.compareSystemNameSuffix("1", "01", myMemory_2));
     }
 
     // The minimal setup for log4J

--- a/java/test/jmri/implementation/DefaultMemoryTest.java
+++ b/java/test/jmri/implementation/DefaultMemoryTest.java
@@ -24,6 +24,12 @@ public class DefaultMemoryTest {
         DefaultMemory myMemory_2 = new DefaultMemory("IM01");
         Assert.assertEquals("Memory system name is correct", "IM1", myMemory_1.getSystemName());
         Assert.assertEquals("Memory system name is correct", "IM01", myMemory_2.getSystemName());
+    }
+    
+    @Test
+    public void testCompareTo() {
+        DefaultMemory myMemory_1 = new DefaultMemory("IM1");
+        DefaultMemory myMemory_2 = new DefaultMemory("IM01");
         Assert.assertNotEquals("Memory's are different", myMemory_1, myMemory_2);
         Assert.assertNotEquals("Memory compareTo returns not zero", 0, myMemory_1.compareTo(myMemory_2));
     }

--- a/java/test/jmri/implementation/DefaultMemoryTest.java
+++ b/java/test/jmri/implementation/DefaultMemoryTest.java
@@ -26,7 +26,12 @@ public class DefaultMemoryTest {
         Assert.assertEquals("Memory system name is correct", "IM01", myMemory_2.getSystemName());
         Assert.assertNotEquals("Memory's are different", myMemory_1, myMemory_2);
         Assert.assertNotEquals("Memory compareTo returns not zero", 0, myMemory_1.compareTo(myMemory_2));
-        
+    }
+    
+    @Test
+    public void testCompareSystemNameSuffix() {
+        DefaultMemory myMemory_1 = new DefaultMemory("IM1");
+        DefaultMemory myMemory_2 = new DefaultMemory("IM01");
         Assert.assertEquals("compareSystemNameSuffix returns correct value",
                 -1, myMemory_1.compareSystemNameSuffix("01", "1", myMemory_2));
         Assert.assertEquals("compareSystemNameSuffix returns correct value",


### PR DESCRIPTION
Fixes issue #7323 for Memory and StringIO.

There are probably more classes that needs to be fixed but I don't have enough knowledge about which system names that are valid for each class. If anyone else points out which classes that needs this fix, I will fix it for those classes too.