### PR TITLE
Implement a custom getNamedBeanSet for Conditionals

### DIFF
--- a/java/src/jmri/managers/DefaultConditionalManager.java
+++ b/java/src/jmri/managers/DefaultConditionalManager.java
@@ -8,6 +8,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
 import jmri.Conditional;
 import jmri.ConditionalManager;
 import jmri.InstanceManager;
@@ -299,8 +300,8 @@ public class DefaultConditionalManager extends AbstractManager<Conditional>
      * Get a list of all Conditional system names
      * Overrides the bean method
      * @since 4.7.4
-     * @deprecated 4.11.5 - use direct access via 
-     *                  {@link #getNamedBeanSet} 
+     * @deprecated 4.11.5 - use direct access via
+     *                  {@link #getNamedBeanSet}
      * @return a list of conditional system names regardless of parent Logix
      */
     @Deprecated // 4.11.5
@@ -319,7 +320,32 @@ public class DefaultConditionalManager extends AbstractManager<Conditional>
     }
 
     /**
-     * 
+     * Create a named bean set for conditionals.  This requires special logic since conditional
+     * beans are not registered.
+     * @since 4.17.5
+     * @returns a sorted named bean set of conditionals.
+     */
+    @Override
+    @Nonnull
+    public SortedSet<Conditional> getNamedBeanSet() {
+        TreeSet<Conditional> conditionals = new TreeSet<>(new jmri.util.NamedBeanComparator<>());
+
+        jmri.LogixManager logixManager = InstanceManager.getDefault(jmri.LogixManager.class);
+        for (Logix lgx : logixManager.getNamedBeanSet()) {
+            for (int i = 0; i < lgx.getNumConditionals(); i++) {
+                Conditional cdl = getBySystemName(lgx.getConditionalByNumberOrder(i));
+                if (cdl == null) {
+                    log.error("Conditional not found for \"{}\"", lgx.getConditionalByNumberOrder(i));
+                } else {
+                    conditionals.add(cdl);
+                }
+            }
+        }
+        return Collections.unmodifiableSortedSet(conditionals);
+    }
+
+    /**
+     *
      * @return the default instance of the DefaultConditionalManager
      * @deprecated since 4.17.3; use {@link jmri.InstanceManager#getDefault(java.lang.Class)} instead
      */

--- a/java/src/jmri/managers/DefaultConditionalManager.java
+++ b/java/src/jmri/managers/DefaultConditionalManager.java
@@ -323,7 +323,7 @@ public class DefaultConditionalManager extends AbstractManager<Conditional>
      * Create a named bean set for conditionals.  This requires special logic since conditional
      * beans are not registered.
      * @since 4.17.5
-     * @returns a sorted named bean set of conditionals.
+     * @return a sorted named bean set of conditionals.
      */
     @Override
     @Nonnull

--- a/java/test/jmri/configurexml/loadref/LoadFileTest-4.7.4.xml
+++ b/java/test/jmri/configurexml/loadref/LoadFileTest-4.7.4.xml
@@ -158,6 +158,14 @@
       <logixConditional systemName="IX1C1" order="0" />
     </logix>
   </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX1C1" antecedent="R1 and R2" logicType="1" triggerOnChange="yes">
+      <systemName>IX1C1</systemName>
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="User 1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="17" systemName="User 1" data="2" delay="1" string="1" />
+    </conditional>
+  </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Jun 06 08:42:04 CEST 2009" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <filehistory>
     <operation>

--- a/java/test/jmri/configurexml/loadref/LoadFileTest.xml
+++ b/java/test/jmri/configurexml/loadref/LoadFileTest.xml
@@ -158,6 +158,14 @@
       <logixConditional systemName="IX1C1" order="0" />
     </logix>
   </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX1C1" antecedent="R1 and R2" logicType="1" triggerOnChange="yes">
+      <systemName>IX1C1</systemName>
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="User 1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="17" systemName="User 1" data="2" delay="1" string="1" />
+    </conditional>
+  </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Jun 06 08:42:04 CEST 2009" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <filehistory>
     <operation>

--- a/java/test/jmri/configurexml/loadref/LoadFileTest277-4.7.4.xml
+++ b/java/test/jmri/configurexml/loadref/LoadFileTest277-4.7.4.xml
@@ -147,6 +147,14 @@
       <logixConditional systemName="IX1C1" order="0" />
     </logix>
   </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX1C1" antecedent="R1 and R2" logicType="1" triggerOnChange="yes">
+      <systemName>IX1C1</systemName>
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="User 1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="17" systemName="User 1" data="2" delay="1" string="1" />
+    </conditional>
+  </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Jun 06 08:42:04 CEST 2009" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <filehistory>
     <operation>

--- a/java/test/jmri/configurexml/loadref/LoadFileTest277.xml
+++ b/java/test/jmri/configurexml/loadref/LoadFileTest277.xml
@@ -147,6 +147,14 @@
       <logixConditional systemName="IX1C1" order="0" />
     </logix>
   </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX1C1" antecedent="R1 and R2" logicType="1" triggerOnChange="yes">
+      <systemName>IX1C1</systemName>
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="User 1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="17" systemName="User 1" data="2" delay="1" string="1" />
+    </conditional>
+  </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Jun 06 08:42:04 CEST 2009" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <filehistory>
     <operation>

--- a/java/test/jmri/configurexml/loadref/LoadFileTest295-4.7.4.xml
+++ b/java/test/jmri/configurexml/loadref/LoadFileTest295-4.7.4.xml
@@ -144,6 +144,14 @@
       <logixConditional systemName="IX1C1" order="0" />
     </logix>
   </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX1C1" antecedent="R1 and R2" logicType="1" triggerOnChange="yes">
+      <systemName>IX1C1</systemName>
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="User 1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="17" systemName="User 1" data="2" delay="1" string="1" />
+    </conditional>
+  </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Jun 06 08:42:04 CEST 2009" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <filehistory>
     <operation>

--- a/java/test/jmri/configurexml/loadref/LoadFileTest295.xml
+++ b/java/test/jmri/configurexml/loadref/LoadFileTest295.xml
@@ -144,6 +144,14 @@
       <logixConditional systemName="IX1C1" order="0" />
     </logix>
   </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX1C1" antecedent="R1 and R2" logicType="1" triggerOnChange="yes">
+      <systemName>IX1C1</systemName>
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="User 1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="17" systemName="User 1" data="2" delay="1" string="1" />
+    </conditional>
+  </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Jun 06 08:42:04 CEST 2009" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <filehistory>
     <operation>

--- a/java/test/jmri/configurexml/loadref/PanelFileSchemaTest.xml
+++ b/java/test/jmri/configurexml/loadref/PanelFileSchemaTest.xml
@@ -144,6 +144,14 @@
       <logixConditional systemName="IX1C1" order="0" />
     </logix>
   </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX1C1" antecedent="R1 and R2" logicType="1" triggerOnChange="yes">
+      <systemName>IX1C1</systemName>
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="User 1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="17" systemName="User 1" data="2" delay="1" string="1" />
+    </conditional>
+  </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Jun 06 08:42:04 CEST 2009" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <filehistory>
     <operation>

--- a/java/test/jmri/configurexml/loadref/PanelFileSchemaTest295.xml
+++ b/java/test/jmri/configurexml/loadref/PanelFileSchemaTest295.xml
@@ -144,6 +144,14 @@
       <logixConditional systemName="IX1C1" order="0" />
     </logix>
   </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX1C1" antecedent="R1 and R2" logicType="1" triggerOnChange="yes">
+      <systemName>IX1C1</systemName>
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="User 1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="17" systemName="User 1" data="2" delay="1" string="1" />
+    </conditional>
+  </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Jun 06 08:42:04 CEST 2009" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <filehistory>
     <operation>

--- a/java/test/jmri/configurexml/loadref/PanelFileSchemaTest382-4.7.4.xml
+++ b/java/test/jmri/configurexml/loadref/PanelFileSchemaTest382-4.7.4.xml
@@ -144,6 +144,14 @@
       <logixConditional systemName="IX1C1" order="0" />
     </logix>
   </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX1C1" antecedent="R1 and R2" logicType="1" triggerOnChange="yes">
+      <systemName>IX1C1</systemName>
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="User 1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="17" systemName="User 1" data="2" delay="1" string="1" />
+    </conditional>
+  </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Jun 06 08:42:04 CEST 2009" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <filehistory>
     <operation>

--- a/java/test/jmri/configurexml/loadref/PanelFileSchemaTest382.xml
+++ b/java/test/jmri/configurexml/loadref/PanelFileSchemaTest382.xml
@@ -144,6 +144,14 @@
       <logixConditional systemName="IX1C1" order="0" />
     </logix>
   </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX1C1" antecedent="R1 and R2" logicType="1" triggerOnChange="yes">
+      <systemName>IX1C1</systemName>
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="User 1" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="17" systemName="User 1" data="2" delay="1" string="1" />
+    </conditional>
+  </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Jun 06 08:42:04 CEST 2009" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <filehistory>
     <operation>

--- a/java/test/jmri/implementation/configurexml/loadref/ActiveLogixTestDefinitions.xml
+++ b/java/test/jmri/implementation/configurexml/loadref/ActiveLogixTestDefinitions.xml
@@ -133,6 +133,63 @@
       <logixConditional systemName="IX:AUTO:0005C1" order="0" />
     </logix>
   </logixs>
+  <conditionals class="jmri.managers.configurexml.DefaultConditionalManagerXml">
+    <conditional systemName="IX:AUTO:0001C1" antecedent="R1" logicType="1" triggerOnChange="yes">
+      <systemName>IX:AUTO:0001C1</systemName>
+      <conditionalStateVariable operator="4" negated="no" type="3" systemName="IT101" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="9" systemName="IS101" data="2" delay="0" string="" />
+      <conditionalAction option="2" type="9" systemName="IS101" data="4" delay="0" string="" />
+    </conditional>
+    <conditional systemName="IX:AUTO:0002C1" antecedent="(R1 and R2) or (R3 and R4) or (R5 and R6)" logicType="3" triggerOnChange="yes">
+      <systemName>IX:AUTO:0002C1</systemName>
+      <conditionalStateVariable operator="4" negated="no" type="1" systemName="IS201" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="IS202" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="IS203" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="IS204" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="IS205" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalStateVariable operator="1" negated="no" type="1" systemName="IS206" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="2" systemName="IT201" data="4" delay="0" string="" />
+      <conditionalAction option="2" type="2" systemName="IT201" data="2" delay="0" string="" />
+    </conditional>
+    <conditional systemName="IX:AUTO:0003C1" userName="IS301 ACTIVE if 03:30 to 04:30" antecedent="R1R1" logicType="1" triggerOnChange="yes">
+      <systemName>IX:AUTO:0003C1</systemName>
+      <userName>IS301 ACTIVE if 03:30 to 04:30</userName>
+      <conditionalStateVariable operator="4" negated="no" type="10" systemName="Clock" dataString="" num1="210" num2="270" triggersCalc="yes" />
+      <conditionalAction option="1" type="9" systemName="IS301" data="2" delay="0" string="" />
+      <conditionalAction option="2" type="9" systemName="IS301" data="4" delay="0" string="" />
+    </conditional>
+    <conditional systemName="IX:AUTO:0003C2" userName="IT301 sets 04:01" antecedent="R1" logicType="1" triggerOnChange="yes">
+      <systemName>IX:AUTO:0003C2</systemName>
+      <userName>IT301 sets 04:01</userName>
+      <conditionalStateVariable operator="4" negated="no" type="3" systemName="IT301" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="23" systemName=" " data="241" delay="0" string="" />
+    </conditional>
+    <conditional systemName="IX:AUTO:0003C3" userName="IT302 sets 14:02" antecedent="R1" logicType="1" triggerOnChange="yes">
+      <systemName>IX:AUTO:0003C3</systemName>
+      <userName>IT302 sets 14:02</userName>
+      <conditionalStateVariable operator="4" negated="no" type="3" systemName="IT302" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="23" systemName=" " data="842" delay="0" string="" />
+    </conditional>
+    <conditional systemName="IX:AUTO:0004C1" userName="IM401 case-insensitive aaa copies to IM402" antecedent="R1" logicType="1" triggerOnChange="yes">
+      <systemName>IX:AUTO:0004C1</systemName>
+      <userName>IM401 case-insensitive aaa copies to IM402</userName>
+      <conditionalStateVariable operator="4" negated="no" type="23" systemName="IM401" dataString="aaa" num1="3" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="26" systemName="IM401" data="-1" delay="0" string="IM402" />
+    </conditional>
+    <conditional systemName="IX:AUTO:0004C2" userName="IM403 less than IM402 case insensitive sets IM404" antecedent="R1" logicType="1" triggerOnChange="yes">
+      <systemName>IX:AUTO:0004C2</systemName>
+      <userName>IM403 less than IM402 case insensitive sets IM404</userName>
+      <conditionalStateVariable operator="4" negated="no" type="24" systemName="IM403" dataString="IM402" num1="1" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="12" systemName="IM404" data="-1" delay="0" string="OK" />
+    </conditional>
+    <conditional systemName="IX:AUTO:0005C1" userName="IL501 sets IL502 opposite" antecedent="R1" logicType="1" triggerOnChange="yes">
+      <systemName>IX:AUTO:0005C1</systemName>
+      <userName>IL501 sets IL502 opposite</userName>
+      <conditionalStateVariable operator="4" negated="no" type="7" systemName="IL501" dataString="" num1="0" num2="0" triggersCalc="yes" />
+      <conditionalAction option="1" type="11" systemName="IL502" data="4" delay="0" string="" />
+      <conditionalAction option="2" type="11" systemName="IL502" data="2" delay="0" string="" />
+    </conditional>
+  </conditionals>
   <timebase class="jmri.jmrit.simpleclock.configurexml.SimpleTimebaseXml" time="Sat Nov 24 03:09:00 CET 2018" rate="1.0" startrate="1.0" run="yes" master="yes" sync="no" correct="no" display="no" startstopped="no" startrunning="yes" startsettime="no" startclockoption="0" showbutton="no" startsetrate="yes" />
   <filehistory>
     <operation>


### PR DESCRIPTION
This is a proposed solution to issue #7504.  

Since Conditionals are not registered named beans, the standard getNamedBeanSet returns an empty set which results in no Conditionals being save in the panel xml file.

This is an alternative to reverting ConditionalManagerXml to use the system name list approach.