### PR TITLE
Add SetUnknownTurnoutsClosed new script

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -388,7 +388,8 @@
     <h3>Scripting</h3>
         <a id="Scripting" name="Scripting"></a>
         <ul>
-            <li></li>
+            <li>Added a new SetUnknownTurnoutsClosed script that does what it says on the tin</li>
+            <li>Added script tests for SetUnknownTurnoutsClosed and SetAllTurnoutsClosed
         </ul>
 
     <h3>Signals</h3>

--- a/jython/SetAllTurnoutsClosed.py
+++ b/jython/SetAllTurnoutsClosed.py
@@ -1,5 +1,12 @@
 # Sample script to set all un-closed turnouts to Closed
 #
+# After this script is turn, all the Turnouts defined in JMRI
+# should be in the CLOSED state.
+#
+# Note that some "Turnouts" may actually drive other things on the layout,
+# such as signal heads. This script should be run _before_ anything that
+# sets those.  
+#
 # Part of the JMRI distribution
 
 import jmri

--- a/jython/SetUnknownTurnoutsClosed.py
+++ b/jython/SetUnknownTurnoutsClosed.py
@@ -1,0 +1,27 @@
+# Sample script to set all turnouts in Unknown state to Closed
+#
+# Note that some "Turnouts" may actually drive other things on the layout,
+# such as signal heads. This script should be run _before_ anything that
+# sets those.  
+#
+# Part of the JMRI distribution
+
+import jmri
+
+from time import sleep
+
+toCnt = 0
+chgCnt = 0
+
+# loop thru all defined turnouts
+print "Starting to set turnouts in UNKNOWN state to CLOSED"
+for to in turnouts.getNamedBeanSet():
+  toCnt += 1
+  cs = to.getState()
+  if (cs == UNKNOWN) :
+    chgCnt += 1
+    to.setState(CLOSED)
+    sleep(0.1) #pause for 1/10 second between commands
+print str(toCnt) + " turnouts checked, " + str(chgCnt) + " found in UNKNOWN state and changed to CLOSED"
+
+

--- a/jython/SetUnknownTurnoutsClosed.py
+++ b/jython/SetUnknownTurnoutsClosed.py
@@ -1,8 +1,11 @@
 # Sample script to set all turnouts in Unknown state to Closed
 #
-# Note that some "Turnouts" may actually drive other things on the layout,
-# such as signal heads. This script should be run _before_ anything that
-# sets those.  
+# After this script is turn, there should be no Turnouts in the
+# UNKNOWN state; any that were at the start should have been set to CLOSED.
+#
+# By skipping over Turnouts that have already been set, this minimizes
+# the chance of disturbing e.g. Turnouts driving signals that have already been set 
+# by signal logic.
 #
 # Part of the JMRI distribution
 

--- a/jython/test/SetAllTurnoutsClosedTest.py
+++ b/jython/test/SetAllTurnoutsClosedTest.py
@@ -1,0 +1,18 @@
+
+# Test SetAllTurnoutsClosed.py script
+import jmri
+
+# test structure setup
+turnouts.provideTurnout("IS1").setState(UNKNOWN)
+turnouts.provideTurnout("IS2").setState(CLOSED)
+turnouts.provideTurnout("IS3").setState(THROWN)
+turnouts.provideTurnout("IS4").setState(INCONSISTENT)
+
+# run script
+execfile("jython/SetAllTurnoutsClosed.py")
+
+# test resuts
+if (turnouts.provideTurnout("IS1").getState() != CLOSED) : raise AssertionError('UNKNOWN not set to CLOSED')
+if (turnouts.provideTurnout("IS2").getState() != CLOSED) : raise AssertionError('CLOSED not left at CLOSED')
+if (turnouts.provideTurnout("IS3").getState() != CLOSED) : raise AssertionError('THROWN not set to CLOSED')
+if (turnouts.provideTurnout("IS4").getState() != CLOSED) : raise AssertionError('INCONSISTENT not set to CLOSED')

--- a/jython/test/SetUnknownTurnoutsClosedTest.py
+++ b/jython/test/SetUnknownTurnoutsClosedTest.py
@@ -1,0 +1,17 @@
+# Test SetUnknownTurnoutsClosed.py script
+import jmri
+
+# test structure setup
+turnouts.provideTurnout("IS1").setState(UNKNOWN)
+turnouts.provideTurnout("IS2").setState(CLOSED)
+turnouts.provideTurnout("IS3").setState(THROWN)
+turnouts.provideTurnout("IS4").setState(INCONSISTENT)
+
+# run script
+execfile("jython/SetUnknownTurnoutsClosed.py")
+
+# test resuts
+if (turnouts.provideTurnout("IS1").getState() != CLOSED) : raise AssertionError('UNKNOWN not set to CLOSED')
+if (turnouts.provideTurnout("IS2").getState() != CLOSED) : raise AssertionError('CLOSED not left at CLOSED')
+if (turnouts.provideTurnout("IS3").getState() != THROWN) : raise AssertionError('THROWN not left at THROWN')
+if (turnouts.provideTurnout("IS4").getState() != INCONSISTENT) : raise AssertionError('INCONSISTENT not left at INCONSISTENT')


### PR DESCRIPTION
Add new `SetUnknownTurnoutsClosed` script.  Similar to `SetAllTurnoutsClosed` except it only sets turnouts in `UNKNOWN` status. This reduces the change that the script will interfere with previously-set SE8c signal heads and similar

Also:

 - Add comments to `SetAllTurnoutsClosed` to explain function
 - Also adds tests for `SetUnknownTurnoutsClosed` and `SetAllTurnoutsClosed`
