### PR TITLE
Handle difference between Jenkins build and local

### DIFF
--- a/archunit_ignore_patterns.txt
+++ b/archunit_ignore_patterns.txt
@@ -5,6 +5,7 @@
 
 # For checkStandardStreams
 Method <jmri\.jmrit\.XmlFile\.lambda\$dumpElement\$.*\(org\.jdom2\.Element\)> gets field <java\.lang\.System\.out>.*
+Method <jmri\.jmrit\.XmlFile\.lambda\$0\(org\.jdom2\.Element\)> gets field <java\.lang\.System\.out>.*
 Method <jmri\.jmrit\.XmlFileValidateAction\$2\.showFailResults\(java\.awt\.Component, java\.lang\.String\)> gets field <java\.lang\.System\.out>.*
 Method <jmri\.jmrit\.automat\.JythonAutomaton\.handle\(\)> gets field <java\.lang\.System\.out>.*
 Method <jmri\.jmrit\.automat\.JythonSiglet\.defineIO\(\)> gets field <java\.lang\.System\.out>.*


### PR DESCRIPTION
For some reason, the way that the Jenkins box builds JMRI throws a different error for the permitted use of `java.lang.System.out` in `jmri.jmrit.XmlFile`.

This adds a suitable pattern to match that specific case to, for now, allow this to pass.