### PR TITLE
Check that old time is different from new time.

### DIFF
--- a/jython/test/SetSignalFlashRateTest.py
+++ b/jython/test/SetSignalFlashRateTest.py
@@ -1,6 +1,9 @@
 # Test the SetSignalFlashRate.py script
 import jmri
 
+if ( jmri.implementation.DefaultSignalHead.masterDelay == 1000) :
+    raise AssertionError("We cannot test and verify the change if the original value is the same as in the script")
+
 execfile("jython/SetSignalFlashRate.py")
 
 if ( jmri.implementation.DefaultSignalHead.masterDelay != 1000) :


### PR DESCRIPTION
While reading PR #7532, I noticed that if somebody changes the master delay in JMRI to 1000, the test will stop working since it assumes that the original value is not 1000. The PR is already merged so I created a new PR.