### PR TITLE
fix: better protect against unexpected heap values

### DIFF
--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -128,11 +128,11 @@ function parse_args() {
 # - with an absolute minimum of 192MB
 function heap_size() {
     # get Java heap size
-    heap=$( "${JAVACMD}" -XX:+PrintFlagsFinal -version 2>/dev/null | grep MaxHeapSize | awk '{print $4}' )
-    [ ! -z "$heap" ] && heap=$( expr ${heap} / 1048576 ) || heap=0 # bytes to MB
+    heap=$( "${JAVACMD}" -XX:+PrintFlagsFinal -version 2>/dev/null | grep MaxHeapSize | grep -v SoftMaxHeapSize | awk '{print $4}' )
+    heap=$( expr ${heap} / 1048576 2>/dev/null ) # bytes to MB
     # Java heap defaults to 1/4 total memory size
     # if <= 768MB (1/4 of 3GB), set it ourselves
-    if [ ${heap} -le 768 ] ; then
+    if [ -z "${heap}" ] || [ ${heap} -le 768 ] ; then
         case "$( uname )" in
             Linux*)
                 mem=$( cat /proc/meminfo | grep MemTotal | tr -d [:space:][:alpha:]: )


### PR DESCRIPTION
This protects in two ways:
- Increases possiblity that a number will be returned at initial `heap` assignment
- Handles heap being empty later than done in #7542

Fixes #7541 by ignoring `SoftMaxHeapSize` HotSpot JVM setting for ZGC garbage collector.