### PR TITLE
Fix URL hrefs causing missing content or infinite crawl issues

### DIFF
--- a/help/en/html/apps/PanelPro/index.shtml
+++ b/help/en/html/apps/PanelPro/index.shtml
@@ -94,7 +94,7 @@
             "../../../package/jmri/jmrit/dispatcher/Dispatcher.shtml">Dispatcher</a>.
             In addition, the Layout description of your railway can be
             used by scripts such as the included
-            <a href="../..//tools/scripting/Examples.shtml">AutoDispatcher2</a>
+            <a href="../../tools/scripting/Examples.shtml">AutoDispatcher2</a>
             to automatically control your trains. There are many other
             tools within JMRI which require a description of your
             railroad and the description comes from the Layout built in

--- a/help/en/html/tools/scripting/Examples.shtml
+++ b/help/en/html/tools/scripting/Examples.shtml
@@ -289,7 +289,7 @@
       <p>Try to send some bytes to a parallel port.</p>
 
       <p><a href=
-      "../../../../../../../ParallelPortTurnouts.py">ParallelPortTurnouts.py</a></p>
+      "../../../../../jython/ParallelPortTurnouts.py">ParallelPortTurnouts.py</a></p>
 
       <p>Connect JMRI Turnouts to parallel port logic. Maps internal
       Turnouts to specific values to be send to the parallel port.


### PR DESCRIPTION
When running a crawl on the main website, ended up in an infinite crawling loop.

Hopefully, this fixes that problem.

Plus, while at it, fix a bad link.