### PR TITLE
Use new https URLs and add context to Jenkins badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,28 @@
 
 Model railroad software
 
-For more information, see [JMRI.org](http://jmri.org)
+For more information, see [JMRI.org](https://www.jmri.org)
 
-For development information, see [Technical Info](http://jmri.org/help/en/html/doc/Technical)
+For development information, see [Technical Info](https://www.jmri.org/help/en/html/doc/Technical)
 
 User discussions are on the [JMRI users Groups.io group](https://groups.io/g/jmriusers)
 
-Infrastructure status available at [status.jmri.org](http://status.jmri.org)
+Infrastructure status available at [status.jmri.org](https://status.jmri.org)
 
 Test:
-[![Test release](https://img.shields.io/github/release/JMRI/JMRI.svg)](http://jmri.org/download/index.shtml#test-rel)
-[![Test release](https://img.shields.io/github/downloads/JMRI/JMRI/latest/total.svg)](http://jmri.org/download/index.shtml#test-rel)
+[![Test release](https://img.shields.io/github/release/JMRI/JMRI.svg)](https://www.jmri.org/download/index.shtml#test-rel)
+[![Test release](https://img.shields.io/github/downloads/JMRI/JMRI/latest/total.svg)](https://www.jmri.org/download/index.shtml#test-rel)
 Production:
-[![Test release](https://img.shields.io/github/downloads/JMRI/JMRI/v4.16/total.svg)](http://jmri.org/download/index.shtml#prod-rel)
+[![Test release](https://img.shields.io/github/downloads/JMRI/JMRI/v4.16/total.svg)](https://www.jmri.org/download/index.shtml#prod-rel)
 Total (since 9/2017):
-[![Test release](https://img.shields.io/github/downloads/JMRI/JMRI/total.svg)](http://jmri.org/download/index.shtml)
+[![Test release](https://img.shields.io/github/downloads/JMRI/JMRI/total.svg)](https://www.jmri.org/download/index.shtml)
 
-Jenkins: [![Build Status](http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/Builds)](http://jmri.tagadab.com/jenkins/job/Development/job/Builds/)
-[![Build Status](http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/Packages)](http://jmri.tagadab.com/jenkins/job/Development/job/Packages/)
-[![Build Status](http://jmri.tagadab.com/jenkins/buildStatus/icon?job=WebSite/generate-website)](http://jmri.tagadab.com/jenkins/job/WebSite/job/generate-website/)
-[![Build Status](http://jmri.tagadab.com/jenkins/buildStatus/icon?job=WebSite/JMRI_repository)](http://jmri.tagadab.com/jenkins/job/WebSite/job/JMRI_repository/)
-[![Build Status](http://jmri.tagadab.com/jenkins/buildStatus/icon?job=WebSite/website_repository)](http://jmri.tagadab.com/jenkins/job/WebSite/job/website_repository/)
-[![Build Status](http://jmri.tagadab.com/jenkins/buildStatus/icon?job=Development/Separate_Tests)](http://jmri.tagadab.com/jenkins/job/Development/job/Separate_Tests/)
+Jenkins: [![Build Status](http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/Builds&subject=Development/Builds)](http://builds.jmri.org/jenkins/job/Development/job/Builds/)
+[![Build Status](http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/Packages&subject=Development/Packages)](http://builds.jmri.org/jenkins/job/Development/job/Packages/)
+[![Build Status](http://builds.jmri.org/jenkins/buildStatus/icon?job=WebSite/generate-website&subject=WebSite/generate-website)](http://builds.jmri.org/jenkins/job/WebSite/job/generate-website/)
+[![Build Status](http://builds.jmri.org/jenkins/buildStatus/icon?job=WebSite/JMRI_repository&subject=WebSite/JMRI_repository)](http://builds.jmri.org/jenkins/job/WebSite/job/JMRI_repository/)
+[![Build Status](http://builds.jmri.org/jenkins/buildStatus/icon?job=WebSite/website_repository&subject=WebSite/website_repository)](http://builds.jmri.org/jenkins/job/WebSite/job/website_repository/)
+[![Build Status](http://builds.jmri.org/jenkins/buildStatus/icon?job=Development/Separate_Tests&subject=Development/Separate_Tests)](http://builds.jmri.org/jenkins/job/Development/job/Separate_Tests/)
 
 Travis: [![Build Status](https://travis-ci.org/JMRI/JMRI.svg?branch=master)](https://travis-ci.org/JMRI/JMRI)
 AppVeyor: [![Build status](https://ci.appveyor.com/api/projects/status/lmdrtxjxf62xym0p/branch/master?svg=true)](https://ci.appveyor.com/project/JMRI/jmri/branch/master)


### PR DESCRIPTION
This changes the URLs to reference the https versions as opposed to the http ones.

Additionally, add context to the various Jenkins badges so that we can more easily at a glance tell which job badge is which.