### PR TITLE
tweak JoalAudioSource.cleanup()

### DIFF
--- a/java/src/jmri/jmrit/audio/JoalAudioSource.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioSource.java
@@ -521,7 +521,7 @@ public class JoalAudioSource extends AbstractAudioSource {
         log.debug("Cleanup JoalAudioSource ({})", this.getSystemName());
         int[] source_type = new int[1];
         al.alGetSourcei(_source[0], AL.AL_SOURCE_TYPE, source_type, 0);
-        if (_initialised && (isBound() || isQueued() || source_type[0] == AL.AL_UNDETERMINED)) {
+        if (_initialised && (isBound() || isQueued() || source_type[0] == AL.AL_UNDETERMINED) || source_type[0] == AL.AL_STREAMING) {
             al.alSourceStop(_source[0]);
             al.alDeleteSources(1, _source, 0);
             this._source = null;

--- a/java/src/jmri/jmrit/audio/JoalAudioSource.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioSource.java
@@ -519,7 +519,9 @@ public class JoalAudioSource extends AbstractAudioSource {
     @Override
     protected void cleanup() {
         log.debug("Cleanup JoalAudioSource ({})", this.getSystemName());
-        if (_initialised) {
+        int[] source_type = new int[1];
+        al.alGetSourcei(_source[0], AL.AL_SOURCE_TYPE, source_type, 0);
+        if (_initialised && (isBound() || isQueued() || source_type[0] == AL.AL_UNDETERMINED)) {
             al.alSourceStop(_source[0]);
             al.alDeleteSources(1, _source, 0);
             this._source = null;

--- a/java/src/jmri/jmrit/audio/JoalAudioSource.java
+++ b/java/src/jmri/jmrit/audio/JoalAudioSource.java
@@ -519,7 +519,7 @@ public class JoalAudioSource extends AbstractAudioSource {
     @Override
     protected void cleanup() {
         log.debug("Cleanup JoalAudioSource ({})", this.getSystemName());
-        if (_initialised && isAudioAlive() && (isBound() || isQueued())) {
+        if (_initialised) {
             al.alSourceStop(_source[0]);
             al.alDeleteSources(1, _source, 0);
             this._source = null;


### PR DESCRIPTION
I noticed warnings in my ALSOFT_LOGFILE like e.g.
```AL lib: (WW) FreeContext: (0023FB90) Deleting 16 Source(s)```
```AL lib: (WW) FreeDevice: (2E8DF270) Deleting 15 Buffer(s)```

That's not good. Sources and Buffers should be deleted by the application/API. So I'd like to revert the ```isAudioAlive()``` check to handle JoalAudioSource deletion correctly. I think ```isAudioAlive()``` goes "false" early, when shutting down VSD/Audio. This prevents the deletion.

A further change allows the deletion of a JoalAudioSource, which is neither ```isBound()``` nor ```isQueued()```. Such an AudioSource is the ```engine loop sound``` in VSD, when there is no more buffer queued.

Since the JoalAudioSource (bound to a JoalAudioBuffer) must be deleted before the JoalAudiobuffer can be deleted, the Buffer warnings will disappear also.
