### PR TITLE
Bugfix: trailing space in property caused Windows build to fail.

### DIFF
--- a/project.properties
+++ b/project.properties
@@ -7,23 +7,23 @@
 
 jmri.copyright.year=1997-2019
 
-# The Jenkins official release builds force: 
-#    release.official=true                   
-#    nsis.home=/opt/nsis/nsis-2.46/          
-# in their "invoke ant" step                 
-# The Packages build (dev downloads) forces: 
-#    release.official=false                  
-#    nsis.home=/opt/nsis/nsis-2.46/          
-# in its "invoke ant" step                   
+# The Jenkins official release builds force:
+#    release.official=true
+#    nsis.home=/opt/nsis/nsis-2.46/
+# in their "invoke ant" step
+# The Packages build (dev downloads) forces:
+#    release.official=false
+#    nsis.home=/opt/nsis/nsis-2.46/
+# in its "invoke ant" step
 
 release.build_user=${user.name}
 release=${release.major}.${release.minor}.${release.build}
 
-# Should compiler warn of use of deprecated APIs? (on/off) 
-# This is overridden in a number of targets 
+# Should compiler warn of use of deprecated APIs? (on/off)
+# This is overridden in a number of targets
 deprecation=off
 
-# SDK version (1.8 as of JMRI 3.11.1 [3.12/4.0 pre-releases]) 
+# SDK version (1.8 as of JMRI 3.11.1 [3.12/4.0 pre-releases])
 sdk_version=1.8
 source_version=${sdk_version}
 jre_version=${sdk_version}
@@ -46,13 +46,13 @@ acceptancetest=${javadir}/acceptancetest
 templatedir=${javadir}/template
 tmptarget=${javadir}/tmp
 lineendtmp=${tmptarget}/lineend
-tempdir=${basedir}/temp 
+tempdir=${basedir}/temp
 genjavasrcdir=${tmptarget}
 jacocoexec=${maventarget}/jacoco.exec
 
 java.debugging=yes
 
-# PureJavaComm default log level - override in local.properties or Ant command line 
+# PureJavaComm default log level - override in local.properties or Ant command line
 purejavacomm.loglevel=0
 
 checkerframework=${libdir}/checker-framework/
@@ -66,7 +66,7 @@ dist.scripts=${dist}/scripts
 dist.apps=${dist}/apps
 
 # set this next to a standard remote, e.g. "origin", if you don't want to
-# go directly back to the main repo; direct JMRI/JMRI require write access 
+# go directly back to the main repo; direct JMRI/JMRI require write access
 jmri.repository.url=https://github.com/JMRI/JMRI.git
 
 branch-name=release-${release}


### PR DESCRIPTION
Removed trailing spaces form the `.properties` file. Actually just one property seem to be affected, the rest is in comments.