### PR TITLE
fix: protect against JVM not implementing optional feature

### DIFF
--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -129,7 +129,7 @@ function parse_args() {
 function heap_size() {
     # get Java heap size
     heap=$( "${JAVACMD}" -XX:+PrintFlagsFinal -version 2>/dev/null | grep MaxHeapSize | awk '{print $4}' )
-    heap=$( expr ${heap} / 1048576 ) # bytes to MB
+    [ ! -z "$heap" ] && heap=$( expr ${heap} / 1048576 ) || heap=0 # bytes to MB
     # Java heap defaults to 1/4 total memory size
     # if <= 768MB (1/4 of 3GB), set it ourselves
     if [ ${heap} -le 768 ] ; then


### PR DESCRIPTION
It appears the OpenJ9 JVM does not provide output for `-XX:+PrintFlagsFinal`. From [the `java` command reference](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html):

> Non-standard options are general purpose options that are specific to the Java HotSpot Virtual Machine, so they are not guaranteed to be supported by all JVM implementations, and are subject to change. These options start with -X.

This may address one source of failure outlined in #7541