### PR TITLE
Allow direct access to signal timing

### DIFF
--- a/help/en/releasenotes/current-draft-note.shtml
+++ b/help/en/releasenotes/current-draft-note.shtml
@@ -399,12 +399,21 @@
             <li>JMRI's scripting support now defaults to the UTF-8 character encoding for all
               script files on all platforms. This may require that some scripts be re-saved
               using UTF-8.</li>
+            <li>The jython/SetSignalFlashRate.py sample script shows how to 
+                change the flashing on/off time for your signals.  Just invoke
+                it before defining the signals, i.e. before loading your
+                configuration and panel files.
+            </li>
         </ul>
 
     <h3>Signals</h3>
         <a id="Signals" name="Signals"></a>
         <ul>
-            <li></li>
+            <li>The jython/SetSignalFlashRate.py sample script shows how to 
+                change the flashing on/off time for your signals.  Just invoke
+                it before defining the signals, i.e. before loading your
+                configuration and panel files.
+            </li>
         </ul>
         <h4>Signal Systems</h4>
             <ul>

--- a/jython/SetSignalFlashRate.py
+++ b/jython/SetSignalFlashRate.py
@@ -1,0 +1,12 @@
+# Set the period for flashing signals
+#
+# This should be invoked before the signals are defined,
+# i.e. before the panel files are read.
+#
+# Author: Bob Jacobsen, copyright 2019
+# Part of the JMRI distribution
+
+import jmri
+
+# set the on and off time
+jmri.implementation.DefaultSignalHead.masterDelay = 1000

--- a/jython/test/SetSignalFlashRateTest.py
+++ b/jython/test/SetSignalFlashRateTest.py
@@ -1,0 +1,8 @@
+# Test the SetSignalFlashRate.py script
+import jmri
+
+execfile("jython/SetSignalFlashRate.py")
+
+if ( jmri.implementation.DefaultSignalHead.masterDelay != 1000) :
+    raise AssertionError("Time not changed")
+


### PR DESCRIPTION
Provides a sample script that can change the on/off timing of flashing signals.