### PR TITLE
feat: Support Oracle JRE for Java 10 for macOS

### DIFF
--- a/scripts/AppScriptTemplate
+++ b/scripts/AppScriptTemplate
@@ -298,19 +298,21 @@ if [ -z "${JAVA_HOME}" ] ; then
         # Otherwise, use java_home if it's present
         # Otherwise, prompt the user to install Java
         #
-        # Default JRE location
+        # Oracle JRE location; note that Oracle only shipped JREs for Java 8, 9, and 10
+        # and now only ships the JRE for Java 8.
         JAVA_HOME="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home"
         if [ -x "${JAVA_HOME}/bin/java" ] ; then
             JAVACMD="${JAVA_HOME}/bin/java"
-            # Test if java is present and version 1.8 or 9
+            # Test if java is present and version 1.8, 9, or 10
             java_version="$( "${JAVACMD}" -version 2>&1 | grep version )"
-            if [[ ! "${java_version}" =~ \"1.8 && ! "${java_version}" =~ \"9 ]] ; then
+            if [[ ! "${java_version}" =~ \"1.8|\"9|\"10 ]] ; then
                 JAVA_HOME=""
             fi
         else
             # Reset JAVA_HOME since there is no java executable in it
             JAVA_HOME=""
         fi
+        # Find an installed JRE/JDK location
         if [[ -z "${JAVA_HOME}" && -x /usr/libexec/java_home ]] ; then
             # Test for any JDKs of version 1.8 or newer
             JAVA_HOME=$( /usr/libexec/java_home --version 1.8+ --failfast 2>/dev/null )


### PR DESCRIPTION
The JRE for Java 10 appears to be the last Oracle provided JRE.

While the only Oracle JRE that works with JMRI and is supported by Oracle is the JRE for Java 1.8, this ensures that *all* Oracle JREs supported by JMRI work with the macOS launcher.