### PR TITLE
Update CodeClimate settings

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,7 +11,7 @@ checks:
       threshold: 250 # CodeClimate default
   method-complexity:
     config:
-      threshold: 15 # AKA Cognitive Complexity. 5 is CodeClimate default
+      threshold: 20 # AKA Cognitive Complexity. 5 is CodeClimate default
   method-count:
     config:
       threshold: 20 # CodeClimate default

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -26,11 +26,13 @@ checks:
       threshold: 4 # CodeClimate default
   similar-code:
     config:
-      threshold: # language-specific defaults. an override will affect all languages.
+      threshold: 40 # language-specific defaults. an override will affect all languages.
+                    # Java default is documented at 40, but seems smaller
       exclude_patterns:
       - "**/Bundle.java"
   identical-code:
     config:
-      threshold: # language-specific defaults. an override will affect all languages.
+      threshold: 40 # language-specific defaults. an override will affect all languages.
+                    # Java default is documented at 40, but seems smaller
       exclude_patterns:
       - "**/Bundle.java"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,7 +11,7 @@ checks:
       threshold: 250 # CodeClimate default
   method-complexity:
     config:
-      threshold: 5 # CodeClimate default
+      threshold: 15 # AKA Cognitive Complexity. 5 is CodeClimate default
   method-count:
     config:
       threshold: 20 # CodeClimate default


### PR DESCRIPTION
As discussed in Issue #7463 and (closed) test PR #7464, this PR changes the CodeClimate settings
 - Raise the `method-complexity` limit (a.k.a. Conceptual Complexity) from 5 to 20
 - Explicitly set the `similar-code` and `identical-code` code limits to their documented value of 40; for some reason, they appeared to be acting as a much smaller value when left unset

Although this was tested both here via #7464 and offline via a separate CodeClimate instance, it's not clear what will happen to the CodeClimate statistics when this is first merged.  Existing PRs, for example, may show Really Big Issues with CodeClimate incremental values, for example.