### PR TITLE
Add timeout and retry to tests

### DIFF
--- a/java/test/jmri/jmrit/operations/trains/TrainsTableActionTest.java
+++ b/java/test/jmri/jmrit/operations/trains/TrainsTableActionTest.java
@@ -1,14 +1,20 @@
 package jmri.jmrit.operations.trains;
 
 import jmri.jmrit.operations.OperationsTestCase;
-import org.junit.Assert;
-import org.junit.Test;
+
+import org.junit.*;
 
 /**
  *
  * @author Paul Bender Copyright (C) 2017
  */
 public class TrainsTableActionTest extends OperationsTestCase {
+
+    @Rule
+    public org.junit.rules.Timeout globalTimeout = org.junit.rules.Timeout.seconds(10);
+
+    @Rule
+    public jmri.util.junit.rules.RetryRule retryRule = new jmri.util.junit.rules.RetryRule(3); // first, plus three retries
 
     @Test
     public void testCTor() {

--- a/java/test/jmri/jmrit/operations/trains/TrainsTableFrameTest.java
+++ b/java/test/jmri/jmrit/operations/trains/TrainsTableFrameTest.java
@@ -13,15 +13,20 @@ import jmri.util.JUnitOperationsUtil;
 import jmri.util.JUnitUtil;
 import jmri.util.JmriJFrame;
 import jmri.util.swing.JemmyUtil;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
+
+import org.junit.*;
 
 /**
  *
  * @author Paul Bender Copyright (C) 2017
  */
 public class TrainsTableFrameTest extends OperationsTestCase {
+
+    @Rule
+    public org.junit.rules.Timeout globalTimeout = org.junit.rules.Timeout.seconds(10);
+
+    @Rule
+    public jmri.util.junit.rules.RetryRule retryRule = new jmri.util.junit.rules.RetryRule(3); // first, plus three retries
 
     @Test
     public void testCTor() {


### PR DESCRIPTION
Add timeout and retry to
 - jmri.jmrit.operations.trains.TrainsTableActionTest
 - jmri.jmrit.operations.trains.TrainsTableFrameTest

These were having trouble in the Separate Test task on Jenkins.  This is unlikely to fix that, but hopefully will make it possible track down the problem.