### PR TITLE
Update CV 3 and 4 range from 1-31 to 0-255

### DIFF
--- a/xml/decoders/Lenz_54.xml
+++ b/xml/decoders/Lenz_54.xml
@@ -13,6 +13,7 @@
 <!-- FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License  -->
 <!-- for more details.                                                      -->
 <decoder-config xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://jmri.org/xml/schema/decoder.xsd">
+  <version author="Alain Carasso" version="8" lastUpdated="20191007"/> <!-- CV3 and 4 range now 0 to 255 -->
   <version author="Bob Jacobsen" version="7" lastUpdated="20190727"/> <!-- xinclude for CV19 -->
   <version author="Michael Mosher mjmx@comcast.net" version="5" lastUpdated="20030815"/>
   <version author="Jack Shall lcrr@bellsouth.net" version="6" lastUpdated="20090116"/>
@@ -25,6 +26,7 @@
   <!--    change lowVersionID to 51, move Lighting options to Lights pane -->
   <!-- These are the version 5.1 thru 5.4 decoders, with "12 bit BEMF" or "5th gen BEMF " -->
   <!-- and "XF & special" -->
+   <!-- version 8: update decimal range for CV 3 and 4 -->
   <decoder>
     <family name="Lenz 5th gen BEMF decoders" mfg="Lenz" lowVersionID="51" highVersionID="54">
       <model model="LE010XF" numOuts="2" nmraWarrant="yes" nmraWarrantStart="200506">
@@ -82,17 +84,17 @@
         <tooltip xml:lang="de">Sets the starting voltage at throttle speed step 1.  Note: some decoders only accept a max value of 15</tooltip>
       </variable>
       <variable CV="3" item="Accel" default="1" tooltip="Sets the acceleration rate (delay)">
-        <decVal min="1" max="31"/>
-        <label>Acceleration Momentum (1-31)</label>
-        <label xml:lang="it">Accellerazione (0-31)</label>
-        <label xml:lang="fr">Accelération (0-31)</label>
-        <label xml:lang="de">Anfahrverzögerung (0-31)</label>
+        <decVal min="0" max="255"/>
+        <label>Acceleration Momentum (0-255)</label>
+        <label xml:lang="it">Accellerazione (0-255)</label>
+        <label xml:lang="fr">Accelération (0-255)</label>
+        <label xml:lang="de">Anfahrverzögerung (0-255)</label>
         <tooltip xml:lang="de">Sets the acceleration rate (delay)</tooltip>
       </variable>
       <variable CV="4" item="Decel" default="1" tooltip="Sets the deceleration rate (delay)">
-        <decVal min="1" max="31"/>
-        <label>Deceleration (Brake) Momentum (1-31)</label>
-        <label xml:lang="it">Inerzia decellerazione (frenata)  (1-31)</label>
+        <decVal min="0" max="255"/>
+        <label>Deceleration (Brake) Momentum (0-255)</label>
+        <label xml:lang="it">Inerzia decellerazione (frenata)  (0-255)</label>
         <label xml:lang="de">Decel</label>
         <tooltip xml:lang="de">Sets the deceleration rate (delay)</tooltip>
       </variable>


### PR DESCRIPTION
As described in Lenz Manual, CV 3 and 4 range is 0 to 255, not 1 to 31
Definition updated accordingly. This update also include comments which were forgotten on my 1st PR.