### PR TITLE
WIP Synchronize lastAuto*Ref in managers

### DIFF
--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -101,7 +101,7 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
         /*The following keeps track of the last created auto system name.
          currently we do not reuse numbers, although there is nothing to stop the
          user from manually recreating them*/
-        if (systemName.startsWith(getSystemPrefix() + typeLetter() + ":AUTO:")) {
+        if (systemName.startsWith(getSystemNamePrefix() + ":AUTO:")) {
             try {
                 int autoNumber = Integer.parseInt(systemName.substring(8));
                 if (autoNumber > lastAutoBlockRef) {
@@ -130,7 +130,7 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
     @CheckForNull
     public Block createNewBlock(@Nonnull String userName) {
         int nextAutoBlockRef = lastAutoBlockRef + 1;
-        StringBuilder b = new StringBuilder(getSystemPrefix() + typeLetter() + ":AUTO:");
+        StringBuilder b = new StringBuilder(getSystemNamePrefix() + ":AUTO:");
         String nextNumber = paddedNumber.format(nextAutoBlockRef);
         b.append(nextNumber);
         return createNewBlock(b.toString(), userName);
@@ -155,7 +155,7 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
         if (b != null) {
             return b;
         }
-        if (name.startsWith(getSystemPrefix() + typeLetter())) {
+        if (name.startsWith(getSystemNamePrefix())) {
             b = createNewBlock(name, null);
         } else {
             b = createNewBlock(name);

--- a/java/src/jmri/BlockManager.java
+++ b/java/src/jmri/BlockManager.java
@@ -101,7 +101,7 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
         /*The following keeps track of the last created auto system name.
          currently we do not reuse numbers, although there is nothing to stop the
          user from manually recreating them*/
-        if (systemName.startsWith("IB:AUTO:")) {
+        if (systemName.startsWith(getSystemPrefix() + typeLetter() + ":AUTO:")) {
             try {
                 int autoNumber = Integer.parseInt(systemName.substring(8));
                 if (autoNumber > lastAutoBlockRef) {
@@ -130,7 +130,7 @@ public class BlockManager extends AbstractManager<Block> implements ProvidingMan
     @CheckForNull
     public Block createNewBlock(@Nonnull String userName) {
         int nextAutoBlockRef = lastAutoBlockRef + 1;
-        StringBuilder b = new StringBuilder("IB:AUTO:");
+        StringBuilder b = new StringBuilder(getSystemPrefix() + typeLetter() + ":AUTO:");
         String nextNumber = paddedNumber.format(nextAutoBlockRef);
         b.append(nextNumber);
         return createNewBlock(b.toString(), userName);

--- a/java/src/jmri/SectionManager.java
+++ b/java/src/jmri/SectionManager.java
@@ -118,7 +118,7 @@ public class SectionManager extends AbstractManager<Section> implements Instance
 
     DecimalFormat paddedNumber = new DecimalFormat("0000");
 
-	@GuardedBy("this")
+    @GuardedBy("this")
     int lastAutoSectionRef = 0;
 
     /**

--- a/java/src/jmri/SectionManager.java
+++ b/java/src/jmri/SectionManager.java
@@ -17,9 +17,9 @@ import org.slf4j.LoggerFactory;
  * This doesn't have a "new" interface, since Sections are independently
  * implemented, instead of being system-specific.
  * <p>
- * Note that Section system names must begin with IY, and be followed by a
- * string, usually, but not always, a number. This is enforced when a Section is
- * created.
+ * Note that Section system names must begin with system prefix and type character,
+ * usually IY, and be followed by a string, usually, but not always, a number. This
+ * is enforced when a Section is created.
  * <br>
  * <hr>
  * This file is part of JMRI.
@@ -68,8 +68,8 @@ public class SectionManager extends AbstractManager<Section> implements Instance
             return null;
         }
         String sysName = systemName;
-        if ((sysName.length() < 2) || (!sysName.substring(0, 2).equals("IY"))) {
-            sysName = "IY" + sysName;
+        if (!sName.startsWith(getSystemPrefix() + typeLetter())) {
+            sysName = getSystemPrefix() + typeLetter() + sysName;
         }
         // Check that Section does not already exist
         Section y;
@@ -90,7 +90,7 @@ public class SectionManager extends AbstractManager<Section> implements Instance
         /*The following keeps trace of the last created auto system name.
          currently we do not reuse numbers, although there is nothing to stop the
          user from manually recreating them*/
-        if (systemName.startsWith("IY:AUTO:")) {
+        if (systemName.startsWith(getSystemPrefix() + typeLetter() + ":AUTO:")) {
             try {
                 int autoNumber = Integer.parseInt(systemName.substring(8));
                 synchronized(this) {
@@ -110,7 +110,7 @@ public class SectionManager extends AbstractManager<Section> implements Instance
         synchronized(this) {
             nextAutoSectionRef = ++lastAutoSectionRef;
         }
-        StringBuilder b = new StringBuilder("IY:AUTO:");
+        StringBuilder b = new StringBuilder(getSystemPrefix() + typeLetter() + ":AUTO:");
         String nextNumber = paddedNumber.format(nextAutoSectionRef);
         b.append(nextNumber);
         return createNewSection(b.toString(), userName);

--- a/java/src/jmri/managers/AbstractMemoryManager.java
+++ b/java/src/jmri/managers/AbstractMemoryManager.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Abstract partial implementation of a MemoryManager.
  *
- * @author	Bob Jacobsen Copyright (C) 2004
+ * @author  Bob Jacobsen Copyright (C) 2004
  */
 public abstract class AbstractMemoryManager extends AbstractManager<Memory>
         implements MemoryManager {
@@ -150,7 +150,7 @@ public abstract class AbstractMemoryManager extends AbstractManager<Memory>
 
     DecimalFormat paddedNumber = new DecimalFormat("0000");
 
-	@GuardedBy("this")
+    @GuardedBy("this")
     int lastAutoMemoryRef = 0;
 
     /**

--- a/java/src/jmri/managers/AbstractMemoryManager.java
+++ b/java/src/jmri/managers/AbstractMemoryManager.java
@@ -48,7 +48,7 @@ public abstract class AbstractMemoryManager extends AbstractManager<Memory>
         if (t != null) {
             return t;
         }
-        if (sName.startsWith("" + getSystemPrefix() + typeLetter())) {
+        if (sName.startsWith(getSystemPrefix() + typeLetter())) {
             return newMemory(sName, null);
         } else {
             return newMemory(makeSystemName(sName), null);
@@ -120,7 +120,7 @@ public abstract class AbstractMemoryManager extends AbstractManager<Memory>
         /*The following keeps trace of the last created auto system name.  
          currently we do not reuse numbers, although there is nothing to stop the 
          user from manually recreating them*/
-        if (systemName.startsWith("IM:AUTO:")) {
+        if (systemName.startsWith(getSystemPrefix() + typeLetter() + ":AUTO:")) {
             try {
                 int autoNumber = Integer.parseInt(systemName.substring(8));
                 synchronized(this) {
@@ -142,7 +142,7 @@ public abstract class AbstractMemoryManager extends AbstractManager<Memory>
         synchronized(this) {
             nextAutoMemoryRef = ++lastAutoMemoryRef;
         }
-        StringBuilder b = new StringBuilder("IM:AUTO:");
+        StringBuilder b = new StringBuilder(getSystemPrefix() + typeLetter() + ":AUTO:");
         String nextNumber = paddedNumber.format(nextAutoMemoryRef);
         b.append(nextNumber);
         return newMemory(b.toString(), userName);

--- a/java/src/jmri/managers/DefaultLogixManager.java
+++ b/java/src/jmri/managers/DefaultLogixManager.java
@@ -15,8 +15,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Basic Implementation of a LogixManager.
  * <p>
- * Note that Logix system names must begin with IX, and be followed by a string,
- * usually, but not always, a number. This is enforced when a Logix is created.
+ * Note that Logix system names must begin with system prefix and type character,
+ * usually IX, and be followed by a string, usually, but not always, a number. This
+ * is enforced when a Logix is created.
  * <p>
  * The system names of Conditionals belonging to a Logix begin with the Logix's
  * system name, then there is a capital C and a number.
@@ -80,7 +81,7 @@ public class DefaultLogixManager extends AbstractManager<Logix>
         /*The following keeps track of the last created auto system name.
          currently we do not reuse numbers, although there is nothing to stop the
          user from manually recreating them*/
-        if (systemName.startsWith("IX:AUTO:")) {
+        if (systemName.startsWith(getSystemPrefix() + typeLetter() + ":AUTO:")) {
             try {
                 int autoNumber = Integer.parseInt(systemName.substring(8));
                 synchronized(this) {
@@ -101,7 +102,7 @@ public class DefaultLogixManager extends AbstractManager<Logix>
         synchronized(this) {
             nextAutoLogixRef = ++lastAutoLogixRef;
         }
-        StringBuilder b = new StringBuilder("IX:AUTO:");
+        StringBuilder b = new StringBuilder(getSystemPrefix() + typeLetter() + ":AUTO:");
         String nextNumber = paddedNumber.format(nextAutoLogixRef);
         b.append(nextNumber);
         return createNewLogix(b.toString(), userName);

--- a/java/src/jmri/managers/DefaultLogixManager.java
+++ b/java/src/jmri/managers/DefaultLogixManager.java
@@ -109,7 +109,7 @@ public class DefaultLogixManager extends AbstractManager<Logix>
 
     DecimalFormat paddedNumber = new DecimalFormat("0000");
 
-	@GuardedBy("this")
+    @GuardedBy("this")
     int lastAutoLogixRef = 0;
 
     /**

--- a/java/src/jmri/managers/DefaultRouteManager.java
+++ b/java/src/jmri/managers/DefaultRouteManager.java
@@ -62,7 +62,7 @@ public class DefaultRouteManager extends AbstractManager<Route>
         /* The following keeps track of the last created auto system name.
          Currently we do not reuse numbers, although there is nothing to stop the
          user from manually recreating them. */
-        if (systemName.startsWith("IR:AUTO:")) {
+        if (systemName.startsWith(getSystemPrefix() + typeLetter() + ":AUTO:")) {
             try {
                 int autoNumber = Integer.parseInt(systemName.substring(8));
                 synchronized(this) {
@@ -89,7 +89,7 @@ public class DefaultRouteManager extends AbstractManager<Route>
         synchronized(this) {
             nextAutoRouteRef = ++lastAutoRouteRef;
         }
-        StringBuilder b = new StringBuilder("IR:AUTO:");
+        StringBuilder b = new StringBuilder(getSystemPrefix() + typeLetter() + ":AUTO:");
         String nextNumber = paddedNumber.format(nextAutoRouteRef);
         b.append(nextNumber);
         return provideRoute(b.toString(), userName);

--- a/java/src/jmri/managers/DefaultRouteManager.java
+++ b/java/src/jmri/managers/DefaultRouteManager.java
@@ -97,7 +97,7 @@ public class DefaultRouteManager extends AbstractManager<Route>
 
     DecimalFormat paddedNumber = new DecimalFormat("0000");
 
-	@GuardedBy("this")
+    @GuardedBy("this")
     int lastAutoRouteRef = 0;
 
     /**

--- a/java/src/jmri/managers/DefaultSignalGroupManager.java
+++ b/java/src/jmri/managers/DefaultSignalGroupManager.java
@@ -90,7 +90,7 @@ public class DefaultSignalGroupManager extends AbstractManager<SignalGroup>
         /* The following keeps track of the last created auto system name.
          Currently we do not reuse numbers, although there is nothing to stop the
          user from manually recreating them. */
-        if (systemName.startsWith("IG:AUTO:")) {
+        if (systemName.startsWith(getSystemPrefix() + typeLetter() + ":AUTO:")) {
             try {
                 int autoNumber = Integer.parseInt(systemName.substring(8));
                 synchronized(this) {
@@ -130,7 +130,7 @@ public class DefaultSignalGroupManager extends AbstractManager<SignalGroup>
         synchronized(this) {
             nextAutoGroupRef = ++lastAutoGroupRef;
         }
-        StringBuilder b = new StringBuilder("IG:AUTO:");
+        StringBuilder b = new StringBuilder(getSystemPrefix() + typeLetter() + ":AUTO:");
         String nextNumber = paddedNumber.format(nextAutoGroupRef);
         b.append(nextNumber);
         log.debug("SignalGroupManager - new autogroup with sName: {}", b);

--- a/java/src/jmri/managers/DefaultSignalGroupManager.java
+++ b/java/src/jmri/managers/DefaultSignalGroupManager.java
@@ -139,7 +139,7 @@ public class DefaultSignalGroupManager extends AbstractManager<SignalGroup>
 
     DecimalFormat paddedNumber = new DecimalFormat("0000");
 
-	@GuardedBy("this")
+    @GuardedBy("this")
     int lastAutoGroupRef = 0;
 
     List<String> getListOfNames() {


### PR DESCRIPTION
@pabender [discovered](https://github.com/JMRI/JMRI/pull/7468#issuecomment-538763505) a race condition in BlockManager. PR #7468 fixes that race condition, but the same pattern exists in SectionManager, AbstractMemoryManager, DefaultLogixManager, DefaultRouteManager and DefaultSignalGroupManager. This PR fixes the race condition in these managers.